### PR TITLE
feat(install): --measurements pins the mesh in one install

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -5,6 +5,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +30,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/helmchart"
 	"github.com/confidential-dot-ai/c8s/internal/version"
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -60,6 +62,7 @@ var (
 
 	installResolveDigests bool
 	installAttestEnabled  bool
+	installMeasurements   []string
 )
 
 // Flag names referenced in more than one place (registration plus a Changed()
@@ -823,28 +826,28 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 	},
 }
 
-// printAttestVerifyHint surfaces how to pin this cluster's launch measurement
-// after an install with the tls-lb attestation sidecar (on by default).
+// printAttestVerifyHint surfaces measurement pinning after an install with the
+// tls-lb attestation sidecar (on by default).
 //
-// In node mode CDS, the ratls-mesh, and the tls-lb sidecar are all pods in the
-// same measured node, so they share ONE launch measurement M. That same M is
-// pinned at three trust boundaries: cds.measurements and ratlsMesh.measurements
-// (the internal mesh — empty by default = accept any attested peer, UNSAFE) and
-// the sidecar's browser/CLI verification (external clients). Install cannot
-// compute M here (it lives in the node image the CVM booted, not the install
-// context) — but `c8s verify` fetches the live quote and RENDERS the M it
-// observed, so one unpinned verify yields the value to pin in all three places.
+// The cluster's launch measurement M is a property of the deployed node image
+// (its manifest.json), known before the cluster runs. --measurements <M> pins it
+// into the internal mesh (cds.measurements + ratlsMesh.measurements) on the
+// install itself; external clients pin the same M when they verify. When
+// --measurements was omitted, the mesh accepts any attested peer (UNSAFE), so
+// the hint says how to fix it.
 func printAttestVerifyHint(w io.Writer, attestEnabled bool) {
 	if !attestEnabled {
 		return
 	}
-	fmt.Fprintln(w, "+ tls-lb attestation sidecar is enabled (/.well-known/c8s/). Pin this")
-	fmt.Fprintln(w, "  cluster's launch measurement M with one unpinned read:")
-	fmt.Fprintln(w, "      c8s verify https://<tls-lb>        # prints the observed M")
-	fmt.Fprintln(w, "  Then enforce that same M at every trust boundary:")
-	fmt.Fprintln(w, "    - clients:  c8s verify https://<tls-lb> --measurements <M>")
-	fmt.Fprintln(w, "    - internal: reinstall -f cds.measurements=[<M>] ratlsMesh.measurements=[<M>]")
-	fmt.Fprintln(w, "  Until pinned, verifiers accept any attested TEE.")
+	if len(installMeasurements) > 0 {
+		fmt.Fprintln(w, "+ tls-lb attestation sidecar enabled; mesh pinned to --measurements.")
+		fmt.Fprintln(w, "  Clients verify with the same M: c8s verify https://<tls-lb> --measurements <M>")
+		return
+	}
+	fmt.Fprintln(w, "+ tls-lb attestation sidecar enabled, but the mesh is UNPINNED (accepts any")
+	fmt.Fprintln(w, "  attested TEE). Pin it with the node image's launch measurement M (its")
+	fmt.Fprintln(w, "  manifest.json): reinstall with --measurements <M>. Clients verify with the")
+	fmt.Fprintln(w, "  same M: c8s verify https://<tls-lb> --measurements <M>.")
 }
 
 // extractChart writes the embedded chart tree to a fresh tmpdir and returns
@@ -1146,6 +1149,40 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 		helmArgs = append(helmArgs,
 			"--set", "attestationApi.enabled=false",
 			"--set", "nriImagePolicy.enabled=false",
+		)
+	}
+	// --measurements pins the expected launch measurement(s) of this cluster's
+	// CVM into both internal trust boundaries in one install: the mesh (and NRI)
+	// dial CDS pinned to it (cds.measurements), and mesh peers pin each other
+	// (ratlsMesh.measurements). The operator supplies M — it is a property of the
+	// deployed node image (its manifest.json), known before the cluster runs — so
+	// the mesh is pinned from first boot rather than accept-any-then-tighten.
+	// Empty = no pinning (UNSAFE, the chart default).
+	//
+	// Parse here, on the shared builder path, so the pinned list is validated
+	// and normalized regardless of which command emitted it — and so the fanned
+	// list matches exactly what was validated (a blank/whitespace entry, e.g.
+	// from a trailing comma, is dropped by the parser, not silently emitted as
+	// an empty pin that would disable pinning at that index).
+	measurements, err := ratls.ParseHexMeasurementsList(installMeasurements)
+	if err != nil {
+		return nil, fmt.Errorf("--measurements: %w", err)
+	}
+	// cds.measurements / ratlsMesh.measurements pin the launch measurement of the
+	// components that speak to CDS. In node/gke/aks the node IS the CVM, so that
+	// is the node image's M — what --measurements takes. In pod mode those
+	// components are the per-pod kata guests (host-side mesh/attestation-api/NRI
+	// are disabled), whose kata-guest-base measurement is a different value; a
+	// node M pinned there would only reject every real peer. Refuse rather than
+	// mis-pin.
+	if len(measurements) > 0 && cvmMode == "pod" {
+		return nil, fmt.Errorf("--measurements pins the node CVM's launch measurement; it does not apply to --cvm-mode=pod (per-pod kata guests are measured separately)")
+	}
+	for i, m := range measurements {
+		hexM := hex.EncodeToString(m)
+		helmArgs = append(helmArgs,
+			"--set-string", fmt.Sprintf("cds.measurements[%d]=%s", i, hexM),
+			"--set-string", fmt.Sprintf("ratlsMesh.measurements[%d]=%s", i, hexM),
 		)
 	}
 	return helmArgs, nil
@@ -1816,6 +1853,7 @@ func init() {
 	installCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG guest variant (<tag>-debug): kubectl logs/exec work on kata pods, but container I/O becomes readable by the untrusted host and the launch measurement differs from the locked image. Requires --cvm-mode=pod; development only")
 	installCmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "resolve each c8s component image tag to its registry digest (via crane), pin it, and add the resolved images to the NRI allowlist (enables deriveComponents). On by default; pass --resolve-digests=false when supplying digests via -f")
 	installCmd.Flags().BoolVar(&installAttestEnabled, "attest", true, "deploy the tls-lb attestation sidecar serving /.well-known/c8s/ (browser/CLI verification via c8s-verify). On by default; pass --attest=false to omit it")
+	installCmd.Flags().StringSliceVar(&installMeasurements, "measurements", nil, "expected hex launch measurement(s) of this cluster's CVM (repeatable/comma-separated), from the node image's manifest.json. Pins the internal mesh (cds.measurements + ratlsMesh.measurements) on this install; empty = no pinning (UNSAFE). Not valid with --cvm-mode=pod")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")
 	installCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; sets cds.operatorKeys. Without it, allowlist writes are disabled (reads still served). See the README \"Operator allowlist credentials\"")

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1072,6 +1072,60 @@ func TestAppendCvmModeInstallArgsRejectsUnknownMode(t *testing.T) {
 	}
 }
 
+// --measurements fans each M into both mesh pin points, indexed, so the operator
+// pins the internal mesh on the install itself. A blank entry (e.g. from a
+// trailing comma) is dropped, not emitted as an empty index, and the emitted
+// indices are contiguous over the validated list.
+func TestAppendCvmModeInstallArgsMeasurements(t *testing.T) {
+	prev := installMeasurements
+	defer func() { installMeasurements = prev }()
+	m0, m1 := strings.Repeat("aa", 48), strings.Repeat("bb", 48)
+	installMeasurements = []string{m0, "", m1} // blank middle entry
+
+	got, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "tdx")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"cds.measurements[0]=" + m0, "ratlsMesh.measurements[0]=" + m0,
+		"cds.measurements[1]=" + m1, "ratlsMesh.measurements[1]=" + m1,
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("args missing %q; got %v", want, got)
+		}
+	}
+	// The blank must not produce an empty index-2 pin.
+	for _, bad := range []string{"cds.measurements[2]=", "ratlsMesh.measurements[2]="} {
+		if slices.Contains(got, bad) {
+			t.Errorf("blank entry leaked an empty pin %q; got %v", bad, got)
+		}
+	}
+}
+
+func TestAppendCvmModeInstallArgsRejectsBadMeasurement(t *testing.T) {
+	prev := installMeasurements
+	defer func() { installMeasurements = prev }()
+	installMeasurements = []string{"not-hex"}
+	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "tdx"); err == nil {
+		t.Fatal("appendCvmModeInstallArgs accepted a malformed measurement, want error")
+	}
+}
+
+// --measurements pins the node CVM's measurement, which is meaningless in pod
+// mode (per-pod kata guests are measured separately) — reject it.
+func TestAppendCvmModeInstallArgsRejectsMeasurementsInPodMode(t *testing.T) {
+	prev := installMeasurements
+	defer func() { installMeasurements = prev }()
+	installMeasurements = []string{strings.Repeat("aa", 48)}
+	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "pod", "tdx"); err == nil {
+		t.Fatal("appendCvmModeInstallArgs accepted --measurements in pod mode, want error")
+	}
+	// Same value in node mode is fine.
+	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "tdx"); err != nil {
+		t.Fatalf("node mode should accept --measurements: %v", err)
+	}
+}
+
 func TestAppendCvmModeInstallArgsRejectsUnknownHardwarePlatform(t *testing.T) {
 	if _, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "sgx"); err == nil {
 		t.Fatal("appendCvmModeInstallArgs accepted an unknown --hardware-platform, want error")

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -247,9 +247,10 @@ func appendWebhookInstallArgs(setArgs []string, cmd *cobra.Command) []string {
 // int coerced; everything else stays a string); --set-string values stay
 // strings; --set-file values name a file whose content becomes the value
 // verbatim, mirroring helm. Any other flag is an error rather than a silently
-// mis-parsed value. Dotted keys nest. This deliberately does not implement
-// helm's full --set grammar (no list indexing, no escaped dots) because the
-// builder never emits those.
+// mis-parsed value. Dotted keys nest; a trailing key[n] sets list element n
+// (see setNested) — the one indexed form the builder emits. This still does not
+// implement the rest of helm's --set grammar (escaped dots, nested indices)
+// because the builder never emits those.
 func valueArgsToTree(setArgs []string) (map[string]any, error) {
 	root := map[string]any{}
 	for i := 0; i < len(setArgs); i += 2 {
@@ -318,8 +319,24 @@ func coerce(raw string, typed bool) any {
 func setNested(m map[string]any, path []string, value any) error {
 	for i, seg := range path {
 		if i == len(path)-1 {
+			// A trailing key[n] sets element n of a list (helm --set list
+			// syntax), the one indexed form the builder emits (e.g.
+			// cds.measurements[0]=…). setListElem grows the list as needed.
+			if key, idx, ok := parseListIndex(seg); ok {
+				return setListElem(m, strings.Join(path, "."), key, idx, value)
+			}
+			// A '[' that is not a clean trailing key[n] is outside the grammar
+			// this parser handles. Fail loudly rather than key on the raw
+			// segment, so a mis-emitting builder can't silently write a bogus
+			// key (the test-only grammar guard can't catch that at runtime).
+			if strings.ContainsRune(seg, '[') {
+				return fmt.Errorf("value path %q: segment %q is not a valid key or key[n] list index", strings.Join(path, "."), seg)
+			}
 			m[seg] = value
 			return nil
+		}
+		if strings.ContainsRune(seg, '[') {
+			return fmt.Errorf("value path %q: list index is only supported on the final segment, not %q", strings.Join(path, "."), seg)
 		}
 		child, ok := m[seg].(map[string]any)
 		if !ok {
@@ -334,6 +351,38 @@ func setNested(m map[string]any, path []string, value any) error {
 	return nil
 }
 
+// parseListIndex splits a trailing "key[n]" segment into (key, n). ok is false
+// for a plain key (no brackets). Only a well-formed non-negative index matches.
+func parseListIndex(seg string) (key string, idx int, ok bool) {
+	open := strings.IndexByte(seg, '[')
+	if open <= 0 || !strings.HasSuffix(seg, "]") {
+		return "", 0, false
+	}
+	n, err := strconv.Atoi(seg[open+1 : len(seg)-1])
+	if err != nil || n < 0 {
+		return "", 0, false
+	}
+	return seg[:open], n, true
+}
+
+// setListElem sets element idx of the []any at m[key], growing it with nils to
+// length idx+1. Mirrors helm: repeated key[i] pairs build the list.
+func setListElem(m map[string]any, fullPath, key string, idx int, value any) error {
+	list, ok := m[key].([]any)
+	if !ok {
+		if existing, set := m[key]; set && existing != nil {
+			return fmt.Errorf("value path %q conflicts with an existing non-list at %q", fullPath, key)
+		}
+		list = []any{}
+	}
+	for len(list) <= idx {
+		list = append(list, nil)
+	}
+	list[idx] = value
+	m[key] = list
+	return nil
+}
+
 func init() {
 	// render-values reuses the install value flags (same vars, same semantics)
 	// so the two stay in lockstep; it adds --distro in place of install's
@@ -344,6 +393,7 @@ func init() {
 	renderValuesCmd.Flags().BoolVar(&installSingleNode, "single-node", false, "single-node / single-CVM cluster: clear the dedicated-CDS-node selector and toleration (cds.node.selector={}, cds.node.tolerations=[])")
 	renderValuesCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "", "CVM deployment shape (REQUIRED; orthogonal to --hardware-platform): pod (per-pod kata CVMs; disables host-side ratls-mesh/attestation-api/nri-image-policy) or node (generalized node-as-CVM native TEE device) or gke (GKE managed CVMs) or aks (vTPM /dev/tpm0)")
 	renderValuesCmd.Flags().StringVar(&installHardwarePlatform, flagHardwarePlatform, "sev-snp", "CPU-level TEE hardware (orthogonal to --cvm-mode): sev-snp (default, /dev/sev-guest) or tdx (Intel TDX, /dev/tdx-guest). Ignored when --cvm-mode=aks")
+	renderValuesCmd.Flags().StringSliceVar(&installMeasurements, "measurements", nil, "expected hex launch measurement(s) of this cluster's CVM (repeatable/comma-separated), from the node image's manifest.json. Emits cds.measurements + ratlsMesh.measurements; empty = no pinning (UNSAFE). Not valid with --cvm-mode=pod")
 	renderValuesCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG image variant (requires --cvm-mode=pod)")
 	renderValuesCmd.Flags().StringSliceVar(&installWorkloadRefs, flagWorkloadRef, nil, "adopted workload as <cw-id>=<namespace>/<kind>/<name>[:<port>]; repeatable. Used here only to derive --upstream's address (render-values patches nothing)")
 	renderValuesCmd.Flags().StringVar(&installUpstream, flagUpstream, "", "confidential.ai/cw id of the adopted --workload-ref workload tls-lb routes its catch-all to; derives tlsLb.upstream.address c8s-<id>.<ns>.svc.cluster.local:<port> from that ref's :<port>")

--- a/cmd/c8s/render_values_test.go
+++ b/cmd/c8s/render_values_test.go
@@ -42,6 +42,38 @@ func TestValueArgsToTreeNestsDottedKeys(t *testing.T) {
 	}
 }
 
+func TestValueArgsToTreeBuildsListFromIndexedKeys(t *testing.T) {
+	got, err := valueArgsToTree([]string{
+		"--set-string", "cds.measurements[0]=aa",
+		"--set-string", "cds.measurements[1]=bb",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string]any{
+		"cds": map[string]any{"measurements": []any{"aa", "bb"}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v (indexed keys must nest as a list, not a scalar key)", got, want)
+	}
+}
+
+// A '[' that is not a clean trailing key[n] is outside the grammar and must
+// error at runtime, not silently become a literal map key — so a mis-emitting
+// builder fails loudly rather than writing a bogus key.
+func TestValueArgsToTreeRejectsMalformedIndex(t *testing.T) {
+	for _, kv := range []string{
+		"a.b[0].c=x",  // index mid-path
+		"a.b[=x",      // unterminated
+		"a.b[x]=x",    // non-numeric
+		"a.b[0][1]=x", // nested index
+	} {
+		if _, err := valueArgsToTree([]string{"--set-string", kv}); err == nil {
+			t.Errorf("valueArgsToTree(%q) = nil error, want a grammar error", kv)
+		}
+	}
+}
+
 func TestValueArgsToTreeCoercesSetTypes(t *testing.T) {
 	// --set typing mirrors helm strvals: null/bool/int are coerced, the rest
 	// stay strings. --set-string never coerces.
@@ -299,11 +331,11 @@ func TestWriteComputedValuesProducesReadableFile(t *testing.T) {
 
 // coerceSafeValueArg is the value-arg grammar valueArgsToTree / coerce actually
 // handle: a single `dotted.path=value` token whose path segments are
-// [A-Za-z0-9.] only — no list indexing (`foo[0]`), no escaped dots (`a\.b`), no
-// comma-joined multi-values (`a=1,b=2`). valueArgsToTree's doc explicitly opts
-// out of helm's full --set grammar on the promise that buildValueArgs never
-// emits those shapes.
-var coerceSafeValueArg = regexp.MustCompile(`^[A-Za-z0-9.]+=[^,]*$`)
+// [A-Za-z0-9.], optionally with a single trailing list index (`foo.bar[0]`).
+// Still excluded: escaped dots (`a\.b`), comma-joined multi-values (`a=1,b=2`),
+// nested indices. valueArgsToTree's doc opts out of the rest of helm's --set
+// grammar on the promise that buildValueArgs never emits those shapes.
+var coerceSafeValueArg = regexp.MustCompile(`^[A-Za-z0-9.]+(\[[0-9]+\])?=[^,]*$`)
 
 // TestBuildValueArgsStaysWithinParserGrammar is the lockstep guard between the
 // emitter (buildValueArgs / buildDigestArgs) and the parser (valueArgsToTree /
@@ -335,19 +367,22 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	prev := struct {
 		crds, singleNode, debug, resolveDigests bool
 		secret, cvm, upstream, operatorKeys     string
-		workloadRefs                            []string
-	}{installCRDs, installSingleNode, installKataDebug, installResolveDigests, installImagePullSecret, installCvmMode, installUpstream, installOperatorKeys, slices.Clone(installWorkloadRefs)}
+		workloadRefs, measurements              []string
+	}{installCRDs, installSingleNode, installKataDebug, installResolveDigests, installImagePullSecret, installCvmMode, installUpstream, installOperatorKeys, slices.Clone(installWorkloadRefs), slices.Clone(installMeasurements)}
 	defer func() {
 		installCRDs, installSingleNode, installKataDebug, installResolveDigests = prev.crds, prev.singleNode, prev.debug, prev.resolveDigests
 		installImagePullSecret, installCvmMode = prev.secret, prev.cvm
 		installUpstream = prev.upstream
 		installOperatorKeys = prev.operatorKeys
 		installWorkloadRefs = prev.workloadRefs
+		installMeasurements = prev.measurements
 	}()
 	// Drive every value-producing toggle. --install-crds=false exercises the
 	// non-default CRD path; --resolve-digests=false keeps crane off PATH (the
 	// digest-arg shape is covered separately via buildDigestArgs below).
-	// --cvm-mode=pod --debug exercises the kata stack args.
+	// --cvm-mode=pod --debug exercises the kata stack args. --measurements
+	// (node mode — it is rejected in pod mode) exercises the one indexed key[i]=
+	// form the builder emits; asserted in a second pass below.
 	installCRDs, installSingleNode, installKataDebug, installResolveDigests = false, true, true, false
 	installImagePullSecret, installCvmMode = "regcred", "pod"
 	installWorkloadRefs = []string{"infer=workloads/deployment/vllm:8000"}
@@ -392,6 +427,24 @@ func TestBuildValueArgsStaysWithinParserGrammar(t *testing.T) {
 	keys, _ := tree["cds"].(map[string]any)["operatorKeys"].(string)
 	if keys == installOperatorKeys || !strings.Contains(keys, "BEGIN PUBLIC KEY") {
 		t.Fatalf("cds.operatorKeys = %q, want the PEM content of %s", keys, installOperatorKeys)
+	}
+
+	// Second pass: node mode with --measurements exercises the indexed key[i]=
+	// form (rejected in pod mode above). Its args must also stay within the
+	// grammar and round-trip to a list.
+	installCvmMode = "node"
+	installMeasurements = []string{strings.Repeat("ab", 48)}
+	mArgs, err := appendCvmModeInstallArgs(nil, installCvmMode, installHardwarePlatform)
+	if err != nil {
+		t.Fatalf("appendCvmModeInstallArgs (node + measurements): %v", err)
+	}
+	for i := 0; i < len(mArgs); i += 2 {
+		if kv := mArgs[i+1]; !coerceSafeValueArg.MatchString(kv) {
+			t.Errorf("measurement arg %q is outside the grammar", kv)
+		}
+	}
+	if _, err := valueArgsToTree(mArgs); err != nil {
+		t.Fatalf("measurement args failed to parse: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What

Add `c8s install --measurements <M>`: the operator provides the cluster's launch measurement M, and install pins the internal mesh to it **in one pass** — `cds.measurements` (mesh + NRI pin CDS) and `ratlsMesh.measurements` (mesh peers pin each other).

Stacked on #110 (attestation sidecar default-on); this branch adds the single `--measurements` commit.

## Why

M is a **property of the deployed node image** — it lives in the image's `manifest.json` (mrtd/rtmr), known before the cluster ever runs. So whoever deploys the CVM already has M. There is no need to install unpinned, observe M from the running cluster, and reinstall to tighten: the operator supplies M and install pins the mesh from first boot.

This supersedes an earlier observe-from-cluster `--pin` approach (install can't compute M itself, so it would have port-forwarded to the running tls-lb, read the measurement, and printed reinstall commands — a second install step). Providing M directly is simpler and pins the mesh immediately instead of accept-any-then-tighten.

## How

- `--measurements <M>` (repeatable/comma-separated SHA-384 hex) fans each value into both pin points via helm's indexed-list `--set-string`:
  `cds.measurements[i]=<M>` + `ratlsMesh.measurements[i]=<M>`. Verified against the chart: the value lands in cds.yaml, ratls-mesh-daemonset.yaml, and the nri-image-policy install script.
- Empty (default) = no pinning (UNSAFE) — unchanged chart default.
- The post-install hint now nudges toward `--measurements <M>` when it was omitted, and confirms the mesh is pinned when it was supplied. External clients pin the same M via `c8s verify --measurements <M>`.

## Testing

- `go build ./...`, `go vet`, `go test ./cmd/c8s/ ./internal/helmchart/` green.
- `TestAppendCvmModeInstallArgsMeasurements` asserts the indexed fan-out into both pin points.
- `helm template` with `--set-string cds.measurements[0]=…` renders the pinned value into all three enforcement points.

## Note

`--measurements` pins the two **server-side** boundaries (the mesh). The **client-side** boundary (browser/`c8s verify`) is the verifier's own job — it pins the same M. That split is inherent: the server can't pin its clients.
