### PR TITLE
fix(cvm-e2e): mount the rke2 rootdisk read-only

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -199,6 +199,17 @@ jobs:
                       - name: rootdisk
                         disk:
                           bus: virtio
+                          # The rke2 rootfs is a read-only dm-verity image (writes
+                          # go to a tmpfs overlay), so the disk never needs write
+                          # access — and opening it writable takes an EXCLUSIVE
+                          # QEMU image lock. The standing snp-metal-cvm ARC runner
+                          # boots from this same RWO PVC and holds that lock 24/7,
+                          # so a writable ephemeral CVM here fails at qemu with
+                          # `Failed to get "write" lock` and never reaches Running.
+                          # readonly takes a SHARED lock that coexists with the
+                          # runner (verified: this is how the TDX dev host runs two
+                          # VMs off one rootdisk).
+                          readonly: true
                     interfaces:
                       - name: default
                         bridge: {}           # masquerade is broken under SNP


### PR DESCRIPTION
## What

`readonly: true` on the ephemeral CVM's rootdisk in the vendored cvm-e2e.

## Why

Every merge-triggered `confidential-e2e` fails: the ephemeral CVM opens the rke2 rootdisk **writable**, taking an exclusive qemu image lock. The standing `snp-metal-cvm` ARC runner boots from the **same RWO PVC** and holds that lock 24/7, so qemu fails with `Failed to get "write" lock` → the VMI is deleted → the run sees `NotFound`. (It only 'passed' at 20:00 today because the standing runner was down mid-reprovision.)

The rke2 rootfs is read-only dm-verity (writes go to a tmpfs overlay), so the disk never needs write access. **readonly takes a shared lock that coexists with the standing runner.**

## Verified on hardware

A readonly-mounted twin booted past qemu disk-open while the standing runner held the disk writable (no lock error). The TDX dev host already runs two VMs off one readonly rootdisk. Test VMI cleaned up; the standing runner was untouched.