### PR TITLE
fix: various cleanups from agent testing

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -183,6 +183,147 @@ func preflightCDSNode(ctx context.Context, chartPath string) error {
 	return nil
 }
 
+// preflightTLSLBHostPort fails fast when tls-lb's host port is already bound on
+// every node, so the tls-lb pod would sit Pending and `--wait` would time out
+// with an opaque scheduler error. The classic collision is a bundled ingress
+// controller (rke2 ships rke2-ingress-nginx on host 80/443). Reads chart
+// defaults, so the caller gates it to the default (no -f) path where they apply.
+func preflightTLSLBHostPort(ctx context.Context, chartPath, namespace string) error {
+	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()
+	if err != nil {
+		return fmt.Errorf("helm show values %q: %w", chartPath, err)
+	}
+	var tree map[string]any
+	if err := yaml.Unmarshal(out, &tree); err != nil {
+		return fmt.Errorf("parse chart values: %w", err)
+	}
+	if !boolAtPath(tree, "tlsLb.enabled") || !boolAtPath(tree, "tlsLb.hostPort.enabled") {
+		return nil
+	}
+	port, err := tlsLBHostPort(tree)
+	if err != nil {
+		return err
+	}
+
+	nodesOut, err := exec.CommandContext(ctx, "kubectl", "get", "nodes",
+		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}`).Output()
+	if err != nil {
+		return fmt.Errorf("kubectl get nodes: %w", err)
+	}
+	var nodes []string
+	for _, n := range strings.Split(strings.TrimSpace(string(nodesOut)), "\n") {
+		if n = strings.TrimSpace(n); n != "" {
+			nodes = append(nodes, n)
+		}
+	}
+
+	podsJSON, err := exec.CommandContext(ctx, "kubectl", "get", "pods",
+		"--all-namespaces", "-o", "json").Output()
+	if err != nil {
+		return fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
+	}
+	var list corev1.PodList
+	if err := json.Unmarshal(podsJSON, &list); err != nil {
+		return fmt.Errorf("parse pod list: %w", err)
+	}
+
+	// Ignore the install namespace: c8s's own tls-lb pod lives there, so a
+	// re-install (Recreate) does not flag itself.
+	if blocked, holders := hostPortConflict(list.Items, nodes, port, namespace); blocked {
+		return fmt.Errorf("tls-lb wants host port %d but it is already bound on every node by: %s. "+
+			"tls-lb would stay Pending and --wait would time out. Reach tls-lb via its Service, or install with "+
+			"-f setting tlsLb.hostPort.enabled=false (or tlsLb.hostPort.https to a free port, or tlsLb.enabled=false)",
+			port, strings.Join(holders, ", "))
+	}
+	return nil
+}
+
+// boolAtPath walks a dotted path through a decoded YAML tree and returns the
+// bool at it, or false if a segment is missing or the leaf is not a bool.
+func boolAtPath(tree map[string]any, path string) bool {
+	var cur any = tree
+	for _, seg := range strings.Split(path, ".") {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return false
+		}
+		cur = m[seg]
+	}
+	b, _ := cur.(bool)
+	return b
+}
+
+// tlsLBHostPort resolves tlsLb.hostPort.https, defaulting to 443 (the chart's
+// empty-string default derives 443).
+func tlsLBHostPort(tree map[string]any) (int32, error) {
+	m, ok := nestedMap(tree, "tlsLb", "hostPort")
+	if !ok {
+		return 443, nil
+	}
+	switch v := m["https"].(type) {
+	case nil:
+		return 443, nil
+	case string:
+		if v == "" {
+			return 443, nil
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("tlsLb.hostPort.https %q is not a port number: %w", v, err)
+		}
+		return int32(n), nil
+	case int:
+		return int32(v), nil
+	case float64:
+		return int32(v), nil
+	default:
+		return 0, fmt.Errorf("tlsLb.hostPort.https has unexpected type %T", v)
+	}
+}
+
+// hostPortConflict reports whether port is already bound on every node (so a new
+// host-port pod cannot schedule anywhere), along with the pods that hold it.
+// Pods in ignoreNamespace are skipped so c8s's own tls-lb does not self-flag.
+func hostPortConflict(pods []corev1.Pod, nodes []string, port int32, ignoreNamespace string) (bool, []string) {
+	taken := map[string]bool{}
+	holderSet := map[string]bool{}
+	for _, p := range pods {
+		if p.Namespace == ignoreNamespace || !podBindsHostPort(p, port) {
+			continue
+		}
+		holderSet[p.Namespace+"/"+p.Name] = true
+		if p.Spec.NodeName != "" {
+			taken[p.Spec.NodeName] = true
+		}
+	}
+	holders := make([]string, 0, len(holderSet))
+	for h := range holderSet {
+		holders = append(holders, h)
+	}
+	sort.Strings(holders)
+
+	if len(nodes) == 0 {
+		return false, holders
+	}
+	for _, n := range nodes {
+		if !taken[n] {
+			return false, holders // a free node exists; tls-lb can bind there
+		}
+	}
+	return true, holders
+}
+
+func podBindsHostPort(p corev1.Pod, port int32) bool {
+	for _, c := range append(append([]corev1.Container{}, p.Spec.InitContainers...), p.Spec.Containers...) {
+		for _, cp := range c.Ports {
+			if cp.HostPort == port {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // preflightTDXNodes fails fast when --hardware-platform=tdx but no node carries
 // the confidential.ai/tdx=true label — the label the kata-qemu-tdx*
 // RuntimeClass nodeSelectors expect (kata.tdxNodeSelector default). On the
@@ -382,6 +523,29 @@ func stringAtPath(tree map[string]any, path string) (string, error) {
 	return s, nil
 }
 
+// valuesFilesSetDistro reports whether any -f values file explicitly sets
+// kata.distro or nriImagePolicy.distro. When one does, that file owns the host
+// containerd layout and cluster auto-detection must stand aside; when none
+// does, detection still applies even though other values were supplied.
+func valuesFilesSetDistro(files []string) (bool, error) {
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return false, fmt.Errorf("read values file %q: %w", f, err)
+		}
+		var tree map[string]any
+		if err := yaml.Unmarshal(data, &tree); err != nil {
+			return false, fmt.Errorf("parse values file %q: %w", f, err)
+		}
+		for _, path := range []string{"kata.distro", "nriImagePolicy.distro"} {
+			if v, err := stringAtPath(tree, path); err == nil && v != "" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install the c8s operator, CRDs, attestation-api, and component charts via Helm",
@@ -499,13 +663,16 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// kata-deploy and nri-image-policy must bind the host's containerd
 		// layout in every install mode, so the distro is detected from the
 		// cluster's kubelet versions and plumbed; letting the chart default
-		// (k8s) stand would silently mis-target RKE2. With -f nothing is
-		// plumbed — helm gives --set precedence over -f, and the values-file
-		// owner owns the layout (kata.distro / nriImagePolicy.distro there if
-		// the chart default doesn't fit). buildValueArgs skips the distro when
-		// it is empty.
+		// (k8s) stand would silently mis-target RKE2. Detection is suppressed
+		// only when a -f file actually sets kata.distro / nriImagePolicy.distro
+		// (that file then owns the layout) — not merely because some -f is
+		// present. buildValueArgs skips the distro when it is empty.
 		distro := ""
-		if len(installValues) == 0 {
+		distroInValues, err := valuesFilesSetDistro(installValues)
+		if err != nil {
+			return err
+		}
+		if !distroInValues {
 			distro, err = detectDistro(cmd.Context())
 			if err != nil {
 				return err
@@ -545,6 +712,15 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// clears the selector so no node needs the label.
 		if len(installValues) == 0 && !installSingleNode {
 			if err := preflightCDSNode(cmd.Context(), chartPath); err != nil {
+				return err
+			}
+		}
+
+		// Fail fast when tls-lb's host port is already taken cluster-wide (e.g.
+		// an existing ingress owns 443), which would otherwise wedge `--wait`.
+		// Default path only: a -f owner controls tlsLb.* and node placement.
+		if len(installValues) == 0 {
+			if err := preflightTLSLBHostPort(cmd.Context(), chartPath, installNamespace); err != nil {
 				return err
 			}
 		}

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -260,6 +260,7 @@ func tlsLBHostPort(tree map[string]any) (int32, error) {
 	if !ok {
 		return 443, nil
 	}
+	var port int64
 	switch v := m["https"].(type) {
 	case nil:
 		return 443, nil
@@ -267,18 +268,23 @@ func tlsLBHostPort(tree map[string]any) (int32, error) {
 		if v == "" {
 			return 443, nil
 		}
-		n, err := strconv.Atoi(v)
+		// ParseInt with bitSize 32 rejects values that would overflow int32.
+		n, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
-			return 0, fmt.Errorf("tlsLb.hostPort.https %q is not a port number: %w", v, err)
+			return 0, fmt.Errorf("tlsLb.hostPort.https %q is not a valid port number: %w", v, err)
 		}
-		return int32(n), nil
+		port = n
 	case int:
-		return int32(v), nil
+		port = int64(v)
 	case float64:
-		return int32(v), nil
+		port = int64(v)
 	default:
 		return 0, fmt.Errorf("tlsLb.hostPort.https has unexpected type %T", v)
 	}
+	if port < 1 || port > 65535 {
+		return 0, fmt.Errorf("tlsLb.hostPort.https %d is out of range (1-65535)", port)
+	}
+	return int32(port), nil
 }
 
 // hostPortConflict reports whether port is already bound on every node (so a new

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -15,6 +15,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/confidential-dot-ai/c8s/internal/helmchart"
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
@@ -797,6 +798,165 @@ func TestChooseDistroRejectsMixedClusters(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error %q missing %q (should name the fix and both node sets)", err.Error(), want)
 		}
+	}
+}
+
+// A -f file suppresses distro auto-detection only when it actually sets a
+// distro; passing -f for any other value must leave detection in force (the
+// bug: any -f used to silently drop the CLI to the chart's k8s default).
+func TestValuesFilesSetDistro(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "values.yaml")
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write values: %v", err)
+		}
+		return p
+	}
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"nri distro set", "nriImagePolicy:\n  distro: rke2\n", true},
+		{"kata distro set", "kata:\n  distro: rke2\n", true},
+		{"unrelated value only", "tlsLb:\n  enabled: false\n", false},
+		{"distro key absent under section", "nriImagePolicy:\n  enabled: true\n", false},
+		{"empty distro string is not a choice", "nriImagePolicy:\n  distro: \"\"\n", false},
+		{"empty file", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := valuesFilesSetDistro([]string{write(t, tc.body)})
+			if err != nil {
+				t.Fatalf("valuesFilesSetDistro: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("valuesFilesSetDistro(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("no files means detect", func(t *testing.T) {
+		got, err := valuesFilesSetDistro(nil)
+		if err != nil || got {
+			t.Errorf("valuesFilesSetDistro(nil) = (%v, %v), want (false, nil)", got, err)
+		}
+	})
+
+	t.Run("one of several files sets it", func(t *testing.T) {
+		a := write(t, "tlsLb:\n  enabled: false\n")
+		b := write(t, "kata:\n  distro: rke2\n")
+		got, err := valuesFilesSetDistro([]string{a, b})
+		if err != nil || !got {
+			t.Errorf("valuesFilesSetDistro(two files) = (%v, %v), want (true, nil)", got, err)
+		}
+	})
+}
+
+func TestTLSLBHostPort(t *testing.T) {
+	hp := func(https any) map[string]any {
+		return map[string]any{"tlsLb": map[string]any{"hostPort": map[string]any{"https": https}}}
+	}
+	for _, tc := range []struct {
+		name string
+		tree map[string]any
+		want int32
+	}{
+		{"empty string derives 443", hp(""), 443},
+		{"no hostPort map", map[string]any{"tlsLb": map[string]any{}}, 443},
+		{"string override", hp("8443"), 8443},
+		{"int override", hp(9443), 9443},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tlsLBHostPort(tc.tree)
+			if err != nil || got != tc.want {
+				t.Fatalf("tlsLBHostPort = (%d, %v), want (%d, nil)", got, err, tc.want)
+			}
+		})
+	}
+	t.Run("non-numeric string errors", func(t *testing.T) {
+		if _, err := tlsLBHostPort(hp("https")); err == nil {
+			t.Fatal("want error for a non-numeric port")
+		}
+	})
+}
+
+func TestHostPortConflict(t *testing.T) {
+	pod := func(ns, name, node string, port int32) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+			Spec: corev1.PodSpec{
+				NodeName:   node,
+				Containers: []corev1.Container{{Name: "c", Ports: []corev1.ContainerPort{{HostPort: port}}}},
+			},
+		}
+	}
+	const ignoreNS = "c8s-system"
+
+	for _, tc := range []struct {
+		name        string
+		pods        []corev1.Pod
+		nodes       []string
+		wantBlocked bool
+		wantHolder  string // substring expected in holders, or "" for none
+	}{
+		{
+			name:        "single node, ingress holds 443",
+			pods:        []corev1.Pod{pod("kube-system", "rke2-ingress-nginx-abc", "node-a", 443)},
+			nodes:       []string{"node-a"},
+			wantBlocked: true,
+			wantHolder:  "kube-system/rke2-ingress-nginx-abc",
+		},
+		{
+			name: "two nodes, ingress on both",
+			pods: []corev1.Pod{
+				pod("kube-system", "ing-a", "node-a", 443),
+				pod("kube-system", "ing-b", "node-b", 443),
+			},
+			nodes:       []string{"node-a", "node-b"},
+			wantBlocked: true,
+		},
+		{
+			name:        "two nodes, ingress on only one leaves a free node",
+			pods:        []corev1.Pod{pod("kube-system", "ing-a", "node-a", 443)},
+			nodes:       []string{"node-a", "node-b"},
+			wantBlocked: false,
+		},
+		{
+			name:        "holder only in ignored namespace",
+			pods:        []corev1.Pod{pod(ignoreNS, "c8s-tls-lb", "node-a", 443)},
+			nodes:       []string{"node-a"},
+			wantBlocked: false,
+		},
+		{
+			name:        "different port is not a conflict",
+			pods:        []corev1.Pod{pod("kube-system", "ing-a", "node-a", 8080)},
+			nodes:       []string{"node-a"},
+			wantBlocked: false,
+		},
+		{
+			name:        "unscheduled holder occupies no node",
+			pods:        []corev1.Pod{pod("kube-system", "pending", "", 443)},
+			nodes:       []string{"node-a"},
+			wantBlocked: false,
+			wantHolder:  "kube-system/pending",
+		},
+		{
+			name:        "no nodes",
+			pods:        []corev1.Pod{pod("kube-system", "ing-a", "node-a", 443)},
+			nodes:       nil,
+			wantBlocked: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocked, holders := hostPortConflict(tc.pods, tc.nodes, 443, ignoreNS)
+			if blocked != tc.wantBlocked {
+				t.Errorf("blocked = %v, want %v (holders=%v)", blocked, tc.wantBlocked, holders)
+			}
+			if tc.wantHolder != "" && !strings.Contains(strings.Join(holders, ","), tc.wantHolder) {
+				t.Errorf("holders %v missing %q", holders, tc.wantHolder)
+			}
+		})
 	}
 }
 

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -874,11 +874,22 @@ func TestTLSLBHostPort(t *testing.T) {
 			}
 		})
 	}
-	t.Run("non-numeric string errors", func(t *testing.T) {
-		if _, err := tlsLBHostPort(hp("https")); err == nil {
-			t.Fatal("want error for a non-numeric port")
-		}
-	})
+	for _, tc := range []struct {
+		name  string
+		https any
+	}{
+		{"non-numeric string", "https"},
+		{"string overflows int32", "4294967297"}, // 2^32 + 1 — would wrap to 1 on a bare int32 cast
+		{"string above port range", "70000"},
+		{"int above port range", 70000},
+		{"zero is not a port", 0},
+	} {
+		t.Run(tc.name+" errors", func(t *testing.T) {
+			if _, err := tlsLBHostPort(hp(tc.https)); err == nil {
+				t.Fatalf("want error for %v", tc.https)
+			}
+		})
+	}
 }
 
 func TestHostPortConflict(t *testing.T) {

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -7,6 +7,7 @@ final security model. Each bullet links to the tracking issue.
 ## Trust model
 
 - Chart-managed CDS runs as a singleton and keeps the active CA key in memory (tracked at [#18](https://github.com/confidential-dot-ai/c8s/issues/18)).
+- CDS allowlist persistence is off by default (`cds.persistence.enabled=false`), so a restart resets the served allowlist to the install seed and operator-added digests (`c8s allowlist add`) are lost — workloads using them are denied ~30s later. CDS warns at startup when persistence is off; enable `cds.persistence.enabled=true` to retain dynamic entries. See `docs/operator.md` "Operator-added allowlist entries need persistence to survive a restart".
 - Active/active CDS replica handoff is opt-in via `cds.handoff.enabled`; it is off by default (tracked at [#18](https://github.com/confidential-dot-ai/c8s/issues/18)).
 - Application-secret release is not implemented (tracked at [#46](https://github.com/confidential-dot-ai/c8s/issues/46)).
 - Per-workload measurement allowlists are not enforced at `/attest` (tracked at [#57](https://github.com/confidential-dot-ai/c8s/issues/57)).
@@ -140,3 +141,9 @@ could close.
   ticker/select loops, signal handlers, real-listener `run()` entrypoints, and
   `crypto/rand`/marshal failure branches that cannot be triggered deterministically
   without injecting faults into non-test source.
+- Cross-CVM mesh CA handoff cannot be exercised end-to-end on a single-node
+  cluster: a CDS on one CVM handing its CA to a **differently-measured** CDS on a
+  second CVM, and `/handoff` **rejecting** a peer whose launch measurement is not
+  in `cds.measurements`, both need a second, independently-measured confidential
+  VM. The measurement-gating logic is unit-tested with synthetic measurements;
+  the two-CVM path itself needs multi-node confidential infrastructure in CI.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -293,6 +293,20 @@ without crashing the binary; the handoff handler stays unregistered and the
 restart-fragility window above applies until the operator fixes the
 underlying issue.
 
+### Operator-added allowlist entries need persistence to survive a restart
+
+The same restart that re-bootstraps the mesh CA also resets the **served
+allowlist**. CDS seeds its store from the install seed at startup, then serves
+whatever an operator adds with `c8s allowlist add`. With
+`cds.persistence.enabled=false` (the default) that store is an `emptyDir`, so a
+restart (OOM, drain, upgrade, scale) drops every operator-added digest back to
+the install seed — workloads pulling those images are denied roughly one worker
+poll interval (~30s) later. CDS logs a warning at startup when persistence is
+off. To keep dynamic entries across restarts set `cds.persistence.enabled=true`
+(an RWO PVC); otherwise re-run `c8s allowlist add` after any CDS restart.
+Component/floor digests are unaffected — they are re-seeded and, unlike dynamic
+entries, are also enforced from the baked floor.
+
 ## Verifying attestation after install
 
 `c8s verify` (and `c8s cds verify`, shorthand for `c8s verify --kind cds`) fetches

--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -214,6 +214,20 @@ func (o *options) signer() (*operatorauth.Signer, error) {
 	return signer, nil
 }
 
+// matchedComponents returns the required component identifiers that appear as a
+// (case-insensitive) substring of image — the same name-based signal the upload
+// guard uses, applied to a single reference to recognise a component floor image.
+func matchedComponents(image string, required []string) []string {
+	low := strings.ToLower(image)
+	var hits []string
+	for _, comp := range required {
+		if strings.Contains(low, strings.ToLower(comp)) {
+			hits = append(hits, comp)
+		}
+	}
+	return hits
+}
+
 // missingComponents returns the required component identifiers not present as a
 // (case-insensitive) substring of any image reference in images.
 func missingComponents(images map[string]string, required []string) []string {

--- a/internal/cmds/allowlist/integration_test.go
+++ b/internal/cmds/allowlist/integration_test.go
@@ -10,11 +10,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	internalallowlist "github.com/confidential-dot-ai/c8s/internal/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // newOperatorKeypair writes an operator EC private key to dir and returns its
@@ -100,4 +102,43 @@ func TestUploadRejectedWhenKeyNotPinned(t *testing.T) {
 	if len(digests) != 0 {
 		t.Fatalf("store mutated despite rejected auth: %d entries", len(digests))
 	}
+}
+
+// TestRemoveWarnsOnComponentFloorImage drives the real CLI + CDS handler.
+// Removing a digest whose served ref names a c8s component must warn that
+// enforcement is unchanged (the floor keeps admitting it); removing a plain
+// workload digest must not.
+func TestRemoveWarnsOnComponentFloorImage(t *testing.T) {
+	dir := t.TempDir()
+	keyPath, pub := newOperatorKeypair(t, dir, "op.key")
+	srv, store := cdsTestServer(t, []*ecdsa.PublicKey{pub})
+
+	cdsD, _ := types.ParseDigest("sha256:1111111111111111111111111111111111111111111111111111111111111111")
+	workloadD, _ := types.ParseDigest("sha256:2222222222222222222222222222222222222222222222222222222222222222")
+	if err := store.Add(cdsD, "ghcr.io/confidential-dot-ai/cds@"+cdsD.String()); err != nil {
+		t.Fatalf("seed cds digest: %v", err)
+	}
+	if err := store.Add(workloadD, "registry.example.com/team/app@"+workloadD.String()); err != nil {
+		t.Fatalf("seed workload digest: %v", err)
+	}
+
+	t.Run("component digest warns", func(t *testing.T) {
+		_, stderr, err := runCmd("remove", cdsD.String(), "--url", srv.URL, "--insecure", "--operator-key", keyPath)
+		if err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		if !strings.Contains(stderr, "component floor image") {
+			t.Errorf("expected component floor-image warning, stderr=%q", stderr)
+		}
+	})
+
+	t.Run("workload digest does not warn", func(t *testing.T) {
+		_, stderr, err := runCmd("remove", workloadD.String(), "--url", srv.URL, "--insecure", "--operator-key", keyPath)
+		if err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+		if strings.Contains(stderr, "component floor image") {
+			t.Errorf("unexpected floor-image warning for workload digest, stderr=%q", stderr)
+		}
+	})
 }

--- a/internal/cmds/allowlist/write.go
+++ b/internal/cmds/allowlist/write.go
@@ -80,10 +80,33 @@ func newRemoveCmd(o *options) *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			// Resolve the digests' image refs before deleting, so we can flag any
+			// that are c8s component floor images: removing those from CDS does
+			// not lock them out — the NRI plugin always_allow and the in-guest
+			// baked seed keep admitting them — so a bare "removed" is misleading.
+			served := map[types.Digest]string{}
+			if resp, err := c.List(ctx(cmd)); err == nil {
+				served = resp.Digests
+			} else {
+				fmt.Fprintf(cmd.ErrOrStderr(), "warning: could not fetch allowlist to check for component floor images: %v\n", err)
+			}
+
 			if err := c.Delete(ctx(cmd), digests, signer); err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "removed %d digest(s)\n", len(digests))
+
+			for _, d := range digests {
+				if len(matchedComponents(served[d], defaultRequiredComponents)) == 0 {
+					continue
+				}
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"warning: %s (%s) is a c8s component floor image; removing it from CDS does not lock it out — "+
+						"the NRI plugin always_allow and the in-guest baked seed still admit it. "+
+						"To block a compromised component image, roll the chart with the bad digest replaced.\n",
+					d, served[d])
+			}
 			return nil
 		},
 	}

--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -106,19 +106,10 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 	reportData := types.NewBase64Bytes(expectedReportData[:sha512.Size384])
 	verifyReq := types.VerifyReportData(req.Evidence, reportData)
 	verifyResp, err := h.AttestationClient.VerifyEnforced(ctx, verifyReq)
-	switch {
-	case errors.Is(err, attestationclient.ErrSignatureInvalid):
-		slog.Warn("attestation signature invalid")
-		attestation.WriteError(w, http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "attestation signature invalid")
-		return
-	case errors.Is(err, attestationclient.ErrReportDataMismatch):
-		slog.Warn("challenge did not match attestation evidence")
-		attestation.WriteError(w, http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "challenge mismatch in attestation evidence")
-		return
-	case err != nil:
-		slog.Warn("attestation-api error", "error", err)
-		attestation.WriteError(w, http.StatusBadGateway, types.ErrorCodeAttestationApiUnreachable,
-			fmt.Sprintf("failed to reach attestation-api: %s", err))
+	if err != nil {
+		status, code, msg := classifyVerifyError(err)
+		slog.Warn("attestation verification failed", "status", status, "error", err)
+		attestation.WriteError(w, status, code, msg)
 		return
 	}
 
@@ -176,4 +167,24 @@ func (h AttestHandler) caChainPEM() []byte {
 		return nil
 	}
 	return certutil.EncodeCertPEM(h.CA.Cert.Raw)
+}
+
+// classifyVerifyError maps a VerifyEnforced error to (HTTP status, error code,
+// message). A rejected verdict — bad signature, REPORTDATA mismatch, or a 4xx
+// the attestation-api returns for malformed/unacceptable evidence — is the
+// caller's fault and must not be reported as attestation_api_unreachable.
+// Only a transport failure or a 5xx/garbage upstream response is a real outage.
+func classifyVerifyError(err error) (int, string, string) {
+	switch {
+	case errors.Is(err, attestationclient.ErrSignatureInvalid):
+		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "attestation signature invalid"
+	case errors.Is(err, attestationclient.ErrReportDataMismatch):
+		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "challenge mismatch in attestation evidence"
+	}
+	var apiErr *attestationclient.APIError
+	if errors.As(err, &apiErr) && apiErr.Status >= 400 && apiErr.Status < 500 {
+		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation evidence rejected by attestation-api"
+	}
+	return http.StatusBadGateway, types.ErrorCodeAttestationApiUnreachable,
+		fmt.Sprintf("failed to reach attestation-api: %s", err)
 }

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -397,3 +397,35 @@ func TestAttest_AttestationApiFailureReturns502(t *testing.T) {
 		t.Fatalf("status: got %d, want 502; body=%s", w.Code, w.Body.String())
 	}
 }
+
+// A 4xx from the attestation-api means it judged the evidence bad — a client
+// error, not an outage. It must not be reported as attestation_api_unreachable.
+func TestAttest_RejectedEvidenceReturns4xxNotUnreachable(t *testing.T) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{
+			Error:   types.ErrorCodeInvalidRequest,
+			Message: "malformed evidence",
+		})
+	}))
+	t.Cleanup(bad.Close)
+	h := newTestAttestHandler(t, bad.URL, nil)
+	challenge := issueChallenge(t, h)
+	csrPEM, _ := generateCSR(t)
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", w.Code, w.Body.String())
+	}
+	var resp types.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Error == types.ErrorCodeAttestationApiUnreachable {
+		t.Fatalf("bad evidence mislabeled as %q", resp.Error)
+	}
+	if resp.Error != types.ErrorCodeVerificationFailed {
+		t.Fatalf("error code: got %q, want %q", resp.Error, types.ErrorCodeVerificationFailed)
+	}
+}

--- a/internal/cmds/cds/cmd.go
+++ b/internal/cmds/cds/cmd.go
@@ -62,6 +62,7 @@ func NewCmd() *cobra.Command {
 	flags.DurationVar(&cfg.readinessInterval, "readiness-interval", 10*time.Second, "")
 	flags.DurationVar(&cfg.minCAValidity, "min-ca-validity", time.Hour, "/readyz fails when the loaded mesh CA has less than this remaining lifetime")
 	flags.StringVar(&cfg.allowlistDB, "allowlist-db", "", "Path to the allowlist SQLite database")
+	flags.BoolVar(&cfg.allowlistPersistent, "allowlist-persistent", false, "whether --allowlist-db is on durable storage; false makes CDS warn at startup that operator-added digests and the mesh CA do not survive a restart")
 	flags.StringVar(&cfg.allowlistSeed, "allowlist-seed", "", "Path to a JSON allowlist (version + digests map) seeded into the store at startup before serving; missing digests are added, existing entries are left untouched (empty disables seeding)")
 	flags.StringVar(&cfg.operatorKeys, "operator-keys", "", "Path to a PEM bundle of pinned operator EC public keys; /allowlist writes (POST/PUT/DELETE) require an operator token signed by one of them (empty = writes disabled, reads still served)")
 	flags.StringSliceVar(&cfg.handoffMeasurements, "handoff-measurements", nil, "SHA-384 hex launch measurements allowed to pull the mesh CA via /handoff (empty = /handoff disabled)")
@@ -127,6 +128,7 @@ type config struct {
 	readinessInterval   time.Duration
 	minCAValidity       time.Duration
 	allowlistDB         string
+	allowlistPersistent bool
 	allowlistSeed       string
 	operatorKeys        string
 	handoffMeasurements []string

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -125,6 +125,10 @@ func run(cfg config) error {
 		}
 	}
 
+	if !cfg.allowlistPersistent {
+		slog.Warn("allowlist store is not persistent (cds.persistence.enabled=false): a restart resets the served allowlist to the install seed and regenerates the mesh CA. Operator-added digests do not survive — re-add them after a restart, or enable persistence.")
+	}
+
 	// /allowlist mutations (POST/PUT/DELETE) are authorized by an operator token
 	// signed by one of the pinned operator keys (--operator-keys). Without any
 	// pinned key, writes fail closed while reads keep serving.

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -531,6 +531,24 @@ cache_max_entries = 1024
 {{- $_ := set $digests $lbImg.digest (printf "%s@%s" $lbImg.repository $lbImg.digest) -}}
 {{- end -}}
 {{- end -}}
+{{- /* containerd-prep init-container images (rke2-only): the host NRI plugin
+       checks every container node-wide, so its own and kata's busybox prep
+       image must be in the floor or a DaemonSet re-roll self-deadlocks on
+       "image not in allowlist: busybox". Only seeded when the plugin enforces. */}}
+{{- if .Values.nriImagePolicy.enabled -}}
+{{- if eq .Values.nriImagePolicy.distro "rke2" -}}
+{{- $prep := .Values.nriImagePolicy.containerdPrep.image -}}
+{{- if $prep.digest -}}
+{{- $_ := set $digests $prep.digest (printf "%s@%s" $prep.repository $prep.digest) -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.kata.enabled (eq .Values.kata.distro "rke2") -}}
+{{- $kprep := .Values.kata.containerdPrep.image -}}
+{{- if $kprep.digest -}}
+{{- $_ := set $digests $kprep.digest (printf "%s@%s" $kprep.repository $kprep.digest) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- range $digest, $image := .Values.nriImagePolicy.bootstrapAllowlist.digests -}}
 {{- $_ := set $digests $digest $image -}}
 {{- end -}}

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -155,6 +155,7 @@ spec:
             # attestation-service listens) and to the host Service otherwise.
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
             - --allowlist-db={{ .Values.cds.allowlistDB }}
+            - --allowlist-persistent={{ .Values.cds.persistence.enabled }}
             {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
             - --allowlist-seed=/etc/cds/allowlist-seed.json
             {{- end }}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -3529,6 +3529,29 @@ func TestChartCDSWiresInProcessTrustRoot(t *testing.T) {
 	}
 }
 
+// TestChartCDSAllowlistPersistentTracksPVC pins --allowlist-persistent to
+// cds.persistence.enabled, so CDS knows whether its allowlist store is durable
+// and warns at startup when it is not (operator-added digests are lost on a
+// restart otherwise).
+func TestChartCDSAllowlistPersistentTracksPVC(t *testing.T) {
+	t.Run("default (no persistence) renders false", func(t *testing.T) {
+		out, err := helmTemplate(t)
+		if err != nil {
+			t.Fatalf("helm template: %v\n%s", err, out)
+		}
+		args := renderedDeploymentContainer(t, out, "c8s-cds", "cds").Args
+		assertContainerHasArg(t, "cds", args, "--allowlist-persistent=false")
+	})
+	t.Run("persistence enabled renders true", func(t *testing.T) {
+		out, err := helmTemplate(t, "--set", "cds.persistence.enabled=true")
+		if err != nil {
+			t.Fatalf("helm template: %v\n%s", err, out)
+		}
+		args := renderedDeploymentContainer(t, out, "c8s-cds", "cds").Args
+		assertContainerHasArg(t, "cds", args, "--allowlist-persistent=true")
+	})
+}
+
 // TestChartCDSServesRATLS confirms the cds container renders with a non-empty
 // --ratls-platform by default, i.e. RA-TLS serving is ON. An empty platform
 // makes cds serve /attest, /sign-csr, and /attest-key over plaintext HTTP,
@@ -4273,6 +4296,63 @@ func TestChartAllowlistsTlsLbNginxSelfEntry(t *testing.T) {
 		}
 		if _, ok := seed.Digests[nxDigest]; ok {
 			t.Errorf("tls-lb nginx self-entry present with tls-lb disabled: %v", seed.Digests)
+		}
+	})
+}
+
+// The nri-image-policy containerd-prep init container (rke2 only) runs busybox,
+// which is not a c8sComponent, so it is never in the derive set. The host plugin
+// enforces every container node-wide, so unless busybox is self-seeded a
+// DaemonSet re-roll self-deadlocks ("image not in allowlist: busybox"). It must
+// be in both the CDS seed and the worker always_allow on rke2, and absent on k8s
+// where the init container is not rendered.
+func TestChartAllowlistsContainerdPrepOnRke2(t *testing.T) {
+	const (
+		prepDigest = "sha256:00000000000000000000000000000000000000000000000000000000000000c1"
+		prepRepo   = "example.test/busybox"
+	)
+	t.Run("rke2: self-entry present", func(t *testing.T) {
+		out, err := helmTemplate(t,
+			"--set-string", "nriImagePolicy.distro=rke2",
+			"--set-string", "nriImagePolicy.containerdPrep.image.repository="+prepRepo,
+			"--set-string", "nriImagePolicy.containerdPrep.image.digest="+prepDigest,
+		)
+		if err != nil {
+			t.Fatalf("helm template: %v\n%s", err, out)
+		}
+		wantRef := prepRepo + "@" + prepDigest
+
+		cm := renderedConfigMap(t, out, "c8s-cds-allowlist-seed")
+		seed, err := pkgallowlist.ParseJSON([]byte(cm.Data["allowlist-seed.json"]))
+		if err != nil {
+			t.Fatalf("seed JSON does not parse: %v", err)
+		}
+		if got := seed.Digests[prepDigest]; got != wantRef {
+			t.Errorf("containerd-prep seed entry = %q, want %q\nseed: %v", got, wantRef, seed.Digests)
+		}
+
+		worker := bootConfigFromInstaller(t, out, "c8s-nri-image-policy-worker")
+		if got := worker.Allowlist.AlwaysAllow[prepDigest]; got != wantRef {
+			t.Errorf("worker always_allow[%s] = %q, want %q\nalways_allow: %v", prepDigest, got, wantRef, worker.Allowlist.AlwaysAllow)
+		}
+	})
+
+	t.Run("k8s: no self-entry", func(t *testing.T) {
+		out, err := helmTemplate(t,
+			"--set-string", "nriImagePolicy.distro=k8s",
+			"--set-string", "nriImagePolicy.containerdPrep.image.repository="+prepRepo,
+			"--set-string", "nriImagePolicy.containerdPrep.image.digest="+prepDigest,
+		)
+		if err != nil {
+			t.Fatalf("helm template: %v\n%s", err, out)
+		}
+		cm := renderedConfigMap(t, out, "c8s-cds-allowlist-seed")
+		seed, err := pkgallowlist.ParseJSON([]byte(cm.Data["allowlist-seed.json"]))
+		if err != nil {
+			t.Fatalf("seed JSON does not parse: %v", err)
+		}
+		if _, ok := seed.Digests[prepDigest]; ok {
+			t.Errorf("containerd-prep self-entry present on k8s (init container not rendered): %v", seed.Digests)
 		}
 	})
 }


### PR DESCRIPTION
- cds/attest: classify attestation-api verification failures as 4xx, reserving 502 attestation_api_unreachable for real transport/upstream outages
- install: keep RKE2 distro auto-detection unless a -f file sets the distro
- chart: seed rke2 containerd-prep busybox into the allowlist floor so an nri-image-policy DaemonSet re-roll is not self-denied
- cds: warn at startup when the allowlist store is non-persistent (a restart drops operator-added digests); wire --allowlist-persistent from the chart
- allowlist: warn when `remove` targets a component floor image (no-op for enforcement)
- install: preflight tls-lb host-port conflicts instead of letting --wait hang
- docs: record CDS allowlist-persistence and cross-CVM handoff coverage gaps