### PR TITLE
fix(webhook): reject non-memory-backed reserved cert volume collisions

### DIFF
--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -548,6 +548,14 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	}
 
 	if getCertNeeded {
+		// ensureVolume keeps a pre-declared same-named volume rather than
+		// overwriting it, so a pod that declares the reserved cert volume as a
+		// hostPath/PVC/disk-backed emptyDir would have its private keys written
+		// to persistent, host-visible storage outside the TEE memory boundary.
+		// Reject anything but the expected memory-backed emptyDir.
+		if err := rejectReservedCertVolume(pod, inj.withDefaults(m.cfg).Cert.Volume); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
 		l.Info("injecting c8s get-cert containers", "workload", inj.WorkloadID)
 		mutatePod(pod, inj, m.cfg)
 	}
@@ -1138,6 +1146,27 @@ func rejectReservedCertContainer(pod *corev1.Pod) error {
 
 func isReservedCertName(name string) bool {
 	return name == reservedCertContainerName || name == reservedCertWaitContainerName
+}
+
+// rejectReservedCertVolume denies a pod that pre-declares the reserved cert
+// volume as anything other than the expected memory-backed emptyDir (see
+// certsVolume). ensureVolume keeps an existing same-named volume instead of
+// overwriting it, so without this guard an author could point the cert volume
+// at a hostPath, PVC, or disk-backed emptyDir and have the injected sidecar
+// write private keys to persistent, host-visible storage outside the TEE
+// memory boundary. Omitting the volume is fine — the webhook injects it.
+func rejectReservedCertVolume(pod *corev1.Pod, volName string) error {
+	for i := range pod.Spec.Volumes {
+		v := &pod.Spec.Volumes[i]
+		if v.Name != volName {
+			continue
+		}
+		if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumMemory {
+			return fmt.Errorf("%w: volume %q is reserved for the injected in-memory cert store; it must be a memory-backed emptyDir (medium: Memory) or omitted",
+				errInvalidInjectionAnnotation, volName)
+		}
+	}
+	return nil
 }
 
 func mountAll(pod *corev1.Pod, mount corev1.VolumeMount) {

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -990,6 +990,68 @@ func TestHandleRejectsReservedCertContainerName(t *testing.T) {
 	}
 }
 
+func TestHandleRejectsReservedCertVolumeCollision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	m := &podMutator{
+		decoder: admission.NewDecoder(scheme),
+		cfg: Config{
+			GetCertImage: "ghcr.io/confidential-dot-ai/c8s-operator:test",
+			CDSURL:       "http://cds.c8s-system.svc:8443",
+			CertDir:      "/etc/c8s/certs",
+		},
+	}
+	// The default reserved cert volume name (see withDefaults / certsVolume).
+	const certVol = "c8s-certs"
+	hostPathType := corev1.HostPathDirectory
+
+	handle := func(t *testing.T, vol corev1.Volume) admission.Response {
+		t.Helper()
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationWorkload: "api"}},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app"}},
+				Volumes:    []corev1.Volume{vol},
+			},
+		}
+		raw, err := json.Marshal(pod)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.Handle(context.Background(), admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "default", Object: runtime.RawExtension{Raw: raw}},
+		})
+	}
+
+	rejected := map[string]corev1.Volume{
+		"hostPath": {Name: certVol, VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/leak", Type: &hostPathType}}},
+		"disk-backed emptyDir": {Name: certVol, VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{}}}, // Medium "" == node disk
+	}
+	for name, vol := range rejected {
+		t.Run("rejects "+name, func(t *testing.T) {
+			resp := handle(t, vol)
+			if resp.Allowed {
+				t.Fatalf("Handle admitted a cw pod whose reserved cert volume is %s; want denial", name)
+			}
+			if resp.Result == nil || !strings.Contains(resp.Result.Message, "reserved") {
+				t.Fatalf("denial message = %+v, want it to mention the reserved volume", resp.Result)
+			}
+		})
+	}
+
+	t.Run("accepts memory emptyDir", func(t *testing.T) {
+		resp := handle(t, corev1.Volume{Name: certVol, VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}}})
+		if !resp.Allowed {
+			t.Fatalf("Handle denied a cw pod with a correct memory-backed cert volume: %+v", resp.Result)
+		}
+	})
+}
+
 // TestHandleInjectsDespitePresetInjectedMarker proves the
 // confidential.ai/c8s-injected marker no longer suppresses injection: a pod
 // that presets it (with no real sidecar) is still given the c8s-cert sidecar,


### PR DESCRIPTION
## Problem

The webhook injects the mesh cert store as a **memory-backed emptyDir** (`certsVolume`) so the sidecar's private keys never touch persistent, host-visible storage — they stay inside the TEE memory boundary. But `ensureVolume` keeps a pre-declared same-named volume instead of overwriting it:

```go
func ensureVolume(pod *corev1.Pod, v corev1.Volume) {
    for _, existing := range pod.Spec.Volumes {
        if existing.Name == v.Name {
            return // keeps the author's volume
        }
    }
    ...
}
```

So a pod that declares the reserved cert volume (`c8s-certs`) as a `hostPath`, PVC, or **disk-backed** emptyDir (`medium: ""`) gets the injected sidecar mounting *its* volume — writing private keys to persistent storage the host can read. (Audit finding M-07.)

## Fix

Add `rejectReservedCertVolume`, called from `Handle` when get-cert injection applies (mirroring the existing `rejectReservedCertContainer` guard). If the pod pre-declares the reserved cert volume as anything other than a memory-backed emptyDir, admission is denied. Omitting the volume is unchanged (the webhook injects the correct one); a correctly declared `emptyDir` with `medium: Memory` is accepted.

## Test

`TestHandleRejectsReservedCertVolumeCollision` covers hostPath (denied), disk-backed emptyDir (denied), and memory emptyDir (allowed). Verified the deny cases fail without the production change. Full `internal/webhook` race tests and `golangci-lint` are green.