### PR TITLE
fix(ratls): re-verify embedded evidence on the CA fast path (production mode)

### DIFF
--- a/pkg/ratls/tls.go
+++ b/pkg/ratls/tls.go
@@ -607,7 +607,25 @@ func dualVerifyPeerCallback(policy *VerifyPolicy, shared *sharedCACerts) func([]
 			KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 		})
 		if chainErr == nil {
-			// A valid CA chain authenticates the issuer, but any configured
+			// A valid CA chain authenticates the issuer; what else must hold
+			// depends on the trust mode (see VerifyPolicy.RequireCAEvidence).
+			if policy != nil && policy.RequireCAEvidence {
+				// Production mode: the CA chain alone is not sufficient. The leaf
+				// must carry re-verifiable RA-TLS evidence (issuer.SignCSR copies
+				// the requester's nonce-free .1.1 extension onto the leaf), which
+				// we re-verify here so a CA compromise or wrong issuance policy is
+				// caught at the peer instead of trusted from the chain. VerifyCert
+				// checks the hardware evidence, launch measurement, config-claims
+				// pins, and the key/claims binding via the attestation-api. The
+				// embedded evidence is nonce-free by construction, so verify with
+				// a nil nonce; TLS 1.3 supplies connection liveness. A leaf with
+				// no (or stale/forged) evidence fails closed.
+				if _, err := VerifyCert(cert, policy, nil); err != nil {
+					return fmt.Errorf("ratls: CA-signed peer failed embedded-evidence re-verification: %w", err)
+				}
+				return nil
+			}
+			// Legacy/dev mode: trust the CA chain, but any configured
 			// config-claims pins (operator-keys/seed/workload) still must hold —
 			// they ride the certificate, so a CA-signed leaf with absent or
 			// mismatched claims must not be accepted when a pin is configured.

--- a/pkg/ratls/tls_test.go
+++ b/pkg/ratls/tls_test.go
@@ -849,6 +849,85 @@ func TestDualVerifyPeerCallback_CASignedEnforcesClaimPins(t *testing.T) {
 	})
 }
 
+// TestDualVerifyPeerCallback_RequireCAEvidence covers the production trust mode:
+// a valid CA chain is no longer sufficient — the leaf's embedded RA-TLS evidence
+// (issuer copies the requester's nonce-free .1.1 extension onto the leaf) is
+// re-verified per connection, catching a CA compromise or wrong issuance policy.
+func TestDualVerifyPeerCallback_RequireCAEvidence(t *testing.T) {
+	caKey, caCert := generateCACert(t)
+	shared := newSharedCACerts([]*x509.Certificate{caCert})
+	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
+	srv := newMockedVerifySrv(t, verifyResponse(measurement))
+	defer srv.Close()
+
+	// caSignedLeaf builds a CA-signed leaf over key, optionally carrying the
+	// RA-TLS .1.1 evidence extension.
+	caSignedLeaf := func(t *testing.T, key *ecdsa.PrivateKey, ratlsExt *pkix.Extension) []byte {
+		t.Helper()
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(500),
+			Subject:      pkix.Name{CommonName: "workload"},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		}
+		if ratlsExt != nil {
+			tmpl.ExtraExtensions = []pkix.Extension{*ratlsExt}
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return der
+	}
+	freshKey := func(t *testing.T) *ecdsa.PrivateKey {
+		t.Helper()
+		k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return k
+	}
+
+	// A CA-signed leaf carrying evidence bound to its own key (the shape the
+	// issuer produces by copying the requester's .1.1 extension).
+	key, att := testKeyAndAttestation(t)
+	ext, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafWithEvidence := caSignedLeaf(t, key, &ext)
+
+	t.Run("accepts CA leaf with re-verifiable evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err != nil {
+			t.Fatalf("valid CA leaf with embedded evidence rejected: %v", err)
+		}
+	})
+
+	t.Run("rejects CA leaf without embedded evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err == nil {
+			t.Fatal("CA leaf without embedded evidence accepted in production mode")
+		}
+	})
+
+	t.Run("rejects CA leaf whose measurement is not pinned", func(t *testing.T) {
+		other := bytes.Repeat([]byte{0x99}, SNPMeasurementSize)
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{other}, RequireCAEvidence: true}
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err == nil {
+			t.Fatal("CA leaf with an unpinned launch measurement accepted in production mode")
+		}
+	})
+
+	t.Run("legacy mode still accepts CA leaf without evidence", func(t *testing.T) {
+		policy := &VerifyPolicy{AttestationApiURL: srv.URL} // RequireCAEvidence: false
+		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err != nil {
+			t.Fatalf("legacy CA-only mode rejected a CA-signed leaf: %v", err)
+		}
+	})
+}
+
 func TestSwapProvider(t *testing.T) {
 	// Create a server TLS config with fakeAttestFunc.
 	cfg := testServerConfig()

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -72,6 +72,22 @@ type VerifyPolicy struct {
 	// AttestationVerifyTimeout bounds online attestation-api verification.
 	// If unset, a conservative default is used.
 	AttestationVerifyTimeout time.Duration
+
+	// RequireCAEvidence selects the production trust mode for the dual CA /
+	// RA-TLS peer verifier (dualVerifyPeerCallback). When false (default), a
+	// peer whose leaf chains to a configured CA is accepted on the CA chain
+	// alone (config-claims pins are still enforced) — the legacy/dev mode that
+	// eases rolling upgrades and CA rotation. When true, a valid CA chain is no
+	// longer sufficient: the leaf must ALSO carry re-verifiable RA-TLS evidence
+	// (issuer.SignCSR copies the requester's nonce-free .1.1 extension onto the
+	// leaf), which is re-verified per connection so a CA compromise or wrong
+	// issuance policy is caught at the peer rather than trusted from the chain.
+	// The embedded evidence is nonce-free by construction (bound to the leaf
+	// key and claims, no per-connection nonce); connection liveness comes from
+	// the TLS 1.3 proof-of-possession of the leaf key. Set by the production
+	// profile; a self-signed RA-TLS peer is unaffected (it always verifies its
+	// evidence via the fallback path).
+	RequireCAEvidence bool
 }
 
 // VerifyResult contains the verified attestation claims extracted from the cert.


### PR DESCRIPTION
**Stacked on #120** (base branch `fix/ratls-ca-fastpath-claim-pins`). Review/merge #120 first; this PR's diff is only the evidence-re-verification commit on top.

## Problem (audit R-01 / plan PR 43)

#120 makes the CA fast path enforce config-claims **pins**, but a CA-signed peer is still trusted on the **CA chain alone** — its measurement is never re-checked per connection. So a CA compromise, a stolen CA key, or a wrong issuance policy is not independently caught at the peer; the connection just trusts "some configured CA signed this leaf."

**#104** (merged) turned this into a *fixable* problem: getcert now always embeds the requester's **nonce-free** RA-TLS evidence as OID `.1.1` on every issued leaf (`AttestationExtensionForClaims`, bound to `SHA-384(pubkey ‖ claims)` — "the same nonce-free embed the mesh client uses"), specifically so a downstream verifier *can* re-verify it. Nothing was consuming that yet on the CA path.

## Fix

Add `VerifyPolicy.RequireCAEvidence` (default **false** = current legacy/dev behavior). When **true** (set by the production profile), `dualVerifyPeerCallback` no longer accepts a CA chain by itself — it re-verifies the leaf's embedded evidence through `VerifyCert`:

- hardware evidence + signature chain (via the attestation-api),
- launch measurement against `policy.Measurements`,
- config-claims pins,
- key/claims REPORTDATA binding.

The embedded evidence is nonce-free by construction, so it's verified with a **nil nonce**; TLS 1.3 supplies per-connection liveness via proof-of-possession of the leaf key. A leaf with **missing, stale, forged, or wrong-measurement** evidence fails closed.

Default-off means rolling upgrades / CA rotation are unaffected until the production profile opts in; self-signed RA-TLS peers are unchanged (they already verify via the fallback path). This reuses the existing, tested `VerifyCert` rather than duplicating verification logic.

## Test

`TestDualVerifyPeerCallback_RequireCAEvidence`: production mode accepts a CA leaf with re-verifiable evidence, rejects one with no embedded evidence, rejects one whose measurement isn't pinned; legacy mode (flag off) still accepts a CA leaf without evidence (no regression to rolling upgrades). Verified the reject cases fail without the callback change. Full `go test ./...` + `golangci-lint run ./...` green tree-wide.