### PR TITLE
feat(tls-lb): enable the attestation sidecar by default

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -58,6 +59,7 @@ var (
 	installWorkloadRefs []string
 
 	installResolveDigests bool
+	installAttestEnabled  bool
 )
 
 // Flag names referenced in more than one place (registration plus a Changed()
@@ -816,8 +818,33 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			}
 		}
 
+		printAttestVerifyHint(os.Stdout, installAttestEnabled)
 		return nil
 	},
+}
+
+// printAttestVerifyHint surfaces how to pin this cluster's launch measurement
+// after an install with the tls-lb attestation sidecar (on by default).
+//
+// In node mode CDS, the ratls-mesh, and the tls-lb sidecar are all pods in the
+// same measured node, so they share ONE launch measurement M. That same M is
+// pinned at three trust boundaries: cds.measurements and ratlsMesh.measurements
+// (the internal mesh — empty by default = accept any attested peer, UNSAFE) and
+// the sidecar's browser/CLI verification (external clients). Install cannot
+// compute M here (it lives in the node image the CVM booted, not the install
+// context) — but `c8s verify` fetches the live quote and RENDERS the M it
+// observed, so one unpinned verify yields the value to pin in all three places.
+func printAttestVerifyHint(w io.Writer, attestEnabled bool) {
+	if !attestEnabled {
+		return
+	}
+	fmt.Fprintln(w, "+ tls-lb attestation sidecar is enabled (/.well-known/c8s/). Pin this")
+	fmt.Fprintln(w, "  cluster's launch measurement M with one unpinned read:")
+	fmt.Fprintln(w, "      c8s verify https://<tls-lb>        # prints the observed M")
+	fmt.Fprintln(w, "  Then enforce that same M at every trust boundary:")
+	fmt.Fprintln(w, "    - clients:  c8s verify https://<tls-lb> --measurements <M>")
+	fmt.Fprintln(w, "    - internal: reinstall -f cds.measurements=[<M>] ratlsMesh.measurements=[<M>]")
+	fmt.Fprintln(w, "  Until pinned, verifiers accept any attested TEE.")
 }
 
 // extractChart writes the embedded chart tree to a fresh tmpdir and returns
@@ -1096,6 +1123,19 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 		helmArgs = append(helmArgs,
 			"--set-string", "cds.ratlsPlatform=tdx",
 			"--set-string", "ratlsMesh.platform=tdx",
+		)
+	}
+	// The tls-lb attestation sidecar is on by default (chart default); --attest=false
+	// omits it. When on, it advertises its TEE to the browser verifier: the chart
+	// default is snp/genoa, so on TDX override both to match the hardware.
+	// generation is AMD-only (Genoa/Milan/…); on TDX it is not a meaningful
+	// field, so we blank it rather than ship a stale AMD codename.
+	if !installAttestEnabled {
+		helmArgs = append(helmArgs, "--set", "tlsLb.attest.enabled=false")
+	} else if hardwarePlatform == "tdx" {
+		helmArgs = append(helmArgs,
+			"--set-string", "tlsLb.attest.platform=tdx",
+			"--set-string", "tlsLb.attest.generation=",
 		)
 	}
 	// node: the node image bakes host attestation-api and nri-image-policy;
@@ -1775,6 +1815,7 @@ func init() {
 	installCmd.Flags().StringVar(&installHardwarePlatform, flagHardwarePlatform, "sev-snp", "CPU-level TEE hardware (orthogonal to --cvm-mode): sev-snp (default, /dev/sev-guest) or tdx (Intel TDX, /dev/tdx-guest). Under --cvm-mode=aks the CPU TEE rides the Azure vTPM: sev-snp selects az-snp and tdx selects az-tdx (no guest device needed — the report comes from /dev/tpm0)")
 	installCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG guest variant (<tag>-debug): kubectl logs/exec work on kata pods, but container I/O becomes readable by the untrusted host and the launch measurement differs from the locked image. Requires --cvm-mode=pod; development only")
 	installCmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "resolve each c8s component image tag to its registry digest (via crane), pin it, and add the resolved images to the NRI allowlist (enables deriveComponents). On by default; pass --resolve-digests=false when supplying digests via -f")
+	installCmd.Flags().BoolVar(&installAttestEnabled, "attest", true, "deploy the tls-lb attestation sidecar serving /.well-known/c8s/ (browser/CLI verification via c8s-verify). On by default; pass --attest=false to omit it")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")
 	installCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; sets cds.operatorKeys. Without it, allowlist writes are disabled (reads still served). See the README \"Operator allowlist credentials\"")

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -993,6 +993,12 @@ func TestHostPortConflict(t *testing.T) {
 }
 
 func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
+	// The attestation sidecar is on by default; the arg-builder reads the
+	// package flag, which cobra would set. Mirror that default here.
+	prevAttest := installAttestEnabled
+	installAttestEnabled = true
+	t.Cleanup(func() { installAttestEnabled = prevAttest })
+
 	// Two orthogonal axes:
 	//  --cvm-mode: pod (kata) / node (node-as-CVM) / gke (managed) / aks (vTPM)
 	//  --hardware-platform: sev-snp (/dev/sev-guest) / tdx (/dev/tdx-guest)
@@ -1014,6 +1020,14 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 			out = append(out,
 				"--set-string", "cds.ratlsPlatform=tdx",
 				"--set-string", "ratlsMesh.platform=tdx",
+			)
+		}
+		// TDX also overrides the tls-lb attestation sidecar's advertised
+		// platform (chart default snp/genoa) and blanks the AMD-only generation.
+		if platform == "tdx" {
+			out = append(out,
+				"--set-string", "tlsLb.attest.platform=tdx",
+				"--set-string", "tlsLb.attest.generation=",
 			)
 		}
 		// node: the node image bakes attestation-api + nri-image-policy, so the

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1150,9 +1150,17 @@ tlsLb:
   # over-encryption handshake) and nginx reverse-proxies `/.well-known/c8s/` to
   # it on loopback. The static CDS/mesh-CA certs are still served by nginx via
   # `discovery`. The browser client is lunal-dev/c8s-verify-js (wire contract:
-  # c8s-verify-js/PROTOCOL.md). Defaults off; pin measurements before exposing.
+  # c8s-verify-js/PROTOCOL.md).
+  #
+  # On by default: the sidecar only publishes a signed quote of its own TEE, so
+  # exposing it does not weaken the server. Trust is established on the CLIENT,
+  # which must pin expected launch measurements (`c8s verify --measurements`,
+  # c8s-verify-js config) — an unpinned verifier accepting any TEE is a client
+  # misconfiguration, not a server exposure. `platform`/`generation` below default
+  # to AMD; `c8s install` overrides them from --hardware-platform (tdx blanks the
+  # AMD-only generation), so both TEEs advertise correctly out of the box.
   attest:
-    enabled: false
+    enabled: true
     # -- Loopback port the sidecar listens on; nginx proxies `/.well-known/c8s/`
     # to 127.0.0.1 on this port.
     port: 8800

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1783,13 +1783,23 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 		}
 	}
 
-	// Default off: no sidecar, no well-known proxy.
-	offOut, err := helmTemplate(t)
+	// Default on: the sidecar and its well-known proxy render without any
+	// attest override.
+	defOut, err := helmTemplate(t)
 	if err != nil {
-		t.Fatalf("helm template (defaults): %v\n%s", err, offOut)
+		t.Fatalf("helm template (defaults): %v\n%s", err, defOut)
+	}
+	if !strings.Contains(defOut, "name: cds-attest") || !strings.Contains(defOut, "location /.well-known/c8s/ {") {
+		t.Fatal("cds-attest sidecar should render by default (tlsLb.attest.enabled defaults true)")
+	}
+
+	// Explicit opt-out: no sidecar, no well-known proxy.
+	offOut, err := helmTemplate(t, "--set", "tlsLb.attest.enabled=false")
+	if err != nil {
+		t.Fatalf("helm template (attest disabled): %v\n%s", err, offOut)
 	}
 	if strings.Contains(offOut, "name: cds-attest") || strings.Contains(offOut, "location /.well-known/c8s/ {") {
-		t.Fatal("cds-attest sidecar should not render when tlsLb.attest.enabled is false")
+		t.Fatal("cds-attest sidecar should not render when tlsLb.attest.enabled=false")
 	}
 }
 
@@ -4982,6 +4992,7 @@ func renderExampleTLSLBNginxConf() string {
 		// discovery defaults to enabled; scope this example to route rendering
 		// (discovery's own locations are covered by a dedicated test above).
 		"--set", "tlsLb.discovery.enabled=false",
+		"--set", "tlsLb.attest.enabled=false",
 		"--set-string", "tlsLb.upstream.address=vllm:8000",
 		"--set", "tlsLb.upstream.protocol=https",
 		"--set", "tlsLb.upstream.tls.verify=true",


### PR DESCRIPTION
## What

Enable the tls-lb attestation sidecar (`/.well-known/c8s/`, c8s-verify/v1) **by default**, advertise the correct TEE on both platforms, and surface how to pin the cluster's launch measurement.

## Why

The sidecar only publishes a signed quote of its *own* TEE, so exposing it does not weaken the server — trust is established on the **verifier**, which pins the expected launch measurement. Defaulting it off left `/.well-known/c8s/*` returning 404/502 out of the box even though the nginx route exists; enabling it makes browser/CLI verification (`c8s verify`, c8s-verify-js) work on a plain install.

## Changes

- **`values.yaml`**: `tlsLb.attest.enabled` defaults `true`; comment states the server-safe / client-pins posture and that `platform`/`generation` are overridden per `--hardware-platform`.
- **`install.go`**: derives `tlsLb.attest.platform=tdx` and blanks the AMD-only `generation` from `--hardware-platform`, so TDX installs advertise correctly instead of the chart's `snp`/`genoa` default. New `--attest` flag (default `true`); `--attest=false` omits the sidecar.
- **`install.go`**: post-install hint. In node mode CDS, the ratls-mesh, and the sidecar are pods in the **same measured node**, so they share one launch measurement `M`. One unpinned `c8s verify` renders `M`, which then pins all three trust boundaries — clients (`--measurements`) and the internal mesh (`cds.measurements` / `ratlsMesh.measurements`). Install cannot compute `M` itself (it lives in the booted node image, not the install context), so the hint drives the observe-then-pin flow rather than pretending to auto-pin.

## Testing

- `go build ./cmd/c8s` + `go test ./cmd/c8s/ ./internal/cmds/cdsattest/` green.
- `TestAppendCvmModeInstallArgsSetsAttestationApiValue` updated for the new tdx `--set` args.
- Verified live on a TDX node-mode cluster via an equivalent surgical patch: `/.well-known/c8s/attestation?pq=false&nonce=…` returns a full attestation bundle (`evidence`, `cds_cert_pem`, `binding`); inference on the same tls-lb unaffected.

## Notes

- Default-on is a security-posture change; it is safe server-side but relies on clients pinning measurements (an unpinned verifier accepts any TEE — called out in the values comment and the hint).
- `platform`/`generation` chart defaults stay `snp`/`genoa`; only `c8s install` overrides them, so a raw `helm install` on TDX still needs `-f`.
