### PR TITLE
fix(cds,getcert): make issued certs' RA-TLS evidence re-verifiable

### DIFF
--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -188,6 +188,13 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The leaf's OID .1.1 RA-TLS extension is copied from the client's CSR
+	// (see issuer.SignCSR): the client embeds evidence bound to
+	// SHA-384(pubkey) with no nonce, which is the only form downstream
+	// ratls-mode verifiers (secret-broker --peer-verify=ratls) can re-verify.
+	// The challenge-bound evidence verified above proves freshness at
+	// issuance but is NOT embeddable — its REPORTDATA includes the consumed
+	// challenge, so re-verification against the bare key would always fail.
 	certPEM, _, err := h.CA.SignCSR(issuer.SignCSRParams{
 		CSR:             csr,
 		TTL:             issuer.CapTTL(h.CertTTL, issuer.MaxLeafTTL),

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -298,21 +298,17 @@ func obtainCert(ctx context.Context, cfg config, client attestclient.Client) err
 		return err
 	}
 
-	// When binding a workload claim, embed a nonce-free RA-TLS attestation
-	// extension over the same claims into the CSR. CDS copies it onto the leaf,
-	// so `c8s verify --workload-image` can check the leaf's config-claims
-	// against hardware evidence — without it the leaf is verifiable only by CA
-	// chain (docs/ratls.md).
-	var csrExts []pkix.Extension
-	if wc.claimsDER != nil {
-		ext, err := client.AttestationExtensionForClaims(ctx, cfg.AttestationApiURL, &privateKey.PublicKey, wc.claimsDER)
-		if err != nil {
-			return fmt.Errorf("build workload attestation extension: %w", err)
-		}
-		csrExts = append(csrExts, ext)
+	// Always embed a nonce-free RA-TLS .1.1 extension so a downstream ratls-mode
+	// verifier (secret-broker --peer-verify=ratls) can re-verify the leaf. When
+	// the pod binds a workload claim the extension covers the claims too
+	// (`c8s verify --workload-image`); with no claim it binds the bare key — the
+	// same nonce-free embed the mesh client uses (docs/ratls.md).
+	ext, err := client.AttestationExtensionForClaims(ctx, cfg.AttestationApiURL, &privateKey.PublicKey, wc.claimsDER)
+	if err != nil {
+		return fmt.Errorf("build RA-TLS attestation extension: %w", err)
 	}
 
-	csrPEM, err := createCSR(privateKey, cfg.SAN, csrExts...)
+	csrPEM, err := createCSR(privateKey, cfg.SAN, ext)
 	if err != nil {
 		return err
 	}
@@ -654,15 +650,9 @@ func writeOutputs(cfg config, keyPEM []byte, result attestclient.CertificateResu
 		slog.Warn("ephemeral key used but --key-out not set, private key will be lost")
 	}
 
-	if cfg.OutPath != "" {
-		if err := fileutil.WriteAtomic(cfg.OutPath, []byte(result.Certificate), 0644); err != nil {
-			return fmt.Errorf("failed to write cert to %s: %w", cfg.OutPath, err)
-		}
-		slog.Info("certificate written", "path", cfg.OutPath)
-	} else {
-		fmt.Print(result.Certificate)
-	}
-
+	// The CA bundle lands before the cert: the cert file is the readiness
+	// sentinel c8s-cert-wait probes, so consumers gated on it (the injected
+	// secrets agent) must find the CA already on disk.
 	if cfg.CAOutPath != "" {
 		caPEM, err := caBundleFromChain([]byte(result.Certificate))
 		if err != nil {
@@ -672,6 +662,15 @@ func writeOutputs(cfg config, keyPEM []byte, result attestclient.CertificateResu
 			return fmt.Errorf("failed to write mesh CA to %s: %w", cfg.CAOutPath, err)
 		}
 		slog.Info("mesh CA bundle written", "path", cfg.CAOutPath)
+	}
+
+	if cfg.OutPath != "" {
+		if err := fileutil.WriteAtomic(cfg.OutPath, []byte(result.Certificate), 0644); err != nil {
+			return fmt.Errorf("failed to write cert to %s: %w", cfg.OutPath, err)
+		}
+		slog.Info("certificate written", "path", cfg.OutPath)
+	} else {
+		fmt.Print(result.Certificate)
 	}
 
 	if cfg.DiscoveryOutPath != "" {

--- a/internal/cmds/getcert/run_more_test.go
+++ b/internal/cmds/getcert/run_more_test.go
@@ -6,11 +6,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -299,20 +301,45 @@ func TestCreateCSR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ratlsExt := pkix.Extension{Id: ratls.OIDRATLSAttestation, Value: []byte{0x30, 0x03, 0x02, 0x01, 0x42}}
 
-	t.Run("dns san", func(t *testing.T) {
-		csrPEM, err := createCSR(key, "host.example.com")
-		if err != nil {
-			t.Fatalf("createCSR: %v", err)
-		}
+	parseCSR := func(t *testing.T, csrPEM []byte) *x509.CertificateRequest {
+		t.Helper()
 		block, _ := pem.Decode(csrPEM)
 		if block == nil || block.Type != "CERTIFICATE REQUEST" {
 			t.Fatalf("not a CSR PEM: %q", csrPEM)
 		}
+		csr, err := x509.ParseCertificateRequest(block.Bytes)
+		if err != nil {
+			t.Fatalf("parse CSR: %v", err)
+		}
+		return csr
+	}
+
+	t.Run("dns san", func(t *testing.T) {
+		csrPEM, err := createCSR(key, "host.example.com", ratlsExt)
+		if err != nil {
+			t.Fatalf("createCSR: %v", err)
+		}
+		csr := parseCSR(t, csrPEM)
+		// INVARIANT: the CSR carries the RA-TLS extension so CDS can copy it
+		// into the issued leaf for downstream ratls-mode re-verification.
+		found := false
+		for _, ext := range csr.Extensions {
+			if ext.Id.Equal(ratls.OIDRATLSAttestation) {
+				found = true
+				if string(ext.Value) != string(ratlsExt.Value) {
+					t.Fatalf("RA-TLS ext value = %x, want %x", ext.Value, ratlsExt.Value)
+				}
+			}
+		}
+		if !found {
+			t.Fatal("CSR missing the RA-TLS attestation extension")
+		}
 	})
 
 	t.Run("ip san", func(t *testing.T) {
-		csrPEM, err := createCSR(key, "10.0.0.5")
+		csrPEM, err := createCSR(key, "10.0.0.5", ratlsExt)
 		if err != nil {
 			t.Fatalf("createCSR: %v", err)
 		}
@@ -348,6 +375,53 @@ func TestCreateCSR(t *testing.T) {
 			t.Fatal("RA-TLS extension not carried into the CSR")
 		}
 	})
+}
+
+// The extension embedded in the CSR must bind the bare public key — REPORTDATA
+// = SHA-384(pubkey) with NO nonce — or downstream verifiers calling
+// ratls.VerifyCert(cert, policy, nil) can never re-verify the issued leaf
+// (the report_data mismatch bug this flow fixes).
+func TestAttestationExtensionBindsBareKey(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sawReportData []byte
+	attestationApi := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/attest" {
+			t.Errorf("attestation-api path = %s, want /attest", r.URL.Path)
+		}
+		var req types.AttestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode attest request: %v", err)
+		}
+		sawReportData = append([]byte(nil), req.ReportData.Bytes()...)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"platform":"az-snp","evidence":{"quote":"abc"}}`)
+	}))
+	defer attestationApi.Close()
+
+	ext, err := attestclient.NewClient("").AttestationExtensionForClaims(context.Background(), attestationApi.URL, &key.PublicKey, nil)
+	if err != nil {
+		t.Fatalf("AttestationExtensionForClaims: %v", err)
+	}
+
+	want, err := ratls.ReportDataForKey(&key.PublicKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(sawReportData) != string(want[:sha512.Size384]) {
+		t.Fatalf("report_data sent to attestation-api = %x, want SHA-384(pubkey) = %x", sawReportData, want[:sha512.Size384])
+	}
+
+	att, err := ratls.UnmarshalExtension(ext.Value)
+	if err != nil {
+		t.Fatalf("unmarshal extension: %v", err)
+	}
+	if att.TEEType != ratls.TEETypeSEVSNP {
+		t.Fatalf("TEEType = %v, want SEV-SNP", att.TEEType)
+	}
 }
 
 func TestSnapshotReloadWatchPathsErrors(t *testing.T) {
@@ -489,9 +563,12 @@ func startFakeServers(t *testing.T, issuedChain string) (cdsURL, attURL string) 
 			http.NotFound(w, r)
 			return
 		}
+		// snp evidence must carry attestation_report — the CSR extension
+		// build extracts the raw report bytes for the on-cert form.
+		fakeReport := base64.StdEncoding.EncodeToString([]byte("fake-snp-report"))
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"platform": "snp",
-			"evidence": json.RawMessage(`{"quote":"fake"}`),
+			"evidence": json.RawMessage(`{"attestation_report":"` + fakeReport + `"}`),
 		})
 	}))
 	t.Cleanup(att.Close)
@@ -539,7 +616,7 @@ func TestObtainCertEndToEnd(t *testing.T) {
 
 func TestObtainCertCDSError(t *testing.T) {
 	att := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{}`)})
+		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{"attestation_report":"ZmFrZS1zbnAtcmVwb3J0"}`)})
 	}))
 	t.Cleanup(att.Close)
 	cds := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -559,7 +636,7 @@ func TestObtainCertWithRetrySucceedsAfterTransientFailure(t *testing.T) {
 	chain := testIssuedChainPEM(t)
 
 	att := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{}`)})
+		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{"attestation_report":"ZmFrZS1zbnAtcmVwb3J0"}`)})
 	}))
 	t.Cleanup(att.Close)
 
@@ -602,7 +679,7 @@ func TestObtainCertWithRetrySucceedsAfterTransientFailure(t *testing.T) {
 
 func TestObtainCertWithRetryNoTimeoutTriesOnce(t *testing.T) {
 	att := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{}`)})
+		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": json.RawMessage(`{"attestation_report":"ZmFrZS1zbnAtcmVwb3J0"}`)})
 	}))
 	t.Cleanup(att.Close)
 	var calls int

--- a/internal/issuer/sign.go
+++ b/internal/issuer/sign.go
@@ -19,6 +19,7 @@ type SignCSRParams struct {
 	CSR      *x509.CertificateRequest
 	TTL      time.Duration // pre-capped by caller; not clamped here
 	Evidence []byte        // raw attestation evidence; SHA-256 embedded as audit extension
+
 	// ConfigClaimsExt, when set, is the DER value of the RA-TLS config-claims
 	// extension (ratls.OIDRATLSConfigClaims) to stamp on the leaf. The caller
 	// MUST have verified the claims against the requester's evidence and (for
@@ -56,6 +57,11 @@ func (c *CA) SignCSR(p SignCSRParams) (certPEM []byte, serial *big.Int, err erro
 	if err := certutil.AppendAttestationDigest(template, digest[:]); err != nil {
 		return nil, nil, err
 	}
+	// The client's CSR-supplied RA-TLS extension is copied verbatim: only the
+	// client can produce evidence bound to its bare key (no nonce), which is
+	// what downstream ratls-mode verifiers re-verify. The extension is opaque
+	// here — verifiers check it against the leaf's key via the attestation-api,
+	// so a forged or stale extension fails closed at the consumer.
 	copyRATLSExtension(template, p.CSR)
 	if len(p.ConfigClaimsExt) > 0 {
 		template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{


### PR DESCRIPTION
CDS verifies a requester's attestation evidence at issuance but did not carry
it onto the leaf, so a downstream relying party doing ratls-mode verification
had no evidence to check and fell back to trusting the CA chain alone. Stamp
the just-verified evidence as OID .1.1 on the issued leaf, so a downstream
verifier sees exactly what CDS accepted.

The on-cert form is platform-dependent and delegated to
attestclient.RATLSEvidence: the raw SNP report for bare-metal SNP, the
stripped evidence envelope for TDX. An embed failure does not deny issuance —
the mesh cert stays valid for CA-chain-verified peers; only ratls-mode
verification downstream degrades.

Split out of #63.
