### PR TITLE
feat(ratls): expose verified peer config-claims to relying parties

### DIFF
--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -25,8 +25,10 @@ it to a pod, and returns that pod's admitted container image digests.
 `get-cert` hashes them into one `workloadDigest`, binds it into its CSR's
 attestation evidence, and forwards the plain list to CDS. CDS re-derives the
 hash, confirms every listed image is allowlisted, and stamps the claim onto
-the issued leaf. A relying party can then pin the workload:
-`c8s verify --workload-image sha256:…`.
+the issued leaf. A relying party can then pin the workload
+(`c8s verify --workload-image sha256:…`) or read a live mesh peer's digest off
+the connection with `ratls.PeerConfigClaims` (docs/ratls.md, "Reading a peer's
+claims").
 
 ---
 

--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -376,6 +376,24 @@ assumptions are in
 verification rules live in `pkg/ratls` (`claims.go`, `extension.go`,
 `verify.go`).
 
+**Reading a peer's claims.** Pinning answers "is this peer *X*?"; a relying
+party often needs "*which* workload is this?" — to authorize, route, or log.
+`ratls.PeerConfigClaims(*tls.ConnectionState)` returns a verified peer's claims
+off a live connection (an HTTP server passes `r.TLS`), or nil when the peer
+carried none. It reads the leaf extension and does **not** re-verify: a
+completed RA-TLS handshake is the guarantee. The claims are covered on every
+accept path — folded into REPORTDATA on the RA-TLS path, or signed by the mesh
+CA on the CA path (dual mode) — so the accessor is safe on **any accepted
+connection, and only on one**: never read the extension off a connection your
+verify callback did not admit. Two limits: the CA-path guarantee is *CDS vouched
+at issuance*, not fresh attestation (re-verify the leaf with `VerifyCert` if you
+need freshness); and the honest-workload ceiling above holds — a workload digest
+names what an *honest* peer runs. `WorkloadDigest` is the combined role-hash over
+the pod's *whole* image set ([getcert-workload-binding.md](getcert-workload-binding.md),
+"Corner 3"), not a per-image value, so an authorizer
+compares it by recomputing `workloadclaims.Digest(init, main)` over the expected
+set — the same call `c8s verify` makes.
+
 **Cross-implementation note.** Any non-Go verifier (e.g. `c8s-verify-js`) must
 reproduce these byte formats exactly to pin a config-claim: the SHA-384
 REPORTDATA fold above, and the canonical digests it commits — the operator

--- a/pkg/ratls/claims_test.go
+++ b/pkg/ratls/claims_test.go
@@ -3,7 +3,9 @@ package ratls
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/json"
@@ -333,5 +335,68 @@ func TestVerifyCertFoldsClaims(t *testing.T) {
 	}
 	if !bytes.Equal(observedERD, want[:]) {
 		t.Fatalf("expected_report_data = %x, want folded %x", observedERD, want[:])
+	}
+}
+
+// TestVerifyCertUnpinnedSurvivesClaimsVersionSkew locks in the invariant that
+// binding verification never parses the claims (see UnmarshalConfigClaims): a
+// peer on a future claims version, correctly bound into REPORTDATA, must still
+// complete a handshake with a verifier that pins nothing. Adding a parse to
+// VerifyCert would turn a version skew into a dead mesh link.
+func TestVerifyCertUnpinnedSurvivesClaimsVersionSkew(t *testing.T) {
+	future, err := asn1.Marshal(configClaimsASN1{
+		Version:            configClaimsVersion + 1,
+		OperatorKeysDigest: bytes.Repeat([]byte{0xAB}, ClaimsDigestSize),
+		SeedDigest:         bytes.Repeat([]byte{0xCD}, ClaimsDigestSize),
+		WorkloadDigest:     unsetDigest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, _, err := GenerateKeyPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	reportData, err := ReportDataForKeyAndClaims(&key.PublicKey, future, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att := &Attestation{TEEType: TEETypeSEVSNP, Report: fakeSNPReport(reportData)}
+	attExt, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, src := testAttestedCert(t, nil)
+	tmpl := &x509.Certificate{
+		SerialNumber: src.SerialNumber,
+		Subject:      src.Subject,
+		NotBefore:    src.NotBefore,
+		NotAfter:     src.NotAfter,
+		ExtraExtensions: []pkix.Extension{
+			attExt,
+			{Id: OIDRATLSConfigClaims, Value: future},
+		},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
+	var observedERD []byte
+	srv := newCapturingVerifySrv(t, measurement, &observedERD)
+	defer srv.Close()
+
+	if _, err := VerifyCert(cert, &VerifyPolicy{
+		AttestationApiURL: srv.URL,
+		Measurements:      [][]byte{measurement},
+	}, nil); err != nil {
+		t.Fatalf("VerifyCert rejected a validly-bound future claims version: %v", err)
 	}
 }

--- a/pkg/ratls/peerclaims.go
+++ b/pkg/ratls/peerclaims.go
@@ -1,0 +1,26 @@
+package ratls
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// PeerConfigClaims returns the config-claims a verified TLS peer presented,
+// parsed, or nil when the peer carried none. Read-only: the RA-TLS handshake
+// already verified the binding, so this reads the leaf, it does not re-verify.
+// For an HTTP server the connection state is on the request: PeerConfigClaims(r.TLS).
+//
+// INVARIANT: only call on a connection an RA-TLS verify callback accepted (the
+// tls.Config from NewServerTLSConfig / NewClientTLSConfig). Acceptance is what
+// authenticates the claims — the trust model, and its honest-workload ceiling,
+// are in docs/ratls.md, "Reading a peer's claims".
+func PeerConfigClaims(cs *tls.ConnectionState) (*ConfigClaims, error) {
+	if cs == nil || len(cs.PeerCertificates) == 0 {
+		return nil, fmt.Errorf("ratls: no peer certificate")
+	}
+	raw := ExtractConfigClaimsBytes(cs.PeerCertificates[0])
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	return UnmarshalConfigClaims(raw)
+}

--- a/pkg/ratls/peerclaims_test.go
+++ b/pkg/ratls/peerclaims_test.go
@@ -1,0 +1,143 @@
+package ratls
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"testing"
+	"time"
+)
+
+// caSignedLeafWithExt builds a leaf signed by a throwaway CA, optionally
+// carrying a config-claims extension. It models the mesh steady state: a
+// CDS-signed leaf whose claims are covered by the CA signature, not by a
+// per-connection attestation binding.
+func caSignedLeafWithExt(t *testing.T, ext []byte) *x509.Certificate {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-mesh-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "workload"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	if ext != nil {
+		leafTmpl.ExtraExtensions = []pkix.Extension{{Id: OIDRATLSConfigClaims, Value: ext}}
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return leaf
+}
+
+func connState(certs ...*x509.Certificate) *tls.ConnectionState {
+	return &tls.ConnectionState{PeerCertificates: certs}
+}
+
+func assertClaimsEqual(t *testing.T, got, want *ConfigClaims) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("got nil claims, want a value")
+	}
+	if !bytes.Equal(got.OperatorKeysDigest, want.OperatorKeysDigest) ||
+		!bytes.Equal(got.SeedDigest, want.SeedDigest) ||
+		!bytes.Equal(got.WorkloadDigest, want.WorkloadDigest) {
+		t.Fatalf("claims mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestPeerConfigClaims(t *testing.T) {
+	claims, claimsExt := testClaims(t)
+
+	// An RA-TLS self-attested leaf: claims folded into the evidence REPORTDATA.
+	key, att := testKeyAndAttestation(t)
+	ratlsDER, err := CreateAttestedCert(key, att, &CertOptions{ConfigClaims: claims})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ratlsLeaf, err := x509.ParseCertificate(ratlsDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, bareLeaf := testAttestedCert(t, nil)
+
+	t.Run("ra-tls leaf returns the bound claims", func(t *testing.T) {
+		got, err := PeerConfigClaims(connState(ratlsLeaf))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertClaimsEqual(t, got, claims)
+	})
+
+	t.Run("ca-signed leaf returns the signed claims", func(t *testing.T) {
+		got, err := PeerConfigClaims(connState(caSignedLeafWithExt(t, claimsExt)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertClaimsEqual(t, got, claims)
+	})
+
+	t.Run("leaf without the extension returns nil, nil", func(t *testing.T) {
+		got, err := PeerConfigClaims(connState(bareLeaf))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("want nil claims, got %+v", got)
+		}
+	})
+
+	t.Run("malformed extension returns a parse error", func(t *testing.T) {
+		bad := caSignedLeafWithExt(t, []byte{0x01, 0x02, 0x03})
+		if _, err := PeerConfigClaims(connState(bad)); err == nil {
+			t.Fatal("want a parse error, got nil")
+		}
+	})
+
+	t.Run("nil connection state errors", func(t *testing.T) {
+		if _, err := PeerConfigClaims(nil); err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+
+	t.Run("no peer certificate errors", func(t *testing.T) {
+		if _, err := PeerConfigClaims(&tls.ConnectionState{}); err == nil {
+			t.Fatal("want error, got nil")
+		}
+	})
+}


### PR DESCRIPTION
A relying party could pin a config-claim (reject on mismatch) but could not read a verified peer's claims off a live connection: VerifyResult carried no claims and the mTLS verify callback discarded its result. Reading the digest was wired only into the c8s verify CLI.

Add VerifyResult.ConfigClaims (populated by VerifyCert) and ratls.PeerConfigClaims(*tls.ConnectionState), returning a verified peer's claims off the leaf — for an HTTP server, PeerConfigClaims(r.TLS). It reads, it does not re-verify: a completed RA-TLS handshake already covered the claims (folded into REPORTDATA on the RA-TLS path, or signed by the mesh CA on the CA path), so it is safe on any accepted connection. Trust model and honest-workload ceiling documented in docs/ratls.md.