### PR TITLE
fix(earsigner): reject retiring EAR keys past their overlap deadline

### DIFF
--- a/pkg/earsigner/rotator.go
+++ b/pkg/earsigner/rotator.go
@@ -110,8 +110,17 @@ func (r *Rotator) PublicKey(kid string) (*ecdsa.PublicKey, error) {
 	if r.active != nil && r.active.kid == kid {
 		return &r.active.key.PublicKey, nil
 	}
+	// A retiring key is only trusted until its overlap deadline. Eviction from
+	// r.retiring happens on the next rotate(), which with default settings is
+	// ~720h away while the overlap is ~25h — so without this deadline check a
+	// retired (possibly compromised) key would keep verifying tokens for weeks
+	// past its configured retirement. Reject it at lookup time instead.
+	now := time.Now()
 	for _, k := range r.retiring {
 		if k.kid == kid {
+			if !now.Before(k.notAfterT) {
+				return nil, fmt.Errorf("token-signer key for kid %q is retired (past overlap deadline)", kid)
+			}
 			return &k.key.PublicKey, nil
 		}
 	}
@@ -198,7 +207,14 @@ func (r *Rotator) rebuildJWKS() {
 			keys = append(keys, jwk)
 		}
 	}
+	// Only publish retiring keys that are still within their overlap window, so
+	// the JWKS never advertises a key past its retirement deadline (mirrors the
+	// deadline check in PublicKey).
+	now := time.Now()
 	for _, k := range r.retiring {
+		if !now.Before(k.notAfterT) {
+			continue
+		}
 		if jwk, err := jwks.FromPublicKey(&k.key.PublicKey); err == nil {
 			keys = append(keys, jwk)
 		}

--- a/pkg/earsigner/rotator_test.go
+++ b/pkg/earsigner/rotator_test.go
@@ -177,6 +177,61 @@ func TestRun_Rotation(t *testing.T) {
 	}
 }
 
+// TestPublicKey_RetiringKeyExpires proves that a retiring key is rejected once
+// it passes its overlap deadline, even if a later rotation has not yet evicted
+// it from the retiring set. Without the lookup-time deadline check a retired
+// (possibly compromised) key would keep verifying tokens until the next
+// rotation — with defaults ~720h, far beyond the ~25h overlap policy.
+func TestPublicKey_RetiringKeyExpires(t *testing.T) {
+	keyPEM, err := earsigner.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	swapped := make(chan struct{}, 1)
+	r, err := earsigner.NewRotator(earsigner.RotatorConfig{
+		Interval: 200 * time.Millisecond,
+		Overlap:  10 * time.Millisecond,
+		Jitter:   0,
+		Logger:   discardLogger(),
+	}, keyPEM, func(_ *ecdsa.PrivateKey, _ string) {
+		select {
+		case swapped <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewRotator: %v", err)
+	}
+	initialKid := firstKid(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+
+	// Wait for the first rotation (which retires the initial key), then stop the
+	// loop so no subsequent rotation can evict it — isolating the lookup-time
+	// deadline check from eviction.
+	select {
+	case <-swapped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first rotation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	// The initial key was retired with a 10ms overlap; wait well past it.
+	time.Sleep(100 * time.Millisecond)
+
+	if _, err := r.PublicKey(initialKid); err == nil {
+		t.Error("PublicKey accepted a retiring key past its overlap deadline")
+	}
+}
+
 // --- helpers ---
 
 type jwkEntry struct {


### PR DESCRIPTION
## Problem

`Rotator` retires a signing key by setting `notAfterT = now + Overlap` and appending it to `retiring`, but expired keys are only evicted on the **next** `rotate()`. With the default 720h rotation interval and 25h overlap, a retired key stays in the retiring set — and keeps verifying tokens — for up to ~30 days instead of the intended ~25h.

Both trust-relevant lookups ignored `notAfterT`:
- `PublicKey(kid)` returned any matching retiring key regardless of expiry (this is the `issuer.KeyProvider` gate that decides whether an EAR is accepted).
- `rebuildJWKS` published expired retiring keys in the JWKS.

Impact: a compromised retired key can continue minting accepted EARs well beyond the configured overlap. (Audit finding H-10.)

## Fix

Enforce the overlap deadline where the key is actually used:
- `PublicKey` rejects a retiring key once `now >= notAfterT`, even if it has not yet been evicted.
- `rebuildJWKS` skips retiring keys past their deadline.

Eviction on rotation is unchanged; this just stops honoring a key the moment it expires rather than waiting for the next rotation.

## Test

`TestPublicKey_RetiringKeyExpires` runs one rotation, stops the loop so eviction cannot run, waits past a short overlap, and asserts `PublicKey` rejects the retired key. Verified it fails without the production change and passes with it. Full `pkg/earsigner` race tests and `golangci-lint` are green.