### PR TITLE
fix(tls-lb): allow X-C8s-Session in default CORS headers

### DIFF
--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -226,7 +226,7 @@ context.
 {{- if default false $cors.enabled -}}
 {{- $origins := default (list) $cors.allowOrigins -}}
 {{- $methods := join ", " (default (list "GET" "POST" "OPTIONS") $cors.allowMethods) -}}
-{{- $headers := join ", " (default (list "Authorization" "Content-Type") $cors.allowHeaders) -}}
+{{- $headers := join ", " (default (list "Authorization" "Content-Type" "X-C8s-Session") $cors.allowHeaders) -}}
 {{- $exposeHeaders := default (list) $cors.exposeHeaders -}}
 {{- $credentials := ternary "true" "" (default false $cors.allowCredentials) }}
 map $http_origin $cors_origin {
@@ -296,7 +296,7 @@ enabled. Caller nindents into a `location {}` block.
 {{- define "tls-lb.corsLocationDirectives" -}}
 {{- $cors := default dict . -}}
 {{- $methods := join ", " (default (list "GET" "POST" "OPTIONS") $cors.allowMethods) -}}
-{{- $headers := join ", " (default (list "Authorization" "Content-Type") $cors.allowHeaders) -}}
+{{- $headers := join ", " (default (list "Authorization" "Content-Type" "X-C8s-Session") $cors.allowHeaders) -}}
 {{- $maxAge := default 600 $cors.maxAge }}
 proxy_hide_header Access-Control-Allow-Origin;
 proxy_hide_header Access-Control-Allow-Methods;

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1064,8 +1064,10 @@ tlsLb:
     allowOrigins: []
     # -- Methods advertised in Access-Control-Allow-Methods.
     allowMethods: ["GET", "POST", "OPTIONS"]
-    # -- Headers advertised in Access-Control-Allow-Headers.
-    allowHeaders: ["Authorization", "Content-Type"]
+    # -- Headers advertised in Access-Control-Allow-Headers. X-C8s-Session is
+    # sent by browser clients on the /tunnel request, so it must be allowed for
+    # the over-encrypted channel to work cross-origin.
+    allowHeaders: ["Authorization", "Content-Type", "X-C8s-Session"]
     # -- Headers advertised in Access-Control-Expose-Headers. Always emitted
     # by tls-lb (and merged in front of the upstream's value in pass-through
     # mode) so browsers can read these headers from JS regardless of what

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2006,6 +2006,22 @@ func TestTLSLBVerifyDerivesProxySSLNameFromUpstream(t *testing.T) {
 	defaultRoute.assertDirective(t, "proxy_ssl_name", "my-backend.other-ns.svc.cluster.local")
 }
 
+func TestTLSLBCORSAllowsSessionHeaderByDefault(t *testing.T) {
+	// Browser clients send X-C8s-Session on the /tunnel request, so the default
+	// CORS allow-headers must include it or the over-encrypted channel breaks
+	// cross-origin.
+	out, err := helmTemplateTLSLB(t,
+		"--set", "cors.enabled=true",
+		"--set", "cors.allowOrigins={https://example.github.io}",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "X-C8s-Session") {
+		t.Fatalf("CORS Access-Control-Allow-Headers missing X-C8s-Session:\n%s", out)
+	}
+}
+
 func TestTLSLBAdditionalRoutesConfigureNginxLocations(t *testing.T) {
 	// Route backends must be secured (https + verify); the location/upstream
 	// wiring under test is protocol-independent.


### PR DESCRIPTION
Browser clients (c8s-verify-js) send `X-C8s-Session` on the `/.well-known/c8s/tunnel` request. The default `tlsLb.cors.allowHeaders` was `["Authorization", "Content-Type"]`, so with CORS enabled the tunnel preflight failed and the over-encrypted channel could not be established cross-origin — attestation and handshake worked, but `session.fetch()` was blocked.

Add `X-C8s-Session` to the default `allowHeaders` in `values.yaml` and the two template fallbacks in `tls-lb-helpers.tpl`, so `cors.enabled: true` works out of the box for the browser verifier. Adds a chart test asserting the header is present when CORS is enabled.