### PR TITLE
fix: safe uninstall sweep paths (C-07), cgroup-kill match (H-02), workloadRef resolution (M-09)

### DIFF
--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -29,6 +29,21 @@ set -eu
 
 echo "==> c8s kata sweep starting"
 
+# Independent guard mirroring cmd/c8s/uninstall.go's validateSweepPath: the
+# GUEST_IMAGE_DIR* values come from Helm release values and are deleted with
+# `rm -rf /host<dir>`, so a hostile or malformed value ("", "/", "..", "/host")
+# would otherwise destroy the mounted host filesystem. Refuse to sweep anything
+# that is not a dedicated c8s guest-image directory strictly under /var/lib/c8s.
+assert_safe_guest_dir() {
+  case "$1" in
+    */../* | *..) echo "refusing to sweep guest image dir containing '..': '$1'" >&2; exit 1 ;;
+  esac
+  case "$1" in
+    /var/lib/c8s/?*) : ;;
+    *) echo "refusing to sweep unsafe guest image dir (must be under /var/lib/c8s): '$1'" >&2; exit 1 ;;
+  esac
+}
+
 CONTAINERD_DIR="/host${HOST_CONTAINERD_DIR}"
 config_changed=0
 
@@ -63,6 +78,7 @@ rm -f /host/usr/local/bin/containerd-shim-kata-*-v2
 # 3. The kata-guest-base artifact the image-puller pulled (hardened kernel +
 #    dm-verity rootfs, multi-GB). Nothing else cleans this up — kata-deploy
 #    never knew about it, and the puller has no uninstall path.
+assert_safe_guest_dir "${GUEST_IMAGE_DIR}"
 if [ -d "/host${GUEST_IMAGE_DIR}" ]; then
   rm -rf "/host${GUEST_IMAGE_DIR}"
   echo "guest image dir removed: ${GUEST_IMAGE_DIR}"
@@ -74,6 +90,7 @@ fi
 #     dir (see GUEST_IMAGE_DIR_NVIDIA above; empty -> step skipped).
 GUEST_IMAGE_DIR_NVIDIA="${GUEST_IMAGE_DIR_NVIDIA:-}"
 if [ -n "${GUEST_IMAGE_DIR_NVIDIA}" ]; then
+  assert_safe_guest_dir "${GUEST_IMAGE_DIR_NVIDIA}"
   if [ -d "/host${GUEST_IMAGE_DIR_NVIDIA}" ]; then
     rm -rf "/host${GUEST_IMAGE_DIR_NVIDIA}"
     echo "nvidia guest image dir removed: ${GUEST_IMAGE_DIR_NVIDIA}"

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -454,7 +454,53 @@ func filterKataPods(lines []string) []string {
 // runs kata-sweep.sh as an init container on each node, the CLI waits for it
 // to complete everywhere (rollout status blocks until every pod has passed
 // init), then deletes it.
+// sweepGuestImagePrefix is the only host directory tree the kata sweep is
+// allowed to recursively delete. The guest-image host paths come from Helm
+// release values (kata.guestImage.hostPath, kata.gpu.guestImage.hostPath); the
+// sweep concatenates them below /host and runs `rm -rf`, so a hostile or
+// malformed value like "", "/", "..", or "/host" would otherwise destroy the
+// mounted host filesystem. The chart's defaults live under this prefix
+// (/var/lib/c8s/kata-images{,-nvidia}); kata-sweep.sh re-checks the same
+// invariant as an independent guard.
+const sweepGuestImagePrefix = "/var/lib/c8s"
+
+// validateSweepPath rejects a guest-image host path that is not a dedicated
+// c8s directory strictly beneath sweepGuestImagePrefix. allowEmpty is true for
+// the optional GPU path (empty ⇒ the sweep skips it). A rejected custom path
+// fails safe: the operator is told to remove that directory manually rather
+// than have the privileged sweep delete an unvetted location.
+func validateSweepPath(field, p string, allowEmpty bool) error {
+	if p == "" {
+		if allowEmpty {
+			return nil
+		}
+		return fmt.Errorf("%s is empty; refusing to run the privileged host sweep", field)
+	}
+	if !filepath.IsAbs(p) {
+		return fmt.Errorf("%s %q is not an absolute path; refusing to sweep", field, p)
+	}
+	if filepath.Clean(p) != p {
+		return fmt.Errorf("%s %q is not a clean path (has '..', '.', or redundant separators); refusing to sweep", field, p)
+	}
+	if p == sweepGuestImagePrefix || !strings.HasPrefix(p, sweepGuestImagePrefix+"/") {
+		return fmt.Errorf("%s %q must be a directory under %s/; the c8s sweep refuses to recursively delete anything else (remove a custom location manually)", field, p, sweepGuestImagePrefix)
+	}
+	return nil
+}
+
 func runKataSweep(ctx context.Context, namespace, release string, cfg kataUninstallConfig) error {
+	// The sweep launches a privileged DaemonSet that recursively deletes the
+	// guest-image dirs below the mounted host root. Validate those release-
+	// derived paths before doing anything destructive so a hostile/malformed
+	// value cannot turn the sweep into host destruction (defense in depth with
+	// the guard inside kata-sweep.sh).
+	if err := validateSweepPath("kata.guestImage.hostPath", cfg.GuestImageHostPath, false); err != nil {
+		return err
+	}
+	if err := validateSweepPath("kata.gpu.guestImage.hostPath", cfg.GuestImageNvidiaHostPath, true); err != nil {
+		return err
+	}
+
 	// The kata-deploy preStop cleanup and the image-puller's reconcile loop
 	// both race the sweep (the puller re-pulls a guest image it sees
 	// missing), so wait for their pods to be fully gone first. A no-op when

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -388,3 +388,32 @@ func TestKataSweepDaemonSetK8sDisablesRKE2Prep(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSweepPath(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		path       string
+		allowEmpty bool
+		wantErr    bool
+	}{
+		{"default guest image", "/var/lib/c8s/kata-images", false, false},
+		{"default nvidia image", "/var/lib/c8s/kata-images-nvidia", true, false},
+		{"nested under prefix", "/var/lib/c8s/x/y", false, false},
+		{"empty not allowed", "", false, true},
+		{"empty allowed", "", true, false},
+		{"root", "/", false, true},
+		{"host mount", "/host", false, true},
+		{"prefix itself", "/var/lib/c8s", false, true},
+		{"sibling of prefix", "/var/lib/c8s-evil/x", false, true},
+		{"relative", "var/lib/c8s/x", false, true},
+		{"traversal", "/var/lib/c8s/../../etc", false, true},
+		{"trailing slash not clean", "/var/lib/c8s/kata-images/", false, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSweepPath("field", tc.path, tc.allowEmpty)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateSweepPath(%q, allowEmpty=%v) error = %v, wantErr = %v", tc.path, tc.allowEmpty, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -170,7 +170,7 @@ func findCgroupDir(root, containerID string) (string, error) {
 	if containerID == "" {
 		return "", errors.New("empty container id")
 	}
-	var found string
+	var matches []string
 	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			// Permission-denied on a sibling slice (an unreadable systemd
@@ -193,15 +193,27 @@ func findCgroupDir(root, containerID string) (string, error) {
 			return nil
 		}
 		if cgroupDirMatchesCID(d.Name(), containerID) {
-			found = path
-			return filepath.SkipAll
+			matches = append(matches, path)
 		}
 		return nil
 	})
 	if walkErr != nil {
 		return "", walkErr
 	}
-	return found, nil
+	switch len(matches) {
+	case 0:
+		return "", nil
+	case 1:
+		return matches[0], nil
+	default:
+		// Ambiguity: more than one cgroup matches this id. The previous code
+		// returned the first depth-first match, so a container id that also
+		// matched an unrelated cgroup could redirect the SIGKILL onto that
+		// unrelated cgroup (H-02). A running denied container owns exactly one
+		// cgroup, so any collision shows up as a second match here; refuse to
+		// guess rather than terminate the wrong one.
+		return "", fmt.Errorf("ambiguous container id %q matches %d cgroups: %v", containerID, len(matches), matches)
+	}
 }
 
 // cgroupDirMatchesCID reports whether a cgroup directory basename identifies
@@ -210,10 +222,14 @@ func findCgroupDir(root, containerID string) (string, error) {
 //   - systemd scope:            cri-containerd-<cid>.scope, crio-<cid>.scope,
 //     or <cid>.scope
 //
-// containerID is a 64-hex (or similarly high-entropy) kata container id, so a
-// suffix match cannot credibly collide with an unrelated cgroup — the same
-// argument findCgroupDir already relies on for the exact-match case.
+// Only these exact shapes count. The earlier form accepted any basename ending
+// in "-<cid>", so an unrelated cgroup whose name merely ended that way matched —
+// letting a short or adversarially chosen id redirect the kill onto an
+// unrelated scope (H-02). Enumerate the vendor prefixes kata-agent actually
+// emits instead of accepting an arbitrary one.
 func cgroupDirMatchesCID(basename, containerID string) bool {
 	name := strings.TrimSuffix(basename, ".scope")
-	return name == containerID || strings.HasSuffix(name, "-"+containerID)
+	return name == containerID ||
+		name == "cri-containerd-"+containerID ||
+		name == "crio-"+containerID
 }

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -5,6 +5,7 @@ package policymonitor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -107,10 +108,37 @@ func TestCgroupDirMatchesCID(t *testing.T) {
 		{"other-" + cid[:20], false},                // partial id must not match
 		{"deadbeef", false},
 		{"", false},
+		// An arbitrary vendor prefix must NOT match: the old suffix rule
+		// (HasSuffix(name, "-"+cid)) accepted these, letting an unrelated cgroup
+		// redirect the kill (H-02).
+		{"evil-" + cid + ".scope", false},
+		{"foo-" + cid, false},
 	} {
 		if got := cgroupDirMatchesCID(tc.name, cid); got != tc.want {
 			t.Errorf("cgroupDirMatchesCID(%q) = %v, want %v", tc.name, got, tc.want)
 		}
+	}
+}
+
+func TestFindCgroupDir_AmbiguousMatchRejected(t *testing.T) {
+	// A running container owns exactly one cgroup, so two matches mean the id
+	// collides with an unrelated cgroup. findCgroupDir must refuse rather than
+	// SIGKILL whichever it hits first (H-02).
+	root := t.TempDir()
+	cid := "b790433fdb4f223a51940bae06c1cd54d73377fc3ea45c4fa5c7ea3bd4b6c829"
+	flat := filepath.Join(root, cid)
+	scope := filepath.Join(root, "system.slice", "cri-containerd-"+cid+".scope")
+	for _, d := range []string{flat, scope} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := findCgroupDir(root, cid)
+	if err == nil {
+		t.Fatalf("findCgroupDir returned %q with nil error; want an ambiguity error", got)
+	}
+	if !strings.Contains(err.Error(), "ambiguous") {
+		t.Errorf("error = %v, want it to mention ambiguity", err)
 	}
 }
 

--- a/internal/controller/confidentialworkload_controller.go
+++ b/internal/controller/confidentialworkload_controller.go
@@ -17,6 +17,33 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
+// resolveWorkloadCWID maps the CW's spec.workloadRef to the cw id stamped on
+// the referenced workload's pod template (confidential.ai/cw). That id — not
+// the CW object's own metadata.name — is what the webhook writes onto member
+// pods, so aggregating by it lets a CW whose name differs from the workload's
+// cw id still select its pods (M-09: the declared workloadRef was previously
+// ignored, and matching used cw.Name). Falls back to cw.Name when the ref is
+// unset/unsupported, the workload is gone or unreadable, or it carries no cw
+// id — preserving the prior behavior for the common name==id case.
+func (r *ConfidentialWorkloadReconciler) resolveWorkloadCWID(ctx context.Context, cw *v1alpha2.ConfidentialWorkload) string {
+	ref := cw.Spec.WorkloadRef
+	obj := newWorkloadObject(ref.Kind)
+	if obj == nil || ref.Name == "" {
+		return cw.Name
+	}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: cw.Namespace, Name: ref.Name}, obj); err != nil {
+		return cw.Name
+	}
+	tmpl := podTemplate(obj)
+	if tmpl == nil {
+		return cw.Name
+	}
+	if id := tmpl.Annotations[webhook.AnnotationWorkload]; id != "" {
+		return id
+	}
+	return cw.Name
+}
+
 // statusMirrorRequeue keeps the per-pod summary loosely current without
 // hammering the API server. The reconciler watches CW only (not pods), so
 // pod-readiness transitions are picked up at this cadence.
@@ -44,10 +71,12 @@ func (r *ConfidentialWorkloadReconciler) Reconcile(ctx context.Context, req ctrl
 		return ctrl.Result{}, fmt.Errorf("list pods: %w", err)
 	}
 
+	matchID := r.resolveWorkloadCWID(ctx, &cw)
+
 	summary := v1alpha2.AttestationSummary{}
 	for i := range pods.Items {
 		pod := &pods.Items[i]
-		if pod.Annotations[webhook.AnnotationWorkload] != cw.Name {
+		if pod.Annotations[webhook.AnnotationWorkload] != matchID {
 			continue
 		}
 		summary.Total++

--- a/internal/controller/confidentialworkload_controller_test.go
+++ b/internal/controller/confidentialworkload_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,6 +75,43 @@ func getCW(t *testing.T, c client.Client, ns, name string) *v1alpha2.Confidentia
 		t.Fatalf("get ConfidentialWorkload %s/%s: %v", ns, name, err)
 	}
 	return &cw
+}
+
+func TestConfidentialWorkloadResolvesWorkloadRefCWID(t *testing.T) {
+	const ns = "tenant"
+	// The referenced workload's pods carry cw id "api-id", which differs from
+	// the CW object's own name "cw-name". Matching on cw.Name (the pre-fix
+	// behavior) would count the wrong pod; resolving spec.workloadRef finds the
+	// real member pods (M-09).
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-deploy", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{webhook.AnnotationWorkload: "api-id"},
+				},
+			},
+		},
+	}
+	cw := &v1alpha2.ConfidentialWorkload{
+		ObjectMeta: metav1.ObjectMeta{Name: "cw-name", Namespace: ns, Generation: 1},
+		Spec: v1alpha2.ConfidentialWorkloadSpec{
+			WorkloadRef: v1alpha2.WorkloadRef{Kind: v1alpha2.WorkloadKindDeployment, Name: "api-deploy"},
+		},
+	}
+	// Two member pods carry the workload's cw id; a decoy pod carries the CW
+	// object name and must NOT be counted.
+	p1 := cwPod("p1", ns, "api-id", true)
+	p2 := cwPod("p2", ns, "api-id", false)
+	decoy := cwPod("decoy", ns, "cw-name", true)
+
+	r := cwReconcilerFor(cw, dep, p1, p2, decoy)
+	cwReconcile(t, r, ns, "cw-name")
+
+	sum := getCW(t, r.Client, ns, "cw-name").Status.AttestationSummary
+	if sum == nil || sum.Total != 2 || sum.Attested != 1 {
+		t.Fatalf("summary = %#v, want Total=2 Attested=1 (matched via workloadRef cw id, decoy excluded)", sum)
+	}
 }
 
 func TestConfidentialWorkloadReconcileNotFoundIsNoOp(t *testing.T) {

--- a/internal/controller/workloadservice_controller.go
+++ b/internal/controller/workloadservice_controller.go
@@ -72,7 +72,13 @@ var workloadServiceKinds = []v1alpha2.WorkloadKind{
 // newWorkload returns the typed object for r.Kind, or nil for kinds the
 // reconciler does not support (rejected at SetupWithManager time).
 func (r *WorkloadServiceReconciler) newWorkload() client.Object {
-	switch r.Kind {
+	return newWorkloadObject(r.Kind)
+}
+
+// newWorkloadObject returns the typed workload object for kind, or nil for a
+// kind outside the ConfidentialWorkload-mirrored set.
+func newWorkloadObject(kind v1alpha2.WorkloadKind) client.Object {
+	switch kind {
 	case v1alpha2.WorkloadKindDeployment:
 		return &appsv1.Deployment{}
 	case v1alpha2.WorkloadKindStatefulSet:


### PR DESCRIPTION
Three independent audit findings, bundled per request. Each has a regression test verified to fail without its fix; full `go test ./...` + `golangci-lint run ./...` are green tree-wide.

## C-07 — uninstall can `rm -rf` the host root (Critical)

`kata.guestImage.hostPath` / `kata.gpu.guestImage.hostPath` come from Helm release values and flow, unvalidated, into `rm -rf "/host${GUEST_IMAGE_DIR}"` inside a **privileged, host-root-mounted** sweep DaemonSet. A value of `""`, `/`, `..`, or `/host` turns that into destruction of the mounted host filesystem — node loss.

**Fix:** `validateSweepPath` rejects anything not absolute, not `filepath.Clean`, or not strictly beneath the dedicated `/var/lib/c8s` prefix (the chart's defaults live there), run in `runKataSweep` before the DaemonSet is created. Mirrored by an independent `assert_safe_guest_dir` guard in `kata-sweep.sh` as defense-in-depth. A custom hostPath outside the prefix is **refused** (the operator removes it manually) rather than swept — fail-safe.
_Scoped out (follow-up):_ the plan's release-ownership marker and symlink `realpath` resolution; this closes the hostile-values destruction vector.

## H-02 — short/suffix container IDs redirect the cgroup kill (High)

`cgroupDirMatchesCID` accepted any basename ending in `-<cid>` (`HasSuffix(name, "-"+cid)`), so an unrelated cgroup whose name merely ended that way matched — policy-monitor would SIGKILL that scope while the denied container kept running (bypass **and** arbitrary in-guest kill).

**Fix:**
- Restrict matching to the exact shapes kata-agent emits: `<cid>`, `<cid>.scope`, `cri-containerd-<cid>.scope`, `crio-<cid>.scope`.
- `findCgroupDir` now **rejects ambiguous matches** instead of returning the first depth-first hit. A running container owns exactly one cgroup, so a collision (its own `cri-containerd-<id>.scope` plus a colliding scope) shows up as ≥2 matches and fails closed.
_Scoped out (follow-up, plan PR 05):_ canonical full-ID enforcement at ingestion and fail-closed-on-unresolved.

## M-09 — `ConfidentialWorkload.spec.workloadRef` is ignored (Medium)

The status-mirror controller selected pods by the CR's own `metadata.name`, but the pod annotation `confidential.ai/cw` holds a **cwID** that is deliberately distinct from the workload object name (installer syntax `<cw-id>=<ns>/<kind>/<name>`). A CW whose name differed from the cwID reported `NoPods`.

**Fix:** `resolveWorkloadCWID` resolves `spec.workloadRef` to the referenced workload's pod-template `confidential.ai/cw` annotation (reusing the same fetch/`podTemplate` path as the workload-service controller) and aggregates by that id, falling back to `cw.Name` when the ref is unset, unsupported, unreadable, or annotation-less. RBAC already grants `get,list,watch` on deployments/statefulsets/daemonsets; the fetch is error-tolerant so it degrades to the old behavior rather than failing.