### PR TITLE
refactor(install): drop --cvm-mode=baremetal, replace --kata with --cvm-mode=pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ attestation-bound certificate from CDS and renews it. Certificates land in
 
 ### Pod-as-CVM
 
-`--kata` installs the Kata runtime and enforces it: every in-scope workload
+`--cvm-mode=pod` installs the Kata runtime and enforces it: every in-scope workload
 pod becomes a confidential VM, and non-Kata pods are rejected at admission.
 
 ```sh
-c8s install --kata --namespace c8s-system \
+c8s install --cvm-mode=pod --namespace c8s-system \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 \
   --upstream vllm
 ```

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -45,7 +45,6 @@ var (
 	installGetCertRunAsGroup    int64
 	installGetCertRunAsNonRoot  bool
 
-	installKata             bool
 	installKataDebug        bool
 	installCvmMode          string
 	installHardwarePlatform string
@@ -70,6 +69,14 @@ const (
 	flagWorkloadRef      = "workload-ref"
 	flagUpstream         = "upstream"
 )
+
+// allowedCvmModes is the --cvm-mode enum. pod is per-pod confidential VMs via
+// the Kata runtime (what --kata used to select before this replaced it); node/gke/aks are host-shaped
+// deployments. There is no default: the shape must be stated explicitly.
+var allowedCvmModes = []string{"pod", "node", "gke", "aks"}
+
+// cvmModeIsPod reports whether the mode selects the Kata per-pod-CVM stack.
+func cvmModeIsPod(cvmMode string) bool { return cvmMode == "pod" }
 
 // c8sComponent maps a chart image to the helm value keys --resolve-digests
 // pins. valuePrefix is the values path whose image the chart renders;
@@ -333,9 +340,9 @@ func podBindsHostPort(p corev1.Pod, port int32) bool {
 // preflightTDXNodes fails fast when --hardware-platform=tdx but no node carries
 // the confidential.ai/tdx=true label — the label the kata-qemu-tdx*
 // RuntimeClass nodeSelectors expect (kata.tdxNodeSelector default). On the
-// default --kata path the install applies it itself right before this check
+// default pod (kata) path the install applies it itself right before this check
 // (autoLabelTEENodes, trusting --hardware-platform), so a failure there means
-// no node matched the kata node selector at all; with -f, or without --kata
+// no node matched the kata node selector at all; with -f, or outside --cvm-mode=pod
 // (e.g. --cvm-mode=node), the operator owns the label. Without a labelled
 // node, TDX pods would sit Pending until timeout with an opaque scheduler
 // error.
@@ -353,13 +360,13 @@ func preflightTDXNodes(ctx context.Context) error {
 		return fmt.Errorf("kubectl get nodes -l %s=true: %w", tdxHostLabelKey, err)
 	}
 	if strings.TrimSpace(string(out)) == "" {
-		return fmt.Errorf("--hardware-platform=tdx but no node is labelled %s=true. A default `c8s install --kata` labels every kata-targeted node automatically, so either no node matched the kata node selector, or this is a -f/non-kata install where labels are yours to manage. A TDX node also needs /dev/tdx_guest available, qgsd (Intel DCAP Quote Generation Service) running, and a socat unix→vsock bridge so kata's QGS-over-vsock path reaches qgsd. To label a host yourself:\n\n    kubectl label node <node> %s=true",
+		return fmt.Errorf("--hardware-platform=tdx but no node is labelled %s=true. A default `c8s install --cvm-mode=pod` labels every kata-targeted node automatically, so either no node matched the kata node selector, or this is a -f/non-pod install where labels are yours to manage. A TDX node also needs /dev/tdx_guest available, qgsd (Intel DCAP Quote Generation Service) running, and a socat unix→vsock bridge so kata's QGS-over-vsock path reaches qgsd. To label a host yourself:\n\n    kubectl label node <node> %s=true",
 			tdxHostLabelKey, tdxHostLabelKey)
 	}
 	return nil
 }
 
-// preflightTEENodes fails fast (before the helm install) when a --kata
+// preflightTEENodes fails fast (before the helm install) when a --cvm-mode=pod
 // install would schedule confidential pods that can never start: the
 // platform's confidential RuntimeClasses select platform-labelled nodes
 // (kata.snpNodeSelector / kata.tdxNodeSelector), and the chart-managed CDS
@@ -566,12 +573,12 @@ var installCmd = &cobra.Command{
   - the CDS trust root (attestation, EAR issuance, mesh CA, leaf signing)
   - the ratls-mesh, nri-image-policy, and tls-lb components
 
-Under --kata the install is ENFORCING: every workload pod runs as a kata VM
+Under --cvm-mode=pod the install is ENFORCING: every workload pod runs as a kata VM
 (injected and validated at admission), and the host-side ratls-mesh,
 attestation-api, and nri-image-policy are replaced by their in-guest
 counterparts baked into the kata-guest-base image.
 
---debug (with --kata) selects the kata-guest-base DEBUG image variant, whose
+--debug (with --cvm-mode=pod) selects the kata-guest-base DEBUG image variant, whose
 baked guest policy allows the host log/exec stream RPCs so 'kubectl logs' and
 'kubectl exec' work against kata pods. Container I/O then crosses the TEE
 boundary in plaintext, and the debug image's SNP launch measurement differs
@@ -595,7 +602,7 @@ render guards then require those values.
 When the c8s images live in a registry that requires authentication, create a
 kubernetes.io/dockerconfigjson Secret in the release namespace and pass
 --image-pull-secret <name>: the chart wires it into every component's
-imagePullSecrets, so pods authenticate from first start. Under --kata the
+imagePullSecrets, so pods authenticate from first start. Under --cvm-mode=pod the
 same Secret also authenticates the kata-image-puller's in-pod oras pull of
 the kata-guest-base artifact (override: kata.guestImage.pullerAuthSecret).
 This is the cluster-side (kubelet) credential; digest resolution runs locally
@@ -611,12 +618,15 @@ tls-lb routes its catch-all to that adopted workload's headless Service
 (c8s-<id>.<ns>.svc.cluster.local:<port>). With --resolve-digests, install also
 resolves adopted workload images into nriImagePolicy.bootstrapAllowlist.digests
 so image admission (the host NRI plugin, or the in-guest policy-monitor under
---kata) allows those rollouts.
+--cvm-mode=pod) allows those rollouts.
 
 Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 --resolve-digests=false.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateKataDebugFlags(installKata, installKataDebug); err != nil {
+		if err := validateCvmMode(installCvmMode); err != nil {
+			return err
+		}
+		if err := validateDebugFlag(installCvmMode, installKataDebug); err != nil {
 			return err
 		}
 		adoptions, err := collectWorkloadAdoptions(installWorkloadRefs)
@@ -709,7 +719,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			return err
 		}
 		defer os.Remove(computedValues)
-		helmArgs := buildInstallHelmArgs(chartPath, computedValues, installValues, installCRDs, installWait, installKata)
+		helmArgs := buildInstallHelmArgs(chartPath, computedValues, installValues, installCRDs, installWait, cvmModeIsPod(installCvmMode))
 
 		// Fail fast on the default path if the CDS node is unlabelled, before
 		// mutating the cluster. Skipped when -f is supplied: a custom values
@@ -746,7 +756,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			}
 		}
 
-		// --kata: label every kata-targeted node for the declared
+		// --cvm-mode=pod: label every kata-targeted node for the declared
 		// --hardware-platform (refusing if the other platform's label is
 		// still present — a platform switch must be the operator's explicit
 		// act), then fail fast if the platform's confidential pods still
@@ -756,7 +766,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// with -f, whose owner owns node labels; NOT skipped under
 		// --single-node — even a one-node cluster needs its platform label
 		// for confidential pods to schedule.
-		kataDefaultPath := installKata && len(installValues) == 0
+		kataDefaultPath := cvmModeIsPod(installCvmMode) && len(installValues) == 0
 		if kataDefaultPath {
 			if err := autoLabelTEENodes(cmd.Context(), chartPath, installHardwarePlatform); err != nil {
 				return err
@@ -767,10 +777,10 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		}
 
 		// Fail fast when --hardware-platform=tdx but no node carries the TDX
-		// label. Under --kata the TDX RuntimeClasses have a nodeSelector on
+		// label. Under --cvm-mode=pod the TDX RuntimeClasses have a nodeSelector on
 		// it; under --cvm-mode=node the attestationApi DaemonSet needs at
 		// least one TDX-capable node. Checks a fact about the cluster, not
-		// the values, so it runs with -f too — but the default --kata path
+		// the values, so it runs with -f too — but the default pod (kata) path
 		// above already checked the chart's actual tdxNodeSelector (which
 		// may be customized or cleared), so skip the fixed-key check there.
 		if installHardwarePlatform == "tdx" && installCvmMode != "aks" && !kataDefaultPath {
@@ -782,8 +792,8 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// The install always ships pods that exceed the restricted pod-security
 		// profile: nri-image-policy runs privileged unconditionally, ratls-mesh's
 		// iptables init containers run as root with NET_ADMIN/NET_RAW, and
-		// attestation-api needs SYS_RAWIO (baremetal/gke) or privileged (aks).
-		// --kata adds kata-deploy on top. No supported shape fits restricted, so
+		// attestation-api needs SYS_RAWIO (node/gke) or privileged (aks).
+		// --cvm-mode=pod adds kata-deploy on top. No supported shape fits restricted, so
 		// the namespace is always labelled privileged (a CIS-hardened cluster, e.g.
 		// RKE2 with profile: cis, would otherwise reject those pods at admission).
 		if err := applyNamespace(cmd.Context(), installNamespace); err != nil {
@@ -885,7 +895,7 @@ func defaultInstallImageTag(buildVersion string) string {
 // load-bearing: the operator's -f files come first and the computed values file
 // LAST, so the CLI's computed values win on the keys they set (helm merges -f
 // last-wins) — matching the prior "--set beats -f" precedence. --skip-crds is a
-// helm invocation flag (not a value), emitted iff CRDs are skipped. A --kata
+// helm invocation flag (not a value), emitted iff CRDs are skipped. A pod-mode (kata)
 // install waits 10m instead of 5m: on a node without a prior kata install,
 // kata-deploy downloads the multi-GB kata-static payload inside the --wait
 // window, and 5m routinely left the release `failed` with the cluster
@@ -972,7 +982,7 @@ func appendInstallCRDArgs(setArgs []string, installCRDs bool) []string {
 // appendDistroInstallArgs translates the detected host distro into the
 // per-component values. Both targets are always set — each install shape uses
 // exactly one of them (nri-image-policy on the host shape, kata-deploy under
-// --kata) and both must bind the containerd config layout the host distro
+// --cvm-mode=pod) and both must bind the containerd config layout the host distro
 // uses; the unused one is inert. No enum guard: the value comes from
 // chooseDistro, and the chart re-validates anyway.
 func appendDistroInstallArgs(helmArgs []string, distro string) []string {
@@ -990,13 +1000,18 @@ func appendDistroInstallArgs(helmArgs []string, distro string) []string {
 // level — all modes render privileged: true, since a hostPath device mount alone
 // does not grant device-cgroup access):
 //
-//	baremetal, node, gke → native /dev/sev-guest (SEV-SNP) by default, or
-//	                       /dev/tdx-guest (Intel TDX) if --hardware-platform tdx
-//	aks                  → vTPM /dev/tpm0
+//	pod, node, gke → native /dev/sev-guest (SEV-SNP) by default, or
+//	                 /dev/tdx-guest (Intel TDX) if --hardware-platform tdx
+//	aks            → vTPM /dev/tpm0
 //
-// node and gke are distinct deployment targets that happen to share the
+// pod, node, and gke are distinct deployment targets that happen to share the
 // native-TEE-device wiring (they are NOT aliases):
 //
+//	pod  → per-pod confidential VMs via the Kata runtime: every workload pod is
+//	       a kata CVM. appendKataInstallArgs turns on the kata stack and turns
+//	       off host-side attestation-api/nri/ratls-mesh (served by the in-guest
+//	       counterparts baked into kata-guest-base). The device is still mounted
+//	       for the host-side attestation-api that kata-guest-base derives from.
 //	node → generalized node-as-CVM: our own nodes (bare-metal TDX/SNP,
 //	       self-managed) are themselves confidential VMs. Pods run as ordinary
 //	       processes attested via the node's own quote. Cloud-agnostic. The node
@@ -1013,7 +1028,7 @@ func appendDistroInstallArgs(helmArgs []string, distro string) []string {
 // hostPath CharDevice check.
 //
 // `--cvm-mode` (deployment shape) and `--hardware-platform` (CPU TEE) are
-// ORTHOGONAL axes. baremetal/gke pair with either SEV-SNP
+// ORTHOGONAL axes. pod/node/gke pair with either SEV-SNP
 // (--hardware-platform sev-snp, default) or Intel TDX (--hardware-platform
 // tdx). aks uses its own vTPM path regardless, and combining `--cvm-mode aks`
 // with `--hardware-platform tdx` is refused (AKS doesn't expose
@@ -1032,9 +1047,8 @@ func appendDistroInstallArgs(helmArgs []string, distro string) []string {
 // GitOps/HelmRelease installs get it too), not emitted as a --set here; see
 // internal/helmchart/c8s/templates/webhook.yaml.
 func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform string) ([]string, error) {
-	allowedModes := []string{"baremetal", "node", "gke", "aks"}
-	if !slices.Contains(allowedModes, cvmMode) {
-		return nil, fmt.Errorf("--%s must be one of %s, got %q", flagCvmMode, strings.Join(allowedModes, ", "), cvmMode)
+	if !slices.Contains(allowedCvmModes, cvmMode) {
+		return nil, fmt.Errorf("--%s must be one of %s, got %q", flagCvmMode, strings.Join(allowedCvmModes, ", "), cvmMode)
 	}
 	allowedPlatforms := []string{"sev-snp", "tdx"}
 	if !slices.Contains(allowedPlatforms, hardwarePlatform) {
@@ -1046,8 +1060,8 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 	helmArgs = append(helmArgs, "--set-string", "attestationApi.cvmMode="+cvmMode)
 	// aks: vTPM regardless of --hardware-platform (validated above; only
 	// --hardware-platform sev-snp reaches here)
-	// baremetal/gke + --hardware-platform sev-snp: native /dev/sev-guest
-	// baremetal/gke + --hardware-platform tdx:     native /dev/tdx-guest
+	// pod/node/gke + --hardware-platform sev-snp: native /dev/sev-guest
+	// pod/node/gke + --hardware-platform tdx:     native /dev/tdx-guest
 	sevGuest, tdxGuest, tpm := "false", "false", "false"
 	switch {
 	case cvmMode == "aks":
@@ -1089,19 +1103,35 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 	return helmArgs, nil
 }
 
-// validateKataDebugFlags rejects --debug without --kata: the flag selects the
+// validateDebugFlag rejects --debug outside --cvm-mode=pod: the flag selects the
 // kata-guest-base debug image, which only exists under the kata stack, so a
 // bare --debug is meaningless and almost certainly a mistaken expectation
 // (e.g. hoping for verbose install output). Checked first in RunE, before
 // anything touches the cluster.
-func validateKataDebugFlags(kata, debug bool) error {
-	if debug && !kata {
-		return fmt.Errorf("--debug selects the kata-guest-base debug image, which only exists under --kata; add --kata or drop --debug")
+// validateCvmMode enforces that --cvm-mode is set and is a known shape. There
+// is no default: an unstated deployment shape silently mismatching the cluster
+// (baked vs chart-provided attestation stack, kata vs plain runtime) is exactly
+// the failure this makes impossible.
+func validateCvmMode(cvmMode string) error {
+	if cvmMode == "" {
+		return fmt.Errorf("--%s is required; one of %s", flagCvmMode, strings.Join(allowedCvmModes, ", "))
+	}
+	if !slices.Contains(allowedCvmModes, cvmMode) {
+		return fmt.Errorf("--%s must be one of %s, got %q", flagCvmMode, strings.Join(allowedCvmModes, ", "), cvmMode)
 	}
 	return nil
 }
 
-// appendKataInstallArgs translates --kata into helm --set values. kata is
+// validateDebugFlag rejects --debug outside --cvm-mode=pod: the flag selects the
+// kata-guest-base debug image, which only exists under the pod (kata) stack.
+func validateDebugFlag(cvmMode string, debug bool) error {
+	if debug && !cvmModeIsPod(cvmMode) {
+		return fmt.Errorf("--debug selects the kata-guest-base debug image, which only exists under --%s=pod; set --%s=pod or drop --debug", flagCvmMode, flagCvmMode)
+	}
+	return nil
+}
+
+// appendKataInstallArgs translates --cvm-mode=pod into helm --set values. kata is
 // enforcing — there is no kata-without-enforcement shape: the chart renders
 // the runtime stack, the runtimeClass-injecting webhook behavior, and the
 // ValidatingAdmissionPolicy together off kata.enabled.
@@ -1117,11 +1147,11 @@ func validateKataDebugFlags(kata, debug bool) error {
 // derives the `<tag>-debug` artifact tag). The confidential-GPU stack (runtime
 // class, shim, GPU image puller, sandbox device plugin) ships with every kata
 // install — it renders off kata.enabled, so there is no GPU flag here. RunE
-// rejects --debug without --kata before args are built; everything here still
+// rejects --debug outside --cvm-mode=pod before args are built; everything here still
 // keys on kata so a call-order change cannot emit a debug value for a non-kata
 // install.
-func appendKataInstallArgs(helmArgs []string, kata, debug bool) []string {
-	if !kata {
+func appendKataInstallArgs(helmArgs []string, cvmMode string, debug bool) []string {
+	if !cvmModeIsPod(cvmMode) {
 		return helmArgs
 	}
 	helmArgs = append(helmArgs,
@@ -1668,10 +1698,9 @@ func init() {
 	installCmd.Flags().BoolVar(&installSingleNode, "single-node", false, "single-node / single-CVM cluster: clear the dedicated-CDS-node selector and taint toleration so every node is CDS-eligible (no role=cds label or dedicated node needed). Sets cds.node.selector={} and cds.node.tolerations=[]")
 	installCmd.Flags().StringSliceVar(&installWorkloadRefs, flagWorkloadRef, nil, "existing workload to adopt as a c8s confidential workload, as <cw-id>=<namespace>/<kind>/<name>[:<port>]; repeatable. Kind is any resource exposing a pod template at spec.template (deployment, statefulset, daemonset, or an operator CRD such as <kind>.<group>). The optional :<port> is the tls-lb upstream port, needed on the ref --upstream selects")
 	installCmd.Flags().StringVar(&installUpstream, flagUpstream, "", "confidential.ai/cw id of the adopted --workload-ref workload tls-lb routes its catch-all to; derives the mesh-wrapped upstream c8s-<id>.<ns>.svc.cluster.local:<port> from that ref's :<port>. Without this or a verified-https tlsLb.upstream, tls-lb renders no catch-all route until one is attached")
-	installCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "baremetal", "CVM deployment shape (orthogonal to --hardware-platform): baremetal, or node (generalized node-as-CVM: our own TDX/SNP nodes are themselves confidential VMs, pods run as ordinary processes), or gke (GKE managed confidential VMs), or aks (vTPM /dev/tpm0). All modes render a privileged attestation-api (a hostPath device mount alone does not grant device-cgroup access)")
+	installCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "", "CVM deployment shape (REQUIRED; orthogonal to --hardware-platform): pod (per-pod confidential VMs via the Kata runtime — every workload pod is a kata CVM, host-side attestation-api/nri/ratls-mesh served by the in-guest counterparts), node (generalized node-as-CVM: our own TDX/SNP nodes are themselves confidential VMs, pods run as ordinary processes, attestation-api + nri baked into the node image), gke (GKE managed confidential VMs), or aks (vTPM /dev/tpm0)")
 	installCmd.Flags().StringVar(&installHardwarePlatform, flagHardwarePlatform, "sev-snp", "CPU-level TEE hardware (orthogonal to --cvm-mode): sev-snp (default, /dev/sev-guest) or tdx (Intel TDX, /dev/tdx-guest). Ignored when --cvm-mode=aks (Azure vTPM path); combining --cvm-mode=aks with --hardware-platform=tdx is refused")
-	installCmd.Flags().BoolVar(&installKata, "kata", false, "install and enforce the Kata Containers runtime stack: every workload pod runs as a confidential VM (kata RuntimeClass injected; non-kata classes rejected), including NVIDIA GPU pods. Labels every kata node for the declared --hardware-platform (clearing the other platform's label), failing fast when no node qualifies")
-	installCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG guest variant (<tag>-debug): kubectl logs/exec work on kata pods, but container I/O becomes readable by the untrusted host and the launch measurement differs from the locked image. Requires --kata; development only")
+	installCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG guest variant (<tag>-debug): kubectl logs/exec work on kata pods, but container I/O becomes readable by the untrusted host and the launch measurement differs from the locked image. Requires --cvm-mode=pod; development only")
 	installCmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "resolve each c8s component image tag to its registry digest (via crane), pin it, and add the resolved images to the NRI allowlist (enables deriveComponents). On by default; pass --resolve-digests=false when supplying digests via -f")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -999,7 +999,9 @@ func appendDistroInstallArgs(helmArgs []string, distro string) []string {
 //
 //	node → generalized node-as-CVM: our own nodes (bare-metal TDX/SNP,
 //	       self-managed) are themselves confidential VMs. Pods run as ordinary
-//	       processes attested via the node's own quote. Cloud-agnostic.
+//	       processes attested via the node's own quote. Cloud-agnostic. The node
+//	       image bakes attestation-api and nri-image-policy, so both are disabled
+//	       here (ratlsMesh is not baked, stays on).
 //	gke  → GKE specifically: Google's managed confidential VMs.
 //
 // GKE is the reason a plain managed→vTPM mapping is wrong: GKE confidential VMs
@@ -1072,6 +1074,16 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 		helmArgs = append(helmArgs,
 			"--set-string", "cds.ratlsPlatform=tdx",
 			"--set-string", "ratlsMesh.platform=tdx",
+		)
+	}
+	// node: the node image bakes host attestation-api and nri-image-policy;
+	// re-rendering them duplicates the baked pair and the baked fail-closed NRI
+	// floor denies the chart copies' own images. ratlsMesh stays: it is not
+	// baked (unlike kata-guest-base).
+	if cvmMode == "node" {
+		helmArgs = append(helmArgs,
+			"--set", "attestationApi.enabled=false",
+			"--set", "nriImagePolicy.enabled=false",
 		)
 	}
 	return helmArgs, nil

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -993,6 +993,14 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 				"--set-string", "ratlsMesh.platform=tdx",
 			)
 		}
+		// node: the node image bakes attestation-api + nri-image-policy, so the
+		// chart copies are skipped (ratlsMesh is not baked, stays on).
+		if mode == "node" {
+			out = append(out,
+				"--set", "attestationApi.enabled=false",
+				"--set", "nriImagePolicy.enabled=false",
+			)
+		}
 		return out
 	}
 	cases := map[string]struct {

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -199,18 +199,20 @@ func TestBuildInstallHelmArgsOrdering(t *testing.T) {
 	})
 }
 
-func TestAppendKataInstallArgsDisabledIsNoOp(t *testing.T) {
-	got := appendKataInstallArgs([]string{"upgrade"}, false, false)
-	assertArgsEqual(t, got, []string{"upgrade"})
+func TestAppendKataInstallArgsNonPodModeIsNoOp(t *testing.T) {
+	for _, mode := range []string{"node", "gke", "aks", ""} {
+		got := appendKataInstallArgs([]string{"upgrade"}, mode, false)
+		assertArgsEqual(t, got, []string{"upgrade"})
+	}
 }
 
-func TestAppendKataInstallArgsEnabledIsEnforcing(t *testing.T) {
-	// --kata is enforcing: alongside the kata stack it must turn off the
+func TestAppendKataInstallArgsPodModeIsEnforcing(t *testing.T) {
+	// --cvm-mode=pod is enforcing: alongside the kata stack it must turn off the
 	// host-side components whose function runs inside the kata-guest-base
 	// image (the chart's enforce_host_components validation rejects them left
 	// on). Enforcement itself (webhook injection + ValidatingAdmissionPolicy)
 	// is keyed on kata.enabled in the chart — no separate value.
-	got := appendKataInstallArgs([]string{"upgrade"}, true, false)
+	got := appendKataInstallArgs([]string{"upgrade"}, "pod", false)
 	assertArgsEqual(t, got, []string{
 		"upgrade",
 		"--set", "kata.enabled=true",
@@ -221,9 +223,9 @@ func TestAppendKataInstallArgsEnabledIsEnforcing(t *testing.T) {
 }
 
 func TestAppendKataInstallArgsDebugSelectsDebugGuestImage(t *testing.T) {
-	// --kata --debug keeps the enforcing shape and additionally points the
-	// puller at the -debug guest image (host log/exec streams allowed).
-	got := appendKataInstallArgs([]string{"upgrade"}, true, true)
+	// --cvm-mode=pod --debug keeps the enforcing shape and additionally points
+	// the puller at the -debug guest image (host log/exec streams allowed).
+	got := appendKataInstallArgs([]string{"upgrade"}, "pod", true)
 	assertArgsEqual(t, got, []string{
 		"upgrade",
 		"--set", "kata.enabled=true",
@@ -234,29 +236,47 @@ func TestAppendKataInstallArgsDebugSelectsDebugGuestImage(t *testing.T) {
 	})
 }
 
-func TestAppendKataInstallArgsDebugWithoutKataIsNoOp(t *testing.T) {
-	// RunE rejects --debug without --kata before args are built; the builder
-	// still keys everything on kata so a call-order change cannot silently
-	// emit a debug guest image for a non-kata install.
-	got := appendKataInstallArgs([]string{"upgrade"}, false, true)
+func TestAppendKataInstallArgsDebugNonPodModeIsNoOp(t *testing.T) {
+	// RunE rejects --debug outside --cvm-mode=pod before args are built; the
+	// builder still keys everything on the pod mode so a call-order change
+	// cannot silently emit a debug guest image for a non-pod install.
+	got := appendKataInstallArgs([]string{"upgrade"}, "node", true)
 	assertArgsEqual(t, got, []string{"upgrade"})
 }
 
-// --debug without --kata is meaningless (the debug guest image only exists
-// under the kata stack) and must error rather than silently no-op.
-func TestValidateKataDebugFlagsRejectsDebugWithoutKata(t *testing.T) {
-	err := validateKataDebugFlags(false, true)
-	if err == nil {
-		t.Fatal("--debug without --kata: want error, got nil")
+// --cvm-mode is required: empty or unknown must error.
+func TestValidateCvmModeRequiresKnownValue(t *testing.T) {
+	if err := validateCvmMode(""); err == nil {
+		t.Fatal("empty --cvm-mode: want error, got nil")
 	}
-	for _, want := range []string{"--kata", "--debug"} {
-		if !strings.Contains(err.Error(), want) {
-			t.Errorf("error %q missing %q (should name both flags)", err.Error(), want)
+	if err := validateCvmMode("bogus"); err == nil {
+		t.Fatal("unknown --cvm-mode: want error, got nil")
+	}
+	for _, mode := range allowedCvmModes {
+		if err := validateCvmMode(mode); err != nil {
+			t.Errorf("mode %q: unexpected error: %v", mode, err)
 		}
 	}
-	for _, tc := range []struct{ kata, debug bool }{{false, false}, {true, false}, {true, true}} {
-		if err := validateKataDebugFlags(tc.kata, tc.debug); err != nil {
-			t.Errorf("kata=%t debug=%t: unexpected error: %v", tc.kata, tc.debug, err)
+}
+
+// --debug outside --cvm-mode=pod is meaningless (the debug guest image only
+// exists under the kata stack) and must error rather than silently no-op.
+func TestValidateDebugFlagRejectsDebugOutsidePod(t *testing.T) {
+	err := validateDebugFlag("node", true)
+	if err == nil {
+		t.Fatal("--debug with --cvm-mode=node: want error, got nil")
+	}
+	for _, want := range []string{"--cvm-mode=pod", "--debug"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+	for _, tc := range []struct {
+		mode  string
+		debug bool
+	}{{"node", false}, {"pod", false}, {"pod", true}} {
+		if err := validateDebugFlag(tc.mode, tc.debug); err != nil {
+			t.Errorf("mode=%s debug=%t: unexpected error: %v", tc.mode, tc.debug, err)
 		}
 	}
 }
@@ -973,9 +993,9 @@ func TestHostPortConflict(t *testing.T) {
 
 func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 	// Two orthogonal axes:
-	//  --cvm-mode: baremetal / node (node-as-CVM) / gke (managed) / aks (vTPM)
+	//  --cvm-mode: pod (kata) / node (node-as-CVM) / gke (managed) / aks (vTPM)
 	//  --hardware-platform: sev-snp (/dev/sev-guest) / tdx (/dev/tdx-guest)
-	// baremetal+node+gke all take either hardware-platform; aks always emits vTPM
+	// pod+node+gke all take either hardware-platform; aks always emits vTPM
 	// (and combining aks with tdx is rejected).
 	build := func(mode string, sevGuest, tdxGuest, tpm string) []string {
 		out := []string{
@@ -1008,13 +1028,13 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 		hardwarePlatform string
 		want             []string
 	}{
-		"baremetal + sev-snp": {"baremetal", "sev-snp", build("baremetal", "true", "false", "false")},
-		"gke + sev-snp":       {"gke", "sev-snp", build("gke", "true", "false", "false")},
-		"node + sev-snp":      {"node", "sev-snp", build("node", "true", "false", "false")},
-		"baremetal + tdx":     {"baremetal", "tdx", build("baremetal", "false", "true", "false")},
-		"gke + tdx":           {"gke", "tdx", build("gke", "false", "true", "false")},
-		"node + tdx":          {"node", "tdx", build("node", "false", "true", "false")},
-		"aks + sev-snp":       {"aks", "sev-snp", build("aks", "false", "false", "true")},
+		"pod + sev-snp":  {"pod", "sev-snp", build("pod", "true", "false", "false")},
+		"gke + sev-snp":  {"gke", "sev-snp", build("gke", "true", "false", "false")},
+		"node + sev-snp": {"node", "sev-snp", build("node", "true", "false", "false")},
+		"pod + tdx":      {"pod", "tdx", build("pod", "false", "true", "false")},
+		"gke + tdx":      {"gke", "tdx", build("gke", "false", "true", "false")},
+		"node + tdx":     {"node", "tdx", build("node", "false", "true", "false")},
+		"aks + sev-snp":  {"aks", "sev-snp", build("aks", "false", "false", "true")},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -1034,7 +1054,7 @@ func TestAppendCvmModeInstallArgsRejectsUnknownMode(t *testing.T) {
 }
 
 func TestAppendCvmModeInstallArgsRejectsUnknownHardwarePlatform(t *testing.T) {
-	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "baremetal", "sgx"); err == nil {
+	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "sgx"); err == nil {
 		t.Fatal("appendCvmModeInstallArgs accepted an unknown --hardware-platform, want error")
 	}
 }

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -40,7 +40,7 @@ var renderValuesDistro string
 // values.yaml, without touching a cluster. It runs the same value computation
 // as `c8s install` — resolve each component image tag to its registry digest
 // (via crane), map --cvm-mode to the TEE devices, --single-node to the cleared
-// CDS node selector, --kata to the runtime toggles, and enable the NRI
+// CDS node selector, --cvm-mode=pod runtime toggles, and enable the NRI
 // allowlist derivation — but writes the values to stdout instead of running
 // helm upgrade --install.
 //
@@ -60,7 +60,7 @@ var renderValuesCmd = &cobra.Command{
 	Short: "Print the resolved Helm values an install would apply (no cluster needed)",
 	Long: `Computes the install-time Helm values that need a registry or the chart
 to resolve — resolved image digests, --cvm-mode TEE devices, --single-node node
-selector, --kata toggles, and the NRI allowlist derivation — and writes them to
+selector, --cvm-mode=pod toggles, and the NRI allowlist derivation — and writes them to
 stdout as a values.yaml, without contacting a cluster. Per-cluster tuning a
 consumer already owns (webhook cert settings, tls-lb, nodeSelectors, …) is not
 emitted; layer it in the consuming HelmRelease values.
@@ -80,7 +80,10 @@ the consuming -f.
 
 Requires the 'helm' CLI on PATH, and 'crane' unless --resolve-digests=false.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := validateKataDebugFlags(installKata, installKataDebug); err != nil {
+		if err := validateCvmMode(installCvmMode); err != nil {
+			return err
+		}
+		if err := validateDebugFlag(installCvmMode, installKataDebug); err != nil {
 			return err
 		}
 		if _, err := exec.LookPath("helm"); err != nil {
@@ -172,17 +175,13 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, components []c8sCom
 	if distro != "" {
 		setArgs = appendDistroInstallArgs(setArgs, distro)
 	}
-	// Either flag changing on the CLI triggers the --set flow. A user who
-	// wants to drive teeDevices purely via -f leaves both flags unset and the
-	// chart's own defaults hold.
-	if cmd.Flags().Changed(flagCvmMode) || cmd.Flags().Changed(flagHardwarePlatform) {
-		var err error
-		setArgs, err = appendCvmModeInstallArgs(setArgs, installCvmMode, installHardwarePlatform)
-		if err != nil {
-			return nil, err
-		}
+	// --cvm-mode is required and validated in RunE, so always emit the mode's
+	// teeDevices/attestation-api values (and the --hardware-platform propagation).
+	setArgs, err = appendCvmModeInstallArgs(setArgs, installCvmMode, installHardwarePlatform)
+	if err != nil {
+		return nil, err
 	}
-	setArgs = appendKataInstallArgs(setArgs, installKata, installKataDebug)
+	setArgs = appendKataInstallArgs(setArgs, installCvmMode, installKataDebug)
 	setArgs = appendSingleNodeInstallArgs(setArgs, installSingleNode)
 	// --upstream derives a c8s-<id>.<ns>.svc.cluster.local address; the chart
 	// recognizes that headless-Service shape as mesh-wrapped and admits plaintext
@@ -340,10 +339,9 @@ func init() {
 	renderValuesCmd.Flags().BoolVar(&installCRDs, "install-crds", true, "emit values for chart CRDs (false sets statusMirror.enabled=false, matching install --install-crds=false)")
 	renderValuesCmd.Flags().StringVar(&renderValuesDistro, "distro", "", "host Kubernetes distro (k8s | rke2) — install autodetects this from the cluster; render-values has no cluster, so pass it explicitly when you need it pinned. Unset leaves the chart default")
 	renderValuesCmd.Flags().BoolVar(&installSingleNode, "single-node", false, "single-node / single-CVM cluster: clear the dedicated-CDS-node selector and toleration (cds.node.selector={}, cds.node.tolerations=[])")
-	renderValuesCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "baremetal", "CVM deployment shape (orthogonal to --hardware-platform): baremetal or node (generalized node-as-CVM native TEE device) or gke (GKE managed CVMs) or aks (vTPM /dev/tpm0)")
+	renderValuesCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "", "CVM deployment shape (REQUIRED; orthogonal to --hardware-platform): pod (per-pod kata CVMs; disables host-side ratls-mesh/attestation-api/nri-image-policy) or node (generalized node-as-CVM native TEE device) or gke (GKE managed CVMs) or aks (vTPM /dev/tpm0)")
 	renderValuesCmd.Flags().StringVar(&installHardwarePlatform, flagHardwarePlatform, "sev-snp", "CPU-level TEE hardware (orthogonal to --cvm-mode): sev-snp (default, /dev/sev-guest) or tdx (Intel TDX, /dev/tdx-guest). Ignored when --cvm-mode=aks")
-	renderValuesCmd.Flags().BoolVar(&installKata, "kata", false, "emit the Kata Containers runtime values (kata.enabled=true; disables host-side ratls-mesh/attestation-api/nri-image-policy)")
-	renderValuesCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG image variant (requires --kata)")
+	renderValuesCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG image variant (requires --cvm-mode=pod)")
 	renderValuesCmd.Flags().StringSliceVar(&installWorkloadRefs, flagWorkloadRef, nil, "adopted workload as <cw-id>=<namespace>/<kind>/<name>[:<port>]; repeatable. Used here only to derive --upstream's address (render-values patches nothing)")
 	renderValuesCmd.Flags().StringVar(&installUpstream, flagUpstream, "", "confidential.ai/cw id of the adopted --workload-ref workload tls-lb routes its catch-all to; derives tlsLb.upstream.address c8s-<id>.<ns>.svc.cluster.local:<port> from that ref's :<port>")
 	renderValuesCmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "resolve each component image tag to its registry digest (via crane), pin it, and enable the NRI allowlist derivation")

--- a/cmd/c8s/render_values_test.go
+++ b/cmd/c8s/render_values_test.go
@@ -149,12 +149,23 @@ func TestValueArgsToTreeRejectsUnknownFlag(t *testing.T) {
 	}
 }
 
+// setCvmModeForTest pins the required --cvm-mode global for a buildValueArgs
+// test and restores the prior value, so a mode leaked from another test cannot
+// change the emitted args.
+func setCvmModeForTest(t *testing.T, mode string) {
+	t.Helper()
+	prev := installCvmMode
+	installCvmMode = mode
+	t.Cleanup(func() { installCvmMode = prev })
+}
+
 // buildValueArgs must assume nothing the operator did not pass — like install,
 // an unset --distro (distro == "") emits no distro keys, leaving the chart
 // default to stand; a set --distro plumbs both component distro keys.
 func TestBuildValueArgsOmitsDistroWhenUnset(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.Flags().String(flagCvmMode, "baremetal", "") // registered, not Changed
+	cmd.Flags().String(flagCvmMode, "node", "")
+	setCvmModeForTest(t, "node")
 
 	// Isolate the distro logic from the crane digest path (which needs the
 	// binary on PATH); this test is about what the builder assumes, not digests.
@@ -187,7 +198,8 @@ func TestBuildValueArgsOmitsDistroWhenUnset(t *testing.T) {
 // coerce never int-coerces it (0640 -> 640 would pin the wrong image).
 func TestBuildValueArgsKeepsNumericImageTagAString(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.Flags().String(flagCvmMode, "baremetal", "")
+	cmd.Flags().String(flagCvmMode, "node", "")
+	setCvmModeForTest(t, "node")
 	prev := installResolveDigests
 	installResolveDigests = false // tag is the sole image ref only when digests are off
 	defer func() { installResolveDigests = prev }()
@@ -215,7 +227,8 @@ func TestBuildValueArgsKeepsNumericImageTagAString(t *testing.T) {
 // PATH.
 func TestBuildValueArgsOmitsTagWhenDigestsResolved(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.Flags().String(flagCvmMode, "baremetal", "")
+	cmd.Flags().String(flagCvmMode, "node", "")
+	setCvmModeForTest(t, "node")
 
 	prevFlag := installResolveDigests
 	defer func() { installResolveDigests = prevFlag }()
@@ -302,7 +315,7 @@ var coerceSafeValueArg = regexp.MustCompile(`^[A-Za-z0-9.]+=[^,]*$`)
 // shared path hides the divergence) with every existing test still green.
 func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.Flags().String(flagCvmMode, "baremetal", "")
+	cmd.Flags().String(flagCvmMode, "node", "")
 	cmd.Flags().Int64("webhook-cert-fs-group", 0, "")
 	cmd.Flags().String("webhook-cert-key-mode", "", "")
 	cmd.Flags().Duration("webhook-get-cert-renew-interval", 0, "")
@@ -320,12 +333,12 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	}
 
 	prev := struct {
-		crds, singleNode, kata, resolveDigests bool
-		secret, cvm, upstream, operatorKeys    string
-		workloadRefs                           []string
-	}{installCRDs, installSingleNode, installKata, installResolveDigests, installImagePullSecret, installCvmMode, installUpstream, installOperatorKeys, slices.Clone(installWorkloadRefs)}
+		crds, singleNode, debug, resolveDigests bool
+		secret, cvm, upstream, operatorKeys     string
+		workloadRefs                            []string
+	}{installCRDs, installSingleNode, installKataDebug, installResolveDigests, installImagePullSecret, installCvmMode, installUpstream, installOperatorKeys, slices.Clone(installWorkloadRefs)}
 	defer func() {
-		installCRDs, installSingleNode, installKata, installResolveDigests = prev.crds, prev.singleNode, prev.kata, prev.resolveDigests
+		installCRDs, installSingleNode, installKataDebug, installResolveDigests = prev.crds, prev.singleNode, prev.debug, prev.resolveDigests
 		installImagePullSecret, installCvmMode = prev.secret, prev.cvm
 		installUpstream = prev.upstream
 		installOperatorKeys = prev.operatorKeys
@@ -334,8 +347,9 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	// Drive every value-producing toggle. --install-crds=false exercises the
 	// non-default CRD path; --resolve-digests=false keeps crane off PATH (the
 	// digest-arg shape is covered separately via buildDigestArgs below).
-	installCRDs, installSingleNode, installKata, installResolveDigests = false, true, true, false
-	installImagePullSecret, installCvmMode = "regcred", "aks"
+	// --cvm-mode=pod --debug exercises the kata stack args.
+	installCRDs, installSingleNode, installKataDebug, installResolveDigests = false, true, true, false
+	installImagePullSecret, installCvmMode = "regcred", "pod"
 	installWorkloadRefs = []string{"infer=workloads/deployment/vllm:8000"}
 	installUpstream = "infer"
 	installOperatorKeys = writeTestOperatorKeys(t)
@@ -385,7 +399,8 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 // duplicate ref dedups to one adoption, so --upstream still resolves it.
 func TestBuildValueArgsDerivesUpstreamFromRef(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.Flags().String(flagCvmMode, "baremetal", "")
+	cmd.Flags().String(flagCvmMode, "node", "")
+	setCvmModeForTest(t, "node")
 
 	prev := struct {
 		resolveDigests bool

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -57,6 +57,6 @@ kubectl delete -f samples/confidentialworkload.yaml
 c8s uninstall
 ```
 
-`c8s uninstall` wraps `helm uninstall c8s -n c8s-system`; on a `--kata`
+`c8s uninstall` wraps `helm uninstall c8s -n c8s-system`; on a `--cvm-mode=pod`
 install it also sweeps the kata runtime artifacts off the nodes (see
 [`kata.md`](kata.md#uninstalling)).

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -117,7 +117,7 @@ Note this is the cluster-side (kubelet) credential: `--resolve-digests` runs
 `crane` on your workstation and uses your local docker login, not this
 Secret.
 
-Under `--kata`, the same Secret also feeds the kata-image-puller's in-pod
+Under `--cvm-mode=pod`, the same Secret also feeds the kata-image-puller's in-pod
 `oras pull` of the kata-guest-base artifact, which reads
 `/root/.docker/config.json` rather than kubelet pull secrets (set
 `kata.guestImage.pullerAuthSecret` if that artifact needs a different

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -33,13 +33,13 @@ flag selects a **mode**, which is a fixed set of `--set` choices.
 | Mode | Flag | One-liner |
 |---|---|---|
 | **base** | *(none)* | Normal Kubernetes. No kata, no per-pod confidentiality. Host-side mesh + attestation + image policy. The dev/baseline shape. |
-| **kata** | `--kata` | Installs the kata runtime + RuntimeClasses **and enforces them**: the webhook *injects* a kata RuntimeClass into every in-scope workload pod, a ValidatingAdmissionPolicy *rejects* non-kata pods, and the host-side mesh/attestation/image-policy move into the guest image. The production "pod-as-CVM" shape — kata is enforcing, there is no kata-without-enforcement mode. |
+| **kata** | `--cvm-mode=pod` | Installs the kata runtime + RuntimeClasses **and enforces them**: the webhook *injects* a kata RuntimeClass into every in-scope workload pod, a ValidatingAdmissionPolicy *rejects* non-kata pods, and the host-side mesh/attestation/image-policy move into the guest image. The production "pod-as-CVM" shape — kata is enforcing, there is no kata-without-enforcement mode. |
 
 ```mermaid
 flowchart LR
     A["c8s install"] --> B{flags}
     B -->|none| BASE["base<br/>host-side everything<br/>no confidentiality"]
-    B -->|"--kata"| KATA["kata (enforcing)<br/>all workloads forced<br/>into kata VMs"]
+    B -->|"--cvm-mode=pod"| KATA["kata (enforcing)<br/>all workloads forced<br/>into kata VMs"]
 ```
 
 There is no distro flag: the host distro (`k8s` vs `rke2`), which picks the
@@ -50,13 +50,13 @@ rke2). An install with `-f` values owns the distro instead: set
 doesn't fit — a mixed cluster cannot be detected and always needs that, plus
 nodeSelectors to partition the install.
 
-The kata-image-puller and node-taint sidecar are on by default under `--kata*`.
+The kata-image-puller and node-taint sidecar are on by default under `--cvm-mode=pod`.
 A single-node / local build can switch either off, and pin the guest image
 tag, through a `-f` values file (`kata.guestImage.enabled=false` /
 `kata.nodeTaint.enabled=false` / `kata.guestImage.tag=<tag>`) — there is no
 dedicated CLI flag for these.
 
-`--kata --debug` points the puller at the `<tag>-debug` guest image —
+`--cvm-mode=pod --debug` points the puller at the `<tag>-debug` guest image —
 identical except the baked guest policy allows host log/exec streams, so
 `kubectl logs` / `kubectl exec` work against kata pods. Container I/O becomes
 host-readable and the launch measurement differs from the locked image; dev
@@ -70,7 +70,7 @@ only (see [`kata.md`](kata.md)).
 "CVM" = `kata-qemu-snp` confidential VM; "in-VM" = baked into the guest image,
 not a cluster resource.
 
-| Component | base | `--kata` | Runs on |
+| Component | base | `--cvm-mode=pod` | Runs on |
 |---|:--:|:--:|---|
 | c8s operator (webhook + controllers) | ✓ | ✓ | host (runc; always webhook-exempt) |
 | MWC `pod-injector` | ✓ | ✓ | cluster (release-tracked resource) |
@@ -91,7 +91,7 @@ not a cluster resource.
 
 Under kata, **every host-side security component (attestation-service,
 ratls-mesh, nri-image-policy) moves *inside* the confidential guest**, where
-the host (adversarial) cannot tamper with it. `c8s install --kata` sets their
+the host (adversarial) cannot tamper with it. `c8s install --cvm-mode=pod` sets their
 `.enabled=false`, and the chart fails the render
 (`kind=enforce_host_components`, `templates/validations.yaml`) if any is left
 enabled alongside `kata.enabled` — the host versions would be a second,
@@ -159,7 +159,7 @@ sequenceDiagram
     participant Op as operator pod
     participant Pods as workloads
 
-    CLI->>K: kubectl apply Namespace (privileged label if --kata)
+    CLI->>K: kubectl apply Namespace (privileged label if --cvm-mode=pod)
     CLI->>Helm: helm upgrade --install --wait
     Note over Helm: normal resources (kind-order)
     Helm->>K: create operator Deployment, kata-deploy, CDS, ...
@@ -209,7 +209,7 @@ flowchart TD
     EX -->|no| CW{"has confidential.ai/cw?"}
     CW -->|yes| GC["inject get-cert<br/>(c8s-cert sidecar)"]
     CW -->|no| RC
-    GC --> RC{"--kata<br/>AND no runtimeClass<br/>AND not hostNet/PID/IPC?"}
+    GC --> RC{"--cvm-mode=pod<br/>AND no runtimeClass<br/>AND not hostNet/PID/IPC?"}
     RC -->|no| DONE["admit"]
     RC -->|yes| INJ["set runtimeClassName<br/>(kata-qemu-snp if cw, else kata-qemu)<br/>+ kata nodeSelector + toleration"]
     INJ --> DONE
@@ -227,7 +227,7 @@ Two independent injections, both keyed off the pod (not a CR):
    blocks until the initial cert is written so downstream containers wait for
    it before launching. (An exec startupProbe cannot gate here: the locked
    kata guest denies `ExecProcessRequest`.)
-2. **runtimeClass** — only under `--kata` (which is enforcing).
+2. **runtimeClass** — only under `--cvm-mode=pod` (which is enforcing).
    `kata-qemu-snp` for `cw`-annotated pods (confidential), `kata-qemu`
    otherwise.
 
@@ -345,15 +345,15 @@ c8s install --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --
 # Kata (enforcing): every workload pod becomes a kata VM, non-kata pods
 # rejected, host-side mesh/attestation/image-policy replaced by their
 # in-guest counterparts.
-c8s install --kata --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 
 # RKE2 host — the distro is detected from the cluster, no extra flag.
-c8s install --kata --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 
 # Single-node / local build (no registry artifact, don't starve the one node).
 # The puller + node-taint are on by default; switch them off via a values file:
 #   kata: {guestImage: {enabled: false}, nodeTaint: {enabled: false}}
-c8s install --kata --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm -f single-node.values.yaml
+c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm -f single-node.values.yaml
 
 # Uninstall: helm uninstall + sweep the kata artifacts off every node.
 c8s uninstall

--- a/docs/kata-gpu.md
+++ b/docs/kata-gpu.md
@@ -2,14 +2,14 @@
 
 Runs a Kubernetes pod as a confidential VM (SEV-SNP or Intel TDX, per the
 install's `--hardware-platform`) with an NVIDIA GPU passed through over VFIO.
-**The GPU stack ships with every `c8s install --kata`** — there is no separate
+**The GPU stack ships with every `c8s install --cvm-mode=pod`** — there is no separate
 flag or mode. Every kata cluster can run both CPU and GPU confidential pods.
 **NVIDIA only. Pod-as-CVM only** (node-as-CVM GPU is a separate story — see
 "Out of scope" below).
 
-## What ships with `--kata` (the GPU stack)
+## What ships with `--cvm-mode=pod` (the GPU stack)
 
-`c8s install --kata` renders, alongside the CPU kata stack — for the declared
+`c8s install --cvm-mode=pod` renders, alongside the CPU kata stack — for the declared
 platform (SNP shown; a `--hardware-platform=tdx` install gets the `-tdx`
 equivalents instead):
 
@@ -173,7 +173,7 @@ Two deliberate deltas from the non-GPU guest:
 
 ### `--debug` and the GPU guest
 
-`c8s install --kata --debug` switches every guest image to its debug variant:
+`c8s install --cvm-mode=pod --debug` switches every guest image to its debug variant:
 the non-GPU puller pulls `<tag>-debug` and the GPU puller pulls
 `<tag>-nvidia-debug`, both published in lockstep by CI (`kata-guest-base.yml`).
 The GPU pair is a real locked/debug split, identical in mechanism to the
@@ -348,7 +348,7 @@ with `/opt/kata` and the containerd drop-in. The GPU dir is read from the
 
 ```yaml
 kata:
-  gpu:                          # no `enabled` — the GPU stack ships with --kata
+  gpu:                          # no `enabled` — the GPU stack ships with --cvm-mode=pod
     guestImage:
       hostPath: /var/lib/c8s/kata-images-nvidia   # swept on uninstall
       pcieRootPort: 8           # VFIO cold-plug ports (stock ships 0)
@@ -364,6 +364,6 @@ kata:
 The `<tag>-nvidia` guest image reuses `kata.guestImage.{repository,insecure,
 registryAuth,pullerAuthSecret}` — same registry and credentials as the non-GPU
 image, with a `-nvidia` tag suffix. `kata.guestImage.debug` drives both
-pullers: `--kata --debug` switches the non-GPU image to `<tag>-debug` and the
+pullers: `--cvm-mode=pod --debug` switches the non-GPU image to `<tag>-debug` and the
 GPU image to `<tag>-nvidia-debug` in the same install (see "`--debug` and the
 GPU guest" above).

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -309,7 +309,7 @@ in-guest binaries. On a release tag (`v*`) the same image also gets the
 release version; `latest` moves only on `main`.
 
 Operators select the artifact tag by setting `kata.guestImage.tag` in a values
-file (`c8s install --kata -f values.yaml`). The
+file (`c8s install --cvm-mode=pod -f values.yaml`). The
 `c8s-kata-image-puller` DaemonSet picks that up and pulls accordingly —
 see "How it's consumed in-cluster" in
 [`kata-guest-base/README.md`](../kata-guest-base/README.md).
@@ -324,7 +324,7 @@ supply it to `cds.measurements`, `ratlsMesh.measurements`, or client-side
 
 Every tag has a `-debug` sibling published from the same build whose guest
 policy allows the host log/exec stream RPCs (`kubectl logs`/`exec` work;
-container I/O becomes host-readable). `c8s install --kata --debug` selects
+container I/O becomes host-readable). `c8s install --cvm-mode=pod --debug` selects
 it via `kata.guestImage.debug=true`; its launch measurement differs from
 the locked image, so locked-reference attestation rejects it. See "Debug
 variant" in [`kata-guest-base/README.md`](../kata-guest-base/README.md).
@@ -378,5 +378,5 @@ launch-digest mismatch at attestation time and clients refuse the pod.
 
 - [`kata-guest-base/README.md`](../kata-guest-base/README.md) — the recipe: boot model, what's baked in, build, consume, measure.
 - [`kata-image-policy.md`](kata-image-policy.md) — in-guest per-image enforcement (`policy-monitor`).
-- [`kata.md`](kata.md) — installing and enforcing the kata runtime (`c8s install --kata`).
+- [`kata.md`](kata.md) — installing and enforcing the kata runtime (`c8s install --cvm-mode=pod`).
 - [`install-flows.md`](install-flows.md) — how the two install modes assemble the platform.

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -15,7 +15,7 @@ injection and enforcement).
 
 ## What it installs
 
-`c8s install --kata` makes the embedded Helm chart render, in addition to the
+`c8s install --cvm-mode=pod` makes the embedded Helm chart render, in addition to the
 normal c8s components:
 
 - **The upstream `kata-deploy` DaemonSet** (`quay.io/kata-containers/kata-deploy`,
@@ -43,7 +43,7 @@ normal c8s components:
   classes would be unschedulable decoys the enforcement allowlist should not
   accept.
 
-`c8s install --kata` is **enforcing** — installing the Kata stack and
+`c8s install --cvm-mode=pod` is **enforcing** — installing the Kata stack and
 enforcing it are one shape, not two (see [Enforcement](#enforcement)).
 
 | RuntimeClass | Hypervisor | Confidential? | Renders under |
@@ -64,11 +64,11 @@ enforcing it are one shape, not two (see [Enforcement](#enforcement)).
 # (see below). tls-lb runs as a kata CVM; --upstream (with the port on its
 # --workload-ref) points tls-lb at an adopted workload's mesh-wrapped headless
 # Service (see operator.md, "tls-lb upstream").
-c8s install --kata --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 
 # Dev only: use the -debug guest image so `kubectl logs` and `kubectl exec`
 # work against kata pods (host log/exec RPCs allowed in the guest policy).
-c8s install --kata --debug --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --debug --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
 
 Confidential pods only schedule to nodes carrying their platform label —
@@ -156,7 +156,7 @@ installed by c8s and one provisioned by Ansible or booted from the
 
 ## Enforcement
 
-`--kata` is enforcing — there is no kata-without-enforcement shape: a
+`--cvm-mode=pod` is enforcing — there is no kata-without-enforcement shape: a
 workload that can dodge the CVM boundary makes the kata stack decorative.
 Enforcement is two cooperating pieces, installed together with the stack.
 
@@ -200,7 +200,7 @@ kata-guest-base image:
 | `attestation-api` DaemonSet | in-guest attestation-api on loopback `:8400` (`c8s.attestationApiURL`) |
 | `nri-image-policy` (host NRI plugin) | in-guest policy-monitor, fed from CDS's served `/allowlist` |
 
-`c8s install --kata` sets `ratlsMesh.enabled=false`,
+`c8s install --cvm-mode=pod` sets `ratlsMesh.enabled=false`,
 `attestationApi.enabled=false`, and `nriImagePolicy.enabled=false` for you;
 the chart fails the render (`kind=enforce_host_components`) if any of them is
 left enabled alongside `kata.enabled`, since the host versions would be dead
@@ -292,7 +292,7 @@ kubectl get pod kata-smoketest -o jsonpath='{.spec.runtimeClassName}{"\n"}'
 ```
 
 If the field is empty, the operator is running without its `--kata-enforce`
-flag — i.e. the release was installed without `--kata` (verify with
+flag — i.e. the release was installed without `--cvm-mode=pod` (verify with
 `kubectl get deploy c8s-operator -n c8s-system -o yaml | grep kata-enforce`).
 The mutating webhook is wired in either way; injection is gated on the flag,
 which the chart sets whenever `kata.enabled` is.
@@ -396,7 +396,7 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   (`kata.snpNodeSelector`), the TDX classes on `confidential.ai/tdx=true`
   (`kata.tdxNodeSelector`), so confidential pods — including the chart's own
   CDS and tls-lb — only land on nodes declared capable.
-  `c8s install --kata` labels every kata-targeted node automatically from
+  `c8s install --cvm-mode=pod` labels every kata-targeted node automatically from
   `--hardware-platform` (see [Installing](#installing) — declarative, no
   hardware probe; refuses when the other platform's label lingers) and fails
   fast when none qualifies; with `-f` or a GitOps install the labels are
@@ -485,9 +485,9 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   # → true
   ```
 
-  Then `c8s install --hardware-platform=tdx --kata …` proceeds cleanly.
+  Then `c8s install --hardware-platform=tdx --cvm-mode=pod …` proceeds cleanly.
 
-- **One-shot `--kata` has a brief bootstrap window.** `c8s install --kata`
+- **One-shot `--cvm-mode=pod` has a brief bootstrap window.** `c8s install --cvm-mode=pod`
   brings up the webhook and the policy in the same release as kata-deploy,
   but kata-deploy takes 1–2 minutes per node to install the runtime. Pods
   created in that window are mutated to a Kata RuntimeClass and stay
@@ -511,7 +511,7 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   only on its own namespace (`c8s-system`); it does **not** label tenant
   namespaces. If your cluster has no PSA floor (or sets `privileged` as the
   default), any namespace user with create-pod RBAC can opt out of kata
-  enforcement by setting `hostNetwork: true`. Treat `--kata` as a
+  enforcement by setting `hostNetwork: true`. Treat `--cvm-mode=pod` as a
   cluster-operator gate that must be paired with PSA `restricted` or
   `baseline` on workload namespaces — without it, the host-namespace
   exemption is a tenant-accessible bypass, not just an operator carve-out.
@@ -534,14 +534,14 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   selector, so it lands on every Linux node — including control-plane nodes
   and nodes you have tainted to keep workloads off (quarantined,
   GPU-reserved, etc.). This is the deliberate "one-shot install" posture: a
-  bare `c8s install --kata` produces a cluster where every node can run kata
+  bare `c8s install --cvm-mode=pod` produces a cluster where every node can run kata
   pods. If you need to exclude nodes, override `kata.tolerations` /
   `kata.nodeSelector` in your values file. Because kata-deploy runs
   privileged with the host root mounted, narrow this if your trust model
   treats some nodes as out-of-scope for c8s.
 
-- **Confidential GPU ships with every `--kata` install.** There is no separate
-  flag: `c8s install --kata` always renders the platform's confidential-GPU
+- **Confidential GPU ships with every `--cvm-mode=pod` install.** There is no separate
+  flag: `c8s install --cvm-mode=pod` always renders the platform's confidential-GPU
   RuntimeClass (`kata-qemu-snp-nvidia` / `kata-qemu-tdx-nvidia`, handler
   `kata-qemu-nvidia-gpu-*`), the webhook injection for pods requesting
   `nvidia.com/*`, the `<tag>-nvidia` guest image puller, and the NVIDIA
@@ -559,7 +559,7 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   can read the pod's memory. Only the platform's confidential classes (pods
   annotated `confidential.ai/cw`, or requesting a GPU) are confidential VMs.
   "Pod-as-kata-cvm by default" is a posture the operator opts into with
-  `confidential.ai/cw`, not something a bare `c8s install --kata` gives every
+  `confidential.ai/cw`, not something a bare `c8s install --cvm-mode=pod` gives every
   pod.
 
 ## Uninstalling

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -134,7 +134,7 @@ Services. `--upstream vllm-router` points tls-lb at
 `c8s-vllm-router.vllm.svc.cluster.local:8000` (its `<cw-id>` must be one of the
 adopted refs, carrying a `:<port>`). With `--resolve-digests=true`, install resolves adopted workload
 images into `nriImagePolicy.bootstrapAllowlist.digests` so image admission (the
-host NRI plugin, or the in-guest policy-monitor under `--kata`) allows those
+host NRI plugin, or the in-guest policy-monitor under `--cvm-mode=pod`) allows those
 rollouts.
 
 `c8s install --install-crds=false` passes Helm's `--skip-crds`; CRDs are
@@ -144,14 +144,14 @@ operator skips that controller rather than failing startup.
 
 ## Kata runtime installation and enforcement
 
-`c8s install --kata` additionally installs the Kata Containers runtime onto
+`c8s install --cvm-mode=pod` additionally installs the Kata Containers runtime onto
 the cluster: the embedded chart renders the upstream `kata-deploy` DaemonSet
 (which installs QEMU, the kata runtime, and the `containerd-shim-kata-v2`
 shim onto every node) and the `kata-qemu` / `kata-clh` / `kata-qemu-snp` /
 `kata-qemu-tdx` RuntimeClass objects. The host containerd config path (`k8s` vs `rke2`
 layout) is detected from the cluster's kubelet versions.
 
-`--kata` is **enforcing** — there is no kata-without-enforcement shape:
+`--cvm-mode=pod` is **enforcing** — there is no kata-without-enforcement shape:
 
 - the operator's pod webhook injects a `runtimeClassName` into workload pods
   that don't request one — `kata-qemu`, or `kata-qemu-snp` for pods annotated
@@ -177,7 +177,7 @@ webhook configuration, RuntimeClasses, and the enforcement policy). The
 release — a `failurePolicy: Fail` webhook cannot outlive the operator Service
 and block pod creation cluster-wide.
 
-For a `--kata` install it then **sweeps the host-side kata artifacts** that the
+For a `--cvm-mode=pod` install it then **sweeps the host-side kata artifacts** that the
 `kata-deploy` preStop cleanup cannot guarantee: a short-lived privileged
 DaemonSet removes `/opt/kata`, the containerd runtime drop-in (restarting the
 runtime only when the drop-in was still registered), the pulled

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -121,7 +121,7 @@ mesh client (ratls-mesh, nri-image-policy, get-cert, policy-monitor — all
 
 `internal/webhook/pod_mutator.go` + `internal/helmchart/c8s/templates/kata.yaml`
 
-A `--kata` install renders the GPU RuntimeClass, shim, puller, and device plugin
+A `--cvm-mode=pod` install renders the GPU RuntimeClass, shim, puller, and device plugin
 off `kata.enabled`, but the *injection* — the platform's confidential classes
 for `confidential.ai/cw` and `nvidia.com/*` pods — lives in the operator binary
 (`kataRuntimeClassFor`). The chart and the operator binary ship as a unit: bump
@@ -208,7 +208,7 @@ cannot boot: QEMU SIGABRTs (`kvm run failed Input/output error`, vCPU dead at
 the reset vector; dmesg: `kvm_intel: Guest access before accepting 0x807000`)
 and kubelet retries forever — an unbounded crash-loop spamming register dumps
 every ~90 s, not an error surfaced on the pod. Since the chart pins
-`kata-qemu-snp` on CDS and tls-lb, a `--kata` install on such a
+`kata-qemu-snp` on CDS and tls-lb, a `--cvm-mode=pod` install on such a
 host crash-loops its own control plane.
 
 Two guards exist; keep both intact:
@@ -217,7 +217,7 @@ Two guards exist; keep both intact:
    `scheduling.nodeSelector` on the `confidential.ai/sev-snp=true` label
    (`kata.snpNodeSelector`), so a confidential pod on an unlabelled node stays
    `Pending` with a clear scheduling message;
-2. `c8s install --kata` labels every kata-targeted node from the declared
+2. `c8s install --cvm-mode=pod` labels every kata-targeted node from the declared
    `--hardware-platform` (`cmd/c8s/tee_label.go` — declarative, no hardware
    probe; it refuses to run while any node still carries the other
    platform's label, printing the clear command) and fails fast when no
@@ -273,7 +273,7 @@ values) to wire it into every component's `imagePullSecrets` at install time
 
 cds's RA-TLS serving cert needs SNP evidence from `/dev/sev-guest`, which only
 exists **inside** an SNP guest (the host has `/dev/sev`, not `/dev/sev-guest`).
-The non-kata probes are httpGet/HTTPS. So running cds as host runc (no `--kata`)
+The non-kata probes are httpGet/HTTPS. So running cds as host runc (no `--cvm-mode=pod`)
 on bare metal has no clean Ready path — it is intended to run as `kata-qemu-snp`
 (gated on `kata.enabled`). For a non-confidential dev box, disable cds's RA-TLS
 (`cds.ratlsPlatform=""`, plaintext) and expect the HTTPS probe to fail.
@@ -366,7 +366,7 @@ Error response from registry: failed to resolve <tag>: GET …/manifests/<tag>: 
 exactly where `oras` looks (the container runs as root under
 `privileged: true`, so `$HOME=/root`). That Secret defaults to the
 install-time `imagePullSecret`, so a plain
-`c8s install --kata --image-pull-secret ghcr-secret` covers the oras pull
+`c8s install --cvm-mode=pod --image-pull-secret ghcr-secret` covers the oras pull
 along with every kubelet pull. Set `kata.guestImage.pullerAuthSecret` only
 when the artifact needs a different credential than the c8s images:
 
@@ -507,12 +507,12 @@ mesh-trust-assuming endpoints on 8443 in kata pods; rebuild the guest image
 with the variable emptied for a fully-meshed posture (front doors then need
 `kubectl port-forward` + a mesh client cert, i.e. are effectively internal).
 
-## First `--kata` install can exceed helm's `--wait` window
+## First `--cvm-mode=pod` install can exceed helm's `--wait` window
 
 `cmd/c8s/install.go` (`buildInstallHelmArgs`)
 
 On a node without a prior kata install, kata-deploy downloads the multi-GB kata
-payload inside the helm `--wait` window. `c8s install --kata` therefore waits
+payload inside the helm `--wait` window. `c8s install --cvm-mode=pod` therefore waits
 10 minutes (vs 5 for non-kata installs), which covers typical first installs —
 but a slow registry path can still blow it: the release lands as `failed` while
 the cluster converges fine underneath, and a second `c8s install` run (helm
@@ -525,7 +525,7 @@ check the pods first.
 
 The kata sweep removes `confidential.ai/sev-snp` / `confidential.ai/tdx`
 along with the kata artifacts. A subsequent
-`c8s install --kata -f <values>` can fail fast at the TDX/SNP node check (the
+`c8s install --cvm-mode=pod -f <values>` can fail fast at the TDX/SNP node check (the
 auto-label path doesn't cover every `-f` shape). Relabel by hand and rerun.
 
 ## `cds.node.selector: null` in a values file does not survive helm's multi-file merge

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -622,14 +622,22 @@ cache_max_entries = 1024
 
 {{/*
   c8s.serveAllowlistSeed is true when CDS should render the --allowlist-seed
-  ConfigMap/flag/mount. Two admission shapes consume CDS's served allowlist and
-  so need the seed: the host NRI plugin (nriImagePolicy.enabled), and the
-  in-guest policy-monitor baked into the kata-guest-base image (kata.enabled),
-  where the host plugin is off. Gating on nriImagePolicy.enabled alone dropped
-  the seed under kata, so adopted --workload-ref digests never reached CDS.
+  ConfigMap/flag/mount. Three admission shapes consume CDS's served allowlist
+  and so need the seed:
+    - the chart's host NRI plugin (nriImagePolicy.enabled),
+    - the in-guest policy-monitor baked into the kata-guest-base image
+      (kata.enabled, i.e. --cvm-mode=pod), where the host plugin is off, and
+    - the BAKED host NRI plugin on a node-as-CVM (--cvm-mode=node), where the
+      chart's nriImagePolicy is disabled because the node image bakes the
+      plugin — but that plugin still pulls the live allowlist from CDS, so the
+      seed must be served or CDS starts empty and every un-baked component
+      (operator, ratls-mesh, tls-lb's nginx, adopted workloads) is denied
+      until an operator hand-runs `c8s allowlist add`.
+  Gating on nriImagePolicy.enabled alone dropped the seed under both pod and
+  node mode.
 */}}
 {{- define "c8s.serveAllowlistSeed" -}}
-{{- or .Values.nriImagePolicy.enabled .Values.kata.enabled -}}
+{{- or .Values.nriImagePolicy.enabled .Values.kata.enabled (eq .Values.attestationApi.cvmMode "node") -}}
 {{- end -}}
 
 {{/*

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -282,17 +282,43 @@ a floating tag would be root on every GPU node — so the digest is what's used.
 
 {{- /*
 c8s.attestationApiURL — the attestation-api endpoint injected into the operator
-and CDS. Under kata.enabled the host attestation-api DaemonSet is typically not
-rendered; the kata-guest-base image bakes an in-guest attestation-service on
-loopback, and the components that consume this URL (the operator's get-cert
-sidecars and CDS) run INSIDE the CVM, so they must dial 127.0.0.1, not the
-(absent) host Service.
+and CDS. Three shapes:
+
+  - kata.enabled: the kata-guest-base image bakes an in-guest attestation-service
+    on loopback, and the consumers (the operator's get-cert sidecars and CDS) run
+    INSIDE the CVM, so they dial 127.0.0.1 — not the (absent) host Service.
+  - cvmMode=node: the node image bakes a HOST attestation-api on the node's
+    loopback :8400 (no in-cluster Service). Pod-netns consumers cannot reach host
+    loopback, so they dial the node's own IP via the $(HOST_IP) downward-API env
+    var (c8s.attestationApiHostIPEnv), which the kubelet expands per-node before
+    the process sees the arg. The operator forwards this string verbatim to the
+    tenant get-cert sidecars it injects, so it must stay unexpanded there (the
+    operator container deliberately omits HOST_IP); each tenant pod expands it
+    against its own node.
+  - otherwise: the in-cluster host Service DNS.
 */ -}}
 {{- define "c8s.attestationApiURL" -}}
 {{- if .Values.kata.enabled -}}
 http://127.0.0.1:{{ .Values.attestationApi.port }}
+{{- else if eq (.Values.attestationApi.cvmMode | default "baremetal") "node" -}}
+http://$(HOST_IP):{{ .Values.attestationApi.port }}
 {{- else -}}
 http://{{ include "c8s.attestationApiName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.attestationApi.port }}
+{{- end -}}
+{{- end -}}
+
+{{- /*
+c8s.attestationApiHostIPEnv — the HOST_IP downward-API env var that expands the
+$(HOST_IP) placeholder in c8s.attestationApiURL. Rendered only under
+cvmMode=node, where pod-netns consumers reach the node-baked host attestation-api
+via the node's own IP. Empty in every other mode.
+*/ -}}
+{{- define "c8s.attestationApiHostIPEnv" -}}
+{{- if eq (.Values.attestationApi.cvmMode | default "baremetal") "node" -}}
+- name: HOST_IP
+  valueFrom:
+    fieldRef:
+      fieldPath: status.hostIP
 {{- end -}}
 {{- end -}}
 
@@ -377,6 +403,12 @@ Caller passes a dict:
     {{- range .extraArgs }}
     - {{ . }}
     {{- end }}
+  {{- with (include "c8s.attestationApiHostIPEnv" $root) }}
+  # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node IP so
+  # this pod-netns sidecar reaches the node-baked host attestation-api.
+  env:
+    {{- . | nindent 4 }}
+  {{- end }}
   volumeMounts:
     - name: {{ .volume }}
       mountPath: {{ .mountPath }}

--- a/internal/helmchart/c8s/templates/attestation-api.yaml
+++ b/internal/helmchart/c8s/templates/attestation-api.yaml
@@ -87,7 +87,7 @@ spec:
             - name: http
               containerPort: {{ .Values.attestationApi.port }}
           securityContext:
-            {{- if has .Values.attestationApi.cvmMode (list "baremetal" "node" "gke" "aks") }}
+            {{- if has .Values.attestationApi.cvmMode (list "pod" "node" "gke" "aks") }}
             # All modes need privileged. A hostPath device mount does NOT add a
             # device-cgroup rule, so open(/dev/sev-guest|/dev/tdx-guest|/dev/tpm0)
             # is EPERM from an unprivileged container regardless of SYS_RAWIO
@@ -107,7 +107,7 @@ spec:
             seccompProfile:
               type: RuntimeDefault
             {{- else }}
-{{ fail (printf "attestationApi.cvmMode must be one of baremetal, node, gke, aks (got %q)" .Values.attestationApi.cvmMode) }}
+{{ fail (printf "attestationApi.cvmMode must be one of pod, node, gke, aks (got %q)" .Values.attestationApi.cvmMode) }}
             {{- end }}
           volumeMounts:
             - name: config

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -347,7 +347,7 @@ spec:
   # listener); a Service ClusterIP has no port-15006 endpoint, so the dial
   # times out (see ratls_mesh_tls_dial_failures_total). A pod IP routes
   # straight to the peer VM, where PREROUTING redirects port 15006 to the
-  # local mesh inbound. NodePort is unused under kata anyway — install --kata
+  # local mesh inbound. NodePort is unused under kata anyway — install --cvm-mode=pod
   # disables nriImagePolicy, the only consumer of cds NodePort.
   type: ClusterIP
   clusterIP: None

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -237,6 +237,12 @@ spec:
             - --rate-limiter-idle-timeout={{ .Values.cds.rateLimiterIdleTimeout }}
             - --ratls-platform={{ .Values.cds.ratlsPlatform }}
             - --ratls-cert-ttl={{ .Values.cds.ratlsCertTTL }}
+          {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+          # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node
+          # IP so this pod-netns pod reaches the node-baked host attestation-api.
+          env:
+            {{- . | nindent 12 }}
+          {{- end }}
           ports:
             - name: https
               containerPort: {{ .Values.cds.port }}

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ratlsMesh.enabled }}
-{{- $attestationApiURL := printf "http://%s-attestation-api.%s.svc:8400" .Release.Name .Release.Namespace -}}
+{{- $attestationApiURL := include "c8s.attestationApiURL" . -}}
 {{/*
   cds mode points a single --cds-url at the unified CDS, which serves both
   /attest and /ca.
@@ -283,6 +283,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            {{- /* cvmMode=node: HOST_IP expands $(HOST_IP) in
+                   --attestation-api-url. hostNetwork, so the node IP is this
+                   pod's own — the node-baked host attestation-api. */}}
+            {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+            {{- . | nindent 12 }}
+            {{- end }}
           ports:
             - name: outbound
               containerPort: {{ .Values.ratlsMesh.ports.outbound }}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -171,6 +171,12 @@ spec:
             {{- end }}
             - --upstream-server-name={{ $attestUpstreamServerName }}
             {{- end }}
+          {{- with (include "c8s.attestationApiHostIPEnv" .) }}
+          # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node
+          # IP so this pod-netns pod reaches the node-baked host attestation-api.
+          env:
+            {{- . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: tls-certs
               mountPath: {{ .Values.tlsLb.tlsMountPath }}

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -47,7 +47,7 @@
 {{- if .Values.attestationApi.enabled -}}{{- $hostSide = append $hostSide "attestationApi.enabled" -}}{{- end -}}
 {{- if .Values.nriImagePolicy.enabled -}}{{- $hostSide = append $hostSide "nriImagePolicy.enabled" -}}{{- end -}}
 {{- with $hostSide -}}
-{{- fail (printf "VALIDATION_ERROR kind=enforce_host_components: kata.enabled=true requires %s =false. kata is enforcing — every workload runs as a kata CVM, where these host-side components are replaced by their in-guest counterparts in the kata-guest-base image (in-VM ratls routing, in-guest attestation-api on loopback, in-guest policy-monitor image admission). `c8s install --kata` sets them for you." (join ", " .)) -}}
+{{- fail (printf "VALIDATION_ERROR kind=enforce_host_components: kata.enabled=true requires %s =false. kata is enforcing — every workload runs as a kata CVM, where these host-side components are replaced by their in-guest counterparts in the kata-guest-base image (in-VM ratls routing, in-guest attestation-api on loopback, in-guest policy-monitor image admission). `c8s install --cvm-mode=pod` sets them for you." (join ", " .)) -}}
 {{- end -}}
 {{- end -}}
 {{- if and .Values.nriImagePolicy.enabled (not .Values.cds.image.digest) -}}

--- a/internal/helmchart/c8s/templates/webhook.yaml
+++ b/internal/helmchart/c8s/templates/webhook.yaml
@@ -15,7 +15,7 @@ metadata:
     stays authoritative across re-installs. An explicit webhook.annotations
     value for the same key wins.
   */}}
-  {{- if and (eq (.Values.attestationApi.cvmMode | default "baremetal") "aks") (not (hasKey $webhookAnnotations "admissions.enforcer/disabled")) }}
+  {{- if and (eq (.Values.attestationApi.cvmMode | default "node") "aks") (not (hasKey $webhookAnnotations "admissions.enforcer/disabled")) }}
   {{- $_ := set $webhookAnnotations "admissions.enforcer/disabled" "true" }}
   {{- end }}
   {{- with $webhookAnnotations }}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -293,7 +293,7 @@ attestationApi:
   ## so the host DaemonSet is redundant (and crashloops on bare-metal nodes
   ## that don't attest as a TEE). c8s.attestationApiURL then resolves to the
   ## in-guest loopback endpoint for in-CVM consumers. Must be false under
-  ## kata.enabled (`c8s install --kata` sets it).
+  ## kata.enabled (`c8s install --cvm-mode=pod` sets it).
   enabled: true
   image:
     repository: ghcr.io/confidential-dot-ai/attestation-api
@@ -386,7 +386,7 @@ attestationApi:
 ## Kubernetes 1.30+ (ValidatingAdmissionPolicy v1), and the host-side
 ## ratls-mesh, attestation-api, and nriImagePolicy must be disabled — their
 ## function runs inside the kata-guest-base image (the render fails
-## otherwise; `c8s install --kata` sets all of it).
+## otherwise; `c8s install --cvm-mode=pod` sets all of it).
 kata:
   enabled: false
   image:
@@ -434,7 +434,7 @@ kata:
   ## scheduling.nodeSelector on the confidential SNP RuntimeClasses so a
   ## wrong-TEE node leaves pods Pending instead of crash-looping QEMU (see
   ## docs/pitfalls.md "kata-qemu-snp on a non-SNP host"). Scheduling aid, not
-  ## a security boundary — attestation is. `c8s install --kata` applies it to
+  ## a security boundary — attestation is. `c8s install --cvm-mode=pod` applies it to
   ## every kata-targeted node (declarative, no probe); -f/GitOps installs
   ## label out-of-band. Swept by `c8s uninstall` — keep in lockstep with
   ## snpCapabilityNodeLabel in cmd/c8s/uninstall.go. Set {} for unrestricted
@@ -443,7 +443,7 @@ kata:
   snpNodeSelector:
     confidential.ai/sev-snp: "true"
   ## TDX twin of snpNodeSelector: rendered as scheduling.nodeSelector on the
-  ## confidential TDX RuntimeClasses, applied by `c8s install --kata
+  ## confidential TDX RuntimeClasses, applied by `c8s install --cvm-mode=pod
   ## --hardware-platform=tdx`, swept by `c8s uninstall` — keep in lockstep
   ## with tdxHostLabelKey in cmd/c8s/install.go. Same opt-out and
   ## repoint-at-NFD semantics as snpNodeSelector.
@@ -483,7 +483,7 @@ kata:
     ## tolerates a non-CC GPU instead of refusing to boot. The debug launch
     ## measurement differs from the locked one, so attestation pinned to the
     ## locked reference value rejects debug guests. Dev/debugging only;
-    ## `c8s install --kata --debug` sets this.
+    ## `c8s install --cvm-mode=pod --debug` sets this.
     debug: false
     ## Pull the kata-guest-base oras artifact over plain HTTP (no TLS). For a
     ## local / in-cluster registry mirror only. Never set for a real registry.
@@ -552,7 +552,7 @@ kata:
         memory: 256Mi
 
   ## Confidential GPU (NVIDIA). Ships with every kata install — no
-  ## gpu.enabled: `c8s install --kata` renders the GPU shim + RuntimeClass,
+  ## gpu.enabled: `c8s install --cvm-mode=pod` renders the GPU shim + RuntimeClass,
   ## webhook injection for nvidia.com/* pods, the <tag>-nvidia guest-image
   ## puller, and the sandbox device plugin (its `enabled` below is the only
   ## opt-out). Host GPU provisioning (vfio-pci binding, GPU CC mode, BAR
@@ -625,7 +625,7 @@ kata:
 ratlsMesh:
   ## Host-side mesh routing. Must be false under kata.enabled — the ratls
   ## routing runs in-VM via kata-guest-base in that shape
-  ## (`c8s install --kata` sets it).
+  ## (`c8s install --cvm-mode=pod` sets it).
   enabled: true
 
   image:
@@ -797,7 +797,7 @@ ratlsMesh:
 nriImagePolicy:
   ## Host-side NRI image admission. Must be false under kata.enabled — image
   ## admission is the in-guest policy-monitor in that shape, fed from CDS's
-  ## served allowlist (`c8s install --kata` sets it). The bootstrapAllowlist
+  ## served allowlist (`c8s install --cvm-mode=pod` sets it). The bootstrapAllowlist
   ## below still feeds CDS's served seed when this is disabled but kata is on:
   ## the seed renders whenever host NRI or kata consumes it (see
   ## c8s.serveAllowlistSeed).

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -326,11 +326,13 @@ attestationApi:
     - gcp-tdx
   ## CVM platform shape — selects (via the install CLI) the TEE device:
   ##
-  ## baremetal (default): bare-metal CVM, native /dev/sev-guest.
-  ## node: generalized node-as-CVM — our own nodes (self-managed TDX/SNP) are
-  ##   themselves confidential VMs exposing a native TEE device (/dev/sev-guest,
-  ##   or /dev/tdx-guest with --hardware-platform tdx); pods run as ordinary
-  ##   processes attested via the node's own quote. Cloud-agnostic.
+  ## pod: per-pod confidential VMs via the Kata runtime — every workload pod is
+  ##   a kata CVM; host-side attestation-api/nri/ratls-mesh are disabled and
+  ##   served by the in-guest counterparts. Native TEE device.
+  ## node (default): generalized node-as-CVM — our own nodes (self-managed
+  ##   TDX/SNP) are themselves confidential VMs exposing a native TEE device
+  ##   (/dev/sev-guest, or /dev/tdx-guest with --hardware-platform tdx); pods run
+  ##   as ordinary processes attested via the node's own quote. Cloud-agnostic.
   ## gke: GKE managed confidential VM — also native /dev/sev-guest.
   ## aks: Azure confidential VM — SEV-SNP via the vTPM at /dev/tpm0.
   ##
@@ -338,7 +340,10 @@ attestationApi:
   ## device-cgroup rule, so open() on the TEE device is EPERM from an unprivileged
   ## container regardless of SYS_RAWIO. TODO: drop privileged by routing SNP attest
   ## through the TSM configfs report interface (/sys/kernel/config/tsm/report).
-  cvmMode: baremetal
+  ##
+  ## The install CLI requires --cvm-mode explicitly (no default there); this
+  ## chart default serves GitOps/HelmRelease consumers that set values directly.
+  cvmMode: node
   ## Unused while all modes render privileged: true (see cvmMode above). Retained
   ## for the planned least-privilege configfs path.
   securityContext:

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -3101,7 +3101,7 @@ func TestChartCwLabelIntegrityPolicyDisabled(t *testing.T) {
 	}
 }
 
-// helmTemplateKata renders the chart in the shape `c8s install --kata`
+// helmTemplateKata renders the chart in the shape `c8s install --cvm-mode=pod`
 // produces. kata is enforcing, so the host-side components whose function
 // moves into the kata-guest-base image are switched off (the chart validates
 // they are off — see TestChartKataRejectsHostSideComponents).
@@ -3169,7 +3169,7 @@ func TestChartKataRejectsHostSideComponents(t *testing.T) {
 	}
 }
 
-// The kata shape (what `c8s install --kata` renders) must drop the host-side
+// The kata shape (what `c8s install --cvm-mode=pod` renders) must drop the host-side
 // DaemonSets entirely — their in-guest counterparts ship in kata-guest-base.
 func TestChartKataShapeDropsHostSideComponents(t *testing.T) {
 	out, err := helmTemplateKata(t)
@@ -5172,7 +5172,7 @@ func pullerEnv(t *testing.T, helmOut, name string) string {
 
 // kata.guestImage.debug must repoint the puller at the `<tag>-debug` artifact
 // — the variant whose guest policy allows host log/exec streams (published in
-// lockstep by the kata-guest-base workflow; `c8s install --kata --debug` sets
+// lockstep by the kata-guest-base workflow; `c8s install --cvm-mode=pod --debug` sets
 // the value). Default off: a plain kata install pulls the locked image.
 func TestChartKataGuestImageDebugSelectsDebugTag(t *testing.T) {
 	out, err := helmTemplateKata(t)

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -153,7 +153,10 @@ func containerArgValue(args []string, flag string) (string, bool) {
 }
 
 func TestChartDefaultRendersReplacementStack(t *testing.T) {
-	out, err := helmTemplate(t)
+	// gke keeps the host-side attestation-api enabled and reachable at its
+	// in-cluster Service DNS (node disables it and points components at the
+	// baked host attestation-api via HOST_IP; that path is covered separately).
+	out, err := helmTemplate(t, "--set", "attestationApi.cvmMode=gke")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
@@ -1030,13 +1033,13 @@ func TestChartWebhookExtraExcludedFlowsToWebhookAndSweep(t *testing.T) {
 // pod-injector MutatingWebhookConfiguration carries
 // admissions.enforcer/disabled=true, so AKS's admissionsenforcer controller
 // stops rewriting the webhook namespaceSelector and conflicting with helm
-// re-applies. The default (baremetal) must NOT carry it — the annotation is
+// re-applies. The default (node) must NOT carry it — the annotation is
 // pure AKS plumbing and shouldn't appear on other platforms. A user-set
 // webhook.annotations value flows through alongside it.
 func TestChartWebhookOptsOutOfAKSAdmissionsEnforcer(t *testing.T) {
 	const annotation = "admissions.enforcer/disabled"
 
-	// Default (baremetal): no AKS opt-out annotation.
+	// Default (node): no AKS opt-out annotation.
 	out, err := helmTemplate(t)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
@@ -1046,7 +1049,7 @@ func TestChartWebhookOptsOutOfAKSAdmissionsEnforcer(t *testing.T) {
 		t.Fatalf("default chart missing MutatingWebhookConfiguration c8s-pod-injector\n%s", out)
 	}
 	if _, ok := def.Annotations[annotation]; ok {
-		t.Errorf("default (baremetal) webhook must not carry %s; got %v", annotation, def.Annotations)
+		t.Errorf("default (node) webhook must not carry %s; got %v", annotation, def.Annotations)
 	}
 
 	// aks: opt-out annotation present and "true".
@@ -1425,15 +1428,14 @@ func TestChartIntValueRejectsNonInteger(t *testing.T) {
 func TestChartAttestationApiPrivileged(t *testing.T) {
 	for _, tc := range []struct {
 		mode string
-		// baremetal is the chart default, so render it via the no-arg path to
+		// node is the chart default, so render it via the no-arg path to
 		// also guard that a plain install is privileged.
 		useDefault bool
 		// aks renders the privilege axis only — it must NOT also carry the
 		// least-privilege capabilities map (the modes are either/or, not merged).
 		noCapabilities bool
 	}{
-		{mode: "baremetal", useDefault: true},
-		{mode: "node"},
+		{mode: "node", useDefault: true},
 		{mode: "gke"},
 		{mode: "aks", noCapabilities: true},
 	} {
@@ -1466,7 +1468,7 @@ func TestChartAttestationApiInvalidCvmMode(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected render to fail on invalid cvmMode; got success\n%s", out)
 	}
-	assertHelmFailMessage(t, out, `attestationApi.cvmMode must be one of baremetal, node, gke, aks (got "bogus")`)
+	assertHelmFailMessage(t, out, `attestationApi.cvmMode must be one of pod, node, gke, aks (got "bogus")`)
 }
 
 // hasHostIPEnv reports whether the container carries a HOST_IP env var sourced
@@ -1539,10 +1541,10 @@ func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
 }
 
 // TestChartNonNodeModeKeepsServiceDNS proves the node-mode wiring does not leak
-// into the other cvmModes: baremetal/gke/aks still dial the in-cluster host
+// into the other cvmModes: pod/gke/aks still dial the in-cluster host
 // Service DNS and render no HOST_IP env anywhere.
 func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
-	for _, mode := range []string{"baremetal", "gke", "aks"} {
+	for _, mode := range []string{"pod", "gke", "aks"} {
 		t.Run(mode, func(t *testing.T) {
 			out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode="+mode, "--set", "tlsLb.attest.enabled=true")
 			if err != nil {
@@ -3618,7 +3620,10 @@ func TestChartPointsClientsAtCDS(t *testing.T) {
 // (no Secret/ca-cert flag), the allowlist DB, and the in-process JWKS (no
 // --jwks-url, since signing happens in the same binary).
 func TestChartCDSWiresInProcessTrustRoot(t *testing.T) {
-	out, err := helmTemplate(t)
+	// gke: host-side attestation-api at its Service DNS. node points CDS at the
+	// baked host attestation-api via HOST_IP (covered separately), so pin the
+	// Service-URL mode here.
+	out, err := helmTemplate(t, "--set", "attestationApi.cvmMode=gke")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1469,6 +1469,94 @@ func TestChartAttestationApiInvalidCvmMode(t *testing.T) {
 	assertHelmFailMessage(t, out, `attestationApi.cvmMode must be one of baremetal, node, gke, aks (got "bogus")`)
 }
 
+// hasHostIPEnv reports whether the container carries a HOST_IP env var sourced
+// from the status.hostIP downward-API field — the substitution source for the
+// $(HOST_IP) placeholder in the node-mode attestation-api URL.
+func hasHostIPEnv(c corev1.Container) bool {
+	for _, e := range c.Env {
+		if e.Name == "HOST_IP" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil &&
+			e.ValueFrom.FieldRef.FieldPath == "status.hostIP" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestChartNodeModeAttestationApiURLUsesHostIP proves cvmMode=node points the
+// pod-netns components (cds, tls-lb's cert sidecar, ratls-mesh) at the
+// node-baked host attestation-api via the $(HOST_IP) downward-API env var, since
+// there is no in-cluster Service and pods cannot reach host loopback. The
+// operator is the exception: it forwards its --attestation-api-url verbatim into
+// the tenant get-cert sidecars it injects, so the placeholder must stay
+// UNEXPANDED there — the operator container deliberately omits HOST_IP so each
+// tenant pod expands it against its own node.
+func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
+	const hostIPURL = "--attestation-api-url=http://$(HOST_IP):8400"
+	out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode=node", "--set", "tlsLb.attest.enabled=true")
+	if err != nil {
+		t.Fatalf("helm template (cvmMode=node): %v\n%s", err, out)
+	}
+
+	// cds: pod-netns, dials the host attestation-api via $(HOST_IP).
+	cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+	assertContainerArgs(t, cds, hostIPURL)
+	if !hasHostIPEnv(cds) {
+		t.Errorf("cds container missing HOST_IP downward-API env; have %+v", cds.Env)
+	}
+
+	// tls-lb c8s-cert sidecar (via c8s.getCertContainers).
+	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
+	assertContainerArgs(t, cert, hostIPURL)
+	if !hasHostIPEnv(cert) {
+		t.Errorf("tls-lb c8s-cert missing HOST_IP downward-API env; have %+v", cert.Env)
+	}
+
+	// tls-lb cds-attest sidecar (rendered under tlsLb.attest.enabled).
+	attest := renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest")
+	assertContainerArgs(t, attest, hostIPURL)
+	if !hasHostIPEnv(attest) {
+		t.Errorf("tls-lb cds-attest missing HOST_IP downward-API env; have %+v", attest.Env)
+	}
+
+	// ratls-mesh: hostNetwork, so $(HOST_IP) is its own node IP. Two-arg form.
+	mesh := renderedDaemonSetContainer(t, out, "c8s-ratls-mesh", "ratls-mesh")
+	if !slices.Contains(mesh.Args, "http://$(HOST_IP):8400") {
+		t.Errorf("ratls-mesh missing http://$(HOST_IP):8400 arg; have %v", mesh.Args)
+	}
+	if !hasHostIPEnv(mesh) {
+		t.Errorf("ratls-mesh missing HOST_IP downward-API env; have %+v", mesh.Env)
+	}
+
+	// operator: forwards the string verbatim; the placeholder must NOT be
+	// expanded here, so the container must NOT define HOST_IP.
+	if !slices.Contains(renderedOperatorArgs(t, out), hostIPURL) {
+		t.Errorf("operator missing verbatim %q\n%v", hostIPURL, renderedOperatorArgs(t, out))
+	}
+	op := renderedDeploymentContainer(t, out, "c8s-operator", "operator")
+	if hasHostIPEnv(op) {
+		t.Errorf("operator MUST NOT define HOST_IP (it forwards $(HOST_IP) verbatim to tenant sidecars); env %+v", op.Env)
+	}
+}
+
+// TestChartNonNodeModeKeepsServiceDNS proves the node-mode wiring does not leak
+// into the other cvmModes: baremetal/gke/aks still dial the in-cluster host
+// Service DNS and render no HOST_IP env anywhere.
+func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
+	for _, mode := range []string{"baremetal", "gke", "aks"} {
+		t.Run(mode, func(t *testing.T) {
+			out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode="+mode, "--set", "tlsLb.attest.enabled=true")
+			if err != nil {
+				t.Fatalf("helm template (cvmMode=%s): %v\n%s", mode, err, out)
+			}
+			cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+			assertContainerArgs(t, cds, "--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400")
+			if strings.Contains(out, "name: HOST_IP") {
+				t.Errorf("cvmMode=%s must not render any HOST_IP env\n%s", mode, out)
+			}
+		})
+	}
+}
+
 func TestChartRendersManagedClusterKnobs(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set", "serviceAccount.imagePullSecrets[0].name=ghcr-secret",

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -4583,6 +4583,53 @@ func TestChartAllowlistsTlsLbNginxSelfEntry(t *testing.T) {
 	})
 }
 
+// TestChartServesAllowlistSeedInNodeMode guards the node-as-CVM seed path: with
+// --cvm-mode=node the chart's nriImagePolicy is disabled (the node image bakes
+// the plugin) and kata is off, yet the baked plugin still pulls the live
+// allowlist from CDS. If the seed is not served, CDS starts empty and every
+// un-baked component (operator, ratls-mesh, tls-lb's nginx) is denied until an
+// operator hand-runs `c8s allowlist add`. Regression for that deadlock: the seed
+// ConfigMap must render, be mounted, and carry the deployed digests.
+func TestChartServesAllowlistSeedInNodeMode(t *testing.T) {
+	const (
+		opD = "sha256:00000000000000000000000000000000000000000000000000000000000000c1"
+		rmD = "sha256:00000000000000000000000000000000000000000000000000000000000000c2"
+	)
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=node",
+		"--set", "attestationApi.enabled=false",
+		"--set", "nriImagePolicy.enabled=false",
+		"--set", "nriImagePolicy.bootstrapAllowlist.deriveComponents=true",
+		"--set-string", "image.digest="+opD,
+		"--set-string", "ratlsMesh.image.digest="+rmD,
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+
+	cm := renderedConfigMap(t, out, "c8s-cds-allowlist-seed")
+	seed, err := pkgallowlist.ParseJSON([]byte(cm.Data["allowlist-seed.json"]))
+	if err != nil {
+		t.Fatalf("node-mode seed JSON does not parse (CDS would start empty): %v\n%s", err, cm.Data["allowlist-seed.json"])
+	}
+	// The un-baked components denied in the un-seeded case: operator, ratls-mesh,
+	// and tls-lb's nginx (default digest from values.yaml).
+	if got := seed.Digests[opD]; got != "ghcr.io/confidential-dot-ai/c8s-operator@"+opD {
+		t.Errorf("node-mode seed missing operator entry; got %q\nseed: %v", got, seed.Digests)
+	}
+	if got := seed.Digests[rmD]; got != "ghcr.io/confidential-dot-ai/ratls-mesh@"+rmD {
+		t.Errorf("node-mode seed missing ratls-mesh entry; got %q\nseed: %v", got, seed.Digests)
+	}
+	const nginxD = "sha256:4359d693e04e2384cafa10a0fcdca850767dcf541457470124542356a9852c3f"
+	if _, ok := seed.Digests[nginxD]; !ok {
+		t.Errorf("node-mode seed missing tls-lb nginx self-entry\nseed: %v", seed.Digests)
+	}
+	// The flag/mount must be present so CDS actually loads the seed.
+	if !strings.Contains(out, "--allowlist-seed=/etc/cds/allowlist-seed.json") {
+		t.Errorf("node-mode CDS missing --allowlist-seed flag; seed rendered but not loaded")
+	}
+}
+
 // The nri-image-policy containerd-prep init container (rke2 only) runs busybox,
 // which is not a c8sComponent, so it is never in the derive set. The host plugin
 // enforces every container node-wide, so unless busybox is self-seeded a
@@ -4804,13 +4851,21 @@ func TestChartWiresCDSAllowlistSeedFlagAndVolume(t *testing.T) {
 
 // With host NRI disabled and no kata, nothing consumes CDS's served allowlist,
 // so the seed wiring must drop out entirely.
-func TestChartOmitsCDSSeedWhenImagePolicyDisabled(t *testing.T) {
-	out, err := helmTemplate(t, "--set", "nriImagePolicy.enabled=false")
+func TestChartOmitsCDSSeedWhenNoAllowlistConsumer(t *testing.T) {
+	// The seed is served only when something consumes CDS's allowlist: the host
+	// NRI plugin (nriImagePolicy.enabled), the in-guest policy-monitor (kata), or
+	// the baked node-mode plugin (cvmMode=node). With all three off — a cloud
+	// mode whose host plugin is explicitly disabled — there is no consumer, so
+	// the seed ConfigMap and flag must not render.
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=gke",
+		"--set", "nriImagePolicy.enabled=false",
+	)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
 	if renderedManifestHasNamedKind(t, out, "ConfigMap", "c8s-cds-allowlist-seed") {
-		t.Fatalf("seed ConfigMap should not render when nriImagePolicy is disabled")
+		t.Fatalf("seed ConfigMap should not render when no allowlist consumer is enabled")
 	}
 	cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
 	assertContainerNoArgPrefix(t, "cds", cds.Args, "--allowlist-seed")

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -883,6 +883,15 @@ func getCertEnv(inj *injection) []corev1.EnvVar {
 		{Name: "C8S_POD_UID", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},
 		}},
+		// cvmMode=node: the chart passes the operator a verbatim
+		// --attestation-api-url=http://$(HOST_IP):8400, forwarded unexpanded into
+		// this arg (certContainer). The kubelet expands $(HOST_IP) against THIS
+		// tenant pod's node, so the sidecar reaches the node-baked host
+		// attestation-api on whichever node it lands. Unused (harmless) in modes
+		// whose URL has no $(HOST_IP).
+		{Name: "HOST_IP", ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
+		}},
 	}
 }
 

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -111,6 +111,43 @@ func TestMutatePodInjectsCertSidecar(t *testing.T) {
 	}
 }
 
+// TestMutatePodCertSidecarCarriesHostIPEnv proves the injected c8s-cert sidecar
+// defines HOST_IP from status.hostIP. Under cvmMode=node the chart passes the
+// operator --attestation-api-url=http://$(HOST_IP):8400 verbatim, forwarded into
+// this sidecar's args; the kubelet expands $(HOST_IP) against the tenant pod's
+// own node so the sidecar reaches the node-baked host attestation-api wherever
+// it lands. The env is unconditional (harmless when the URL has no placeholder).
+func TestMutatePodCertSidecarCarriesHostIPEnv(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+
+	mutatePod(pod, &injection{WorkloadID: "api"}, Config{
+		GetCertImage:      "image",
+		CDSURL:            "http://cds",
+		AttestationApiURL: "http://$(HOST_IP):8400",
+		CertDir:           "/etc/c8s/certs",
+	})
+
+	cert := pod.Spec.InitContainers[0]
+	if !hasArg(cert.Args, "--attestation-api-url=http://$(HOST_IP):8400") {
+		t.Fatalf("c8s-cert args %v missing verbatim $(HOST_IP) URL", cert.Args)
+	}
+	var found bool
+	for _, e := range cert.Env {
+		if e.Name == "HOST_IP" {
+			found = true
+			if e.ValueFrom == nil || e.ValueFrom.FieldRef == nil || e.ValueFrom.FieldRef.FieldPath != "status.hostIP" {
+				t.Fatalf("HOST_IP env = %#v, want fieldRef status.hostIP", e)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("c8s-cert env %#v missing HOST_IP (tenant sidecar cannot expand $(HOST_IP))", cert.Env)
+	}
+}
+
 func TestMutatePodPreservesExistingFSGroup(t *testing.T) {
 	existing := int64(1234)
 	pod := &corev1.Pod{

--- a/kata-guest-base/README.md
+++ b/kata-guest-base/README.md
@@ -8,7 +8,7 @@ kata-containers runtime on each c8s node; kata-runtime boots this guest
 for every `runtimeClassName: kata-qemu-snp*` pod. The pod *is* the
 SEV-SNP confidential VM — its memory is encrypted against the host. See
 [`../docs/kata-guest-base.md`](../docs/kata-guest-base.md) for the design
-rationale, the attestation flow, and how it fits into `c8s install --kata`.
+rationale, the attestation flow, and how it fits into `c8s install --cvm-mode=pod`.
 
 ## Boot model — why this is NOT an IGVM/UKI image
 
@@ -189,7 +189,7 @@ only, never production. Because the policy is in the dm-verity root, the
 debug image's launch measurement necessarily differs from the locked one:
 attestation pinned to the locked reference value rejects debug guests, so
 a debug image can't silently stand in for a locked one. Select it with
-`c8s install --kata --debug` (`kata.guestImage.debug=true`).
+`c8s install --cvm-mode=pod --debug` (`kata.guestImage.debug=true`).
 
 ## Constraints
 

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -36,7 +36,7 @@
 #   it (e.g. to add a non-permissive default to some RPC), the operator
 #   rebuilds the guest image and rolls kata-qemu-snp pods to pick up the
 #   new kata-guest-base tag by setting `kata.guestImage.tag` in a values
-#   file (`c8s install --kata -f values.yaml`).
+#   file (`c8s install --cvm-mode=pod -f values.yaml`).
 #
 # Historical note:
 #

--- a/kata-guest-base/scripts/ci/compute-tags.sh
+++ b/kata-guest-base/scripts/ci/compute-tags.sh
@@ -4,7 +4,7 @@
 # `debug_tags` (comma-joined) to GITHUB_OUTPUT. `debug_tags` is every tag
 # with a `-debug` suffix — the debug-policy variant (build.sh Step 5/5,
 # output-debug/) publishes under it in lockstep with the locked image, so
-# `kata.guestImage.debug=true` (`c8s install --kata --debug`) can derive the
+# `kata.guestImage.debug=true` (`c8s install --cvm-mode=pod --debug`) can derive the
 # debug ref from any locked tag.
 #
 # Always publish the immutable, commit-pinned short-SHA tag. Then add exactly one


### PR DESCRIPTION
Stacks on #88 (`feat/cvm-mode-node-baked-components`).

## What

Cleans up the `--cvm-mode` enum to `{pod, node, gke, aks}` and makes it **required** (no default on the CLI).

- **Drop `baremetal`.** It was the pre-baked-components alias of `node`. Since #88 gave `node` its own wiring (disable the baked attestation-api + nri), the only remaining baremetal shape — chart-provided stack on a plain confidential host — is covered by `aks` / `gke`/`pod`, and every install now states its shape explicitly instead of defaulting to a mode that may silently mismatch the cluster.
- **`--kata` → `--cvm-mode=pod`.** Kata was always a distinct *deployment shape* (per-pod confidential VMs), not an orthogonal toggle. It now lives on the mode axis. `--debug` gates on `--cvm-mode=pod`. The kata wiring (`kata.enabled` + host-service disables) is unchanged, just keyed off the mode. `--kata` is **removed entirely** (no alias).

## Decisions

- **`--cvm-mode` required, no default** — an unstated shape silently mismatching the cluster (baked vs chart-provided attestation stack, kata vs plain runtime) is exactly the failure this makes impossible.
- The **chart** keeps a default (`node`) for GitOps/HelmRelease consumers that set values directly; only the CLI requires the flag.

## Scope

install.go / render_values.go flag surface + arg builders, chart validation + webhook AKS-annotation default + values.yaml default, and a full `--kata` → `--cvm-mode=pod` sweep across docs, chart comments, and kata-guest-base. All cmd + chart tests updated and passing; `go vet ./...` clean.

## Breaking

`c8s install` now requires `--cvm-mode`; `--kata` is gone (use `--cvm-mode=pod`); `--cvm-mode=baremetal` is gone (use `node`, `gke`, or `pod`).