### PR TITLE
test(cred-release): guard the serving-CA release (regression, missed by #86 squash)

### DIFF
--- a/internal/cmds/credrelease/handler_test.go
+++ b/internal/cmds/credrelease/handler_test.go
@@ -1,0 +1,99 @@
+package credrelease
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// TestHandlerReleasesServerCA drives POST /release-credential end to end and
+// checks the wire response: CAPEM is the serving-CA PEM verbatim and the
+// issued cert chains to the client CA.
+func TestHandlerReleasesServerCA(t *testing.T) {
+	opKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opKeyPEM, err := certutil.MarshalECKeyPEM(opKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(opKeyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&opKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	ca := testCA(t)
+	serverCA, err := issuer.NewCA("server-ca", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca.pem = certutil.EncodeCertPEM(serverCA.Cert.Raw)
+
+	h, err := NewHandler(pubPEM, ca, "system:masters", "operator", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "ignored-by-signer"},
+	}, csrKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+	body, err := json.Marshal(releaseRequest{CSRPEM: string(csrPEM)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authz, err := signer.Authorization(http.MethodPost, "/release-credential", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/release-credential", bytes.NewReader(body))
+	req.Header.Set("Authorization", authz)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body %q", rec.Code, rec.Body.String())
+	}
+
+	var resp releaseResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.CAPEM != string(ca.pem) {
+		t.Error("released CA is not the serving-CA PEM")
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(ca.cert)
+	if _, err := parseLeaf(t, []byte(resp.CertPEM)).Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Errorf("released cert does not chain to the client CA: %v", err)
+	}
+}

--- a/internal/cmds/credrelease/helpers_test.go
+++ b/internal/cmds/credrelease/helpers_test.go
@@ -2,11 +2,8 @@ package credrelease
 
 import (
 	"encoding/pem"
-	"math/big"
 	"testing"
 )
-
-func bigOne() *big.Int { return big.NewInt(1) }
 
 // decodeOnePEM decodes a single PEM block and asserts its type.
 func decodeOnePEM(t *testing.T, pemBytes []byte, wantType string) []byte {

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -171,11 +171,9 @@ func namedCA(t *testing.T, dir, name string) (certPath, keyPath string, cert *x5
 	return certPath, keyPath, ca.Cert
 }
 
-// TestLoadClusterCAReleasesServerCA is the regression guard for the CA-confusion
-// bug: RKE2 signs the apiserver serving cert with a server-CA distinct from the
-// client-CA that signs kube clients. The released kubeconfig's trust anchor
-// (clusterCA.pem) MUST be the server CA, or kubectl fails with "certificate
-// signed by unknown authority". Signing must still use the client CA.
+// TestLoadClusterCAReleasesServerCA guards the CA-confusion regression: the
+// released kubeconfig anchors on the server CA while issued certs chain to the
+// client CA (the CA-path consts in sign.go explain the RKE2/kubeadm split).
 func TestLoadClusterCAReleasesServerCA(t *testing.T) {
 	dir := t.TempDir()
 	clientCertPath, clientKeyPath, clientCA := namedCA(t, dir, "client-ca")

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -7,11 +7,13 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 )
 
 // testCA builds a self-signed ECDSA CA standing in for the RKE2 client-CA.
@@ -160,93 +162,66 @@ func parseLeaf(t *testing.T, certPEM []byte) *x509.Certificate {
 	return cert
 }
 
-// namedCA writes a self-signed ECDSA CA (cert+key PEM) to files in dir and
-// returns the cert path, key path, and cert PEM. Stands in for RKE2's distinct
+// namedCA writes a fresh self-signed CA (cert+key PEM) to files in dir and
+// returns the paths and the CA cert. Stands in for RKE2's distinct
 // client-ca / server-ca on disk.
-func namedCA(t *testing.T, dir, name string) (certPath, keyPath string, certPEM []byte) {
+func namedCA(t *testing.T, dir, name string) (certPath, keyPath string, cert *x509.Certificate) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ca, err := issuer.NewCA(name, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          bigOne(),
-		Subject:               pkix.Name{CommonName: name},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	keyPEM, err := certutil.MarshalECKeyPEM(ca.Key)
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
-	keyDER, _ := x509.MarshalECPrivateKey(key)
-	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
-
 	certPath = filepath.Join(dir, name+".crt")
 	keyPath = filepath.Join(dir, name+".key")
-	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+	if err := os.WriteFile(certPath, certutil.EncodeCertPEM(ca.Cert.Raw), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	return certPath, keyPath, certPEM
+	return certPath, keyPath, ca.Cert
 }
 
 // TestLoadClusterCAReleasesServerCA is the regression guard for the CA-confusion
 // bug: RKE2 signs the apiserver serving cert with a server-CA distinct from the
 // client-CA that signs kube clients. The released kubeconfig's trust anchor
 // (clusterCA.pem) MUST be the server CA, or kubectl fails with "certificate
-// signed by unknown authority". Signing must still chain to the client CA.
+// signed by unknown authority". Signing must still use the client CA.
 func TestLoadClusterCAReleasesServerCA(t *testing.T) {
 	dir := t.TempDir()
-	clientCert, clientKey, clientPEM := namedCA(t, dir, "client-ca")
-	serverCert, _, serverPEM := namedCA(t, dir, "server-ca")
+	clientCertPath, clientKeyPath, clientCA := namedCA(t, dir, "client-ca")
+	serverCertPath, _, serverCA := namedCA(t, dir, "server-ca")
 
-	ca, err := loadClusterCA(clientCert, clientKey, serverCert)
+	ca, err := loadClusterCA(clientCertPath, clientKeyPath, serverCertPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// The kubeconfig anchor is the SERVER CA, not the client CA.
-	if string(ca.pem) != string(serverPEM) {
-		t.Error("clusterCA.pem is not the server CA — kubeconfig would fail apiserver verification")
+	// The kubeconfig anchor is the SERVER CA; releasing the client CA there
+	// is the exact bug being guarded.
+	if !parseLeaf(t, ca.pem).Equal(serverCA) {
+		t.Error("clusterCA.pem is not the server CA; kubeconfig would fail apiserver verification")
 	}
-	if string(ca.pem) == string(clientPEM) {
-		t.Error("clusterCA.pem is the client CA — this is the exact bug being guarded")
-	}
-
-	// Signing still uses the CLIENT CA: the issued cert must chain to it.
-	certPEM, err := ca.signOperatorCert(signParams{
-		csr: testCSR(t), org: "system:masters", cn: "operator", ttl: time.Hour,
-	}, time.Now())
-	if err != nil {
-		t.Fatal(err)
-	}
-	leaf := parseLeaf(t, certPEM)
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(clientPEM) {
-		t.Fatal("append client CA")
-	}
-	if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
-		t.Errorf("issued cert does not chain to the client CA: %v", err)
+	// The signer stays the CLIENT CA (signing behavior itself is covered by
+	// TestSignOperatorCert).
+	if !ca.cert.Equal(clientCA) {
+		t.Error("clusterCA.cert is not the client CA; issued certs would not chain to it")
 	}
 }
 
 // TestLoadClusterCAKubeadmSingleCA covers the kubeadm case: one ca.crt signs
 // both serving and client certs, so all three paths point at the same file.
 func TestLoadClusterCAKubeadmSingleCA(t *testing.T) {
-	dir := t.TempDir()
-	certPath, keyPath, certPEM := namedCA(t, dir, "ca")
+	certPath, keyPath, cert := namedCA(t, t.TempDir(), "ca")
 	ca, err := loadClusterCA(certPath, keyPath, certPath)
 	if err != nil {
 		t.Fatalf("single-CA (kubeadm) load failed: %v", err)
 	}
-	if string(ca.pem) != string(certPEM) {
+	if !parseLeaf(t, ca.pem).Equal(cert) {
 		t.Error("single-CA anchor mismatch")
 	}
 }

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -162,19 +163,20 @@ func parseLeaf(t *testing.T, certPEM []byte) *x509.Certificate {
 	return cert
 }
 
-// namedCA writes a fresh self-signed CA (cert+key PEM) to files in dir and
-// returns the paths and the CA cert. Stands in for RKE2's distinct
-// client-ca / server-ca on disk.
+// namedCA writes a fresh self-signed CA to files in dir, the key in the SEC1
+// "EC PRIVATE KEY" form RKE2 writes, and returns the paths and the CA cert.
+// Stands in for RKE2's distinct client-ca / server-ca on disk.
 func namedCA(t *testing.T, dir, name string) (certPath, keyPath string, cert *x509.Certificate) {
 	t.Helper()
 	ca, err := issuer.NewCA(name, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	keyPEM, err := certutil.MarshalECKeyPEM(ca.Key)
+	keyDER, err := x509.MarshalECPrivateKey(ca.Key)
 	if err != nil {
 		t.Fatal(err)
 	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 	certPath = filepath.Join(dir, name+".crt")
 	keyPath = filepath.Join(dir, name+".key")
 	if err := os.WriteFile(certPath, certutil.EncodeCertPEM(ca.Cert.Raw), 0o600); err != nil {

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -7,6 +7,9 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -155,4 +158,95 @@ func parseLeaf(t *testing.T, certPEM []byte) *x509.Certificate {
 		t.Fatal(err)
 	}
 	return cert
+}
+
+// namedCA writes a self-signed ECDSA CA (cert+key PEM) to files in dir and
+// returns the cert path, key path, and cert PEM. Stands in for RKE2's distinct
+// client-ca / server-ca on disk.
+func namedCA(t *testing.T, dir, name string) (certPath, keyPath string, certPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          bigOne(),
+		Subject:               pkix.Name{CommonName: name},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, _ := x509.MarshalECPrivateKey(key)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	certPath = filepath.Join(dir, name+".crt")
+	keyPath = filepath.Join(dir, name+".key")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath, certPEM
+}
+
+// TestLoadClusterCAReleasesServerCA is the regression guard for the CA-confusion
+// bug: RKE2 signs the apiserver serving cert with a server-CA distinct from the
+// client-CA that signs kube clients. The released kubeconfig's trust anchor
+// (clusterCA.pem) MUST be the server CA, or kubectl fails with "certificate
+// signed by unknown authority". Signing must still chain to the client CA.
+func TestLoadClusterCAReleasesServerCA(t *testing.T) {
+	dir := t.TempDir()
+	clientCert, clientKey, clientPEM := namedCA(t, dir, "client-ca")
+	serverCert, _, serverPEM := namedCA(t, dir, "server-ca")
+
+	ca, err := loadClusterCA(clientCert, clientKey, serverCert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The kubeconfig anchor is the SERVER CA, not the client CA.
+	if string(ca.pem) != string(serverPEM) {
+		t.Error("clusterCA.pem is not the server CA — kubeconfig would fail apiserver verification")
+	}
+	if string(ca.pem) == string(clientPEM) {
+		t.Error("clusterCA.pem is the client CA — this is the exact bug being guarded")
+	}
+
+	// Signing still uses the CLIENT CA: the issued cert must chain to it.
+	certPEM, err := ca.signOperatorCert(signParams{
+		csr: testCSR(t), org: "system:masters", cn: "operator", ttl: time.Hour,
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf := parseLeaf(t, certPEM)
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(clientPEM) {
+		t.Fatal("append client CA")
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		t.Errorf("issued cert does not chain to the client CA: %v", err)
+	}
+}
+
+// TestLoadClusterCAKubeadmSingleCA covers the kubeadm case: one ca.crt signs
+// both serving and client certs, so all three paths point at the same file.
+func TestLoadClusterCAKubeadmSingleCA(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath, certPEM := namedCA(t, dir, "ca")
+	ca, err := loadClusterCA(certPath, keyPath, certPath)
+	if err != nil {
+		t.Fatalf("single-CA (kubeadm) load failed: %v", err)
+	}
+	if string(ca.pem) != string(certPEM) {
+		t.Error("single-CA anchor mismatch")
+	}
 }

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -17,31 +17,14 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 )
 
-// testCA builds a self-signed ECDSA CA standing in for the RKE2 client-CA.
+// testCA builds a self-signed CA standing in for the RKE2 client-CA.
 func testCA(t *testing.T) *clusterCA {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ca, err := issuer.NewCA("test-client-ca", time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tmpl := &x509.Certificate{
-		SerialNumber:          bigOne(),
-		Subject:               pkix.Name{CommonName: "test-client-ca"},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-		KeyUsage:              x509.KeyUsageCertSign,
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cert, err := x509.ParseCertificate(der)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return &clusterCA{cert: cert, key: key}
+	return &clusterCA{cert: ca.Cert, key: ca.Key}
 }
 
 func testCSR(t *testing.T) *x509.CertificateRequest {

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -226,15 +226,41 @@ func TestLoadClusterCAReleasesServerCA(t *testing.T) {
 	}
 }
 
-// TestLoadClusterCAKubeadmSingleCA covers the kubeadm case: one ca.crt signs
-// both serving and client certs, so all three paths point at the same file.
+// TestLoadClusterCAKubeadmSingleCA covers the kubeadm shape: one RSA ca.crt
+// with a PKCS#1 ca.key signs both serving and client certs, so all three
+// paths point at the same files.
 func TestLoadClusterCAKubeadmSingleCA(t *testing.T) {
-	certPath, keyPath, cert := namedCA(t, t.TempDir(), "ca")
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serial, err := certutil.GenerateSerial()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := certutil.NewCATemplate(serial, "kubernetes", time.Now().Add(time.Hour))
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := certutil.EncodeCertPEM(der)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+	if err := os.WriteFile(certPath, certPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
 	ca, err := loadClusterCA(certPath, keyPath, certPath)
 	if err != nil {
 		t.Fatalf("single-CA (kubeadm) load failed: %v", err)
 	}
-	if !parseLeaf(t, ca.pem).Equal(cert) {
+	if string(ca.pem) != string(certPEM) {
 		t.Error("single-CA anchor mismatch")
 	}
 }

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -201,15 +201,26 @@ func TestLoadClusterCAReleasesServerCA(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// The kubeconfig anchor is the SERVER CA; releasing the client CA there
-	// is the exact bug being guarded.
-	if !parseLeaf(t, ca.pem).Equal(serverCA) {
-		t.Error("clusterCA.pem is not the server CA; kubeconfig would fail apiserver verification")
+	// The kubeconfig anchor is the SERVER CA and nothing else.
+	if string(ca.pem) != string(certutil.EncodeCertPEM(serverCA.Raw)) {
+		t.Error("clusterCA.pem is not exactly the server CA; kubeconfig would fail apiserver verification")
 	}
-	// The signer stays the CLIENT CA (signing behavior itself is covered by
-	// TestSignOperatorCert).
-	if !ca.cert.Equal(clientCA) {
-		t.Error("clusterCA.cert is not the client CA; issued certs would not chain to it")
+
+	// A cert issued by the loaded CA chains to the CLIENT CA: proves the cert
+	// and the key both came from the client-CA files.
+	certPEM, err := ca.signOperatorCert(signParams{
+		csr: testCSR(t), org: "system:masters", cn: "operator", ttl: time.Hour,
+	}, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots := x509.NewCertPool()
+	roots.AddCert(clientCA)
+	if _, err := parseLeaf(t, certPEM).Verify(x509.VerifyOptions{
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}); err != nil {
+		t.Errorf("issued cert does not chain to the client CA: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `TestLoadClusterCAReleasesServerCA` — the regression guard for the
CA-confusion bug fixed in #86. The fix itself (release the apiserver SERVING
CA as the kubeconfig anchor, sign with the CLIENT CA) landed in main via #86's
squash, but this test was committed after the squash point and didn't come
along. No production code changes here — test only.

## Why it matters

The test is **mutation-verified**: flipping `loadClusterCA` back to release
the client CA (the bug — kubectl fails with "certificate signed by unknown
authority") makes it fail; the shipped server-CA behaviour makes it pass. Also
covers the kubeadm single-CA case (all three CA paths = one `ca.crt`).

Validated end-to-end on b200: an operator obtained a working
`O=system:masters` kubeconfig from a sealed TDX CVM and `kubectl get nodes`
succeeded with no `--insecure-skip-tls-verify`.