### PR TITLE
fix(install): --cvm-mode=node uses the node-baked attestation-api + nri, skips duplicates

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -999,7 +999,9 @@ func appendDistroInstallArgs(helmArgs []string, distro string) []string {
 //
 //	node → generalized node-as-CVM: our own nodes (bare-metal TDX/SNP,
 //	       self-managed) are themselves confidential VMs. Pods run as ordinary
-//	       processes attested via the node's own quote. Cloud-agnostic.
+//	       processes attested via the node's own quote. Cloud-agnostic. The node
+//	       image bakes attestation-api and nri-image-policy, so both are disabled
+//	       here (ratlsMesh is not baked, stays on).
 //	gke  → GKE specifically: Google's managed confidential VMs.
 //
 // GKE is the reason a plain managed→vTPM mapping is wrong: GKE confidential VMs
@@ -1072,6 +1074,16 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 		helmArgs = append(helmArgs,
 			"--set-string", "cds.ratlsPlatform=tdx",
 			"--set-string", "ratlsMesh.platform=tdx",
+		)
+	}
+	// node: the node image bakes host attestation-api and nri-image-policy;
+	// re-rendering them duplicates the baked pair and the baked fail-closed NRI
+	// floor denies the chart copies' own images. ratlsMesh stays: it is not
+	// baked (unlike kata-guest-base).
+	if cvmMode == "node" {
+		helmArgs = append(helmArgs,
+			"--set", "attestationApi.enabled=false",
+			"--set", "nriImagePolicy.enabled=false",
 		)
 	}
 	return helmArgs, nil

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -993,6 +993,14 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 				"--set-string", "ratlsMesh.platform=tdx",
 			)
 		}
+		// node: the node image bakes attestation-api + nri-image-policy, so the
+		// chart copies are skipped (ratlsMesh is not baked, stays on).
+		if mode == "node" {
+			out = append(out,
+				"--set", "attestationApi.enabled=false",
+				"--set", "nriImagePolicy.enabled=false",
+			)
+		}
 		return out
 	}
 	cases := map[string]struct {

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -282,17 +282,43 @@ a floating tag would be root on every GPU node — so the digest is what's used.
 
 {{- /*
 c8s.attestationApiURL — the attestation-api endpoint injected into the operator
-and CDS. Under kata.enabled the host attestation-api DaemonSet is typically not
-rendered; the kata-guest-base image bakes an in-guest attestation-service on
-loopback, and the components that consume this URL (the operator's get-cert
-sidecars and CDS) run INSIDE the CVM, so they must dial 127.0.0.1, not the
-(absent) host Service.
+and CDS. Three shapes:
+
+  - kata.enabled: the kata-guest-base image bakes an in-guest attestation-service
+    on loopback, and the consumers (the operator's get-cert sidecars and CDS) run
+    INSIDE the CVM, so they dial 127.0.0.1 — not the (absent) host Service.
+  - cvmMode=node: the node image bakes a HOST attestation-api on the node's
+    loopback :8400 (no in-cluster Service). Pod-netns consumers cannot reach host
+    loopback, so they dial the node's own IP via the $(HOST_IP) downward-API env
+    var (c8s.attestationApiHostIPEnv), which the kubelet expands per-node before
+    the process sees the arg. The operator forwards this string verbatim to the
+    tenant get-cert sidecars it injects, so it must stay unexpanded there (the
+    operator container deliberately omits HOST_IP); each tenant pod expands it
+    against its own node.
+  - otherwise: the in-cluster host Service DNS.
 */ -}}
 {{- define "c8s.attestationApiURL" -}}
 {{- if .Values.kata.enabled -}}
 http://127.0.0.1:{{ .Values.attestationApi.port }}
+{{- else if eq (.Values.attestationApi.cvmMode | default "baremetal") "node" -}}
+http://$(HOST_IP):{{ .Values.attestationApi.port }}
 {{- else -}}
 http://{{ include "c8s.attestationApiName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.attestationApi.port }}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+c8s.attestationApiHostIPEnv — the HOST_IP downward-API env var that expands the
+$(HOST_IP) placeholder in c8s.attestationApiURL. Rendered only under
+cvmMode=node, where pod-netns consumers reach the node-baked host attestation-api
+via the node's own IP. Empty in every other mode.
+*/ -}}
+{{- define "c8s.attestationApiHostIPEnv" -}}
+{{- if eq (.Values.attestationApi.cvmMode | default "baremetal") "node" -}}
+- name: HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
 {{- end -}}
 {{- end -}}
 
@@ -377,6 +403,12 @@ Caller passes a dict:
     {{- range .extraArgs }}
     - {{ . }}
     {{- end }}
+  {{- with (include "c8s.attestationApiHostIPEnv" $root) }}
+  # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node IP so
+  # this pod-netns sidecar reaches the node-baked host attestation-api.
+  env:
+    {{- . | nindent 4 }}
+  {{- end }}
   volumeMounts:
     - name: {{ .volume }}
       mountPath: {{ .mountPath }}

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -237,6 +237,12 @@ spec:
             - --rate-limiter-idle-timeout={{ .Values.cds.rateLimiterIdleTimeout }}
             - --ratls-platform={{ .Values.cds.ratlsPlatform }}
             - --ratls-cert-ttl={{ .Values.cds.ratlsCertTTL }}
+          {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+          # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node
+          # IP so this pod-netns pod reaches the node-baked host attestation-api.
+          env:
+            {{- . | nindent 12 }}
+          {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.cds.port }}

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ratlsMesh.enabled }}
-{{- $attestationApiURL := printf "http://%s-attestation-api.%s.svc:8400" .Release.Name .Release.Namespace -}}
+{{- $attestationApiURL := include "c8s.attestationApiURL" . -}}
 {{/*
   cds mode points a single --cds-url at the unified CDS, which serves both
   /attest and /ca.
@@ -283,6 +283,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- /* cvmMode=node: HOST_IP expands $(HOST_IP) in
+                   --attestation-api-url. hostNetwork, so the node IP is this
+                   pod's own — the node-baked host attestation-api. */}}
+            {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+            {{- . | nindent 12 }}
+            {{- end }}
           ports:
             - name: outbound
               containerPort: {{ .Values.ratlsMesh.ports.outbound }}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -171,6 +171,12 @@ spec:
             {{- end }}
             - --upstream-server-name={{ $attestUpstreamServerName }}
             {{- end }}
+          {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+          # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node
+          # IP so this pod-netns pod reaches the node-baked host attestation-api.
+          env:
+            {{- . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: tls-certs
               mountPath: {{ .Values.tlsLb.tlsMountPath }}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1469,6 +1469,94 @@ func TestChartAttestationApiInvalidCvmMode(t *testing.T) {
 	assertHelmFailMessage(t, out, `attestationApi.cvmMode must be one of baremetal, node, gke, aks (got "bogus")`)
 }
 
+// hasHostIPEnv reports whether the container carries a HOST_IP env var sourced
+// from the status.hostIP downward-API field — the substitution source for the
+// $(HOST_IP) placeholder in the node-mode attestation-api URL.
+func hasHostIPEnv(c corev1.Container) bool {
+	for _, e := range c.Env {
+		if e.Name == "HOST_IP" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil &&
+			e.ValueFrom.FieldRef.FieldPath == "status.hostIP" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestChartNodeModeAttestationApiURLUsesHostIP proves cvmMode=node points the
+// pod-netns components (cds, tls-lb's cert sidecar, ratls-mesh) at the
+// node-baked host attestation-api via the $(HOST_IP) downward-API env var, since
+// there is no in-cluster Service and pods cannot reach host loopback. The
+// operator is the exception: it forwards its --attestation-api-url verbatim into
+// the tenant get-cert sidecars it injects, so the placeholder must stay
+// UNEXPANDED there — the operator container deliberately omits HOST_IP so each
+// tenant pod expands it against its own node.
+func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
+	const hostIPURL = "--attestation-api-url=http://$(HOST_IP):8400"
+	out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode=node", "--set", "tlsLb.attest.enabled=true")
+	if err != nil {
+		t.Fatalf("helm template (cvmMode=node): %v\n%s", err, out)
+	}
+
+	// cds: pod-netns, dials the host attestation-api via $(HOST_IP).
+	cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+	assertContainerArgs(t, cds, hostIPURL)
+	if !hasHostIPEnv(cds) {
+		t.Errorf("cds container missing HOST_IP downward-API env; have %+v", cds.Env)
+	}
+
+	// tls-lb c8s-cert sidecar (via c8s.getCertContainers).
+	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
+	assertContainerArgs(t, cert, hostIPURL)
+	if !hasHostIPEnv(cert) {
+		t.Errorf("tls-lb c8s-cert missing HOST_IP downward-API env; have %+v", cert.Env)
+	}
+
+	// tls-lb cds-attest sidecar (rendered under tlsLb.attest.enabled).
+	attest := renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest")
+	assertContainerArgs(t, attest, hostIPURL)
+	if !hasHostIPEnv(attest) {
+		t.Errorf("tls-lb cds-attest missing HOST_IP downward-API env; have %+v", attest.Env)
+	}
+
+	// ratls-mesh: hostNetwork, so $(HOST_IP) is its own node IP. Two-arg form.
+	mesh := renderedDaemonSetContainer(t, out, "c8s-ratls-mesh", "ratls-mesh")
+	if !slices.Contains(mesh.Args, "http://$(HOST_IP):8400") {
+		t.Errorf("ratls-mesh missing http://$(HOST_IP):8400 arg; have %v", mesh.Args)
+	}
+	if !hasHostIPEnv(mesh) {
+		t.Errorf("ratls-mesh missing HOST_IP downward-API env; have %+v", mesh.Env)
+	}
+
+	// operator: forwards the string verbatim; the placeholder must NOT be
+	// expanded here, so the container must NOT define HOST_IP.
+	if !slices.Contains(renderedOperatorArgs(t, out), hostIPURL) {
+		t.Errorf("operator missing verbatim %q\n%v", hostIPURL, renderedOperatorArgs(t, out))
+	}
+	op := renderedDeploymentContainer(t, out, "c8s-operator", "operator")
+	if hasHostIPEnv(op) {
+		t.Errorf("operator MUST NOT define HOST_IP (it forwards $(HOST_IP) verbatim to tenant sidecars); env %+v", op.Env)
+	}
+}
+
+// TestChartNonNodeModeKeepsServiceDNS proves the node-mode wiring does not leak
+// into the other cvmModes: baremetal/gke/aks still dial the in-cluster host
+// Service DNS and render no HOST_IP env anywhere.
+func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
+	for _, mode := range []string{"baremetal", "gke", "aks"} {
+		t.Run(mode, func(t *testing.T) {
+			out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode="+mode, "--set", "tlsLb.attest.enabled=true")
+			if err != nil {
+				t.Fatalf("helm template (cvmMode=%s): %v\n%s", mode, err, out)
+			}
+			cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+			assertContainerArgs(t, cds, "--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400")
+			if strings.Contains(out, "name: HOST_IP") {
+				t.Errorf("cvmMode=%s must not render any HOST_IP env\n%s", mode, out)
+			}
+		})
+	}
+}
+
 func TestChartRendersManagedClusterKnobs(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set", "serviceAccount.imagePullSecrets[0].name=ghcr-secret",

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -883,6 +883,15 @@ func getCertEnv(inj *injection) []corev1.EnvVar {
 		{Name: "C8S_POD_UID", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},
 		}},
+		// cvmMode=node: the chart passes the operator a verbatim
+		// --attestation-api-url=http://$(HOST_IP):8400, forwarded unexpanded into
+		// this arg (certContainer). The kubelet expands $(HOST_IP) against THIS
+		// tenant pod's node, so the sidecar reaches the node-baked host
+		// attestation-api on whichever node it lands. Unused (harmless) in modes
+		// whose URL has no $(HOST_IP).
+		{Name: "HOST_IP", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+		}},
 	}
 }
 

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -111,6 +111,43 @@ func TestMutatePodInjectsCertSidecar(t *testing.T) {
 	}
 }
 
+// TestMutatePodCertSidecarCarriesHostIPEnv proves the injected c8s-cert sidecar
+// defines HOST_IP from status.hostIP. Under cvmMode=node the chart passes the
+// operator --attestation-api-url=http://$(HOST_IP):8400 verbatim, forwarded into
+// this sidecar's args; the kubelet expands $(HOST_IP) against the tenant pod's
+// own node so the sidecar reaches the node-baked host attestation-api wherever
+// it lands. The env is unconditional (harmless when the URL has no placeholder).
+func TestMutatePodCertSidecarCarriesHostIPEnv(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+
+	mutatePod(pod, &injection{WorkloadID: "api"}, Config{
+		GetCertImage:      "image",
+		CDSURL:            "http://cds",
+		AttestationApiURL: "http://$(HOST_IP):8400",
+		CertDir:           "/etc/c8s/certs",
+	})
+
+	cert := pod.Spec.InitContainers[0]
+	if !hasArg(cert.Args, "--attestation-api-url=http://$(HOST_IP):8400") {
+		t.Fatalf("c8s-cert args %v missing verbatim $(HOST_IP) URL", cert.Args)
+	}
+	var found bool
+	for _, e := range cert.Env {
+		if e.Name == "HOST_IP" {
+			found = true
+			if e.ValueFrom == nil || e.ValueFrom.FieldRef == nil || e.ValueFrom.FieldRef.FieldPath != "status.hostIP" {
+				t.Fatalf("HOST_IP env = %#v, want fieldRef status.hostIP", e)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("c8s-cert env %#v missing HOST_IP (tenant sidecar cannot expand $(HOST_IP))", cert.Env)
+	}
+}
+
 func TestMutatePodPreservesExistingFSGroup(t *testing.T) {
 	existing := int64(1234)
 	pod := &corev1.Pod{


### PR DESCRIPTION
## What

Makes `c8s install --cvm-mode=node` (the node-as-CVM model) correctly defer to the components the c8s node image already bakes into its measured rootfs, instead of re-deploying duplicates that collide with the baked, fail-closed setup.

Two commits:

1. **Skip the baked components.** The node image bakes host `attestation-api` (:8400) and the `nri-image-policy` plugin. Under `--cvm-mode=node` the install now sets `attestationApi.enabled=false` + `nriImagePolicy.enabled=false` (mirrors what `--kata` does for kata-guest-base). `ratlsMesh` stays on — it is NOT baked, unlike kata-guest-base.

2. **Point pod components at the node-baked attestation-api.** With the chart attestation-api Service gone, `c8s.attestationApiURL` gains a `cvmMode==node` branch rendering `http://$(HOST_IP):8400`. Pod-netns consumers (cds, tls-lb cds-attest, the c8s-cert get-cert sidecars) get `HOST_IP` from `fieldRef: status.hostIP`, so the kubelet expands it to each pod's node IP. ratls-mesh (hostNetwork) routes through the same helper. The operator deliberately gets NO `HOST_IP` env: it forwards `--attestation-api-url` verbatim into the tenant get-cert sidecars it injects, so `$(HOST_IP)` must stay literal at the operator and expand inside each tenant pod (`getCertEnv` in the pod mutator carries HOST_IP into the injected sidecar).

Only `cvmMode=node` changes behavior — baremetal/gke/aks keep the Service DNS, kata keeps loopback (verified via `helm template`). Tests added in `chart_test.go` + `pod_mutator_test.go`; `go build/vet/test` green across cmd/c8s, internal/helmchart, internal/webhook.

## Requires (paired change)

This alone does NOT make a node-mode install converge on the measured image: the baked fail-closed NRI floor self-allows only the plugin's own image, so CDS (and thus every component) is denied and can't cold-start to serve the allowlist. The confidential-os-builder c8s profile must add the CDS digest to the baked floor's `always_allow` (resolved from C8S_REF, in lockstep with the nri pin) — tracked separately.