### PR TITLE
fix(policy-monitor): race between policy-monitor and kata agent

### DIFF
--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -118,18 +118,23 @@ func (c *cgroupLocator) findInitPID(containerID string) (int, bool, error) {
 	deadline := time.Now().Add(c.waitTimeout)
 	for {
 		dir, err := findCgroupDir(c.cgroupRoot, containerID)
-		switch {
-		case err == nil && dir != "":
-			pid, err := readFirstPID(filepath.Join(dir, "cgroup.procs"))
-			if err == nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return 0, false, fmt.Errorf("walk cgroup hierarchy: %w", err)
+		}
+		if dir != "" {
+			if pid, perr := readFirstPID(filepath.Join(dir, "cgroup.procs")); perr == nil {
 				return pid, true, nil
 			}
-			// cgroup.procs exists but is empty (container init forked
-			// then exited already) or unreadable. Treat as "not found"
-			// — the kill path is a no-op in either case.
-			return 0, false, nil
-		case err != nil && !errors.Is(err, os.ErrNotExist):
-			return 0, false, fmt.Errorf("walk cgroup hierarchy: %w", err)
+			// The cgroup exists but cgroup.procs is empty (or unreadable):
+			// kata-agent creates the cgroup and writes config.json — our
+			// trigger — BEFORE it forks the container init into the cgroup, so
+			// procs is briefly empty right when we look. Keep polling within
+			// the budget rather than giving up: the common race populates and
+			// we get the init PID to SIGKILL, while a container that genuinely
+			// exited stays empty and times out to a harmless no-op. Returning
+			// "not found" here (as this used to) is why a denied container's
+			// kill silently missed — the enforce decision was correct, the
+			// SIGKILL never landed.
 		}
 		if time.Now().After(deadline) {
 			return 0, false, nil

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -190,6 +190,71 @@ func TestCgroupLocator_WaitsForCgroupToAppear(t *testing.T) {
 	}
 }
 
+// TestCgroupLocator_WaitsForProcsToPopulate is the regression test for the
+// silent kill miss: kata-agent creates the container cgroup and writes
+// config.json (policy-monitor's trigger) BEFORE it forks the init into the
+// cgroup, so cgroup.procs is briefly empty. findInitPID must poll until the
+// PID appears, not give up on the first empty read.
+func TestCgroupLocator_WaitsForProcsToPopulate(t *testing.T) {
+	root := t.TempDir()
+	cid := "b790433fdb4f223a51940bae06c1cd54d73377fc3ea45c4fa5c7ea3bd4b6c829"
+	scope := filepath.Join(root, "kubepods.slice", "cri-containerd-"+cid+".scope")
+	if err := os.MkdirAll(scope, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	procs := filepath.Join(scope, "cgroup.procs")
+	// cgroup exists but procs is empty — the init hasn't been forked in yet.
+	if err := os.WriteFile(procs, []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locator := &cgroupLocator{
+		cgroupRoot:   root,
+		waitTimeout:  1 * time.Second,
+		pollInterval: 20 * time.Millisecond,
+	}
+	go func() {
+		time.Sleep(75 * time.Millisecond)
+		_ = os.WriteFile(procs, []byte("4242\n1234\n"), 0o644)
+	}()
+	pid, ok, err := locator.findInitPID(cid)
+	if err != nil {
+		t.Fatalf("findInitPID: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ok=true — findInitPID must wait for cgroup.procs to populate")
+	}
+	if pid != 4242 {
+		t.Errorf("pid = %d, want 4242 (first/lowest in cgroup.procs)", pid)
+	}
+}
+
+// TestCgroupLocator_EmptyProcsTimesOut confirms a cgroup that stays empty
+// (a container that genuinely exited before we looked) times out to a
+// harmless no-op rather than blocking or erroring.
+func TestCgroupLocator_EmptyProcsTimesOut(t *testing.T) {
+	root := t.TempDir()
+	cid := "cafef00d"
+	scope := filepath.Join(root, "cri-containerd-"+cid+".scope")
+	if err := os.MkdirAll(scope, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(scope, "cgroup.procs"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	locator := &cgroupLocator{
+		cgroupRoot:   root,
+		waitTimeout:  60 * time.Millisecond,
+		pollInterval: 20 * time.Millisecond,
+	}
+	_, ok, err := locator.findInitPID(cid)
+	if err != nil {
+		t.Fatalf("findInitPID: %v", err)
+	}
+	if ok {
+		t.Fatal("expected ok=false when cgroup.procs never populates")
+	}
+}
+
 func TestCgroupLocator_Timeout(t *testing.T) {
 	root := t.TempDir()
 	locator := &cgroupLocator{

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -399,23 +399,46 @@ func (m *monitor) kill(cid string) {
 }
 
 // readConfigJSON retries reading + parsing config.json for the budget
-// configReadDeadline. The retry absorbs the small gap between
-// directory creation (which triggers our IN_CREATE event) and
-// kata-agent finishing the config.json write.
+// configReadDeadline. The retry absorbs the gap between directory creation
+// (which triggers our IN_CREATE event, and re-seed after kata-agent replaces
+// the watch dir) and kata-agent finishing the config.json write.
+//
+// It waits not just for the file to parse but for the OCI annotations to be
+// present (hasContainerType): kata-agent writes config.json and its CRI/kata
+// annotations as part of one create-container step, but policy-monitor can
+// observe the file after it parses yet before the annotations land — and a
+// decision on that half-written spec misclassifies the pod sandbox (denied,
+// which would SIGKILL the measured pause and break the pod) and reads no image
+// digest for a workload. On deadline it returns the last parsed spec anyway
+// (never nil-with-no-error for a spec that did parse) so the caller still fails
+// closed: a genuinely annotation-less bundle — e.g. a host that stripped the
+// annotations to evade policy — is denied, not skipped.
 func (m *monitor) readConfigJSON(ctx context.Context, path string) (*ociSpec, error) {
 	deadline := time.Now().Add(m.configReadDeadline)
+	var lastSpec *ociSpec
 	var lastErr error
 	for {
 		spec, err := readOCISpec(path)
-		if err == nil {
+		switch {
+		case err == nil && hasContainerType(spec.Annotations):
 			return spec, nil
-		}
-		lastErr = err
-		if !errors.Is(err, os.ErrNotExist) && !isPartialJSON(err) {
-			// Unrecoverable: not a transient race. Return immediately.
-			return nil, err
+		case err == nil:
+			// Parsed, but the annotations we key on aren't written yet.
+			// Remember it so a deadline still fails closed rather than skipping
+			// enforcement, and retry for the annotations to appear.
+			lastSpec = spec
+			lastErr = errPartialJSON
+		default:
+			lastErr = err
+			if !errors.Is(err, os.ErrNotExist) && !isPartialJSON(err) {
+				// Unrecoverable: not a transient race. Return immediately.
+				return nil, err
+			}
 		}
 		if time.Now().After(deadline) {
+			if lastSpec != nil {
+				return lastSpec, nil
+			}
 			return nil, lastErr
 		}
 		select {
@@ -424,6 +447,22 @@ func (m *monitor) readConfigJSON(ctx context.Context, path string) (*ociSpec, er
 		case <-time.After(m.configReadInterval):
 		}
 	}
+}
+
+// hasContainerType reports whether the OCI annotations carry a CRI
+// container-type marker (io.kubernetes.cri.container-type / the CRI-O
+// equivalent). Every container kata-agent creates for a Kubernetes pod — both
+// the sandbox and the workload — carries one, so its presence is a reliable
+// "kata-agent finished writing the annotations" signal. Absence means either a
+// mid-write read (retry) or a bundle with no CRI annotations at all (denied on
+// deadline, fail-closed).
+func hasContainerType(annotations map[string]string) bool {
+	for _, key := range k8sContainerTypeKeys {
+		if _, ok := annotations[key]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ociSpec is the subset of the OCI Runtime Spec we care about: the

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -97,7 +97,8 @@ func TestHandleNewContainer_AllowedDigest(t *testing.T) {
 
 	cid := "abcdef0123"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
-		"io.kubernetes.cri.image-name": "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
 	})
 
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
@@ -114,7 +115,8 @@ func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 
 	cid := "deadbeef"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
-		"io.kubernetes.cri.image-name": "ghcr.io/evil/badimage@sha256:" + denied,
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/evil/badimage@sha256:" + denied,
 	})
 
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
@@ -200,7 +202,8 @@ func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		body, _ := json.Marshal(ociSpec{
 			Annotations: map[string]string{
-				"io.kubernetes.cri.image-name": "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
+				"io.kubernetes.cri.container-type": "container",
+				"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
 			},
 		})
 		_ = os.WriteFile(filepath.Join(dir, "config.json"), body, 0o644)
@@ -208,6 +211,79 @@ func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 	m.handleNewContainer(context.Background(), dir)
 	if calls := killer.snapshot(); len(calls) != 0 {
 		t.Fatalf("expected allow (no kills) after late config.json, got %+v", calls)
+	}
+}
+
+// TestReadConfigJSON_WaitsForContainerType covers the mid-write race: config.json
+// parses as valid JSON but its CRI annotations haven't landed yet.
+// readConfigJSON must keep polling until container-type is present, not decide
+// on the annotation-less spec.
+func TestReadConfigJSON_WaitsForContainerType(t *testing.T) {
+	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := "mid-write"
+	// A valid but annotation-less config.json (kata-agent has written the file
+	// but not the annotations yet).
+	writeConfigJSON(t, watchDir, cid, map[string]string{})
+	path := filepath.Join(watchDir, cid, "config.json")
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		writeConfigJSON(t, watchDir, cid, map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name":     "repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		})
+	}()
+	spec, err := m.readConfigJSON(context.Background(), path)
+	if err != nil {
+		t.Fatalf("readConfigJSON: %v", err)
+	}
+	if _, ok := spec.Annotations["io.kubernetes.cri.container-type"]; !ok {
+		t.Fatalf("expected readConfigJSON to wait for the container-type annotation; got %+v", spec.Annotations)
+	}
+}
+
+// TestReadConfigJSON_DeadlineFailsClosed proves that a config.json that parses
+// but never grows a container-type annotation (a bundle with the CRI
+// annotations stripped, e.g. a host trying to evade policy) returns the parsed
+// spec with a nil error on deadline — so the caller still classifies and denies
+// it, rather than getting an error and skipping enforcement (fail-open).
+func TestReadConfigJSON_DeadlineFailsClosed(t *testing.T) {
+	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := "stripped"
+	writeConfigJSON(t, watchDir, cid, map[string]string{"unrelated": "x"})
+	path := filepath.Join(watchDir, cid, "config.json")
+	spec, err := m.readConfigJSON(context.Background(), path)
+	if err != nil {
+		t.Fatalf("want nil error so the caller fails closed on the returned spec, got %v", err)
+	}
+	if spec == nil {
+		t.Fatal("want the parsed (annotation-less) spec returned so the caller denies")
+	}
+	if isSandbox(spec.Annotations) {
+		t.Fatal("annotation-less spec must not classify as a sandbox")
+	}
+	if _, ok := extractDigest(spec.Annotations); ok {
+		t.Fatal("annotation-less spec must not yield a digest — caller must deny")
+	}
+}
+
+// TestHandleNewContainer_SandboxLateContainerType_NotKilled is the safety test
+// for the fix: the pod sandbox (pause) container's container-type=sandbox
+// annotation can be observed late. policy-monitor must wait for it and allow
+// the sandbox — decking it on the mid-write spec would SIGKILL the measured
+// pause and break the pod.
+func TestHandleNewContainer_SandboxLateContainerType_NotKilled(t *testing.T) {
+	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := "late-sandbox"
+	writeConfigJSON(t, watchDir, cid, map[string]string{}) // annotations not written yet
+	go func() {
+		time.Sleep(40 * time.Millisecond)
+		writeConfigJSON(t, watchDir, cid, map[string]string{
+			"io.kubernetes.cri.container-type": "sandbox",
+		})
+	}()
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+	if calls := killer.snapshot(); len(calls) != 0 {
+		t.Fatalf("sandbox must be allowed once its container-type lands; got kills %+v", calls)
 	}
 }
 


### PR DESCRIPTION
led to non-whitelisted workloads sometimes not being killed