### PR TITLE
fix(verify): bound the AMD KDS collateral fetch with --timeout

### DIFF
--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -20,6 +20,20 @@ cluster-internal pinning (which shapes per platform in
 and let each platform verifier do its own shaping; `c8s-verify-js/PROTOCOL.md`
 ("az-snp") is the contract.
 
+## The bare-report KDS fetch is attestation-go's job; c8s only bounds and classifies it
+
+`internal/cmds/verify/verify.go` (`verifyEvidence`), `internal/cmds/verify/localverify.go` (`verifyInProcess`, `runAttestationGo`)
+
+`c8s verify` of a bare RA-TLS cert (SNP report, no inline VCEK) once hung for
+minutes on Zen4c (Siena/Bergamo) hosts, ignoring `--timeout`: verification ran
+with no context, and go-sev-guest's own KDS fetcher retried an unclassifiable
+`Unknown`-product URL. The VCEK fetch — including the Zen4c→Genoa product-line
+mapping — now lives in attestation-go (`snp.VerifyReportContext`; background in
+its README, "AMD KDS collateral for bare SNP reports"). What c8s must uphold:
+the verification context carries the `--timeout` deadline (`verifyEvidence`),
+and a failed fetch (`snp.ErrCollateralUnavailable`) maps to exit 3 (collateral
+unavailable), never a verification verdict (exit 2).
+
 ## get-cert injection integrity is name-based — reserve the name, don't trust it
 
 `internal/webhook/pod_mutator.go`, `internal/helmchart/c8s/templates/cw-label-integrity-policy.yaml`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/confidential-dot-ai/attestation-go v0.2.0
+	github.com/confidential-dot-ai/attestation-go v0.3.0
 	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/confidential-dot-ai/attestation-go v0.2.0 h1:cn3nmuehwYOQvLlMGyZmIUmZ2cJUv74tNZw+XITdaKM=
-github.com/confidential-dot-ai/attestation-go v0.2.0/go.mod h1:eF9ml9GSjHhsUF9ZByfXxVI5vIfjZZB72JnnOXtGs+s=
+github.com/confidential-dot-ai/attestation-go v0.3.0 h1:jAU14MS5f87vEd49T7r8r6JnZXUF4pQHFGTLis40+5Q=
+github.com/confidential-dot-ai/attestation-go v0.3.0/go.mod h1:eF9ml9GSjHhsUF9ZByfXxVI5vIfjZZB72JnnOXtGs+s=
 github.com/containerd/cgroups/v3 v3.1.2 h1:OSosXMtkhI6Qove637tg1XgK4q+DhR0mX8Wi8EhrHa4=
 github.com/containerd/cgroups/v3 v3.1.2/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd/api v1.10.0 h1:5n0oHYVBwN4VhoX9fFykCV9dF1/BvAXeg2F8W6UYq1o=

--- a/internal/cmds/verify/localverify.go
+++ b/internal/cmds/verify/localverify.go
@@ -1,9 +1,12 @@
 package verify
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/go-sev-guest/verify/trust"
 
@@ -14,21 +17,37 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
+// KDS getter bounds: the retry backoff is capped so several attempts fit inside
+// the default 15s --timeout (upstream's 30s cap assumes a 2min budget), and the
+// getter's own timeout backstops the fetch when the context carries no deadline
+// (--timeout 0).
+const (
+	kdsMaxRetryDelay = 8 * time.Second
+	kdsMaxFetchTime  = 2 * time.Minute
+)
+
 // verifyInProcess verifies already-gathered evidence with attestation-go — the
 // Go port of the attestation-rs engine the cluster runs (same self-describing
 // envelope, same VerifyParams/VerificationResult/Claims). It auto-detects the
 // platform (SEV-SNP incl. Zen4c Siena/Bergamo, TDX, az-snp, az-tdx) from the
 // envelope tag, so no product line is supplied by hand and no container is
-// launched.
-func verifyInProcess(ev *evidence, policy *ratls.VerifyPolicy, minTCB *teetypes.SnpTcb) (*teetypes.VerificationResult, error) {
+// launched. ctx bounds any AMD KDS collateral fetch (see docs/pitfalls.md —
+// Zen4c KDS product line).
+func verifyInProcess(ctx context.Context, ev *evidence, policy *ratls.VerifyPolicy, minTCB *teetypes.SnpTcb) (*teetypes.VerificationResult, error) {
 	params := teetypes.VerifyParams{
 		ExpectedReportData: ev.erd,
 		AllowDebug:         policy.AllowDebug,
 		MinTCB:             minTCB,
 	}
 
-	res, err := runAttestationGo(ev, params)
+	res, err := runAttestationGo(ctx, ev, params)
 	if err != nil {
+		// A failed KDS collateral fetch (unreachable, --timeout hit) means no
+		// verdict was reached: exit 3, like any other unobtainable evidence.
+		var re *trust.AttestationRecreationErr
+		if errors.Is(err, snp.ErrCollateralUnavailable) || errors.As(err, &re) {
+			return nil, &connectError{err: err}
+		}
 		// attestation-go returns an error (not a false verdict) on a bad
 		// signature, chain, policy, or REPORTDATA mismatch — all of which are a
 		// reachable-but-rejected outcome, i.e. a security verdict (exit 2).
@@ -50,9 +69,10 @@ func verifyInProcess(ev *evidence, policy *ratls.VerifyPolicy, minTCB *teetypes.
 // inline (a discovery doc or endpoint response). A bare RA-TLS serving cert
 // carries the SNP report but no VCEK, and the envelope path requires it inline
 // (attestation-go does no KDS fetch there); for that case we drop to
-// snp.VerifyReport with a KDS Getter — it resolves the product from the report
-// (Zen4c/Siena-aware) and fetches the VCEK from AMD KDS itself.
-func runAttestationGo(ev *evidence, params teetypes.VerifyParams) (*teetypes.VerificationResult, error) {
+// snp.VerifyReportContext with a KDS Getter — it resolves the product from the
+// report (Zen4c/Siena-aware) and fetches the VCEK from AMD KDS itself, bounded
+// by ctx.
+func runAttestationGo(ctx context.Context, ev *evidence, params teetypes.VerifyParams) (*teetypes.VerificationResult, error) {
 	if mayMissVCEK(ev.platform) {
 		var se snp.SnpEvidence
 		if err := json.Unmarshal(ev.rawEvidence, &se); err != nil {
@@ -63,11 +83,17 @@ func runAttestationGo(ev *evidence, params teetypes.VerifyParams) (*teetypes.Ver
 			if err != nil {
 				return nil, fmt.Errorf("decode attestation_report: %w", err)
 			}
-			// nil VCEK + a Getter ⇒ go-sev-guest fetches the VCEK from AMD KDS,
-			// using the product attestation-go resolves from the report.
-			return snp.VerifyReport(report, nil, params,
+			// nil VCEK + a Getter ⇒ attestation-go fetches the VCEK from AMD KDS,
+			// retrying until the --timeout ctx (verifyEvidence) or the backstop
+			// expires, whichever is sooner.
+			getter := &trust.RetryHTTPSGetter{
+				Timeout:       kdsMaxFetchTime,
+				MaxRetryDelay: kdsMaxRetryDelay,
+				Getter:        &trust.SimpleHTTPSGetter{},
+			}
+			return snp.VerifyReportContext(ctx, report, nil, params,
 				teetypes.PlatformType(ev.platform), snp.MinReportVersion,
-				snp.Options{Getter: trust.DefaultHTTPSGetter()})
+				snp.Options{Getter: getter})
 		}
 	}
 

--- a/internal/cmds/verify/localverify_test.go
+++ b/internal/cmds/verify/localverify_test.go
@@ -1,0 +1,102 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// bareSnpEvidence strips cert_chain from the real Zen4c/Genoa fixture, yielding
+// the {attestation_report}-only evidence a bare RA-TLS serving cert produces —
+// the shape that forces the AMD KDS fetch.
+func bareSnpEvidence(t *testing.T) *evidence {
+	t.Helper()
+	fixture, err := os.ReadFile("testdata/snp-evidence-genoa.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env struct {
+		Platform string `json:"platform"`
+		Evidence struct {
+			AttestationReport string `json:"attestation_report"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal(fixture, &env); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(map[string]string{"attestation_report": env.Evidence.AttestationReport})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &evidence{platform: env.Platform, rawEvidence: raw, source: "test"}
+}
+
+// TestVerifyInProcess_KDSFetchBoundedByContext is the regression test for the
+// Siena hang: a bare report needs a KDS fetch, and an expired context must stop
+// it promptly with a connectError (exit 3 — collateral unavailable, not a
+// verdict). A cancelled context aborts http before any I/O, so no network is
+// touched. Pre-fix this path ignored ctx entirely and retried KDS for minutes.
+func TestVerifyInProcess_KDSFetchBoundedByContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_, err := verifyInProcess(ctx, bareSnpEvidence(t), &ratls.VerifyPolicy{}, nil)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("expired ctx took %v, want prompt return", elapsed)
+	}
+	if err == nil {
+		t.Fatal("expired ctx must fail")
+	}
+	if !isConnectError(err) {
+		t.Fatalf("KDS fetch failure must be a connectError (exit 3), got: %v", err)
+	}
+}
+
+// TestRun_BareEvidenceTimeoutExitsNoEvidence drives the full command path
+// (--from-file, bare evidence) with a dead parent context standing in for an
+// elapsed --timeout: the command must exit 3 promptly, with the collateral
+// failure on stderr — not hang, and not report a verification verdict.
+func TestRun_BareEvidenceTimeoutExitsNoEvidence(t *testing.T) {
+	ev := bareSnpEvidence(t)
+	doc, err := json.Marshal(map[string]any{
+		"platform": ev.platform,
+		"evidence": json.RawMessage(ev.rawEvidence),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "bare.json")
+	if err := os.WriteFile(path, doc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg := config{
+		fromFile:      path,
+		kind:          "cds",
+		timeout:       50 * time.Millisecond,
+		expectedRDHex: "00", // bare evidence needs an anchor to parse; never reached
+		output:        "text",
+	}
+
+	var out, errOut bytes.Buffer
+	start := time.Now()
+	code := run(ctx, cfg, &out, &errOut)
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("run took %v, want prompt return", elapsed)
+	}
+	if code != exitNoEvidence {
+		t.Fatalf("exit = %d, want %d (collateral unavailable); stderr: %s", code, exitNoEvidence, errOut.String())
+	}
+	if !bytes.Contains(errOut.Bytes(), []byte("collateral")) {
+		t.Fatalf("stderr should name the collateral failure, got: %s", errOut.String())
+	}
+}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -30,8 +30,8 @@ const (
 	exitNoEvidence = 3 // could not obtain evidence (connect/parse/file)
 )
 
-// connectError marks a failure to obtain evidence (vs. a verification verdict),
-// so the orchestration can map it to exit code 3.
+// connectError marks a failure to obtain evidence or verification collateral
+// (vs. a verification verdict), so the orchestration can map it to exit code 3.
 type connectError struct{ err error }
 
 func (e *connectError) Error() string { return e.err.Error() }
@@ -121,8 +121,8 @@ Verification runs in-process using attestation-go — the Go port of the
 attestation-rs engine the cluster runs. It auto-detects the platform and AMD
 product — including Zen4c (Siena/Bergamo), which stock go-sev-guest cannot — so
 the product line never has to be supplied by hand, and it fetches the VCEK for a
-bare report from AMD KDS, so the machine running it needs outbound HTTPS to
-kdsintf.amd.com (no container runtime required).
+bare report from AMD KDS (bounded by --timeout), so the machine running it needs
+outbound HTTPS to kdsintf.amd.com (no container runtime required).
 
 Evidence sources:
   https://host:port      GET the discovery endpoint (/v1/discovery — cert +
@@ -155,7 +155,7 @@ unavailable (unreachable / unparseable).`,
 	f.StringVar(&cfg.mode, "mode", orDefault(d.Mode, "auto"), "evidence mode: auto, ratls-cert, discovery, or attestation-endpoint")
 	f.StringVar(&cfg.discoveryPath, "discovery-path", defaultDiscoveryPath, "path of the LB discovery document (discovery mode)")
 	f.StringVar(&cfg.server, "server-name", "", "TLS SNI server name (for port-forward / routed domains)")
-	f.DurationVar(&cfg.timeout, "timeout", 15*time.Second, "per-attempt timeout")
+	f.DurationVar(&cfg.timeout, "timeout", 15*time.Second, "per-attempt timeout (evidence fetch and AMD KDS collateral fetch)")
 	f.StringVar(&cfg.fromFile, "from-file", "", "verify evidence from a saved PEM certificate or attestation-response JSON instead of dialing")
 
 	f.StringSliceVar(&cfg.measurements, "measurements", nil, "allowed SHA-384 hex launch measurement(s) (repeatable / comma-separated); empty = no pinning (UNSAFE)")
@@ -212,7 +212,7 @@ func run(ctx context.Context, cfg config, out, errOut io.Writer) int {
 		fmt.Fprintf(errOut, "error: could not obtain evidence: %v\n", err)
 		return exitNoEvidence
 	}
-	return verifyEvidence(cfg, policy, ev, gatherOperatorKeys(ctx, cfg, ev), out)
+	return verifyEvidence(ctx, cfg, policy, ev, gatherOperatorKeys(ctx, cfg, ev), out, errOut)
 }
 
 // operatorKeysReport is the (informational) pinned-operator-key section of the
@@ -249,9 +249,20 @@ func gatherOperatorKeys(ctx context.Context, cfg config, ev *evidence) operatorK
 // in-process with attestation-go (the Go port of the attestation-rs engine the
 // cluster runs), which auto-detects the product and fetches the VCEK from KDS
 // when it is not shipped inline — so a bare RA-TLS report and a discovery doc
-// both work — then renders the verdict.
-func verifyEvidence(cfg config, policy *ratls.VerifyPolicy, ev *evidence, opKeys operatorKeysReport, out io.Writer) int {
-	result, verr := verifyInProcess(ev, policy, minTCBFromCfg(cfg))
+// both work — then renders the verdict. The verification attempt (including the
+// KDS fetch) is bounded by --timeout; an unobtainable-collateral failure is
+// exit 3, not a verification verdict.
+func verifyEvidence(ctx context.Context, cfg config, policy *ratls.VerifyPolicy, ev *evidence, opKeys operatorKeysReport, out, errOut io.Writer) int {
+	if cfg.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, cfg.timeout)
+		defer cancel()
+	}
+	result, verr := verifyInProcess(ctx, ev, policy, minTCBFromCfg(cfg))
+	if isConnectError(verr) {
+		fmt.Fprintf(errOut, "error: could not fetch verification collateral: %v\n", verr)
+		return exitNoEvidence
+	}
 	oc := newOutcome(cfg, ev, result, verr, policy)
 	oc.OperatorKeys = opKeys.fingerprints
 	oc.OperatorKeysNote = opKeys.note

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -400,7 +400,7 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 	if ev.platform != "az-snp" {
 		t.Fatalf("platform = %q, want az-snp", ev.platform)
 	}
-	res, err := verifyInProcess(ev, &ratls.VerifyPolicy{}, nil)
+	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil)
 	if err != nil {
 		t.Fatalf("az-snp evidence with its bound nonce must verify: %v", err)
 	}
@@ -410,7 +410,7 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 
 	// A different anchor fails closed, at the nonce gate specifically.
 	ev.erd = []byte("not-the-nonce")
-	if _, err := verifyInProcess(ev, &ratls.VerifyPolicy{}, nil); err == nil || !strings.Contains(err.Error(), "nonce") {
+	if _, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil); err == nil || !strings.Contains(err.Error(), "nonce") {
 		t.Fatalf("wrong nonce must fail closed at the nonce check, got: %v", err)
 	}
 }


### PR DESCRIPTION
`c8s verify` of a bare RA-TLS cert (SNP report without an inline VCEK) hung for minutes on Zen4c (Siena/Bergamo) hosts and ignored --timeout: verification ran with no context and go-sev-guest's default 2-minute retry getter, against an "Unknown"-product KDS URL that 404s (see docs/pitfalls.md, "Zen4c KDS product line"