### PR TITLE
revert(cvm-e2e): drop readonly rootdisk on ephemeral CVM

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -199,17 +199,6 @@ jobs:
                       - name: rootdisk
                         disk:
                           bus: virtio
-                          # The rke2 rootfs is a read-only dm-verity image (writes
-                          # go to a tmpfs overlay), so the disk never needs write
-                          # access — and opening it writable takes an EXCLUSIVE
-                          # QEMU image lock. The standing snp-metal-cvm ARC runner
-                          # boots from this same RWO PVC and holds that lock 24/7,
-                          # so a writable ephemeral CVM here fails at qemu with
-                          # `Failed to get "write" lock` and never reaches Running.
-                          # readonly takes a SHARED lock that coexists with the
-                          # runner (verified: this is how the TDX dev host runs two
-                          # VMs off one rootdisk).
-                          readonly: true
                     interfaces:
                       - name: default
                         bridge: {}           # masquerade is broken under SNP


### PR DESCRIPTION
## Why

#117 added `readonly: true` to the ephemeral CVM's rootdisk to dodge the qemu **write-lock** it hits against the standing `snp-metal-cvm` ARC runner (both boot the same RWO golden rootdisk PVC). The write-lock did go away, but the SNP/IGVM guest then **never boots** — validation run [29976325784](https://github.com/confidential-dot-ai/c8s/actions/runs/29976325784) shows an **empty serial console (0 lines)** and the VMI stuck at `Scheduled` until the 7-min timeout.

So both states are red:
- **writable** ephemeral CVM → `Failed to get "write" lock` → VMI deleted → NotFound
- **readonly** ephemeral CVM → no lock error, but guest never starts → timeout

readonly is not a viable escape for the SNP boot path (the TDX dev host boots readonly VMs; SNP/IGVM here does not). This restores the prior writable block so we're back to the clean, fast-failing state.

## The real issue (not fixed here)

The standing lib-runner holds the golden rootdisk **writable 24/7**; the c8s e2e boots its ephemeral cluster from the **same** PVC. Two VMs, one writable RWO disk. Neither cvm-e2e copy clones per-run. The coexistence fix is a design decision tracked separately:
1. **per-run disk isolation** — ephemeral CVM boots from its own PVC imported from the OCI ref (single box, +1-2 min/run), or
2. **separate hosts** — c8s e2e and the standing lib-runner on different confidential boxes (aligns with the OVH TDX capacity already in flight).

Does not touch the standing runner. No behavior change beyond removing the non-working readonly.