### PR TITLE
ci: vendor the confidential-e2e lane in-repo to unblock the merge trigger

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -37,4 +37,12 @@ jobs:
     # the trailing @main tag is a human label only.
     uses: ./.github/workflows/e2e-c8s.yml
     with:
-      c8s_ref: ${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}
+      # INTERIM -- pin the KNOWN-GREEN bundle, NOT the merge head. c8s main's
+      # cvmMode=node (#88) dials a node-baked attestation-api on $(HOST_IP):8400
+      # that the current staged rke2 node image does not bake, so main reds until
+      # confos PR#51 (c8s-profile baked-AA node image) is merged + staged.
+      # 70aea72 + attestation-api sha-63a97d3 is the last set proven green here.
+      # REVERT to `${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}`
+      # and drop aa_ref once the baked-AA node image is staged.
+      c8s_ref: 70aea72fac1f3dc7c96e016ecc95667366cf7837
+      aa_ref: sha-63a97d3

--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -35,6 +35,6 @@ jobs:
        (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')))
     # Reusable lane pinned by commit SHA (bump deliberately when the lane changes);
     # the trailing @main tag is a human label only.
-    uses: confidential-dot-ai/confidential-ci/.github/workflows/e2e-c8s.yml@cad0dd13ac445188a3bd1641b6506c45658f274f
+    uses: ./.github/workflows/e2e-c8s.yml
     with:
       c8s_ref: ${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}

--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -1,0 +1,404 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# THE PRIMITIVE — "run CI inside a CVM", reusable across the whole stack.
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This is the ONE generic thing: boot a measured CVM on a platform, attest it,
+# hand a caller-supplied PAYLOAD a way to run commands inside it, tear it down.
+# It knows NOTHING about c8s. c8s-install is just one payload; `cargo test
+# --features attest` is another. Consumers stay ~15 lines.
+#
+#   WHAT to test  -> the caller's `payload_b64`   (per-repo)
+#   WHERE to test -> `platform` + `flavor`        (this file's matrix knowledge)
+#   WHEN to test  -> the caller's trigger         (not our business)
+#
+# PAYLOAD CONTRACT (runs as root INSIDE the guest):
+#   given:  $K          in-guest kubectl (timeout-wrapped) — cluster flavors only
+#           $MEAS       the node's RUNTIME SNP launch measurement (configfs-tsm),
+#                       i.e. the exact value CDS/verifiers compare against
+#           $GHCR_USER / $GHCR_TOKEN   registry creds, if the caller passed them
+#   must:   echo "@@PAYLOAD_OK@@" on success (that is the gate)
+#   may:    echo "@@ANYTHING@@" for progress — relayed to the run log live
+#
+# Everything the payload prints is streamed to the serial console and read back
+# host-side from the guest-console-log sidecar (fast); the console is used ONLY
+# to deliver + launch, never to poll.
+name: cvm-e2e (primitive)
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: 'target cell: snp-metal | tdx-metal | gke-snp | gke-tdx'
+        type: string
+        required: true
+      runner:
+        description: 'runs-on label serving that platform'
+        type: string
+        required: true
+      payload_b64:
+        description: 'base64 of the bash script to run IN the guest (see contract above)'
+        type: string
+        required: true
+      flavor:
+        description: 'CVM image flavor: rke2-node (a k8s cluster) | base-cpu (plain attested VM)'
+        type: string
+        default: rke2-node
+      timeout_minutes:
+        type: number
+        default: 55
+    secrets:
+      ghcr_user:
+        required: false
+      ghcr_token:
+        required: false
+    outputs:
+      measurement:
+        description: 'the CVM runtime launch measurement this run attested'
+        value: ${{ jobs.cvm.outputs.measurement }}
+
+jobs:
+  cvm:
+    name: cvm (${{ inputs.platform }}/${{ inputs.flavor }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
+    concurrency: cvm-e2e-${{ inputs.platform }}   # console is exclusive per VMI
+    outputs:
+      measurement: ${{ steps.run.outputs.measurement }}
+    env:
+      NS: confai-images
+      VM: cvm-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: platform config
+        run: |
+          set -euo pipefail
+          # keyed on platform/flavor: the flavor picks the image (refs CM), the
+          # platform picks the hardware cell. base-cpu = plain attested VM
+          # (attestation-api :8400, /dev/sev-guest, NO toolchain — verity rootfs).
+          case '${{ inputs.platform }}/${{ inputs.flavor }}' in
+            snp-metal/rke2-node) echo "REFS_CM=rke2-image-refs"; echo "CORES=4"; echo "MEMORY=16Gi";
+                                 echo "NODE_LABEL=confidential.ai/sev-snp" ;;
+            snp-metal/base-cpu)  echo "REFS_CM=base-image-refs"; echo "CORES=4"; echo "MEMORY=8Gi";
+                                 echo "NODE_LABEL=confidential.ai/sev-snp" ;;
+            *) echo "::error::cell '${{ inputs.platform }}/${{ inputs.flavor }}' not wired yet (tdx-metal/gke-* are stubs)"; exit 1 ;;
+          esac >> "$GITHUB_ENV"
+
+      - name: tools (kubectl + virtctl pinned to host KubeVirt + expect)
+        run: |
+          set -euo pipefail
+          sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends jq ca-certificates bsdutils expect
+          mkdir -p "$PWD/bin"
+          curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl
+          curl -fsSL https://github.com/kubevirt/kubevirt/releases/download/v1.7.0/virtctl-v1.7.0-linux-amd64 -o bin/virtctl
+          echo "ec6ee5619290e19590f3f9cd8b8dfce1affe0380eaaca77b3784c7b1acea86a6  bin/virtctl" | sha256sum -c -
+          chmod +x bin/*; echo "$PWD/bin" >> "$GITHUB_PATH"
+
+      - name: resolve producer image refs
+        run: |
+          set -euo pipefail
+          ROOTPVC=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.rootPvc}')
+          [ -n "$ROOTPVC" ] || { echo "::error::$REFS_CM missing rootPvc — run c8s-e2e/cluster-prep/apply.sh"; exit 1; }
+          # rke2-image-refs pins one file (igvmFile); base-image-refs publishes a
+          # per-core-count pattern (igvmFilePattern: guest-smp{cores}.igvm)
+          IGVMFILE=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFile}')
+          if [ -z "$IGVMFILE" ]; then
+            PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
+            [ -n "$PAT" ] || { echo "::error::$REFS_CM has neither igvmFile nor igvmFilePattern"; exit 1; }
+            IGVMFILE=${PAT//\{cores\}/$CORES}
+          fi
+          {
+            echo "ROOTPVC=$ROOTPVC"
+            echo "IGVMFILE=$IGVMFILE"
+          } >> "$GITHUB_ENV"
+
+      # reap-before-provision: a killed run leaks its CVM + its rootdisk clone.
+      # CROSS-REPO SAFE: this primitive is called from ANY org repo, so a CVM may be
+      # owned by a run in a DIFFERENT repo than the one reaping. Read the owning repo
+      # off the CVM and query THAT repo. Fail SAFE: only reap on a positive
+      # "completed" — an unknown status (403/404/no token for a foreign repo) KEEPS
+      # the CVM, or we'd kill a live run's cluster. Age is the only override.
+      - name: reap leaked CVMs from finished runs
+        run: |
+          set +e +o pipefail
+          NOW=$(date -u +%s)
+          for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
+            rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
+            orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
+            [ -z "$rid" ] && continue
+            [ "$rid" = "${{ github.run_id }}" ] && continue
+            # age fallback: our runs are capped well under 3h, so anything older is
+            # certainly orphaned even if we can't read its run status
+            ct=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null)
+            age=$(( NOW - $(date -u -d "$ct" +%s 2>/dev/null || echo "$NOW") ))
+            st=$(gh api "repos/${orepo:-${{ github.repository }}}/actions/runs/$rid" -q .status 2>/dev/null)
+            if [ "$st" = "completed" ]; then
+              echo "reaping $vm (run ${orepo}#$rid completed)"; kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+            elif [ -z "$st" ] && [ "$age" -gt 10800 ]; then
+              echo "reaping $vm (status unknown, age ${age}s > 3h -> orphaned)"; kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+            else
+              echo "keeping $vm (run ${orepo}#$rid status=${st:-unknown} age=${age}s)"
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: boot the measured CVM
+        run: |
+          set -euo pipefail
+          kubectl apply -f - <<EOF
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: $VM
+            namespace: $NS
+            labels:
+              ci.confidential.ai/managed: "true"
+              ci.confidential.ai/run-id: "${{ github.run_id }}"
+              ci.confidential.ai/run-attempt: "${{ github.run_attempt }}"
+              ci.confidential.ai/platform: "${{ inputs.platform }}"
+              ci.confidential.ai/flavor: "${{ inputs.flavor }}"
+            annotations:
+              # which repo's run owns this CVM — the reaper needs it because ANY org
+              # repo can call this primitive (label values can't hold the '/' in owner/repo)
+              ci.confidential.ai/repo: "${{ github.repository }}"
+              ci.confidential.ai/run-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          spec:
+            runStrategy: Always
+            template:
+              metadata:
+                labels:
+                  vm.kubevirt.io/name: $VM
+                annotations:
+                  igvm.confidential.ai/file: "$IGVMFILE"
+                  hooks.kubevirt.io/hookSidecars: '[{"image":"ghcr.io/confidential-dot-ai/igvm-hook-sidecar@sha256:7450bb136bfc4d9434a7c1eb9e478ab3237e7d9acf5c211e7d080f2008b01ba0","imagePullPolicy":"IfNotPresent","args":["--version","v1alpha3"],"pvc":{"name":"igvm-files","volumePath":"/igvm","sharedComputePath":"/var/run/igvm"}}]'
+              spec:
+                nodeSelector:
+                  ${NODE_LABEL}: "true"
+                domain:
+                  cpu:
+                    model: EPYC-Genoa
+                    cores: ${CORES}          # MUST match the image's measured smp
+                  memory:
+                    guest: ${MEMORY}
+                  resources:
+                    requests:
+                      memory: ${MEMORY}
+                  firmware:
+                    bootloader:
+                      efi:
+                        secureBoot: false
+                  launchSecurity:
+                    snp: {}
+                  devices:
+                    disks:
+                      - name: rootdisk
+                        disk:
+                          bus: virtio
+                    interfaces:
+                      - name: default
+                        bridge: {}           # masquerade is broken under SNP
+                    rng: {}
+                networks:
+                  - name: default
+                    pod: {}
+                volumes:
+                  - name: rootdisk
+                    persistentVolumeClaim:
+                      claimName: $ROOTPVC
+          EOF
+          for i in $(seq 1 70); do
+            PHASE=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+            [ "$PHASE" = Running ] && break; sleep 6
+          done
+          [ "$PHASE" = Running ] || { kubectl -n "$NS" describe vmi "$VM" | tail -30; echo "::error::VMI not Running"; exit 1; }
+          POD=$(kubectl -n "$NS" get pods -l vm.kubevirt.io/name="$VM" -o name | head -1)
+          echo "POD=${POD#pod/}" >> "$GITHUB_ENV"
+          echo "VMI Running (launcher ${POD#pod/})"
+
+      - name: assert genuine confidential boot
+        run: |
+          set -uo pipefail
+          kubectl -n "$NS" exec "$POD" -c compute -- sh -c \
+            "tr '\0' '\n' < /proc/\$(pgrep -f qemu-system | head -1)/cmdline | grep -cE 'sev-snp-guest'" | tee /tmp/snp.cnt
+          [ "$(cat /tmp/snp.cnt 2>/dev/null)" = "1" ] && echo 'OK: genuine sev-snp-guest' || { echo '::error::not a sev-snp-guest'; exit 1; }
+
+      - name: run payload in the CVM
+        id: run
+        env:
+          GHCR_USER: ${{ secrets.ghcr_user }}
+          GHCR_TOKEN: ${{ secrets.ghcr_token }}
+        run: |
+          # best-effort loops: GHA's default bash -e + pipefail turn a no-match grep
+          # into a silent step kill
+          set +e +o pipefail
+          export VM NS
+          SA=/var/run/secrets/kubernetes.io/serviceaccount
+          kubectl config set-cluster h --server="https://kubernetes.default.svc" --certificate-authority="$SA/ca.crt" --kubeconfig=/tmp/host.kubeconfig >/dev/null
+          kubectl config set-credentials s --token="$(cat $SA/token)" --kubeconfig=/tmp/host.kubeconfig >/dev/null
+          kubectl config set-context h --cluster=h --user=s -n "$NS" --kubeconfig=/tmp/host.kubeconfig >/dev/null
+          kubectl config use-context h --kubeconfig=/tmp/host.kubeconfig >/dev/null
+          # expect gives virtctl a real pty (a piped `script` does NOT forward keys)
+          cat > /tmp/send.exp <<'EXP'
+          set timeout 6
+          spawn virtctl --kubeconfig /tmp/host.kubeconfig console $env(VM) -n $env(NS)
+          expect timeout
+          send -- "\r"
+          expect timeout
+          send -- "$env(GUESTCMD)\r"
+          set timeout 4
+          expect timeout
+          send -- "\x1d"
+          EXP
+          cat > /tmp/gsend.sh <<'SH'
+          GUESTCMD="$1" VM="$VM" NS="$NS" timeout -k5 45 expect -f /tmp/send.exp >/dev/null 2>&1
+          SH
+
+          echo "waiting for the guest autologin shell (~180s; boot blocks on networkd-wait-online)..."
+          shell_ready=
+          for i in $(seq 1 30); do
+            kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | grep -q 'automatic login' && { shell_ready=1; echo "shell ready"; break; }
+            sleep 15
+          done
+          if [ -z "$shell_ready" ]; then
+            # don't attempt delivery into a console nobody is listening on — say WHY.
+            # (probe finding 2026-07-15: the base-cpu image emits NOTHING after the
+            # EFI stub — no kernel console, no autologin. Console delivery requires
+            # an image that autologins on the serial console, like rke2-node. For
+            # consoleless images the path forward is the in-guest HTTP agent —
+            # research/guest-transport.md.)
+            echo "::error::guest console never showed an autologin shell — this image cannot take console-delivered payloads. Console tail:"
+            kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | tail -15
+            exit 1
+          fi
+
+          # DRIVER = primitive preamble + caller payload. The preamble discovers the
+          # node's own runtime launch measurement (configfs-tsm: raw SNP report,
+          # MEASUREMENT at offset 0x90/144, 48 bytes) — the exact value verifiers
+          # compare — and exports it to the payload as $MEAS.
+          printf '%s' '${{ inputs.payload_b64 }}' | base64 -d > /tmp/payload.sh
+          cat > /tmp/drive.sh <<DRIVER
+          #!/bin/bash
+          set +e
+          export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+          export K="timeout 25 /var/lib/rancher/rke2/bin/kubectl"
+          say(){ echo "@@\$1@@"; }
+          say DRIVE_START
+          if [ '${{ inputs.flavor }}' = 'rke2-node' ]; then
+            for i in \$(seq 1 40); do \$K get nodes --no-headers 2>/dev/null | grep -q ' Ready' && break; sleep 6; done
+            \$K get nodes --no-headers 2>&1 | grep -q ' Ready' && say NODE_READY || { say FAIL_NODE; exit 0; }
+          fi
+          MEAS=""
+          TD=/sys/kernel/config/tsm/report/cvmci
+          if mkdir -p "\$TD" 2>/dev/null; then
+            head -c 64 /dev/urandom > "\$TD/inblob" 2>/dev/null
+            MEAS=\$(python3 -c "import binascii,sys; d=open('\$TD/outblob','rb').read(); sys.stdout.write(binascii.hexlify(d[144:192]).decode())" 2>/dev/null)
+            rmdir "\$TD" 2>/dev/null
+          fi
+          export MEAS
+          echo "@@MEAS \${MEAS:-none}@@"
+          export GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN'
+          # ───────── caller payload ─────────
+          $(cat /tmp/payload.sh)
+          # ───────── end payload ─────────
+          say DRIVE_END
+          DRIVER
+
+          # deliver (chunked base64). A dropped chunk truncates the script, so verify
+          # byte-count + `bash -n` and retry. Build the OK marker from a runtime var so
+          # the success string can't appear in the typed command (else grep matches the echo).
+          DB=$(base64 -w0 /tmp/drive.sh); EXPLEN=${#DB}
+          echo "delivering driver ($EXPLEN b64 chars)..."
+          delivered=
+          for att in 1 2 3 4 5; do
+            bash /tmp/gsend.sh "rm -f /tmp/d.b64"
+            # 3000-char chunks (the guest tty's canonical input limit is ~4096 and the
+            # wrapper is ~30) — payloads are caller-supplied and vary in size, and at
+            # w700 a ~7KB driver was ~11 sends x ~15s = ~3min PER attempt.
+            # `|| [ -n "$c" ]` processes fold's LAST (newline-less) chunk — without it
+            # every delivery truncates identically.
+            printf '%s' "$DB" | fold -w3000 | while IFS= read -r c || [ -n "$c" ]; do bash /tmp/gsend.sh "printf %s '$c' >>/tmp/d.b64"; done
+            bash /tmp/gsend.sh "L=\$(wc -c </tmp/d.b64 | tr -d ' '); R=x; [ \"\$L\" = \"$EXPLEN\" ] && R=OK; echo \"@@DLEN\${R}${att}v\${L}@@\""
+            sleep 4
+            LOG=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n')
+            printf '%s' "$LOG" | grep -q "@@DLENOK${att}v" && { delivered=1; echo "driver delivered intact (attempt $att)"; break; }
+            printf '%s' "$LOG" | grep -oE "@@DLENx${att}v[0-9]*@@" | tail -1 | sed 's/^/  short: /'
+          done
+          [ -n "$delivered" ] || { echo "::error::driver delivery kept truncating"; exit 1; }
+          bash /tmp/gsend.sh "R=ERR; base64 -d /tmp/d.b64 >/tmp/drive.sh 2>/dev/null && bash -n /tmp/drive.sh 2>/dev/null && R=OK; echo \"@@DEC\${R}z@@\""
+          sleep 4
+          kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | grep -q '@@DECOKz@@' || { echo "::error::driver failed bash -n"; exit 1; }
+          # launch detached with stdout on the console (NOT nohup: it redirects a tty
+          # stdout to nohup.out and swallows everything)
+          bash /tmp/gsend.sh "(setsid sh -c 'bash /tmp/drive.sh 2>&1 | tee /tmp/drive.out >/dev/ttyS0' </dev/null &) ; echo @@LAUNCHED@@"
+
+          echo "--- payload progress (host-side polling of guest-console-log) ---"
+          seen=""; ok=""
+          for i in $(seq 1 110); do
+            LOG=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g')
+            NEW=$(printf '%s' "$LOG" | grep -oE '@@[^@]{1,140}@@' | sed 's/@@//g')
+            comm -13 <(printf '%s\n' "$seen" | sort -u) <(printf '%s\n' "$NEW" | sort -u) 2>/dev/null | grep -vE '^$' | sed 's/^/  · /'
+            seen="$NEW"
+            printf '%s' "$LOG" | grep -q '@@PAYLOAD_OK@@' && { ok=1; echo "PAYLOAD_OK"; break; }
+            printf '%s' "$LOG" | grep -qE '@@FAIL_' && { echo "payload reported a failure marker"; break; }
+            printf '%s' "$LOG" | grep -q '@@DRIVE_END@@' && { echo "driver ended without PAYLOAD_OK"; break; }
+            sleep 10
+          done
+          M=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | grep -oE '@@MEAS [0-9a-f]{96}@@' | tail -1 | grep -oE '[0-9a-f]{96}')
+          echo "measurement=${M:-}" >> "$GITHUB_OUTPUT"
+          # golden drift check (warn-mode; promote to fail-closed after one clean
+          # image bump). The reference is the RUNTIME measurement captured at
+          # image-bump time into the refs CM — NOT the image manifest's
+          # snp_launch_digest, which is computed under different boot assumptions
+          # and has been wrong twice. Capture/refresh after a bump:
+          #   kubectl -n confai-images patch cm <refs-cm> --type merge \
+          #     -p '{"data":{"runtimeLaunchDigest":"<measurement from a green run>"}}'
+          GOLD=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.runtimeLaunchDigest}' 2>/dev/null)
+          if [ -n "$GOLD" ] && [ -n "$M" ] && [ "${GOLD,,}" != "${M,,}" ]; then
+            echo "::warning title=launch measurement drift::runtime $M != $REFS_CM.runtimeLaunchDigest $GOLD — image bumped without refreshing the golden, or unexpected boot-config change"
+          fi
+          if [ -z "$ok" ]; then
+            echo "::error::payload did not report PAYLOAD_OK. Driver console output:"
+            kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '@@.*@@' | tail -60
+            exit 1
+          fi
+          echo "✅ ${{ inputs.platform }}/${{ inputs.flavor }}: attested CVM (runtime launch measurement ${M:-unknown}) ran the payload to PAYLOAD_OK"
+
+      - name: diagnostics (on failure)
+        if: failure()
+        run: kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g' | tail -60 || true
+
+      # forensics: the console log is the ONLY record of what the payload actually
+      # did (the driver's stdout goes to ttyS0). Keep it beyond teardown.
+      - name: capture console log + summary (always)
+        if: always()
+        env:
+          GHCR_USER: ${{ secrets.ghcr_user }}
+          GHCR_TOKEN: ${{ secrets.ghcr_token }}
+        run: |
+          set +e
+          kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null \
+            | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g' > /tmp/console.log
+          # scrub caller secrets (raw + base64 forms). A secret base64-split across
+          # console delivery chunks is NOT fully scrubbable — treat artifacts of
+          # secret-carrying payloads as sensitive (the flagship payload carries none).
+          for s in "$GHCR_TOKEN" "$(printf %s "${GHCR_TOKEN:-}" | base64 -w0)" "$GHCR_USER"; do
+            [ -n "$s" ] && sed -i "s|$s|***|g" /tmp/console.log
+          done
+          {
+            echo "### cvm-e2e ${{ inputs.platform }}/${{ inputs.flavor }} — ${VM}"
+            echo "- runtime launch measurement: \`${{ steps.run.outputs.measurement || 'n/a' }}\`"
+            echo '```'
+            grep -oE '@@[^@]{1,140}@@' /tmp/console.log | tail -20
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          true
+
+      - name: upload console artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: guest-console-${{ inputs.platform }}-${{ inputs.flavor }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/console.log
+          if-no-files-found: ignore
+
+      - name: "teardown (always — tmpfs CVM: deleting the VM is total)"
+        if: always()
+        run: kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -1,0 +1,256 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# CONSUMER: c8s — the flagship payload ("install c8s + prove a cw workload runs")
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# This file owns only WHAT to test (the c8s payload) and WHEN (the trigger).
+# WHERE (boot/attest/teardown a CVM per platform) belongs to the primitive:
+#   .github/workflows/cvm-e2e.yml
+#
+# Adding a platform = adding a matrix row. Adding a DIFFERENT repo's test = a new
+# consumer file with a different payload on the SAME primitive (e.g.
+# attestation-rs: payload = `cargo test --features attest`, flavor: base-cpu).
+#
+# WHY NO OCI PULLS BY <sha> TAG: BOTH c8s publish workflows are PATH-GATED, so
+# a given main commit may have neither artifact under its own sha:
+#  - chart.yml (internal/helmchart/**): a Go-only merge publishes NO chart tag
+#    0.1.0-g<sha> -> helm pull 404s, c8s-system stays empty (failure mode 1).
+#  - docker.yml (source paths): a commit touching neither runs NO Docker at all,
+#    so retag-unchanged never fires and NO :<sha> image tags exist -> pods sit
+#    in ImagePullBackOff (failure mode 2; both observed live on main 70aea72).
+# Resolution, per artifact kind:
+#  - chart: packaged FROM SOURCE at the exact sha (anonymous codeload tarball),
+#    inlined via the HelmChart CR's chartContent.
+#  - images: can't be built from source here — resolve each component to the
+#    NEWEST existing sha tag at-or-before the commit under test (= what that
+#    commit would actually deploy). Under the post-merge trigger this is the
+#    head sha itself, because workflow_run chains off a completed Docker run.
+# No registry credential anywhere in this payload — the whole chain is public.
+name: e2e-c8s
+on:
+  # Reusable: c8s's confidential-e2e.yml wrapper owns triggering (workflow_run
+  # off Docker + dispatch). Vendored from confidential-ci for Phase 0 — a public
+  # repo (c8s) cannot `uses:` a private repo's (confidential-ci) reusable
+  # workflow, so the lane lives here and is called locally (`uses: ./`).
+  workflow_call:
+    inputs:
+      c8s_ref:
+        description: c8s commit to test
+        type: string
+        required: false
+        default: main
+
+concurrency:
+  group: e2e-c8s-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── WHAT: build the c8s payload (the only c8s-specific work) ──────────────
+  payload:
+    runs-on: ubuntu-latest
+    outputs:
+      b64: ${{ steps.build.outputs.b64 }}
+      short: ${{ steps.build.outputs.short }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: confidential-dot-ai/c8s
+          ref: ${{ inputs.c8s_ref || 'main' }}   # push/schedule have no inputs
+          path: c8s
+          fetch-depth: 50                        # the image-tag resolver walks ancestors
+
+      - id: build
+        run: |
+          set -euo pipefail
+          SHORT=$(cd c8s && git rev-parse --short=7 HEAD)
+          FULL=$(cd c8s && git rev-parse HEAD)
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+
+          # IMAGE TAGS: docker.yml is path-gated too — a commit that touches no
+          # source paths triggers NO Docker run, so retag-unchanged never fires
+          # and :<short-sha> tags don't exist for it (found live: main 70aea72 had
+          # NO cds/c8s-operator tags -> ImagePullBackOff). The image a commit X
+          # would actually deploy is "the newest built tag at or before X" — so
+          # resolve each component by walking X's ancestry until a tag exists.
+          # Under the post-merge trigger (workflow_run off Docker) this resolves
+          # to $SHORT on the first probe. Anonymous pulls — the packages are public.
+          resolve_tag(){
+            local comp=$1 tok code
+            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
+            for sha in $(git -C c8s log --format=%h --abbrev=7 -50); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $tok" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+                "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${sha}")
+              [ "$code" = "200" ] && { echo "$sha"; return; }
+            done
+            echo "::warning::no sha tag found for ${comp} in the last 50 commits — falling back to :main (racy)" >&2
+            echo main
+          }
+          # PLATFORM digest (linux/amd64), not the index digest: the NRI allowlist
+          # floor matches what the runtime resolves — an index digest would reject
+          # the very image it pins (docs/attestation/allowlist multi-arch pitfall).
+          resolve_digest(){
+            local comp=$1 tag=$2 tok m d
+            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
+            m=$(curl -fsSL -H "Authorization: Bearer $tok"               -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json'               "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}")
+            d=$(printf '%s' "$m" | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest' | head -1)
+            if [ -z "$d" ]; then
+              d=$(curl -fsSI -H "Authorization: Bearer $tok" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}" | awk '{ gsub("\r","") } tolower($1)=="docker-content-digest:"{ print $2 }')
+            fi
+            [ -n "$d" ] || { echo "::error::no digest for ${comp}:${tag}"; exit 1; }
+            echo "$d"
+          }
+          OPTAG=$(resolve_tag c8s-operator)      # global image.tag: operator + tls-lb init
+          CDSTAG=$(resolve_tag cds)
+          NRITAG=$(resolve_tag nri-image-policy)
+          CDSDIG=$(resolve_digest cds "$CDSTAG")            # nriImagePolicy floor pins CDS by digest
+          NRIDIG=$(resolve_digest nri-image-policy "$NRITAG")  # installer self-allow needs its own
+          # attestation-api is versioned by the attestation-rs repo, NOT c8s — a
+          # c8s-ancestry walk can never find its tags (learned the hard way:
+          # InvalidImageName, run 29473241754). :main is the canonical pointer the
+          # c8s-integration fleet uses; accepted race until c8s pins a digest.
+          AATAG=main
+          echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
+
+          # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:
+          #  - cds.node.selector/tolerations null : the --single-node effect. The chart
+          #    default pins role=cds, so CDS sits Pending forever on a single node.
+          #  - measurements: RUNTIME_MEASUREMENT  : placeholder. The payload substitutes
+          #    the node's OWN runtime launch digest ($MEAS from the primitive). The image
+          #    manifest's snp_launch_digest is NOT that value (CDS -> measurement_denied).
+          #  - ratlsMesh disabled                 : the L4 mesh proxy needs kernel netfilter
+          #    modules the monolithic guest kernel lacks (base-images ask). nri-image-policy
+          #    is a containerd NRI hook — no netfilter — so it runs (audit mode for now).
+          VALS=$(cat <<EOF | base64 -w0
+          image:
+            tag: "$OPTAG"
+          cds:
+            image:
+              tag: "$CDSTAG"
+              digest: "$CDSDIG"
+            node:
+              selector: null      # null DELETES the key from the merged values (chart
+              tolerations: null   # default incl.) -> renders NO selector. {} counts as
+                                  # "empty" to the template's `default` -> role=cds
+                                  # resurfaces -> CDS Pending (run 29536583462).
+            ratlsPlatform: sev-snp
+            measurements: ["RUNTIME_MEASUREMENT"]
+          attestationApi:
+            image:
+              tag: "$AATAG"
+            cvmMode: node
+            teeDevices:
+              sevGuest: true
+              tdxGuest: false
+              tpm: false
+          ratlsMesh:
+            enabled: false
+          nriImagePolicy:
+            enabled: true          # NRI hook needs no netfilter (that was ratls-mesh's constraint)
+            distro: rke2
+            image:
+              tag: "$NRITAG"
+              digest: "$NRIDIG"
+            policy:
+              mode: audit          # bring-up: log would-be denials, admit all (chart-blessed).
+                                   # enforce needs an operator-keyed allowlist first — roadmap.
+          tlsLb:
+            hostPort:
+              enabled: false
+          EOF
+          )
+          CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
+
+          # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
+          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' > /tmp/gate-vals.yaml
+          helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
+          echo "render gate: chart+values validate clean"
+
+          # ── THE PAYLOAD: runs in-guest as root. Given $K, $MEAS; emits PAYLOAD_OK.
+          cat > payload.sh <<PAYLOAD
+          dl(){ curl -fsSL --retry 3 "\$1" -o "\$2" 2>/dev/null || wget -qO "\$2" "\$1" 2>/dev/null || python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])" "\$1" "\$2"; }
+          dl "https://codeload.github.com/confidential-dot-ai/c8s/tar.gz/$FULL" /tmp/src.tgz || { say FAIL_CHART_FETCH; exit 0; }
+          tar -xzf /tmp/src.tgz -C /tmp || { say FAIL_CHART_EXTRACT; exit 0; }
+          CD=\$(echo /tmp/c8s-*/internal/helmchart)
+          tar -czf /tmp/chart.tgz -C "\$CD" c8s || { say FAIL_CHART_PACK; exit 0; }
+          CC=\$(base64 -w0 /tmp/chart.tgz)
+          say CHART_FROM_SOURCE
+          \$K create ns c8s-system >/dev/null 2>&1
+          \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
+          if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
+          { printf 'apiVersion: helm.cattle.io/v1\nkind: HelmChart\nmetadata:\n  name: c8s\n  namespace: kube-system\nspec:\n  chartContent: %s\n  targetNamespace: c8s-system\n  createNamespace: false\n  valuesContent: |\n' "\$CC"
+            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed 's/^/    /'
+          } | \$K apply -f - 2>&1 | sed 's/^/@@HCAPPLY /;s/\$/@@/'
+          say \$MMARK
+          HOK=0
+          for i in \$(seq 1 45); do
+            s=\$(\$K -n kube-system get job helm-install-c8s -o jsonpath='{.status.succeeded}' 2>/dev/null)
+            echo "@@HJOB \$i succ=\${s:-0}@@"
+            \$K -n kube-system logs job/helm-install-c8s --tail=2 2>/dev/null | sed 's/^/@@HLOG /;s/\$/@@/'
+            [ "\$s" = "1" ] && { HOK=1; say HELM_DONE; break; }
+            sleep 12
+          done
+          if [ "\$HOK" != "1" ]; then
+            \$K -n kube-system get helmchart c8s -o jsonpath='{.status}' 2>&1 | head -c 600 | sed 's/^/@@HCSTATUS /;s/\$/@@/'
+            \$K -n kube-system logs job/helm-install-c8s --tail=40 2>&1 | sed 's/^/@@HLOG /;s/\$/@@/'
+            say FAIL_HELM
+            exit 0
+          fi
+          CDSOK=0
+          for i in \$(seq 1 45); do
+            PODS=\$(\$K -n c8s-system get pods --no-headers 2>&1)
+            printf '%s\n' "\$PODS" | sed 's/^/@@POD /;s/\$/@@/'
+            CDS=\$(printf '%s\n' "\$PODS" | grep '^c8s-cds-' | head -1)
+            echo "@@CDSR \$i: \${CDS:-nopod}@@"
+            printf '%s' "\$CDS" | grep -qE ' 1/1 +Running' && { CDSOK=1; say CDS_READY; break; }
+            printf '%s\n' "\$PODS" | grep -q 'ImagePullBackOff' && IPB=\$((\${IPB:-0}+1)) || IPB=0
+            [ "\$IPB" -ge 5 ] && { \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'; say FAIL_IMAGEPULL; exit 0; }
+            sleep 12
+          done
+          # consumption proof: a cw workload must RUN with the CDS-issued cert injected.
+          # Under MEAS_ENFORCED that cert is only issued if the node attests the pinned
+          # measurement — so this IS the enforcement test, not a separate assertion.
+          WOK=0; COK=0
+          if [ "\$CDSOK" != "1" ]; then
+            \$K -n c8s-system logs deploy/c8s-cds --tail=15 2>&1 | sed 's/^/@@CDSLOG /;s/\$/@@/'
+            \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
+          fi
+          if [ "\$CDSOK" = "1" ]; then
+            printf %s '$CW' | base64 -d | \$K apply -f - 2>&1 | sed 's/^/@@CWAPPLY /;s/\$/@@/'
+            for i in \$(seq 1 60); do
+              DP=\$(\$K -n default get deploy demo-nginx --no-headers 2>&1)
+              echo "@@CWDEP \$i: \$DP@@"
+              printf '%s' "\$DP" | grep -qE ' 1/1 ' && { WOK=1; say WORKLOAD_OK; break; }
+              sleep 10
+            done
+            IC=\$(\$K -n default get pods -l app=demo-nginx -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null)
+            echo "@@CWCONTAINERS \${IC:-none}@@"
+            printf '%s' "\$IC" | grep -q 'c8s-cert' && { COK=1; say CERT_INJECTED; }
+            [ "\$WOK" = "1" ] && [ "\$COK" = "1" ] && say PAYLOAD_OK
+            if [ "\$WOK" != "1" ]; then
+              \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
+              \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
+            fi
+          fi
+          \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | tail -10 | sed 's/^/@@EV /;s/\$/@@/'
+          PAYLOAD
+          echo "b64=$(base64 -w0 payload.sh)" >> "$GITHUB_OUTPUT"
+
+  # ── WHERE: one call per platform cell; the primitive boots/attests/tears down.
+  #    bare metal (power-cord customers: CW/Nebius/Humain) | cloud (rent-infra:
+  #    Baseten/Modal/RunPod). Adding a cell = adding a row.
+  e2e:
+    needs: payload
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: snp-metal
+            runner: cvm-launcher
+          # - { platform: tdx-metal, runner: cvm-launcher-tdx }  # needs a TDX rke2-node image
+          # - { platform: gke-snp,   runner: ubuntu-latest }        # needs the c8s-fleet provisioner seam
+    uses: ./.github/workflows/cvm-e2e.yml
+    with:
+      platform: ${{ matrix.platform }}
+      runner: ${{ matrix.runner }}
+      flavor: rke2-node
+      payload_b64: ${{ needs.payload.outputs.b64 }}

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -108,7 +108,11 @@ jobs:
           # c8s-ancestry walk can never find its tags (learned the hard way:
           # InvalidImageName, run 29473241754). :main is the canonical pointer the
           # c8s-integration fleet uses; accepted race until c8s pins a digest.
-          AATAG=main
+          # PINNED to the fleet-promoted attestation-api (c8s-fleet ships sha-63a97d3
+          # across c8s-integration/gke/aks). Floating :main drifts onto UNPROMOTED
+          # builds (e.g. attestation-rs enforce-VMPL0/reject-debug-policy) and reds a
+          # bundle that ships nowhere. Bump this line deliberately when the fleet promotes.
+          AATAG=sha-63a97d3
           echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
 
           # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -38,6 +38,11 @@ on:
         type: string
         required: false
         default: main
+      aa_ref:
+        description: attestation-api image ref (tag or sha-<short>). Caller pins to a known-good build to avoid floating :main drift; default main keeps prior behaviour.
+        type: string
+        required: false
+        default: main
 
 concurrency:
   group: e2e-c8s-${{ github.ref }}
@@ -108,11 +113,10 @@ jobs:
           # c8s-ancestry walk can never find its tags (learned the hard way:
           # InvalidImageName, run 29473241754). :main is the canonical pointer the
           # c8s-integration fleet uses; accepted race until c8s pins a digest.
-          # PINNED to the fleet-promoted attestation-api (c8s-fleet ships sha-63a97d3
-          # across c8s-integration/gke/aks). Floating :main drifts onto UNPROMOTED
-          # builds (e.g. attestation-rs enforce-VMPL0/reject-debug-policy) and reds a
-          # bundle that ships nowhere. Bump this line deliberately when the fleet promotes.
-          AATAG=sha-63a97d3
+          # aa_ref lets a caller PIN it (tag or sha-<short>) — floating :main drifts
+          # (e.g. attestation-rs enforce-VMPL0/reject-debug-policy landed on :main and
+          # broke this dev-sandbox CVM while the boot image was unchanged).
+          AATAG="${{ inputs.aa_ref || 'main' }}"
           echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
 
           # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:


### PR DESCRIPTION
## The bug (live on main)

`confidential-e2e.yml` calls a reusable workflow in **confidential-dot-ai/confidential-ci** (private). GitHub **forbids a public repo from calling a private repo's reusable workflow** — so since it merged, every post-`Docker` run fails to parse (`error parsing called workflow … workflow was not found`). The confidential e2e has not actually run on merge.

## The fix — make the lane self-contained (the-machine pattern)

Vendor the lane into c8s and call it **locally**:
- `cvm-e2e.yml` — the measured-CVM boot primitive (boot rke2-node-as-CVM on SNP metal, assert genuine `sev-snp-guest`, deliver payload, teardown + reap)
- `e2e-c8s.yml` — the c8s payload builder (install c8s in-guest + prove a cw workload gets its CDS-issued cert). Trimmed to `on: workflow_call` only — the wrapper owns triggering; the removed `push:`/`paths:` referenced confidential-ci dirs that don't exist here.
- `confidential-e2e.yml` → `uses: ./.github/workflows/e2e-c8s.yml`

## Behavior is unchanged

Same measured rke2-node CVM boot, same in-guest install (chart packaged from c8s source at the sha under test, component image tags resolved to the newest built ≤ the sha, launch measurement **enforced** via CDS, NRI image-policy in audit), same consumption proof (cw workload gets a CDS-issued cert). **No secrets** — the c8s pull chain is anonymous-public.

## Fork-safety unchanged

The wrapper's if-gate still requires a **same-repo** (`head_repository == github.repository`) `push`/`workflow_dispatch` `Docker` success on `main`/`v*`, and there is **no `pull_request` trigger** anywhere near the self-hosted confidential runner. A fork PR cannot reach it.

## Note on duplication

`cvm-e2e.yml` now lives here and in confidential-ci (which runs the nightly drift lane). This is deliberate and temporary per the matrix ADR — c8s's boot orchestration is c8s-specific (the lib repos move to a shared runner rail and won't use it). Proven mechanism: the same lane has run green many times from confidential-ci.