### PR TITLE
fix(ratls): enforce config-claims pins on the CA fast path

### DIFF
--- a/pkg/ratls/tls.go
+++ b/pkg/ratls/tls.go
@@ -607,7 +607,25 @@ func dualVerifyPeerCallback(policy *VerifyPolicy, shared *sharedCACerts) func([]
 			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		})
 		if chainErr == nil {
-			// A valid CA chain authenticates the issuer, but any configured
+			// A valid CA chain authenticates the issuer; what else must hold
+			// depends on the trust mode (see VerifyPolicy.RequireCAEvidence).
+			if policy != nil && policy.RequireCAEvidence {
+				// Production mode: the CA chain alone is not sufficient. The leaf
+				// must carry re-verifiable RA-TLS evidence (issuer.SignCSR copies
+				// the requester's nonce-free .1.1 extension onto the leaf), which
+				// we re-verify here so a CA compromise or wrong issuance policy is
+				// caught at the peer instead of trusted from the chain. VerifyCert
+				// checks the hardware evidence, launch measurement, config-claims
+				// pins, and the key/claims binding via the attestation-api. The
+				// embedded evidence is nonce-free by construction, so verify with
+				// a nil nonce; TLS 1.3 supplies connection liveness. A leaf with
+				// no (or stale/forged) evidence fails closed.
+				if _, err := VerifyCert(cert, policy, nil); err != nil {
+					return fmt.Errorf("ratls: CA-signed peer failed embedded-evidence re-verification: %w", err)
+				}
+				return nil
+			}
+			// Legacy/dev mode: trust the CA chain, but any configured
 			// config-claims pins (operator-keys/seed/workload) still must hold —
 			// they ride the certificate, so a CA-signed leaf with absent or
 			// mismatched claims must not be accepted when a pin is configured.

--- a/pkg/ratls/tls.go
+++ b/pkg/ratls/tls.go
@@ -607,7 +607,19 @@ func dualVerifyPeerCallback(policy *VerifyPolicy, shared *sharedCACerts) func([]
 			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		})
 		if chainErr == nil {
-			return nil // CA-signed cert — valid.
+			// A valid CA chain authenticates the issuer, but any configured
+			// config-claims pins (operator-keys/seed/workload) still must hold —
+			// they ride the certificate, so a CA-signed leaf with absent or
+			// mismatched claims must not be accepted when a pin is configured.
+			// Without this, configuring claim pins silently degrades to CA-only
+			// trust for every CA-signed peer (the RA-TLS path already enforces
+			// them via VerifyCert). checkClaimsPins is a no-op when no pin is set.
+			if policy != nil {
+				if err := checkClaimsPins(ExtractConfigClaimsBytes(cert), policy); err != nil {
+					return fmt.Errorf("ratls: CA-signed peer failed config-claims pins: %w", err)
+				}
+			}
+			return nil // CA-signed cert with satisfied claim pins — valid.
 		}
 
 		// Fall back to RA-TLS attestation verification.

--- a/pkg/ratls/tls_test.go
+++ b/pkg/ratls/tls_test.go
@@ -780,6 +780,75 @@ func TestDualVerifyPeerCallback_BothFail(t *testing.T) {
 	}
 }
 
+func TestDualVerifyPeerCallback_CASignedEnforcesClaimPins(t *testing.T) {
+	caKey, caCert := generateCACert(t)
+	shared := newSharedCACerts([]*x509.Certificate{caCert})
+
+	// makeLeaf builds a CA-signed leaf, optionally carrying a config-claims
+	// extension (nil = none).
+	makeLeaf := func(t *testing.T, ext []byte) []byte {
+		t.Helper()
+		leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(400),
+			Subject:      pkix.Name{CommonName: "workload"},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		}
+		if ext != nil {
+			tmpl.ExtraExtensions = []pkix.Extension{{Id: OIDRATLSConfigClaims, Value: ext}}
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &leafKey.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return der
+	}
+	claimsExt := func(t *testing.T, operatorKeys []byte) []byte {
+		t.Helper()
+		c := &ConfigClaims{
+			OperatorKeysDigest: operatorKeys,
+			SeedDigest:         UnsetDigest(),
+			WorkloadDigest:     UnsetDigest(),
+		}
+		ext, err := c.MarshalExtension()
+		if err != nil {
+			t.Fatal(err)
+		}
+		return ext.Value
+	}
+
+	pinned := bytes.Repeat([]byte{0x11}, ClaimsDigestSize)
+	verify := dualVerifyPeerCallback(&VerifyPolicy{OperatorKeysDigest: pinned}, shared)
+
+	t.Run("missing claims rejected", func(t *testing.T) {
+		if err := verify([][]byte{makeLeaf(t, nil)}, nil); err == nil {
+			t.Fatal("CA-signed leaf without config-claims accepted despite a configured pin")
+		}
+	})
+	t.Run("mismatched claims rejected", func(t *testing.T) {
+		wrong := bytes.Repeat([]byte{0x22}, ClaimsDigestSize)
+		if err := verify([][]byte{makeLeaf(t, claimsExt(t, wrong))}, nil); err == nil {
+			t.Fatal("CA-signed leaf with mismatched operator-keys digest accepted")
+		}
+	})
+	t.Run("matching claims accepted", func(t *testing.T) {
+		if err := verify([][]byte{makeLeaf(t, claimsExt(t, pinned))}, nil); err != nil {
+			t.Fatalf("CA-signed leaf with matching pin rejected: %v", err)
+		}
+	})
+	t.Run("no pin accepts CA-signed", func(t *testing.T) {
+		v := dualVerifyPeerCallback(&VerifyPolicy{}, shared)
+		if err := v([][]byte{makeLeaf(t, nil)}, nil); err != nil {
+			t.Fatalf("CA-signed leaf rejected when no pin configured: %v", err)
+		}
+	})
+}
+
 func TestSwapProvider(t *testing.T) {
 	// Create a server TLS config with fakeAttestFunc.
 	cfg := testServerConfig()

--- a/pkg/ratls/tls_test.go
+++ b/pkg/ratls/tls_test.go
@@ -849,6 +849,85 @@ func TestDualVerifyPeerCallback_CASignedEnforcesClaimPins(t *testing.T) {
 	})
 }
 
+// TestDualVerifyPeerCallback_RequireCAEvidence covers the production trust mode:
+// a valid CA chain is no longer sufficient — the leaf's embedded RA-TLS evidence
+// (issuer copies the requester's nonce-free .1.1 extension onto the leaf) is
+// re-verified per connection, catching a CA compromise or wrong issuance policy.
+func TestDualVerifyPeerCallback_RequireCAEvidence(t *testing.T) {
+	caKey, caCert := generateCACert(t)
+	shared := newSharedCACerts([]*x509.Certificate{caCert})
+	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
+	srv := newMockedVerifySrv(t, verifyResponse(measurement))
+	defer srv.Close()
+
+	// caSignedLeaf builds a CA-signed leaf over key, optionally carrying the
+	// RA-TLS .1.1 evidence extension.
+	caSignedLeaf := func(t *testing.T, key *ecdsa.PrivateKey, ratlsExt *pkix.Extension) []byte {
+		t.Helper()
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(500),
+			Subject:      pkix.Name{CommonName: "workload"},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		}
+		if ratlsExt != nil {
+			tmpl.ExtraExtensions = []pkix.Extension{*ratlsExt}
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return der
+	}
+	freshKey := func(t *testing.T) *ecdsa.PrivateKey {
+		t.Helper()
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return k
+	}
+
+	// A CA-signed leaf carrying evidence bound to its own key (the shape the
+	// issuer produces by copying the requester's .1.1 extension).
+	key, att := testKeyAndAttestation(t)
+	ext, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafWithEvidence := caSignedLeaf(t, key, &ext)
+
+	t.Run("accepts CA leaf with re-verifiable evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err != nil {
+			t.Fatalf("valid CA leaf with embedded evidence rejected: %v", err)
+		}
+	})
+
+	t.Run("rejects CA leaf without embedded evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err == nil {
+			t.Fatal("CA leaf without embedded evidence accepted in production mode")
+		}
+	})
+
+	t.Run("rejects CA leaf whose measurement is not pinned", func(t *testing.T) {
+		other := bytes.Repeat([]byte{0x99}, SNPMeasurementSize)
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{other}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err == nil {
+			t.Fatal("CA leaf with an unpinned launch measurement accepted in production mode")
+		}
+	})
+
+	t.Run("legacy mode still accepts CA leaf without evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL} // RequireCAEvidence: false
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err != nil {
+			t.Fatalf("legacy CA-only mode rejected a CA-signed leaf: %v", err)
+		}
+	})
+}
+
 func TestSwapProvider(t *testing.T) {
 	// Create a server TLS config with fakeAttestFunc.
 	cfg := testServerConfig()

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -72,6 +72,22 @@ type VerifyPolicy struct {
 	// AttestationVerifyTimeout bounds online attestation-api verification.
 	// If unset, a conservative default is used.
 	AttestationVerifyTimeout time.Duration
+
+	// RequireCAEvidence selects the production trust mode for the dual CA /
+	// RA-TLS peer verifier (dualVerifyPeerCallback). When false (default), a
+	// peer whose leaf chains to a configured CA is accepted on the CA chain
+	// alone (config-claims pins are still enforced) — the legacy/dev mode that
+	// eases rolling upgrades and CA rotation. When true, a valid CA chain is no
+	// longer sufficient: the leaf must ALSO carry re-verifiable RA-TLS evidence
+	// (issuer.SignCSR copies the requester's nonce-free .1.1 extension onto the
+	// leaf), which is re-verified per connection so a CA compromise or wrong
+	// issuance policy is caught at the peer rather than trusted from the chain.
+	// The embedded evidence is nonce-free by construction (bound to the leaf
+	// key and claims, no per-connection nonce); connection liveness comes from
+	// the TLS 1.3 proof-of-possession of the leaf key. Set by the production
+	// profile; a self-signed RA-TLS peer is unaffected (it always verifies its
+	// evidence via the fallback path).
+	RequireCAEvidence bool
 }
 
 // VerifyResult contains the verified attestation claims extracted from the cert.


### PR DESCRIPTION
## Problem

`dualVerifyPeerCallback` accepts a peer via **either** a valid X.509 chain to a configured CA **or** RA-TLS attestation (this dual path exists for rolling upgrades / CA rotation). The CA fast path returned `nil` the moment `cert.Verify` succeeded — *before* checking any configured config-claims pins:

```go
if chainErr == nil {
    return nil // CA-signed cert — valid.
}
```

The RA-TLS path (`VerifyCert`) does enforce those pins via `checkClaimsPins`. So a relying party that configured `OperatorKeysDigest` / `SeedDigest` / `WorkloadDigest` pins had them silently ignored for every CA-signed peer: a CA-issued leaf with **absent or mismatched** claims was accepted, degrading configured authorization to CA-only trust. (Audit finding H-08.)

## Fix

After successful chain verification, run `checkClaimsPins(ExtractConfigClaimsBytes(cert), policy)` before returning. `checkClaimsPins` is a no-op when no pin is configured, so the rolling-upgrade path is unchanged for deployments that don't pin claims. When a pin *is* set, a CA-signed leaf must carry matching claims or verification fails — matching the RA-TLS path's behavior. `policy` is nil-guarded (nil policy ⇒ no pins).

## Test

`TestDualVerifyPeerCallback_CASignedEnforcesClaimPins` covers: CA-signed leaf with no claims (rejected), mismatched claims (rejected), matching claims (accepted), and no-pin-configured (still accepts CA-signed, proving no regression). Verified the missing/mismatched cases fail without the production change. Full `pkg/ratls` race tests and `golangci-lint` are green.