### PR TITLE
fix(verify): use explicit Intel TDX trust root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/confidential-dot-ai/attestation-go v0.4.0
+	github.com/confidential-dot-ai/attestation-go v0.4.1-0.20260724193516-457fa3c182c3
 	github.com/containerd/containerd/v2 v2.3.3
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.12.1

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/confidential-dot-ai/attestation-go v0.4.0 h1:651L7UQZKXN4jX793Yv/xnuPWInnx0mBXG4soRNeCx0=
-github.com/confidential-dot-ai/attestation-go v0.4.0/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
+github.com/confidential-dot-ai/attestation-go v0.4.1-0.20260724193516-457fa3c182c3 h1:aU02Mw/xUjAhPKWdxoMpaamzQFE1xSv6O2j1K+dQ2j4=
+github.com/confidential-dot-ai/attestation-go v0.4.1-0.20260724193516-457fa3c182c3/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=


### PR DESCRIPTION
## Summary

- pin attestation-go to https://github.com/confidential-dot-ai/attestation-go/pull/22, which supplies a validated Intel SGX Root CA pool explicitly to TDX quote verification
- remove the embedded-root warning without suppressing logs or weakening certificate-chain verification
- retain the root fingerprint check and caller override in the dependency

Depends on: https://github.com/confidential-dot-ai/attestation-go/pull/22

## Verification

- go test ./internal/localverify ./internal/cmds/verify ./internal/cmds/getkubeconfig -count=1
- go vet ./...
- make fmt

The full race suite reaches and passes all verifier packages. Three unrelated Unix-socket packages fail on unchanged main as well because macOS temp paths exceed sockaddr_un and a Linux peer-PID assertion is not portable; Linux CI is authoritative for those packages.