### PR TITLE
fix(install): skip disabled components in --resolve-digests

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -1678,7 +1678,9 @@ func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []
 	if err := yaml.Unmarshal(out, &tree); err != nil {
 		return nil, fmt.Errorf("parse chart values: %w", err)
 	}
-	overlaySetArgs(tree, setArgs)
+	if err := overlaySetArgs(tree, setArgs); err != nil {
+		return nil, err
+	}
 	return func(valuePath string) (bool, error) {
 		return boolAtPath(tree, valuePath), nil
 	}, nil
@@ -1687,7 +1689,7 @@ func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []
 // overlaySetArgs applies the scalar --set/--set-string overrides in setArgs onto
 // tree (--set values are type-coerced, --set-string stay strings). --set-file is
 // skipped: it names a file and never carries a component enable toggle.
-func overlaySetArgs(tree map[string]any, setArgs []string) {
+func overlaySetArgs(tree map[string]any, setArgs []string) error {
 	for i := 0; i+1 < len(setArgs); i += 2 {
 		flag, kv := setArgs[i], setArgs[i+1]
 		eq := strings.IndexByte(kv, '=')
@@ -1695,13 +1697,18 @@ func overlaySetArgs(tree map[string]any, setArgs []string) {
 			continue
 		}
 		path, raw := kv[:eq], kv[eq+1:]
+		var err error
 		switch flag {
 		case "--set":
-			setNested(tree, strings.Split(path, "."), coerce(raw, true))
+			err = setNested(tree, strings.Split(path, "."), coerce(raw, true))
 		case "--set-string":
-			setNested(tree, strings.Split(path, "."), raw)
+			err = setNested(tree, strings.Split(path, "."), raw)
+		}
+		if err != nil {
+			return fmt.Errorf("overlay %s %s: %w", flag, kv, err)
 		}
 	}
+	return nil
 }
 
 // buildDigestArgs appends, for every component, the --set flags that pin both

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -87,6 +87,7 @@ func cvmModeIsPod(cvmMode string) bool { return cvmMode == "pod" }
 type c8sComponent struct {
 	valuePrefix string // values path, e.g. "cds.image" (renders {repository}@{digest})
 	repository  string // values.yaml default repository resolved against
+	enabledPath string // values path guarding the render, e.g. "attestationApi.enabled" ("" = always rendered)
 }
 
 // chartComponents reads the component set from the chart at chartPath via
@@ -125,7 +126,9 @@ func chartComponents(ctx context.Context, chartPath string) ([]c8sComponent, err
 		if err != nil {
 			return nil, fmt.Errorf("component %q: %w", valuePath, err)
 		}
-		comps = append(comps, c8sComponent{valuePrefix: valuePath, repository: repo})
+		// enabledPath is optional; absent/empty means the component always renders.
+		enabledPath, _ := m["enabledPath"].(string)
+		comps = append(comps, c8sComponent{valuePrefix: valuePath, repository: repo, enabledPath: enabledPath})
 	}
 	return comps, nil
 }
@@ -704,7 +707,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// override an operator's -f is preserved by ordering: the computed file
 		// is the LAST -f, so it wins on the keys it sets (matching the previous
 		// "--set beats -f" precedence) while the operator's files supply the rest.
-		setArgs, err := buildValueArgs(cmd.Context(), cmd, components, imageTag, distro, appendResolvedDigestArgs)
+		setArgs, err := buildValueArgs(cmd.Context(), cmd, chartPath, components, imageTag, distro, appendResolvedDigestArgs)
 		if err != nil {
 			return err
 		}
@@ -1640,9 +1643,13 @@ func craneDigest(ctx context.Context, ref string) (string, error) {
 
 // appendResolvedDigestArgs resolves each chart component's repo:tag to its
 // registry digest (via crane) and appends the helm --set flags that pin it.
-func appendResolvedDigestArgs(ctx context.Context, helmArgs []string, tag string, components []c8sComponent) ([]string, error) {
+func appendResolvedDigestArgs(ctx context.Context, chartPath string, helmArgs []string, tag string, components []c8sComponent) ([]string, error) {
 	if _, err := exec.LookPath("crane"); err != nil {
 		return nil, fmt.Errorf("digest resolution needs the 'crane' CLI on PATH; install it or pass --resolve-digests=false and supply digests via -f: %w", err)
+	}
+	enabled, err := componentEnabledPredicate(ctx, chartPath, helmArgs)
+	if err != nil {
+		return nil, err
 	}
 	return buildDigestArgs(helmArgs, tag, components, func(ref string) (string, error) {
 		digest, err := craneDigest(ctx, ref)
@@ -1653,7 +1660,48 @@ func appendResolvedDigestArgs(ctx context.Context, helmArgs []string, tag string
 		// so stdout must stay clean. Install's stdout is diagnostic too.
 		fmt.Fprintf(os.Stderr, "+ resolved %s -> %s\n", ref, digest)
 		return digest, nil
-	})
+	}, enabled)
+}
+
+// componentEnabledPredicate reports the effective enabled value at a component's
+// enabledPath, given the chart defaults and the --set overrides assembled so
+// far. attestationApi.enabled / nriImagePolicy.enabled are plain values fields
+// (default true) that the --cvm-mode=node/pod args flip to false via --set, so
+// the base values overlaid with those --set flags is the authoritative answer.
+// The merged tree is built once and shared across the per-component calls.
+func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []string) (func(valuePath string) (bool, error), error) {
+	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("helm show values %q: %w", chartPath, err)
+	}
+	var tree map[string]any
+	if err := yaml.Unmarshal(out, &tree); err != nil {
+		return nil, fmt.Errorf("parse chart values: %w", err)
+	}
+	overlaySetArgs(tree, setArgs)
+	return func(valuePath string) (bool, error) {
+		return boolAtPath(tree, valuePath), nil
+	}, nil
+}
+
+// overlaySetArgs applies the scalar --set/--set-string overrides in setArgs onto
+// tree (--set values are type-coerced, --set-string stay strings). --set-file is
+// skipped: it names a file and never carries a component enable toggle.
+func overlaySetArgs(tree map[string]any, setArgs []string) {
+	for i := 0; i+1 < len(setArgs); i += 2 {
+		flag, kv := setArgs[i], setArgs[i+1]
+		eq := strings.IndexByte(kv, '=')
+		if eq < 0 {
+			continue
+		}
+		path, raw := kv[:eq], kv[eq+1:]
+		switch flag {
+		case "--set":
+			setNested(tree, strings.Split(path, "."), coerce(raw, true))
+		case "--set-string":
+			setNested(tree, strings.Split(path, "."), raw)
+		}
+	}
 }
 
 // buildDigestArgs appends, for every component, the --set flags that pin both
@@ -1666,8 +1714,21 @@ func appendResolvedDigestArgs(ctx context.Context, helmArgs []string, tag string
 // partially-pinned floor would let the render guard pass while the served
 // allowlist pointed at the wrong digest. The resolver is injected so the arg
 // assembly is testable without a registry.
-func buildDigestArgs(helmArgs []string, tag string, components []c8sComponent, resolve func(ref string) (string, error)) ([]string, error) {
+func buildDigestArgs(helmArgs []string, tag string, components []c8sComponent, resolve func(ref string) (string, error), enabled func(valuePath string) (bool, error)) ([]string, error) {
 	for _, c := range components {
+		// Skip components the effective config disables: they never render, so
+		// resolving their tag is pointless and aborts a valid install if that
+		// baked-only image (e.g. attestationApi under --cvm-mode=node) is
+		// unpublished at the install tag.
+		if c.enabledPath != "" {
+			on, err := enabled(c.enabledPath)
+			if err != nil {
+				return nil, fmt.Errorf("component %s: resolve %s: %w", c.valuePrefix, c.enabledPath, err)
+			}
+			if !on {
+				continue
+			}
+		}
 		repo := c.repository
 		digest, err := resolve(repo + ":" + tag)
 		if err != nil {

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -1089,12 +1090,16 @@ func TestAppendCvmModeInstallArgsAcceptsAksWithTdx(t *testing.T) {
 // which exercise buildDigestArgs without reading a real chart. The chart-read
 // path (chartComponents) is covered separately by TestChartComponentsFromValues.
 var testComponents = []c8sComponent{
-	{"image", "ghcr.io/confidential-dot-ai/c8s-operator"},
-	{"attestationApi.image", "ghcr.io/confidential-dot-ai/attestation-api"},
-	{"cds.image", "ghcr.io/confidential-dot-ai/cds"},
-	{"ratlsMesh.image", "ghcr.io/confidential-dot-ai/ratls-mesh"},
-	{"nriImagePolicy.image", "ghcr.io/confidential-dot-ai/nri-image-policy"},
+	{valuePrefix: "image", repository: "ghcr.io/confidential-dot-ai/c8s-operator"},
+	{valuePrefix: "attestationApi.image", repository: "ghcr.io/confidential-dot-ai/attestation-api", enabledPath: "attestationApi.enabled"},
+	{valuePrefix: "cds.image", repository: "ghcr.io/confidential-dot-ai/cds"},
+	{valuePrefix: "ratlsMesh.image", repository: "ghcr.io/confidential-dot-ai/ratls-mesh", enabledPath: "ratlsMesh.enabled"},
+	{valuePrefix: "nriImagePolicy.image", repository: "ghcr.io/confidential-dot-ai/nri-image-policy", enabledPath: "nriImagePolicy.enabled"},
 }
+
+// allEnabled is the buildDigestArgs predicate for tests that resolve every
+// component (the skip path is covered by TestBuildDigestArgsSkipsDisabledComponent).
+func allEnabled(string) (bool, error) { return true, nil }
 
 func TestBuildDigestArgsPinsEveryComponent(t *testing.T) {
 	// Deterministic fake resolver: digest derived from the ref so each
@@ -1116,7 +1121,7 @@ func TestBuildDigestArgsPinsEveryComponent(t *testing.T) {
 		return "", nil
 	}
 
-	got, err := buildDigestArgs([]string{"upgrade"}, "v1", testComponents, resolve)
+	got, err := buildDigestArgs([]string{"upgrade"}, "v1", testComponents, resolve, allEnabled)
 	if err != nil {
 		t.Fatalf("buildDigestArgs: %v", err)
 	}
@@ -1147,13 +1152,73 @@ func TestBuildDigestArgsResolvesEachComponentOnce(t *testing.T) {
 		calls[ref]++
 		return "sha256:1111111111111111111111111111111111111111111111111111111111111111", nil
 	}
-	if _, err := buildDigestArgs(nil, "v1", testComponents, resolve); err != nil {
+	if _, err := buildDigestArgs(nil, "v1", testComponents, resolve, allEnabled); err != nil {
 		t.Fatalf("buildDigestArgs: %v", err)
 	}
 	for ref, n := range calls {
 		if n != 1 {
 			t.Errorf("ref %q resolved %d times, want 1", ref, n)
 		}
+	}
+}
+
+// A component whose enabledPath resolves to false never renders, so its tag
+// must not be resolved (that image may be unpublished at the install tag — e.g.
+// attestationApi under --cvm-mode=node) and it must contribute no --set args.
+// Enabled components still resolve and pin.
+func TestBuildDigestArgsSkipsDisabledComponent(t *testing.T) {
+	resolved := map[string]bool{}
+	resolve := func(ref string) (string, error) {
+		resolved[ref] = true
+		return "sha256:3333333333333333333333333333333333333333333333333333333333333333", nil
+	}
+	// Node-mode shape: attestation-api and nri-image-policy are baked into the
+	// node image and disabled in the chart.
+	disabled := map[string]bool{"attestationApi.enabled": true, "nriImagePolicy.enabled": true}
+	enabled := func(path string) (bool, error) { return !disabled[path], nil }
+
+	args, err := buildDigestArgs(nil, "v1", testComponents, resolve, enabled)
+	if err != nil {
+		t.Fatalf("buildDigestArgs: %v", err)
+	}
+	for _, ref := range []string{
+		"ghcr.io/confidential-dot-ai/attestation-api:v1",
+		"ghcr.io/confidential-dot-ai/nri-image-policy:v1",
+	} {
+		if resolved[ref] {
+			t.Errorf("disabled component %q was resolved, want skipped", ref)
+		}
+	}
+	joined := strings.Join(args, " ")
+	for _, prefix := range []string{"attestationApi.image", "nriImagePolicy.image"} {
+		if strings.Contains(joined, prefix+".repository") || strings.Contains(joined, prefix+".digest") {
+			t.Errorf("disabled component %q emitted --set args: %v", prefix, args)
+		}
+	}
+	// Enabled components still pin both repository and digest.
+	for _, want := range []string{
+		"cds.image.repository=ghcr.io/confidential-dot-ai/cds",
+		"ratlsMesh.image.repository=ghcr.io/confidential-dot-ai/ratls-mesh",
+		"image.repository=ghcr.io/confidential-dot-ai/c8s-operator",
+	} {
+		if !slices.Contains(args, want) {
+			t.Errorf("enabled component arg %q missing from %v", want, args)
+		}
+	}
+	if !resolved["ghcr.io/confidential-dot-ai/cds:v1"] {
+		t.Error("enabled component cds was not resolved")
+	}
+}
+
+// A predicate error (the effective-enabled read failed) must abort rather than
+// silently resolve or skip the component.
+func TestBuildDigestArgsFailsClosedOnEnabledError(t *testing.T) {
+	resolve := func(string) (string, error) {
+		return "sha256:4444444444444444444444444444444444444444444444444444444444444444", nil
+	}
+	enabled := func(string) (bool, error) { return false, errTestResolve }
+	if _, err := buildDigestArgs(nil, "v1", testComponents, resolve, enabled); err == nil {
+		t.Fatal("buildDigestArgs ignored an enabled-predicate error, want fail-closed")
 	}
 }
 
@@ -1167,7 +1232,7 @@ func TestBuildDigestArgsFailsClosedOnResolveError(t *testing.T) {
 		}
 		return "sha256:2222222222222222222222222222222222222222222222222222222222222222", nil
 	}
-	if _, err := buildDigestArgs(nil, "v1", testComponents, resolve); err == nil {
+	if _, err := buildDigestArgs(nil, "v1", testComponents, resolve, allEnabled); err == nil {
 		t.Fatal("buildDigestArgs ignored a resolver error, want fail-closed")
 	}
 }
@@ -1178,7 +1243,7 @@ func TestBuildDigestArgsFailsClosedOnResolveError(t *testing.T) {
 func TestBuildDigestArgsExplainsTagCouplingOnMissingTag(t *testing.T) {
 	notFound := errors.New(`crane digest "ghcr.io/confidential-dot-ai/c8s-operator:gpu-test": exit status 1: MANIFEST_UNKNOWN: manifest unknown`)
 	resolve := func(string) (string, error) { return "", notFound }
-	_, err := buildDigestArgs(nil, "gpu-test", testComponents, resolve)
+	_, err := buildDigestArgs(nil, "gpu-test", testComponents, resolve, allEnabled)
 	if err == nil {
 		t.Fatal("buildDigestArgs accepted a missing tag, want fail-closed")
 	}
@@ -1202,7 +1267,7 @@ func TestBuildDigestArgsExplainsTagCouplingOnMissingTag(t *testing.T) {
 // wrong path.
 func TestBuildDigestArgsLeavesOtherResolveErrorsUnhinted(t *testing.T) {
 	resolve := func(string) (string, error) { return "", errTestResolve }
-	_, err := buildDigestArgs(nil, "v1", testComponents, resolve)
+	_, err := buildDigestArgs(nil, "v1", testComponents, resolve, allEnabled)
 	if err == nil {
 		t.Fatal("buildDigestArgs ignored a resolver error, want fail-closed")
 	}

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -110,7 +110,7 @@ Requires the 'helm' CLI on PATH, and 'crane' unless --resolve-digests=false.`,
 		if cmd.Flags().Changed("distro") {
 			distro = renderValuesDistro
 		}
-		setArgs, err := buildValueArgs(cmd.Context(), cmd, components, resolveImageTag(), distro, appendResolvedDigestArgs)
+		setArgs, err := buildValueArgs(cmd.Context(), cmd, chartPath, components, resolveImageTag(), distro, appendResolvedDigestArgs)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,10 @@ Requires the 'helm' CLI on PATH, and 'crane' unless --resolve-digests=false.`,
 // digestResolver appends the --set flags that pin each component's resolved
 // registry digest. Both commands pass appendResolvedDigestArgs (crane-backed);
 // it is injected so the full builder is testable offline without a registry.
-type digestResolver func(ctx context.Context, setArgs []string, imageTag string, components []c8sComponent) ([]string, error)
+// chartPath lets the resolver read the chart's default values (to skip
+// components the effective config disables); setArgs carries the overrides
+// assembled so far, which drive that disable.
+type digestResolver func(ctx context.Context, chartPath string, setArgs []string, imageTag string, components []c8sComponent) ([]string, error)
 
 // buildValueArgs assembles the helm --set/--set-string value args shared by
 // install and render-values. distro is passed in (install autodetects it from
@@ -143,7 +146,7 @@ type digestResolver func(ctx context.Context, setArgs []string, imageTag string,
 // returned slice is value args only — install prepends the `upgrade --install
 // <release> <chart>` verb and appends -f / wait flags, render-values converts
 // these to a values tree.
-func buildValueArgs(ctx context.Context, cmd *cobra.Command, components []c8sComponent, imageTag, distro string, resolveDigests digestResolver) ([]string, error) {
+func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, components []c8sComponent, imageTag, distro string, resolveDigests digestResolver) ([]string, error) {
 	// Derive the upstream address from the same deduped adoptions install's RunE
 	// validates against, so the address the chart receives and the id the RunE
 	// checks can never diverge on duplicate refs.
@@ -203,7 +206,7 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, components []c8sCom
 	}
 	if installResolveDigests {
 		var err error
-		setArgs, err = resolveDigests(ctx, setArgs, imageTag, components)
+		setArgs, err = resolveDigests(ctx, chartPath, setArgs, imageTag, components)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/c8s/render_values_test.go
+++ b/cmd/c8s/render_values_test.go
@@ -173,7 +173,7 @@ func TestBuildValueArgsOmitsDistroWhenUnset(t *testing.T) {
 	installResolveDigests = false
 	defer func() { installResolveDigests = prev }()
 
-	args, err := buildValueArgs(context.Background(), cmd, nil, "main", "", appendResolvedDigestArgs)
+	args, err := buildValueArgs(context.Background(), cmd, "", nil, "main", "", appendResolvedDigestArgs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,7 +184,7 @@ func TestBuildValueArgsOmitsDistroWhenUnset(t *testing.T) {
 		t.Fatalf("unset distro should emit no distro keys, got %v", args)
 	}
 
-	args, err = buildValueArgs(context.Background(), cmd, nil, "main", "rke2", appendResolvedDigestArgs)
+	args, err = buildValueArgs(context.Background(), cmd, "", nil, "main", "rke2", appendResolvedDigestArgs)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestBuildValueArgsKeepsNumericImageTagAString(t *testing.T) {
 	installResolveDigests = false // tag is the sole image ref only when digests are off
 	defer func() { installResolveDigests = prev }()
 
-	args, err := buildValueArgs(context.Background(), cmd,
+	args, err := buildValueArgs(context.Background(), cmd, "",
 		[]c8sComponent{{valuePrefix: "cds.image", repository: "ghcr.io/x/cds"}},
 		"0640", "", appendResolvedDigestArgs)
 	if err != nil {
@@ -233,7 +233,7 @@ func TestBuildValueArgsOmitsTagWhenDigestsResolved(t *testing.T) {
 	prevFlag := installResolveDigests
 	defer func() { installResolveDigests = prevFlag }()
 	installResolveDigests = true
-	stubResolver := func(_ context.Context, args []string, _ string, comps []c8sComponent) ([]string, error) {
+	stubResolver := func(_ context.Context, _ string, args []string, _ string, comps []c8sComponent) ([]string, error) {
 		for _, c := range comps {
 			args = append(args, "--set-string", c.valuePrefix+".repository="+c.repository,
 				"--set-string", c.valuePrefix+".digest=sha256:abc")
@@ -241,7 +241,7 @@ func TestBuildValueArgsOmitsTagWhenDigestsResolved(t *testing.T) {
 		return append(args, "--set", "nriImagePolicy.bootstrapAllowlist.deriveComponents=true"), nil
 	}
 
-	got, err := buildValueArgs(context.Background(), cmd,
+	got, err := buildValueArgs(context.Background(), cmd, "",
 		[]c8sComponent{{valuePrefix: "cds.image", repository: "ghcr.io/x/cds"}},
 		"main", "", stubResolver)
 	if err != nil {
@@ -354,14 +354,15 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	installUpstream = "infer"
 	installOperatorKeys = writeTestOperatorKeys(t)
 
-	args, err := buildValueArgs(context.Background(), cmd, nil, "main", "rke2", appendResolvedDigestArgs)
+	args, err := buildValueArgs(context.Background(), cmd, "", nil, "main", "rke2", appendResolvedDigestArgs)
 	if err != nil {
 		t.Fatalf("buildValueArgs: %v", err)
 	}
 	// Add the digest helper's repository/digest tokens (stubbed resolver, no crane).
 	args, err = buildDigestArgs(args, "main",
 		[]c8sComponent{{valuePrefix: "cds.image", repository: "ghcr.io/x/cds"}},
-		func(string) (string, error) { return "sha256:abc", nil })
+		func(string) (string, error) { return "sha256:abc", nil },
+		func(string) (bool, error) { return true, nil })
 	if err != nil {
 		t.Fatalf("buildDigestArgs: %v", err)
 	}
@@ -416,7 +417,7 @@ func TestBuildValueArgsDerivesUpstreamFromRef(t *testing.T) {
 	installWorkloadRefs = []string{"infer=vllm/deployment/x:8000", "infer=vllm/deployment/x:8000"}
 	installUpstream = "infer"
 
-	args, err := buildValueArgs(context.Background(), cmd, nil, "main", "", appendResolvedDigestArgs)
+	args, err := buildValueArgs(context.Background(), cmd, "", nil, "main", "", appendResolvedDigestArgs)
 	if err != nil {
 		t.Fatalf("buildValueArgs: %v", err)
 	}


### PR DESCRIPTION
## Problem

`c8s install --resolve-digests` resolves the registry digest of **every** component in the chart's `c8sComponents` list, ignoring each entry's `enabledPath`. Under `--cvm-mode=node`, `attestationApi` and `nriImagePolicy` are baked into the measured node image and disabled in the chart (`attestation-api.yaml`: `{{- if .Values.attestationApi.enabled }}`). Their standalone component images aren't necessarily published at the release tag — so a valid node-mode install **aborts on a 404 for an image it will never deploy**:

```
component attestationApi.image: image …/attestation-api:v0.1.0-rc1 is not published
Error: MANIFEST_UNKNOWN
```

Hit live validating `v0.1.0-rc1` on a TDX node CVM.

## Fix

`buildDigestArgs` now skips a component whose `enabledPath` resolves **false** in the effective config. `chartComponents` reads the (already-declared) `enabledPath` per entry; `componentEnabledPredicate` builds the merged tree once (`helm show values` overlaid with the `--set`/`--set-string` overrides the install already assembled — which include node-mode's `attestationApi.enabled=false`) and caches it. Because `appendCvmModeInstallArgs`/`appendKataInstallArgs` run before the resolver, the disable flags are present when the predicate reads them.

## Tests

`go build ./...`, `go vet ./...` clean; `go test ./cmd/c8s/` passes. New: `TestBuildDigestArgsSkipsDisabledComponent` (disabled component's resolver never called, no `--set` emitted; enabled ones still pin) + `TestBuildDigestArgsFailsClosedOnEnabledError`. Verified against the real chart: default -> all enabled; node -> attestationApi/nriImagePolicy disabled; pod -> all three disabled.

## Note

Separately, `v0.1.0-rc1` doesn't publish `attestation-api` at that tag — a release-completeness gap. This fix makes it **harmless for node mode** (the image is skipped), but pod mode (where attestationApi *is* deployed) would still need it published.
