### PR TITLE
fix(chart): omit cds-attest --upstream when no workload is adopted

### DIFF
--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -162,6 +162,10 @@ spec:
             # app layer; pointed at a headless Service (an adopted workload),
             # the node mesh wraps the pod-IP hop in attested mTLS. An https
             # upstream terminates TLS itself and gets the mTLS args below.
+            # No adopted workload (empty upstream address) -> omit --upstream
+            # entirely; the sidecar then serves attestation with its echo
+            # backend instead of crashing on a scheme-only URL.
+            {{- if $upstreamAddress }}
             - --upstream={{ .Values.tlsLb.upstream.protocol }}://{{ $upstreamAddress }}
             {{- if $attestUsesHTTPSUpstream }}
             - --upstream-ca={{ $upstreamTrustedCAPath }}
@@ -170,6 +174,7 @@ spec:
             - --upstream-key={{ .Values.tlsLb.tlsMountPath }}/key.pem
             {{- end }}
             - --upstream-server-name={{ $attestUpstreamServerName }}
+            {{- end }}
             {{- end }}
           {{- with (include "c8s.attestationApiHostIPEnv" .) }}
           # cvmMode=node: expands $(HOST_IP) in --attestation-api-url to the node

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1699,6 +1699,25 @@ func TestChartTLSLBServiceType(t *testing.T) {
 	}
 }
 
+// With no adopted workload the upstream address is empty; the sidecar must
+// render without any --upstream* flag (its echo backend takes over) instead
+// of a scheme-only "--upstream=http://" that crash-loops the container.
+func TestChartTLSLBAttestSidecarNoUpstream(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "tlsLb.attest.enabled=true",
+		"--set-string", "tlsLb.upstream.address=",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	sidecar := renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest")
+	for _, arg := range sidecar.Args {
+		if strings.HasPrefix(arg, "--upstream") {
+			t.Fatalf("cds-attest must omit %q when no upstream address is set: %v", arg, sidecar.Args)
+		}
+	}
+}
+
 func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set", "tlsLb.attest.enabled=true",


### PR DESCRIPTION
## Problem

Since the attest sidecar became default-on (#110), a `c8s install` with **no adopted workload** (no `--workload-ref`/`--upstream`) renders the cds-attest container arg as a scheme-only URL:

```
--upstream=http://
```

The sidecar's URL validation rejects it (`upstream must be an http:// or https:// URL, got "http:"`) and the container crash-loops — tls-lb stuck at 2/3 forever. Hit live on the b200 node-CVM bring-up of `c8s-dev-cdi` @ `6b86a17` (first install, before any workload existed).

## Fix

Omit the `--upstream*` args entirely when `tlsLb.upstream.address` is empty. The sidecar already implements the no-upstream mode — it falls back to its built-in echo backend (`no --upstream set: using echo backend`) and keeps serving `/.well-known/c8s/` attestation, which is the correct degraded behavior for a workload-less install.

## Test

`TestChartTLSLBAttestSidecarNoUpstream` renders with `tlsLb.upstream.address=` and asserts no `--upstream*` arg appears; the existing `TestChartRendersTLSLBAttestSidecar` (default upstream present) still passes, so the adopted-workload path is unchanged.