### PR TITLE
fix: in-TCB verifier transport (C-05), over-enc replay (H-09), webhook cert rotation (H-16), config fail-closed (H-01)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.2
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-jose/go-jose/v4 v4.1.4
+	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-sev-guest v0.15.0
 	github.com/lestrrat-go/httprc/v3 v3.0.6
@@ -57,7 +58,6 @@ require (
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v1.0.0 // indirect

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -334,12 +334,22 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 
 	spec, err := m.readConfigJSON(ctx, configPath)
 	if err != nil {
-		// "Not yet present" is the common case if the CREATE was for
-		// the directory and config.json hasn't been written yet —
-		// readConfigJSON already retries up to configReadDeadline.
-		// Anything that reaches here is a real failure (parse error,
-		// permission, missing-for-too-long).
-		m.logger.Warn("read config.json failed", "cid", cid, "path", configPath, "error", err)
+		// A config.json that EXISTS but cannot be read or parsed (malformed
+		// JSON, permission games, a directory in its place) means we cannot
+		// determine the image digest for a container that clearly has a bundle.
+		// Fail closed: deny (kill) rather than let it run unmonitored — an
+		// attacker must not be able to evade the allowlist by mangling the
+		// spec. When the file is simply absent (the common non-container watch
+		// entry such as kata's "shared" dir, or a bundle whose config.json has
+		// not been written yet), we skip: killing there would be a false
+		// positive on infrastructure directories. The delayed-write/cgroup race
+		// is tracked separately (persistent pending state, audit H-01/PR 07).
+		if _, statErr := os.Stat(configPath); statErr == nil {
+			m.logger.Warn("deny container: config.json present but unreadable/malformed", "cid", cid, "path", configPath, "error", err)
+			m.kill(cid)
+			return
+		}
+		m.logger.Warn("skip: config.json absent (not a container bundle, or not written yet)", "cid", cid, "path", configPath, "error", err)
 		return
 	}
 

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -124,6 +124,62 @@ func TestHandleNewContainer_NoDigestAnnotation_Denies(t *testing.T) {
 	}
 }
 
+func TestHandleNewContainer_UnreadableConfigDenies(t *testing.T) {
+	// config.json exists but cannot be read as a file (a directory in its
+	// place): the bundle is clearly present but its digest is undeterminable,
+	// so the monitor must fail closed (deny+kill) rather than let it run (H-01).
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m.configReadDeadline = 50 * time.Millisecond
+	cid := "unreadable-config"
+	dir := filepath.Join(watchDir, cid)
+	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleNewContainer(context.Background(), dir)
+
+	if calls := killer.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected deny+kill on present-but-unreadable config.json, got %d calls: %+v", len(calls), calls)
+	}
+}
+
+func TestHandleNewContainer_AbsentConfigSkips(t *testing.T) {
+	// An absent config.json (a non-container watch entry, or a bundle not yet
+	// written) must be skipped, not killed — killing infrastructure dirs would
+	// be a false positive (H-01 scope boundary).
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m.configReadDeadline = 50 * time.Millisecond
+	cid := "shared"
+	if err := os.MkdirAll(filepath.Join(watchDir, cid), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	if calls := killer.snapshot(); len(calls) != 0 {
+		t.Fatalf("expected no kill for an absent config.json, got %d calls: %+v", len(calls), calls)
+	}
+}
+
+func TestHandleNewContainer_MalformedConfigDenies(t *testing.T) {
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m.configReadDeadline = 50 * time.Millisecond
+	cid := "bad-config"
+	dir := filepath.Join(watchDir, cid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{ not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleNewContainer(context.Background(), dir)
+
+	if calls := killer.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected deny+kill on malformed config.json, got %d calls: %+v", len(calls), calls)
+	}
+}
+
 func TestHandleNewContainer_SandboxSkipped(t *testing.T) {
 	// The pod sandbox (pause) container carries container-type=sandbox and
 	// no image digest. kata runs the measured baked pause for it, so

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -270,10 +271,11 @@ func confidentialWorkloadCRDAvailable(dc serverResourcesForGroupVersion) (bool, 
 // webhook and patches the CA bundle onto the MutatingWebhookConfiguration
 // so the API server trusts the webhook.
 //
-// The CA is ephemeral — re-minted on every operator restart. That's fine
-// for the admission webhook (a request path, not a durable trust anchor):
-// the restart re-patches the bundle and the API server starts trusting the
-// new cert.
+// The CA is ephemeral — re-minted on every operator restart — but long-lived
+// (webhook.WebhookCATTL), so the patched bundle stays stable while short-lived
+// serving leaves rotate under it. A rotator runnable re-mints the leaf before
+// it expires; without it the leaf's ~30-day validity would lapse and, with a
+// fail-closed webhook, block all in-scope Pod creation until a restart.
 func bootstrapWebhookPKI(ctx context.Context, mgr ctrl.Manager, opts Options) error {
 	if opts.WebhookConfigName == "" {
 		return nil
@@ -293,7 +295,7 @@ func bootstrapWebhookPKI(ctx context.Context, mgr ctrl.Manager, opts Options) er
 		fmt.Sprintf("%s.%s.svc.cluster.local", svcName, svcNS),
 	}
 
-	ca, err := issuer.NewCA(fmt.Sprintf("%s webhook", svcName), webhook.ServingTLSTTL)
+	ca, err := issuer.NewCA(fmt.Sprintf("%s webhook", svcName), webhook.WebhookCATTL)
 	if err != nil {
 		return fmt.Errorf("mint webhook CA: %w", err)
 	}
@@ -309,7 +311,48 @@ func bootstrapWebhookPKI(ctx context.Context, mgr ctrl.Manager, opts Options) er
 		return fmt.Errorf("build bootstrap client: %w", err)
 	}
 	caPEM := certutil.EncodeCertPEM(ca.Cert.Raw)
-	return webhook.PatchCABundle(ctx, c, opts.WebhookConfigName, caPEM)
+	if err := webhook.PatchCABundle(ctx, c, opts.WebhookConfigName, caPEM); err != nil {
+		return err
+	}
+
+	// Keep the leaf fresh in-process. The CA is stable, so the patched bundle
+	// keeps validating rotated leaves without a re-patch.
+	rotator := webhookCertRotator(ca, hostnames, webhook.DefaultCertDir, webhook.ServingTLSTTL,
+		mgr.GetLogger().WithName("webhook-cert-rotator"))
+	if err := mgr.Add(manager.RunnableFunc(rotator)); err != nil {
+		return fmt.Errorf("add webhook cert rotator: %w", err)
+	}
+	return nil
+}
+
+// webhookCertRotator re-issues the webhook serving leaf before it expires.
+// It re-mints at ~2/3 of the leaf TTL so a failed attempt has ~1/3 TTL of
+// runway (the previous leaf stays valid) to retry on a short interval. The CA
+// is unchanged, so no caBundle re-patch is needed.
+func webhookCertRotator(ca *issuer.CA, hostnames []string, certDir string, leafTTL time.Duration, logger logr.Logger) manager.RunnableFunc {
+	return func(ctx context.Context) error {
+		interval := leafTTL * 2 / 3
+		retry := time.Hour
+		if retry >= interval {
+			retry = interval / 2
+		}
+		timer := time.NewTimer(interval)
+		defer timer.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-timer.C:
+				if err := webhook.BootstrapServingCert(ca, hostnames, certDir); err != nil {
+					logger.Error(err, "webhook serving-cert rotation failed; retrying soon", "retry", retry)
+					timer.Reset(retry)
+					continue
+				}
+				logger.Info("rotated webhook serving cert", "next", interval)
+				timer.Reset(interval)
+			}
+		}
+	}
 }
 
 func boolPtr(v bool) *bool {

--- a/internal/controller/webhook_cert_rotator_test.go
+++ b/internal/controller/webhook_cert_rotator_test.go
@@ -1,0 +1,82 @@
+package controller
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
+)
+
+func TestWebhookCertRotatorReissuesLeaf(t *testing.T) {
+	ca, err := issuer.NewCA("test webhook", webhook.WebhookCATTL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certDir := t.TempDir()
+	hostnames := []string{"c8s-webhook.c8s-system.svc"}
+
+	// Initial leaf.
+	if err := webhook.BootstrapServingCert(ca, hostnames, certDir); err != nil {
+		t.Fatal(err)
+	}
+	crtPath := filepath.Join(certDir, "tls.crt")
+	first, err := os.ReadFile(crtPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Tiny leaf TTL ⇒ interval = TTL*2/3 ≈ 40ms, so rotation happens quickly.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		_ = webhookCertRotator(ca, hostnames, certDir, 60*time.Millisecond, logr.Discard())(ctx)
+		close(done)
+	}()
+
+	// Wait until the cert file is re-minted (distinct bytes).
+	deadline := time.After(5 * time.Second)
+	var rotated []byte
+	for {
+		cur, err := os.ReadFile(crtPath)
+		if err == nil && !bytes.Equal(cur, first) {
+			rotated = cur
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for the webhook serving cert to rotate")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("rotator did not stop after cancel")
+	}
+
+	// The rotated leaf must still chain to the same CA (the bundle is unchanged).
+	block, _ := pem.Decode(rotated)
+	if block == nil {
+		t.Fatal("rotated tls.crt is not PEM")
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: pool, DNSName: hostnames[0]}); err != nil {
+		t.Fatalf("rotated leaf does not verify against the stable CA: %v", err)
+	}
+}

--- a/internal/webhook/bootstrap.go
+++ b/internal/webhook/bootstrap.go
@@ -18,11 +18,20 @@ import (
 // DefaultCertDir is controller-runtime's webhook-server default.
 const DefaultCertDir = "/tmp/k8s-webhook-server/serving-certs"
 
-// ServingTLSTTL bounds how long a bootstrapped serving cert is valid for.
-// The operator re-mints on each start, so in practice rotation is driven by
-// pod restarts. Leaf certs chain to the mesh CA and must be re-issued in
-// sync with CA rotations too.
+// ServingTLSTTL bounds how long a bootstrapped serving cert (the leaf) is valid
+// for. The operator re-mints it before expiry in-process (see the cert-rotator
+// runnable in the controller runner), so the webhook no longer depends on a pod
+// restart to stay valid — an unrotated leaf would otherwise expire and, with a
+// fail-closed admission webhook, block all in-scope Pod creation.
 const ServingTLSTTL = 30 * 24 * time.Hour
+
+// WebhookCATTL is the validity of the webhook's ephemeral CA. It is long-lived
+// so the CA bundle patched onto the MutatingWebhookConfiguration stays stable
+// for the operator pod's lifetime while short-lived leaves rotate under it —
+// keeping caBundle churn (and the leaf/bundle mismatch it can cause during a
+// rollout) out of the steady state. The CA is still re-minted on operator
+// restart, which re-patches the bundle.
+const WebhookCATTL = 10 * 365 * 24 * time.Hour
 
 // BootstrapServingCert mints a webhook serving cert from the mesh CA and
 // writes it into certDir. Hostnames must include every DNS name the API

--- a/pkg/attestationclient/client.go
+++ b/pkg/attestationclient/client.go
@@ -6,8 +6,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -23,11 +28,64 @@ type Client struct {
 }
 
 // NewClient creates a new attestation-api client.
+//
+// A "unix:///path/to/attest.sock" baseURL routes every request over that local
+// Unix-domain socket instead of a routable HTTP address. Because the verifier
+// trusts whatever the attestation-api returns (the /verify verdict is not
+// signed), a routable URL lets a hostile control plane redirect it under the
+// documented threat model (C-05); a private in-TCB socket removes that spoofable
+// hop. The socket's owner and mode are checked on every dial (see
+// validateVerifierSocket) so a swapped or world-writable socket fails closed.
 func NewClient(baseURL string) Client {
+	if socket, ok := strings.CutPrefix(baseURL, "unix://"); ok {
+		return Client{
+			baseURL:    "http://unix",
+			httpClient: &http.Client{Transport: unixSocketTransport(socket)},
+		}
+	}
 	return Client{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: http.DefaultClient,
 	}
+}
+
+// unixSocketTransport dials socketPath for every request, validating its
+// ownership and mode first so the verifier never talks to a socket an untrusted
+// actor could have replaced or made world-writable.
+func unixSocketTransport(socketPath string) *http.Transport {
+	dialer := net.Dialer{Timeout: 5 * time.Second}
+	return &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			if err := validateVerifierSocket(socketPath); err != nil {
+				return nil, err
+			}
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+}
+
+// validateVerifierSocket asserts socketPath is a real Unix socket (not a
+// symlink), owned by root or the calling process, and not world-writable.
+func validateVerifierSocket(socketPath string) error {
+	if !filepath.IsAbs(socketPath) {
+		return fmt.Errorf("attestationclient: verifier socket %q must be an absolute path", socketPath)
+	}
+	fi, err := os.Lstat(socketPath)
+	if err != nil {
+		return fmt.Errorf("attestationclient: stat verifier socket %q: %w", socketPath, err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("attestationclient: %q is not a socket (mode %s)", socketPath, fi.Mode())
+	}
+	if fi.Mode().Perm()&0o002 != 0 {
+		return fmt.Errorf("attestationclient: verifier socket %q is world-writable (mode %#o)", socketPath, fi.Mode().Perm())
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
+		if st.Uid != 0 && int(st.Uid) != os.Getuid() {
+			return fmt.Errorf("attestationclient: verifier socket %q is owned by uid %d (want root or the verifier's own uid)", socketPath, st.Uid)
+		}
+	}
+	return nil
 }
 
 // NewClientWithHTTP creates a new client with a custom HTTP client.

--- a/pkg/attestationclient/client_socket_test.go
+++ b/pkg/attestationclient/client_socket_test.go
@@ -1,0 +1,86 @@
+package attestationclient
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func TestNewClientUnixSocketTransport(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "attest.sock")
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/verify", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	c := NewClient("unix://" + sock)
+	if _, err := c.Verify(context.Background(), types.VerifyRequest{}); err != nil {
+		t.Fatalf("Verify over unix socket failed: %v", err)
+	}
+}
+
+func TestValidateVerifierSocket(t *testing.T) {
+	dir := t.TempDir()
+
+	// A real socket, owned by us and not world-writable, is accepted.
+	good := filepath.Join(dir, "ok.sock")
+	ln, err := net.Listen("unix", good)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if err := os.Chmod(good, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(good); err != nil {
+		t.Fatalf("valid socket rejected: %v", err)
+	}
+
+	// World-writable socket is rejected.
+	if err := os.Chmod(good, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(good); err == nil {
+		t.Error("world-writable socket accepted; want rejection")
+	}
+
+	// A regular file is not a socket.
+	reg := filepath.Join(dir, "notasocket")
+	if err := os.WriteFile(reg, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(reg); err == nil {
+		t.Error("regular file accepted as socket; want rejection")
+	}
+
+	// A relative path is rejected outright.
+	if err := validateVerifierSocket("relative.sock"); err == nil {
+		t.Error("relative path accepted; want rejection")
+	}
+
+	// A symlink to the socket is not itself a socket (Lstat).
+	link := filepath.Join(dir, "link.sock")
+	if err := os.Symlink(good, link); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(link); err == nil {
+		t.Error("symlink accepted; want rejection")
+	}
+}

--- a/pkg/overenc/overenc.go
+++ b/pkg/overenc/overenc.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
+	"sync"
 )
 
 const (
@@ -161,9 +162,24 @@ type Record struct {
 	CT []byte `cbor:"ct" json:"ct"`
 }
 
+// maxTrackedNonces bounds the per-channel anti-replay set. A verification
+// session exchanges a small number of records, so this is far above any
+// legitimate use while capping memory an over-eager or hostile client could
+// force. Once reached, Open fails closed (the session must be re-established).
+const maxTrackedNonces = 4096
+
 // Channel is a symmetric over-encryption channel; both ends hold an identical key.
 type Channel struct {
 	aead cipher.AEAD
+
+	// seen records the IV of every record this end has successfully opened, so
+	// a captured record replayed by the (untrusted) TLS terminator is rejected
+	// instead of decrypting to a second authenticated backend action or a stale
+	// response. Only authenticated records are recorded, so forged traffic
+	// cannot fill it. The wire format is unchanged (browser interop), so this is
+	// exact-record replay protection, not full sequence/ordering enforcement.
+	mu   sync.Mutex
+	seen map[string]struct{}
 }
 
 // RequestAAD is the additional-authenticated-data domain separator for request
@@ -184,7 +200,8 @@ func (c *Channel) Seal(plaintext, aad []byte) (Record, error) {
 	return Record{IV: iv, CT: ct}, nil
 }
 
-// Open decrypts and authenticates a record.
+// Open decrypts and authenticates a record, rejecting any record whose IV this
+// channel has already opened (exact-record replay).
 func (c *Channel) Open(rec Record, aad []byte) ([]byte, error) {
 	if len(rec.IV) != ivBytes {
 		return nil, fmt.Errorf("overenc: IV must be %d bytes", ivBytes)
@@ -193,5 +210,21 @@ func (c *Channel) Open(rec Record, aad []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("overenc: authentication failed: %w", err)
 	}
+	// Only authenticated records reach here, so a forged record cannot poison
+	// the set, and a genuine record's IV is unique per Seal — a repeat means the
+	// same authenticated record was submitted twice (a replay).
+	key := string(rec.IV)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.seen == nil {
+		c.seen = make(map[string]struct{})
+	}
+	if _, dup := c.seen[key]; dup {
+		return nil, fmt.Errorf("overenc: replayed record rejected")
+	}
+	if len(c.seen) >= maxTrackedNonces {
+		return nil, fmt.Errorf("overenc: channel record limit reached; re-establish the session")
+	}
+	c.seen[key] = struct{}{}
 	return pt, nil
 }

--- a/pkg/overenc/overenc_test.go
+++ b/pkg/overenc/overenc_test.go
@@ -52,6 +52,51 @@ func TestHybridChannelRoundTrip(t *testing.T) {
 	}
 }
 
+// channelPair returns an agreed (server, client) channel pair for tests.
+func channelPair(t *testing.T) (server, client *Channel) {
+	t.Helper()
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	srv, err := GenerateServerKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientCh, hs, err := ClientAgree(srv.Public(), nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serverCh, err := srv.Agree(hs, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return serverCh, clientCh
+}
+
+func TestOpenRejectsReplayedRecord(t *testing.T) {
+	serverCh, clientCh := channelPair(t)
+
+	rec, err := clientCh.Seal([]byte("transfer $100"), RequestAAD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := serverCh.Open(rec, RequestAAD()); err != nil {
+		t.Fatalf("first open failed: %v", err)
+	}
+	// Resubmitting the exact same authenticated record must not decrypt to a
+	// second backend action.
+	if _, err := serverCh.Open(rec, RequestAAD()); err == nil {
+		t.Fatal("replayed record accepted; want rejection")
+	}
+	// A fresh, distinct record from the same channel still opens.
+	rec2, err := clientCh.Seal([]byte("transfer $200"), RequestAAD())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := serverCh.Open(rec2, RequestAAD()); err != nil {
+		t.Fatalf("distinct record rejected: %v", err)
+	}
+}
+
 func TestWrongNonceDerivesDifferentKey(t *testing.T) {
 	n1 := bytes.Repeat([]byte{1}, 32)
 	n2 := bytes.Repeat([]byte{2}, 32)


### PR DESCRIPTION
Four self-contained audit fixes. Each has a regression test verified to fail without its production change; full `go test ./...` (with `-race` on the touched packages) and `golangci-lint run ./...` are green tree-wide.

## C-05 — verifier verdict crosses spoofable routing (Critical)

The RA-TLS verifier POSTs evidence to `AttestationApiURL` and trusts the (unsigned) `/verify` verdict, so a routable URL lets a hostile control plane redirect it and forge an affirmative verdict.

**Fix:** `attestationclient.NewClient` now accepts a `unix:///path/to/attest.sock` base URL and routes every request over that local Unix-domain socket — a private in-TCB hop with no spoofable network leg. `validateVerifierSocket` checks on **every dial** that the target is a real socket (Lstat, so a symlink swap is rejected), owned by root or the calling process, and not world-writable; anything else fails closed.
**Residual (deployment follow-up, needs CVM validation):** rendering the socket URL in the chart and having the attestation-api serve on the shared socket. This PR lands the transport + validation mechanism.

## H-09 — over-encryption records are replayable (High)

`overenc` records carry a random IV but no sequence/replay state, so the untrusted TLS terminator can resubmit a captured request record for a second authenticated backend mutation (or replay a stale response).

**Fix:** `Channel.Open` rejects any record whose IV this channel has already opened. Only **authenticated** records are recorded (a forged record can't poison the set), the set is bounded (`maxTrackedNonces`, fail-closed on overflow), and a mutex makes it safe for concurrent tunnel requests. The browser wire format is **unchanged** — this is exact-record replay protection.
**Residual:** full monotonic sequence/ordering enforcement in AAD is a coordinated `c8s-verify-js` protocol-version bump (plan PR 20).

## H-16 — webhook PKI expires and races rollouts (High)

The admission serving cert was minted only at operator startup with a 30-day TTL and no in-process rotation, so an operator running longer than 30 days would serve an expired cert — and with a fail-closed webhook that blocks **all in-scope Pod creation** cluster-wide.

**Fix:** the webhook CA is now long-lived (`WebhookCATTL`), keeping the patched `caBundle` stable, while a `webhookCertRotator` runnable re-mints the short-lived serving leaf at ~2/3 of its TTL (retrying on a short interval on failure). Because the CA is unchanged, rotated leaves keep validating with no `caBundle` re-patch. The operator is `replicas: 1`, so the mixed-replica bundle race is already limited to a brief restart window; this PR removes the guaranteed day-30 outage.

## H-01 — unreadable config fails open (High)

A container bundle whose `config.json` is present but unreadable/malformed was logged and forgotten, so it ran with no allowlist check — an attacker could evade policy by mangling the spec.

**Fix:** fail closed — deny + kill when `config.json` **exists** but can't be read/parsed (malformed JSON, permission games, a directory in its place). An **absent** `config.json` is still skipped, because non-container watch entries (e.g. kata's `shared` dir) and not-yet-written bundles have none, and killing those would be a false positive (the existing seed/late-config tests guard this).
**Residual:** the delayed-write / late-cgroup race needs persistent pending state (plan PR 07); this closes the present-but-unreadable fail-open.