### PR TITLE
fix(policy-monitor): terminate denied cgroups atomically

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.26
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/confidential-dot-ai/attestation-go v0.3.0
-	github.com/containerd/cgroups/v3 v3.1.2
 	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.11.0
@@ -41,6 +40,7 @@ require (
 	github.com/Microsoft/hcsshim v0.14.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/containerd/cgroups/v3 v3.1.2 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/confidential-dot-ai/attestation-go v0.3.0
+	github.com/containerd/cgroups/v3 v3.1.2
 	github.com/containerd/containerd/v2 v2.2.5
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.11.0
@@ -40,7 +41,6 @@ require (
 	github.com/Microsoft/hcsshim v0.14.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/containerd/cgroups/v3 v3.1.2 // indirect
 	github.com/containerd/containerd/api v1.10.0 // indirect
 	github.com/containerd/continuity v0.4.5 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/internal/cmds/policymonitor/coverage_test.go
+++ b/internal/cmds/policymonitor/coverage_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -194,40 +193,21 @@ func TestRunAllowlistRefresh_EmptyMeasurementsFailsClosed(t *testing.T) {
 
 // --- monitor.kill paths ---------------------------------------------------
 
-func TestMonitorKill_LocatorError(t *testing.T) {
-	m, killer, locator, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	locator.err = os.ErrPermission
-	m.kill("somecid")
-	if calls := killer.snapshot(); len(calls) != 0 {
-		t.Fatalf("expected no kill when locator errors, got %+v", calls)
-	}
-}
-
-func TestMonitorKill_PIDNotFound(t *testing.T) {
-	m, killer, locator, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	locator.ok = false
-	m.kill("somecid")
-	if calls := killer.snapshot(); len(calls) != 0 {
-		t.Fatalf("expected no kill when pid not found, got %+v", calls)
-	}
-}
-
-func TestMonitorKill_ESRCHIsBenign(t *testing.T) {
-	m, killer, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	killer.err = syscall.ESRCH
-	// kill should swallow ESRCH (process already gone) without panicking.
+func TestMonitorKill_KillerError(t *testing.T) {
+	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	killer.err = os.ErrPermission
 	m.kill("somecid")
 	if calls := killer.snapshot(); len(calls) != 1 {
-		t.Fatalf("expected the kill syscall to be attempted once, got %+v", calls)
+		t.Fatalf("expected one cgroup kill attempt, got %+v", calls)
 	}
 }
 
-func TestMonitorKill_OtherKillError(t *testing.T) {
-	m, killer, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	killer.err = syscall.EPERM
+func TestMonitorKill_CgroupNotFound(t *testing.T) {
+	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	killer.ok = false
 	m.kill("somecid")
 	if calls := killer.snapshot(); len(calls) != 1 {
-		t.Fatalf("expected one attempted kill, got %+v", calls)
+		t.Fatalf("expected one cgroup lookup, got %+v", calls)
 	}
 }
 
@@ -235,7 +215,7 @@ func TestMonitorKill_OtherKillError(t *testing.T) {
 
 func TestSeedExisting_DeniesPreexistingContainer(t *testing.T) {
 	denied := strings.Repeat("b", 64)
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 
 	// A container directory already present when the monitor starts (e.g.
 	// systemd restarted policy-monitor while a workload was live).
@@ -256,7 +236,7 @@ func TestSeedExisting_DeniesPreexistingContainer(t *testing.T) {
 }
 
 func TestSeedExisting_MissingWatchDir(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	m.cfg.WatchDir = filepath.Join(watchDir, "does-not-exist")
 	if err := m.seedExisting(); err == nil {
 		t.Fatal("expected error reading a missing watch dir")
@@ -266,7 +246,7 @@ func TestSeedExisting_MissingWatchDir(t *testing.T) {
 // --- readConfigJSON / readOCISpec error paths -----------------------------
 
 func TestReadConfigJSON_MissingForeverTimesOut(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	m.configReadDeadline = 60 * time.Millisecond
 	m.configReadInterval = 10 * time.Millisecond
 	_, err := m.readConfigJSON(context.Background(), filepath.Join(watchDir, "nope", "config.json"))
@@ -276,7 +256,7 @@ func TestReadConfigJSON_MissingForeverTimesOut(t *testing.T) {
 }
 
 func TestReadConfigJSON_ContextCancelled(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	m.configReadDeadline = 5 * time.Second
 	m.configReadInterval = 10 * time.Millisecond
 	ctx, cancel := context.WithCancel(context.Background())
@@ -288,7 +268,7 @@ func TestReadConfigJSON_ContextCancelled(t *testing.T) {
 }
 
 func TestReadConfigJSON_UnrecoverableIsADir(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	// Point at a directory: os.ReadFile returns a non-ENOENT, non-partial
 	// error, which readConfigJSON must surface immediately rather than
 	// retrying to the deadline.
@@ -331,7 +311,7 @@ func TestReadOCISpec_BadJSONIsPartial(t *testing.T) {
 }
 
 func TestHandleNewContainer_ConfigNeverAppears_NoKill(t *testing.T) {
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	m.configReadDeadline = 40 * time.Millisecond
 	m.configReadInterval = 10 * time.Millisecond
 	// Only the directory, no config.json ever. The read fails and the
@@ -347,49 +327,15 @@ func TestHandleNewContainer_ConfigNeverAppears_NoKill(t *testing.T) {
 	}
 }
 
-// --- signalSender ---------------------------------------------------------
-
-func TestSignalSender_RefusesLowPID(t *testing.T) {
-	s := signalSender{}
-	if err := s.kill(1, syscall.SIGKILL); err == nil {
-		t.Error("expected refusal to signal pid 1")
-	}
-	if err := s.kill(0, syscall.SIGKILL); err == nil {
-		t.Error("expected refusal to signal pid 0")
-	}
-}
-
-func TestSignalSender_UnsupportedSignalType(t *testing.T) {
-	s := signalSender{}
-	if err := s.kill(4242, fakeSignal{}); err == nil {
-		t.Error("expected error for non-syscall.Signal type")
-	}
-}
-
-func TestSignalSender_ESRCHForDeadPID(t *testing.T) {
-	s := signalSender{}
-	// PID 2^30 is overwhelmingly unlikely to exist; signal 0 only checks
-	// for existence and never actually delivers, so this is safe.
-	err := s.kill(1<<30, syscall.Signal(0))
-	if err == nil {
-		t.Skip("pid unexpectedly existed; skipping")
-	}
-}
-
-type fakeSignal struct{}
-
-func (fakeSignal) String() string { return "fake" }
-func (fakeSignal) Signal()        {}
-
 // --- cgroup helpers -------------------------------------------------------
 
-func TestNewCgroupLocator_Defaults(t *testing.T) {
-	loc := newCgroupLocator("/sys/fs/cgroup")
-	if loc.cgroupRoot != "/sys/fs/cgroup" {
-		t.Errorf("cgroupRoot = %q", loc.cgroupRoot)
+func TestNewCgroupKiller_Defaults(t *testing.T) {
+	killer := newCgroupKiller("/sys/fs/cgroup")
+	if killer.cgroupRoot != "/sys/fs/cgroup" {
+		t.Errorf("cgroupRoot = %q", killer.cgroupRoot)
 	}
-	if loc.waitTimeout <= 0 || loc.pollInterval <= 0 {
-		t.Errorf("expected positive wait/poll, got %v/%v", loc.waitTimeout, loc.pollInterval)
+	if killer.waitTimeout <= 0 || killer.pollInterval <= 0 {
+		t.Errorf("expected positive wait/poll, got %v/%v", killer.waitTimeout, killer.pollInterval)
 	}
 }
 
@@ -397,43 +343,6 @@ func TestFindCgroupDir_EmptyID(t *testing.T) {
 	_, err := findCgroupDir(t.TempDir(), "")
 	if err == nil {
 		t.Fatal("expected error for empty container id")
-	}
-}
-
-func TestFindInitPID_EmptyProcsTreatedAsNotFound(t *testing.T) {
-	root := t.TempDir()
-	cid := "emptyprocs"
-	dir := filepath.Join(root, cid)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	loc := &cgroupLocator{cgroupRoot: root, waitTimeout: 100 * time.Millisecond, pollInterval: 20 * time.Millisecond}
-	pid, ok, err := loc.findInitPID(cid)
-	if err != nil {
-		t.Fatalf("findInitPID: %v", err)
-	}
-	if ok {
-		t.Fatalf("expected ok=false for empty cgroup.procs, got pid=%d", pid)
-	}
-}
-
-func TestReadFirstPID_NonNumeric(t *testing.T) {
-	dir := t.TempDir()
-	procs := filepath.Join(dir, "cgroup.procs")
-	if err := os.WriteFile(procs, []byte("not-a-pid\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := readFirstPID(procs); err == nil {
-		t.Fatal("expected parse error for non-numeric pid")
-	}
-}
-
-func TestReadFirstPID_MissingFile(t *testing.T) {
-	if _, err := readFirstPID(filepath.Join(t.TempDir(), "absent")); err == nil {
-		t.Fatal("expected error opening a missing file")
 	}
 }
 
@@ -533,7 +442,7 @@ func TestRunMonitor_RunsAndStopsOnContextCancel(t *testing.T) {
 
 func TestMonitorRun_AllowedContainerNotKilled(t *testing.T) {
 	digest := strings.Repeat("a", 64)
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -559,7 +468,7 @@ func TestMonitorRun_AllowedContainerNotKilled(t *testing.T) {
 // is not an error. "Uncreatable" still must be: a regular file where the
 // parent dir should be.
 func TestMonitorRun_WatchDirUncreatable(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	blocker := filepath.Join(watchDir, "blocker")
 	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -2,7 +2,7 @@
 
 package policymonitor
 
-// Container init PID discovery + SIGKILL.
+// Container cgroup discovery + termination.
 //
 // kata-agent does not write a state.json or a pid file for the
 // container's init process — the PID lives in the in-memory
@@ -14,14 +14,10 @@ package policymonitor
 // (systemd >= 232 enables it by default; the upstream kata-agent and
 // runc work in this mode when systemd is PID 1, which is our case).
 // Each container created by kata-agent ends up with its own cgroup
-// directory under /sys/fs/cgroup; the directory's `cgroup.procs` file
-// lists every PID in the cgroup, one per line, lowest PID first.
-//
-// The init process is, by construction, the first process in the
-// cgroup (kata-agent creates the cgroup, then forks the init into it
-// before any exec setup; later children inherit the cgroup but get
-// higher PIDs because they're descendants of init). So `head -1
-// cgroup.procs` is the init PID.
+// directory under /sys/fs/cgroup. We wait for the cgroup to become
+// populated, then terminate the cgroup as a unit. Selecting a PID from
+// cgroup.procs is incorrect: the kernel does not order that file, and a
+// PID can be recycled between the read and a signal syscall.
 //
 // We walk the hierarchy to find the subdirectory that identifies the
 // container, because kata-agent's cgroup naming depends on the guest's
@@ -39,58 +35,28 @@ package policymonitor
 //                     ran. cgroupDirMatchesCID recognises both shapes.
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
+
+	"github.com/containerd/cgroups/v3/cgroup2"
 )
 
-// killer is the dependency-injection surface the monitor uses to send
-// signals. Real production: signalSender{} which wraps syscall.Kill.
-// Tests: a fake that records its arguments.
-type killer interface {
-	kill(pid int, signal os.Signal) error
+// containerKiller is the dependency-injection surface used by the monitor.
+// The boolean is false when the container has already exited or its cgroup
+// never materialised within the configured budget.
+type containerKiller interface {
+	kill(containerID string) (bool, error)
 }
 
-type signalSender struct{}
-
-var _ killer = signalSender{}
-
-func (signalSender) kill(pid int, sig os.Signal) error {
-	if pid <= 1 {
-		// Guard against killing init / a wrap-around. kata-agent never
-		// allocates PID 1 (that's systemd inside the guest) or PID 0
-		// (kernel) for a container; treat as a programming error.
-		return fmt.Errorf("refusing to signal pid %d", pid)
-	}
-	s, ok := sig.(syscall.Signal)
-	if !ok {
-		return fmt.Errorf("unsupported signal type %T", sig)
-	}
-	return syscall.Kill(pid, s)
-}
-
-// pidLocator finds the init PID for a container. Like killer, it's an
-// interface so tests can substitute a tempdir-rooted fake without
-// having to fabricate a /sys/fs/cgroup hierarchy.
-type pidLocator interface {
-	// findInitPID returns the init PID for containerID. The boolean is
-	// false if the container's cgroup couldn't be located in the
-	// configured time budget — the monitor logs and skips, because a
-	// container whose cgroup we can't find has probably already exited
-	// (the desirable outcome anyway).
-	findInitPID(containerID string) (int, bool, error)
-}
-
-// cgroupLocator is the production implementation. It searches the
-// configured cgroup root for a directory whose basename equals the
-// container id, then reads cgroup.procs.
-type cgroupLocator struct {
+// cgroupKiller searches the configured cgroup root and terminates the
+// matching cgroup as a unit. It uses the existing containerd cgroups library,
+// which writes cgroup.kill on modern kernels and has a compatibility fallback
+// for older unified cgroup kernels.
+type cgroupKiller struct {
 	cgroupRoot string
 	// waitTimeout caps how long we re-scan for the cgroup directory
 	// before giving up. kata-agent creates the cgroup and forks the
@@ -104,40 +70,48 @@ type cgroupLocator struct {
 	pollInterval time.Duration
 }
 
-var _ pidLocator = (*cgroupLocator)(nil)
+var _ containerKiller = (*cgroupKiller)(nil)
 
-func newCgroupLocator(root string) *cgroupLocator {
-	return &cgroupLocator{
+func newCgroupKiller(root string) *cgroupKiller {
+	return &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  2 * time.Second,
 		pollInterval: 50 * time.Millisecond,
 	}
 }
 
-func (c *cgroupLocator) findInitPID(containerID string) (int, bool, error) {
+func (c *cgroupKiller) kill(containerID string) (bool, error) {
 	deadline := time.Now().Add(c.waitTimeout)
 	for {
 		dir, err := findCgroupDir(c.cgroupRoot, containerID)
 		if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return 0, false, fmt.Errorf("walk cgroup hierarchy: %w", err)
+			return false, fmt.Errorf("walk cgroup hierarchy: %w", err)
 		}
 		if dir != "" {
-			if pid, perr := readFirstPID(filepath.Join(dir, "cgroup.procs")); perr == nil {
-				return pid, true, nil
+			group, err := filepath.Rel(c.cgroupRoot, dir)
+			if err != nil {
+				return false, fmt.Errorf("resolve cgroup path: %w", err)
 			}
-			// The cgroup exists but cgroup.procs is empty (or unreadable):
-			// kata-agent creates the cgroup and writes config.json — our
-			// trigger — BEFORE it forks the container init into the cgroup, so
-			// procs is briefly empty right when we look. Keep polling within
-			// the budget rather than giving up: the common race populates and
-			// we get the init PID to SIGKILL, while a container that genuinely
-			// exited stays empty and times out to a harmless no-op. Returning
-			// "not found" here (as this used to) is why a denied container's
-			// kill silently missed — the enforce decision was correct, the
-			// SIGKILL never landed.
+			manager, err := cgroup2.Load("/"+filepath.ToSlash(group), cgroup2.WithMountpoint(c.cgroupRoot))
+			if err != nil {
+				return false, fmt.Errorf("load cgroup: %w", err)
+			}
+			// Include descendants: cgroup.kill terminates the entire subtree,
+			// so a child cgroup must also make the group eligible for killing.
+			procs, err := manager.Procs(true)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					return false, fmt.Errorf("read cgroup processes: %w", err)
+				}
+			} else if len(procs) > 0 {
+				if err := manager.Kill(); err != nil {
+					return false, fmt.Errorf("kill cgroup: %w", err)
+				}
+				return true, nil
+			}
 		}
 		if time.Now().After(deadline) {
-			return 0, false, nil
+			return false, nil
 		}
 		time.Sleep(c.pollInterval)
 	}
@@ -169,7 +143,7 @@ func findCgroupDir(root, containerID string) (string, error) {
 			// fine for a denied container (kata-agent reaps it when
 			// CreateContainer returns). But do NOT swallow *every* error:
 			// anything else (an I/O error, a broken/zombie cgroup) is a
-			// real signal, so propagate it. findInitPID returns it as
+			// real signal, so propagate it. cgroupKiller returns it as
 			// "walk cgroup hierarchy: ..." and the monitor logs it at
 			// Warn — rather than silently continuing and reporting a
 			// misleading no-op kill for a container we never searched.
@@ -205,31 +179,4 @@ func findCgroupDir(root, containerID string) (string, error) {
 func cgroupDirMatchesCID(basename, containerID string) bool {
 	name := strings.TrimSuffix(basename, ".scope")
 	return name == containerID || strings.HasSuffix(name, "-"+containerID)
-}
-
-// readFirstPID reads the first line of path and returns it as an int.
-// The cgroup.procs format is one PID per line; we want the lowest,
-// which is the file's first line on every kernel that produces sorted
-// output (Linux >= 3.16 always sorts cgroup.procs; we don't care to
-// support older kernels because kata SEV-SNP requires a much newer
-// kernel anyway).
-func readFirstPID(path string) (int, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return 0, err
-	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	if !scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return 0, err
-		}
-		return 0, errors.New("cgroup.procs is empty")
-	}
-	line := strings.TrimSpace(scanner.Text())
-	pid, err := strconv.Atoi(line)
-	if err != nil {
-		return 0, fmt.Errorf("parse pid %q: %w", line, err)
-	}
-	return pid, nil
 }

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -54,6 +54,9 @@ type containerKiller interface {
 
 // cgroupKiller searches the configured cgroup root and terminates the
 // matching cgroup as a unit by writing the kernel's cgroup.kill interface.
+// The supported Kata guest kernels provide this interface; no best-effort
+// PID fallback is permitted because a failed kill must never be reported as
+// successful.
 type cgroupKiller struct {
 	cgroupRoot string
 	// waitTimeout caps how long we re-scan for the cgroup directory

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -37,12 +37,12 @@ package policymonitor
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
-
-	"github.com/containerd/cgroups/v3/cgroup2"
 )
 
 // containerKiller is the dependency-injection surface used by the monitor.
@@ -53,9 +53,7 @@ type containerKiller interface {
 }
 
 // cgroupKiller searches the configured cgroup root and terminates the
-// matching cgroup as a unit. It uses the existing containerd cgroups library,
-// which writes cgroup.kill on modern kernels and has a compatibility fallback
-// for older unified cgroup kernels.
+// matching cgroup as a unit by writing the kernel's cgroup.kill interface.
 type cgroupKiller struct {
 	cgroupRoot string
 	// waitTimeout caps how long we re-scan for the cgroup directory
@@ -92,19 +90,15 @@ func (c *cgroupKiller) kill(containerID string) (bool, error) {
 			if err != nil {
 				return false, fmt.Errorf("resolve cgroup path: %w", err)
 			}
-			manager, err := cgroup2.Load("/"+filepath.ToSlash(group), cgroup2.WithMountpoint(c.cgroupRoot))
-			if err != nil {
-				return false, fmt.Errorf("load cgroup: %w", err)
-			}
 			// Include descendants: cgroup.kill terminates the entire subtree,
 			// so a child cgroup must also make the group eligible for killing.
-			procs, err := manager.Procs(true)
+			procs, err := readCgroupProcs(c.cgroupRoot, group)
 			if err != nil {
 				if !errors.Is(err, os.ErrNotExist) {
 					return false, fmt.Errorf("read cgroup processes: %w", err)
 				}
 			} else if len(procs) > 0 {
-				if err := manager.Kill(); err != nil {
+				if err := writeCgroupKill(dir); err != nil {
 					return false, fmt.Errorf("kill cgroup: %w", err)
 				}
 				return true, nil
@@ -115,6 +109,46 @@ func (c *cgroupKiller) kill(containerID string) (bool, error) {
 		}
 		time.Sleep(c.pollInterval)
 	}
+}
+
+func readCgroupProcs(root, group string) ([]string, error) {
+	var procs []string
+	err := filepath.WalkDir(filepath.Join(root, filepath.FromSlash(group)), func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "cgroup.procs" {
+			return nil
+		}
+		entries, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		for _, proc := range strings.Fields(string(entries)) {
+			if _, err := strconv.ParseUint(proc, 10, 64); err != nil {
+				return fmt.Errorf("parse pid %q: %w", proc, err)
+			}
+			procs = append(procs, proc)
+		}
+		return nil
+	})
+	return procs, err
+}
+
+func writeCgroupKill(dir string) error {
+	f, err := os.OpenFile(filepath.Join(dir, "cgroup.kill"), os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	n, writeErr := io.WriteString(f, "1")
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return closeErr
 }
 
 // findCgroupDir walks root looking for a directory that identifies

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -255,3 +255,19 @@ func TestCgroupKiller_PropagatesMalformedProcs(t *testing.T) {
 		t.Fatalf("kill = (%v, %v), want permanent parse error", ok, err)
 	}
 }
+
+func TestCgroupKiller_PropagatesMissingKillInterface(t *testing.T) {
+	root := t.TempDir()
+	cid := "missing-kill"
+	dir := filepath.Join(root, cid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("1234\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	killer := &cgroupKiller{cgroupRoot: root, waitTimeout: time.Second, pollInterval: time.Millisecond}
+	if ok, err := killer.kill(cid); err == nil || ok {
+		t.Fatalf("kill = (%v, %v), want missing cgroup.kill error", ok, err)
+	}
+}

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -10,39 +10,29 @@ import (
 	"time"
 )
 
-// (The thread-safe pidLocator test double lives in monitor_test.go as
-// threadSafeFakeLocator, because it's used from goroutines started by
-// the inotify dispatcher. There is no second non-thread-safe variant —
-// the kill_test.go cases drive findInitPID directly through the real
-// cgroupLocator against a tempdir-rooted fake hierarchy.)
-
-// fakeKiller records every call and lets the test assert on it. The
+// fakeKiller records every cgroup termination and lets the test assert on it. The
 // mutex makes it safe to share between the inotify dispatch goroutine
 // and the test's polling loop in monitor_test.go.
 type fakeKiller struct {
 	mu    sync.Mutex
-	calls []killCall
+	calls []string
+	ok    bool
 	err   error
 }
 
-type killCall struct {
-	pid int
-	sig os.Signal
-}
-
-func (k *fakeKiller) kill(pid int, sig os.Signal) error {
+func (k *fakeKiller) kill(containerID string) (bool, error) {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.calls = append(k.calls, killCall{pid: pid, sig: sig})
-	return k.err
+	k.calls = append(k.calls, containerID)
+	return k.ok, k.err
 }
 
 // snapshot returns a copy of the recorded calls so tests can assert
 // without holding the lock.
-func (k *fakeKiller) snapshot() []killCall {
+func (k *fakeKiller) snapshot() []string {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	out := make([]killCall, len(k.calls))
+	out := make([]string, len(k.calls))
 	copy(out, k.calls)
 	return out
 }
@@ -135,67 +125,33 @@ func TestFindCgroupDir_NotFound(t *testing.T) {
 	}
 }
 
-func TestReadFirstPID(t *testing.T) {
-	dir := t.TempDir()
-	procs := filepath.Join(dir, "cgroup.procs")
-	if err := os.WriteFile(procs, []byte("12345\n67890\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	pid, err := readFirstPID(procs)
-	if err != nil {
-		t.Fatalf("readFirstPID: %v", err)
-	}
-	if pid != 12345 {
-		t.Errorf("pid = %d, want 12345", pid)
-	}
-}
-
-func TestReadFirstPID_EmptyFile(t *testing.T) {
-	dir := t.TempDir()
-	procs := filepath.Join(dir, "cgroup.procs")
-	if err := os.WriteFile(procs, []byte(""), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	_, err := readFirstPID(procs)
-	if err == nil {
-		t.Fatal("expected error on empty file")
-	}
-}
-
-func TestCgroupLocator_WaitsForCgroupToAppear(t *testing.T) {
+func TestCgroupKiller_WaitsForCgroupToAppear(t *testing.T) {
 	root := t.TempDir()
 	cid := "feedface"
-	locator := &cgroupLocator{
+	killer := &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  500 * time.Millisecond,
 		pollInterval: 20 * time.Millisecond,
 	}
-	// Drop the cgroup in after a short delay; the locator should
+	// Drop the cgroup in after a short delay; the killer should
 	// re-scan and find it.
 	go func() {
 		time.Sleep(75 * time.Millisecond)
 		dir := filepath.Join(root, cid)
 		_ = os.MkdirAll(dir, 0o755)
 		_ = os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("4242\n"), 0o644)
+		_ = os.WriteFile(filepath.Join(dir, "cgroup.kill"), nil, 0o644)
 	}()
-	pid, ok, err := locator.findInitPID(cid)
+	ok, err := killer.kill(cid)
 	if err != nil {
-		t.Fatalf("findInitPID: %v", err)
+		t.Fatalf("kill: %v", err)
 	}
 	if !ok {
 		t.Fatal("expected ok=true")
 	}
-	if pid != 4242 {
-		t.Errorf("pid = %d, want 4242", pid)
-	}
 }
 
-// TestCgroupLocator_WaitsForProcsToPopulate is the regression test for the
-// silent kill miss: kata-agent creates the container cgroup and writes
-// config.json (policy-monitor's trigger) BEFORE it forks the init into the
-// cgroup, so cgroup.procs is briefly empty. findInitPID must poll until the
-// PID appears, not give up on the first empty read.
-func TestCgroupLocator_WaitsForProcsToPopulate(t *testing.T) {
+func TestCgroupKiller_WaitsForProcsToPopulateAndKillsGroup(t *testing.T) {
 	root := t.TempDir()
 	cid := "b790433fdb4f223a51940bae06c1cd54d73377fc3ea45c4fa5c7ea3bd4b6c829"
 	scope := filepath.Join(root, "kubepods.slice", "cri-containerd-"+cid+".scope")
@@ -207,7 +163,10 @@ func TestCgroupLocator_WaitsForProcsToPopulate(t *testing.T) {
 	if err := os.WriteFile(procs, []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	locator := &cgroupLocator{
+	if err := os.WriteFile(filepath.Join(scope, "cgroup.kill"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	killer := &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  1 * time.Second,
 		pollInterval: 20 * time.Millisecond,
@@ -216,22 +175,26 @@ func TestCgroupLocator_WaitsForProcsToPopulate(t *testing.T) {
 		time.Sleep(75 * time.Millisecond)
 		_ = os.WriteFile(procs, []byte("4242\n1234\n"), 0o644)
 	}()
-	pid, ok, err := locator.findInitPID(cid)
+	ok, err := killer.kill(cid)
 	if err != nil {
-		t.Fatalf("findInitPID: %v", err)
+		t.Fatalf("kill: %v", err)
 	}
 	if !ok {
-		t.Fatal("expected ok=true — findInitPID must wait for cgroup.procs to populate")
+		t.Fatal("expected ok=true — killer must wait for cgroup.procs to populate")
 	}
-	if pid != 4242 {
-		t.Errorf("pid = %d, want 4242 (first/lowest in cgroup.procs)", pid)
+	contents, err := os.ReadFile(filepath.Join(scope, "cgroup.kill"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "1" {
+		t.Errorf("cgroup.kill = %q, want 1", contents)
 	}
 }
 
-// TestCgroupLocator_EmptyProcsTimesOut confirms a cgroup that stays empty
+// TestCgroupKiller_EmptyProcsTimesOut confirms a cgroup that stays empty
 // (a container that genuinely exited before we looked) times out to a
 // harmless no-op rather than blocking or erroring.
-func TestCgroupLocator_EmptyProcsTimesOut(t *testing.T) {
+func TestCgroupKiller_EmptyProcsTimesOut(t *testing.T) {
 	root := t.TempDir()
 	cid := "cafef00d"
 	scope := filepath.Join(root, "cri-containerd-"+cid+".scope")
@@ -241,32 +204,54 @@ func TestCgroupLocator_EmptyProcsTimesOut(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(scope, "cgroup.procs"), []byte(""), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	locator := &cgroupLocator{
+	if err := os.WriteFile(filepath.Join(scope, "cgroup.kill"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	killer := &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  60 * time.Millisecond,
 		pollInterval: 20 * time.Millisecond,
 	}
-	_, ok, err := locator.findInitPID(cid)
+	ok, err := killer.kill(cid)
 	if err != nil {
-		t.Fatalf("findInitPID: %v", err)
+		t.Fatalf("kill: %v", err)
 	}
 	if ok {
 		t.Fatal("expected ok=false when cgroup.procs never populates")
 	}
 }
 
-func TestCgroupLocator_Timeout(t *testing.T) {
+func TestCgroupKiller_Timeout(t *testing.T) {
 	root := t.TempDir()
-	locator := &cgroupLocator{
+	killer := &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  50 * time.Millisecond,
 		pollInterval: 20 * time.Millisecond,
 	}
-	pid, ok, err := locator.findInitPID("never-appears")
+	ok, err := killer.kill("never-appears")
 	if err != nil {
-		t.Fatalf("findInitPID: %v", err)
+		t.Fatalf("kill: %v", err)
 	}
 	if ok {
-		t.Fatalf("expected ok=false, got pid=%d", pid)
+		t.Fatal("expected ok=false")
+	}
+}
+
+func TestCgroupKiller_PropagatesMalformedProcs(t *testing.T) {
+	root := t.TempDir()
+	cid := "malformed"
+	dir := filepath.Join(root, cid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte("not-a-pid\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup.kill"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	killer := &cgroupKiller{cgroupRoot: root, waitTimeout: time.Second, pollInterval: time.Millisecond}
+	if ok, err := killer.kill(cid); err == nil || ok {
+		t.Fatalf("kill = (%v, %v), want permanent parse error", ok, err)
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -46,7 +46,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -80,11 +79,10 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	logger.Info("allowlist loaded", "entries", a.Size())
 
 	m := &monitor{
-		cfg:        cfg,
-		logger:     logger,
-		allowlist:  a,
-		killer:     signalSender{},
-		pidLocator: newCgroupLocator(cfg.CgroupRoot),
+		cfg:       cfg,
+		logger:    logger,
+		allowlist: a,
+		killer:    newCgroupKiller(cfg.CgroupRoot),
 		// configReadDeadline is the budget for re-reading config.json
 		// after the initial CREATE event. kata-agent's setup_bundle
 		// finishes well under this; the limit is just to bound a
@@ -109,15 +107,14 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 }
 
 // monitor encapsulates the runtime state. Exposed via dependency
-// injection (killer + pidLocator) so the test suite can drive
+// injection (killer) so the test suite can drive
 // decisions against a tempdir without touching /sys/fs/cgroup or
 // real PIDs.
 type monitor struct {
 	cfg                *Config
 	logger             *slog.Logger
 	allowlist          *allowlist
-	killer             killer
-	pidLocator         pidLocator
+	killer             containerKiller
 	configReadDeadline time.Duration
 	configReadInterval time.Duration
 	revalidateInterval time.Duration
@@ -369,33 +366,20 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 	m.kill(cid)
 }
 
-// kill resolves the container's init PID via its cgroup and sends
-// SIGKILL. Best-effort: if the init has already exited, or its
-// cgroup hasn't materialised yet, we log and move on (the worst-case
-// is that an unallowlisted container ran for the duration of the
-// kata-agent CreateContainer call before kata-agent's own cleanup
-// reaps it — same as the inherent post-start window).
+// kill resolves the container's cgroup and terminates it as a unit.
+// Best-effort: if the container has already exited, or its cgroup never
+// materialises within the budget, we log and move on.
 func (m *monitor) kill(cid string) {
-	pid, ok, err := m.pidLocator.findInitPID(cid)
+	ok, err := m.killer.kill(cid)
 	if err != nil {
-		m.logger.Warn("locate init pid failed", "cid", cid, "error", err)
+		m.logger.Warn("kill cgroup failed", "cid", cid, "error", err)
 		return
 	}
 	if !ok {
-		m.logger.Warn("init pid not found", "cid", cid)
+		m.logger.Warn("container cgroup not found", "cid", cid)
 		return
 	}
-	if err := m.killer.kill(pid, syscall.SIGKILL); err != nil {
-		// ESRCH = process already gone. Not an error from our POV;
-		// the only goal was "this PID is dead", and it is.
-		if errors.Is(err, syscall.ESRCH) {
-			m.logger.Info("init already exited", "cid", cid, "pid", pid)
-			return
-		}
-		m.logger.Warn("SIGKILL failed", "cid", cid, "pid", pid, "error", err)
-		return
-	}
-	m.logger.Info("SIGKILLed container init", "cid", cid, "pid", pid)
+	m.logger.Info("SIGKILLed container cgroup", "cid", cid)
 }
 
 // readConfigJSON retries reading + parsing config.json for the budget
@@ -403,42 +387,25 @@ func (m *monitor) kill(cid string) {
 // (which triggers our IN_CREATE event, and re-seed after kata-agent replaces
 // the watch dir) and kata-agent finishing the config.json write.
 //
-// It waits not just for the file to parse but for the OCI annotations to be
-// present (hasContainerType): kata-agent writes config.json and its CRI/kata
-// annotations as part of one create-container step, but policy-monitor can
-// observe the file after it parses yet before the annotations land — and a
-// decision on that half-written spec misclassifies the pod sandbox (denied,
-// which would SIGKILL the measured pause and break the pod) and reads no image
-// digest for a workload. On deadline it returns the last parsed spec anyway
-// (never nil-with-no-error for a spec that did parse) so the caller still fails
-// closed: a genuinely annotation-less bundle — e.g. a host that stripped the
-// annotations to evade policy — is denied, not skipped.
+// A successfully parsed spec is complete: kata-agent builds the OCI spec in
+// memory and saves config.json once. A valid spec without annotations is
+// therefore an enforcement decision, not a partial write. The host controls
+// this file, so delaying that decision based on an optional annotation would
+// give a stripped workload an avoidable execution window.
 func (m *monitor) readConfigJSON(ctx context.Context, path string) (*ociSpec, error) {
 	deadline := time.Now().Add(m.configReadDeadline)
-	var lastSpec *ociSpec
 	var lastErr error
 	for {
 		spec, err := readOCISpec(path)
-		switch {
-		case err == nil && hasContainerType(spec.Annotations):
+		if err == nil {
 			return spec, nil
-		case err == nil:
-			// Parsed, but the annotations we key on aren't written yet.
-			// Remember it so a deadline still fails closed rather than skipping
-			// enforcement, and retry for the annotations to appear.
-			lastSpec = spec
-			lastErr = errPartialJSON
-		default:
-			lastErr = err
-			if !errors.Is(err, os.ErrNotExist) && !isPartialJSON(err) {
-				// Unrecoverable: not a transient race. Return immediately.
-				return nil, err
-			}
+		}
+		lastErr = err
+		if !errors.Is(err, os.ErrNotExist) && !isPartialJSON(err) {
+			// Unrecoverable: not a transient race. Return immediately.
+			return nil, err
 		}
 		if time.Now().After(deadline) {
-			if lastSpec != nil {
-				return lastSpec, nil
-			}
 			return nil, lastErr
 		}
 		select {
@@ -447,22 +414,6 @@ func (m *monitor) readConfigJSON(ctx context.Context, path string) (*ociSpec, er
 		case <-time.After(m.configReadInterval):
 		}
 	}
-}
-
-// hasContainerType reports whether the OCI annotations carry a CRI
-// container-type marker (io.kubernetes.cri.container-type / the CRI-O
-// equivalent). Every container kata-agent creates for a Kubernetes pod — both
-// the sandbox and the workload — carries one, so its presence is a reliable
-// "kata-agent finished writing the annotations" signal. Absence means either a
-// mid-write read (retry) or a bundle with no CRI annotations at all (denied on
-// deadline, fail-closed).
-func hasContainerType(annotations map[string]string) bool {
-	for _, key := range k8sContainerTypeKeys {
-		if _, ok := annotations[key]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 // ociSpec is the subset of the OCI Runtime Spec we care about: the

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
-	"syscall"
 	"testing"
 	"time"
 
@@ -34,7 +32,7 @@ func writeConfigJSON(t *testing.T, watchDir, cid string, annotations map[string]
 }
 
 // newTestMonitor wires the monitor against tempdirs + fakes.
-func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKiller, *threadSafeFakeLocator, string) {
+func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKiller, string) {
 	t.Helper()
 	watchDir := t.TempDir()
 
@@ -53,7 +51,7 @@ func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKil
 	}
 
 	killer := &fakeKiller{}
-	locator := &threadSafeFakeLocator{pid: 4242, ok: true}
+	killer.ok = true
 
 	logger, err := certutil.NewJSONLogger("debug")
 	if err != nil {
@@ -69,31 +67,15 @@ func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKil
 		logger:             logger,
 		allowlist:          a,
 		killer:             killer,
-		pidLocator:         locator,
 		configReadDeadline: 200 * time.Millisecond,
 		configReadInterval: 10 * time.Millisecond,
 	}
-	return m, killer, locator, watchDir
-}
-
-// threadSafeFakeLocator is a fakePIDLocator with a mutex so the
-// concurrent inotify-event goroutines can read it without -race tripping.
-type threadSafeFakeLocator struct {
-	mu  sync.Mutex
-	pid int
-	ok  bool
-	err error
-}
-
-func (l *threadSafeFakeLocator) findInitPID(string) (int, bool, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.pid, l.ok, l.err
+	return m, killer, watchDir
 }
 
 func TestHandleNewContainer_AllowedDigest(t *testing.T) {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
 	cid := "abcdef0123"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
@@ -111,7 +93,7 @@ func TestHandleNewContainer_AllowedDigest(t *testing.T) {
 func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 	allowed := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
 
 	cid := "deadbeef"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
@@ -125,16 +107,13 @@ func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 	if len(calls) != 1 {
 		t.Fatalf("expected 1 kill, got %d: %+v", len(calls), calls)
 	}
-	if calls[0].pid != 4242 {
-		t.Errorf("pid = %d, want 4242", calls[0].pid)
-	}
-	if calls[0].sig != syscall.SIGKILL {
-		t.Errorf("signal = %v, want SIGKILL", calls[0].sig)
+	if calls[0] != cid {
+		t.Errorf("container ID = %q, want %q", calls[0], cid)
 	}
 }
 
 func TestHandleNewContainer_NoDigestAnnotation_Denies(t *testing.T) {
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := "no-anno"
 	writeConfigJSON(t, watchDir, cid, map[string]string{})
 
@@ -150,7 +129,7 @@ func TestHandleNewContainer_SandboxSkipped(t *testing.T) {
 	// no image digest. kata runs the measured baked pause for it, so
 	// policy-monitor must skip it rather than deny — otherwise every pod's
 	// sandbox gets killed and no pod can start.
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := "sandbox0"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "sandbox",
@@ -172,7 +151,7 @@ func TestHandleNewContainer_SandboxSkippedEvenWithUnallowlistedDigest(t *testing
 	// never runs. policy-monitor identifies the sandbox the same way kata
 	// does (isSandbox), keeping the two in lockstep.
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := "sandbox-evil"
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "sandbox",
@@ -188,7 +167,7 @@ func TestHandleNewContainer_SandboxSkippedEvenWithUnallowlistedDigest(t *testing
 
 func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
 	cid := "late-config"
 	// Create only the directory; spawn a goroutine to drop config.json
@@ -214,81 +193,27 @@ func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 	}
 }
 
-// TestReadConfigJSON_WaitsForContainerType covers the mid-write race: config.json
-// parses as valid JSON but its CRI annotations haven't landed yet.
-// readConfigJSON must keep polling until container-type is present, not decide
-// on the annotation-less spec.
-func TestReadConfigJSON_WaitsForContainerType(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "mid-write"
-	// A valid but annotation-less config.json (kata-agent has written the file
-	// but not the annotations yet).
-	writeConfigJSON(t, watchDir, cid, map[string]string{})
+// A valid annotation-less spec is a complete policy input and must not wait
+// for an attacker-controlled annotation to appear.
+func TestReadConfigJSON_ValidAnnotationlessSpecReturnsImmediately(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := "annotationless"
 	path := filepath.Join(watchDir, cid, "config.json")
-	go func() {
-		time.Sleep(40 * time.Millisecond)
-		writeConfigJSON(t, watchDir, cid, map[string]string{
-			"io.kubernetes.cri.container-type": "container",
-			"io.kubernetes.cri.image-name":     "repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		})
-	}()
-	spec, err := m.readConfigJSON(context.Background(), path)
+	writeConfigJSON(t, watchDir, cid, map[string]string{"unrelated": "x"})
+	m.configReadDeadline = time.Second
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	spec, err := m.readConfigJSON(ctx, path)
 	if err != nil {
 		t.Fatalf("readConfigJSON: %v", err)
 	}
-	if _, ok := spec.Annotations["io.kubernetes.cri.container-type"]; !ok {
-		t.Fatalf("expected readConfigJSON to wait for the container-type annotation; got %+v", spec.Annotations)
-	}
-}
-
-// TestReadConfigJSON_DeadlineFailsClosed proves that a config.json that parses
-// but never grows a container-type annotation (a bundle with the CRI
-// annotations stripped, e.g. a host trying to evade policy) returns the parsed
-// spec with a nil error on deadline — so the caller still classifies and denies
-// it, rather than getting an error and skipping enforcement (fail-open).
-func TestReadConfigJSON_DeadlineFailsClosed(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "stripped"
-	writeConfigJSON(t, watchDir, cid, map[string]string{"unrelated": "x"})
-	path := filepath.Join(watchDir, cid, "config.json")
-	spec, err := m.readConfigJSON(context.Background(), path)
-	if err != nil {
-		t.Fatalf("want nil error so the caller fails closed on the returned spec, got %v", err)
-	}
-	if spec == nil {
-		t.Fatal("want the parsed (annotation-less) spec returned so the caller denies")
-	}
-	if isSandbox(spec.Annotations) {
-		t.Fatal("annotation-less spec must not classify as a sandbox")
-	}
-	if _, ok := extractDigest(spec.Annotations); ok {
-		t.Fatal("annotation-less spec must not yield a digest — caller must deny")
-	}
-}
-
-// TestHandleNewContainer_SandboxLateContainerType_NotKilled is the safety test
-// for the fix: the pod sandbox (pause) container's container-type=sandbox
-// annotation can be observed late. policy-monitor must wait for it and allow
-// the sandbox — decking it on the mid-write spec would SIGKILL the measured
-// pause and break the pod.
-func TestHandleNewContainer_SandboxLateContainerType_NotKilled(t *testing.T) {
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "late-sandbox"
-	writeConfigJSON(t, watchDir, cid, map[string]string{}) // annotations not written yet
-	go func() {
-		time.Sleep(40 * time.Millisecond)
-		writeConfigJSON(t, watchDir, cid, map[string]string{
-			"io.kubernetes.cri.container-type": "sandbox",
-		})
-	}()
-	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
-	if calls := killer.snapshot(); len(calls) != 0 {
-		t.Fatalf("sandbox must be allowed once its container-type lands; got kills %+v", calls)
+	if spec == nil || spec.Annotations["unrelated"] != "x" {
+		t.Fatalf("got spec %+v, want complete annotationless spec", spec)
 	}
 }
 
 func TestPathLooksLikeContainer(t *testing.T) {
-	m, _, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	for _, tc := range []struct {
 		path string
 		want bool
@@ -310,7 +235,7 @@ func TestPathLooksLikeContainer(t *testing.T) {
 func TestRun_DetectsCreatedContainer(t *testing.T) {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -358,7 +283,7 @@ func killSeen(k *fakeKiller) bool {
 func TestRun_SurvivesWatchDirReplacement(t *testing.T) {
 	allowed := strings.Repeat("a", 64)
 	denied := strings.Repeat("b", 64)
-	m, killer, _, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
 	// Shrink the revalidation backstop so the test doesn't depend on
 	// the Remove event being delivered (either recovery path must work).
 	m.revalidateInterval = 25 * time.Millisecond

--- a/internal/cmds/policymonitor/run.go
+++ b/internal/cmds/policymonitor/run.go
@@ -18,8 +18,8 @@
 // the allowlist (the baked /etc/c8s/bootstrap-allowlist.json seed on the
 // dm-verity root, plus whatever the CDS refresh has merged on top). If
 // the digest is not allowlisted, the monitor
-// resolves the container's init PID via the kata-agent / runc cgroup
-// (cgroup.procs under the container's cgroup) and sends SIGKILL.
+// resolves the container's cgroup via the kata-agent / runc hierarchy and
+// sends SIGKILL to the cgroup as a unit.
 //
 // # Why post-start kill, not pre-start gate
 //
@@ -35,7 +35,7 @@
 //
 // So we accept the post-start window. The container's init process runs
 // for the duration of the inotify event delivery + config.json parse +
-// cgroup.procs read + SIGKILL syscall — typically a handful of
+// cgroup lookup + cgroup.kill write — typically a handful of
 // milliseconds on hardware. That window is documented as a known
 // limitation in docs/kata-image-policy.md, with the BPF-LSM upgrade
 // path noted as the way to close it (intercept execve in the
@@ -58,11 +58,10 @@
 //     in-memory (LinuxContainer struct in
 //     src/agent/rustjail/src/container.rs). The init process PID is
 //     stored in LinuxContainer.init_process_pid (set at line 1182 of
-//     container.rs after fork). The external observation channel for
-//     that PID is the container's cgroup: the agent's cgroup_manager
-//     puts the init under /sys/fs/cgroup/<container_id>/cgroup.procs
-//     (unified hierarchy) or one of the v1 controller paths. We read
-//     that file.
+//     container.rs after fork). The external observation channel is the
+//     container's cgroup: the agent's cgroup_manager puts the init under
+//     /sys/fs/cgroup/<container_id> (unified hierarchy) or one of the v1
+//     controller paths. We terminate the cgroup as a unit.
 //
 //   - The container_id format is verified by kata_sys_util::validate::
 //     verify_id (rpc.rs:222), which restricts to a conservative
@@ -138,8 +137,8 @@ func newMonitorCommand() *cobra.Command {
   - Sets up an inotify watch on /run/kata-containers/.
   - For each new container directory, reads <id>/config.json, extracts
     the image digest from OCI annotations, checks the allowlist.
-  - If denied, locates the container's init PID via cgroup.procs and
-    sends SIGKILL.
+  - If denied, locates the container cgroup and sends SIGKILL to the
+    cgroup as a unit.
 
 Decisions are logged at info level for operator visibility. If the
 allowlist file is missing or unparseable, monitor exits non-zero — the


### PR DESCRIPTION
## Summary

- terminate denied workloads through cgroup-wide kill, avoiding unordered PID selection and PID-reuse races
- retry only transient cgroup population states and propagate permanent process-read errors
- decide successfully parsed OCI specs immediately instead of waiting for attacker-controlled annotations
- update regression tests and policy-monitor documentation

## Validation

- Linux amd64 policy-monitor tests cross-compile successfully (CGO disabled)
- Linux arm64 policy-monitor tests cross-compile successfully (CGO disabled)
- Linux-targeted `go vet` passes
- `go test ./...` was attempted; sandbox network/socket restrictions prevent unrelated `httptest` and listener tests from binding

Fixes the follow-up issues identified during review of #71.