### PR TITLE
ci: reaper must spare standing runner CVMs

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -122,12 +122,11 @@ jobs:
           for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
             rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
             orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
-            # standing runner CVMs (confidential-ci provision-*-cvm.yml,
-            # keep_alive) have a manual lifecycle — never reap them, even
-            # though their owning provision run has long since "completed"
-            # (that check would otherwise kill the shared runner: this exact
-            # reaper, run by the merge of c8s#103, deleted the org's
-            # snp-metal-cvm standing runner on 2026-07-22).
+            # Standing runner CVMs (booted with keep_alive) have a MANUAL
+            # lifecycle: they outlive the run that created them and serve jobs
+            # for other repos. Their provision run completes within minutes, so
+            # the run-status check below would see a live shared runner as an
+            # orphan and delete it mid-job. Skip them entirely.
             standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
             [ "$standing" = "true" ] && { echo "keeping $vm (standing runner — manual lifecycle)"; continue; }
             [ -z "$rid" ] && continue

--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -122,6 +122,14 @@ jobs:
           for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
             rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
             orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
+            # standing runner CVMs (confidential-ci provision-*-cvm.yml,
+            # keep_alive) have a manual lifecycle — never reap them, even
+            # though their owning provision run has long since "completed"
+            # (that check would otherwise kill the shared runner: this exact
+            # reaper, run by the merge of c8s#103, deleted the org's
+            # snp-metal-cvm standing runner on 2026-07-22).
+            standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
+            [ "$standing" = "true" ] && { echo "keeping $vm (standing runner — manual lifecycle)"; continue; }
             [ -z "$rid" ] && continue
             [ "$rid" = "${{ github.run_id }}" ] && continue
             # age fallback: our runs are capped well under 3h, so anything older is


### PR DESCRIPTION
## What

Ports the standing-runner skip from confidential-ci's `cvm-e2e.yml` reaper into the vendored copy.

## Why

Standing runner CVMs are booted with `keep_alive` and have a manual lifecycle: they outlive the run that created them and serve jobs for other repos. Their provision run completes within minutes, so the reaper's run-status check treats a live shared runner as an orphan and deletes it mid-job. This happened today — the shared `snp-metal-cvm` runner was deleted by a merge-triggered e2e, and every job targeting it queued until it was re-provisioned.

## Scope

Reaper skip only, byte-identical to confidential-ci's where the copies overlap. The `keep_alive`/`vm_name` inputs are deliberately not ported: c8s never provisions standing VMs, it just must not delete other lanes' runners. Full re-sync of the vendored copy remains a separate item.