### PR TITLE
feat: attested RKE2 operator credential release (B4 server + client)

### DIFF
--- a/cmd/c8s/cred_release.go
+++ b/cmd/c8s/cred_release.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/credrelease"
+
+func init() {
+	rootCmd.AddCommand(credrelease.NewCmd())
+}

--- a/cmd/c8s/get_kubeconfig.go
+++ b/cmd/c8s/get_kubeconfig.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/getkubeconfig"
+
+func init() {
+	rootCmd.AddCommand(getkubeconfig.NewCmd())
+}

--- a/internal/cmds/cds/cmd_test.go
+++ b/internal/cmds/cds/cmd_test.go
@@ -24,26 +24,3 @@ func TestNewCmdDefaultsToSupportedRATLSPlatform(t *testing.T) {
 		t.Fatalf("default --ratls-platform is not accepted by ratls: %v", err)
 	}
 }
-
-func TestNormalizeRATLSPlatform(t *testing.T) {
-	for _, tc := range []struct {
-		input string
-		want  string
-	}{
-		{"", ""},
-		{" ", ""},
-		{"snp", "sev-snp"},
-		{"SEV-SNP", "sev-snp"},
-		{"az-snp", "sev-snp"},
-		{"gcp-snp", "sev-snp"},
-		{"tdx", "tdx"},
-		{"az-tdx", "tdx"},
-		{"unknown", "unknown"},
-	} {
-		t.Run(tc.input, func(t *testing.T) {
-			if got := normalizeRATLSPlatform(tc.input); got != tc.want {
-				t.Fatalf("normalizeRATLSPlatform(%q) = %q, want %q", tc.input, got, tc.want)
-			}
-		})
-	}
-}

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
-	"strings"
 	"syscall"
 	"time"
 
@@ -46,7 +45,7 @@ func run(cfg config) error {
 	if err := validateConfig(cfg); err != nil {
 		return err
 	}
-	cfg.ratlsPlatform = normalizeRATLSPlatform(cfg.ratlsPlatform)
+	cfg.ratlsPlatform = ratls.NormalizePlatform(cfg.ratlsPlatform)
 
 	// EAR JWT validation reads the clock-skew leeway from this package-level
 	// var; set it before any /sign-csr request can be served.
@@ -437,16 +436,5 @@ func readinessFn(svcReady func() bool, caCert *x509.Certificate, minCAValidity t
 			return false
 		}
 		return true
-	}
-}
-
-func normalizeRATLSPlatform(platform string) string {
-	switch p := strings.ToLower(strings.TrimSpace(platform)); p {
-	case "snp", "sev-snp", "az-snp", "gcp-snp":
-		return "sev-snp"
-	case "tdx", "az-tdx", "gcp-tdx":
-		return "tdx"
-	default:
-		return p
 	}
 }

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -1,0 +1,118 @@
+// Package credrelease implements the in-guest credential-release service (B4
+// of the operator-key design). It issues an operator a short-lived RKE2 client
+// certificate, but only to a caller who proves possession of the operator
+// private key whose public half was bound into the CVM's RTMR[3] at launch —
+// giving an external operator console-free, non-TOFU admin access with no
+// pre-shared cluster secret and no trust in the untrusted host.
+package credrelease
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"fmt"
+	"os"
+)
+
+// operatorPubkeyPath is where the measured initrd stages the operator public
+// key it read off the opkeydata disk (and hashed into RTMR[3]). The service
+// reads this file rather than mounting the ISO itself — mounting fails under
+// the unit's systemd hardening, and the initrd is the single, measured reader
+// of the disk anyway.
+const operatorPubkeyPath = "/etc/confai/operator-pubkey"
+
+// rtmr3SysfsPath is the TDX runtime-measurement register the initrd extended
+// with the operator key digest before switch_root. Reading it back lets the
+// service confirm the on-disk operator pubkey is the one that was measured.
+const rtmr3SysfsPath = "/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384"
+
+// expectedRTMR3ForKey computes the RTMR[3] value a guest reports after the
+// initrd extends the zeroed register once with SHA-384(pubkey):
+//
+//	RTMR[3] = SHA384( 0x00*48 || SHA384(pubkey) )
+//
+// This is the same value the operator computes offline from their own key, so
+// matching it proves the guest was launched to trust exactly this key.
+func expectedRTMR3ForKey(pubkey []byte) []byte {
+	keyDigest := sha512.Sum384(pubkey)
+	rtmr3 := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	return rtmr3[:]
+}
+
+// readOwnRTMR3 reads the guest's current RTMR[3] from the tdx_guest sysfs.
+// Returns the raw 48 bytes.
+func readOwnRTMR3() ([]byte, error) {
+	b, err := os.ReadFile(rtmr3SysfsPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w (is this a TDX guest with runtime measurement?)", rtmr3SysfsPath, err)
+	}
+	if len(b) != 48 {
+		return nil, fmt.Errorf("%s: got %d bytes, want 48", rtmr3SysfsPath, len(b))
+	}
+	return b, nil
+}
+
+// verifyKeyMeasured is the load-bearing anchor check: the operator pubkey file
+// is NOT itself measured (only its hash, via RTMR[3]), so before trusting the
+// on-disk key the service confirms it is the key that was measured. A host
+// that swapped the pubkey file post-boot produces a mismatch here — it cannot
+// forge RTMR[3], which is set by the (measured) initrd and sealed by the TD.
+//
+// With this check, the on-disk pubkey is anchored to RTMR[3], and RTMR[3] is
+// what the operator's own attestation pins to their key: both directions bind
+// to the same measured key, so neither side trusts the host.
+func verifyKeyMeasured(pubkey []byte) error {
+	own, err := readOwnRTMR3()
+	if err != nil {
+		return err
+	}
+	want := expectedRTMR3ForKey(pubkey)
+	// Not secret (a public-key hash) — plain compare is fine.
+	if !equalBytes(own, want) {
+		return fmt.Errorf(
+			"operator pubkey does not match the measured RTMR[3]: got %s, key implies %s (was the pubkey file substituted after boot?)",
+			hex.EncodeToString(own), hex.EncodeToString(want))
+	}
+	return nil
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// readOperatorPubkey reads the operator public key the initrd staged from the
+// opkeydata disk. The bytes are exactly what the initrd hashed into RTMR[3],
+// so verifyKeyMeasured can re-derive the same digest. Absence means the VM was
+// launched without an operator key (no opkeydata disk).
+func readOperatorPubkey() ([]byte, error) {
+	pub, err := os.ReadFile(operatorPubkeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w — was the VM launched with an operator key?", operatorPubkeyPath, err)
+	}
+	if len(pub) == 0 {
+		return nil, fmt.Errorf("%s is empty", operatorPubkeyPath)
+	}
+	return pub, nil
+}
+
+// LoadMeasuredOperatorKey reads the operator pubkey off the opkeydata disk and
+// verifies it against RTMR[3]. The returned bytes are safe to trust as the
+// authorized operator key. This is called once at service start; the key is
+// fixed for the life of the TD.
+func LoadMeasuredOperatorKey() ([]byte, error) {
+	pub, err := readOperatorPubkey()
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyKeyMeasured(pub); err != nil {
+		return nil, err
+	}
+	return pub, nil
+}

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -7,6 +7,7 @@
 package credrelease
 
 import (
+	"bytes"
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
@@ -67,24 +68,12 @@ func verifyKeyMeasured(pubkey []byte) error {
 	}
 	want := expectedRTMR3ForKey(pubkey)
 	// Not secret (a public-key hash) — plain compare is fine.
-	if !equalBytes(own, want) {
+	if !bytes.Equal(own, want) {
 		return fmt.Errorf(
 			"operator pubkey does not match the measured RTMR[3]: got %s, key implies %s (was the pubkey file substituted after boot?)",
 			hex.EncodeToString(own), hex.EncodeToString(want))
 	}
 	return nil
-}
-
-func equalBytes(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // readOperatorPubkey reads the operator public key the initrd staged from the

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -1,5 +1,5 @@
 // Package credrelease implements the in-guest credential-release service (B4
-// of the operator-key design). It issues an operator a short-lived RKE2 client
+// of the operator-key design). It issues an operator a short-lived kube client
 // certificate, but only to a caller who proves possession of the operator
 // private key whose public half was bound into the CVM's RTMR[3] at launch —
 // giving an external operator console-free, non-TOFU admin access with no

--- a/internal/cmds/credrelease/binding_test.go
+++ b/internal/cmds/credrelease/binding_test.go
@@ -1,0 +1,53 @@
+package credrelease
+
+import (
+	"crypto/sha512"
+	"encoding/hex"
+	"testing"
+)
+
+// TestExpectedRTMR3ForKey checks the two-step formula
+// RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)) against an independent compute.
+func TestExpectedRTMR3ForKey(t *testing.T) {
+	pub := []byte("some operator public key bytes")
+	got := hex.EncodeToString(expectedRTMR3ForKey(pub))
+
+	keyDigest := sha512.Sum384(pub)
+	want := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	if got != hex.EncodeToString(want[:]) {
+		t.Errorf("expectedRTMR3ForKey = %s, want %s", got, hex.EncodeToString(want[:]))
+	}
+}
+
+// TestExpectedRTMR3MatchesHardware pins to the exact value the B1+B2 hardware
+// run produced, computed from the same key-digest the guest reported.
+func TestExpectedRTMR3MatchesHardware(t *testing.T) {
+	// keyDigest = SHA-384(operator pubkey) from the b200 run; wantRTMR3 is
+	// what /sys/.../rtmr3:sha384 read back after that launch.
+	const (
+		keyDigest = "0c06aa4f364e480ece13c58b1585dab43d7222fa331ccc9ff05ea18fdd39a4d9d75e87d711ac6aeda2782c2e339de7c1"
+		wantRTMR3 = "db479dfe6333f8d3a2761494b6004bc4332688c6d5b72577b48ecfc0409e4cb53988dcd26b89ec605a81b00e7f0e0863"
+	)
+	dig, err := hex.DecodeString(keyDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// expectedRTMR3ForKey hashes the pubkey; here we already have the digest,
+	// so replicate the second step directly and compare to the pinned value.
+	rtmr3 := sha512.Sum384(append(make([]byte, 48), dig...))
+	if got := hex.EncodeToString(rtmr3[:]); got != wantRTMR3 {
+		t.Errorf("RTMR[3] from key digest = %s, want %s (hardware-confirmed)", got, wantRTMR3)
+	}
+}
+
+func TestEqualBytes(t *testing.T) {
+	if !equalBytes([]byte{1, 2, 3}, []byte{1, 2, 3}) {
+		t.Error("equal slices reported unequal")
+	}
+	if equalBytes([]byte{1, 2, 3}, []byte{1, 2, 4}) {
+		t.Error("differing slices reported equal")
+	}
+	if equalBytes([]byte{1, 2}, []byte{1, 2, 3}) {
+		t.Error("different-length slices reported equal")
+	}
+}

--- a/internal/cmds/credrelease/binding_test.go
+++ b/internal/cmds/credrelease/binding_test.go
@@ -39,15 +39,3 @@ func TestExpectedRTMR3MatchesHardware(t *testing.T) {
 		t.Errorf("RTMR[3] from key digest = %s, want %s (hardware-confirmed)", got, wantRTMR3)
 	}
 }
-
-func TestEqualBytes(t *testing.T) {
-	if !equalBytes([]byte{1, 2, 3}, []byte{1, 2, 3}) {
-		t.Error("equal slices reported unequal")
-	}
-	if equalBytes([]byte{1, 2, 3}, []byte{1, 2, 4}) {
-		t.Error("differing slices reported equal")
-	}
-	if equalBytes([]byte{1, 2}, []byte{1, 2, 3}) {
-		t.Error("different-length slices reported equal")
-	}
-}

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -32,6 +32,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.Platform, "platform", "tdx", "TEE platform (RTMR is TDX-only)")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
+	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
 	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
 	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -20,8 +20,10 @@ func NewCmd() *cobra.Command {
 			"operator key whose public half was bound into RTMR[3] at launch.\n" +
 			"It gives an external operator console-free, non-TOFU cluster-admin\n" +
 			"access with no pre-shared secret and no trust in the host. The cert\n" +
-			"is signed by the cluster's client CA (RKE2 paths by default; any\n" +
-			"distribution works via --client-ca-cert/--client-ca-key).",
+			"is signed by the cluster's client CA and the kubeconfig anchors to\n" +
+			"the serving CA (RKE2 paths by default; any distribution works via\n" +
+			"--client-ca-cert/--client-ca-key/--server-ca-cert — on kubeadm all\n" +
+			"three are /etc/kubernetes/pki/ca.crt).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), cfg)
 		},

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -7,19 +7,21 @@ import (
 )
 
 // NewCmd builds the `cred-release` subcommand: the in-guest service that
-// issues an operator a short-lived RKE2 client cert, gated on possession of
+// issues an operator a short-lived kube client cert, gated on possession of
 // the operator key measured into RTMR[3]. Baked as a systemd unit in the c8s
 // node image; not run by hand in normal operation.
 func NewCmd() *cobra.Command {
 	var cfg Config
 	cmd := &cobra.Command{
 		Use:   "cred-release",
-		Short: "Release an RKE2 operator credential to the attested holder of the RTMR[3]-bound key",
+		Short: "Release a kube operator credential to the attested holder of the RTMR[3]-bound key",
 		Long: "cred-release serves an RA-TLS endpoint that issues a short-lived\n" +
-			"RKE2 client certificate to a caller who proves possession of the\n" +
+			"kube client certificate to a caller who proves possession of the\n" +
 			"operator key whose public half was bound into RTMR[3] at launch.\n" +
 			"It gives an external operator console-free, non-TOFU cluster-admin\n" +
-			"access with no pre-shared secret and no trust in the host.",
+			"access with no pre-shared secret and no trust in the host. The cert\n" +
+			"is signed by the cluster's client CA (RKE2 paths by default; any\n" +
+			"distribution works via --client-ca-cert/--client-ca-key).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), cfg)
 		},
@@ -28,6 +30,8 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
 	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (source of the RA-TLS serving cert's TDX quote)")
 	f.StringVar(&cfg.Platform, "platform", "tdx", "TEE platform (RTMR is TDX-only)")
+	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
+	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
 	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
 	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -1,0 +1,35 @@
+package credrelease
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmd builds the `cred-release` subcommand: the in-guest service that
+// issues an operator a short-lived RKE2 client cert, gated on possession of
+// the operator key measured into RTMR[3]. Baked as a systemd unit in the c8s
+// node image; not run by hand in normal operation.
+func NewCmd() *cobra.Command {
+	var cfg Config
+	cmd := &cobra.Command{
+		Use:   "cred-release",
+		Short: "Release an RKE2 operator credential to the attested holder of the RTMR[3]-bound key",
+		Long: "cred-release serves an RA-TLS endpoint that issues a short-lived\n" +
+			"RKE2 client certificate to a caller who proves possession of the\n" +
+			"operator key whose public half was bound into RTMR[3] at launch.\n" +
+			"It gives an external operator console-free, non-TOFU cluster-admin\n" +
+			"access with no pre-shared secret and no trust in the host.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return Run(cmd.Context(), cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
+	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (source of the RA-TLS serving cert's TDX quote)")
+	f.StringVar(&cfg.Platform, "platform", "tdx", "TEE platform (RTMR is TDX-only)")
+	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
+	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
+	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")
+	return cmd
+}

--- a/internal/cmds/credrelease/handler.go
+++ b/internal/cmds/credrelease/handler.go
@@ -34,7 +34,7 @@ type releaseResponse struct {
 
 // Handler serves POST /release-credential. It authorizes the caller against
 // the measured operator key, validates the CSR, and issues a short-lived kube
-// client cert signed by the RKE2 cluster CA.
+// client cert signed by the cluster CA.
 type Handler struct {
 	verifier operatorauth.Verifier
 	ca       *clusterCA

--- a/internal/cmds/credrelease/handler.go
+++ b/internal/cmds/credrelease/handler.go
@@ -1,0 +1,142 @@
+package credrelease
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// maxBodyBytes caps the request body — a CSR is small; refuse anything large.
+const maxBodyBytes = 1 << 16 // 64 KiB
+
+// releaseRequest is the POST /release-credential body: a PEM CERTIFICATE
+// REQUEST the operator generated locally. The operator authorizes the request
+// with an operatorauth Bearer token whose pbh binds this exact body, so the
+// CSR cannot be swapped in transit.
+type releaseRequest struct {
+	CSRPEM string `json:"csr"`
+}
+
+// releaseResponse returns the signed client cert and the cluster CA so the
+// operator can assemble a kubeconfig. The apiserver address is known to the
+// operator (it dialled this service on the same host).
+type releaseResponse struct {
+	CertPEM string `json:"cert"`
+	CAPEM   string `json:"ca"`
+}
+
+// Handler serves POST /release-credential. It authorizes the caller against
+// the measured operator key, validates the CSR, and issues a short-lived kube
+// client cert signed by the RKE2 cluster CA.
+type Handler struct {
+	verifier operatorauth.Verifier
+	ca       *clusterCA
+	certTTL  time.Duration
+	certOrg  string // Kubernetes group (O) for the issued cert
+	certCN   string // Kubernetes user (CN)
+	now      func() time.Time
+}
+
+// NewHandler builds the release handler from the measured operator pubkey (PEM)
+// and the loaded cluster CA. The pubkey MUST already have been verified against
+// RTMR[3] by LoadMeasuredOperatorKey — NewHandler trusts it as authorized.
+func NewHandler(operatorPubPEM []byte, ca *clusterCA, org, cn string, ttl time.Duration) (*Handler, error) {
+	keys, err := operatorauth.ParsePublicKeysPEM(operatorPubPEM)
+	if err != nil {
+		return nil, fmt.Errorf("operator pubkey (must be ECDSA PKIX PEM): %w", err)
+	}
+	return &Handler{
+		// ClockSkew tolerates a small offset between the operator's clock and
+		// the guest's — without it, a token issued a second ahead of the
+		// guest clock is rejected "used before issued". Bounded (still within
+		// operatorauth's 5-min max validity), so it doesn't widen the replay
+		// window meaningfully.
+		verifier: operatorauth.Verifier{Keys: keys, ClockSkew: 60 * time.Second},
+		ca:       ca,
+		certTTL:  ttl,
+		certOrg:  org,
+		certCN:   cn,
+		now:      time.Now,
+	}, nil
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/release-credential" {
+		http.NotFound(w, r)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodyBytes))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	// AUTHORIZE: the caller must hold the operator private key whose public
+	// half is measured into RTMR[3]. operatorauth verifies the Bearer JWT
+	// (ES256/384/512) under the pinned key, enforces <=5min validity, and
+	// binds the token to this method/path/body (pbh) — so a captured token
+	// can't be replayed against a different CSR.
+	if err := h.verifier.Authorize(r, body); err != nil {
+		http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	var req releaseRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "bad request: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	csr, err := parseCSR([]byte(req.CSRPEM))
+	if err != nil {
+		http.Error(w, "bad CSR: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	certPEM, err := h.ca.signOperatorCert(signParams{
+		csr: csr,
+		org: h.certOrg,
+		cn:  h.certCN,
+		ttl: h.certTTL,
+	}, h.now())
+	if err != nil {
+		http.Error(w, "sign: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp := releaseResponse{CertPEM: string(certPEM), CAPEM: string(h.ca.pem)}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// parseCSR decodes a PEM CERTIFICATE REQUEST. The CSR's public key is what the
+// issued cert binds to; the operator holds the matching private key. The CSR
+// self-signature is checked at sign time.
+func parseCSR(pemBytes []byte) (*x509.CertificateRequest, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("not a PEM CERTIFICATE REQUEST")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	// Reject a CSR whose key we can't reason about; kube client certs here
+	// use ECDSA (matching the CA), but the apiserver accepts others too —
+	// keep it permissive on the CSR key type, strict on the signature.
+	if _, ok := csr.PublicKey.(*ecdsa.PublicKey); !ok {
+		// Not fatal for correctness, but v1 keeps it ECDSA for symmetry.
+		return nil, fmt.Errorf("CSR public key is %T, want ECDSA", csr.PublicKey)
+	}
+	return csr, nil
+}

--- a/internal/cmds/credrelease/helpers_test.go
+++ b/internal/cmds/credrelease/helpers_test.go
@@ -1,0 +1,22 @@
+package credrelease
+
+import (
+	"encoding/pem"
+	"math/big"
+	"testing"
+)
+
+func bigOne() *big.Int { return big.NewInt(1) }
+
+// decodeOnePEM decodes a single PEM block and asserts its type.
+func decodeOnePEM(t *testing.T, pemBytes []byte, wantType string) []byte {
+	t.Helper()
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		t.Fatalf("no PEM block")
+	}
+	if block.Type != wantType {
+		t.Fatalf("PEM type = %q, want %q", block.Type, wantType)
+	}
+	return block.Bytes
+}

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -25,6 +25,9 @@ type Config struct {
 	// (defaults: the RKE2 paths; kubeadm works via /etc/kubernetes/pki/ca.{crt,key}).
 	ClientCACert string
 	ClientCAKey  string
+	// ServerCACert locates the CA that signs the apiserver serving cert — the
+	// trust anchor embedded in the released kubeconfig.
+	ServerCACert string
 	// CertTTL is the lifetime of issued operator certs.
 	CertTTL time.Duration
 	// CertOrg / CertCN are the Kubernetes group / user the issued cert
@@ -56,7 +59,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("load measured operator key: %w", err)
 	}
 
-	ca, err := loadClusterCA(cfg.ClientCACert, cfg.ClientCAKey)
+	ca, err := loadClusterCA(cfg.ClientCACert, cfg.ClientCAKey, cfg.ServerCACert)
 	if err != nil {
 		return fmt.Errorf("load cluster CA: %w", err)
 	}

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -1,0 +1,110 @@
+package credrelease
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// Config is the release service configuration.
+type Config struct {
+	// ListenAddr is the HTTPS bind address (e.g. ":8443").
+	ListenAddr string
+	// AttestationAPIURL is the local attestation-api base URL the RA-TLS
+	// serving cert's TDX quote is fetched from (the same :8400 service the
+	// rest of the stack uses).
+	AttestationAPIURL string
+	// Platform is the TEE platform ("tdx").
+	Platform string
+	// CertTTL is the lifetime of issued operator certs.
+	CertTTL time.Duration
+	// CertOrg / CertCN are the Kubernetes group / user the issued cert
+	// carries. v1: O=system:masters, CN=operator (cluster-admin).
+	CertOrg string
+	CertCN  string
+}
+
+// Run loads the measured operator key and cluster CA, then serves the
+// RA-TLS-protected /release-credential endpoint. It blocks until ctx is done.
+//
+// Startup order matters for the trust story:
+//  1. LoadMeasuredOperatorKey — read the opkeydata pubkey and CONFIRM it
+//     matches RTMR[3]. Fails closed if the key was substituted after boot.
+//  2. loadClusterCA — the RKE2 client-CA that signs the operator's cert.
+//  3. serve over an RA-TLS config so the caller can attest this is the real
+//     guest before trusting the returned cert.
+func Run(ctx context.Context, cfg Config) error {
+	// RA-TLS is mandatory here: this endpoint hands out cluster-admin creds,
+	// so serving without an attested cert (empty platform => plain HTTP in the
+	// ratls package) would let a host MITM impersonate the guest. Reject it.
+	cfg.Platform = ratls.NormalizePlatform(cfg.Platform)
+	if cfg.Platform == "" {
+		return fmt.Errorf("--platform is required (RA-TLS is mandatory for credential release)")
+	}
+
+	operatorPub, err := LoadMeasuredOperatorKey()
+	if err != nil {
+		return fmt.Errorf("load measured operator key: %w", err)
+	}
+
+	ca, err := loadClusterCA()
+	if err != nil {
+		return fmt.Errorf("load cluster CA: %w", err)
+	}
+
+	handler, err := NewHandler(operatorPub, ca, cfg.CertOrg, cfg.CertCN, cfg.CertTTL)
+	if err != nil {
+		return fmt.Errorf("build handler: %w", err)
+	}
+
+	// RA-TLS serving config: the presented cert embeds a fresh TDX quote
+	// bound to its own public key, so the operator's RA-TLS client verifies
+	// it's talking to a genuine, correctly-measured guest before sending the
+	// CSR or trusting the returned cert. AttestFunc fetches the quote from the
+	// local attestation-api (platform-generic despite the SNP name — it reads
+	// resp.Platform, so it yields a TDX quote here); same pattern as cds.
+	attestFunc := attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), cfg.AttestationAPIURL)
+	tlsCfg, certMgr, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+		Platform:   cfg.Platform,
+		AttestFunc: attestFunc,
+		Logger:     slog.Default(),
+	})
+	if err != nil {
+		return fmt.Errorf("build RA-TLS config: %w", err)
+	}
+	// Provision the serving cert (and its quote) before accepting traffic, so
+	// the first request doesn't race a cold cert manager.
+	warmCtx, cancelWarm := context.WithTimeout(ctx, 30*time.Second)
+	err = certMgr.WarmUp(warmCtx)
+	cancelWarm()
+	if err != nil {
+		return fmt.Errorf("warm up RA-TLS serving cert: %w", err)
+	}
+
+	srv := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           handler,
+		TLSConfig:         tlsCfg,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		// certs come from tlsCfg (RA-TLS), so no cert/key files.
+		errCh <- srv.ListenAndServeTLS("", "")
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return srv.Shutdown(shutCtx)
+	case err := <-errCh:
+		return err
+	}
+}

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -21,6 +21,10 @@ type Config struct {
 	AttestationAPIURL string
 	// Platform is the TEE platform ("tdx").
 	Platform string
+	// ClientCACert / ClientCAKey locate the cluster's client-signing CA
+	// (defaults: the RKE2 paths; kubeadm works via /etc/kubernetes/pki/ca.{crt,key}).
+	ClientCACert string
+	ClientCAKey  string
 	// CertTTL is the lifetime of issued operator certs.
 	CertTTL time.Duration
 	// CertOrg / CertCN are the Kubernetes group / user the issued cert
@@ -35,7 +39,7 @@ type Config struct {
 // Startup order matters for the trust story:
 //  1. LoadMeasuredOperatorKey — read the opkeydata pubkey and CONFIRM it
 //     matches RTMR[3]. Fails closed if the key was substituted after boot.
-//  2. loadClusterCA — the RKE2 client-CA that signs the operator's cert.
+//  2. loadClusterCA — the cluster client-CA that signs the operator's cert.
 //  3. serve over an RA-TLS config so the caller can attest this is the real
 //     guest before trusting the returned cert.
 func Run(ctx context.Context, cfg Config) error {
@@ -52,7 +56,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("load measured operator key: %w", err)
 	}
 
-	ca, err := loadClusterCA()
+	ca, err := loadClusterCA(cfg.ClientCACert, cfg.ClientCAKey)
 	if err != nil {
 		return fmt.Errorf("load cluster CA: %w", err)
 	}

--- a/internal/cmds/credrelease/sign.go
+++ b/internal/cmds/credrelease/sign.go
@@ -1,7 +1,7 @@
 package credrelease
 
 import (
-	"crypto/ecdsa"
+	"crypto"
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -12,68 +12,75 @@ import (
 	"time"
 )
 
-// RKE2 keeps the CA that signs client certs the apiserver trusts here. The
-// baked admin identity (rke2.yaml) is O=system:masters, CN=system:admin signed
-// by this CA; the release service issues an operator a cert under the same CA.
+// Default CA paths: where RKE2 (the c8s node image's distribution) keeps the
+// CA that signs client certs the apiserver trusts. The mechanism is not
+// RKE2-specific: any distribution with a client CA works by pointing
+// --client-ca-cert/--client-ca-key at it (kubeadm: /etc/kubernetes/pki/ca.{crt,key}).
 const (
-	rke2ClientCACert = "/var/lib/rancher/rke2/server/tls/client-ca.crt"
-	rke2ClientCAKey  = "/var/lib/rancher/rke2/server/tls/client-ca.key"
+	defaultClientCACert = "/var/lib/rancher/rke2/server/tls/client-ca.crt"
+	defaultClientCAKey  = "/var/lib/rancher/rke2/server/tls/client-ca.key"
 )
 
-// clusterCA holds the RKE2 client-signing CA loaded from the guest FS.
+// clusterCA holds the cluster's client-signing CA loaded from the guest FS.
 type clusterCA struct {
 	cert *x509.Certificate
-	key  *ecdsa.PrivateKey
+	key  crypto.Signer
 	pem  []byte // the CA cert PEM, for the returned kubeconfig's trust anchor
 }
 
-// loadClusterCA reads the RKE2 client-CA cert+key. RKE2's client-CA is ECDSA
-// P-256 (confirmed on the target), so the key parses as *ecdsa.PrivateKey.
-func loadClusterCA() (*clusterCA, error) {
-	certPEM, err := os.ReadFile(rke2ClientCACert)
+// loadClusterCA reads the cluster client-CA cert+key.
+func loadClusterCA(certPath, keyPath string) (*clusterCA, error) {
+	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
-		return nil, fmt.Errorf("read client-ca.crt: %w", err)
+		return nil, fmt.Errorf("read client CA cert: %w", err)
 	}
-	keyPEM, err := os.ReadFile(rke2ClientCAKey)
+	keyPEM, err := os.ReadFile(keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("read client-ca.key: %w", err)
+		return nil, fmt.Errorf("read client CA key: %w", err)
 	}
 
 	cb, _ := pem.Decode(certPEM)
 	if cb == nil || cb.Type != "CERTIFICATE" {
-		return nil, fmt.Errorf("client-ca.crt is not a CERTIFICATE PEM")
+		return nil, fmt.Errorf("%s is not a CERTIFICATE PEM", certPath)
 	}
 	cert, err := x509.ParseCertificate(cb.Bytes)
 	if err != nil {
-		return nil, fmt.Errorf("parse client-ca.crt: %w", err)
+		return nil, fmt.Errorf("parse client CA cert: %w", err)
 	}
 
 	kb, _ := pem.Decode(keyPEM)
 	if kb == nil {
-		return nil, fmt.Errorf("client-ca.key is not PEM")
+		return nil, fmt.Errorf("%s is not PEM", keyPath)
 	}
-	key, err := parseECPrivateKey(kb.Bytes, kb.Type)
+	key, err := parseCAKey(kb.Bytes, kb.Type)
 	if err != nil {
-		return nil, fmt.Errorf("parse client-ca.key: %w", err)
+		return nil, fmt.Errorf("parse client CA key: %w", err)
 	}
 	return &clusterCA{cert: cert, key: key, pem: certPEM}, nil
 }
 
-// parseECPrivateKey handles the two PEM encodings RKE2 may emit (SEC1 "EC
-// PRIVATE KEY" or PKCS#8 "PRIVATE KEY") and asserts the result is ECDSA.
-func parseECPrivateKey(der []byte, pemType string) (*ecdsa.PrivateKey, error) {
-	if pemType == "EC PRIVATE KEY" {
+// parseCAKey handles the PEM encodings the supported distributions emit:
+// SEC1 "EC PRIVATE KEY" (RKE2), PKCS#1 "RSA PRIVATE KEY" (kubeadm), or PKCS#8
+// "PRIVATE KEY".
+func parseCAKey(der []byte, pemType string) (crypto.Signer, error) {
+	switch pemType {
+	case "EC PRIVATE KEY":
 		return x509.ParseECPrivateKey(der)
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(der)
+	case "PRIVATE KEY":
+		k, err := x509.ParsePKCS8PrivateKey(der)
+		if err != nil {
+			return nil, err
+		}
+		s, ok := k.(crypto.Signer)
+		if !ok {
+			return nil, fmt.Errorf("key is %T, which cannot sign", k)
+		}
+		return s, nil
+	default:
+		return nil, fmt.Errorf("unsupported key PEM type %q", pemType)
 	}
-	k, err := x509.ParsePKCS8PrivateKey(der)
-	if err != nil {
-		return nil, err
-	}
-	ec, ok := k.(*ecdsa.PrivateKey)
-	if !ok {
-		return nil, fmt.Errorf("client-ca.key is %T, want ECDSA", k)
-	}
-	return ec, nil
 }
 
 // signOperatorCert signs csr with the cluster CA, producing a kube CLIENT

--- a/internal/cmds/credrelease/sign.go
+++ b/internal/cmds/credrelease/sign.go
@@ -1,0 +1,130 @@
+package credrelease
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+)
+
+// RKE2 keeps the CA that signs client certs the apiserver trusts here. The
+// baked admin identity (rke2.yaml) is O=system:masters, CN=system:admin signed
+// by this CA; the release service issues an operator a cert under the same CA.
+const (
+	rke2ClientCACert = "/var/lib/rancher/rke2/server/tls/client-ca.crt"
+	rke2ClientCAKey  = "/var/lib/rancher/rke2/server/tls/client-ca.key"
+)
+
+// clusterCA holds the RKE2 client-signing CA loaded from the guest FS.
+type clusterCA struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pem  []byte // the CA cert PEM, for the returned kubeconfig's trust anchor
+}
+
+// loadClusterCA reads the RKE2 client-CA cert+key. RKE2's client-CA is ECDSA
+// P-256 (confirmed on the target), so the key parses as *ecdsa.PrivateKey.
+func loadClusterCA() (*clusterCA, error) {
+	certPEM, err := os.ReadFile(rke2ClientCACert)
+	if err != nil {
+		return nil, fmt.Errorf("read client-ca.crt: %w", err)
+	}
+	keyPEM, err := os.ReadFile(rke2ClientCAKey)
+	if err != nil {
+		return nil, fmt.Errorf("read client-ca.key: %w", err)
+	}
+
+	cb, _ := pem.Decode(certPEM)
+	if cb == nil || cb.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("client-ca.crt is not a CERTIFICATE PEM")
+	}
+	cert, err := x509.ParseCertificate(cb.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse client-ca.crt: %w", err)
+	}
+
+	kb, _ := pem.Decode(keyPEM)
+	if kb == nil {
+		return nil, fmt.Errorf("client-ca.key is not PEM")
+	}
+	key, err := parseECPrivateKey(kb.Bytes, kb.Type)
+	if err != nil {
+		return nil, fmt.Errorf("parse client-ca.key: %w", err)
+	}
+	return &clusterCA{cert: cert, key: key, pem: certPEM}, nil
+}
+
+// parseECPrivateKey handles the two PEM encodings RKE2 may emit (SEC1 "EC
+// PRIVATE KEY" or PKCS#8 "PRIVATE KEY") and asserts the result is ECDSA.
+func parseECPrivateKey(der []byte, pemType string) (*ecdsa.PrivateKey, error) {
+	if pemType == "EC PRIVATE KEY" {
+		return x509.ParseECPrivateKey(der)
+	}
+	k, err := x509.ParsePKCS8PrivateKey(der)
+	if err != nil {
+		return nil, err
+	}
+	ec, ok := k.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("client-ca.key is %T, want ECDSA", k)
+	}
+	return ec, nil
+}
+
+// signOperatorCert signs csr with the cluster CA, producing a kube CLIENT
+// certificate with the requested identity. The caller sets group/CN via
+// SignParams — v1 uses O=system:masters (cluster-admin), matching the baked
+// admin. TTL is short so the operator re-releases.
+type signParams struct {
+	csr      *x509.CertificateRequest
+	org      string // certificate Subject O -> maps to a Kubernetes group
+	cn       string // Subject CN -> the Kubernetes user
+	ttl      time.Duration
+	serialFn func() (*big.Int, error) // injectable for tests; nil -> crypto/rand
+}
+
+func (ca *clusterCA) signOperatorCert(p signParams, now time.Time) (certPEM []byte, err error) {
+	if p.csr == nil {
+		return nil, fmt.Errorf("nil CSR")
+	}
+	if err := p.csr.CheckSignature(); err != nil {
+		return nil, fmt.Errorf("CSR self-signature invalid: %w", err)
+	}
+	serialFn := p.serialFn
+	if serialFn == nil {
+		serialFn = randSerial
+	}
+	serial, err := serialFn()
+	if err != nil {
+		return nil, fmt.Errorf("serial: %w", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   p.cn,
+			Organization: []string{p.org},
+		},
+		NotBefore: now.Add(-1 * time.Minute), // small backdate for clock skew
+		NotAfter:  now.Add(p.ttl),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		// Client auth only — this is a kube client cert, not a serving cert.
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, p.csr.PublicKey, ca.key)
+	if err != nil {
+		return nil, fmt.Errorf("sign: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), nil
+}
+
+func randSerial() (*big.Int, error) {
+	// 128-bit random serial (RFC 5280 recommends >= 64-bit, unpredictable).
+	return rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+}

--- a/internal/cmds/credrelease/sign.go
+++ b/internal/cmds/credrelease/sign.go
@@ -12,24 +12,29 @@ import (
 	"time"
 )
 
-// Default CA paths: where RKE2 (the c8s node image's distribution) keeps the
-// CA that signs client certs the apiserver trusts. The mechanism is not
-// RKE2-specific: any distribution with a client CA works by pointing
-// --client-ca-cert/--client-ca-key at it (kubeadm: /etc/kubernetes/pki/ca.{crt,key}).
+// Default CA paths: where RKE2 (the c8s node image's distribution) keeps its
+// CAs. client-ca signs the kube client certs the apiserver trusts; server-ca
+// signs the apiserver SERVING cert and is what the released kubeconfig must
+// carry as certificate-authority-data — RKE2 keeps them distinct, so releasing
+// the client CA there fails kubectl with "certificate signed by unknown
+// authority". The mechanism is not RKE2-specific: kubeadm signs both with one
+// ca.crt, so all three flags point at the same file there.
 const (
 	defaultClientCACert = "/var/lib/rancher/rke2/server/tls/client-ca.crt"
 	defaultClientCAKey  = "/var/lib/rancher/rke2/server/tls/client-ca.key"
+	defaultServerCACert = "/var/lib/rancher/rke2/server/tls/server-ca.crt"
 )
 
-// clusterCA holds the cluster's client-signing CA loaded from the guest FS.
+// clusterCA holds the cluster's client-signing CA plus the serving-CA PEM the
+// released kubeconfig anchors apiserver verification to.
 type clusterCA struct {
 	cert *x509.Certificate
 	key  crypto.Signer
-	pem  []byte // the CA cert PEM, for the returned kubeconfig's trust anchor
+	pem  []byte // the SERVING CA cert PEM — the kubeconfig's trust anchor
 }
 
-// loadClusterCA reads the cluster client-CA cert+key.
-func loadClusterCA(certPath, keyPath string) (*clusterCA, error) {
+// loadClusterCA reads the cluster client-CA cert+key and the serving-CA cert.
+func loadClusterCA(certPath, keyPath, serverCAPath string) (*clusterCA, error) {
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("read client CA cert: %w", err)
@@ -37,6 +42,10 @@ func loadClusterCA(certPath, keyPath string) (*clusterCA, error) {
 	keyPEM, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, fmt.Errorf("read client CA key: %w", err)
+	}
+	serverCAPEM, err := os.ReadFile(serverCAPath)
+	if err != nil {
+		return nil, fmt.Errorf("read server CA cert: %w", err)
 	}
 
 	cb, _ := pem.Decode(certPEM)
@@ -56,7 +65,11 @@ func loadClusterCA(certPath, keyPath string) (*clusterCA, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse client CA key: %w", err)
 	}
-	return &clusterCA{cert: cert, key: key, pem: certPEM}, nil
+	sb, _ := pem.Decode(serverCAPEM)
+	if sb == nil || sb.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("%s is not a CERTIFICATE PEM", serverCAPath)
+	}
+	return &clusterCA{cert: cert, key: key, pem: serverCAPEM}, nil
 }
 
 // parseCAKey handles the PEM encodings the supported distributions emit:

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"testing"
@@ -114,6 +115,35 @@ func TestSignOperatorCertRejectsBadCSR(t *testing.T) {
 		csr: csr, org: "system:masters", cn: "operator", ttl: time.Hour,
 	}, time.Now()); err == nil {
 		t.Error("expected error for CSR with invalid self-signature")
+	}
+}
+
+// TestParseCAKey covers the PEM encodings the supported distributions emit:
+// SEC1 EC (RKE2), PKCS#1 RSA (kubeadm), and PKCS#8.
+func TestParseCAKey(t *testing.T) {
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sec1, _ := x509.MarshalECPrivateKey(ecKey)
+	if _, err := parseCAKey(sec1, "EC PRIVATE KEY"); err != nil {
+		t.Errorf("SEC1 EC: %v", err)
+	}
+	pkcs1 := x509.MarshalPKCS1PrivateKey(rsaKey)
+	if _, err := parseCAKey(pkcs1, "RSA PRIVATE KEY"); err != nil {
+		t.Errorf("PKCS#1 RSA: %v", err)
+	}
+	pkcs8, _ := x509.MarshalPKCS8PrivateKey(ecKey)
+	if _, err := parseCAKey(pkcs8, "PRIVATE KEY"); err != nil {
+		t.Errorf("PKCS#8: %v", err)
+	}
+	if _, err := parseCAKey(sec1, "CERTIFICATE"); err == nil {
+		t.Error("unsupported PEM type accepted")
 	}
 }
 

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -1,0 +1,128 @@
+package credrelease
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"testing"
+	"time"
+)
+
+// testCA builds a self-signed ECDSA CA standing in for the RKE2 client-CA.
+func testCA(t *testing.T) *clusterCA {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          bigOne(),
+		Subject:               pkix.Name{CommonName: "test-client-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &clusterCA{cert: cert, key: key}
+}
+
+func testCSR(t *testing.T) *x509.CertificateRequest {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "ignored-by-signer"},
+	}, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csr, err := x509.ParseCertificateRequest(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return csr
+}
+
+// TestSignOperatorCert issues a cert and checks it: chains to the CA, carries
+// the requested kube identity (O -> group, CN -> user), is client-auth only,
+// and honours the TTL.
+func TestSignOperatorCert(t *testing.T) {
+	ca := testCA(t)
+	csr := testCSR(t)
+	now := time.Now()
+
+	certPEM, err := ca.signOperatorCert(signParams{
+		csr: csr,
+		org: "system:masters",
+		cn:  "operator",
+		ttl: 24 * time.Hour,
+	}, now)
+	if err != nil {
+		t.Fatalf("signOperatorCert: %v", err)
+	}
+
+	cert := parseLeaf(t, certPEM)
+
+	// Identity: the signer sets Subject from signParams, not the CSR.
+	if cert.Subject.CommonName != "operator" {
+		t.Errorf("CN = %q, want operator", cert.Subject.CommonName)
+	}
+	if len(cert.Subject.Organization) != 1 || cert.Subject.Organization[0] != "system:masters" {
+		t.Errorf("O = %v, want [system:masters]", cert.Subject.Organization)
+	}
+	// Client auth only.
+	if len(cert.ExtKeyUsage) != 1 || cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
+		t.Errorf("ExtKeyUsage = %v, want [ClientAuth]", cert.ExtKeyUsage)
+	}
+	// Chains to the CA.
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.cert)
+	if _, err := cert.Verify(x509.VerifyOptions{
+		Roots:       roots,
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		CurrentTime: now,
+	}); err != nil {
+		t.Errorf("issued cert does not chain to CA: %v", err)
+	}
+	// TTL.
+	if got := cert.NotAfter.Sub(now).Round(time.Hour); got != 24*time.Hour {
+		t.Errorf("TTL = %v, want 24h", got)
+	}
+}
+
+// TestSignOperatorCertRejectsBadCSR: a CSR with a broken self-signature is
+// refused (the signer verifies it).
+func TestSignOperatorCertRejectsBadCSR(t *testing.T) {
+	ca := testCA(t)
+	csr := testCSR(t)
+	csr.Signature = []byte("tampered") // invalidate the self-signature
+
+	if _, err := ca.signOperatorCert(signParams{
+		csr: csr, org: "system:masters", cn: "operator", ttl: time.Hour,
+	}, time.Now()); err == nil {
+		t.Error("expected error for CSR with invalid self-signature")
+	}
+}
+
+func parseLeaf(t *testing.T, certPEM []byte) *x509.Certificate {
+	t.Helper()
+	block := decodeOnePEM(t, certPEM, "CERTIFICATE")
+	cert, err := x509.ParseCertificate(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -56,7 +56,6 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")
 	f.StringVar(&cfg.OutPath, "out", "", "output kubeconfig path (required)")
-	f.BoolVar(&cfg.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "drop the :8443 RA-TLS channel check (debug only; the release stays gated by the RTMR[3] attestation check + CA signature + JWT PoP)")
 	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
 	return cmd
 }

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -1,0 +1,62 @@
+package getkubeconfig
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmd builds the `get-kubeconfig` subcommand: the operator-side client that
+// obtains an RKE2 admin kubeconfig from a measured TDX CVM by attesting the
+// node, confirming it was launched to trust the operator's key (RTMR[3]), and
+// exchanging a CSR for a signed client cert over the cred-release endpoint.
+func NewCmd() *cobra.Command {
+	var (
+		cfg  Config
+		node string
+	)
+	cmd := &cobra.Command{
+		Use:   "get-kubeconfig",
+		Short: "Attest a c8s CVM and obtain an operator kubeconfig via the RTMR[3]-bound key",
+		Long: "get-kubeconfig attests a measured c8s TDX CVM, confirms rtmr[3] proves\n" +
+			"the node trusts the operator's key, then exchanges a CSR for a\n" +
+			"short-lived RKE2 client cert over the cred-release endpoint and writes\n" +
+			"a kubeconfig. Needs attestation-cli on PATH (or $ATTESTATION_CLI).",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if cfg.OperatorKeyPath == "" || cfg.OutPath == "" {
+				return fmt.Errorf("--operator-key and --out are required")
+			}
+			// --node <host> is a convenience that fills the three URLs with the
+			// standard ports; explicit --attest-url/--release-url/--apiserver-url
+			// override. At least one of node or the explicit URLs must be set.
+			if node != "" {
+				if cfg.AttestURL == "" {
+					cfg.AttestURL = fmt.Sprintf("http://%s:8400/attest", node)
+				}
+				if cfg.ReleaseBaseURL == "" {
+					cfg.ReleaseBaseURL = fmt.Sprintf("https://%s:8443", node)
+				}
+				if cfg.APIServerURL == "" {
+					cfg.APIServerURL = fmt.Sprintf("https://%s:6443", node)
+				}
+			}
+			if cfg.AttestURL == "" || cfg.ReleaseBaseURL == "" || cfg.APIServerURL == "" {
+				return fmt.Errorf("set --node, or all of --attest-url/--release-url/--apiserver-url")
+			}
+			return Run(cmd.Context(), cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&node, "node", "", "guest host/IP; fills --attest-url/--release-url/--apiserver-url with standard ports (8400/8443/6443)")
+	f.StringVar(&cfg.AttestURL, "attest-url", "", "attestation-api /attest URL (overrides --node)")
+	f.StringVar(&cfg.ReleaseBaseURL, "release-url", "", "cred-release base URL (overrides --node)")
+	f.StringVar(&cfg.APIServerURL, "apiserver-url", "", "apiserver URL for the kubeconfig (overrides --node)")
+	f.StringVar(&cfg.OperatorKeyPath, "operator-key", "", "operator ECDSA private key PEM (its public half is bound into RTMR[3]) (required)")
+	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
+	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")
+	f.StringVar(&cfg.OutPath, "out", "", "output kubeconfig path (required)")
+	f.BoolVar(&cfg.InsecureSkipTLSVerify, "insecure-skip-tls-verify", true, "skip :8443 server-cert verification (v1: the attestation gate + CA signature + JWT PoP secure the release; RA-TLS pinning is a follow-up)")
+	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
+	return cmd
+}

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -22,7 +22,7 @@ func NewCmd() *cobra.Command {
 		Long: "get-kubeconfig attests a measured c8s TDX CVM, confirms rtmr[3] proves\n" +
 			"the node trusts the operator's key, then exchanges a CSR for a\n" +
 			"short-lived RKE2 client cert over the cred-release endpoint and writes\n" +
-			"a kubeconfig. Needs attestation-cli on PATH (or $ATTESTATION_CLI).",
+			"a kubeconfig. Verification runs in-process (attestation-go).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cfg.OperatorKeyPath == "" || cfg.OutPath == "" {
 				return fmt.Errorf("--operator-key and --out are required")

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -56,7 +56,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")
 	f.StringVar(&cfg.OutPath, "out", "", "output kubeconfig path (required)")
-	f.BoolVar(&cfg.InsecureSkipTLSVerify, "insecure-skip-tls-verify", true, "skip :8443 server-cert verification (v1: the attestation gate + CA signature + JWT PoP secure the release; RA-TLS pinning is a follow-up)")
+	f.BoolVar(&cfg.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "drop the :8443 RA-TLS channel check (debug only; the release stays gated by the RTMR[3] attestation check + CA signature + JWT PoP)")
 	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
 	return cmd
 }

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 // NewCmd builds the `get-kubeconfig` subcommand: the operator-side client that
-// obtains an RKE2 admin kubeconfig from a measured TDX CVM by attesting the
+// obtains an admin kubeconfig from a measured TDX CVM by attesting the
 // node, confirming it was launched to trust the operator's key (RTMR[3]), and
 // exchanging a CSR for a signed client cert over the cred-release endpoint.
 func NewCmd() *cobra.Command {
@@ -21,7 +21,7 @@ func NewCmd() *cobra.Command {
 		Short: "Attest a c8s CVM and obtain an operator kubeconfig via the RTMR[3]-bound key",
 		Long: "get-kubeconfig attests a measured c8s TDX CVM, confirms rtmr[3] proves\n" +
 			"the node trusts the operator's key, then exchanges a CSR for a\n" +
-			"short-lived RKE2 client cert over the cred-release endpoint and writes\n" +
+			"short-lived kube client cert over the cred-release endpoint and writes\n" +
 			"a kubeconfig. Verification runs in-process (attestation-go).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cfg.OperatorKeyPath == "" || cfg.OutPath == "" {

--- a/internal/cmds/getkubeconfig/getkubeconfig_test.go
+++ b/internal/cmds/getkubeconfig/getkubeconfig_test.go
@@ -1,0 +1,90 @@
+package getkubeconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"strings"
+	"testing"
+)
+
+// TestExpectedRTMR3 checks the client computes the same value the guest
+// measures: RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)).
+func TestExpectedRTMR3(t *testing.T) {
+	pub := []byte("-----BEGIN PUBLIC KEY-----\nMFk...\n-----END PUBLIC KEY-----\n")
+	got := expectedRTMR3(pub)
+
+	keyDigest := sha512.Sum384(pub)
+	want := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	if got != hex.EncodeToString(want[:]) {
+		t.Errorf("expectedRTMR3 = %s, want %s", got, hex.EncodeToString(want[:]))
+	}
+}
+
+// TestPublicKeyPEMFromPrivateMatchesMarshal confirms deriving the pubkey from a
+// private key yields the PKIX PEM the launcher put on the opkeydata disk (the
+// same encoding openssl ec -pubout / x509.MarshalPKIXPublicKey produce), so the
+// RTMR[3] expected value matches. Both SEC1 and PKCS#8 private-key PEMs work.
+func TestPublicKeyPEMFromPrivate(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDER, _ := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	want := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: wantDER})
+
+	// SEC1 "EC PRIVATE KEY"
+	sec1, _ := x509.MarshalECPrivateKey(key)
+	sec1PEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: sec1})
+	got, err := publicKeyPEMFromPrivate(sec1PEM)
+	if err != nil {
+		t.Fatalf("SEC1: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("SEC1 derived pubkey != MarshalPKIXPublicKey")
+	}
+
+	// PKCS#8 "PRIVATE KEY"
+	pkcs8, _ := x509.MarshalPKCS8PrivateKey(key)
+	pkcs8PEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: pkcs8})
+	got, err = publicKeyPEMFromPrivate(pkcs8PEM)
+	if err != nil {
+		t.Fatalf("PKCS8: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("PKCS8 derived pubkey != MarshalPKIXPublicKey")
+	}
+}
+
+// TestBuildKubeconfig checks the assembled kubeconfig is well-formed: the
+// context/cluster/user names, the server URL, and base64 of the cert/key/CA.
+func TestBuildKubeconfig(t *testing.T) {
+	cert := []byte("CERTPEM")
+	key := []byte("KEYPEM")
+	ca := []byte("CAPEM")
+	kc := string(buildKubeconfig("https://node:6443", "c8s", "c8s-cvm", cert, key, ca))
+
+	for _, want := range []string{
+		"current-context: c8s",
+		"server: https://node:6443",
+		"tls-server-name: c8s-cvm",
+		"certificate-authority-data: " + base64.StdEncoding.EncodeToString(ca),
+		"client-certificate-data: " + base64.StdEncoding.EncodeToString(cert),
+		"client-key-data: " + base64.StdEncoding.EncodeToString(key),
+	} {
+		if !strings.Contains(kc, want) {
+			t.Errorf("kubeconfig missing %q\n%s", want, kc)
+		}
+	}
+
+	// Empty tls-server-name omits the line entirely.
+	kc2 := string(buildKubeconfig("https://node:6443", "c8s", "", cert, key, ca))
+	if strings.Contains(kc2, "tls-server-name") {
+		t.Errorf("empty tlsServerName should omit the line\n%s", kc2)
+	}
+}

--- a/internal/cmds/getkubeconfig/kubeconfig.go
+++ b/internal/cmds/getkubeconfig/kubeconfig.go
@@ -1,0 +1,42 @@
+package getkubeconfig
+
+import (
+	"encoding/base64"
+	"fmt"
+)
+
+// buildKubeconfig assembles a minimal kubeconfig from the issued client cert +
+// key, the cluster CA, and the apiserver address. Written directly as YAML — no
+// clientcmd dependency for a fixed single-context shape.
+//
+// tlsServerName, when non-empty, is emitted as tls-server-name: the operator
+// dials the guest at a per-launch IP the apiserver cert has no SAN for, so
+// verification is pinned to a stable SAN the image bakes into tls-san
+// (c8s-cvm) instead. Without it the kubeconfig would need
+// --insecure-skip-tls-verify.
+func buildKubeconfig(apiserverURL, contextName, tlsServerName string, clientCertPEM, clientKeyPEM, caPEM []byte) []byte {
+	b64 := func(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+	tlsLine := ""
+	if tlsServerName != "" {
+		tlsLine = fmt.Sprintf("\n    tls-server-name: %s", tlsServerName)
+	}
+	return []byte(fmt.Sprintf(`apiVersion: v1
+kind: Config
+current-context: %[1]s
+clusters:
+- name: %[1]s
+  cluster:
+    server: %[2]s
+    certificate-authority-data: %[3]s%[6]s
+contexts:
+- name: %[1]s
+  context:
+    cluster: %[1]s
+    user: %[1]s
+users:
+- name: %[1]s
+  user:
+    client-certificate-data: %[4]s
+    client-key-data: %[5]s
+`, contextName, apiserverURL, b64(caPEM), b64(clientCertPEM), b64(clientKeyPEM), tlsLine))
+}

--- a/internal/cmds/getkubeconfig/ratls_verify.go
+++ b/internal/cmds/getkubeconfig/ratls_verify.go
@@ -1,25 +1,23 @@
 package getkubeconfig
 
 import (
-	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
 // newRATLSClient builds an HTTP client whose :8443 dial is verified with the
-// operator's OWN local attestation-cli — no trust in the guest's attestation-api,
-// not TOFU. The cred-release serving cert embeds a fresh TDX quote bound to the
-// cert's public key (ratls.ReportDataForKey); verifyServerCert extracts it,
-// asserts the quote covers this exact cert key, and asserts rtmr_3 == H(op_pub).
-// A host MITM can't forge that quote, so a successful handshake proves the
-// channel terminates inside the measured, operator-key-bound guest.
+// operator's OWN in-process verifier (attestation-go), with no trust in the
+// guest's attestation-api and not TOFU. The cred-release serving cert embeds a
+// fresh TDX quote bound to the cert's public key (ratls.ReportDataForKey);
+// verifyServerCert extracts it, asserts the quote covers this exact cert key,
+// and asserts rtmr_3 == H(op_pub). A host MITM can't forge that quote, so a
+// successful handshake proves the channel terminates inside the measured,
+// operator-key-bound guest.
 //
 // Go's own chain/hostname verification is disabled (InsecureSkipVerify): the
 // serving cert is self-signed and carries no SAN for the per-launch IP. RA-TLS
@@ -42,8 +40,8 @@ func newRATLSClient(cfg Config, operatorPubPEM []byte) *http.Client {
 }
 
 // verifyServerCert runs the RA-TLS check on the :8443 leaf cert: it pulls the
-// embedded TDX quote, binds it to the cert's own public key, verifies it with
-// the local attestation-cli (HW chain + report_data freshness), and asserts
+// embedded TDX quote, binds it to the cert's own public key, verifies it
+// in-process with attestation-go (HW chain + report_data binding), and asserts
 // rtmr_3 equals expectedRTMR3(op_pub). Fails closed on any missing piece.
 func verifyServerCert(leaf *x509.Certificate, operatorPubPEM []byte) error {
 	att, err := ratls.ExtractAttestation(leaf)
@@ -58,9 +56,9 @@ func verifyServerCert(leaf *x509.Certificate, operatorPubPEM []byte) error {
 	}
 
 	// The quote's report_data must be SHA-384(cert pubkey) — this is what ties
-	// the attested guest to THIS TLS channel. attestation-cli zero-pads the
-	// expected value to the quote's 64-byte report_data, so the 64-byte
-	// ReportDataForKey output (48-byte hash + zero tail) matches exactly.
+	// the attested guest to THIS TLS channel. The 64-byte ReportDataForKey
+	// output (48-byte hash + zero tail) matches the quote's report_data field
+	// exactly.
 	rd, err := ratls.ReportDataForKey(leaf.PublicKey, nil)
 	if err != nil {
 		return fmt.Errorf("ratls: compute expected report_data: %w", err)
@@ -71,30 +69,13 @@ func verifyServerCert(leaf *x509.Certificate, operatorPubPEM []byte) error {
 		return fmt.Errorf("ratls: marshal embedded evidence: %w", err)
 	}
 
-	// Reuse the same local verifier the RTMR[3] gate uses. No context here (the
-	// TLS callback has none); Background is fine — the client Timeout still
-	// bounds the surrounding request.
-	claims, err := runAttestationCLIVerify(context.Background(), envJSON, hex.EncodeToString(rd[:]))
+	// Reuse the same in-process verifier the RTMR[3] gate uses.
+	res, err := verifyEvidence(envJSON, rd[:])
 	if err != nil {
-		return fmt.Errorf("ratls: attestation-cli verify: %w", err)
+		return fmt.Errorf("ratls: %w", err)
 	}
-
-	sigValid, _ := claims["signature_valid"].(bool)
-	rdMatch, _ := claims["report_data_match"].(bool)
-	if !sigValid {
-		return fmt.Errorf("ratls: server quote signature invalid")
-	}
-	if !rdMatch {
-		return fmt.Errorf("ratls: server quote report_data not bound to the presented cert key (MITM)")
-	}
-
-	got := platformDataString(claims, "rtmr_3")
-	want := expectedRTMR3(operatorPubPEM)
-	if got == "" {
-		return fmt.Errorf("ratls: server quote carries no rtmr_3")
-	}
-	if !strings.EqualFold(got, want) {
-		return fmt.Errorf("ratls: server RTMR[3] mismatch: node reports %s, operator key implies %s", got, want)
+	if err := checkRTMR3(res, operatorPubPEM); err != nil {
+		return fmt.Errorf("ratls: %w", err)
 	}
 	return nil
 }

--- a/internal/cmds/getkubeconfig/ratls_verify.go
+++ b/internal/cmds/getkubeconfig/ratls_verify.go
@@ -1,0 +1,100 @@
+package getkubeconfig
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// newRATLSClient builds an HTTP client whose :8443 dial is verified with the
+// operator's OWN local attestation-cli — no trust in the guest's attestation-api,
+// not TOFU. The cred-release serving cert embeds a fresh TDX quote bound to the
+// cert's public key (ratls.ReportDataForKey); verifyServerCert extracts it,
+// asserts the quote covers this exact cert key, and asserts rtmr_3 == H(op_pub).
+// A host MITM can't forge that quote, so a successful handshake proves the
+// channel terminates inside the measured, operator-key-bound guest.
+//
+// Go's own chain/hostname verification is disabled (InsecureSkipVerify): the
+// serving cert is self-signed and carries no SAN for the per-launch IP. RA-TLS
+// replaces it — the quote binding is strictly stronger than a CA chain here.
+func newRATLSClient(cfg Config, operatorPubPEM []byte) *http.Client {
+	return &http.Client{
+		Timeout: cfg.Timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // RA-TLS in VerifyConnection is the real check
+				VerifyConnection: func(cs tls.ConnectionState) error {
+					if len(cs.PeerCertificates) == 0 {
+						return fmt.Errorf("ratls: server presented no certificate")
+					}
+					return verifyServerCert(cs.PeerCertificates[0], operatorPubPEM)
+				},
+			},
+		},
+	}
+}
+
+// verifyServerCert runs the RA-TLS check on the :8443 leaf cert: it pulls the
+// embedded TDX quote, binds it to the cert's own public key, verifies it with
+// the local attestation-cli (HW chain + report_data freshness), and asserts
+// rtmr_3 equals expectedRTMR3(op_pub). Fails closed on any missing piece.
+func verifyServerCert(leaf *x509.Certificate, operatorPubPEM []byte) error {
+	att, err := ratls.ExtractAttestation(leaf)
+	if err != nil {
+		return fmt.Errorf("ratls: %w", err)
+	}
+	evidence, ok := att.EmbeddedEvidence()
+	if !ok {
+		// TDX always carries a JSON envelope in the RA-TLS extension; its
+		// absence means the cert isn't a genuine TDX RA-TLS cert.
+		return fmt.Errorf("ratls: server cert carries no TDX attestation envelope")
+	}
+
+	// The quote's report_data must be SHA-384(cert pubkey) — this is what ties
+	// the attested guest to THIS TLS channel. attestation-cli zero-pads the
+	// expected value to the quote's 64-byte report_data, so the 64-byte
+	// ReportDataForKey output (48-byte hash + zero tail) matches exactly.
+	rd, err := ratls.ReportDataForKey(leaf.PublicKey, nil)
+	if err != nil {
+		return fmt.Errorf("ratls: compute expected report_data: %w", err)
+	}
+
+	envJSON, err := json.Marshal(evidence)
+	if err != nil {
+		return fmt.Errorf("ratls: marshal embedded evidence: %w", err)
+	}
+
+	// Reuse the same local verifier the RTMR[3] gate uses. No context here (the
+	// TLS callback has none); Background is fine — the client Timeout still
+	// bounds the surrounding request.
+	claims, err := runAttestationCLIVerify(context.Background(), envJSON, hex.EncodeToString(rd[:]))
+	if err != nil {
+		return fmt.Errorf("ratls: attestation-cli verify: %w", err)
+	}
+
+	sigValid, _ := claims["signature_valid"].(bool)
+	rdMatch, _ := claims["report_data_match"].(bool)
+	if !sigValid {
+		return fmt.Errorf("ratls: server quote signature invalid")
+	}
+	if !rdMatch {
+		return fmt.Errorf("ratls: server quote report_data not bound to the presented cert key (MITM)")
+	}
+
+	got := platformDataString(claims, "rtmr_3")
+	want := expectedRTMR3(operatorPubPEM)
+	if got == "" {
+		return fmt.Errorf("ratls: server quote carries no rtmr_3")
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("ratls: server RTMR[3] mismatch: node reports %s, operator key implies %s", got, want)
+	}
+	return nil
+}

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -1,0 +1,132 @@
+package getkubeconfig
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// operatorPub is a throwaway operator public key PEM for the tests.
+func operatorPub(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub, err := publicKeyPEMFromPrivate(mustKeyPEM(t, key))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func mustKeyPEM(t *testing.T, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+}
+
+// attestedCert builds a genuine RA-TLS TDX cert carrying the given evidence
+// envelope, bound to the cert's own key (as the real serving path does).
+func attestedCert(t *testing.T, envelope types.AttestationEvidence) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	report, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att := &ratls.Attestation{TEEType: ratls.TEETypeTDX, Report: report}
+	der, err := ratls.CreateAttestedCert(key, att, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+// fakeAttestationCLI writes a stub attestation-cli that prints the given claims
+// JSON and points ATTESTATION_CLI at it. Lets the tests drive verifyServerCert's
+// post-extraction logic deterministically without real hardware.
+func fakeAttestationCLI(t *testing.T, claimsJSON string) {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-attestation-cli")
+	script := "#!/bin/sh\ncat >/dev/null\ncat <<'EOF'\n" + claimsJSON + "\nEOF\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ATTESTATION_CLI", bin)
+}
+
+func TestVerifyServerCertNoExtension(t *testing.T) {
+	// A plain (non-RA-TLS) cert must be rejected before any CLI call.
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1)}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, _ := x509.ParseCertificate(der)
+
+	err = verifyServerCert(cert, operatorPub(t))
+	if err == nil || !strings.Contains(err.Error(), "ratls:") {
+		t.Fatalf("want RA-TLS extraction error, got %v", err)
+	}
+}
+
+func TestVerifyServerCertRejectsBadReportData(t *testing.T) {
+	// The CLI reports the quote is valid but report_data isn't bound to the
+	// cert key — a MITM presenting someone else's quote. Must fail closed.
+	fakeAttestationCLI(t, `{"signature_valid":true,"report_data_match":false,"claims":{"platform_data":{"rtmr_3":"aa"}}}`)
+	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
+
+	err := verifyServerCert(cert, operatorPub(t))
+	if err == nil || !strings.Contains(err.Error(), "report_data") {
+		t.Fatalf("want report_data binding failure, got %v", err)
+	}
+}
+
+func TestVerifyServerCertRejectsWrongRTMR3(t *testing.T) {
+	// Genuine, key-bound quote, but rtmr_3 doesn't equal H(op_pub): the node
+	// wasn't launched to trust this operator. Must fail closed.
+	fakeAttestationCLI(t, `{"signature_valid":true,"report_data_match":true,"claims":{"platform_data":{"rtmr_3":"00"}}}`)
+	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
+
+	err := verifyServerCert(cert, operatorPub(t))
+	if err == nil || !strings.Contains(err.Error(), "RTMR[3] mismatch") {
+		t.Fatalf("want RTMR[3] mismatch, got %v", err)
+	}
+}
+
+func TestVerifyServerCertAccepts(t *testing.T) {
+	// Genuine quote, bound to the cert key, rtmr_3 == H(op_pub): accept.
+	pub := operatorPub(t)
+	want := expectedRTMR3(pub)
+	claims := `{"signature_valid":true,"report_data_match":true,"claims":{"platform_data":{"rtmr_3":"` + want + `"}}}`
+	fakeAttestationCLI(t, claims)
+	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
+
+	if err := verifyServerCert(cert, pub); err != nil {
+		t.Fatalf("want accept, got %v", err)
+	}
+}

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -88,6 +88,16 @@ func verifiedResult(rtmr3 string) *teetypes.VerificationResult {
 	}
 }
 
+func TestVerifyEvidenceRejectsNonTDX(t *testing.T) {
+	// A SEV-SNP node can never satisfy the RTMR[3] key binding; the gate must
+	// name the platform up front, before any verification runs.
+	stubVerify(t, verifiedResult("aa"), nil) // must not be reached
+	_, err := verifyEvidence([]byte(`{"platform":"snp","evidence":{}}`), nil)
+	if err == nil || !strings.Contains(err.Error(), "requires a TDX guest") {
+		t.Fatalf("want TDX-required error, got %v", err)
+	}
+}
+
 func TestVerifyServerCertNoExtension(t *testing.T) {
 	// A plain (non-RA-TLS) cert must be rejected before any verification.
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -8,10 +8,10 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"math/big"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -64,22 +64,32 @@ func attestedCert(t *testing.T, envelope types.AttestationEvidence) *x509.Certif
 	return cert
 }
 
-// fakeAttestationCLI writes a stub attestation-cli that prints the given claims
-// JSON and points ATTESTATION_CLI at it. Lets the tests drive verifyServerCert's
-// post-extraction logic deterministically without real hardware.
-func fakeAttestationCLI(t *testing.T, claimsJSON string) {
+// stubVerify replaces the in-process attestation-go verifier with one that
+// returns the given result/error. Lets the tests drive verifyServerCert's
+// post-verification logic deterministically without real hardware.
+func stubVerify(t *testing.T, res *teetypes.VerificationResult, err error) {
 	t.Helper()
-	dir := t.TempDir()
-	bin := filepath.Join(dir, "fake-attestation-cli")
-	script := "#!/bin/sh\ncat >/dev/null\ncat <<'EOF'\n" + claimsJSON + "\nEOF\n"
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+	orig := verifyEnvelope
+	verifyEnvelope = func([]byte, teetypes.VerifyParams) (*teetypes.VerificationResult, error) {
+		return res, err
 	}
-	t.Setenv("ATTESTATION_CLI", bin)
+	t.Cleanup(func() { verifyEnvelope = orig })
+}
+
+// verifiedResult builds a passing VerificationResult carrying the given rtmr_3.
+func verifiedResult(rtmr3 string) *teetypes.VerificationResult {
+	return &teetypes.VerificationResult{
+		SignatureValid:  true,
+		Platform:        teetypes.PlatformTDX,
+		ReportDataMatch: teetypes.Ptr(true),
+		Claims: teetypes.Claims{
+			PlatformData: map[string]any{"rtmr_3": rtmr3},
+		},
+	}
 }
 
 func TestVerifyServerCertNoExtension(t *testing.T) {
-	// A plain (non-RA-TLS) cert must be rejected before any CLI call.
+	// A plain (non-RA-TLS) cert must be rejected before any verification.
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	tmpl := &x509.Certificate{SerialNumber: big.NewInt(1)}
 	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
@@ -95,9 +105,11 @@ func TestVerifyServerCertNoExtension(t *testing.T) {
 }
 
 func TestVerifyServerCertRejectsBadReportData(t *testing.T) {
-	// The CLI reports the quote is valid but report_data isn't bound to the
-	// cert key — a MITM presenting someone else's quote. Must fail closed.
-	fakeAttestationCLI(t, `{"signature_valid":true,"report_data_match":false,"claims":{"platform_data":{"rtmr_3":"aa"}}}`)
+	// The verifier reports the quote is valid but report_data isn't bound to
+	// the cert key — a MITM presenting someone else's quote. Must fail closed.
+	res := verifiedResult("aa")
+	res.ReportDataMatch = teetypes.Ptr(false)
+	stubVerify(t, res, nil)
 	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
 
 	err := verifyServerCert(cert, operatorPub(t))
@@ -109,7 +121,7 @@ func TestVerifyServerCertRejectsBadReportData(t *testing.T) {
 func TestVerifyServerCertRejectsWrongRTMR3(t *testing.T) {
 	// Genuine, key-bound quote, but rtmr_3 doesn't equal H(op_pub): the node
 	// wasn't launched to trust this operator. Must fail closed.
-	fakeAttestationCLI(t, `{"signature_valid":true,"report_data_match":true,"claims":{"platform_data":{"rtmr_3":"00"}}}`)
+	stubVerify(t, verifiedResult("00"), nil)
 	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
 
 	err := verifyServerCert(cert, operatorPub(t))
@@ -121,9 +133,7 @@ func TestVerifyServerCertRejectsWrongRTMR3(t *testing.T) {
 func TestVerifyServerCertAccepts(t *testing.T) {
 	// Genuine quote, bound to the cert key, rtmr_3 == H(op_pub): accept.
 	pub := operatorPub(t)
-	want := expectedRTMR3(pub)
-	claims := `{"signature_valid":true,"report_data_match":true,"claims":{"platform_data":{"rtmr_3":"` + want + `"}}}`
-	fakeAttestationCLI(t, claims)
+	stubVerify(t, verifiedResult(expectedRTMR3(pub)), nil)
 	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
 
 	if err := verifyServerCert(cert, pub); err != nil {

--- a/internal/cmds/getkubeconfig/release.go
+++ b/internal/cmds/getkubeconfig/release.go
@@ -1,0 +1,111 @@
+package getkubeconfig
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// releaseRequest / releaseResponse mirror the cred-release handler's shapes.
+type releaseRequest struct {
+	CSRPEM string `json:"csr"`
+}
+type releaseResponse struct {
+	CertPEM string `json:"cert"`
+	CAPEM   string `json:"ca"`
+}
+
+const releasePath = "/release-credential"
+
+// clientIdentity is the kube-client keypair the operator generates locally.
+// The private key never leaves the operator; the cert binds to its public key.
+type clientIdentity struct {
+	key    *ecdsa.PrivateKey
+	keyPEM []byte
+}
+
+func newClientIdentity() (*clientIdentity, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+	return &clientIdentity{
+		key:    key,
+		keyPEM: pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}),
+	}, nil
+}
+
+// csrPEM builds a CSR for this identity. The Subject is ignored by the server
+// (it sets O/CN from its own config), so it's left empty.
+func (id *clientIdentity) csrPEM() ([]byte, error) {
+	der, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{},
+	}, id.key)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}), nil
+}
+
+// requestCredential mints an operator-signed JWT bound to the exact request
+// body, POSTs the CSR to the cred-release endpoint, and returns the issued
+// cert + cluster CA. httpClient is the (RA-TLS or plain) transport to :8443;
+// operatorKeyPEM is the operator PRIVATE key that authorizes the release.
+func requestCredential(ctx context.Context, httpClient *http.Client, baseURL string, operatorKeyPEM, csrPEM []byte) (*releaseResponse, error) {
+	signer, err := operatorauth.NewSignerFromKeyPEM(operatorKeyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("operator key: %w", err)
+	}
+
+	body, err := json.Marshal(releaseRequest{CSRPEM: string(csrPEM)})
+	if err != nil {
+		return nil, err
+	}
+
+	// The JWT binds method/path/body (pbh) — must match exactly what we send.
+	authz, err := signer.Authorization(http.MethodPost, releasePath, body)
+	if err != nil {
+		return nil, fmt.Errorf("sign operator token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+releasePath, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authz)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("release request: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("release HTTP %d: %s", resp.StatusCode, respBody)
+	}
+
+	var out releaseResponse
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("parse release response: %w", err)
+	}
+	if out.CertPEM == "" || out.CAPEM == "" {
+		return nil, fmt.Errorf("release response missing cert or ca")
+	}
+	return &out, nil
+}

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -37,7 +37,7 @@ type Config struct {
 	OutPath string
 	// InsecureSkipTLSVerify drops the :8443 dial from RA-TLS verification to a
 	// plain (unverified) TLS dial. Default false: the dial is RA-TLS-verified
-	// against the operator's local attestation-cli, so the host can't MITM the
+	// in-process by the operator's own verifier, so the host can't MITM the
 	// channel. Set only to bypass RA-TLS for debugging — the release is still
 	// gated by the RTMR[3] attestation check + the RKE2-CA signature + JWT PoP.
 	InsecureSkipTLSVerify bool
@@ -78,8 +78,8 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	// 3. Exchange the CSR for a signed cert over cred-release. By default the
-	//    :8443 dial is RA-TLS-verified against the operator's local
-	//    attestation-cli (newRATLSClient): the serving cert's embedded quote
+	//    :8443 dial is RA-TLS-verified in-process by the operator's own
+	//    verifier (newRATLSClient): the serving cert's embedded quote
 	//    must bind to the cert key AND carry rtmr_3 == H(op_pub), so the host
 	//    can't MITM the channel. --insecure-skip-tls-verify drops that to a
 	//    plain TLS dial (the release is still gated by attestation + the RKE2-CA

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -1,0 +1,137 @@
+package getkubeconfig
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+)
+
+// Config is the get-kubeconfig client configuration.
+type Config struct {
+	// AttestURL is the guest attestation-api /attest endpoint (e.g.
+	// http://<node>:8400/attest) used for the RTMR[3] trust gate.
+	AttestURL string
+	// ReleaseBaseURL is the cred-release endpoint base (e.g. https://<node>:8443).
+	ReleaseBaseURL string
+	// APIServerURL is the guest apiserver the kubeconfig points at
+	// (e.g. https://<node>:6443).
+	APIServerURL string
+	// OperatorKeyPath is the operator ECDSA PRIVATE key (PEM). Its public half
+	// was bound into the node's RTMR[3] at launch.
+	OperatorKeyPath string
+	// ContextName names the kubeconfig cluster/context/user.
+	ContextName string
+	// TLSServerName is emitted as the kubeconfig's tls-server-name, so cert
+	// verification is pinned to a stable SAN the image bakes (c8s-cvm) rather
+	// than the per-launch IP the operator dials (which the apiserver cert has
+	// no SAN for). Empty omits it (verification then needs the dialed IP to be
+	// a cert SAN, which it usually isn't).
+	TLSServerName string
+	// OutPath is where the kubeconfig is written.
+	OutPath string
+	// InsecureSkipTLSVerify skips server-cert verification on the :8443 dial.
+	// v1 default true: the release is secured by the RTMR[3] attestation gate
+	// (below) + the RKE2-CA signature on the returned cert + the JWT PoP, none
+	// of which the host can forge. RA-TLS pinning of :8443 is a follow-up.
+	InsecureSkipTLSVerify bool
+	// Timeout bounds each network step.
+	Timeout time.Duration
+}
+
+// Run executes the client flow: attest + RTMR[3] gate, then CSR -> cred-release
+// -> kubeconfig.
+func Run(ctx context.Context, cfg Config) error {
+	keyPEM, err := os.ReadFile(cfg.OperatorKeyPath)
+	if err != nil {
+		return fmt.Errorf("read operator key: %w", err)
+	}
+	pubPEM, err := publicKeyPEMFromPrivate(keyPEM)
+	if err != nil {
+		return fmt.Errorf("derive operator public key: %w", err)
+	}
+
+	// 1. Trust gate: attest the node and confirm rtmr_3 == H(op_pub). This
+	//    proves genuine TDX + the node was launched to trust THIS key, with no
+	//    host trust and not TOFU. Everything downstream depends on it.
+	attestCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	if err := attestAndCheckRTMR3(attestCtx, cfg.AttestURL, pubPEM); err != nil {
+		cancel()
+		return fmt.Errorf("attestation gate: %w", err)
+	}
+	cancel()
+
+	// 2. Generate the kube-client identity + CSR.
+	id, err := newClientIdentity()
+	if err != nil {
+		return fmt.Errorf("generate client key: %w", err)
+	}
+	csrPEM, err := id.csrPEM()
+	if err != nil {
+		return fmt.Errorf("build CSR: %w", err)
+	}
+
+	// 3. Exchange the CSR for a signed cert over cred-release.
+	httpClient := &http.Client{
+		Timeout: cfg.Timeout,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipTLSVerify}, //nolint:gosec // see Config.InsecureSkipTLSVerify
+		},
+	}
+	relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel2()
+	resp, err := requestCredential(relCtx, httpClient, cfg.ReleaseBaseURL, keyPEM, csrPEM)
+	if err != nil {
+		return fmt.Errorf("credential release: %w", err)
+	}
+
+	// 4. Assemble + write the kubeconfig.
+	kc := buildKubeconfig(cfg.APIServerURL, cfg.ContextName, cfg.TLSServerName, []byte(resp.CertPEM), id.keyPEM, []byte(resp.CAPEM))
+	if err := os.WriteFile(cfg.OutPath, kc, 0o600); err != nil {
+		return fmt.Errorf("write kubeconfig: %w", err)
+	}
+	fmt.Fprintf(os.Stderr, "wrote %s (context %q) — attested, operator-key-bound\n", cfg.OutPath, cfg.ContextName)
+	return nil
+}
+
+// publicKeyPEMFromPrivate derives the PKIX PEM public key from an ECDSA
+// private key PEM. This MUST byte-match the pubkey the launcher put on the
+// opkeydata disk (confai wrote `openssl ec -pubout`, which is PKIX PEM), or
+// the RTMR[3] expected value won't match. Both use x509.MarshalPKIXPublicKey.
+func publicKeyPEMFromPrivate(keyPEM []byte) ([]byte, error) {
+	block, _ := pem.Decode(keyPEM)
+	if block == nil {
+		return nil, fmt.Errorf("operator key is not PEM")
+	}
+	var key *ecdsa.PrivateKey
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		k, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		key = k
+	case "PRIVATE KEY":
+		k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		ec, ok := k.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("operator key is %T, want ECDSA", k)
+		}
+		key = ec
+	default:
+		return nil, fmt.Errorf("unsupported key PEM type %q", block.Type)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), nil
+}

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -3,11 +3,9 @@ package getkubeconfig
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"net/http"
 	"os"
 	"time"
 )
@@ -35,12 +33,6 @@ type Config struct {
 	TLSServerName string
 	// OutPath is where the kubeconfig is written.
 	OutPath string
-	// InsecureSkipTLSVerify drops the :8443 dial from RA-TLS verification to a
-	// plain (unverified) TLS dial. Default false: the dial is RA-TLS-verified
-	// in-process by the operator's own verifier, so the host can't MITM the
-	// channel. Set only to bypass RA-TLS for debugging — the release is still
-	// gated by the RTMR[3] attestation check + the RKE2-CA signature + JWT PoP.
-	InsecureSkipTLSVerify bool
 	// Timeout bounds each network step.
 	Timeout time.Duration
 }
@@ -77,24 +69,12 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("build CSR: %w", err)
 	}
 
-	// 3. Exchange the CSR for a signed cert over cred-release. By default the
-	//    :8443 dial is RA-TLS-verified in-process by the operator's own
-	//    verifier (newRATLSClient): the serving cert's embedded quote
-	//    must bind to the cert key AND carry rtmr_3 == H(op_pub), so the host
-	//    can't MITM the channel. --insecure-skip-tls-verify drops that to a
-	//    plain TLS dial (the release is still gated by attestation + the RKE2-CA
-	//    signature + JWT PoP, but the channel itself is unpinned).
-	var httpClient *http.Client
-	if cfg.InsecureSkipTLSVerify {
-		httpClient = &http.Client{
-			Timeout: cfg.Timeout,
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // explicit opt-out via --insecure-skip-tls-verify
-			},
-		}
-	} else {
-		httpClient = newRATLSClient(cfg, pubPEM)
-	}
+	// 3. Exchange the CSR for a signed cert over cred-release. The :8443 dial
+	//    is RA-TLS-verified in-process by the operator's own verifier
+	//    (newRATLSClient): the serving cert's embedded quote must bind to the
+	//    cert key AND carry rtmr_3 == H(op_pub), so the host can't MITM the
+	//    channel.
+	httpClient := newRATLSClient(cfg, pubPEM)
 	relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel2()
 	resp, err := requestCredential(relCtx, httpClient, cfg.ReleaseBaseURL, keyPEM, csrPEM)

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -35,10 +35,11 @@ type Config struct {
 	TLSServerName string
 	// OutPath is where the kubeconfig is written.
 	OutPath string
-	// InsecureSkipTLSVerify skips server-cert verification on the :8443 dial.
-	// v1 default true: the release is secured by the RTMR[3] attestation gate
-	// (below) + the RKE2-CA signature on the returned cert + the JWT PoP, none
-	// of which the host can forge. RA-TLS pinning of :8443 is a follow-up.
+	// InsecureSkipTLSVerify drops the :8443 dial from RA-TLS verification to a
+	// plain (unverified) TLS dial. Default false: the dial is RA-TLS-verified
+	// against the operator's local attestation-cli, so the host can't MITM the
+	// channel. Set only to bypass RA-TLS for debugging — the release is still
+	// gated by the RTMR[3] attestation check + the RKE2-CA signature + JWT PoP.
 	InsecureSkipTLSVerify bool
 	// Timeout bounds each network step.
 	Timeout time.Duration
@@ -76,12 +77,23 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("build CSR: %w", err)
 	}
 
-	// 3. Exchange the CSR for a signed cert over cred-release.
-	httpClient := &http.Client{
-		Timeout: cfg.Timeout,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: cfg.InsecureSkipTLSVerify}, //nolint:gosec // see Config.InsecureSkipTLSVerify
-		},
+	// 3. Exchange the CSR for a signed cert over cred-release. By default the
+	//    :8443 dial is RA-TLS-verified against the operator's local
+	//    attestation-cli (newRATLSClient): the serving cert's embedded quote
+	//    must bind to the cert key AND carry rtmr_3 == H(op_pub), so the host
+	//    can't MITM the channel. --insecure-skip-tls-verify drops that to a
+	//    plain TLS dial (the release is still gated by attestation + the RKE2-CA
+	//    signature + JWT PoP, but the channel itself is unpinned).
+	var httpClient *http.Client
+	if cfg.InsecureSkipTLSVerify {
+		httpClient = &http.Client{
+			Timeout: cfg.Timeout,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // explicit opt-out via --insecure-skip-tls-verify
+			},
+		}
+	} else {
+		httpClient = newRATLSClient(cfg, pubPEM)
 	}
 	relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel2()

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -16,15 +16,17 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
-	"os/exec"
 	"strings"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/attestation-go/attestation/teeverify"
 )
 
-// attestationCLIBinary is the external verifier we shell out to — the same
-// tool confai's `verify` requires, so the operator flow uses one verifier.
-// Override with ATTESTATION_CLI.
-const attestationCLIBinary = "attestation-cli"
+// verifyEnvelope verifies a self-describing evidence envelope in-process with
+// attestation-go, the same engine `c8s verify` uses, so the operator flow
+// needs no external verifier binary. A package var so tests can stub the
+// verdict.
+var verifyEnvelope = teeverify.Verify
 
 // expectedRTMR3 computes RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)) — the
 // value the guest reports iff it was launched to trust this exact key. The
@@ -35,39 +37,35 @@ func expectedRTMR3(operatorPubPEM []byte) string {
 	return hex.EncodeToString(rtmr3[:])
 }
 
-// attestAndCheckRTMR3 fetches a nonce-bound quote from the guest's
-// attestation-api, verifies it with attestation-cli (HW chain + report_data
-// freshness), and asserts the quote's rtmr_3 equals expectedRTMR3(pub). It
-// proves: genuine TDX + the node trusts the operator's key. Returns nil on
-// success. The RTMR[3] equality is a plain compare of the (CLI-authenticated)
-// rtmr_3 claim — same posture as confai verify.
-func attestAndCheckRTMR3(ctx context.Context, attestURL string, operatorPubPEM []byte) error {
-	nonce := make([]byte, 32)
-	if _, err := rand.Read(nonce); err != nil {
-		return fmt.Errorf("nonce: %w", err)
-	}
-	nonceHex := hex.EncodeToString(nonce)
-
-	evidence, err := postAttest(ctx, attestURL, nonce)
+// verifyEvidence verifies an evidence envelope with attestation-go (HW chain +
+// report_data binding) and returns the result. expectedReportData is what the
+// quote must be bound to: the caller's nonce on the attest gate, the cert-key
+// hash on the RA-TLS dial. Fails closed on any missing piece.
+func verifyEvidence(envelopeJSON, expectedReportData []byte) (*teetypes.VerificationResult, error) {
+	res, err := verifyEnvelope(envelopeJSON, teetypes.VerifyParams{
+		ExpectedReportData: expectedReportData,
+	})
 	if err != nil {
-		return fmt.Errorf("attest: %w", err)
+		return nil, fmt.Errorf("verify evidence: %w", err)
 	}
+	// Defense in depth: a nil error already implies these, but never report a
+	// success the result contradicts.
+	if !res.SignatureValid {
+		return nil, fmt.Errorf("quote signature invalid")
+	}
+	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
+		return nil, fmt.Errorf("report_data does not match the expected binding (stale/replayed quote)")
+	}
+	return res, nil
+}
 
-	claims, err := runAttestationCLIVerify(ctx, evidence, nonceHex)
-	if err != nil {
-		return fmt.Errorf("attestation-cli verify: %w", err)
-	}
-
-	sigValid, _ := claims["signature_valid"].(bool)
-	rdMatch, _ := claims["report_data_match"].(bool)
-	if !sigValid {
-		return fmt.Errorf("quote signature invalid")
-	}
-	if !rdMatch {
-		return fmt.Errorf("report_data does not match nonce (stale/replayed quote)")
-	}
-
-	got := platformDataString(claims, "rtmr_3")
+// checkRTMR3 asserts the verified quote's rtmr_3 equals expectedRTMR3(pub),
+// i.e. the node was launched to trust the operator's key. The compare is over
+// the rtmr_3 claim attestation-go extracted from the signature-verified quote
+// body, the same posture as confai verify.
+func checkRTMR3(res *teetypes.VerificationResult, operatorPubPEM []byte) error {
+	got, _ := res.Claims.PlatformData["rtmr_3"].(string)
+	got = strings.ToLower(strings.TrimSpace(got))
 	want := expectedRTMR3(operatorPubPEM)
 	if got == "" {
 		return fmt.Errorf("quote carries no rtmr_3")
@@ -79,13 +77,34 @@ func attestAndCheckRTMR3(ctx context.Context, attestURL string, operatorPubPEM [
 	return nil
 }
 
+// attestAndCheckRTMR3 fetches a nonce-bound quote from the guest's
+// attestation-api, verifies it in-process (HW chain + report_data freshness),
+// and asserts the quote's rtmr_3 equals expectedRTMR3(pub). It proves: genuine
+// TDX + the node trusts the operator's key. Returns nil on success.
+func attestAndCheckRTMR3(ctx context.Context, attestURL string, operatorPubPEM []byte) error {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("nonce: %w", err)
+	}
+
+	evidence, err := postAttest(ctx, attestURL, nonce)
+	if err != nil {
+		return fmt.Errorf("attest: %w", err)
+	}
+
+	res, err := verifyEvidence(evidence, nonce)
+	if err != nil {
+		return err
+	}
+	return checkRTMR3(res, operatorPubPEM)
+}
+
 // postAttest sends the nonce to POST /attest and returns the raw evidence body
-// (the same shape attestation-cli verify consumes on stdin).
+// (the self-describing {platform, evidence} envelope attestation-go consumes).
 //
-// report_data goes to /attest base64-encoded (what the attestation-api decodes)
-// but to attestation-cli --expected-report-data as hex; the two encodings must
-// agree on the same bytes or verify reports "report_data mismatch". Matches
-// confai's verify.
+// report_data goes to /attest base64-encoded (what the attestation-api
+// decodes); attestation-go compares the same raw bytes. Matches confai's
+// verify.
 func postAttest(ctx context.Context, attestURL string, nonce []byte) ([]byte, error) {
 	body, _ := json.Marshal(map[string]string{
 		"platform":    "auto",
@@ -109,44 +128,4 @@ func postAttest(ctx context.Context, attestURL string, nonce []byte) ([]byte, er
 		return nil, fmt.Errorf("attest HTTP %d: %s", resp.StatusCode, respBody)
 	}
 	return respBody, nil
-}
-
-// runAttestationCLIVerify pipes evidence to `attestation-cli verify` and
-// returns the parsed claims map. Mirrors confai's invocation.
-func runAttestationCLIVerify(ctx context.Context, evidence []byte, nonceHex string) (map[string]any, error) {
-	bin := attestationCLIBinary
-	if env := os.Getenv("ATTESTATION_CLI"); env != "" {
-		bin = env
-	}
-	cmd := exec.CommandContext(ctx, bin, "verify", "--expected-report-data", nonceHex)
-	cmd.Stdin = bytes.NewReader(evidence)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout, cmd.Stderr = &stdout, &stderr
-	runErr := cmd.Run()
-
-	// attestation-cli exits non-zero on both hard failure (no JSON) and policy
-	// mismatch (full JSON on stdout). Try to parse stdout first.
-	var claims map[string]any
-	if err := json.Unmarshal(stdout.Bytes(), &claims); err != nil {
-		if runErr != nil {
-			return nil, fmt.Errorf("%w: %s", runErr, strings.TrimSpace(stderr.String()))
-		}
-		return nil, fmt.Errorf("parse verify output: %w", err)
-	}
-	return claims, nil
-}
-
-// platformDataString pulls claims.platform_data.<key> (where the TDX RTMRs
-// live), lowercased/trimmed, or "".
-func platformDataString(claims map[string]any, key string) string {
-	c, ok := claims["claims"].(map[string]any)
-	if !ok {
-		return ""
-	}
-	pd, ok := c["platform_data"].(map[string]any)
-	if !ok {
-		return ""
-	}
-	v, _ := pd[key].(string)
-	return strings.ToLower(strings.TrimSpace(v))
 }

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -1,0 +1,152 @@
+// Package getkubeconfig implements the operator-side client (B4 client) that
+// obtains a kube credential from a measured TDX CVM: it attests the node,
+// confirms the node was launched to trust the operator's key (RTMR[3]), then
+// exchanges a CSR for a short-lived RKE2 client cert over the cred-release
+// endpoint and assembles a kubeconfig.
+package getkubeconfig
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// attestationCLIBinary is the external verifier we shell out to — the same
+// tool confai's `verify` requires, so the operator flow uses one verifier.
+// Override with ATTESTATION_CLI.
+const attestationCLIBinary = "attestation-cli"
+
+// expectedRTMR3 computes RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)) — the
+// value the guest reports iff it was launched to trust this exact key. The
+// operator computes it offline from their own key, so a match is not TOFU.
+func expectedRTMR3(operatorPubPEM []byte) string {
+	keyDigest := sha512.Sum384(operatorPubPEM)
+	rtmr3 := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	return hex.EncodeToString(rtmr3[:])
+}
+
+// attestAndCheckRTMR3 fetches a nonce-bound quote from the guest's
+// attestation-api, verifies it with attestation-cli (HW chain + report_data
+// freshness), and asserts the quote's rtmr_3 equals expectedRTMR3(pub). It
+// proves: genuine TDX + the node trusts the operator's key. Returns nil on
+// success. The RTMR[3] equality is a plain compare of the (CLI-authenticated)
+// rtmr_3 claim — same posture as confai verify.
+func attestAndCheckRTMR3(ctx context.Context, attestURL string, operatorPubPEM []byte) error {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return fmt.Errorf("nonce: %w", err)
+	}
+	nonceHex := hex.EncodeToString(nonce)
+
+	evidence, err := postAttest(ctx, attestURL, nonce)
+	if err != nil {
+		return fmt.Errorf("attest: %w", err)
+	}
+
+	claims, err := runAttestationCLIVerify(ctx, evidence, nonceHex)
+	if err != nil {
+		return fmt.Errorf("attestation-cli verify: %w", err)
+	}
+
+	sigValid, _ := claims["signature_valid"].(bool)
+	rdMatch, _ := claims["report_data_match"].(bool)
+	if !sigValid {
+		return fmt.Errorf("quote signature invalid")
+	}
+	if !rdMatch {
+		return fmt.Errorf("report_data does not match nonce (stale/replayed quote)")
+	}
+
+	got := platformDataString(claims, "rtmr_3")
+	want := expectedRTMR3(operatorPubPEM)
+	if got == "" {
+		return fmt.Errorf("quote carries no rtmr_3")
+	}
+	if !strings.EqualFold(got, want) {
+		return fmt.Errorf("RTMR[3] mismatch: node reports %s, operator key implies %s "+
+			"(the node was NOT launched to trust this key)", got, want)
+	}
+	return nil
+}
+
+// postAttest sends the nonce to POST /attest and returns the raw evidence body
+// (the same shape attestation-cli verify consumes on stdin).
+//
+// report_data goes to /attest base64-encoded (what the attestation-api decodes)
+// but to attestation-cli --expected-report-data as hex; the two encodings must
+// agree on the same bytes or verify reports "report_data mismatch". Matches
+// confai's verify.
+func postAttest(ctx context.Context, attestURL string, nonce []byte) ([]byte, error) {
+	body, _ := json.Marshal(map[string]string{
+		"platform":    "auto",
+		"report_data": base64.StdEncoding.EncodeToString(nonce),
+	})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, attestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("attest HTTP %d: %s", resp.StatusCode, respBody)
+	}
+	return respBody, nil
+}
+
+// runAttestationCLIVerify pipes evidence to `attestation-cli verify` and
+// returns the parsed claims map. Mirrors confai's invocation.
+func runAttestationCLIVerify(ctx context.Context, evidence []byte, nonceHex string) (map[string]any, error) {
+	bin := attestationCLIBinary
+	if env := os.Getenv("ATTESTATION_CLI"); env != "" {
+		bin = env
+	}
+	cmd := exec.CommandContext(ctx, bin, "verify", "--expected-report-data", nonceHex)
+	cmd.Stdin = bytes.NewReader(evidence)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	runErr := cmd.Run()
+
+	// attestation-cli exits non-zero on both hard failure (no JSON) and policy
+	// mismatch (full JSON on stdout). Try to parse stdout first.
+	var claims map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &claims); err != nil {
+		if runErr != nil {
+			return nil, fmt.Errorf("%w: %s", runErr, strings.TrimSpace(stderr.String()))
+		}
+		return nil, fmt.Errorf("parse verify output: %w", err)
+	}
+	return claims, nil
+}
+
+// platformDataString pulls claims.platform_data.<key> (where the TDX RTMRs
+// live), lowercased/trimmed, or "".
+func platformDataString(claims map[string]any, key string) string {
+	c, ok := claims["claims"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	pd, ok := c["platform_data"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	v, _ := pd[key].(string)
+	return strings.ToLower(strings.TrimSpace(v))
+}

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -42,6 +42,18 @@ func expectedRTMR3(operatorPubPEM []byte) string {
 // quote must be bound to: the caller's nonce on the attest gate, the cert-key
 // hash on the RA-TLS dial. Fails closed on any missing piece.
 func verifyEvidence(envelopeJSON, expectedReportData []byte) (*teetypes.VerificationResult, error) {
+	// The operator-key binding lives in RTMR[3], which only TDX measures, so
+	// reject other platforms up front with a clear error instead of a late
+	// "quote carries no rtmr_3" (e.g. a SEV-SNP node can never satisfy the
+	// binding, however genuine its quote).
+	var env teetypes.AttestationEvidence
+	if err := json.Unmarshal(envelopeJSON, &env); err != nil {
+		return nil, fmt.Errorf("parse evidence envelope: %w", err)
+	}
+	if env.Platform != teetypes.PlatformTDX {
+		return nil, fmt.Errorf("node platform is %q: the operator-key binding lives in RTMR[3], so credential release requires a TDX guest", env.Platform)
+	}
+
 	res, err := verifyEnvelope(envelopeJSON, teetypes.VerifyParams{
 		ExpectedReportData: expectedReportData,
 	})

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -1,7 +1,7 @@
 // Package getkubeconfig implements the operator-side client (B4 client) that
 // obtains a kube credential from a measured TDX CVM: it attests the node,
 // confirms the node was launched to trust the operator's key (RTMR[3]), then
-// exchanges a CSR for a short-lived RKE2 client cert over the cred-release
+// exchanges a CSR for a short-lived kube client cert over the cred-release
 // endpoint and assembles a kubeconfig.
 package getkubeconfig
 

--- a/pkg/ratls/normalize_test.go
+++ b/pkg/ratls/normalize_test.go
@@ -1,0 +1,26 @@
+package ratls
+
+import "testing"
+
+func TestNormalizePlatform(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{" ", ""},
+		{"snp", "sev-snp"},
+		{"SEV-SNP", "sev-snp"},
+		{"az-snp", "sev-snp"},
+		{"gcp-snp", "sev-snp"},
+		{"tdx", "tdx"},
+		{"az-tdx", "tdx"},
+		{"unknown", "unknown"},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			if got := NormalizePlatform(tc.input); got != tc.want {
+				t.Fatalf("NormalizePlatform(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/ratls/tls.go
+++ b/pkg/ratls/tls.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -609,6 +610,22 @@ func dualVerifyPeerCallback(policy *VerifyPolicy, shared *sharedCACerts) func([]
 			return fmt.Errorf("ratls: peer verification failed (CA chain: %v; RA-TLS: %w)", chainErr, err)
 		}
 		return nil
+	}
+}
+
+// NormalizePlatform maps the platform aliases used across the stack (cloud
+// prefixes like az-/gcp-, and "snp") to the two canonical values the RA-TLS
+// package understands: "sev-snp" and "tdx". Unknown values pass through
+// lowercased/trimmed so validatePlatform can reject them with a clear error.
+// Callers normalize before NewServerTLSConfig/NewClientTLSConfig.
+func NormalizePlatform(platform string) string {
+	switch p := strings.ToLower(strings.TrimSpace(platform)); p {
+	case "snp", "sev-snp", "az-snp", "gcp-snp":
+		return "sev-snp"
+	case "tdx", "az-tdx", "gcp-tdx":
+		return "tdx"
+	default:
+		return p
 	}
 }
 


### PR DESCRIPTION
## What

The c8s half of **console-free, non-TOFU operator access** to a measured TDX CVM. An external operator obtains an RKE2 kubeconfig by attesting the node and proving possession of the key bound into the node's RTMR[3] at launch — no console, no pre-shared cluster secret, no trust in the untrusted host.

This is the culmination of the operator-key design (B1–B3 bind the operator key into RTMR[3] and let the operator verify it; this PR issues the credential to its proven holder).

## Commits

1. **`c8s cred-release`** (server) — in-guest RA-TLS endpoint. Loads the operator pubkey off the opkeydata disk and **anchors it to the measurement** (`SHA384(0x00*48 || SHA384(pubkey)) == own RTMR[3]`, rejecting a host-swapped key file); authorizes callers with `operatorauth` (reused: ES256 JWT PoP, ≤5min, method/path/body bound); signs the caller's CSR with the RKE2 client-CA into an `O=system:masters` client cert. Serves over RA-TLS (reused `pkg/ratls`).
2. **`ratls.NormalizePlatform`** exported — one platform-alias normalizer, used by cds and cred-release (drops cds's private copy).
3. **`c8s get-kubeconfig`** (client) — attests the node + checks `rtmr_3 == H(op_pub)` (via `attestation-cli`, the same verifier confai's verify uses), generates a CSR, mints the operatorauth JWT, POSTs to cred-release, assembles the kubeconfig.
4. **RA-TLS the `:8443` dial** — the client verifies the cred-release serving cert with its own local `attestation-cli`: the cert's embedded TDX quote must bind the cert's public key (`ratls.ReportDataForKey`) AND carry `rtmr_3 == H(op_pub)`, so the host can't MITM the channel. `--insecure-skip-tls-verify` (now default false) keeps a plain-TLS dial for debugging.

## Trust argument

- **Operator → node:** the client verifies a genuine TDX quote whose RTMR[3] equals `H(their own key)` — computed offline, so not TOFU.
- **Node → operator:** the server verifies the caller's JWT under the RTMR[3]-anchored pubkey, and signs with the cluster CA only the real guest holds.
- Neither side trusts the host: a swapped key file breaks the RTMR[3] anchor; a forged CSR fails the signature check; a stale quote fails the nonce.

## CA released to the operator

The kubeconfig's `certificate-authority-data` must verify the apiserver
**serving** cert, which RKE2 signs with `server-ca.crt` — distinct from the
`client-ca.crt` that signs kube clients. cred-release signs the operator's
cert with the client CA but releases the **server** CA as the kubeconfig trust
anchor (`--server-ca-cert`, RKE2 default). Releasing the client CA fails
`kubectl` with "certificate signed by unknown authority" — caught in live
e2e, guarded by a mutation-tested `TestLoadClusterCAReleasesServerCA`. On
kubeadm all three CA flags point at its single `/etc/kubernetes/pki/ca.crt`.

## Reuse vs. net-new

Reuses `operatorauth` + `ratls` verbatim (the audited crypto). Net-new, trust-critical: the RTMR[3] anchor read and the RKE2-CA kube-client signing. The RTMR[3] math is pinned by a test to the value a real operator key produced in a booted b200 TDX CVM.

## Pairs with

confos #53 (B1 initrd + baked cred-release systemd unit), confidential-metal #70/#71/#73 (confai launch/verify/carrier).

## v1 follow-ups (documented, not blockers)

- `:8443` port exposure via the KubeVirt Service for the laptop-operator case.
- Cert identity is `system:masters` (cluster-admin) in v1; scope via RBAC later.

