### PR TITLE
feat(cds-attest): bind PQ sessions to mesh identity

### DIFF
--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -105,6 +105,11 @@ final security model. Each bullet links to the tracking issue.
 - The sidecar's live evidence path requires `--attestation-api-url`; per-session
   binding of the over-encryption key into a fresh hardware report is enforced
   there. The `--evidence-fixture` path is DEV ONLY (fixed `report_data`).
+- The v1 compatibility binding commits only the session keys and nonce. Its
+  separately served certificate-chain check does not prove that the attested
+  session belongs to the pinned cluster. Browser clients should require the v2
+  `over-encryption+mesh-identity-v2` binding; v2 authentication currently uses
+  ECDSA and is not post-quantum.
 - An optional CDS-issued EAR over the bundle (`ear` field) is defined in the
   contract but not yet populated by the LB.
 - The over-encrypted tunnel is not streaming yet. The sidecar buffers each

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -417,18 +417,25 @@ out-of-cluster client (the `c8s-verify-js` library, or `TEErminator`) can verify
 the Load Balancer and open a post-quantum over-encrypted channel to its enclave.
 The wire contract is `c8s-verify-js/PROTOCOL.md`.
 
-- `GET /.well-known/c8s/cds-cert.pem` — the mesh CA / LB cert chain. Served
-  **unauthenticated by design** (same reasoning as in-cluster `GET /ca`): the
-  client MUST chain it through attested evidence before trusting it, never on the
-  strength of the TLS connection it arrived over.
-- `GET /.well-known/c8s/attestation?nonce=` — raw SEV-SNP evidence whose
-  `report_data = SHA-384(x25519 || mlkem768 || nonce)` binds the per-session
-  over-encryption key and the client nonce. The client verifies the hardware
-  signature, the launch measurement against its pinned allowlist, and this
-  binding before deriving the channel. A second binding mode exists
+- `GET /.well-known/c8s/cds-cert.pem` — legacy discovery for the mesh CA / LB
+  cert chain, served unauthenticated. An identity-bound v2 verifier does not
+  trust this standalone response; it verifies the exact chain committed by the
+  attestation bundle. The v1 compatibility flow only checks the discovered
+  chain separately and therefore does not establish cluster identity.
+- `GET /.well-known/c8s/attestation?nonce=&binding=over-encryption+mesh-identity-v2`
+  — raw SEV-SNP evidence whose domain-separated `report_data` transcript commits
+  the X25519 and ML-KEM-768 session keys, 32-byte client nonce, exact mesh leaf,
+  and issuing mesh CA. The leaf also signs the transcript, proving possession
+  of the corresponding private key. The client verifies the hardware signature,
+  a non-empty launch-measurement allowlist, the transcript, the leaf chain to a
+  pinned mesh CA, and the proof signature before deriving the channel. Copying
+  a victim cluster's public certificate chain is insufficient without its leaf
+  private key. The omitted/`over-encryption` binding remains v1-compatible and
+  binds only `SHA-384(x25519 || mlkem768 || nonce)`; it does not identify a
+  cluster. A separate binding mode exists
   (`?pq=false`, `report_data = SHA-384(serving_leaf_spki || nonce)`) where the
   client trusts the LB's outer TLS leaf instead of the over-encryption key — a
-  different, weaker trust decision; prefer the PQ binding.
+  different trust decision.
 - `POST /.well-known/c8s/handshake` + over-encrypted application records —
   X25519 + ML-KEM-768 → HKDF-SHA256 → AES-256-GCM (`pkg/overenc`). The **entire**
   request is sealed — method, path, headers, and body — so a TLS-terminating proxy
@@ -438,20 +445,23 @@ The wire contract is `c8s-verify-js/PROTOCOL.md`.
 
 The tls-lb nginx serves the static `cds-cert.pem`/`mesh-ca.pem` and reverse-proxies the dynamic `/.well-known/c8s/` paths to the sidecar on loopback.
 
-Trust is transitive from this point: the user verifies only the LB (and, through
-the served cert, the mesh CA); the in-cluster RA-TLS mesh vouches for the backend
-pods the LB talks to. **The client must pin both the measurement allowlist and the
-mesh CA** — a measurement alone proves "genuine audited code on real silicon", not
-"*my* cluster"; without the mesh-CA pin an attacker can present a genuine-but-
-attacker-operated LB (§6(5)).
+Under v2, trust is transitive from the identity-bound LB: the user verifies the
+LB measurement and pinned cluster identity; the verified LB implementation uses
+the in-cluster RA-TLS mesh for backend pods. **The client must pin both a non-empty
+measurement allowlist and the mesh CA** — a measurement alone proves "genuine
+audited code on real silicon", not "*my* cluster". The proof uses ECDSA, so cluster
+authentication is classical. X25519 + ML-KEM-768 provides hybrid session-key
+confidentiality; this path does not claim post-quantum authentication.
 
 **Client-side responsibilities and their downgrades** (all supplied out of band by
 the embedding app): the SDK **fails closed** with a typed error taxonomy
 (`nonce_mismatch`, `report_data_mismatch`, `measurement_denied`, `invalid_cert`,
-`key_binding`, …) — *unless* a downgrade is set. `requireFreshness=false`, empty
-`measurements`, or a missing `meshCaPem` each reduce the check to a **warning** and
-return `ok:true` with `warnings[]`; the relying app MUST inspect `warnings[]` or the
-guarantee is void. The WASM verifier's bare-`snp` path also omits several checks the
+`identity_binding`, …). Its default `requireClusterIdentity=true` policy rejects
+v1, an empty measurement allowlist, a missing `meshCaPem`, and disabled freshness.
+Setting `requireClusterIdentity=false` is an explicit legacy downgrade; in that
+mode `requireFreshness=false`, empty `measurements`, or a missing `meshCaPem` can
+reduce checks to warnings, and the result does not carry a cluster-identity
+guarantee. The WASM verifier's bare-`snp` path also omits several checks the
 Go/Rust verifiers enforce (§5 Addressable). Distributing a JS/WASM verifier over
 npm/CDN means the origin that ships the SPA also ships the verifier, and the PQ half
 rides a pre-1.0 `mlkem-wasm` dependency — supply-chain trust roots for this path.

--- a/internal/cmds/cdsattest/cmd.go
+++ b/internal/cmds/cdsattest/cmd.go
@@ -19,17 +19,20 @@ import (
 )
 
 type config struct {
-	host              string
-	port              int
-	logLevel          string
-	cdsCertFile       string
-	servingCertFile   string
-	evidenceFixture   string
-	attestationAPIURL string
-	platform          string
-	generation        string
-	sessionTTL        time.Duration
-	readHeaderTimeout time.Duration
+	host                 string
+	port                 int
+	logLevel             string
+	cdsCertFile          string
+	servingCertFile      string
+	meshIdentityCertFile string
+	meshIdentityKeyFile  string
+	meshIdentityCAFile   string
+	evidenceFixture      string
+	attestationAPIURL    string
+	platform             string
+	generation           string
+	sessionTTL           time.Duration
+	readHeaderTimeout    time.Duration
 
 	// over-encryption backend
 	upstream           string
@@ -58,6 +61,9 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.logLevel, "log-level", "info", "log level: debug, info, warn, error")
 	f.StringVar(&cfg.cdsCertFile, "cds-cert-file", "", "optional PEM (LB leaf + mesh CA): also serve /.well-known/c8s/cds-cert.pem from the sidecar. Normally nginx serves this statically; leave empty.")
 	f.StringVar(&cfg.servingCertFile, "serving-cert-file", "", "path to the LB serving-leaf PEM (the cert nginx presents). Enables the tls-cert attestation binding (GET /.well-known/c8s/attestation?pq=false): report_data binds this leaf's SPKI. Re-read per request to follow get-cert rotation.")
+	f.StringVar(&cfg.meshIdentityCertFile, "mesh-identity-cert-file", "", "TEE-held mesh leaf PEM for identity-bound PQ v2 (re-read per request)")
+	f.StringVar(&cfg.meshIdentityKeyFile, "mesh-identity-key-file", "", "TEE-held mesh leaf private key for identity-bound PQ v2 (re-read per request)")
+	f.StringVar(&cfg.meshIdentityCAFile, "mesh-identity-ca-file", "", "mesh CA bundle that issued the v2 identity leaf (re-read per request)")
 	f.StringVar(&cfg.evidenceFixture, "evidence-fixture", "", "DEV ONLY: serve recorded SNP evidence from this file instead of the attestation-api")
 	f.StringVar(&cfg.attestationAPIURL, "attestation-api-url", "", "attestation-api URL (production evidence source)")
 	f.StringVar(&cfg.platform, "platform", "snp", "TEE platform")
@@ -123,12 +129,15 @@ func run(cfg config) error {
 	}
 
 	srv := NewServer(Config{
-		Logger:          logger,
-		Evidence:        provider,
-		CDSCertPEM:      cdsCertPEM,
-		ServingCertFile: cfg.servingCertFile,
-		Backend:         backend,
-		SessionTTL:      cfg.sessionTTL,
+		Logger:               logger,
+		Evidence:             provider,
+		CDSCertPEM:           cdsCertPEM,
+		ServingCertFile:      cfg.servingCertFile,
+		MeshIdentityCertFile: cfg.meshIdentityCertFile,
+		MeshIdentityKeyFile:  cfg.meshIdentityKeyFile,
+		MeshIdentityCAFile:   cfg.meshIdentityCAFile,
+		Backend:              backend,
+		SessionTTL:           cfg.sessionTTL,
 	})
 
 	addr := cfg.host + ":" + strconv.Itoa(cfg.port)

--- a/internal/cmds/cdsattest/evidence.go
+++ b/internal/cmds/cdsattest/evidence.go
@@ -10,9 +10,8 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// EvidenceProvider yields TEE attestation evidence whose report_data binds the
-// LB's per-session public key and the client nonce
-// (reportData = SHA-384(x25519 || mlkem768 || nonce)). The returned evidence is
+// EvidenceProvider yields TEE attestation evidence whose report_data equals the
+// selected protocol binding. The returned evidence is
 // the attestation-rs SnpEvidence JSON the browser verifier consumes verbatim.
 type EvidenceProvider interface {
 	Evidence(ctx context.Context, reportData []byte) (evidence json.RawMessage, platform, generation string, err error)

--- a/internal/cmds/cdsattest/identity.go
+++ b/internal/cmds/cdsattest/identity.go
@@ -1,0 +1,107 @@
+package cdsattest
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/overenc"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+type meshIdentity struct {
+	leaf      *x509.Certificate
+	ca        *x509.Certificate
+	private   *ecdsa.PrivateKey
+	bundlePEM []byte
+}
+
+// loadMeshIdentity reads all three files for every v2 attestation request so a
+// get-cert rotation is observed without restarting the sidecar. X509KeyPair
+// verifies that the private key matches the leaf. A transient rotation mismatch
+// fails this request closed; the next request can retry after the three files
+// converge on one credential generation.
+func loadMeshIdentity(certFile, keyFile, caFile string) (*meshIdentity, error) {
+	if certFile == "" || keyFile == "" || caFile == "" {
+		return nil, fmt.Errorf("mesh identity cert, key, and CA files are required")
+	}
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("read mesh identity cert: %w", err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("read mesh identity key: %w", err)
+	}
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("read mesh identity CA: %w", err)
+	}
+
+	pair, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("load mesh identity keypair: %w", err)
+	}
+	if len(pair.Certificate) == 0 {
+		return nil, fmt.Errorf("mesh identity certificate file has no leaf")
+	}
+	leaf, err := x509.ParseCertificate(pair.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("parse mesh identity leaf: %w", err)
+	}
+	private, ok := pair.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("mesh identity private key must be ECDSA, got %T", pair.PrivateKey)
+	}
+
+	caCerts, err := certutil.ParsePEMCertificates(caPEM)
+	if err != nil {
+		return nil, fmt.Errorf("parse mesh identity CA bundle: %w", err)
+	}
+	var issuer *x509.Certificate
+	for _, candidate := range caCerts {
+		if leaf.CheckSignatureFrom(candidate) == nil {
+			issuer = candidate
+			break
+		}
+	}
+	if issuer == nil {
+		return nil, fmt.Errorf("mesh identity leaf is not signed by any configured mesh CA")
+	}
+
+	bundle := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw})
+	bundle = append(bundle, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: issuer.Raw})...)
+	return &meshIdentity{leaf: leaf, ca: issuer, private: private, bundlePEM: bundle}, nil
+}
+
+func (m *meshIdentity) bind(pub overenc.PublicKey, nonce []byte) ([]byte, *types.MeshIdentityProof, error) {
+	transcriptHash, err := overenc.IdentityTranscriptHash(pub, nonce, m.leaf.Raw, m.ca.Raw)
+	if err != nil {
+		return nil, nil, err
+	}
+	message, err := overenc.IdentityProofMessage(transcriptHash)
+	if err != nil {
+		return nil, nil, err
+	}
+	digest := sha512.Sum384(message)
+	signature, err := ecdsa.SignASN1(rand.Reader, m.private, digest[:])
+	if err != nil {
+		return nil, nil, fmt.Errorf("sign mesh identity proof: %w", err)
+	}
+	leafHash := sha256.Sum256(m.leaf.Raw)
+	caHash := sha256.Sum256(m.ca.Raw)
+	return transcriptHash, &types.MeshIdentityProof{
+		Algorithm:    types.MeshIdentityProofECDSASHA384,
+		LeafSHA256:   base64.RawURLEncoding.EncodeToString(leafHash[:]),
+		MeshCASHA256: base64.RawURLEncoding.EncodeToString(caHash[:]),
+		Signature:    base64.RawURLEncoding.EncodeToString(signature),
+	}, nil
+}

--- a/internal/cmds/cdsattest/identity_test.go
+++ b/internal/cmds/cdsattest/identity_test.go
@@ -1,0 +1,276 @@
+package cdsattest
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/overenc"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+type testMeshIdentity struct {
+	certFile string
+	keyFile  string
+	caFile   string
+	leaf     *x509.Certificate
+	ca       *x509.Certificate
+	key      *ecdsa.PrivateKey
+}
+
+func writeTestMeshIdentity(t *testing.T) testMeshIdentity {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test mesh CA"},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "lb.c8s-system.svc"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, ca, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+	caFile := filepath.Join(dir, "ca.pem")
+	keyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestPEM(t, certFile, "CERTIFICATE", leafDER)
+	writeTestPEM(t, keyFile, "EC PRIVATE KEY", keyDER)
+	writeTestPEM(t, caFile, "CERTIFICATE", caDER)
+	return testMeshIdentity{certFile: certFile, keyFile: keyFile, caFile: caFile, leaf: leaf, ca: ca, key: leafKey}
+}
+
+func writeTestPEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIdentityBoundAttestationAndChannel(t *testing.T) {
+	identity := writeTestMeshIdentity(t)
+	provider := &capturingProvider{}
+	srv := NewServer(Config{
+		Evidence:             provider,
+		MeshIdentityCertFile: identity.certFile,
+		MeshIdentityKeyFile:  identity.keyFile,
+		MeshIdentityCAFile:   identity.caFile,
+	})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatal(err)
+	}
+	endpoint := ts.URL + "/.well-known/c8s/attestation?nonce=" + b64url(nonce) + "&binding=" + url.QueryEscape(types.BindingOverEncryptionMeshIdentityV2)
+	resp, err := http.Get(endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("attestation status = %d, want 200", resp.StatusCode)
+	}
+	var bundle types.AttestationBundle
+	if err := json.NewDecoder(resp.Body).Decode(&bundle); err != nil {
+		t.Fatal(err)
+	}
+	if bundle.Version != "c8s-verify/v2" || bundle.Binding != types.BindingOverEncryptionMeshIdentityV2 {
+		t.Fatalf("unexpected v2 bundle header: %+v", bundle)
+	}
+	if bundle.IdentityProof == nil || bundle.SessionPubKey == nil {
+		t.Fatalf("v2 bundle missing identity proof or session key: %+v", bundle)
+	}
+
+	x25519, err := base64.RawURLEncoding.DecodeString(bundle.SessionPubKey.X25519)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mlkem, err := base64.RawURLEncoding.DecodeString(bundle.SessionPubKey.MLKEM768)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := overenc.PublicKey{X25519: x25519, MLKEM768: mlkem}
+	wantReportData, err := overenc.IdentityTranscriptHash(pub, nonce, identity.leaf.Raw, identity.ca.Raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(provider.lastReportData, wantReportData) {
+		t.Fatalf("report_data = %x, want identity transcript %x", provider.lastReportData, wantReportData)
+	}
+
+	leafHash := sha256.Sum256(identity.leaf.Raw)
+	caHash := sha256.Sum256(identity.ca.Raw)
+	if bundle.IdentityProof.LeafSHA256 != b64url(leafHash[:]) || bundle.IdentityProof.MeshCASHA256 != b64url(caHash[:]) {
+		t.Fatalf("identity fingerprints do not match committed certificates: %+v", bundle.IdentityProof)
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(bundle.IdentityProof.Signature)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := overenc.IdentityProofMessage(wantReportData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := sha512.Sum384(message)
+	if !ecdsa.VerifyASN1(&identity.key.PublicKey, digest[:], signature) {
+		t.Fatal("mesh identity proof signature did not verify")
+	}
+
+	clientChannel, handshake, err := overenc.ClientAgreeIdentity(pub, wantReportData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sessionID := postHandshake(t, ts.URL, nonce, handshake)
+	got := tunnel(t, ts.URL, clientChannel, sessionID, types.TunnelRequest{Method: "GET", Path: "/identity"})
+	if got.Status != http.StatusOK {
+		t.Fatalf("identity-bound tunnel response status = %d", got.Status)
+	}
+}
+
+func postHandshake(t *testing.T, base string, nonce []byte, hs overenc.Handshake) string {
+	t.Helper()
+	body, err := json.Marshal(types.HandshakeRequest{
+		Nonce:        b64url(nonce),
+		ClientX25519: b64url(hs.ClientX25519),
+		MLKEMCt:      b64url(hs.MLKEMCiphertext),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(base+"/.well-known/c8s/handshake", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("handshake status = %d, want 200", resp.StatusCode)
+	}
+	var result types.HandshakeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result.SessionID == "" {
+		t.Fatal("identity-bound handshake returned no session id")
+	}
+	return result.SessionID
+}
+
+func TestIdentityBoundAttestationFailsClosedWithoutIdentity(t *testing.T) {
+	srv := NewServer(Config{Evidence: &capturingProvider{}})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	nonce := make([]byte, 32)
+	resp, err := http.Get(ts.URL + "/.well-known/c8s/attestation?nonce=" + b64url(nonce) + "&binding=" + url.QueryEscape(types.BindingOverEncryptionMeshIdentityV2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", resp.StatusCode)
+	}
+}
+
+func TestIdentityBoundAttestationFailsClosedOnInvalidConfiguredIdentity(t *testing.T) {
+	srv := NewServer(Config{
+		Evidence:             &capturingProvider{},
+		MeshIdentityCertFile: "/does/not/exist/cert.pem",
+		MeshIdentityKeyFile:  "/does/not/exist/key.pem",
+		MeshIdentityCAFile:   "/does/not/exist/ca.pem",
+	})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/.well-known/c8s/attestation?nonce=" + b64url(make([]byte, 32)) + "&binding=" + url.QueryEscape(types.BindingOverEncryptionMeshIdentityV2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+func TestLoadMeshIdentityRejectsCopiedLeafWithoutPrivateKey(t *testing.T) {
+	identity := writeTestMeshIdentity(t)
+	other, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherDER, err := x509.MarshalECPrivateKey(other)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestPEM(t, identity.keyFile, "EC PRIVATE KEY", otherDER)
+	if _, err := loadMeshIdentity(identity.certFile, identity.keyFile, identity.caFile); err == nil {
+		t.Fatal("copied public leaf was accepted without its private key")
+	}
+}
+
+func TestIdentityBoundAttestationRejectsUnknownBinding(t *testing.T) {
+	srv := NewServer(Config{Evidence: &capturingProvider{}})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/.well-known/c8s/attestation?nonce=" + b64url(make([]byte, 32)) + "&binding=unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/cmds/cdsattest/server.go
+++ b/internal/cmds/cdsattest/server.go
@@ -1,5 +1,5 @@
 // Package cdsattest implements the tls-lb attestation + over-encryption sidecar:
-// the *dynamic* browser-facing endpoints of the c8s-verify/v1 protocol. The
+// the *dynamic* browser-facing endpoints of the c8s-verify v1/v2 protocol. The
 // tls-lb nginx front-end terminates public TLS, serves the static CDS/mesh-CA
 // certs, and reverse-proxies the attestation challenge, the handshake, and the
 // over-encrypted application paths to this sidecar on loopback. It lets an
@@ -56,16 +56,24 @@ type Config struct {
 	// report_data to this leaf's SPKI instead of a per-session over-encryption
 	// key. Empty disables the tls-cert binding.
 	ServingCertFile string
-	Backend         Backend // over-encrypted application backend (nil => EchoBackend)
-	SessionTTL      time.Duration
+	// MeshIdentity* are the TEE-held mesh leaf, matching private key, and CA
+	// bundle used by the identity-bound PQ v2 flow. They are deliberately
+	// separate from ServingCertFile, which may name a host-visible public TLS
+	// credential. All three files are re-read for each v2 attestation request.
+	MeshIdentityCertFile string
+	MeshIdentityKeyFile  string
+	MeshIdentityCAFile   string
+	Backend              Backend // over-encrypted application backend (nil => EchoBackend)
+	SessionTTL           time.Duration
 	// NonceTTL bounds how long a pending handshake nonce stays valid between
 	// the attestation fetch and the handshake POST. Defaults to SessionTTL.
 	NonceTTL time.Duration
 }
 
 type pendingSession struct {
-	key       *overenc.ServerKey
-	createdAt time.Time
+	key                *overenc.ServerKey
+	identityTranscript []byte
+	createdAt          time.Time
 }
 
 type establishedSession struct {
@@ -73,7 +81,7 @@ type establishedSession struct {
 	lastUsed time.Time
 }
 
-// Server serves the c8s-verify/v1 endpoints.
+// Server serves the c8s-verify v1 and v2 endpoints.
 type Server struct {
 	cfg     Config
 	log     *slog.Logger
@@ -155,11 +163,26 @@ func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 	// serving-leaf SPKI instead of a per-session over-encryption key. It is for
 	// clients that ride the validated upstream TLS (e.g. TEErminator Flow B)
 	// rather than the post-quantum tunnel. pq=true (or absent) is the default.
+	binding := r.URL.Query().Get("binding")
 	if r.URL.Query().Get("pq") == "false" {
+		if binding != "" {
+			writeErr(w, http.StatusBadRequest, "invalid_request", "pq=false cannot be combined with a PQ binding")
+			return
+		}
 		s.handleAttestationTLSCert(w, r, nonceB64, nonce)
 		return
 	}
+	switch binding {
+	case "", types.BindingOverEncryption:
+		s.handleAttestationOverEncryption(w, r, nonceB64, nonce, types.BindingOverEncryption)
+	case types.BindingOverEncryptionMeshIdentityV2:
+		s.handleAttestationOverEncryption(w, r, nonceB64, nonce, types.BindingOverEncryptionMeshIdentityV2)
+	default:
+		writeErr(w, http.StatusBadRequest, "invalid_request", "unsupported attestation binding")
+	}
+}
 
+func (s *Server) handleAttestationOverEncryption(w http.ResponseWriter, r *http.Request, nonceB64 string, nonce []byte, binding string) {
 	key, err := overenc.GenerateServerKey()
 	if err != nil {
 		s.log.Error("generate session key", "error", err)
@@ -168,9 +191,38 @@ func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 	}
 	pub := key.Public()
 
-	// report_data = SHA-384(x25519 || mlkem768 || nonce): binds the session key
-	// and the client nonce into the hardware report the verifier checks.
-	reportData := reportDataFor(pub, nonce)
+	version := "c8s-verify/v1"
+	certPEM := s.cfg.CDSCertPEM
+	var proof *types.MeshIdentityProof
+	var reportData []byte
+	switch binding {
+	case types.BindingOverEncryption:
+		// report_data = SHA-384(x25519 || mlkem768 || nonce).
+		reportData = reportDataFor(pub, nonce)
+	case types.BindingOverEncryptionMeshIdentityV2:
+		if len(nonce) != 32 {
+			writeErr(w, http.StatusBadRequest, "invalid_request", "identity-bound PQ requires a 32-byte nonce")
+			return
+		}
+		if s.cfg.MeshIdentityCertFile == "" || s.cfg.MeshIdentityKeyFile == "" || s.cfg.MeshIdentityCAFile == "" {
+			writeErr(w, http.StatusNotImplemented, "binding_unavailable", "identity-bound PQ is not configured on this LB")
+			return
+		}
+		identity, err := loadMeshIdentity(s.cfg.MeshIdentityCertFile, s.cfg.MeshIdentityKeyFile, s.cfg.MeshIdentityCAFile)
+		if err != nil {
+			s.log.Error("mesh identity binding unavailable", "error", err)
+			writeErr(w, http.StatusServiceUnavailable, "binding_unavailable", "identity-bound PQ credentials are temporarily unavailable")
+			return
+		}
+		reportData, proof, err = identity.bind(pub, nonce)
+		if err != nil {
+			s.log.Error("bind mesh identity", "error", err)
+			writeErr(w, http.StatusInternalServerError, "internal", "mesh identity binding failed")
+			return
+		}
+		version = "c8s-verify/v2"
+		certPEM = identity.bundlePEM
+	}
 
 	evidence, platform, generation, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
 	if err != nil {
@@ -181,21 +233,26 @@ func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 
 	s.sweep()
 	s.mu.Lock()
-	s.pending[nonceB64] = pendingSession{key: key, createdAt: time.Now()}
+	pending := pendingSession{key: key, createdAt: time.Now()}
+	if binding == types.BindingOverEncryptionMeshIdentityV2 {
+		pending.identityTranscript = append([]byte(nil), reportData...)
+	}
+	s.pending[nonceB64] = pending
 	s.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, types.AttestationBundle{
-		Version:    "c8s-verify/v1",
+		Version:    version,
 		Platform:   platform,
 		Generation: generation,
 		Nonce:      nonceB64,
 		Evidence:   evidence,
-		CDSCertPEM: string(s.cfg.CDSCertPEM),
-		Binding:    types.BindingOverEncryption,
+		CDSCertPEM: string(certPEM),
+		Binding:    binding,
 		SessionPubKey: &types.SessionPublicKey{
 			X25519:   base64.RawURLEncoding.EncodeToString(pub.X25519),
 			MLKEM768: base64.RawURLEncoding.EncodeToString(pub.MLKEM768),
 		},
+		IdentityProof: proof,
 	})
 }
 
@@ -289,7 +346,13 @@ func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	channel, err := entry.key.Agree(overenc.Handshake{ClientX25519: clientX, MLKEMCiphertext: ct}, nonce)
+	handshake := overenc.Handshake{ClientX25519: clientX, MLKEMCiphertext: ct}
+	var channel *overenc.Channel
+	if len(entry.identityTranscript) > 0 {
+		channel, err = entry.key.AgreeIdentity(handshake, entry.identityTranscript)
+	} else {
+		channel, err = entry.key.Agree(handshake, nonce)
+	}
 	if err != nil {
 		s.log.Warn("handshake agree failed", "error", err)
 		writeErr(w, http.StatusBadRequest, "channel_error", "key agreement failed")

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -156,12 +156,20 @@ spec:
             # publicTLS secret it is that cert (mounted below). Re-read per request, so
             # get-cert renewals are picked up.
             - --serving-cert-file={{ include "tls-lb.publicCertPath" . }}
+            # The identity-bound PQ v2 flow must use the TEE-held mesh
+            # credential, never the optional publicTLS Secret: report_data
+            # commits the hybrid session key to this leaf and the sidecar
+            # proves possession with its matching private key.
+            - --mesh-identity-cert-file={{ .Values.tlsLb.tlsMountPath }}/cert.pem
+            - --mesh-identity-key-file={{ .Values.tlsLb.tlsMountPath }}/key.pem
+            - --mesh-identity-ca-file={{ .Values.tlsLb.tlsMountPath }}/ca.pem
             # --cds-cert-file is intentionally NOT set: nginx serves the same cert
             # statically at /.well-known/c8s/cds-cert.pem from the shared cert volume
             # and hot-reloads it on get-cert renewal (SIGHUP), whereas cds-attest
             # would read it once at startup and embed a stale copy in every bundle.
-            # The cds_cert_pem is not bound to the attestation (report_data binds the
-            # session key), so the client pins the mesh CA out of band instead.
+            # Legacy v1 does not bind cds_cert_pem to attestation. The v2 PQ
+            # response re-reads and embeds the exact mesh leaf + issuing CA
+            # committed by report_data and its proof-of-possession signature.
             # Terminate over-encryption here and forward to the same workload
             # backend nginx proxies to. An http upstream is plaintext at the
             # app layer; pointed at a headless Service (an adopted workload),

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1623,6 +1623,9 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 		"--port=8800",
 		"--generation=milan",
 		"--attestation-api-url=http://",
+		"--mesh-identity-cert-file=/tls/cert.pem",
+		"--mesh-identity-key-file=/tls/key.pem",
+		"--mesh-identity-ca-file=/tls/ca.pem",
 		// The baseline mesh-wrapped upstream is a plain-HTTP workload upstream;
 		// the mTLS args render only for an https upstream.
 		"--upstream=http://c8s-infer.c8s-system.svc.cluster.local:8000",

--- a/pkg/overenc/identity.go
+++ b/pkg/overenc/identity.go
@@ -1,0 +1,89 @@
+package overenc
+
+import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	identityTranscriptDomain = "c8s-verify/pq-mesh-identity/v2"
+	identityProofDomain      = "c8s-verify/pq-mesh-identity-proof/v2"
+	identityNonceBytes       = 32
+)
+
+// IdentityTranscriptHash commits the hybrid server key, client nonce, exact
+// mesh leaf, and issuing mesh CA to one SHA-384 value suitable for TEE
+// report_data. Every variable-length field is length-prefixed to make the
+// transcript unambiguous across the Go and browser implementations.
+func IdentityTranscriptHash(pub PublicKey, nonce, leafDER, caDER []byte) ([]byte, error) {
+	if len(pub.X25519) != X25519PubBytes {
+		return nil, fmt.Errorf("overenc: identity transcript X25519 key must be %d bytes, got %d", X25519PubBytes, len(pub.X25519))
+	}
+	if len(pub.MLKEM768) != MLKEM768EKBytes {
+		return nil, fmt.Errorf("overenc: identity transcript ML-KEM key must be %d bytes, got %d", MLKEM768EKBytes, len(pub.MLKEM768))
+	}
+	if len(nonce) != identityNonceBytes {
+		return nil, fmt.Errorf("overenc: identity transcript nonce must be %d bytes, got %d", identityNonceBytes, len(nonce))
+	}
+	if len(leafDER) == 0 || len(caDER) == 0 {
+		return nil, fmt.Errorf("overenc: identity transcript requires leaf and CA certificates")
+	}
+
+	leafHash := sha256.Sum256(leafDER)
+	caHash := sha256.Sum256(caDER)
+	h := sha512.New384()
+	for _, field := range [][]byte{
+		[]byte(identityTranscriptDomain),
+		pub.X25519,
+		pub.MLKEM768,
+		nonce,
+		leafHash[:],
+		caHash[:],
+	} {
+		if err := writeTranscriptField(h, field); err != nil {
+			return nil, err
+		}
+	}
+	return h.Sum(nil), nil
+}
+
+// IdentityProofMessage returns the domain-separated message signed by the
+// mesh leaf. The TEE report authenticates transcriptHash; this signature proves
+// possession of the private key for the exact leaf committed by that report.
+func IdentityProofMessage(transcriptHash []byte) ([]byte, error) {
+	if len(transcriptHash) != sha512.Size384 {
+		return nil, fmt.Errorf("overenc: identity transcript hash must be %d bytes, got %d", sha512.Size384, len(transcriptHash))
+	}
+	message := make([]byte, 0, 8+len(identityProofDomain)+len(transcriptHash))
+	message = appendLengthPrefixed(message, []byte(identityProofDomain))
+	message = appendLengthPrefixed(message, transcriptHash)
+	return message, nil
+}
+
+type transcriptWriter interface {
+	Write([]byte) (int, error)
+}
+
+func writeTranscriptField(w transcriptWriter, field []byte) error {
+	if uint64(len(field)) > uint64(^uint32(0)) {
+		return fmt.Errorf("overenc: identity transcript field is too large")
+	}
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(field)))
+	if _, err := w.Write(size[:]); err != nil {
+		return fmt.Errorf("overenc: hash identity transcript length: %w", err)
+	}
+	if _, err := w.Write(field); err != nil {
+		return fmt.Errorf("overenc: hash identity transcript field: %w", err)
+	}
+	return nil
+}
+
+func appendLengthPrefixed(dst, field []byte) []byte {
+	var size [4]byte
+	binary.BigEndian.PutUint32(size[:], uint32(len(field)))
+	dst = append(dst, size[:]...)
+	return append(dst, field...)
+}

--- a/pkg/overenc/identity_test.go
+++ b/pkg/overenc/identity_test.go
@@ -1,0 +1,92 @@
+package overenc
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/hex"
+	"testing"
+)
+
+func TestIdentityTranscriptHashBindsEveryField(t *testing.T) {
+	pub := PublicKey{
+		X25519:   bytes.Repeat([]byte{0x11}, X25519PubBytes),
+		MLKEM768: bytes.Repeat([]byte{0x22}, MLKEM768EKBytes),
+	}
+	nonce := bytes.Repeat([]byte{0x33}, identityNonceBytes)
+	leaf := []byte("leaf-der")
+	ca := []byte("ca-der")
+
+	base, err := IdentityTranscriptHash(pub, nonce, leaf, ca)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(base) != sha512.Size384 {
+		t.Fatalf("transcript hash length = %d, want %d", len(base), sha512.Size384)
+	}
+	const vector = "f6f10a6a95249c535ae3210248fa2c2fbe214744edffe53809795a877840731728175a35dd8091a1e15263190032b3f2"
+	if hex.EncodeToString(base) != vector {
+		t.Fatalf("cross-language transcript vector = %x, want %s", base, vector)
+	}
+
+	tests := []struct {
+		name  string
+		pub   PublicKey
+		nonce []byte
+		leaf  []byte
+		ca    []byte
+	}{
+		{name: "x25519", pub: PublicKey{X25519: bytes.Repeat([]byte{0x44}, X25519PubBytes), MLKEM768: pub.MLKEM768}, nonce: nonce, leaf: leaf, ca: ca},
+		{name: "mlkem", pub: PublicKey{X25519: pub.X25519, MLKEM768: bytes.Repeat([]byte{0x55}, MLKEM768EKBytes)}, nonce: nonce, leaf: leaf, ca: ca},
+		{name: "nonce", pub: pub, nonce: bytes.Repeat([]byte{0x66}, identityNonceBytes), leaf: leaf, ca: ca},
+		{name: "leaf", pub: pub, nonce: nonce, leaf: []byte("other-leaf"), ca: ca},
+		{name: "ca", pub: pub, nonce: nonce, leaf: leaf, ca: []byte("other-ca")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IdentityTranscriptHash(tt.pub, tt.nonce, tt.leaf, tt.ca)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Equal(got, base) {
+				t.Fatal("changed field did not change transcript hash")
+			}
+		})
+	}
+}
+
+func TestIdentityTranscriptHashValidatesShape(t *testing.T) {
+	valid := PublicKey{X25519: make([]byte, X25519PubBytes), MLKEM768: make([]byte, MLKEM768EKBytes)}
+	for _, tc := range []struct {
+		name  string
+		pub   PublicKey
+		nonce []byte
+		leaf  []byte
+		ca    []byte
+	}{
+		{name: "x25519", pub: PublicKey{X25519: make([]byte, 1), MLKEM768: valid.MLKEM768}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}},
+		{name: "mlkem", pub: PublicKey{X25519: valid.X25519, MLKEM768: make([]byte, 1)}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}},
+		{name: "nonce", pub: valid, nonce: make([]byte, 16), leaf: []byte{1}, ca: []byte{2}},
+		{name: "leaf", pub: valid, nonce: make([]byte, identityNonceBytes), ca: []byte{2}},
+		{name: "ca", pub: valid, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := IdentityTranscriptHash(tc.pub, tc.nonce, tc.leaf, tc.ca); err == nil {
+				t.Fatal("invalid transcript input accepted")
+			}
+		})
+	}
+}
+
+func TestIdentityProofMessageIsDomainSeparated(t *testing.T) {
+	h := bytes.Repeat([]byte{0x77}, sha512.Size384)
+	message, err := IdentityProofMessage(h)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(message, []byte(identityProofDomain)) || !bytes.Contains(message, h) {
+		t.Fatalf("proof message does not contain its domain and transcript hash: %x", message)
+	}
+	if _, err := IdentityProofMessage(h[:len(h)-1]); err == nil {
+		t.Fatal("short transcript hash accepted")
+	}
+}

--- a/pkg/overenc/overenc.go
+++ b/pkg/overenc/overenc.go
@@ -17,12 +17,14 @@ import (
 	"crypto/mlkem"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/sha512"
 	"fmt"
 )
 
 const (
-	hkdfInfo = "c8s-verify/over-encryption/v1"
-	ivBytes  = 12
+	hkdfInfoV1       = "c8s-verify/over-encryption/v1"
+	hkdfInfoIdentity = "c8s-verify/over-encryption/pq-mesh-identity/v2"
+	ivBytes          = 12
 
 	// X25519PubBytes is the raw X25519 public key length.
 	X25519PubBytes = 32
@@ -80,6 +82,19 @@ func (s *ServerKey) Public() PublicKey { return s.pub }
 // ML-KEM ciphertext, ECDH against the client's X25519 key, and derive the
 // AES-256-GCM channel keyed to nonce.
 func (s *ServerKey) Agree(hs Handshake, nonce []byte) (*Channel, error) {
+	return s.agree(hs, nonce, hkdfInfoV1)
+}
+
+// AgreeIdentity completes the identity-bound v2 handshake. transcriptHash is
+// the SHA-384 value committed to report_data and verified by the client.
+func (s *ServerKey) AgreeIdentity(hs Handshake, transcriptHash []byte) (*Channel, error) {
+	if len(transcriptHash) != sha512.Size384 {
+		return nil, fmt.Errorf("overenc: identity transcript hash must be %d bytes, got %d", sha512.Size384, len(transcriptHash))
+	}
+	return s.agree(hs, transcriptHash, hkdfInfoIdentity)
+}
+
+func (s *ServerKey) agree(hs Handshake, salt []byte, info string) (*Channel, error) {
 	if len(hs.MLKEMCiphertext) != MLKEM768CTBytes {
 		return nil, fmt.Errorf("overenc: ML-KEM ciphertext must be %d bytes, got %d", MLKEM768CTBytes, len(hs.MLKEMCiphertext))
 	}
@@ -98,12 +113,24 @@ func (s *ServerKey) Agree(hs Handshake, nonce []byte) (*Channel, error) {
 	if err != nil {
 		return nil, fmt.Errorf("overenc: X25519 ECDH: %w", err)
 	}
-	return deriveChannel(mlkemSS, x25519SS, nonce)
+	return deriveChannel(mlkemSS, x25519SS, salt, info)
 }
 
 // ClientAgree is the client side, provided for Go clients and interop tests:
 // encapsulate against the LB's hybrid public key and derive the same channel.
 func ClientAgree(pub PublicKey, nonce []byte) (*Channel, Handshake, error) {
+	return clientAgree(pub, nonce, hkdfInfoV1)
+}
+
+// ClientAgreeIdentity is the client half of the identity-bound v2 handshake.
+func ClientAgreeIdentity(pub PublicKey, transcriptHash []byte) (*Channel, Handshake, error) {
+	if len(transcriptHash) != sha512.Size384 {
+		return nil, Handshake{}, fmt.Errorf("overenc: identity transcript hash must be %d bytes, got %d", sha512.Size384, len(transcriptHash))
+	}
+	return clientAgree(pub, transcriptHash, hkdfInfoIdentity)
+}
+
+func clientAgree(pub PublicKey, salt []byte, info string) (*Channel, Handshake, error) {
 	if len(pub.MLKEM768) != MLKEM768EKBytes {
 		return nil, Handshake{}, fmt.Errorf("overenc: ML-KEM key must be %d bytes, got %d", MLKEM768EKBytes, len(pub.MLKEM768))
 	}
@@ -128,18 +155,18 @@ func ClientAgree(pub PublicKey, nonce []byte) (*Channel, Handshake, error) {
 	if err != nil {
 		return nil, Handshake{}, fmt.Errorf("overenc: X25519 ECDH: %w", err)
 	}
-	ch, err := deriveChannel(mlkemSS, x25519SS, nonce)
+	ch, err := deriveChannel(mlkemSS, x25519SS, salt, info)
 	if err != nil {
 		return nil, Handshake{}, err
 	}
 	return ch, Handshake{ClientX25519: clientPriv.PublicKey().Bytes(), MLKEMCiphertext: ct}, nil
 }
 
-func deriveChannel(mlkemSS, x25519SS, nonce []byte) (*Channel, error) {
+func deriveChannel(mlkemSS, x25519SS, salt []byte, info string) (*Channel, error) {
 	ikm := make([]byte, 0, len(mlkemSS)+len(x25519SS))
 	ikm = append(ikm, mlkemSS...)
 	ikm = append(ikm, x25519SS...)
-	key, err := hkdf.Key(sha256.New, ikm, nonce, hkdfInfo, 32)
+	key, err := hkdf.Key(sha256.New, ikm, salt, info, 32)
 	if err != nil {
 		return nil, fmt.Errorf("overenc: HKDF: %w", err)
 	}

--- a/pkg/overenc/overenc_test.go
+++ b/pkg/overenc/overenc_test.go
@@ -3,6 +3,7 @@ package overenc
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha512"
 	"testing"
 )
 
@@ -49,6 +50,57 @@ func TestHybridChannelRoundTrip(t *testing.T) {
 	got2, err := clientCh.Open(rec2, ResponseAAD())
 	if err != nil || string(got2) != "pong" {
 		t.Fatalf("reverse round-trip failed: %v %q", err, got2)
+	}
+}
+
+func TestIdentityChannelRoundTrip(t *testing.T) {
+	srv, err := GenerateServerKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	transcriptHash := bytes.Repeat([]byte{0xA5}, sha512.Size384)
+	clientCh, hs, err := ClientAgreeIdentity(srv.Public(), transcriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh, err := srv.AgreeIdentity(hs, transcriptHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := clientCh.Seal([]byte("identity-bound"), RequestAAD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := serverCh.Open(rec, RequestAAD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "identity-bound" {
+		t.Fatalf("opened %q", got)
+	}
+}
+
+func TestIdentityChannelRejectsMismatchedTranscript(t *testing.T) {
+	srv, err := GenerateServerKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientHash := bytes.Repeat([]byte{0xA5}, sha512.Size384)
+	serverHash := bytes.Repeat([]byte{0x5A}, sha512.Size384)
+	clientCh, hs, err := ClientAgreeIdentity(srv.Public(), clientHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh, err := srv.AgreeIdentity(hs, serverHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := clientCh.Seal([]byte("secret"), RequestAAD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := serverCh.Open(rec, RequestAAD()); err == nil {
+		t.Fatal("mismatched identity transcript derived the same channel")
 	}
 }
 

--- a/pkg/types/verify.go
+++ b/pkg/types/verify.go
@@ -2,15 +2,16 @@ package types
 
 import "encoding/json"
 
-// Browser-facing attestation + over-encryption wire types for the c8s-verify/v1
-// protocol served by the Load Balancer. These mirror c8s-verify-js/PROTOCOL.md
+// Browser-facing attestation + over-encryption wire types for the c8s-verify
+// v1 and v2 protocols served by the Load Balancer. These mirror
+// c8s-verify-js/PROTOCOL.md
 // and are consumed by the JavaScript client (c8s-verify-js) and any other
 // out-of-cluster verifier. All *_pubkey / handshake byte fields are base64url
 // (unpadded); the SNP evidence sub-fields use standard base64 (attestation-rs
 // SnpEvidence shape).
 
 // SessionPublicKey is the LB's per-session hybrid (X25519 + ML-KEM-768) public
-// key, bound into the hardware report_data as SHA-384(x25519 || mlkem768 || nonce).
+// key. The selected Binding defines the report_data transcript that commits it.
 type SessionPublicKey struct {
 	X25519   string `json:"x25519"`   // base64url, 32 bytes
 	MLKEM768 string `json:"mlkem768"` // base64url, 1184 bytes
@@ -25,16 +26,33 @@ const (
 	// BindingOverEncryption: report_data = SHA-384(x25519 || mlkem768 || nonce).
 	// The session key is bound, enabling the over-encryption handshake/tunnel.
 	BindingOverEncryption = "over-encryption"
+	// BindingOverEncryptionMeshIdentityV2 commits report_data to the hybrid
+	// session key, nonce, mesh leaf, and issuing mesh CA. IdentityProof then
+	// proves possession of that exact leaf's private key.
+	BindingOverEncryptionMeshIdentityV2 = "over-encryption+mesh-identity-v2"
 	// BindingTLSCert: report_data = SHA-384(serving_leaf_spki || nonce). The
 	// attestation is bound to the LB's TLS leaf, so a client verifies it against
 	// the certificate it already sees on the (mesh-CA-validated) connection.
 	BindingTLSCert = "tls-cert"
+
+	// MeshIdentityProofECDSASHA384 is the v2 proof-of-possession algorithm.
+	MeshIdentityProofECDSASHA384 = "ecdsa-sha384"
 )
 
+// MeshIdentityProof authenticates the PQ session transcript with the private
+// key corresponding to the mesh leaf in AttestationBundle.CDSCertPEM. Hashes
+// are base64url SHA-256; Signature is base64url ASN.1 DER ECDSA.
+type MeshIdentityProof struct {
+	Algorithm    string `json:"algorithm"`      // MeshIdentityProofECDSASHA384
+	LeafSHA256   string `json:"leaf_sha256"`    // base64url; exact leaf DER committed by report_data
+	MeshCASHA256 string `json:"mesh_ca_sha256"` // base64url; issuing CA DER committed by report_data
+	Signature    string `json:"signature"`      // base64url ASN.1 DER ECDSA signature
+}
+
 // AttestationBundle is the response body of
-// GET /.well-known/c8s/attestation?nonce=<b64url>[&pq=false].
+// GET /.well-known/c8s/attestation?nonce=<b64url>[&binding=...|&pq=false].
 type AttestationBundle struct {
-	Version    string          `json:"version"`      // "c8s-verify/v1"
+	Version    string          `json:"version"`      // "c8s-verify/v1" or "c8s-verify/v2"
 	Platform   string          `json:"platform"`     // "snp" today
 	Generation string          `json:"generation"`   // AMD gen: milan|genoa|turin
 	Nonce      string          `json:"nonce"`        // echoed client nonce (b64url)
@@ -46,6 +64,8 @@ type AttestationBundle struct {
 	// SessionPubKey is the per-session over-encryption key, present only for the
 	// over-encryption binding; omitted (nil) for the tls-cert binding.
 	SessionPubKey *SessionPublicKey `json:"session_pubkey,omitempty"`
+	// IdentityProof is present only for BindingOverEncryptionMeshIdentityV2.
+	IdentityProof *MeshIdentityProof `json:"identity_proof,omitempty"`
 }
 
 // HandshakeRequest is the body of POST /.well-known/c8s/handshake: the client


### PR DESCRIPTION
## Summary

- add an explicit c8s-verify/v2 binding that commits the X25519 and ML-KEM-768 session keys, client nonce, exact mesh leaf, and issuing mesh CA to one domain-separated attestation transcript
- prove possession of the committed leaf private key with a per-session ECDSA-SHA384 signature
- use the verified transcript as the v2 HKDF context, so certificate or session-key substitution derives a different channel
- read the TEE-held mesh leaf, key, and CA for every v2 request, fail closed on missing or inconsistent credentials, and wire those files into the tls-lb chart
- retain the v1 over-encryption and pq=false TLS-certificate bindings for compatibility

## Security guarantee

Previously, an attacker-operated LB with an allowed measurement could copy a victim cluster public leaf/CA chain. The hardware evidence authenticated the attacker session key while the independent certificate check authenticated only copied public bytes.

For a client that requires v2, acceptance now means all of the following hold:

1. hardware evidence from an allowed measurement commits the session keys, nonce, leaf hash, and CA hash;
2. the exact leaf chains to a mesh CA pinned out of band; and
3. the leaf proves possession of its private key by signing the same transcript.

Copying the public chain is therefore insufficient. Authentication is still classical ECDSA; X25519 + ML-KEM-768 provides hybrid session confidentiality. This change does not claim post-quantum authentication.

## Wire compatibility

- v2: binding=over-encryption+mesh-identity-v2, response version c8s-verify/v2
- v1: absent binding or binding=over-encryption remains unchanged
- TLS leaf flow: pq=false remains unchanged and cannot be combined with a PQ binding

Matching browser verifier: confidential-dot-ai/c8s-verify-js#10.

Companion threat-model correction: #56.

## Validation

- go test ./...
- Go/JavaScript cross-language transcript vector
- copied-leaf-without-key rejection
- mismatched transcript/channel rejection
- chart render coverage for the TEE-held identity mounts
