### PR TITLE
fix(e2e-c8s): test the merge head instead of the pinned bundle

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -37,12 +37,9 @@ jobs:
     # the trailing @main tag is a human label only.
     uses: ./.github/workflows/e2e-c8s.yml
     with:
-      # INTERIM -- pin the KNOWN-GREEN bundle, NOT the merge head. c8s main's
-      # cvmMode=node (#88) dials a node-baked attestation-api on $(HOST_IP):8400
-      # that the current staged rke2 node image does not bake, so main reds until
-      # confos PR#51 (c8s-profile baked-AA node image) is merged + staged.
-      # 70aea72 + attestation-api sha-63a97d3 is the last set proven green here.
-      # REVERT to `${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}`
-      # and drop aa_ref once the baked-AA node image is staged.
-      c8s_ref: 70aea72fac1f3dc7c96e016ecc95667366cf7837
-      aa_ref: sha-63a97d3
+      # Test the merge head. The pin existed because cvmMode=node (#88) dials a
+      # node-baked attestation-api on $(HOST_IP):8400 that the staged rke2 image
+      # does not bake; e2e-c8s.yml now aligns the AA port with the NodePort the
+      # chart already publishes, so $(HOST_IP) reaches the node's own AA pod and
+      # no baked-AA image is required.
+      c8s_ref: ${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -109,6 +109,9 @@ jobs:
           NRITAG=$(resolve_tag nri-image-policy)
           CDSDIG=$(resolve_digest cds "$CDSTAG")            # nriImagePolicy floor pins CDS by digest
           NRIDIG=$(resolve_digest nri-image-policy "$NRITAG")  # installer self-allow needs its own
+          # The operator image is ALSO the injected get-cert/c8s-cert sidecar image,
+          # and deriveComponents below only derives components that carry a digest.
+          OPDIG=$(resolve_digest c8s-operator "$OPTAG")
           # attestation-api is versioned by the attestation-rs repo, NOT c8s — a
           # c8s-ancestry walk can never find its tags (learned the hard way:
           # InvalidImageName, run 29473241754). :main is the canonical pointer the
@@ -131,6 +134,7 @@ jobs:
           VALS=$(cat <<EOF | base64 -w0
           image:
             tag: "$OPTAG"
+            digest: "$OPDIG"
           cds:
             image:
               tag: "$CDSTAG"
@@ -146,6 +150,15 @@ jobs:
             image:
               tag: "$AATAG"
             cvmMode: node
+            # cvmMode=node points every consumer at $(HOST_IP):<port>, but the staged
+            # rke2 image bakes no host attestation-api and the chart's AA DaemonSet is
+            # pod-netns, so nothing listens on the node's :8400. When nriImagePolicy is
+            # on, the chart already publishes the AA as a NodePort for host-process
+            # components; aligning the port makes $(HOST_IP) reach the node's own AA
+            # pod (both traffic policies are Local, so it never leaves the node).
+            port: 30840
+            service:
+              nodePort: 30840
             teeDevices:
               sevGuest: true
               tdxGuest: false
@@ -158,6 +171,15 @@ jobs:
             image:
               tag: "$NRITAG"
               digest: "$NRIDIG"
+            bootstrapAllowlist:
+              # c8s.imageAllowlist self-seeds only cds and tls-lb nginx; every other
+              # component (including the operator, i.e. the injected c8s-cert sidecar)
+              # is derived only under this flag, which defaults to false. `c8s install
+              # --resolve-digests` turns it on; this lane writes raw values and bypasses
+              # the CLI. Without it c8s-cert is denied-but-admitted under audit and the
+              # workload-claims broker never records it, so get-cert cannot resolve its
+              # own caller and waits out the 6h renewal interval.
+              deriveComponents: true
             policy:
               mode: audit          # bring-up: log would-be denials, admit all (chart-blessed).
                                    # enforce needs an operator-keyed allowlist first — roadmap.
@@ -223,6 +245,19 @@ jobs:
             \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
           fi
           if [ "\$CDSOK" = "1" ]; then
+            # Gate on the POLICY plane, not just CDS. c8s-cert is only recorded by the
+            # broker if the NRI plugin is ready when its container is created, and CDS
+            # and the plugin become ready independently, so applying on CDS alone is a
+            # coin flip. The installer pod is not a usable signal: its 120s health gate
+            # can expire while the plugin is still completing its initial CDS pull.
+            NRIOK=0
+            for i in \$(seq 1 60); do
+              HC=\$(curl -s -o /dev/null -w '%{http_code}' --unix-socket /var/run/nri-image-policy/health.sock --max-time 3 http://localhost/healthz 2>/dev/null)
+              echo "@@NRIH \$i: \${HC:-none}@@"
+              [ "\$HC" = "200" ] && { NRIOK=1; say NRI_PLUGIN_READY; break; }
+              sleep 5
+            done
+            [ "\$NRIOK" = "1" ] || say WARN_NRI_NOT_READY
             printf %s '$CW' | base64 -d | \$K apply -f - 2>&1 | sed 's/^/@@CWAPPLY /;s/\$/@@/'
             for i in \$(seq 1 60); do
               DP=\$(\$K -n default get deploy demo-nginx --no-headers 2>&1)


### PR DESCRIPTION
Un-pins this lane so it tests the merge head again. Ports the four fixes proven on the confidential-ci copy (confidential-dot-ai/confidential-ci#33) and validated here on real SEV-SNP metal.

### Root cause
`c8s.imageAllowlist` self-seeds only `cds` and `tls-lb nginx`. Every other component is derived only when `nriImagePolicy.bootstrapAllowlist.deriveComponents` is true, which **defaults to false**. `c8s install --resolve-digests` turns it on, which is why the Azure lanes are green, but this lane writes raw values into a HelmChart CR and bypasses the CLI.

The operator image is also the image of the **injected `c8s-cert` sidecar**, so it was absent from both the `always_allow` floor and the CDS seed, denied-but-admitted under `policy.mode: audit`, and never recorded by the workload-claims broker (which records only on the allow path). get-cert could not resolve its own caller:

```
broker returned 500: resolve caller pod: caller cgroup names no tracked container
```

It gave up after ~16s and entered the **6h** renewal interval, so the workload never became ready inside the test window. Bisect: `fc927969` green, `2f86e552` first red, which is where get-cert began requiring the broker.

### Changes
- resolve and pin the **operator digest** (`deriveComponents` only derives components that carry one);
- set **`deriveComponents: true`** so the operator lands in the floor and the CDS seed;
- align `attestationApi.port` with the **NodePort the chart already publishes** for host-process components, so `cvmMode=node`'s `$(HOST_IP)` reaches the node's own AA pod without a baked-AA node image. `cvmMode` stays `node`, which is what we ship;
- **wait for the NRI plugin** before applying the workload. Without this the lane is flaky: the same tree passed once and failed once with a byte-identical values block, because CDS and the plugin become ready independently and `c8s-cert` is only recorded if the plugin is ready when its container is created. The installer pod is not a usable signal, since its 120s health gate can expire while the plugin is still completing its initial CDS pull, which is why that pod can sit at `Init:1/2` even in runs that pass.

With the attestation-api reachable, the pin is unnecessary: `confidential-e2e.yml` goes back to `${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}` and `aa_ref` is dropped (it defaults to `main`).

### Validation
Green on snp-metal against the merge head: https://github.com/confidential-dot-ai/c8s/actions/runs/30171555836 — checked out `ref: main`, resolved `c8s-operator=64b6d7a` (HEAD, not the old pin), gate reported ready, workload `1/1` in 10s, zero broker errors. The confidential-ci copy additionally has two consecutive green runs that took different paths through the gate (one waited `503/503/200`, one was ready immediately), which is the determinism check.

**Not a c8s product bug** — a gap in this lane's hand-written values that only became fatal once get-cert depended on the broker.

Closes #133.