### PR TITLE
fix(nri-image-policy): match nri v0.12 RemoveContainer signature

### DIFF
--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -144,11 +144,11 @@ func (p *plugin) Configure(ctx context.Context, config, runtime, version string)
 
 // RemoveContainer evicts a stopped container from the workload-claims broker.
 // Only subscribed when the broker is enabled (see Configure).
-func (p *plugin) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) ([]*api.ContainerUpdate, error) {
+func (p *plugin) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	if p.broker != nil {
 		p.broker.remove(ctr.GetId())
 	}
-	return nil, nil
+	return nil
 }
 
 // recordForBroker resolves a container's admitted image digest and records it


### PR DESCRIPTION
nri registers optional event handlers by runtime type assertion against
RemoveContainerInterface. Our RemoveContainer returned
([]*api.ContainerUpdate, error) — the v0.11 shape — so the assertion never
matched, Event_REMOVE_CONTAINER was never subscribed, and the handler body
never ran: stopped containers were never evicted from the workload-claims
broker.

It compiles either way, which is why it went unnoticed.


---
Independent — based on `main`, no stack.
Split out of #63.
