### PR TITLE
fix(ci): docker paths-filter watched a directory that does not exist

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -73,11 +73,13 @@ jobs:
       # NOTHING, so paths-filter reports that component unchanged, the build is
       # skipped, and retag-unchanged aliases :main onto the new sha anyway. The
       # published tag then lies about its contents. That is not hypothetical:
-      # this filter watched internal/cmds/nriimagepolicy (the Go package name)
-      # while the directory is internal/cmds/nri-image-policy, so plugin-only
-      # commits never rebuilt the image and :main resolved to a binary several
-      # commits stale. Nothing failed loudly; the lie surfaced downstream as a
-      # cluster whose NRI plugin would not start. Fail closed here instead.
+      # this filter pointed at internal/cmds/nriimagepolicy, which was correct
+      # when written, until the package dir was renamed to nri-image-policy and
+      # the filter did not move with it. For two months plugin-only commits
+      # never rebuilt the image and :main resolved to a stale binary. Nothing
+      # failed loudly; it surfaced downstream as a cluster whose NRI plugin
+      # would not start. A rename is the expected way to break these, so fail
+      # closed here rather than trusting the glob to stay true.
       - name: paths-filter globs must reference real directories
         run: |
           set -euo pipefail

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -69,6 +69,26 @@ jobs:
       has_retag: ${{ steps.docker-matrix.outputs.has_retag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      # A component filter that names a directory which does not exist matches
+      # NOTHING, so paths-filter reports that component unchanged, the build is
+      # skipped, and retag-unchanged aliases :main onto the new sha anyway. The
+      # published tag then lies about its contents. That is not hypothetical:
+      # this filter watched internal/cmds/nriimagepolicy (the Go package name)
+      # while the directory is internal/cmds/nri-image-policy, so plugin-only
+      # commits never rebuilt the image and :main resolved to a binary several
+      # commits stale. Nothing failed loudly; the lie surfaced downstream as a
+      # cluster whose NRI plugin would not start. Fail closed here instead.
+      - name: paths-filter globs must reference real directories
+        run: |
+          set -euo pipefail
+          missing=0
+          for p in $(grep -oE '(cmd|internal/cmds)/[A-Za-z0-9_.-]+/\*\*' \
+                       .github/workflows/docker.yml | sed 's|/\*\*$||' | sort -u); do
+            if [ -d "$p" ]; then echo "ok      $p"; else echo "MISSING $p"; missing=1; fi
+          done
+          [ "$missing" -eq 0 ] || {
+            echo "::error::docker.yml paths-filter references a directory that does not exist: the component would be classed unchanged and silently skip its image build"
+            exit 1; }
       # Skip on workflow_dispatch: a manual run has no before/after diff base for
       # paths-filter to compute against, and we fan out to every component anyway
       # (docker-build-matrix.sh treats workflow_dispatch like a tag push). With
@@ -107,7 +127,7 @@ jobs:
             ratls-mesh:
               - '{cmd/ratls-mesh/**,internal/cmds/ratlsmesh/**}'
             nri-image-policy:
-              - '{cmd/nri-image-policy/**,internal/cmds/nriimagepolicy/**}'
+              - '{cmd/nri-image-policy/**,internal/cmds/nri-image-policy/**}'
       - name: Build Docker matrix
         id: docker-matrix
         env:


### PR DESCRIPTION
## What happened

```diff
             nri-image-policy:
-              - '{cmd/nri-image-policy/**,internal/cmds/nriimagepolicy/**}'
+              - '{cmd/nri-image-policy/**,internal/cmds/nri-image-policy/**}'
```

**This was not a typo.** `git blame` puts the line at `89e84094` ("fix(ci): tighten docker path filters", 2026-05-22), and at that commit `internal/cmds/nriimagepolicy/` was the real directory. Five days later `e37eaf1` ("feat(nri-image-policy): pull from CDS or push from operator", 2026-05-27) renamed the package dir to `internal/cmds/nri-image-policy/` — one bullet in a large feature PR — and the filter did not move with it. It has been pointing at nothing for two months.

## Why nobody noticed

With `predicate-quantifier: every`, a filter naming a path that does not exist matches **nothing**. So a plugin-only commit is classed unchanged, its image build is skipped, and `retag-unchanged` aliases the new short sha and `:main` onto the previous image. The published tag stops describing its commit, and **nothing fails** — that is the whole problem.

The downstream effect was a cluster that would not come up:

1. The workload-claims broker made `Configure()` subscribe to `Event_REMOVE_CONTAINER`, and the chart began rendering the `workload_claims:` block that turns it on.
2. That same image still carried the v0.11-shaped `RemoveContainer` returning `([]*api.ContainerUpdate, error)`, so nri v0.12.1's `stub.plugin.(RemoveContainerInterface)` assertion never matched and the event bit was never set.
3. `stub.Configure` rejects a mask containing events the plugin cannot handle: `internal error: unhandled events RemoveContainer (0x400)`.
4. The plugin exited leaving a **stale** `health.sock`. The installer's `curl --unix-socket --fail` got connection-refused for 120 iterations and reported `ERROR: plugin not healthy after 120s`. `c8s-nri-image-policy-worker` sat at `Init:0/1`, restarting forever.

The signature fix for step 2 already landed in source. It never reached a node: its Docker run reported `Retag unchanged (nri-image-policy)`. Manifest `sha256:7ec9edccc550` currently carries tags for four separate commits plus `latest` and `main`, all pointing at the image built several commits earlier.

Reproduced end to end against a real nri v0.12.1 `pkg/adaptation` runtime: current-source plugin registers `CreateContainer,RemoveContainer` and stays alive with both sockets bound; the published image's revision dies at 8s leaving only the stale `health.sock`.

## The guard

A rename is the *expected* way these globs go stale, and the failure is silent and indefinite, so correcting this one path is not enough. The new step asserts every `cmd/<x>/**` and `internal/cmds/<x>/**` glob in this file resolves to a real directory.

Checked for false positives against broad globs (`{pkg/**,internal/**}`), negations (`!internal/cmds/**`), and mid-path wildcards (`cmd/*/Dockerfile`, `internal/cmds/*/testdata/**`) — none are matched by the extractor, so only concrete component paths are checked. Verified both directions on the real tree: the pre-fix file reports `MISSING internal/cmds/nriimagepolicy` and exits 1; the corrected file passes all 10 paths.

## Merging this republishes every image

Worth being explicit, because it is load-bearing here. `shared-root` includes `.github/workflows/docker.yml`, so touching this file sets `SHARED=true` and `docker-build-matrix.sh:46` fans out to **every** component. This PR's own run shows it: `Docker (c8s)`, `(cds)`, `(get-cert)`, `(nri-image-policy)`, `(ratls-mesh)` all built, and `Retag unchanged` was **skipped**.

On a PR that builds without pushing (GHCR login and `push:` are gated to `push`/`workflow_dispatch`), so the run above proves the plugin image still builds at current main **without publishing anything**. On merge to main the same fan-out runs with push enabled, so **merging this is itself the republish** — `:main` stops resolving to the stale image and picks up the signature fix. No separate `workflow_dispatch` is needed.

Verify afterwards:

```
crane config ghcr.io/confidential-dot-ai/nri-image-policy:main | jq -r '.config.Labels["org.opencontainers.image.revision"]'
```
