### PR TITLE
ix(docs): correct doc/code drift — webhook lifecycle, TDX policy path…

### DIFF
--- a/.github/workflows/extract-kernel-snapshot.yml
+++ b/.github/workflows/extract-kernel-snapshot.yml
@@ -50,9 +50,9 @@ jobs:
           path: |
             steep/output/kernel
             steep/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kata-kernel-v2-${{ env.STEEP_REF }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
+          key: ${{ runner.os }}-kata-kernel-v3-${{ env.STEEP_REF }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
           restore-keys: |
-            ${{ runner.os }}-kata-kernel-v2-${{ env.STEEP_REF }}-
+            ${{ runner.os }}-kata-kernel-v3-${{ env.STEEP_REF }}-
 
       - name: Verify snapshot present + show sha256
         run: |

--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -3,17 +3,17 @@ name: Kata guest base
 # Builds + pushes the kata-guest-base rootfs image — the kata-native
 # guest every c8s kata-qemu-snp pod boots into. kata-qemu does measured
 # direct-kernel boot (no IGVM/UKI), so we publish the parts kata wants: a
-# hardened kernel (built by steep), a dm-verity erofs rootfs (built by
+# hardened kernel (built by steep), a dm-verity ext4 rootfs (built by
 # kata's osbuilder, with our ratls-mesh / attestation-service /
 # policy-monitor + bootstrap allowlist baked into the verity root), and
 # the verity params. The rootfs root hash rides in the kata kernel
 # cmdline and is folded into the SNP kernel-hashes launch measurement;
-# per-pod container images (assam, cert-issuer, workloads) are secondary
+# per-pod container images (cds, get-cert, workloads) are secondary
 # measurements the operator attests post-install.
 #
 # Output: ghcr.io/confidential-dot-ai/kata-guest-base:<tag> via `oras push`. Flat
 # at the org level matches every other c8s artifact
-# (ghcr.io/confidential-dot-ai/{assam,cert-issuer,ratls-mesh,...}).
+# (ghcr.io/confidential-dot-ai/{cds,get-cert,ratls-mesh,...}).
 #
 # Every build also publishes a DEBUG variant at <tag>-debug (build.sh
 # Step 5): the same rootfs except the baked kata-agent policy allows the

--- a/README.md
+++ b/README.md
@@ -308,7 +308,9 @@ attestation and reports the operator keys it pins.
 
 ```text
 api/               CRD types
-cmd/               Binaries: cds, c8s, get-cert, ratls-mesh, nri-image-policy
+cmd/               Binaries: c8s, get-cert, ratls-mesh, nri-image-policy,
+                   policy-monitor, rtmr3-measurer (cmd/cds is only the
+                   Dockerfile for the `c8s cds` subcommand, internal/cmds/cds)
 internal/          Operator, webhook, attestation, mesh CA, embedded Helm chart
 pkg/               Public Go libraries (see Libraries above)
 kata-guest-base/   Confidential guest image recipe for pod-as-CVM

--- a/cmd/ratls-mesh/DESIGN.md
+++ b/cmd/ratls-mesh/DESIGN.md
@@ -540,7 +540,7 @@ Certificates are provisioned lazily on the first TLS handshake and cached in mem
 4. Extract raw attestation report from the structured evidence response
 5. Embed attestation report in X.509 certificate extension
 6. Cache certificate in `certState` (RWMutex-protected)
-7. Rotate at 50% of TTL (default 12h → rotate at 6h)
+7. Rotate at 50% of TTL (default 24h → rotate at 12h)
 
 The `certState.mu` mutex serializes certificate provisioning — at most one attestation process runs at a time per cert type (server/client). After the first provisioning, the cached cert is returned for all subsequent handshakes until rotation.
 

--- a/cmd/ratls-mesh/README.md
+++ b/cmd/ratls-mesh/README.md
@@ -128,7 +128,6 @@ destinations whose `Pod.Status.HostIP` matches this node's `NODE_IP`.
 | `--measurements` | `""` | Comma-separated hex SHA-384 launch measurements (empty = accept any TEE, warns) |
 | `--cert-mode` | `self-signed` | Certificate mode: self-signed (default), cds (boots self-signed, upgrades to CDS-issued in background) |
 | `--cds-url` | `""` | CDS service URL for attestation and CA bundle retrieval (required for cds mode) |
-| `--attestation-api-url` | (required) | Local attestation-api URL (required for cds mode) |
 | `--cds-measurements` | `""` | Comma-separated SHA-384 hex launch measurements that CDS's RA-TLS peer cert must match. Empty = accept any (UNSAFE outside development) |
 | `--ca-cert` | `""` | Path to CA certificate PEM for X.509 chain verification |
 | `--ca-poll-interval` | `5m` | Interval for polling the CDS `/ca` endpoint for CA bundle updates (cds mode) |
@@ -282,7 +281,6 @@ and Helm rendering for `hostNetwork`, `iptables-sync`, and hostPort behavior.
 
 ## Security
 
-- [Threat Model](../../docs/SECURITY/THREAT_MODEL.md) — 21 analyzed threats (T1-T21) with mitigations and risk matrix
-- [Measurement Pinning](../../docs/SECURITY/MEASUREMENT_PINNING.md) — Production setup for TEE launch digest pinning
-- [Certificate Lifecycle](../../docs/SECURITY/CERT_LIFECYCLE.md) — Issuance, rotation, dual verification, bundle management
-- [Production Hardening](../../docs/SECURITY/PRODUCTION_HARDENING.md) — Must/should/could checklist
+- [Threat Model](../../docs/THREAT_MODEL.md) — adversary model, trust graph, enforcement gates, and residual risks
+- [Gaps](../../docs/GAPS.md) — known mesh/certificate limitations (peer measurement pinning, TDX policy path)
+- [Pitfalls](../../docs/pitfalls.md) — operational sharp edges, including the mesh inbound-passthrough trade-off

--- a/docs/GAPS.md
+++ b/docs/GAPS.md
@@ -23,10 +23,12 @@ final security model. Each bullet links to the tracking issue.
   guests. Also note the SNP launch digest covers the VMSA set, so even a correct
   pin is per-VM-shape (vCPU count). Candidate fix is operator-signed allowlist
   entries verified in-guest against a baked operator public key.
-- RA-TLS measurement pinning is SNP-only: the TDX verify path ignores
-  `policy.Measurements` (and `MinTCBVersion`) entirely — see the LIMITATION note
-  on `verifyTDXOnline` (`pkg/ratls/verify.go`). A TDX deployment relying on
-  `cds.measurements` gets signature + report-data + debug checks only.
+- RA-TLS measurement pinning is SNP-only: the TDX verify path drops
+  `policy.Measurements` and `MinTCBVersion` — the attestation-api's TDX
+  verifier surfaces no launch measurement and takes no minimum-TCB parameter,
+  so `verifyTDXEvidence` sends neither (`pkg/attestationclient/verify.go`,
+  `EvidencePolicy`). A TDX deployment relying on `cds.measurements` gets
+  signature + report-data + debug checks only.
 
 ## Mesh and certificates
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -78,13 +78,13 @@ and pass its name at install time:
 
 ```sh
 kubectl create namespace c8s-system
-kubectl create secret docker-registry ghcr-secret \
+kubectl create secret docker-registry ghcr-pull-secret \
   -n c8s-system \
   --docker-server=ghcr.io \
   --docker-username=<user-or-x-access-token> \
   --docker-password="$GITHUB_TOKEN"
 
-c8s install --namespace c8s-system --image-pull-secret ghcr-secret \
+c8s install --namespace c8s-system --image-pull-secret ghcr-pull-secret \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -151,7 +151,7 @@ rather than restating it.
 | In-guest CDS allowlist refresh is **disabled on every default kata install**: policy-monitor fail-closed refuses to run without `C8S_CDS_MEASUREMENTS`, and no shipping path can deliver the pin — baking it is self-referential (CDS runs from the same guest image the pin would be baked into, so the value would change the launch measurement it pins) and per-pod cloud-init is host-controlled (a host-chosen pin defeats the point). Guests therefore enforce the baked seed alone; operator `c8s allowlist add` reaches host-side enforcement and CDS but **not running guests**. Also: the SNP launch digest covers the VMSA set, so even a correct pin is per-VM-shape (vCPU count). Stricter than ratls-mesh (which warns and proceeds on an empty pin) by intent — for the refresh, "any attested TEE" is not enough because the host can boot its own CVM from the same guest image and pass "attested" while serving an attacker-chosen allowlist, and grow-only merging is no defence when additions are the attack. | host / operator drift | Operator-signed allowlist entries verified in-guest against a baked operator public key (candidate design). Interim: the deliberate fail-closed posture — guests enforce the measured seed and nothing else. | kata-image-policy.md; GAPS §Trust model |
 | GPU guest boots **kata's** GPU kernel with NVIDIA modules grafted from kata's rootfs — kernel/driver provenance is the kata release, not the c8s build. | supply chain | A steep GPU kernel flavor (`CONFIG_MODULES=y` + `CONFIG_MODULE_SIG_FORCE=y`, ephemeral build key) compiling/signing the NVIDIA modules. Interim: module loading locked after bring-up (`kernel.modules_disabled=1`). | pitfalls; GAPS §Confidential GPU; #292 |
 | GPU CC mode is assumed correct on the host; no positive GPU attestation (SPDM / `nvidia-smi conf-compute`) reaches the relying party. | host | Wire SPDM / conf-compute attestation. Interim: locked guest fails closed on a non-CC GPU before the agent starts. | GAPS §Confidential GPU; #55 |
-| Mesh peer verification checks the CA chain but does not pin the peer's measurement; leaf certs embed no verified measurement. On **TDX**, `Measurements` and `MinTCBVersion` set by the operator are **silently ignored** (`pkg/ratls/verify.go` `verifyTDXOnline` LIMITATION). | pod-network / co-tenant | Pin peer measurement; wire the TDX measurement/TCB path. | GAPS §Mesh; `pkg/ratls/verify.go:220`; #47 (peer pin), #303 (TDX) |
+| Mesh peer verification checks the CA chain but does not pin the peer's measurement; leaf certs embed no verified measurement. On **TDX**, `Measurements` and `MinTCBVersion` set by the operator are **silently dropped**: the attestation-api's TDX verifier surfaces no launch measurement and takes no minimum-TCB parameter, so `verifyTDXEvidence` sends neither (`pkg/attestationclient/verify.go`). | pod-network / co-tenant | Pin peer measurement; wire the TDX measurement/TCB path. | GAPS §Mesh; `pkg/attestationclient/verify.go` (`EvidencePolicy`); #47 (peer pin), #303 (TDX) |
 | In-guest mesh exempts **all** UID-0 egress (so attestation-service can reach AMD KDS) — a workload running as root egresses in plaintext, bypassing the mesh. | root workload | Scope the exemption to attestation-service, not all of UID 0. Workloads MUST run non-root meanwhile. | GAPS §Mesh; #308 |
 | Kata guests bake `C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443` so the front-door pods (tls-lb nginx, CDS RA-TLS) reach external certless clients — every kata guest therefore accepts inbound TCP:8443 **without mesh mTLS**, and any workload listening on 8443 in a kata pod is reachable without a mesh client cert. (Parser rejects mesh listener ports and non-tcp entries, and logs an audit line when active.) | pod-network / co-tenant | Per-workload rather than per-image passthrough (front doors in dedicated guests; workload guests rebuild with the variable emptied). | pitfalls "kata guests: inbound TCP port 8443 bypasses the mesh"; GAPS §Mesh and certificates |
 | Post-start kill window: policy-monitor SIGKILLs a non-allowlisted container's init *after* kata-agent forks it (single-digit-ms, no network / no user-`execve`). Field regression 2026-07 (fixed): kata-agent's `create_sandbox` does `remove_dir_all` + `create_dir_all` on `/run/kata-containers`, silently detaching the boot-time inotify watch — the monitor logged "active, seed loaded" and made **zero decisions** on any subsequently created sandbox. Now watches in generations (Remove/Rename of the watch dir + periodic inode revalidation → re-Add + re-seed), so the single-digit-ms bound holds again. Any future in-guest watcher of a kata-agent-owned path must handle the same replacement (watch **liveness**, not just existence). **Second 2026-07 miss (fixed):** the kill path's cgroup lookup matched only the bare `<cid>` basename, but a systemd-PID-1 guest names the container cgroup `cri-containerd-<cid>.scope` under `kubepods*.slice`, so `findInitPID` never found it and the SIGKILL silently missed — policy-monitor *denied* the container but it ran **unenforced** (unbounded, not a bounded window). Fixed by `cgroupDirMatchesCID` (`internal/cmds/policymonitor/kill.go`); the bound holds only with **both** fixes. | host presenting a bad image | BPF-LSM `security_bprm_check_security` hook (designed, not committed). | kata-image-policy.md G4; pitfalls "kata-agent replaces /run/kata-containers", "policy-monitor cgroup lookup"; #309 |
@@ -231,11 +231,13 @@ If any of these is false, the corresponding guarantee does not hold.
    with unsigned `oras push`.
    An operator must derive the digest separately with `sev-snp-measure` and supply it
    to the relevant verifier/chart allowlists, which default to empty. The build
-   inputs are pinned, but the rootfs is not yet bit-for-bit reproducible
-   (mkfs.ext4 writes a random UUID and timestamps), so an independent rebuild
-   cannot corroborate the published verity root hash or launch digest; the
-   per-build digest must be pinned as published. Build and pinning mechanics:
-   `docs/kata-guest-base.md`.
+   inputs are pinned and the rootfs `root_hash` is bit-for-bit reproducible
+   (`build.sh` pins mkfs.ext4's UUID/hash-seed/timestamps via
+   `SOURCE_DATE_EPOCH`/`FIXED_FS_UUID`/`FIXED_HASH_SEED` and the verity salt
+   via `VERITY_SALT`), so an independent rebuild can corroborate the published
+   verity root hash and launch digest — provided the rebuild uses the same
+   e2fsprogs/cryptsetup versions (recorded in `manifest.json`
+   `relay_toolchain`). Build and pinning mechanics: `docs/kata-guest-base.md`.
 9. **Host provisioning is correct and is not verified by c8s** — SNP enabled in
    BIOS/firmware, GPU CC mode on, vfio-pci binding clean, node labels honest
    (`--hardware-platform` is trusted, not probed). The node-level kata/containerd
@@ -326,8 +328,9 @@ binary:
 
 - **`/attest`** enforces the `cds.measurements` launch-digest allowlist before
   issuing a leaf. **`/attest-key`** issues a TEE-bound EAR (no cert) for a
-  caller-generated key — used by in-cluster components (CDS's handoff signer) — and
-  is `protected` (requires valid TEE attestation) but **does not** consult
+  caller-generated key — used by in-cluster components (CDS's handoff signer).
+  Its handler verifies the TEE attestation evidence (the `protected` wrapper
+  adds only rate limiting and a body cap) but **does not** consult
   `cds.measurements`. This asymmetry is intentional for in-cluster self-attestation;
   it means measurement pinning does not constrain this route. (Flagged for review —
   confirm whether `/attest-key` should also honor `cds.measurements`.)

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -1,7 +1,7 @@
 # c8s install flows and features (non-kata vs kata)
 
 How `c8s install` assembles the platform, and how the runtime behaviour
-differs across the three install modes. This is the overview that ties the
+differs across the two install modes. This is the overview that ties the
 deeper docs together:
 
 - [`kata.md`](kata.md) — the kata runtime install + enforcement, in depth.
@@ -73,8 +73,7 @@ not a cluster resource.
 | Component | base | `--kata` | Runs on |
 |---|:--:|:--:|---|
 | c8s operator (webhook + controllers) | ✓ | ✓ | host (runc; always webhook-exempt) |
-| MWC `pod-injector` | ✓ | ✓ | cluster (pre-install hook) |
-| webhook-cleanup Job | ✓ | ✓ | host (runc; runs on uninstall) |
+| MWC `pod-injector` | ✓ | ✓ | cluster (release-tracked resource) |
 | **CDS** (Certificate Distribution Service: verify + EAR + mesh-CA + leaf signing) | ✓ host | ✓ **CVM** | runc in base, `kata-qemu-snp` under kata |
 | attestation-service | ✓ host | ✗ (in-VM) | host DaemonSet in base; baked into the guest image under kata |
 | ratls-mesh | ✓ host | ✗ (in-VM) | host DaemonSet in base; in-VM routing under kata |
@@ -137,7 +136,7 @@ measurement), not provided by the host.
 ```
 
 The host-side pods that remain under kata — operator, kata-deploy,
-kata-image-puller, webhook-cleanup — are **infrastructure that cannot itself
+kata-image-puller — are **infrastructure that cannot itself
 run inside a CVM** (they install/serve the very thing CVMs depend on). They are
 explicitly outside the trust boundary and are exempt from kata injection (see
 [Admission flow](#admission-flow)).
@@ -146,10 +145,11 @@ explicitly outside the trust boundary and are exempt from kata injection (see
 
 ## Install flow (ordering)
 
-The ordering is load-bearing: the admission webhook must exist and be trusted
-*before* the pods it mutates are created, or those pods get admitted unmutated
-(as runc). Helm's kind-order installs `MutatingWebhookConfiguration` *after*
-Deployments, so the chart makes the MWC a **`pre-install` hook** to lead.
+The MWC `pod-injector` is an **ordinary release-tracked resource**: Helm's
+kind-order applies it *after* the Deployments, with an empty `caBundle` and
+`failurePolicy: Fail`. The chart's own pods never depend on it — the MWC's
+namespaceSelector excludes the release namespace — and workload pods are
+annotated only after `helm --wait` reports the release ready.
 
 ```mermaid
 sequenceDiagram
@@ -157,36 +157,43 @@ sequenceDiagram
     participant K as kube-apiserver
     participant Helm as helm
     participant Op as operator pod
-    participant Pods as CDS / workloads
+    participant Pods as workloads
 
     CLI->>K: kubectl apply Namespace (privileged label if --kata)
     CLI->>Helm: helm upgrade --install --wait
-    Note over Helm: pre-install hook
-    Helm->>K: create MWC pod-injector (failurePolicy=Fail, empty caBundle)
     Note over Helm: normal resources (kind-order)
     Helm->>K: create operator Deployment, kata-deploy, CDS, ...
-    Op->>Op: bootstrapWebhookPKI: mint CA + serving cert
-    Op->>K: patch MWC caBundle (once, at startup)
-    Note over Pods,K: pods created before caBundle is patched →<br/>webhook call fails → Fail rejects → ReplicaSet retries
+    Helm->>K: create MWC pod-injector (failurePolicy=Fail, empty caBundle)
+    Op->>Op: bootstrapWebhookPKI: mint ephemeral CA + serving cert
+    Op->>K: patch MWC caBundle (every operator start)
+    Op->>K: reinject sweep: delete controller-owned cw pods admitted uninjected
+    Note over Pods,K: in-scope pod created before the caBundle patch →<br/>webhook call fails → Fail rejects → ReplicaSet retries
     Pods->>K: (retry) admitted + mutated correctly
     Helm-->>CLI: --wait: all Ready
 ```
 
 Key properties (see `templates/webhook.yaml`, `controller/runner.go`):
 
-- **`failurePolicy: Fail`** means the window before the operator patches the
-  caBundle *fails closed* — pod creation is rejected and retried, never
-  admitted as an unmutated runc pod.
-- The **operator is exempt** from the webhook (`objectSelector
-  component=operator`), so it can always boot to patch the caBundle — no
-  deadlock.
-- The MWC is **`pre-install` only**, not `pre-upgrade`: the operator patches
-  the caBundle once at startup, so recreating an empty MWC on every `helm
-  upgrade` would wedge the cluster. Cost: MWC spec changes require a clean
-  reinstall. (Detailed rationale in the `webhook.yaml` header comment.)
-- CDS is an **ordinary resource** (not a hook), so it comes up
-  during the main install — bootstrap services must not be gated behind the
-  workloads that depend on them.
+- **`failurePolicy: Fail`** means the window where the MWC exists but the
+  operator hasn't patched the caBundle yet *fails closed* — pod creation is
+  rejected and retried, never admitted as an unmutated runc pod.
+- The **chart's own components are exempt** via the MWC's namespaceSelector,
+  which excludes the release namespace (plus `kube-system`, `kube-public`,
+  `kube-node-lease`, and `webhook.extraExcluded`), so the operator can always
+  boot to patch the caBundle — no deadlock.
+- The webhook CA is **ephemeral**: `bootstrapWebhookPKI` re-mints it and
+  re-patches the caBundle on every operator start. The chart renders the
+  `caBundle` field only when `webhook.caBundle` is set, so a `helm upgrade`
+  leaves the operator-patched bundle in place and MWC spec changes roll out
+  like any other resource.
+- A `cw` pod admitted while the webhook was unavailable (e.g. before the MWC
+  existed on first install) cannot self-heal — admission fires only on CREATE
+  — so the operator runs a **one-shot reinject sweep** at startup that deletes
+  controller-owned `cw` pods missing injection; their controllers recreate
+  them through the webhook.
+- CDS comes up during the main install and, living in the excluded release
+  namespace, is never gated on the webhook — bootstrap services must not be
+  gated behind the workloads that depend on them.
 
 ---
 
@@ -197,8 +204,8 @@ operator's handler (`internal/webhook/pod_mutator.go`) decides:
 
 ```mermaid
 flowchart TD
-    P["Pod CREATE"] --> EX{"component in<br/>operator / webhook-cleanup /<br/>kata-image-puller?"}
-    EX -->|yes| PASS["pass through (runc)<br/>— host infrastructure"]
+    P["Pod CREATE"] --> EX{"namespace excluded?<br/>(release ns, kube-system, ...)"}
+    EX -->|yes| PASS["webhook not called (runc)<br/>— host infrastructure"]
     EX -->|no| CW{"has confidential.ai/cw?"}
     CW -->|yes| GC["inject get-cert<br/>(c8s-cert sidecar)"]
     CW -->|no| RC
@@ -224,13 +231,15 @@ Two independent injections, both keyed off the pod (not a CR):
    `kata-qemu-snp` for `cw`-annotated pods (confidential), `kata-qemu`
    otherwise.
 
-**Exemptions** (must stay in sync across `webhook.yaml` objectSelector and the
-`kata-enforcement.yaml` VAP binding):
+**Exemptions** (the `webhook.yaml` MWC and the `kata-enforcement.yaml` VAP
+binding render the same namespaceSelector exclusion list and must stay in
+sync):
 
-- `operator` — serves the webhook.
-- `webhook-cleanup` — the pre-delete MWC remover.
-- `kata-image-puller` — host-infra that stages the guest image; it cannot run
-  as a kata VM (its `/host` bind-mount would map into the guest, not the host).
+- **excluded namespaces** — the release namespace (operator, CDS,
+  kata-image-puller: host infrastructure that installs/serves what CVMs
+  depend on — the puller cannot run as a kata VM, its `/host` bind-mount
+  would map into the guest) plus `kube-system`, `kube-public`,
+  `kube-node-lease`, and `webhook.extraExcluded`.
 - **host-namespace pods** (`hostNetwork`/`hostPID`/`hostIPC`) — a VM cannot
   share the host's namespaces. This is how `kata-deploy` (which sets
   `hostPID`+`hostNetwork`) is left as runc.
@@ -290,28 +299,25 @@ of the guest image whose SNP digest a client verifies — see
 
 ## Uninstall flow
 
-`helm uninstall` removes normal resources, but the `pre-install`-hooked MWC is
-**not** release-tracked. A leaked `failurePolicy: Fail` MWC pointing at a
-deleted operator Service would reject *every* in-scope pod creation
-cluster-wide. The chart prevents this with a **`pre-delete` hook** Job
-(`templates/webhook-cleanup.yaml`) that deletes the MWC by name before helm
-removes the operator.
+The MWC is release-tracked, so `helm uninstall` deletes it along with every
+other release resource — a `failurePolicy: Fail` webhook pointing at a deleted
+operator Service cannot leak and block pod creation cluster-wide. The only
+`pre-delete` hook in the chart is the nri-image-policy uninstall DaemonSet
+(`templates/nri-image-policy-uninstall-hook.yaml`, base mode only), which
+unwinds the host-side NRI plugin install before the release goes.
 
 ```mermaid
 sequenceDiagram
     participant Helm as helm uninstall
-    participant Job as webhook-cleanup Job
+    participant DS as nri uninstall DaemonSet
     participant K as kube-apiserver
-    Helm->>Job: run pre-delete hook (operator still alive)
-    Job->>K: kubectl delete mutatingwebhookconfiguration <release>-pod-injector
-    Helm->>K: delete release resources (operator, CDS, VAP, ...)
-    Note over K: no orphaned Fail webhook → cluster stays unblocked
+    Helm->>DS: pre-delete hook (base mode: unwind the host NRI plugin)
+    Helm->>K: delete release resources (operator, MWC pod-injector, CDS, VAP, ...)
+    Note over K: MWC removed with the release → no orphaned Fail webhook
 ```
 
-The cleanup Job is labelled `component=webhook-cleanup` (on the exemption list,
-and distinct from the operator's Service selector) and tolerates all taints so
-a single kata-tainted node cannot strand it. kata-deploy separately runs
-`kata-deploy cleanup` on `preStop` to unwind the host runtime install.
+kata-deploy separately runs `kata-deploy cleanup` on `preStop` to unwind the
+host runtime install.
 
 **`c8s uninstall`** wraps the helm step and adds the kata host sweep the
 preStop hook cannot guarantee: after the release is gone, a short-lived

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -19,7 +19,7 @@ enforcement ([`kata-image-policy.md`](kata-image-policy.md)) hangs off
 it.
 
 > **Boot model in one line.** kata-qemu does measured *direct-kernel
-> boot* (a bare `vmlinuz` + a dm-verity erofs rootfs whose root hash
+> boot* (a bare `vmlinuz` + a dm-verity ext4 rootfs whose root hash
 > rides in the kernel cmdline) — no IGVM or UKI on kata's path. The
 > mechanics (`kernel_verity_params`, SNP `kernel-hashes`, 1 vCPU for a
 > stable digest) are in
@@ -379,4 +379,4 @@ launch-digest mismatch at attestation time and clients refuse the pod.
 - [`kata-guest-base/README.md`](../kata-guest-base/README.md) — the recipe: boot model, what's baked in, build, consume, measure.
 - [`kata-image-policy.md`](kata-image-policy.md) — in-guest per-image enforcement (`policy-monitor`).
 - [`kata.md`](kata.md) — installing and enforcing the kata runtime (`c8s install --kata`).
-- [`install-flows.md`](install-flows.md) — how the three install modes assemble the platform.
+- [`install-flows.md`](install-flows.md) — how the two install modes assemble the platform.

--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -11,7 +11,7 @@ the gaps it does not.
 > "part of the launch measurement", that means it sits on the dm-verity
 > root: its bytes are covered by the SNP launch digest and cannot change
 > without changing the digest. The measurement mechanics (osbuilder
-> dm-verity erofs, `kernel-hashes`, the verity root hash in the kata
+> dm-verity ext4, `kernel-hashes`, the verity root hash in the kata
 > kernel cmdline, no IGVM/UKI) live in
 > [`kata-guest-base/README.md`](../kata-guest-base/README.md).
 
@@ -594,9 +594,12 @@ What the host still sees is the *transport*: it brokers the guest's
 outbound network, so for an anonymous pull from a public registry it
 observes which image reference and layers are fetched (a metadata
 leak, not a content-confidentiality break — the bytes are public).
-Registry credentials for private pulls are delivered to the in-guest
-CDH after attestation (KBS) rather than baked, so they are not
-exposed to the host.
+Registry credentials for private pulls are currently baked into the
+dm-verity root (`ghcr-auth.json`, covered by the launch measurement —
+see `kata-guest-base/README.md`), so they are not host-readable at
+runtime but rotate only with an image rebuild. KBS delivery to the
+in-guest CDH after attestation (`kbs://` via
+`kata.guestImage.registryAuth`) is the secret-free alternative.
 
 policy-monitor still enforces on CreateContainer (it reads the
 digest from the bundle's `config.json`). Moving the decision earlier

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -92,7 +92,8 @@ support a non-CVM install shape or a bring-your-own CDS endpoint shape.
   `cds.image.digest` are required; the CLI passes its build version when
   running `c8s install`. Unstamped local builds report version `dev`, and the
   install CLI maps that to the `main` branch tag because CI does not publish
-  `dev` (and `cds` publishes only `main`, not `latest`).
+  `dev` (CI publishes `main` and `latest` for every image on the default
+  branch).
 
 This means a default platform install creates the operator, CRDs, RBAC,
 webhook, attestation-api, and CDS. It does not mutate
@@ -171,10 +172,10 @@ caveat, and the SEV-SNP-host / GPU constraints.
 
 `c8s uninstall` reverses `c8s install`. It runs `helm uninstall` to remove the
 release (operator, CDS, attestation-api, ratls-mesh, tls-lb, the
-webhook configuration, RuntimeClasses, and the enforcement policy). The chart's
-`pre-delete` hook deletes the `MutatingWebhookConfiguration` by name first, so a
-`failurePolicy: Fail` webhook can never outlive the operator Service and block
-pod creation cluster-wide.
+webhook configuration, RuntimeClasses, and the enforcement policy). The
+`MutatingWebhookConfiguration` is release-tracked, so it is deleted with the
+release — a `failurePolicy: Fail` webhook cannot outlive the operator Service
+and block pod creation cluster-wide.
 
 For a `--kata` install it then **sweeps the host-side kata artifacts** that the
 `kata-deploy` preStop cleanup cannot guarantee: a short-lived privileged
@@ -201,8 +202,8 @@ Guardrails:
 
 Requires the `helm` and `kubectl` CLIs on `PATH`. See
 [`docs/install-flows.md`](install-flows.md#uninstall-flow) for the uninstall
-sequence (and the `webhook-cleanup` hook) and
-[`docs/kata.md`](kata.md#uninstalling) for the host sweep in full.
+sequence and [`docs/kata.md`](kata.md#uninstalling) for the host sweep in
+full.
 
 ## Chart-managed CDS
 
@@ -323,21 +324,20 @@ HTTPS to AMD KDS (`kdsintf.amd.com`), which it uses to fetch the VCEK for a bare
 report; no container runtime is needed.
 
 ```bash
-# CDS's RA-TLS endpoint is reachable by unattested clients, but it runs as a
-# locked kata guest: `kubectl port-forward` / `exec` are denied by the guest
-# policy (only the --debug guest image enables them), so localhost forwarding
-# won't work. Dial the pod IP directly from somewhere with cluster-network reach
-# (a node, or over a VPN). c8s-cds is a headless Service, so read its endpoint:
-CDS_IP=$(kubectl get endpoints c8s-cds -n c8s-system -o jsonpath='{.subsets[0].addresses[0].ip}')
+# CDS's RA-TLS endpoint answers unattested clients. Under kata the baked guest
+# env exempts the front-door port from the in-guest mesh redirect
+# (C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443 — see docs/kata.md), so a plain
+# port-forward reaches it:
+kubectl port-forward -n c8s-system svc/c8s-cds 8443:8443 &
 
-c8s cds verify "https://$CDS_IP:8443" --measurements <sha384-launch-digest>
+c8s cds verify https://localhost:8443 --measurements <sha384-launch-digest>
 
 # JSON + exit codes for CI:
-c8s cds verify "https://$CDS_IP:8443" --measurements-file digests.txt -o json
+c8s cds verify https://localhost:8443 --measurements-file digests.txt -o json
 ```
 
-PKI/SAN mismatch when dialing the IP is fine — `verify` trusts the attestation
-embedded in the serving cert, not the certificate chain.
+PKI/SAN mismatch when dialing localhost or a pod IP is fine — `verify` trusts
+the attestation embedded in the serving cert, not the certificate chain.
 
 The launch digest(s) to pin are the same values discussed under measurement
 pinning (kata guest digest via `sev-snp-measure`, or the node CVM digest). They
@@ -345,8 +345,9 @@ are enforced client-side against the report's launch measurement; with no
 `--measurements` the command still runs but prints an UNSAFE warning — any
 genuine TEE is accepted.
 
-Exit codes are a CI contract: `0` verified, `2` verification/policy failed
-(e.g. wrong measurement), `3` evidence unavailable (unreachable/unparseable).
+Exit codes are a CI contract: `0` verified, `1` usage error, `2`
+verification/policy failed (e.g. wrong measurement), `3` evidence unavailable
+(unreachable/unparseable).
 
 Caveats the output surfaces:
 
@@ -363,12 +364,10 @@ Caveats the output surfaces:
 ## Injection contract
 
 The webhook only reads pod metadata. A `ConfidentialWorkload` CR is not
-required for injection. For tls-lb pods in the c8s release namespace, the
-chart uses a dedicated webhook entry selected by the chart's existing
-`app.kubernetes.io/name=tls-lb` and release instance labels. That avoids
-sending every platform pod to the webhook during bootstrap while still ensuring
-tls-lb cannot silently start if its c8s annotation set is partially rendered or
-invalid.
+required for injection. The single webhook entry (`pods.c8s.confidential.ai`)
+excludes the release namespace via its namespaceSelector, so the chart's own
+pods never hit the webhook during bootstrap; tls-lb's get-cert containers are
+rendered directly into its pod template by the chart instead of injected.
 
 Opt a pod template in with:
 
@@ -435,9 +434,9 @@ kata it doubles as the pidns anchor for `shareProcessNamespace` — see
 
 Platform-owned workloads can specialize the same webhook behavior with typed
 c8s annotations for the cert volume, cert/key filenames, renewal interval,
-nginx reload, Secret watch paths, discovery output, and get-cert UID/GID. The
-tls-lb chart uses those annotations to keep its PKI volumes and nginx config in
-the chart while dogfooding the webhook-injected get-cert containers. The
+nginx reload, Secret watch paths, discovery output, and get-cert UID/GID.
+(tls-lb, living in the webhook-excluded release namespace, renders equivalent
+get-cert containers directly from the chart's templates instead.) The
 webhook rejects incomplete reload-watch or discovery annotation sets during pod
 admission instead of admitting a pod that cannot serve its configured
 certificate/discovery path.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -421,7 +421,7 @@ real credentials, keep in mind:
 
 ## Bump `KATA_SRC_COMMIT` in lockstep with `KATA_VERSION`
 
-`kata-guest-base/scripts/build.sh:79`
+`kata-guest-base/scripts/build.sh` (`KATA_SRC_COMMIT`)
 
 The kata source (osbuilder) is fetched by **immutable commit** (`KATA_SRC_COMMIT`),
 not by the `KATA_VERSION` git tag — a git tag is mutable, and a re-pointed

--- a/internal/cmds/cdsattest/server.go
+++ b/internal/cmds/cdsattest/server.go
@@ -136,18 +136,18 @@ func (s *Server) handleCDSCert(w http.ResponseWriter, _ *http.Request) {
 func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 	nonceB64 := r.URL.Query().Get("nonce")
 	if nonceB64 == "" {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "missing nonce")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "missing nonce")
 		return
 	}
 	nonce, err := base64.RawURLEncoding.DecodeString(nonceB64)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "nonce must be base64url")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "nonce must be base64url")
 		return
 	}
 	// The freshness guarantee rests on a high-entropy, client-chosen nonce bound
 	// into report_data; reject anything too short to carry it.
 	if len(nonce) < minNonceBytes {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "nonce too short")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "nonce too short")
 		return
 	}
 
@@ -163,7 +163,7 @@ func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 	key, err := overenc.GenerateServerKey()
 	if err != nil {
 		s.log.Error("generate session key", "error", err)
-		writeErr(w, http.StatusInternalServerError, "internal", "key generation failed")
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "key generation failed")
 		return
 	}
 	pub := key.Public()
@@ -175,7 +175,7 @@ func (s *Server) handleAttestation(w http.ResponseWriter, r *http.Request) {
 	evidence, platform, generation, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
 	if err != nil {
 		s.log.Error("evidence provider failed", "error", err)
-		writeErr(w, http.StatusBadGateway, "attestation_unavailable", "could not obtain attestation evidence")
+		writeErr(w, http.StatusBadGateway, types.ErrorCodeAttestationUnavailable, "could not obtain attestation evidence")
 		return
 	}
 
@@ -207,7 +207,7 @@ func (s *Server) handleAttestationTLSCert(w http.ResponseWriter, r *http.Request
 	spki, err := s.servingLeafSPKI()
 	if err != nil {
 		s.log.Error("tls-cert binding unavailable", "error", err)
-		writeErr(w, http.StatusNotImplemented, "binding_unavailable",
+		writeErr(w, http.StatusNotImplemented, types.ErrorCodeBindingUnavailable,
 			"tls-cert binding is not configured on this LB (set --serving-cert-file)")
 		return
 	}
@@ -219,7 +219,7 @@ func (s *Server) handleAttestationTLSCert(w http.ResponseWriter, r *http.Request
 	evidence, platform, generation, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
 	if err != nil {
 		s.log.Error("evidence provider failed", "error", err)
-		writeErr(w, http.StatusBadGateway, "attestation_unavailable", "could not obtain attestation evidence")
+		writeErr(w, http.StatusBadGateway, types.ErrorCodeAttestationUnavailable, "could not obtain attestation evidence")
 		return
 	}
 
@@ -260,7 +260,7 @@ func (s *Server) servingLeafSPKI() ([]byte, error) {
 func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
 	var req types.HandshakeRequest
 	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "invalid JSON")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "invalid JSON")
 		return
 	}
 
@@ -273,33 +273,33 @@ func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Unlock()
 	if !ok || now.Sub(entry.createdAt) > s.cfg.NonceTTL {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "unknown or expired nonce")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "unknown or expired nonce")
 		return
 	}
 
 	nonce, err := base64.RawURLEncoding.DecodeString(req.Nonce)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "nonce must be base64url")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "nonce must be base64url")
 		return
 	}
 	clientX, err1 := base64.RawURLEncoding.DecodeString(req.ClientX25519)
 	ct, err2 := base64.RawURLEncoding.DecodeString(req.MLKEMCt)
 	if err1 != nil || err2 != nil {
-		writeErr(w, http.StatusBadRequest, "invalid_request", "handshake fields must be base64url")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "handshake fields must be base64url")
 		return
 	}
 
 	channel, err := entry.key.Agree(overenc.Handshake{ClientX25519: clientX, MLKEMCiphertext: ct}, nonce)
 	if err != nil {
 		s.log.Warn("handshake agree failed", "error", err)
-		writeErr(w, http.StatusBadRequest, "channel_error", "key agreement failed")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "key agreement failed")
 		return
 	}
 
 	idRaw := make([]byte, 16)
 	if _, err := rand.Read(idRaw); err != nil {
 		s.log.Error("generate session id", "error", err)
-		writeErr(w, http.StatusInternalServerError, "internal", "session id generation failed")
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "session id generation failed")
 		return
 	}
 	id := base64.RawURLEncoding.EncodeToString(idRaw)
@@ -333,29 +333,29 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 	s.mu.Unlock()
 
 	if session.channel == nil {
-		writeErr(w, http.StatusUnauthorized, "channel_error", "no over-encryption session")
+		writeErr(w, http.StatusUnauthorized, types.ErrorCodeChannelError, "no over-encryption session")
 		return
 	}
 
 	recBytes, err := io.ReadAll(io.LimitReader(r.Body, 8<<20))
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, "channel_error", "read record")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "read record")
 		return
 	}
 	var rec overenc.Record
 	if err := cbor.Unmarshal(recBytes, &rec); err != nil {
-		writeErr(w, http.StatusBadRequest, "channel_error", "invalid record")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "invalid record")
 		return
 	}
 	plaintext, err := session.channel.Open(rec, overenc.RequestAAD())
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, "channel_error", "decrypt failed")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "decrypt failed")
 		return
 	}
 
 	var env types.TunnelRequest
 	if err := cbor.Unmarshal(plaintext, &env); err != nil {
-		writeErr(w, http.StatusBadRequest, "channel_error", "invalid request envelope")
+		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "invalid request envelope")
 		return
 	}
 
@@ -367,12 +367,12 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 
 	respCBOR, err := cbor.Marshal(resp)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "internal", "marshal response envelope")
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "marshal response envelope")
 		return
 	}
 	out, err := session.channel.Seal(respCBOR, overenc.ResponseAAD())
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "internal", "seal failed")
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "seal failed")
 		return
 	}
 	writeCBOR(w, http.StatusOK, out)
@@ -423,7 +423,7 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 func writeCBOR(w http.ResponseWriter, status int, v any) {
 	b, err := cbor.Marshal(v)
 	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "internal", "marshal failed")
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "marshal failed")
 		return
 	}
 	w.Header().Set("Content-Type", "application/cbor")

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -131,7 +131,7 @@ func bindProxyFlags(fs *pflag.FlagSet, c *proxyConfig) {
 	fs.StringVar(&c.cdsMeasurements, "cds-measurements", "", "comma-separated SHA-384 hex launch measurements that CDS's RA-TLS peer cert must match. Empty = accept any (UNSAFE outside development).")
 	fs.IntVar(&c.sessionCacheSize, "session-cache-size", 64, "TLS session cache size per node (0 disables session resumption)")
 	fs.BoolVar(&c.accessLog, "access-log", true, "emit per-connection structured access log")
-	fs.StringVar(&c.certPipelineProbeURL, "cert-pipeline-probe-url", "", "CDS /ready URL for pipeline health probing (empty = disabled)")
+	fs.StringVar(&c.certPipelineProbeURL, "cert-pipeline-probe-url", "", "CDS /readyz URL for pipeline health probing (empty = disabled)")
 	fs.DurationVar(&c.cdsRetryBackoff, "cds-retry-backoff", 2*time.Second, "initial backoff duration for CDS certificate upgrade retries")
 	fs.DurationVar(&c.cdsRetryMaxBackoff, "cds-retry-max-backoff", 60*time.Second, "maximum backoff duration for CDS certificate upgrade retries")
 	fs.IntVar(&c.maxDestHeaderSize, "max-dest-header-size", 256, "maximum destination header size in bytes")
@@ -505,7 +505,7 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		logger.Info("CA bundle refresh enabled", "url", effectiveCAURL, "interval", c.caPollInterval)
 	}
 
-	// Cert pipeline health probe: periodically check CDS /ready.
+	// Cert pipeline health probe: periodically check CDS /readyz.
 	if c.certPipelineProbeURL != "" {
 		m.certPipelineHealthy.Set(0) // Start as unhealthy until first probe succeeds.
 		go func() {

--- a/internal/cmds/ratlsmesh/metrics.go
+++ b/internal/cmds/ratlsmesh/metrics.go
@@ -176,7 +176,7 @@ func newMetrics() *metrics {
 	})
 	m.certPipelineHealthy = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ratls_mesh_cert_pipeline_healthy",
-		Help: "1 when CDS /ready is reachable (0=unreachable). Stays at -1 when CDS probing is not configured.",
+		Help: "1 when CDS /readyz is reachable (0=unreachable). Stays at -1 when CDS probing is not configured.",
 	})
 	m.certPipelineHealthy.Set(-1)
 	m.certExpiry = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -156,12 +156,7 @@ spec:
             # publicTLS secret it is that cert (mounted below). Re-read per request, so
             # get-cert renewals are picked up.
             - --serving-cert-file={{ include "tls-lb.publicCertPath" . }}
-            # --cds-cert-file is intentionally NOT set: nginx serves the same cert
-            # statically at /.well-known/c8s/cds-cert.pem from the shared cert volume
-            # and hot-reloads it on get-cert renewal (SIGHUP), whereas cds-attest
-            # would read it once at startup and embed a stale copy in every bundle.
-            # The cds_cert_pem is not bound to the attestation (report_data binds the
-            # session key), so the client pins the mesh CA out of band instead.
+            # --cds-cert-file intentionally unset: nginx serves the live cert at discovery.cdsCertPath (/.well-known/cds-cert.pem); cds-attest would embed a stale startup copy.
             # Terminate over-encryption here and forward to the same workload
             # backend nginx proxies to. An http upstream is plaintext at the
             # app layer; pointed at a headless Service (an adopted workload),

--- a/kata-guest-base/README.md
+++ b/kata-guest-base/README.md
@@ -98,7 +98,7 @@ attests — is described in [`../docs/pitfalls.md`](../docs/pitfalls.md)
 > The host's CRI also does its own (anonymous) image-exists pull before
 > the guest pulls, so a private workload still needs host-side creds too
 > (`serviceAccount.imagePullSecrets`). See `docs/pitfalls.md`
-> "kata-qemu-snp pods still need a host-side image pull".
+> "Private workload images need registry creds in TWO places under guest-pull".
 
 ## Build
 
@@ -110,7 +110,7 @@ attests — is described in [`../docs/pitfalls.md`](../docs/pitfalls.md)
 sudo apt-get install -y docker.io && sudo systemctl enable --now docker
 
 # Once per c8s/attestation-rs revision: build the in-guest binaries.
-cd /workspace/c8s            && make build-c8s-node && make build-policy-monitor
+cd /workspace/c8s            && make build-c8s-node && make build-policy-monitor && make build-rtmr3-measurer
 cd /workspace/attestation-rs && cargo build --release -p attestation-api --bin attestation-api --target x86_64-unknown-linux-musl
 
 # Stage the binaries + the bootstrap allowlist into extra/. (The attester

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -11,7 +11,7 @@
 # not a self-booting image:
 #
 #   kernel = <vmlinuz>                 a bare bzImage  (steep's hardened kernel)
-#   image  = <kata-rootfs.img>         a 2-partition image: p1=erofs rootfs,
+#   image  = <kata-rootfs.img>         a 2-partition image: p1=ext4 rootfs,
 #                                      p2=dm-verity hash tree (NO superblock)
 #   kernel_verity_params = root_hash=…,salt=…,data_blocks=…,…
 #

--- a/pkg/ratls/extension.go
+++ b/pkg/ratls/extension.go
@@ -155,7 +155,7 @@ func UnmarshalExtension(der []byte) (*Attestation, error) {
 	// first and only normalize the raw SNP report shape when no envelope is
 	// present; verification wraps the raw report in the "snp" envelope for
 	// attestation-api /verify. TDX has no raw-bytes shape (no in-process Go
-	// parser is carried; see verifyTDXOnline in verify.go), so an envelope
+	// parser is carried; see verifyReport in verify.go), so an envelope
 	// is required.
 	embedded, err := parseEmbeddedEvidence(raw.Report)
 	if err != nil {

--- a/pkg/ratls/ratls_test.go
+++ b/pkg/ratls/ratls_test.go
@@ -455,8 +455,8 @@ func TestUnmarshalExtensionReportSize(t *testing.T) {
 
 	t.Run("TDX raw bytes are rejected", func(t *testing.T) {
 		// TDX extensions carry the full attestation-api evidence
-		// envelope (JSON), not raw quote bytes — verifyTDXOnline reads
-		// the envelope back and forwards it to attestation-api. Refuse
+		// envelope (JSON), not raw quote bytes — verifyEnvelopeOnline
+		// reads the envelope back and forwards it to attestation-api. Refuse
 		// raw bytes at parse time so a wire-format regression fails
 		// loudly instead of silently taking the "empty embedded" path.
 		att := &attestationASN1{

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -20,7 +20,8 @@ import (
 type VerifyPolicy struct {
 	// Measurements is the set of acceptable launch measurements (48 bytes each).
 	// If empty, any measurement is accepted (UNSAFE — use only for development).
-	// Enforced on the SNP path only; ignored for TDX (see verifyTDXOnline).
+	// Enforced on the SNP path only; dropped for TDX (see
+	// attestationclient.EvidencePolicy).
 	Measurements [][]byte
 
 	// MinTCBVersion is the minimum acceptable platform TCB version.
@@ -28,7 +29,8 @@ type VerifyPolicy struct {
 	// (bootloader, TEE, reserved, snp, microcode, etc.) — each component
 	// of the current TCB must be >= the corresponding minimum.
 	// If zero, any TCB version is accepted.
-	// Enforced on the SNP path only; ignored for TDX (see verifyTDXOnline).
+	// Enforced on the SNP path only; dropped for TDX (see
+	// attestationclient.EvidencePolicy).
 	MinTCBVersion uint64
 
 	// AllowDebug controls whether debug-mode guests are accepted.

--- a/pkg/types/error_codes.go
+++ b/pkg/types/error_codes.go
@@ -14,4 +14,8 @@ const (
 	ErrorCodeSignFailed                = "sign_failed"
 	ErrorCodeTimeout                   = "timeout"
 	ErrorCodeAttestationApiUnreachable = "attestation_api_unreachable"
+	ErrorCodeChannelError              = "channel_error"
+	ErrorCodeInternal                  = "internal"
+	ErrorCodeAttestationUnavailable    = "attestation_unavailable"
+	ErrorCodeBindingUnavailable        = "binding_unavailable"
 )

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -20,8 +20,10 @@ services:
 
   get-cert:
     build:
+      # cmd/get-cert/Dockerfile COPYs build/c8s, so the context must be the
+      # repo root and `make build` must have run first.
       context: ../..
-      dockerfile: Dockerfile.get-cert
+      dockerfile: cmd/get-cert/Dockerfile
     command:
       - --cds-url=http://mock-cds:8080
       - --attestation-api-url=http://mock-attestation:8400


### PR DESCRIPTION
…, guest-base facts