### PR TITLE
feat(docs): kserve and dynamo tutorials

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -177,6 +177,10 @@ Code examples are the heart of these docs — make them correct and copy-paste-r
 Use Fumadocs `<Callout>` deliberately — they're signposts, not decoration. One or two per page
 at most; if everything is a callout, nothing is.
 
+When a callout opens with a bold title (`**Why Standard mode?**`, `**Verify the node-pool
+shape.**`), put a **blank line after the title** so it renders as its own line, with the body
+as its own paragraph below.
+
 | Type | Use for | Example |
 | --- | --- | --- |
 | `type="info"` | Helpful context, orientation, "new here?" pointers. | The site's intro "this walks you end-to-end" note. |
@@ -189,8 +193,10 @@ use a short, clearly-labeled callout and link to [Limitations](./content/docs/li
 
 ```md
 <Callout type="info">
-  **Planned, not yet shipped.** GPU confidential computing (NVIDIA CC mode) is out of scope for
-  the current milestone. See [Limitations](/docs/c8s/limitations).
+  **Planned, not yet shipped.**
+
+  GPU confidential computing (NVIDIA CC mode) is out of scope for the current milestone. See
+  [Limitations](/docs/c8s/limitations).
 </Callout>
 ```
 

--- a/website/app/globals.css
+++ b/website/app/globals.css
@@ -356,6 +356,12 @@ body {
   font-family: var(--font-mono);
 }
 
+/* Fumadocs caps code blocks at 600px with an inner scrollbar; long manifests in
+   the docs should read top to bottom, so let the block take its full height. */
+figure.shiki .fd-scroll-container {
+  max-height: none;
+}
+
 .code-block .prose pre,
 .prose .code-block pre {
   margin-bottom: 0;

--- a/website/content/docs/c8s/attestation/allowlist.mdx
+++ b/website/content/docs/c8s/attestation/allowlist.mdx
@@ -125,7 +125,9 @@ Know the boundaries of this design before relying on it:
   [Verify who can write](#verify-who-can-write)) — but not *measured*.
 
 <Callout type="info">
-  **Planned, not yet shipped.** Two hardenings are coming: **binding the pinned operator keys
+  **Planned, not yet shipped.**
+
+  Two hardenings are coming: **binding the pinned operator keys
   into the CDS's attestation**, so a verifier *proves* the key list instead of trusting the CDS
   to report it, and a **CA with short-lived operator certificates**, giving delegated issuance
   and real revocation. See [Limitations](/docs/c8s/limitations).
@@ -324,7 +326,9 @@ Registry UIs show it too — ghcr.io lists the digest on a package's version pag
 shows it per tag.
 
 <Callout type="warn">
-  **Multi-arch images:** a tag like `…:v3` can point to a manifest *list* with one entry per
+  **Multi-arch images.**
+
+  A tag like `…:v3` can point to a manifest *list* with one entry per
   platform. `crane digest` returns the **index** digest by default, but a node resolves that tag
   to its **platform-specific** manifest when it pulls — and the enforcer matches the
   `…@sha256:…` digest the runtime actually resolved. Pin *that* one, e.g.

--- a/website/content/docs/c8s/install/azure.mdx
+++ b/website/content/docs/c8s/install/azure.mdx
@@ -78,7 +78,9 @@ az aks create \
 ```
 
 <Callout type="warn">
-  **Verify the node-pool shape.** Some subscriptions/regions only allow the confidential VM size
+  **Verify the node-pool shape.**
+
+  Some subscriptions/regions only allow the confidential VM size
   on a **user** node pool, not the default system pool. If `az aks create` rejects the CVM size,
   create a minimal regular system pool and add the confidential pool separately:
 
@@ -124,7 +126,9 @@ provision-through-verify path on one page, follow
 [Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e).
 
 <Callout type="warn">
-  **Validate the host-side install on managed nodes.** c8s's node-as-CVM install runs privileged
+  **Validate the host-side install on managed nodes.**
+
+  c8s's node-as-CVM install runs privileged
   DaemonSets that touch the node host: `nri-image-policy` patches the node's containerd config and
   restarts it, `ratls-mesh` sets up `iptables`, and `attestation-api` mounts `/dev/tpm0`. This is
   routine on self-managed nodes; on a **managed AKS node pool**, confirm these complete and

--- a/website/content/docs/c8s/install/cli-reference.mdx
+++ b/website/content/docs/c8s/install/cli-reference.mdx
@@ -36,6 +36,9 @@ registered with cobra/pflag.
 | `--image-tag` | string | `""` | No | component image tag to resolve digests at (default: the CLI build version, or `main` for an unstamped build); override to pin a specific branch/tag/release |
 | `--resolve-digests` | bool | `true` | No | resolve each component image tag to its registry digest (via crane), pin it, and add the resolved images to the NRI allowlist. Pass `--resolve-digests=false` when supplying digests via `-f` |
 | `--image-pull-secret` | string | `""` | No | name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; appended to every component's imagePullSecrets |
+| `--engine` | string | `""` | No | inference engine preset deriving tls-lb's upstream (chart `engine.name`): `vllm` or `sglang`. Requires `--engine-workload-id`. Without this or a verified-https `tlsLb.upstream`, tls-lb renders no catch-all route until one is attached |
+| `--engine-workload-id` | string | `""` | No | `confidential.ai/cw` id of the engine workload (chart `engine.workloadId`); with `--engine`, derives the mesh-wrapped upstream `c8s-<id>.<ns>.svc.cluster.local:<port>` |
+| `--engine-namespace` | string | `""` | No | namespace the engine workload runs in (chart `engine.namespace`); empty = release namespace |
 | `--operator-keys` | string | `""` | No | path to a PEM bundle of operator EC public keys that authorize [`c8s allowlist`](#c8s-allowlist) writes; sets `cds.operatorKeys`. Without it, allowlist writes are disabled (reads still served) |
 | `--force` | bool | `false` | No | proceed past guarded prompts — currently: install without `--operator-keys` (allowlist writes disabled). Not needed when values are supplied via `-f` |
 
@@ -80,6 +83,10 @@ pass `--distro` to pin it. Still needs the registry reachable for the default di
 | `--image-tag` | string | `""` | No | component image tag to resolve digests at (default: the CLI build version, or `main`) |
 | `--image-pull-secret` | string | `""` | No | name of an existing dockerconfigjson Secret the chart wires into every component's imagePullSecrets |
 | `--install-crds` | bool | `true` | No | emit values for chart CRDs (false sets `statusMirror.enabled=false`, matching `install --install-crds=false`) |
+| `--engine` | string | `""` | No | inference engine preset deriving tls-lb's upstream (chart `engine.name`): `vllm` or `sglang`. Requires `--engine-workload-id`. Without this or a verified-https `tlsLb.upstream`, tls-lb renders no catch-all route until one is attached |
+| `--engine-workload-id` | string | `""` | No | `confidential.ai/cw` id of the engine workload (chart `engine.workloadId`); with `--engine`, derives the mesh-wrapped upstream `c8s-<id>.<ns>.svc.cluster.local:<port>` |
+| `--engine-namespace` | string | `""` | No | namespace the engine workload runs in (chart `engine.namespace`); empty = release namespace |
+| `--operator-keys` | string | `""` | No | path to a PEM bundle of operator EC public keys that authorize [`c8s allowlist`](#c8s-allowlist) writes; the file's **content** is embedded as `cds.operatorKeys` in the emitted values (the chart value is PEM content, never a path) |
 
 {/* flags:operator */}
 ## `c8s operator`

--- a/website/content/docs/c8s/install/installation.mdx
+++ b/website/content/docs/c8s/install/installation.mdx
@@ -239,10 +239,10 @@ spec:
   The annotation **value is the workload's identity**, not a `true`/`false` flag. The operator
   derives a managed headless Service named `c8s-<value>` from it and the workload's certificate
   SAN is `c8s-<value>.<namespace>.svc` (overridable with `confidential.ai/c8s-san`). So
-  `confidential.ai/cw: my-inference` yields the Service `c8s-my-inference` — which is what a
-  front-door proxy (e.g. tee-proxy's `--upstream`) dials to reach the workload over the RA-TLS
-  mesh. Use a stable, DNS-label-safe name; a value like `"true"` would only produce a Service
-  named `c8s-true`.
+  `confidential.ai/cw: my-inference` yields the Service `c8s-my-inference` — which is what the
+  front door (tls-lb's upstream, derived via `engine.name`/`engine.port` + `engine.workloadId`)
+  dials to reach the workload over the RA-TLS mesh. Use a stable, DNS-label-safe name; a value
+  like `"true"` would only produce a Service named `c8s-true`.
 </Callout>
 
 Make sure the image digest is on the [allowlist](/docs/c8s/attestation/allowlist), or
@@ -296,7 +296,7 @@ c8s uninstall
 ```
 
 It runs `helm uninstall` to remove the release (operator, CDS, attestation-api, ratls-mesh,
-tee-proxy, tls-lb, webhook configuration, RuntimeClasses, enforcement policy), and for a
+tls-lb, webhook configuration, RuntimeClasses, enforcement policy), and for a
 `--kata` install it then **sweeps the host-side kata artifacts** off every node — `/opt/kata`,
 the containerd runtime drop-in, the multi-GB `kata-guest-base` image, the RKE2 prep template,
 and the kata-runtime node labels — via a short-lived privileged DaemonSet. The sweep is read

--- a/website/content/docs/c8s/install/installation.mdx
+++ b/website/content/docs/c8s/install/installation.mdx
@@ -277,7 +277,7 @@ kubectl describe pod <pod> | grep "Runtime Class"
 
 # the webhook-injected get-cert init container is present:
 kubectl get pod <pod> -o jsonpath='{range .spec.initContainers[*]}{.name}{"\n"}{end}'
-#   c8s-init-cert
+#   c8s-cert
 ```
 
 **End-to-end confidentiality** — verify it from *outside* the cluster with

--- a/website/content/docs/c8s/install/installation.mdx
+++ b/website/content/docs/c8s/install/installation.mdx
@@ -51,7 +51,9 @@ not preinstalled on stock Azure images (`sudo apt install make` on Debian/Ubuntu
 </details>
 
 <Callout type="info">
-  **Which TEEs?** The platform — CDS, attestation verification, the RA-TLS mesh, the allowlist,
+  **Which TEEs?**
+
+  The platform — CDS, attestation verification, the RA-TLS mesh, the allowlist,
   and the **node-as-CVM** shape — runs on both **AMD SEV-SNP** and **Intel TDX**. The per-pod
   **Kata runtime** (`--kata`) supports both, but a cluster picks **one** CPU TEE at install time
   with `--hardware-platform` (`sev-snp` by default; `tdx` renders the `kata-qemu-tdx`
@@ -188,7 +190,9 @@ kubectl label node <NODE> intel-tdx.node.kubernetes.io/enabled=true
 </details>
 
 <Callout type="info">
-  **`--image-pull-secret` is only needed while the images are private.** It exists because the
+  **`--image-pull-secret` is only needed while the images are private.**
+
+  It exists because the
   c8s component images currently ship from a private registry. After c8s's public launch those
   images will be public, and you can drop the flag (and skip creating the Secret) entirely —
   you'll only need it if you pull from a **private or custom registry**: an internal mirror, a

--- a/website/content/docs/c8s/runtime/pod-vs-node-cvm.mdx
+++ b/website/content/docs/c8s/runtime/pod-vs-node-cvm.mdx
@@ -71,7 +71,9 @@ In short:
   per-pod measurement pinning, admission enforcement).
 
 <Callout type="warn">
-  **Pod-as-CVM is not available on Azure.** Azure's hypervisor does not expose nested
+  **Pod-as-CVM is not available on Azure.**
+
+  Azure's hypervisor does not expose nested
   virtualization, so a per-pod VM cannot be launched inside an AKS node. On Azure you use
   node-as-CVM, where the AKS node is a single confidential CVM and all its pods share that one
   boundary. See [Provisioning on Azure](/docs/c8s/install/azure) for the details and what you

--- a/website/content/docs/c8s/tutorials/azure-e2e.mdx
+++ b/website/content/docs/c8s/tutorials/azure-e2e.mdx
@@ -70,7 +70,9 @@ az aks create \
 ```
 
 <Callout type="warn">
-  **Verify the node-pool shape.** If your subscription/region only allows the confidential size on
+  **Verify the node-pool shape.**
+
+  If your subscription/region only allows the confidential size on
   a **user** pool, create a regular system pool and add the confidential pool with
   `az aks nodepool add --mode User --node-vm-size Standard_DC4as_v5 --os-sku Ubuntu …` — then drop
   `--single-node` in step 5 and let the CDS schedule onto the confidential pool. See the
@@ -215,7 +217,9 @@ c8s install \
 `--single-node` makes every node CDS-eligible (no dedicated CDS node).
 
 <Callout type="warn">
-  **Validate on managed nodes.** This install runs privileged DaemonSets that touch the node host
+  **Validate on managed nodes.**
+
+  This install runs privileged DaemonSets that touch the node host
   — `nri-image-policy` patches containerd and restarts it, `ratls-mesh` sets up `iptables`, and
   `attestation-api` mounts `/dev/tpm0`. Confirm these complete on your AKS node pool (and survive
   node image upgrades) before relying on it.
@@ -302,7 +306,7 @@ with it over an encrypted channel from your laptop.
 Or bring your serving stack of choice onto this cluster:
 
 - [NVIDIA Dynamo](/docs/c8s/tutorials/dynamo) — a multi-component serving graph (frontend,
-  router, worker, discovery) as confidential workloads.
+  router, worker, discovery) run confidentially.
 - [KServe](/docs/c8s/tutorials/kserve) — `InferenceService` model serving in Standard mode,
   every image digest-allowlisted.
 

--- a/website/content/docs/c8s/tutorials/azure-e2e.mdx
+++ b/website/content/docs/c8s/tutorials/azure-e2e.mdx
@@ -248,9 +248,9 @@ the [install guide](/docs/c8s/install/installation) for the rest of the flags.
 
 ### 6. Verify the install
 
-Confirm the control plane came up. A node-as-CVM install runs seven components — `c8s-cds`,
-`c8s-operator`, `c8s-attestation-api`, `c8s-ratls-mesh`, `c8s-nri-image-policy`, `c8s-tee-proxy`,
-and `c8s-tls-lb` — and all should be `Running` with every container ready:
+Confirm the control plane came up. A node-as-CVM install runs six components — `c8s-cds`,
+`c8s-operator`, `c8s-attestation-api`, `c8s-ratls-mesh`, `c8s-nri-image-policy`, and
+`c8s-tls-lb` — and all should be `Running` with every container ready:
 
 ```bash
 kubectl get pods -n c8s-system

--- a/website/content/docs/c8s/tutorials/azure-e2e.mdx
+++ b/website/content/docs/c8s/tutorials/azure-e2e.mdx
@@ -299,6 +299,13 @@ full comparison.
 deploy a vLLM model server onto **this AKS cluster**, attest that it's running in a TEE, and chat
 with it over an encrypted channel from your laptop.
 
+Or bring your serving stack of choice onto this cluster:
+
+- [NVIDIA Dynamo](/docs/c8s/tutorials/dynamo) — a multi-component serving graph (frontend,
+  router, worker, discovery) as confidential workloads.
+- [KServe](/docs/c8s/tutorials/kserve) — `InferenceService` model serving in Standard mode,
+  every image digest-allowlisted.
+
 Or branch off:
 
 - Run a confidential workload with the `confidential.ai/cw` annotation —

--- a/website/content/docs/c8s/tutorials/dynamo.mdx
+++ b/website/content/docs/c8s/tutorials/dynamo.mdx
@@ -1,0 +1,426 @@
+---
+title: Deploy NVIDIA Dynamo as confidential workloads
+description: Run NVIDIA Dynamo's serving stack — frontend, router, worker, and discovery — on a c8s cluster, with every image digest-allowlisted, both serving components holding CDS-issued TEE identities, and the OpenAI endpoint behind the attested front door.
+---
+
+This tutorial deploys **NVIDIA Dynamo** — the distributed LLM inference framework — onto a
+**c8s** cluster as a set of confidential workloads. Dynamo splits serving into components: an
+OpenAI-compatible **frontend** that routes requests, **workers** that run the engine, and a
+discovery plane that connects them. That makes it a realistic test of running a *multi-component*
+serving system inside the Trusted Execution Environment (TEE): you'll allowlist every image,
+give the frontend and worker identities issued by the **CDS** (Certificate Distribution
+Service, the cluster's attested trust root), and chat with the deployment from your laptop
+over a verified, sealed channel.
+
+<Callout type="info">
+  **CPU cluster, mock engine.** Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship
+  as CUDA images and need GPUs, and GPU confidential computing is not yet part of c8s — see
+  [Limitations](/docs/c8s/limitations). So this tutorial runs Dynamo's own GPU-free **mocker**
+  engine (`dynamo.mocker`, the upstream-supported way to exercise the frontend, router, and
+  discovery without GPUs). Every c8s property you set up — digest enforcement, workload
+  identity, the attested front door — transfers unchanged to a GPU-backed deployment: swap the
+  worker's image and command, keep the annotations.
+</Callout>
+
+## Prerequisites
+
+- A running c8s cluster in **node-as-CVM** mode — one command-for-command path is
+  [Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e). This tutorial
+  assumes that single-node shape; see the callout in Step 2 before scaling out.
+- The `c8s` CLI, `kubectl`, and `crane` on your laptop, plus **Docker** (or another builder) and
+  a registry you can push to.
+- The **operator private key** (`operator.key`) whose public half you pinned at install with
+  `--operator-keys` — [allowlist writes](/docs/c8s/attestation/allowlist#authorizing-mutations)
+  are signed with it.
+- For the final step: **Node ≥ 20**, plus the two pinned values from
+  [Consumer verification](/docs/c8s/verification/consumer) — the LB **launch measurement** and
+  your cluster's **mesh CA** PEM.
+
+## Step by step
+
+<Steps>
+
+<Step>
+
+### 1. Build the Dynamo CPU image
+
+Dynamo's published runtime images are CUDA builds, so build a small CPU image instead. The
+`ai-dynamo` wheel is pure Python (no CUDA dependency) and ships both entrypoints this tutorial
+runs — `dynamo.frontend` and `dynamo.mocker`:
+
+```dockerfile
+# Dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir ai-dynamo==1.2.1
+ENV HF_HOME=/tmp/hf
+USER 65532:65532
+```
+
+`HF_HOME` gives the non-root user a writable cache — the mocker downloads its tokenizer from
+Hugging Face at startup. Build for the cluster's architecture and push to a registry your
+cluster can pull (add an image pull Secret to the pod specs below if it's private):
+
+```bash
+docker build --platform linux/amd64 -t <your-registry>/dynamo-cpu:1.2.1 .
+docker push <your-registry>/dynamo-cpu:1.2.1
+```
+
+One image serves both roles: the frontend and the worker differ only in command.
+
+</Step>
+
+<Step>
+
+### 2. Deploy the discovery and event planes
+
+Plain-Deployment Dynamo (no Dynamo operator) uses **etcd** for endpoint discovery, and its
+KV-event plane defaults to **NATS** under etcd discovery — so deploy both, single-replica.
+These are infrastructure, not confidential workloads: they carry routing metadata, and under
+node-as-CVM they already run inside the node's confidential boundary. Don't annotate them —
+c8s identities belong on the components that terminate model traffic.
+
+```yaml
+# dynamo-infra.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: etcd, namespace: workloads }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: etcd } }
+  template:
+    metadata:
+      labels: { app: etcd }
+    spec:
+      containers:
+        - name: etcd
+          image: quay.io/coreos/etcd:v3.6.13
+          command:
+            - /usr/local/bin/etcd
+            - --listen-client-urls=http://0.0.0.0:2379
+            - --advertise-client-urls=http://etcd.workloads.svc.cluster.local:2379
+          ports: [{ containerPort: 2379 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: etcd, namespace: workloads }
+spec:
+  selector: { app: etcd }
+  ports: [{ port: 2379 }]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: nats, namespace: workloads }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: nats } }
+  template:
+    metadata:
+      labels: { app: nats }
+    spec:
+      containers:
+        - name: nats
+          image: nats:2.14.3-alpine
+          ports: [{ containerPort: 4222 }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: nats, namespace: workloads }
+spec:
+  selector: { app: nats }
+  ports: [{ port: 4222 }]
+```
+
+```bash
+kubectl create namespace workloads   # skip if it exists from another tutorial
+kubectl apply -f dynamo-infra.yaml
+```
+
+The pods won't start yet — their images aren't on the allowlist. That's enforcement working;
+Step 4 fixes it.
+
+<Callout type="warn">
+  **Scaling past one node changes the picture.** The RA-TLS mesh wraps **pod-IP** traffic —
+  which covers Dynamo's frontend→worker request plane, since workers register their pod IPs in
+  etcd. But etcd and NATS are dialed here through Service VIPs, which the mesh cannot
+  intercept: on a single node that traffic never leaves the CVM; across nodes it would cross
+  the wire unmeshed. Keep the graph on one node, or move inter-node infra hops onto meshed
+  pod-IP addressing before scaling out.
+</Callout>
+
+</Step>
+
+<Step>
+
+### 3. Deploy the frontend and worker as confidential workloads
+
+Two more Deployments, both from your image. The `confidential.ai/cw` annotation opts each into
+c8s: the webhook injects the `c8s-cert` identity sidecar (a CDS-issued, TEE-bound certificate),
+and the operator mints a headless Service per workload id — `c8s-dynamo` is what the front door
+will dial in Step 6. The worker finds etcd and NATS via the env vars Dynamo reads
+(`ETCD_ENDPOINTS`, `NATS_SERVER`); requests then flow frontend → worker over Dynamo's TCP
+request plane:
+
+```yaml
+# dynamo.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: dynamo-frontend, namespace: workloads }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: dynamo-frontend } }
+  template:
+    metadata:
+      labels: { app: dynamo-frontend }
+      annotations: { confidential.ai/cw: dynamo }   # workload id → headless Service c8s-dynamo
+    spec:
+      containers:
+        - name: frontend
+          image: <your-registry>/dynamo-cpu:1.2.1
+          command: ["python3", "-m", "dynamo.frontend", "--http-port", "8000"]
+          ports: [{ containerPort: 8000 }]
+          env:
+            - { name: ETCD_ENDPOINTS, value: "http://etcd.workloads.svc.cluster.local:2379" }
+            - { name: NATS_SERVER, value: "nats://nats.workloads.svc.cluster.local:4222" }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: dynamo-worker, namespace: workloads }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: dynamo-worker } }
+  template:
+    metadata:
+      labels: { app: dynamo-worker }
+      annotations: { confidential.ai/cw: dynamo-worker }
+    spec:
+      containers:
+        - name: worker
+          image: <your-registry>/dynamo-cpu:1.2.1
+          command: ["python3", "-m", "dynamo.mocker", "--model-path", "Qwen/Qwen3-0.6B"]
+          env:
+            - { name: ETCD_ENDPOINTS, value: "http://etcd.workloads.svc.cluster.local:2379" }
+            - { name: NATS_SERVER, value: "nats://nats.workloads.svc.cluster.local:4222" }
+```
+
+```bash
+kubectl apply -f dynamo.yaml
+```
+
+On a GPU cluster the worker line would read
+`["python3", "-m", "dynamo.vllm", "--model", "Qwen/Qwen3-0.6B"]` on a CUDA runtime image —
+the c8s wiring around it stays identical.
+
+</Step>
+
+<Step>
+
+### 4. Allow the images
+
+Everything is deployed and nothing runs — check the events and you'll see c8s enforcement
+denying container creation at the node:
+
+```bash
+kubectl get events -n workloads | grep allowlist
+# Warning  Failed  ...  image not in allowlist: quay.io/coreos/etcd:v3.6.13
+```
+
+Add the three digests, signed with your operator key. The CDS has no public ingress, so
+port-forward it first — along with the attestation-api, which the CLI uses to verify the CDS's
+own attestation before talking to it:
+
+```bash
+kubectl port-forward -n c8s-system svc/c8s-cds 8443:8443 &
+kubectl port-forward -n c8s-system svc/c8s-attestation-api 8400:8400 &
+
+for IMAGE in \
+  "<your-registry>/dynamo-cpu:1.2.1" \
+  "quay.io/coreos/etcd:v3.6.13" \
+  "nats:2.14.3-alpine"; do
+  c8s allowlist add "$(crane digest "$IMAGE")" "$IMAGE" \
+    --url https://localhost:8443 \
+    --attestation-api-url http://localhost:8400 \
+    --operator-key operator.key
+done
+```
+
+The CLI warns that no `--measurements` are pinned — it's accepting *any* attested CDS, fine
+for a tutorial cluster; in production pin your CDS launch digest so a write can never land on
+a rogue CDS. The enforcement plugins poll the CDS-served list, so the kubelet's next retry
+succeeds:
+
+```bash
+kubectl get pods -n workloads -w
+# etcd-…             1/1   Running
+# nats-…             1/1   Running
+# dynamo-frontend-…  2/2   Running   ← 2/2: the app container plus the injected c8s-cert sidecar
+# dynamo-worker-…    2/2   Running
+```
+
+Both serving components now hold TEE-bound identities. Mirror that into `kubectl` with two
+optional `ConfidentialWorkload` CRs (a status view — injection works without them):
+
+```yaml
+# dynamo-cwl.yaml
+apiVersion: confidential.ai/v1alpha2
+kind: ConfidentialWorkload
+metadata: { name: dynamo, namespace: workloads }
+spec:
+  workloadRef: { kind: Deployment, name: dynamo-frontend }
+---
+apiVersion: confidential.ai/v1alpha2
+kind: ConfidentialWorkload
+metadata: { name: dynamo-worker, namespace: workloads }
+spec:
+  workloadRef: { kind: Deployment, name: dynamo-worker }
+```
+
+```bash
+kubectl apply -f dynamo-cwl.yaml
+kubectl get cwl -n workloads
+# NAME            WORKLOAD          ATTESTED   TOTAL
+# dynamo          dynamo-frontend   1          1
+# dynamo-worker   dynamo-worker     1          1
+```
+
+</Step>
+
+<Step>
+
+### 5. Smoke-test the serving graph
+
+Before wiring the front door, confirm discovery worked end to end: the worker registered in
+etcd, and the frontend found it. `kubectl port-forward` reaches the pod over the kubelet's
+own path, so it works against confidential pods:
+
+```bash
+kubectl port-forward -n workloads deploy/dynamo-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models
+# {"object":"list","data":[{"id":"Qwen/Qwen3-0.6B", ...}]}
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model": "Qwen/Qwen3-0.6B", "messages": [{"role": "user", "content": "hello"}], "max_tokens": 32}'
+# {"id":"...","choices":[{"message":{"role":"assistant","content":"..."}}], ...}
+
+kill %%   # stop this port-forward (the most recent background job)
+```
+
+The completion text is **mock output** — the mocker simulates engine scheduling and token
+timing, not language. What it proves is the part this tutorial is about: requests traverse
+frontend → router → worker across attested, identity-bearing components.
+
+</Step>
+
+<Step>
+
+### 6. Point the front door at the frontend
+
+External clients come in through the chart's front-door chain — **tls-lb (public TLS +
+over-encryption) → tee-proxy (attested) → your frontend**. The engine presets cover vLLM and
+SGLang; for Dynamo, set the upstream directly to the minted headless Service and the
+frontend's container port. Headless DNS returns pod IPs, which the node mesh wraps in attested
+mTLS — a Service VIP it cannot:
+
+```yaml
+# values.yaml
+teeProxy:
+  upstream: c8s-dynamo.workloads.svc.cluster.local:8000
+
+tlsLb:
+  attest:
+    enabled: true    # serve the c8s-verify/v1 attestation + over-encryption endpoints
+```
+
+Apply it by re-running your original `c8s install` with `-f values.yaml` added (the front door
+has one catch-all upstream — this repoints it if another tutorial's workload was wired first):
+
+```bash
+c8s install -f values.yaml   # plus the flags you first installed with (e.g. --single-node --cvm-mode aks --operator-keys operator.pub)
+```
+
+</Step>
+
+<Step>
+
+### 7. Verify the enclave and chat
+
+From your laptop, prove the front door is a genuine TEE in *your* cluster before the first
+prompt leaves your machine. The CLI check pins the LB launch measurement:
+
+```bash
+c8s verify "https://<LB_ADDRESS>" --kind lb --measurements <LB_LAUNCH_DIGEST>
+# exit code 0: evidence verified against the pinned measurement
+```
+
+Then chat over the sealed channel with [c8s-verify](/docs/c8s/verification/consumer) — it
+re-verifies the attestation, checks the cert chains to your pinned mesh CA, and opens the
+post-quantum over-encrypted tunnel; keep requests non-streaming (the tunnel seals whole
+request/response envelopes):
+
+```js
+// chat.mjs
+import { C8sClient } from "c8s-verify";
+import { readFileSync } from "node:fs";
+
+const client = new C8sClient({
+  baseUrl: "https://<LB_ADDRESS>",                // your c8s front door (tls-lb)
+  measurements: [process.env.LB_MEASUREMENT],     // pinned LB launch digest
+  meshCaPem: readFileSync("mesh-ca.pem", "utf8"), // pinned cluster anchor
+});
+
+const session = await client.connect();           // throws C8sVerifyError on any failure
+
+const res = await session.fetch("/v1/chat/completions", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    model: "Qwen/Qwen3-0.6B",
+    messages: [{ role: "user", content: "hello from outside the enclave" }],
+    max_tokens: 32,
+  }),
+});
+console.log(JSON.parse(res.text()).choices[0].message.content);
+```
+
+```bash
+LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> node chat.mjs
+```
+
+For a full interactive client — REPL loop, failure drills, what each check means — see
+[Verified chat over confidential vLLM](/docs/c8s/tutorials/vllm-chat); the session API is
+identical.
+
+</Step>
+
+</Steps>
+
+## What you've proven
+
+A multi-component serving system — not just a single pod — running with the threat model
+intact:
+
+1. **Every image was admitted by digest** — Dynamo components and infrastructure alike; the
+   node refused each container until its digest was allowlisted.
+2. **Each serving component holds a hardware-rooted identity** — the frontend and worker carry
+   CDS-issued certificates bound to TEE attestation, visible in `kubectl get cwl`.
+3. **The request path stays inside the trust boundary** — client → LB enclave over the
+   over-encrypted channel, LB → frontend → worker over attested pod-IP hops; on this
+   single-node cluster the whole graph shares one confidential boundary.
+4. **The client verified before it trusted** — pinned launch measurement, pinned mesh CA,
+   fail-closed.
+
+## Where to go next
+
+- **The Dynamo Kubernetes Platform** — running the Dynamo operator instead of plain
+  Deployments? The same two ingredients apply: allowlist the platform images, and put
+  `confidential.ai/cw` on the pods via `spec.services.<Name>.extraPodMetadata.annotations`
+  (`v1alpha1`) or `spec.components[].podTemplate.metadata.annotations` (`v1beta1`) in a
+  `DynamoGraphDeployment`.
+- **Real engines need confidential GPUs** — GPU CC is on the roadmap, not in the current
+  milestone: [Limitations](/docs/c8s/limitations). The swap when it lands is the worker's
+  image and command, not the c8s wiring.
+- **Classical model serving** — [Confidential model serving with KServe](/docs/c8s/tutorials/kserve)
+  runs the same pattern with KServe's `InferenceService`.
+- **Automate the digests** — wire `c8s allowlist add` into CI:
+  [Automating the allowlist](/docs/c8s/attestation/allowlist#automating-the-allowlist).

--- a/website/content/docs/c8s/tutorials/dynamo.mdx
+++ b/website/content/docs/c8s/tutorials/dynamo.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy NVIDIA Dynamo as confidential workloads
+title: Deploy NVIDIA Dynamo as a confidential workload
 description: Run NVIDIA Dynamo's serving stack — frontend, router, worker, and discovery — on a c8s cluster, with every image digest-allowlisted, both serving components holding CDS-issued TEE identities, and the OpenAI endpoint behind the attested front door.
 ---
 
@@ -17,7 +17,9 @@ deployment from your laptop over a verified, sealed channel. Every image is publ
 nothing to build or push.
 
 <Callout type="info">
-  **CPU cluster, mock engine.** Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship
+  **CPU cluster, mock engine.**
+
+  Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship
   as CUDA images and need GPUs, and GPU confidential computing is not yet part of c8s — see
   [Limitations](/docs/c8s/limitations). So this tutorial runs Dynamo's own GPU-free **mocker**
   engine (`dynamo.mocker`, the upstream-supported way to exercise the frontend, router, and
@@ -143,7 +145,9 @@ The pods won't start yet — their images aren't on the allowlist. That's enforc
 Step 3 fixes it.
 
 <Callout type="warn">
-  **Scaling past one node changes the picture.** The RA-TLS mesh wraps **pod-IP** traffic —
+  **Scaling past one node changes the picture.**
+
+  The RA-TLS mesh wraps **pod-IP** traffic —
   which covers Dynamo's frontend→worker request plane, since workers register their pod IPs in
   etcd. But etcd and NATS are dialed here through Service VIPs, which the mesh cannot
   intercept: on a single node that traffic never leaves the CVM; across nodes it would cross
@@ -416,9 +420,11 @@ LB_ADDRESS=<EXTERNAL-IP>
 ```
 
 <Callout type="info">
-  **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
-  expose `c8s-tls-lb` however your environment does it. With no cloud load balancer, set
-  `tlsLb.service.type: NodePort` in `values.yaml` and reach the front door on the node:
+  **Not on the Azure tutorial's cluster?**
+
+  Use the flags you originally installed with, and expose `c8s-tls-lb` however your
+  environment does it. With no cloud load balancer, set `tlsLb.service.type: NodePort` in
+  `values.yaml` and reach the front door on the node:
 
   ```bash
   NODE_PORT=$(kubectl get svc -n c8s-system c8s-tls-lb -o jsonpath='{.spec.ports[0].nodePort}')
@@ -526,7 +532,7 @@ intact:
 - **Real engines need confidential GPUs** — GPU CC is on the roadmap, not in the current
   milestone: [Limitations](/docs/c8s/limitations). The swap when it lands is the worker's
   image and command, not the c8s wiring.
-- **Classical model serving** — [Confidential model serving with KServe](/docs/c8s/tutorials/kserve)
+- **Classical model serving** — [Serving a confidential model with KServe](/docs/c8s/tutorials/kserve)
   runs the same pattern with KServe's `InferenceService`.
 - **Automate the digests** — wire `c8s allowlist add` into CI:
   [Automating the allowlist](/docs/c8s/attestation/allowlist#automating-the-allowlist).

--- a/website/content/docs/c8s/tutorials/dynamo.mdx
+++ b/website/content/docs/c8s/tutorials/dynamo.mdx
@@ -19,15 +19,14 @@ nothing to build or push.
 <Callout type="info">
   **CPU cluster, mock engine.**
 
-  Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship
-  as CUDA images and need GPUs, and GPU confidential computing is not yet part of c8s — see
-  [Limitations](/docs/c8s/limitations). So this tutorial runs Dynamo's own GPU-free **mocker**
-  engine (`dynamo.mocker`, the upstream-supported way to exercise the frontend, router, and
-  discovery without GPUs). The mocker downloads only the model's *tokenizer* — a few MB — and
-  never loads weights, so it runs comfortably on the smallest confidential node sizes. Every
-  c8s property you set up — digest enforcement, workload identity, the attested front door —
-  transfers unchanged to a GPU-backed deployment: swap the worker's image and command, keep the
-  annotations.
+  Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship as CUDA images and need
+  GPUs — and this tutorial's AKS cluster is CPU-only. So it runs Dynamo's own GPU-free
+  **mocker** engine (`dynamo.mocker`, the upstream-supported way to exercise the frontend,
+  router, and discovery without GPUs). The mocker downloads only the model's *tokenizer* — a
+  few MB — and never loads weights, so it runs comfortably on the smallest confidential node
+  sizes. Every c8s property you set up — digest enforcement, workload identity, the attested
+  front door — transfers unchanged to a GPU-backed deployment: swap the worker's image and
+  command, keep the annotations.
 </Callout>
 
 ## Prerequisites
@@ -529,9 +528,12 @@ intact:
   `confidential.ai/cw` on the pods via `spec.services.<Name>.extraPodMetadata.annotations`
   (`v1alpha1`) or `spec.components[].podTemplate.metadata.annotations` (`v1beta1`) in a
   `DynamoGraphDeployment`.
-- **Real engines need confidential GPUs** — GPU CC is on the roadmap, not in the current
-  milestone: [Limitations](/docs/c8s/limitations). The swap when it lands is the worker's
-  image and command, not the c8s wiring.
+- **Real engines need GPUs** — on a GPU-equipped c8s cluster they just run: node-as-CVM
+  nodes schedule GPUs as normal Kubernetes resources, and under Kata, GPU pods become
+  confidential VMs with the GPU passed through — see
+  [Kata containers](/docs/c8s/runtime/kata-containers) and
+  [Limitations](/docs/c8s/limitations) for the current gaps. The swap is the worker's image,
+  command, and a GPU resource limit — not the c8s wiring.
 - **Classical model serving** — [Serving a confidential model with KServe](/docs/c8s/tutorials/kserve)
   runs the same pattern with KServe's `InferenceService`.
 - **Automate the digests** — wire `c8s allowlist add` into CI:

--- a/website/content/docs/c8s/tutorials/dynamo.mdx
+++ b/website/content/docs/c8s/tutorials/dynamo.mdx
@@ -4,37 +4,47 @@ description: Run NVIDIA Dynamo's serving stack — frontend, router, worker, and
 ---
 
 This tutorial deploys **NVIDIA Dynamo** — the distributed LLM inference framework — onto a
-**c8s** cluster as a set of confidential workloads. Dynamo splits serving into components: an
-OpenAI-compatible **frontend** that routes requests, **workers** that run the engine, and a
-discovery plane that connects them. That makes it a realistic test of running a *multi-component*
-serving system inside the Trusted Execution Environment (TEE): you'll allowlist every image,
-give the frontend and worker identities issued by the **CDS** (Certificate Distribution
-Service, the cluster's attested trust root), and chat with the deployment from your laptop
-over a verified, sealed channel.
+**c8s** cluster as a set of confidential workloads.
+
+Dynamo splits serving into components: an OpenAI-compatible **frontend** that routes requests,
+**workers** that run the engine, and a discovery plane that connects them. That makes it a
+realistic test of running a *multi-component* serving system inside the Trusted Execution
+Environment (TEE).
+
+You'll allowlist every image, give the frontend and worker identities issued by the **CDS**
+(Certificate Distribution Service, the cluster's attested trust root), and chat with the
+deployment from your laptop over a verified, sealed channel. Every image is public — there is
+nothing to build or push.
 
 <Callout type="info">
   **CPU cluster, mock engine.** Dynamo's real engine backends (vLLM, SGLang, TensorRT-LLM) ship
   as CUDA images and need GPUs, and GPU confidential computing is not yet part of c8s — see
   [Limitations](/docs/c8s/limitations). So this tutorial runs Dynamo's own GPU-free **mocker**
   engine (`dynamo.mocker`, the upstream-supported way to exercise the frontend, router, and
-  discovery without GPUs). Every c8s property you set up — digest enforcement, workload
-  identity, the attested front door — transfers unchanged to a GPU-backed deployment: swap the
-  worker's image and command, keep the annotations.
+  discovery without GPUs). The mocker downloads only the model's *tokenizer* — a few MB — and
+  never loads weights, so it runs comfortably on the smallest confidential node sizes. Every
+  c8s property you set up — digest enforcement, workload identity, the attested front door —
+  transfers unchanged to a GPU-backed deployment: swap the worker's image and command, keep the
+  annotations.
 </Callout>
 
 ## Prerequisites
 
-- A running c8s cluster in **node-as-CVM** mode — one command-for-command path is
-  [Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e). This tutorial
-  assumes that single-node shape; see the callout in Step 2 before scaling out.
-- The `c8s` CLI, `kubectl`, and `crane` on your laptop, plus **Docker** (or another builder) and
-  a registry you can push to.
-- The **operator private key** (`operator.key`) whose public half you pinned at install with
-  `--operator-keys` — [allowlist writes](/docs/c8s/attestation/allowlist#authorizing-mutations)
-  are signed with it.
-- For the final step: **Node ≥ 20**, plus the two pinned values from
-  [Consumer verification](/docs/c8s/verification/consumer) — the LB **launch measurement** and
-  your cluster's **mesh CA** PEM.
+This tutorial **continues from
+[Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e)** and assumes
+that cluster: single-node AKS in **node-as-CVM** mode, with `operator.pub` pinned at install.
+On a different c8s cluster everything here transfers — adjust the install flags in Step 5 and
+how you expose the front door.
+
+You'll also need:
+
+- The `c8s` CLI, `kubectl`, and `crane` on your laptop (all already there if you followed
+  that tutorial).
+- The **operator private key** (`operator.key`) — [allowlist
+  writes](/docs/c8s/attestation/allowlist#authorizing-mutations) are signed with it.
+- For the final step: **Node ≥ 20**, plus the LB **launch measurement** and your cluster's
+  **mesh CA** PEM, supplied out of band — see
+  [Consumer verification](/docs/c8s/verification/consumer).
 
 ## Step by step
 
@@ -42,39 +52,13 @@ over a verified, sealed channel.
 
 <Step>
 
-### 1. Build the Dynamo CPU image
-
-Dynamo's published runtime images are CUDA builds, so build a small CPU image instead. The
-`ai-dynamo` wheel is pure Python (no CUDA dependency) and ships both entrypoints this tutorial
-runs — `dynamo.frontend` and `dynamo.mocker`:
-
-```dockerfile
-# Dockerfile
-FROM python:3.12-slim
-RUN pip install --no-cache-dir ai-dynamo==1.2.1
-ENV HF_HOME=/tmp/hf
-USER 65532:65532
-```
-
-`HF_HOME` gives the non-root user a writable cache — the mocker downloads its tokenizer from
-Hugging Face at startup. Build for the cluster's architecture and push to a registry your
-cluster can pull (add an image pull Secret to the pod specs below if it's private):
-
-```bash
-docker build --platform linux/amd64 -t <your-registry>/dynamo-cpu:1.2.1 .
-docker push <your-registry>/dynamo-cpu:1.2.1
-```
-
-One image serves both roles: the frontend and the worker differ only in command.
-
-</Step>
-
-<Step>
-
-### 2. Deploy the discovery and event planes
+### 1. Deploy the discovery and event planes
 
 Plain-Deployment Dynamo (no Dynamo operator) uses **etcd** for endpoint discovery, and its
 KV-event plane defaults to **NATS** under etcd discovery — so deploy both, single-replica.
+This etcd is Dynamo's own registry, deployed like any app — it is **not** the Kubernetes
+control plane's etcd, which stays untouched (and on AKS isn't even reachable).
+
 These are infrastructure, not confidential workloads: they carry routing metadata, and under
 node-as-CVM they already run inside the node's confidential boundary. Don't annotate them —
 c8s identities belong on the components that terminate model traffic.
@@ -83,13 +67,18 @@ c8s identities belong on the components that terminate model traffic.
 # dynamo-infra.yaml
 apiVersion: apps/v1
 kind: Deployment
-metadata: { name: etcd, namespace: workloads }
+metadata:
+  name: etcd
+  namespace: workloads
 spec:
   replicas: 1
-  selector: { matchLabels: { app: etcd } }
+  selector:
+    matchLabels:
+      app: etcd
   template:
     metadata:
-      labels: { app: etcd }
+      labels:
+        app: etcd
     spec:
       containers:
         - name: etcd
@@ -97,37 +86,52 @@ spec:
           command:
             - /usr/local/bin/etcd
             - --listen-client-urls=http://0.0.0.0:2379
-            - --advertise-client-urls=http://etcd.workloads.svc.cluster.local:2379
-          ports: [{ containerPort: 2379 }]
+            - --advertise-client-urls=http://etcd.workloads.svc:2379
+          ports:
+            - containerPort: 2379
 ---
 apiVersion: v1
 kind: Service
-metadata: { name: etcd, namespace: workloads }
+metadata:
+  name: etcd
+  namespace: workloads
 spec:
-  selector: { app: etcd }
-  ports: [{ port: 2379 }]
+  selector:
+    app: etcd
+  ports:
+    - port: 2379
 ---
 apiVersion: apps/v1
 kind: Deployment
-metadata: { name: nats, namespace: workloads }
+metadata:
+  name: nats
+  namespace: workloads
 spec:
   replicas: 1
-  selector: { matchLabels: { app: nats } }
+  selector:
+    matchLabels:
+      app: nats
   template:
     metadata:
-      labels: { app: nats }
+      labels:
+        app: nats
     spec:
       containers:
         - name: nats
           image: nats:2.14.3-alpine
-          ports: [{ containerPort: 4222 }]
+          ports:
+            - containerPort: 4222
 ---
 apiVersion: v1
 kind: Service
-metadata: { name: nats, namespace: workloads }
+metadata:
+  name: nats
+  namespace: workloads
 spec:
-  selector: { app: nats }
-  ports: [{ port: 4222 }]
+  selector:
+    app: nats
+  ports:
+    - port: 4222
 ```
 
 ```bash
@@ -136,7 +140,7 @@ kubectl apply -f dynamo-infra.yaml
 ```
 
 The pods won't start yet — their images aren't on the allowlist. That's enforcement working;
-Step 4 fixes it.
+Step 3 fixes it.
 
 <Callout type="warn">
   **Scaling past one node changes the picture.** The RA-TLS mesh wraps **pod-IP** traffic —
@@ -151,70 +155,104 @@ Step 4 fixes it.
 
 <Step>
 
-### 3. Deploy the frontend and worker as confidential workloads
+### 2. Deploy the frontend and worker as confidential workloads
 
-Two more Deployments, both from your image. The `confidential.ai/cw` annotation opts each into
-c8s: the webhook injects the `c8s-cert` identity sidecar (a CDS-issued, TEE-bound certificate),
-and the operator mints a headless Service per workload id — `c8s-dynamo` is what the front door
-will dial in Step 6. The worker finds etcd and NATS via the env vars Dynamo reads
-(`ETCD_ENDPOINTS`, `NATS_SERVER`); requests then flow frontend → worker over Dynamo's TCP
-request plane:
+Both components run from one **public** image: `dynamo-frontend` is NVIDIA's non-CUDA Dynamo
+image, and it carries the whole `ai-dynamo` Python package — `dynamo.frontend` *and*
+`dynamo.mocker` — so the two Deployments differ only in `command:` (which overrides the
+image's entrypoint). It pulls anonymously from `nvcr.io`.
+
+The `confidential.ai/cw` annotation opts each Deployment into c8s: the webhook injects the
+`c8s-cert` identity sidecar (a CDS-issued, TEE-bound certificate), and the operator mints a
+headless Service per workload id — `c8s-dynamo` is what the front door will dial in Step 5.
+The components find etcd and NATS via the env vars Dynamo reads (`ETCD_ENDPOINTS`,
+`NATS_SERVER`); requests then flow frontend → worker over Dynamo's TCP request plane. The
+`--model-path` names the tokenizer the mocker fetches — no weights are loaded.
 
 ```yaml
 # dynamo.yaml
 apiVersion: apps/v1
 kind: Deployment
-metadata: { name: dynamo-frontend, namespace: workloads }
+metadata:
+  name: dynamo-frontend
+  namespace: workloads
 spec:
   replicas: 1
-  selector: { matchLabels: { app: dynamo-frontend } }
+  selector:
+    matchLabels:
+      app: dynamo-frontend
   template:
     metadata:
-      labels: { app: dynamo-frontend }
-      annotations: { confidential.ai/cw: dynamo }   # workload id → headless Service c8s-dynamo
+      labels:
+        app: dynamo-frontend
+      annotations:
+        # workload id → headless Service c8s-dynamo
+        confidential.ai/cw: dynamo
     spec:
       containers:
         - name: frontend
-          image: <your-registry>/dynamo-cpu:1.2.1
-          command: ["python3", "-m", "dynamo.frontend", "--http-port", "8000"]
-          ports: [{ containerPort: 8000 }]
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
+          command:
+            - python3
+            - -m
+            - dynamo.frontend
+            - --http-port
+            - "8000"
+          ports:
+            - containerPort: 8000
           env:
-            - { name: ETCD_ENDPOINTS, value: "http://etcd.workloads.svc.cluster.local:2379" }
-            - { name: NATS_SERVER, value: "nats://nats.workloads.svc.cluster.local:4222" }
+            - name: ETCD_ENDPOINTS
+              value: http://etcd.workloads.svc:2379
+            - name: NATS_SERVER
+              value: nats://nats.workloads.svc:4222
 ---
 apiVersion: apps/v1
 kind: Deployment
-metadata: { name: dynamo-worker, namespace: workloads }
+metadata:
+  name: dynamo-worker
+  namespace: workloads
 spec:
   replicas: 1
-  selector: { matchLabels: { app: dynamo-worker } }
+  selector:
+    matchLabels:
+      app: dynamo-worker
   template:
     metadata:
-      labels: { app: dynamo-worker }
-      annotations: { confidential.ai/cw: dynamo-worker }
+      labels:
+        app: dynamo-worker
+      annotations:
+        confidential.ai/cw: dynamo-worker
     spec:
       containers:
         - name: worker
-          image: <your-registry>/dynamo-cpu:1.2.1
-          command: ["python3", "-m", "dynamo.mocker", "--model-path", "Qwen/Qwen3-0.6B"]
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
+          command:
+            - python3
+            - -m
+            - dynamo.mocker
+            - --model-path
+            - Qwen/Qwen3-0.6B
           env:
-            - { name: ETCD_ENDPOINTS, value: "http://etcd.workloads.svc.cluster.local:2379" }
-            - { name: NATS_SERVER, value: "nats://nats.workloads.svc.cluster.local:4222" }
+            - name: ETCD_ENDPOINTS
+              value: http://etcd.workloads.svc:2379
+            - name: NATS_SERVER
+              value: nats://nats.workloads.svc:4222
 ```
 
 ```bash
 kubectl apply -f dynamo.yaml
 ```
 
-On a GPU cluster the worker line would read
-`["python3", "-m", "dynamo.vllm", "--model", "Qwen/Qwen3-0.6B"]` on a CUDA runtime image —
-the c8s wiring around it stays identical.
+On a GPU cluster the worker's command would run `dynamo.vllm --model Qwen/Qwen3-0.6B` on a
+CUDA runtime image — the c8s wiring around it stays identical. (And if you'd rather serve
+from a minimal image you control, `pip install ai-dynamo==1.2.1` on `python:3.12-slim`
+provides the same entrypoints — build it, push it, and allowlist *that* digest instead.)
 
 </Step>
 
 <Step>
 
-### 4. Allow the images
+### 3. Allow the images
 
 Everything is deployed and nothing runs — check the events and you'll see c8s enforcement
 denying container creation at the node:
@@ -225,34 +263,42 @@ kubectl get events -n workloads | grep allowlist
 ```
 
 Add the three digests, signed with your operator key. The CDS has no public ingress, so
-port-forward it first — along with the attestation-api, which the CLI uses to verify the CDS's
-own attestation before talking to it:
+port-forward it first — along with the attestation-api, which the CLI uses to verify the
+CDS's own attestation before talking to it:
 
 ```bash
 kubectl port-forward -n c8s-system svc/c8s-cds 8443:8443 &
 kubectl port-forward -n c8s-system svc/c8s-attestation-api 8400:8400 &
 
-for IMAGE in \
-  "<your-registry>/dynamo-cpu:1.2.1" \
-  "quay.io/coreos/etcd:v3.6.13" \
-  "nats:2.14.3-alpine"; do
-  c8s allowlist add "$(crane digest "$IMAGE")" "$IMAGE" \
-    --url https://localhost:8443 \
-    --attestation-api-url http://localhost:8400 \
-    --operator-key operator.key
-done
+DYNAMO_IMAGE=nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.2.1
+c8s allowlist add "$(crane digest "$DYNAMO_IMAGE")" "$DYNAMO_IMAGE" \
+  --url https://localhost:8443 \
+  --attestation-api-url http://localhost:8400 \
+  --operator-key operator.key
+
+ETCD_IMAGE=quay.io/coreos/etcd:v3.6.13
+c8s allowlist add "$(crane digest "$ETCD_IMAGE")" "$ETCD_IMAGE" \
+  --url https://localhost:8443 \
+  --attestation-api-url http://localhost:8400 \
+  --operator-key operator.key
+
+NATS_IMAGE=nats:2.14.3-alpine
+c8s allowlist add "$(crane digest "$NATS_IMAGE")" "$NATS_IMAGE" \
+  --url https://localhost:8443 \
+  --attestation-api-url http://localhost:8400 \
+  --operator-key operator.key
 ```
 
 The CLI warns that no `--measurements` are pinned — it's accepting *any* attested CDS, fine
 for a tutorial cluster; in production pin your CDS launch digest so a write can never land on
 a rogue CDS. The enforcement plugins poll the CDS-served list, so the kubelet's next retry
-succeeds:
+succeeds — the Dynamo image is large, so its first pull takes a few minutes:
 
 ```bash
 kubectl get pods -n workloads -w
 # etcd-…             1/1   Running
 # nats-…             1/1   Running
-# dynamo-frontend-…  2/2   Running   ← 2/2: the app container plus the injected c8s-cert sidecar
+# dynamo-frontend-…  2/2   Running   ← app + injected c8s-cert sidecar
 # dynamo-worker-…    2/2   Running
 ```
 
@@ -263,15 +309,23 @@ optional `ConfidentialWorkload` CRs (a status view — injection works without t
 # dynamo-cwl.yaml
 apiVersion: confidential.ai/v1alpha2
 kind: ConfidentialWorkload
-metadata: { name: dynamo, namespace: workloads }
+metadata:
+  name: dynamo
+  namespace: workloads
 spec:
-  workloadRef: { kind: Deployment, name: dynamo-frontend }
+  workloadRef:
+    kind: Deployment
+    name: dynamo-frontend
 ---
 apiVersion: confidential.ai/v1alpha2
 kind: ConfidentialWorkload
-metadata: { name: dynamo-worker, namespace: workloads }
+metadata:
+  name: dynamo-worker
+  namespace: workloads
 spec:
-  workloadRef: { kind: Deployment, name: dynamo-worker }
+  workloadRef:
+    kind: Deployment
+    name: dynamo-worker
 ```
 
 ```bash
@@ -286,7 +340,7 @@ kubectl get cwl -n workloads
 
 <Step>
 
-### 5. Smoke-test the serving graph
+### 4. Smoke-test the serving graph
 
 Before wiring the front door, confirm discovery worked end to end: the worker registered in
 etcd, and the frontend found it. `kubectl port-forward` reaches the pod over the kubelet's
@@ -300,8 +354,10 @@ curl -s localhost:8000/v1/models
 
 curl -s localhost:8000/v1/chat/completions \
   -H 'content-type: application/json' \
-  -d '{"model": "Qwen/Qwen3-0.6B", "messages": [{"role": "user", "content": "hello"}], "max_tokens": 32}'
-# {"id":"...","choices":[{"message":{"role":"assistant","content":"..."}}], ...}
+  -d '{"model": "Qwen/Qwen3-0.6B",
+       "messages": [{"role": "user", "content": "hello"}],
+       "max_tokens": 32}'
+# {"id":"...","choices":[{"message":{"role":"assistant", ...
 
 kill %%   # stop this port-forward (the most recent background job)
 ```
@@ -314,13 +370,14 @@ frontend → router → worker across attested, identity-bearing components.
 
 <Step>
 
-### 6. Point the front door at the frontend
+### 5. Point the front door at the frontend
 
 External clients come in through the chart's front-door chain — **tls-lb (public TLS +
 over-encryption) → tee-proxy (attested) → your frontend**. The engine presets cover vLLM and
 SGLang; for Dynamo, set the upstream directly to the minted headless Service and the
-frontend's container port. Headless DNS returns pod IPs, which the node mesh wraps in attested
-mTLS — a Service VIP it cannot:
+frontend's container port. Headless DNS returns pod IPs, which the node mesh wraps in
+attested mTLS — a Service VIP it cannot. `service.type: LoadBalancer` gives the front door a
+public IP on AKS:
 
 ```yaml
 # values.yaml
@@ -329,27 +386,51 @@ teeProxy:
 
 tlsLb:
   attest:
-    enabled: true    # serve the c8s-verify/v1 attestation + over-encryption endpoints
+    enabled: true    # serve the c8s-verify/v1 attestation endpoints
+  service:
+    type: LoadBalancer
 ```
 
-Apply it by re-running your original `c8s install` with `-f values.yaml` added (the front door
-has one catch-all upstream — this repoints it if another tutorial's workload was wired first):
+Apply it by re-running the `c8s install` from the Azure tutorial with `-f values.yaml` added
+(the front door has one catch-all upstream — this repoints it if another tutorial's workload
+was wired first):
 
 ```bash
-c8s install -f values.yaml   # plus the flags you first installed with (e.g. --single-node --cvm-mode aks --operator-keys operator.pub)
+c8s install \
+  --single-node \
+  --cvm-mode aks \
+  --image-pull-secret ghcr-secret \
+  --operator-keys operator.pub \
+  -f values.yaml
 ```
+
+Then grab the public address Azure assigns — it's `<pending>` for a minute or so:
+
+```bash
+kubectl get svc -n c8s-system c8s-tls-lb -w
+# NAME         TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)
+# c8s-tls-lb   LoadBalancer   10.0.…       20.…          443:…/TCP
+
+LB_ADDRESS=<EXTERNAL-IP>
+```
+
+<Callout type="info">
+  **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
+  expose `c8s-tls-lb` however your environment does it — a cloud `LoadBalancer`, a `NodePort`,
+  or your own edge — then set `LB_ADDRESS` to whatever address terminates at it.
+</Callout>
 
 </Step>
 
 <Step>
 
-### 7. Verify the enclave and chat
+### 6. Verify the enclave and chat
 
 From your laptop, prove the front door is a genuine TEE in *your* cluster before the first
 prompt leaves your machine. The CLI check pins the LB launch measurement:
 
 ```bash
-c8s verify "https://<LB_ADDRESS>" --kind lb --measurements <LB_LAUNCH_DIGEST>
+c8s verify "https://$LB_ADDRESS" --kind lb --measurements <LB_LAUNCH_DIGEST>
 # exit code 0: evidence verified against the pinned measurement
 ```
 
@@ -364,12 +445,12 @@ import { C8sClient } from "c8s-verify";
 import { readFileSync } from "node:fs";
 
 const client = new C8sClient({
-  baseUrl: "https://<LB_ADDRESS>",                // your c8s front door (tls-lb)
+  baseUrl: `https://${process.env.LB_ADDRESS}`,
   measurements: [process.env.LB_MEASUREMENT],     // pinned LB launch digest
   meshCaPem: readFileSync("mesh-ca.pem", "utf8"), // pinned cluster anchor
 });
 
-const session = await client.connect();           // throws C8sVerifyError on any failure
+const session = await client.connect(); // throws C8sVerifyError on any failure
 
 const res = await session.fetch("/v1/chat/completions", {
   method: "POST",
@@ -384,8 +465,20 @@ console.log(JSON.parse(res.text()).choices[0].message.content);
 ```
 
 ```bash
-LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> node chat.mjs
+LB_ADDRESS=$LB_ADDRESS \
+LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> \
+NODE_TLS_REJECT_UNAUTHORIZED=0 \
+node chat.mjs
 ```
+
+Why `NODE_TLS_REJECT_UNAUTHORIZED=0` is fine *here*: you dialed a bare IP, and the LB's outer
+TLS cert is its CDS-issued one, which web PKI doesn't know. In this design the outer TLS layer
+is **untrusted transport by definition** — trust comes from the attestation evidence, the
+pinned measurement, and the pinned mesh CA, and every request is sealed inside the
+over-encrypted channel, so a hostile TLS terminator sees only ciphertext. The env var relaxes
+only the outer web-PKI check, for this process. (`c8s verify` above does the equivalent
+internally.) For a real deployment you'd put a public certificate on the LB via
+`tlsLb.publicTLS` and drop the env var.
 
 For a full interactive client — REPL loop, failure drills, what each check means — see
 [Verified chat over confidential vLLM](/docs/c8s/tutorials/vllm-chat); the session API is

--- a/website/content/docs/c8s/tutorials/dynamo.mdx
+++ b/website/content/docs/c8s/tutorials/dynamo.mdx
@@ -372,17 +372,18 @@ frontend → router → worker across attested, identity-bearing components.
 
 ### 5. Point the front door at the frontend
 
-External clients come in through the chart's front-door chain — **tls-lb (public TLS +
-over-encryption) → tee-proxy (attested) → your frontend**. The engine presets cover vLLM and
-SGLang; for Dynamo, set the upstream directly to the minted headless Service and the
-frontend's container port. Headless DNS returns pod IPs, which the node mesh wraps in
-attested mTLS — a Service VIP it cannot. `service.type: LoadBalancer` gives the front door a
-public IP on AKS:
+External clients come in through the chart's front door — **tls-lb (public TLS +
+over-encryption) → your frontend**, dialed over the node mesh's attested mTLS. Point it at the
+frontend's container port (`8000`) with `engine.port`: it derives the minted headless Service
+`c8s-dynamo`, whose DNS returns pod IPs the node mesh wraps in attested mTLS — a Service VIP it
+cannot. `service.type: LoadBalancer` gives the front door a public IP on AKS:
 
 ```yaml
 # values.yaml
-teeProxy:
-  upstream: c8s-dynamo.workloads.svc.cluster.local:8000
+engine:
+  port: "8000"        # the frontend's --http-port → headless Service c8s-dynamo
+  workloadId: dynamo  # the confidential.ai/cw value from Step 2
+  namespace: workloads
 
 tlsLb:
   attest:
@@ -416,8 +417,17 @@ LB_ADDRESS=<EXTERNAL-IP>
 
 <Callout type="info">
   **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
-  expose `c8s-tls-lb` however your environment does it — a cloud `LoadBalancer`, a `NodePort`,
-  or your own edge — then set `LB_ADDRESS` to whatever address terminates at it.
+  expose `c8s-tls-lb` however your environment does it. With no cloud load balancer, set
+  `tlsLb.service.type: NodePort` in `values.yaml` and reach the front door on the node:
+
+  ```bash
+  NODE_PORT=$(kubectl get svc -n c8s-system c8s-tls-lb -o jsonpath='{.spec.ports[0].nodePort}')
+  LB_ADDRESS=<node-ip>:$NODE_PORT
+  ```
+
+  On RKE2, tls-lb also binds the node's `:443` directly (`hostPort`); if RKE2's bundled
+  `rke2-ingress-nginx` already owns `:443`, set `tlsLb.hostPort.enabled: false` and reach it
+  through the NodePort. Then set `LB_ADDRESS` to whatever address terminates at tls-lb.
 </Callout>
 
 </Step>
@@ -434,7 +444,10 @@ c8s verify "https://$LB_ADDRESS" --kind lb --measurements <LB_LAUNCH_DIGEST>
 # exit code 0: evidence verified against the pinned measurement
 ```
 
-Then chat over the sealed channel with [c8s-verify](/docs/c8s/verification/consumer) — it
+Then chat over the sealed channel with [c8s-verify](/docs/c8s/verification/consumer) — a
+**zero-build ES module you vendor** (not an npm package). Follow
+[its installation](/docs/c8s/verification/consumer#installation) — `npm install mlkem-wasm`, then
+map the `c8s-verify` specifier to the vendored `src/index.js` — before `node chat.mjs`. It
 re-verifies the attestation, checks the cert chains to your pinned mesh CA, and opens the
 post-quantum over-encrypted tunnel; keep requests non-streaming (the tunnel seals whole
 request/response envelopes):

--- a/website/content/docs/c8s/tutorials/kserve.mdx
+++ b/website/content/docs/c8s/tutorials/kserve.mdx
@@ -122,7 +122,14 @@ helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.19
   --set kserve.controller.deploymentMode=Standard \
   --set kserve.controller.gateway.disableIngressCreation=true
 
+# Wait for the controller before applying the runtimes: the ClusterServingRuntimes go through
+# KServe's validating webhook, which returns "no endpoints available" until its pod is Ready.
+kubectl wait --for=condition=Available -n kserve deploy/kserve-controller-manager --timeout=180s
+
 kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.19.0/kserve-cluster-resources.yaml
+# This manifest also contains LLMInferenceServiceConfig objects (a KServe LLM CRD the v0.19.0
+# kserve-crd chart doesn't install); the "no matches for kind" lines printed for those are
+# harmless — the sklearn runtime this tutorial serves is created.
 ```
 
 Confirm both control planes are up before moving on:
@@ -228,16 +235,19 @@ kubectl get cwl -n workloads
 
 ### 4. Point the front door at the predictor
 
-External clients reach the model through the chart's front-door chain — **tls-lb (public TLS +
-over-encryption) → tee-proxy (attested) → your predictor**. The engine presets cover vLLM and
-SGLang; for KServe, set the upstream directly to the minted headless Service and the
-`kserve-container` port (`8080` — pod-IP dials bypass Service port mapping, so use the
-container port, not the KServe Service's port 80):
+External clients reach the model through the chart's front door — **tls-lb (public TLS +
+over-encryption) → your predictor**, dialed over the node mesh's attested mTLS. The `engine`
+preset knows vLLM's and SGLang's ports; KServe's predictor serves on `8080`, so point the front
+door there with `engine.port` (the explicit-port form of the preset — it derives the same
+mesh-wrapped headless Service `c8s-iris`, so the hop is attested, not a Service VIP the mesh
+can't intercept):
 
 ```yaml
 # values.yaml
-teeProxy:
-  upstream: c8s-iris.workloads.svc.cluster.local:8080
+engine:
+  port: "8080"        # KServe's kserve-container port → headless Service c8s-iris
+  workloadId: iris    # the confidential.ai/cw value from Step 3
+  namespace: workloads
 
 tlsLb:
   attest:
@@ -260,9 +270,9 @@ c8s install \
   -f values.yaml
 ```
 
-tee-proxy now dials the predictor over the node mesh's attested mTLS, and tls-lb fronts it
-with public TLS. A request from outside is decrypted **inside the LB enclave** and forwarded
-down this chain to KServe's v1 REST endpoint.
+tls-lb now dials the predictor's headless Service over the node mesh's attested mTLS and fronts
+it with public TLS. A request from outside is decrypted **inside the LB enclave** and forwarded
+over the mesh to KServe's v1 REST endpoint.
 
 Grab the public address Azure assigns — it's `<pending>` for a minute or so:
 
@@ -276,8 +286,17 @@ LB_ADDRESS=<EXTERNAL-IP>
 
 <Callout type="info">
   **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
-  expose `c8s-tls-lb` however your environment does it — a cloud `LoadBalancer`, a `NodePort`,
-  or your own edge — then set `LB_ADDRESS` to whatever address terminates at it.
+  expose `c8s-tls-lb` however your environment does it. With no cloud load balancer, set
+  `tlsLb.service.type: NodePort` in `values.yaml` and reach the front door on the node:
+
+  ```bash
+  NODE_PORT=$(kubectl get svc -n c8s-system c8s-tls-lb -o jsonpath='{.spec.ports[0].nodePort}')
+  LB_ADDRESS=<node-ip>:$NODE_PORT
+  ```
+
+  On RKE2, tls-lb also binds the node's `:443` directly (`hostPort`); if RKE2's bundled
+  `rke2-ingress-nginx` already owns `:443`, set `tlsLb.hostPort.enabled: false` and reach it
+  through the NodePort. Then set `LB_ADDRESS` to whatever address terminates at tls-lb.
 </Callout>
 
 </Step>
@@ -294,10 +313,13 @@ c8s verify "https://$LB_ADDRESS" --kind lb --measurements <LB_LAUNCH_DIGEST>
 # exit code 0: evidence verified against the pinned measurement
 ```
 
-Then make a verified prediction. The [c8s-verify](/docs/c8s/verification/consumer) client
-re-checks the attestation, confirms the LB belongs to *your* cluster (its cert chains to your
-pinned mesh CA), and opens the post-quantum over-encrypted channel; only then does the request
-go out — sealed end-to-end into the enclave:
+Then make a verified prediction with the [c8s-verify](/docs/c8s/verification/consumer) client —
+a **zero-build ES module you vendor** (it is not published to npm). Follow
+[its installation](/docs/c8s/verification/consumer#installation) — `npm install mlkem-wasm`, then
+map the `c8s-verify` specifier to the vendored `src/index.js` — before running `node predict.mjs`
+below. The client re-checks the attestation, confirms the LB belongs to *your* cluster (its cert
+chains to your pinned mesh CA), and opens the post-quantum over-encrypted channel; only then does
+the request go out — sealed end-to-end into the enclave:
 
 ```js
 // predict.mjs

--- a/website/content/docs/c8s/tutorials/kserve.mdx
+++ b/website/content/docs/c8s/tutorials/kserve.mdx
@@ -5,7 +5,9 @@ description: Run KServe on a c8s cluster in Standard deployment mode — every i
 
 This tutorial puts **KServe** — the standard Kubernetes model-serving layer — on top of a
 **c8s** cluster, so a deployed model and every request to it stay inside the Trusted Execution
-Environment (TEE). You'll install the KServe control plane with every image on the
+Environment (TEE).
+
+You'll install the KServe control plane with every image on the
 [allowlist](/docs/c8s/attestation/allowlist), deploy a scikit-learn `InferenceService` as a
 confidential workload, and call it from your laptop only after cryptographically verifying the
 enclave — the host, the cloud operator, and any TLS-terminating proxy in between see only
@@ -27,16 +29,21 @@ root) bound to the predictor, and an attested front door.
 
 ## Prerequisites
 
-- A running c8s cluster in **node-as-CVM** mode — one command-for-command path is
-  [Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e).
+This tutorial **continues from
+[Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e)** and assumes
+that cluster: single-node AKS in **node-as-CVM** mode, with `operator.pub` pinned at install.
+On a different c8s cluster everything here transfers — adjust the install flags in Step 4 and
+how you expose the front door.
+
+You'll also need:
+
 - The `c8s` CLI, `kubectl`, `helm`, and `crane` on your laptop (all already there if you
   followed that tutorial).
-- The **operator private key** (`operator.key`) whose public half you pinned at install with
-  `--operator-keys` — [allowlist writes](/docs/c8s/attestation/allowlist#authorizing-mutations)
-  are signed with it.
-- For the final step: **Node ≥ 20**, plus the two pinned values from
-  [Consumer verification](/docs/c8s/verification/consumer) — the LB **launch measurement** and
-  your cluster's **mesh CA** PEM.
+- The **operator private key** (`operator.key`) — [allowlist
+  writes](/docs/c8s/attestation/allowlist#authorizing-mutations) are signed with it.
+- For the final step: **Node ≥ 20**, plus the LB **launch measurement** and your cluster's
+  **mesh CA** PEM, supplied out of band — see
+  [Consumer verification](/docs/c8s/verification/consumer).
 
 ## Step by step
 
@@ -122,7 +129,7 @@ Confirm both control planes are up before moving on:
 
 ```bash
 kubectl get pods -n cert-manager
-# three pods Running — their images were on the allowlist before the kubelet ever asked
+# three pods Running — allowlisted before the kubelet ever asked
 
 kubectl get pods -n kserve
 # kserve-controller-manager-…   2/2   Running
@@ -178,8 +185,11 @@ kubectl get pod -n workloads -l serving.kserve.io/inferenceservice=iris \
 
 kubectl get svc -n workloads c8s-iris
 # NAME       TYPE        CLUSTER-IP   …
-# c8s-iris   ClusterIP   None         ← headless: DNS returns pod IPs, which the mesh wraps
+# c8s-iris   ClusterIP   None         ← headless: resolves to pod IPs
 ```
+
+Headless matters: DNS returns pod IPs, which the RA-TLS mesh intercepts and wraps in attested
+mTLS — a Service VIP it cannot.
 
 Optionally, mirror attestation status into a `ConfidentialWorkload` CR so `kubectl` can show
 it (a status view — injection works with or without it):
@@ -231,19 +241,44 @@ teeProxy:
 
 tlsLb:
   attest:
-    enabled: true    # serve the c8s-verify/v1 attestation + over-encryption endpoints
+    enabled: true    # serve the c8s-verify/v1 attestation endpoints
+  service:
+    type: LoadBalancer
 ```
 
-Apply it by re-running your original `c8s install` with `-f values.yaml` added (the front door
-has one catch-all upstream — this repoints it if another tutorial's workload was wired first):
+`service.type: LoadBalancer` gives the front door a public IP on AKS. Apply it all by
+re-running the `c8s install` from the Azure tutorial with `-f values.yaml` added (the front
+door has one catch-all upstream — this repoints it if another tutorial's workload was wired
+first):
 
 ```bash
-c8s install -f values.yaml   # plus the flags you first installed with (e.g. --single-node --cvm-mode aks --operator-keys operator.pub)
+c8s install \
+  --single-node \
+  --cvm-mode aks \
+  --image-pull-secret ghcr-secret \
+  --operator-keys operator.pub \
+  -f values.yaml
 ```
 
 tee-proxy now dials the predictor over the node mesh's attested mTLS, and tls-lb fronts it
 with public TLS. A request from outside is decrypted **inside the LB enclave** and forwarded
 down this chain to KServe's v1 REST endpoint.
+
+Grab the public address Azure assigns — it's `<pending>` for a minute or so:
+
+```bash
+kubectl get svc -n c8s-system c8s-tls-lb -w
+# NAME         TYPE           CLUSTER-IP   EXTERNAL-IP   PORT(S)
+# c8s-tls-lb   LoadBalancer   10.0.…       20.…          443:…/TCP
+
+LB_ADDRESS=<EXTERNAL-IP>
+```
+
+<Callout type="info">
+  **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
+  expose `c8s-tls-lb` however your environment does it — a cloud `LoadBalancer`, a `NodePort`,
+  or your own edge — then set `LB_ADDRESS` to whatever address terminates at it.
+</Callout>
 
 </Step>
 
@@ -255,7 +290,7 @@ First, prove the front door is a genuine TEE running the image you expect — fr
 before any feature vector leaves it. The CLI check pins the LB launch measurement:
 
 ```bash
-c8s verify "https://<LB_ADDRESS>" --kind lb --measurements <LB_LAUNCH_DIGEST>
+c8s verify "https://$LB_ADDRESS" --kind lb --measurements <LB_LAUNCH_DIGEST>
 # exit code 0: evidence verified against the pinned measurement
 ```
 
@@ -270,12 +305,12 @@ import { C8sClient } from "c8s-verify";
 import { readFileSync } from "node:fs";
 
 const client = new C8sClient({
-  baseUrl: "https://<LB_ADDRESS>",                // your c8s front door (tls-lb)
+  baseUrl: `https://${process.env.LB_ADDRESS}`,
   measurements: [process.env.LB_MEASUREMENT],     // pinned LB launch digest
   meshCaPem: readFileSync("mesh-ca.pem", "utf8"), // pinned cluster anchor
 });
 
-const session = await client.connect();           // throws C8sVerifyError on any failure
+const session = await client.connect(); // throws C8sVerifyError on any failure
 
 const res = await session.fetch("/v1/models/iris:predict", {
   method: "POST",
@@ -291,9 +326,18 @@ console.log(res.text());
 ```
 
 ```bash
-LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> node predict.mjs
+LB_ADDRESS=$LB_ADDRESS \
+LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> \
+NODE_TLS_REJECT_UNAUTHORIZED=0 \
+node predict.mjs
 # {"predictions":[1,1]}
 ```
+
+`NODE_TLS_REJECT_UNAUTHORIZED=0` is fine *here*: you dialed a bare IP whose outer TLS cert is
+the LB's CDS-issued one, which web PKI doesn't know — and in this design the outer TLS layer
+is untrusted transport by definition. Trust comes from the attestation checks and the sealed
+channel, so the env var relaxes only the outer web-PKI check. For a real deployment you'd put
+a public certificate on the LB via `tlsLb.publicTLS` and drop it.
 
 Both flowers classify as class `1` (versicolor). The feature vectors traveled sealed to the LB
 enclave, crossed the cluster only over attested mTLS, and were scored by a model the host

--- a/website/content/docs/c8s/tutorials/kserve.mdx
+++ b/website/content/docs/c8s/tutorials/kserve.mdx
@@ -1,0 +1,334 @@
+---
+title: Confidential model serving with KServe
+description: Run KServe on a c8s cluster in Standard deployment mode — every image digest-allowlisted, the predictor carrying a CDS-issued TEE identity — and serve verified predictions through the attested front door.
+---
+
+This tutorial puts **KServe** — the standard Kubernetes model-serving layer — on top of a
+**c8s** cluster, so a deployed model and every request to it stay inside the Trusted Execution
+Environment (TEE). You'll install the KServe control plane with every image on the
+[allowlist](/docs/c8s/attestation/allowlist), deploy a scikit-learn `InferenceService` as a
+confidential workload, and call it from your laptop only after cryptographically verifying the
+enclave — the host, the cloud operator, and any TLS-terminating proxy in between see only
+ciphertext.
+
+KServe keeps its whole API surface — `InferenceService`, model formats, autoscaling — and c8s
+adds the confidential substrate underneath: digest enforcement at container creation, an
+identity issued by the **CDS** (Certificate Distribution Service, the cluster's attested trust
+root) bound to the predictor, and an attested front door.
+
+<Callout type="info">
+  **Why Standard mode?** KServe's Knative (serverless) mode requires Knative and Istio. c8s
+  already runs its own pod-to-pod mesh — **RA-TLS** (Remote-Attestation TLS) rooted in hardware
+  attestation — and a second service mesh double-intercepts the same traffic and injects
+  un-attested proxies into the confidential path (see [Limitations](/docs/c8s/limitations)).
+  Standard mode runs each predictor as a plain Deployment: no Knative, no Istio, nothing
+  between your pods and the attested mesh.
+</Callout>
+
+## Prerequisites
+
+- A running c8s cluster in **node-as-CVM** mode — one command-for-command path is
+  [Deploy a confidential AKS cluster and run c8s](/docs/c8s/tutorials/azure-e2e).
+- The `c8s` CLI, `kubectl`, `helm`, and `crane` on your laptop (all already there if you
+  followed that tutorial).
+- The **operator private key** (`operator.key`) whose public half you pinned at install with
+  `--operator-keys` — [allowlist writes](/docs/c8s/attestation/allowlist#authorizing-mutations)
+  are signed with it.
+- For the final step: **Node ≥ 20**, plus the two pinned values from
+  [Consumer verification](/docs/c8s/verification/consumer) — the LB **launch measurement** and
+  your cluster's **mesh CA** PEM.
+
+## Step by step
+
+<Steps>
+
+<Step>
+
+### 1. Allowlist the KServe platform images
+
+On a c8s cluster, **nothing runs unless its image digest is on the allowlist** — and that
+includes control planes, not just your models. This is the point, not a hurdle: the same
+enforcement that will gate your model server also gates cert-manager and the KServe
+controller, so a compromised upstream image can't quietly land next to your weights.
+
+Reach the CDS (it has no public ingress), then add the digests of everything this tutorial
+runs: cert-manager's three components, the KServe controller pod's two containers, and the two
+images every sklearn predictor pod uses — `storage-initializer` (the init container that
+fetches the model) and `sklearnserver` (the model server):
+
+```bash
+kubectl port-forward -n c8s-system svc/c8s-cds 8443:8443 &
+kubectl port-forward -n c8s-system svc/c8s-attestation-api 8400:8400 &
+
+for IMAGE in \
+  "quay.io/jetstack/cert-manager-controller:v1.20.3" \
+  "quay.io/jetstack/cert-manager-webhook:v1.20.3" \
+  "quay.io/jetstack/cert-manager-cainjector:v1.20.3" \
+  "kserve/kserve-controller:v0.19.0" \
+  "quay.io/brancz/kube-rbac-proxy:v0.18.0" \
+  "kserve/storage-initializer:v0.19.0" \
+  "kserve/sklearnserver:v0.19.0"; do
+  c8s allowlist add "$(crane digest "$IMAGE")" "$IMAGE" \
+    --url https://localhost:8443 \
+    --attestation-api-url http://localhost:8400 \
+    --operator-key operator.key
+done
+```
+
+Each `add` prints the digest it admitted. The CLI will warn that no `--measurements` are
+pinned — it's accepting *any* attested CDS, fine for a tutorial cluster; in production pin
+your CDS launch digest so a write can never land on a rogue CDS.
+
+<Callout type="info">
+  `crane digest` reads the digest a tag currently points to — for these multi-arch images
+  that's the index digest, the one containerd records when a node pulls the tag. If a pod
+  later still reports `image not in allowlist`, compare against the digest the node actually
+  resolved: `kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[*].imageID}'` —
+  see [Getting an image's digest](/docs/c8s/attestation/allowlist#getting-an-images-digest).
+</Callout>
+
+</Step>
+
+<Step>
+
+### 2. Install cert-manager and KServe
+
+cert-manager issues the serving certificates for KServe's own admission webhooks —
+control-plane plumbing, separate from the CDS-issued workload identities:
+
+```bash
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.3/cert-manager.yaml
+kubectl wait --for=condition=Available -n cert-manager deploy --all --timeout=180s
+```
+
+Then KServe itself: the CRDs, the controller in **Standard** deployment mode, and the
+`ClusterServingRuntime` catalog (runtime images pull only when an `InferenceService` uses
+them, so allowlisting `sklearnserver` alone was enough). `disableIngressCreation` stops the
+controller from minting Ingress objects — the attested front door replaces that role in
+Step 4:
+
+```bash
+helm install kserve-crd oci://ghcr.io/kserve/charts/kserve-crd --version v0.19.0
+
+helm install kserve oci://ghcr.io/kserve/charts/kserve-resources --version v0.19.0 \
+  --namespace kserve --create-namespace \
+  --set kserve.controller.deploymentMode=Standard \
+  --set kserve.controller.gateway.disableIngressCreation=true
+
+kubectl apply --server-side -f https://github.com/kserve/kserve/releases/download/v0.19.0/kserve-cluster-resources.yaml
+```
+
+Confirm both control planes are up before moving on:
+
+```bash
+kubectl get pods -n cert-manager
+# three pods Running — their images were on the allowlist before the kubelet ever asked
+
+kubectl get pods -n kserve
+# kserve-controller-manager-…   2/2   Running
+```
+
+</Step>
+
+<Step>
+
+### 3. Deploy a confidential InferenceService
+
+From here it looks like any KServe cluster — one `InferenceService`, serving the classic
+scikit-learn iris classifier from a public bucket. The only c8s-specific line is the
+`confidential.ai/cw: iris` annotation: predictor-level annotations land on the pods KServe
+creates, so the c8s webhook injects the `c8s-cert` identity sidecar, and the value `iris` is
+the **workload id** from which the operator mints the headless Service `c8s-iris`:
+
+```yaml
+# iris.yaml
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: iris
+  namespace: workloads
+spec:
+  predictor:
+    annotations:
+      confidential.ai/cw: iris    # workload id → headless Service c8s-iris
+    model:
+      modelFormat:
+        name: sklearn
+      storageUri: gs://kfserving-examples/models/sklearn/1.0/model
+```
+
+```bash
+kubectl create namespace workloads   # skip if it exists from another tutorial
+kubectl apply -f iris.yaml
+
+kubectl get inferenceservice -n workloads iris -w
+# NAME   URL   READY
+# iris   …     True
+```
+
+The model downloads *inside* the TEE: `storage-initializer` runs as an init container in the
+predictor pod, so the artifact goes encrypted-in-memory from its first byte on the cluster —
+the host never sees it unwrapped. While it starts, look at what c8s injected:
+
+```bash
+kubectl get pod -n workloads -l serving.kserve.io/inferenceservice=iris \
+  -o jsonpath='{range .items[0].spec.initContainers[*]}{.name}{"\n"}{end}'
+# c8s-cert              ← injected identity sidecar (holds the CDS-issued cert)
+# storage-initializer   ← KServe's model fetcher
+
+kubectl get svc -n workloads c8s-iris
+# NAME       TYPE        CLUSTER-IP   …
+# c8s-iris   ClusterIP   None         ← headless: DNS returns pod IPs, which the mesh wraps
+```
+
+Optionally, mirror attestation status into a `ConfidentialWorkload` CR so `kubectl` can show
+it (a status view — injection works with or without it):
+
+```yaml
+# iris-cwl.yaml
+apiVersion: confidential.ai/v1alpha2
+kind: ConfidentialWorkload
+metadata:
+  name: iris            # must equal the confidential.ai/cw value
+  namespace: workloads
+spec:
+  workloadRef:
+    kind: Deployment
+    name: iris-predictor
+```
+
+```bash
+kubectl apply -f iris-cwl.yaml
+kubectl get cwl -n workloads
+# NAME   WORKLOAD         ATTESTED   TOTAL
+# iris   iris-predictor   1          1
+```
+
+<Callout type="warn">
+  **In-cluster clients: dial `c8s-iris`, not the KServe Service.** KServe also creates an
+  ordinary ClusterIP Service (`iris-predictor`), but the mesh cannot intercept Service-VIP
+  traffic — so c8s **drops** VIP flows to confidential pods rather than let them arrive in
+  plaintext. The headless `c8s-iris` resolves to pod IPs, which the mesh wraps in attested
+  mTLS. (Kubelet probes and the front-door path below are unaffected.)
+</Callout>
+
+</Step>
+
+<Step>
+
+### 4. Point the front door at the predictor
+
+External clients reach the model through the chart's front-door chain — **tls-lb (public TLS +
+over-encryption) → tee-proxy (attested) → your predictor**. The engine presets cover vLLM and
+SGLang; for KServe, set the upstream directly to the minted headless Service and the
+`kserve-container` port (`8080` — pod-IP dials bypass Service port mapping, so use the
+container port, not the KServe Service's port 80):
+
+```yaml
+# values.yaml
+teeProxy:
+  upstream: c8s-iris.workloads.svc.cluster.local:8080
+
+tlsLb:
+  attest:
+    enabled: true    # serve the c8s-verify/v1 attestation + over-encryption endpoints
+```
+
+Apply it by re-running your original `c8s install` with `-f values.yaml` added (the front door
+has one catch-all upstream — this repoints it if another tutorial's workload was wired first):
+
+```bash
+c8s install -f values.yaml   # plus the flags you first installed with (e.g. --single-node --cvm-mode aks --operator-keys operator.pub)
+```
+
+tee-proxy now dials the predictor over the node mesh's attested mTLS, and tls-lb fronts it
+with public TLS. A request from outside is decrypted **inside the LB enclave** and forwarded
+down this chain to KServe's v1 REST endpoint.
+
+</Step>
+
+<Step>
+
+### 5. Verify the enclave and predict
+
+First, prove the front door is a genuine TEE running the image you expect — from your laptop,
+before any feature vector leaves it. The CLI check pins the LB launch measurement:
+
+```bash
+c8s verify "https://<LB_ADDRESS>" --kind lb --measurements <LB_LAUNCH_DIGEST>
+# exit code 0: evidence verified against the pinned measurement
+```
+
+Then make a verified prediction. The [c8s-verify](/docs/c8s/verification/consumer) client
+re-checks the attestation, confirms the LB belongs to *your* cluster (its cert chains to your
+pinned mesh CA), and opens the post-quantum over-encrypted channel; only then does the request
+go out — sealed end-to-end into the enclave:
+
+```js
+// predict.mjs
+import { C8sClient } from "c8s-verify";
+import { readFileSync } from "node:fs";
+
+const client = new C8sClient({
+  baseUrl: "https://<LB_ADDRESS>",                // your c8s front door (tls-lb)
+  measurements: [process.env.LB_MEASUREMENT],     // pinned LB launch digest
+  meshCaPem: readFileSync("mesh-ca.pem", "utf8"), // pinned cluster anchor
+});
+
+const session = await client.connect();           // throws C8sVerifyError on any failure
+
+const res = await session.fetch("/v1/models/iris:predict", {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    instances: [
+      [6.8, 2.8, 4.8, 1.4],
+      [6.0, 3.4, 4.5, 1.6],
+    ],
+  }),
+});
+console.log(res.text());
+```
+
+```bash
+LB_MEASUREMENT=<sha384-launch-digest-of-the-lb> node predict.mjs
+# {"predictions":[1,1]}
+```
+
+Both flowers classify as class `1` (versicolor). The feature vectors traveled sealed to the LB
+enclave, crossed the cluster only over attested mTLS, and were scored by a model the host
+never saw. The full client walkthrough — including a failure drill where a wrong measurement
+refuses to connect — is in
+[Verified chat over confidential vLLM](/docs/c8s/tutorials/vllm-chat).
+
+</Step>
+
+</Steps>
+
+## What you've proven
+
+By the time `{"predictions":[1,1]}` comes back, you've established — from an untrusted client,
+over an untrusted network — that:
+
+1. every image in the serving path, control plane included, was **admitted by digest** before
+   it could run;
+2. the front door is a **genuine TEE** running the exact measured image you pinned, in **your**
+   cluster (cert chained to your pinned mesh CA);
+3. the model was fetched, loaded, and scored **inside the confidential boundary** — by
+   [transitivity](/docs/c8s/verification/consumer#transitivity-of-trust), the attested LB only
+   forwards over the RA-TLS mesh to the predictor behind it;
+4. request and response crossed the infrastructure **sealed end-to-end** — the TLS terminator,
+   the host, and the operator saw ciphertext.
+
+## Where to go next
+
+- **Serve a different model format** — any KServe runtime works the same way: allowlist the
+  runtime image's digest, keep the `confidential.ai/cw` annotation on the predictor. See
+  [the allowlist](/docs/c8s/attestation/allowlist#managing-it-with-the-c8s-cli).
+- **LLM serving** — [Verified chat over confidential vLLM](/docs/c8s/tutorials/vllm-chat) runs
+  the same pattern with an OpenAI-compatible engine and a chat client, and
+  [NVIDIA Dynamo](/docs/c8s/tutorials/dynamo) shows a multi-component serving graph.
+- **Automate the digests** — wire `c8s allowlist add` into the pipeline that builds your model
+  images: [Automating the allowlist](/docs/c8s/attestation/allowlist#automating-the-allowlist).
+- **Pin for production** — set `cds.measurements` and per-cluster operator keys before real
+  traffic: [threat model](/docs/c8s/architecture/threat-model).

--- a/website/content/docs/c8s/tutorials/kserve.mdx
+++ b/website/content/docs/c8s/tutorials/kserve.mdx
@@ -1,5 +1,5 @@
 ---
-title: Confidential model serving with KServe
+title: Serving a confidential model with KServe
 description: Run KServe on a c8s cluster in Standard deployment mode — every image digest-allowlisted, the predictor carrying a CDS-issued TEE identity — and serve verified predictions through the attested front door.
 ---
 
@@ -19,7 +19,9 @@ identity issued by the **CDS** (Certificate Distribution Service, the cluster's 
 root) bound to the predictor, and an attested front door.
 
 <Callout type="info">
-  **Why Standard mode?** KServe's Knative (serverless) mode requires Knative and Istio. c8s
+  **Why Standard mode?**
+
+  KServe's Knative (serverless) mode requires Knative and Istio. c8s
   already runs its own pod-to-pod mesh — **RA-TLS** (Remote-Attestation TLS) rooted in hardware
   attestation — and a second service mesh double-intercepts the same traffic and injects
   un-attested proxies into the confidential path (see [Limitations](/docs/c8s/limitations)).
@@ -222,7 +224,9 @@ kubectl get cwl -n workloads
 ```
 
 <Callout type="warn">
-  **In-cluster clients: dial `c8s-iris`, not the KServe Service.** KServe also creates an
+  **In-cluster clients: dial `c8s-iris`, not the KServe Service.**
+
+  KServe also creates an
   ordinary ClusterIP Service (`iris-predictor`), but the mesh cannot intercept Service-VIP
   traffic — so c8s **drops** VIP flows to confidential pods rather than let them arrive in
   plaintext. The headless `c8s-iris` resolves to pod IPs, which the mesh wraps in attested
@@ -285,9 +289,11 @@ LB_ADDRESS=<EXTERNAL-IP>
 ```
 
 <Callout type="info">
-  **Not on the Azure tutorial's cluster?** Use the flags you originally installed with, and
-  expose `c8s-tls-lb` however your environment does it. With no cloud load balancer, set
-  `tlsLb.service.type: NodePort` in `values.yaml` and reach the front door on the node:
+  **Not on the Azure tutorial's cluster?**
+
+  Use the flags you originally installed with, and expose `c8s-tls-lb` however your
+  environment does it. With no cloud load balancer, set `tlsLb.service.type: NodePort` in
+  `values.yaml` and reach the front door on the node:
 
   ```bash
   NODE_PORT=$(kubectl get svc -n c8s-system c8s-tls-lb -o jsonpath='{.spec.ports[0].nodePort}')

--- a/website/content/docs/c8s/tutorials/meta.json
+++ b/website/content/docs/c8s/tutorials/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Tutorials",
-  "pages": ["azure-e2e", "vllm-chat"]
+  "pages": ["azure-e2e", "vllm-chat", "dynamo", "kserve"]
 }

--- a/website/content/docs/c8s/tutorials/vllm-chat.mdx
+++ b/website/content/docs/c8s/tutorials/vllm-chat.mdx
@@ -144,9 +144,9 @@ kubectl get pods -n workloads -w
 
 ### 3. Point the Load Balancer at vLLM
 
-You don't hand-edit nginx. The chart wires the front door as a chain —
-**tls-lb (public TLS + over-encryption) → tee-proxy (attested) → your engine** — and you aim the
-last hop at your vLLM workload with the inference-engine preset, in a small values file:
+You don't hand-edit nginx. The chart wires the front door —
+**tls-lb (public TLS + over-encryption) → your engine**, over the node mesh's attested mTLS — and
+you aim it at your vLLM workload with the inference-engine preset, in a small values file:
 
 ```yaml
 # values.yaml
@@ -167,11 +167,11 @@ added:
 c8s install -f values.yaml   # plus the flags you first installed with (e.g. --single-node --operator-keys operator.pub)
 ```
 
-The preset derives `teeProxy.upstream = c8s-vllm.workloads.svc.cluster.local:8000`, so tee-proxy
-dials vLLM's headless Service and that hop rides the node mesh's attested mTLS; tls-lb already
-proxies to tee-proxy over attested mTLS by default — hence no nginx surgery. A request your client
-sends over the over-encryption tunnel (Step 6) is decrypted **inside the LB enclave** and forwarded
-down this chain to vLLM's OpenAI-compatible `/v1/chat/completions`.
+The preset derives `tlsLb.upstream = c8s-vllm.workloads.svc.cluster.local:8000`, so tls-lb dials
+vLLM's headless Service directly and that hop rides the node mesh's attested mTLS — hence no nginx
+surgery. A request your client sends over the over-encryption tunnel (Step 6) is decrypted
+**inside the LB enclave** and forwarded over the mesh to vLLM's OpenAI-compatible
+`/v1/chat/completions`.
 
 </Step>
 

--- a/website/content/docs/c8s/tutorials/vllm-chat.mdx
+++ b/website/content/docs/c8s/tutorials/vllm-chat.mdx
@@ -127,7 +127,7 @@ pod from Step 1 starts on its next retry:
 
 ```bash
 kubectl get pods -n workloads -w
-# vllm-…   1/1   Running
+# vllm-…   2/2   Running   ← the vLLM container plus the injected c8s-cert sidecar
 ```
 
 <Callout type="info">

--- a/website/content/docs/c8s/tutorials/vllm-chat.mdx
+++ b/website/content/docs/c8s/tutorials/vllm-chat.mdx
@@ -42,7 +42,9 @@ Headless DNS returns pod IPs, which the node mesh wraps in attested mTLS. We ser
 **`facebook/opt-125m`**, a tiny model that's quick to load on CPU.
 
 <Callout type="warn">
-  **This tutorial uses a CPU build of vLLM.** vLLM's published `vllm/vllm-openai` image is a
+  **This tutorial uses a CPU build of vLLM.**
+
+  vLLM's published `vllm/vllm-openai` image is a
   **CUDA** build that won't start without a GPU, and vLLM ships no official prebuilt CPU image —
   so build one from
   [vLLM's CPU Dockerfile](https://docs.vllm.ai/en/latest/getting_started/installation/cpu/), push


### PR DESCRIPTION
- add confidential model serving with KServe tutorial (Standard mode)
- add NVIDIA Dynamo confidential-workloads tutorial (mocker engine, CPU-only)
- cross-link the new tutorials from azure-e2e next steps
- fix injected container name in installation verify step (c8s-cert)
- fix vllm-chat pod READY count (native sidecar counts toward 2/2)