### PR TITLE
fix(chart): stream tls-lb responses instead of buffering them

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -595,6 +595,45 @@ nothing (tls-lb has no backend) rather than a plaintext leak; the runtime
 boundary that a peer is a genuine cw pod is the mesh's always-on cw inbound
 guard, not this render guard.
 
+### Response streaming
+
+Every proxied location (the catch-all upstream and each `tlsLb.routes[]` entry)
+hands the response to the client as the backend produces it:
+
+```nginx
+proxy_buffering off;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+```
+
+This is unconditional; there is no value to turn it off. nginx's defaults are
+store-and-forward, which is wrong for the workload tls-lb exists to front: an
+SSE token stream is held until a proxy buffer fills, so clients get bursts
+instead of generation-rate delivery, and the default HTTP/1.0 upstream hop
+cannot carry a chunked response at all. `proxy_http_version 1.1` requires the
+empty `Connection` header, or nginx sends `close` upstream on every request.
+
+Two consequences worth knowing:
+
+- Unbuffered proxying stops nginx from shielding the backend from slow clients.
+  A client that reads slowly holds the upstream connection (and, for an
+  inference engine, its generation slot) for as long as it takes. An upstream
+  that would rather be buffered can set `X-Accel-Buffering: yes` on that
+  response; the server-level `proxy_buffers` still applies when it does.
+- The client sees the *proxy's* framing, not the upstream's. Anything that
+  hashes or signs response wire bytes has to account for re-chunking across the
+  hop.
+
+The over-encryption tunnel (`/.well-known/c8s/`, when `tlsLb.attest.enabled`)
+is deliberately left on nginx's defaults: `cds-attest` seals one complete
+response envelope per request, so a response through the post-quantum channel
+cannot stream regardless of proxy settings. Streaming clients ride the
+validated TLS path instead.
+
+WebSocket upgrades are not proxied. They do not work on nginx's defaults
+either (upgrade proxying needs HTTP/1.1 plus `Upgrade`/`Connection` forwarding),
+so nothing regressed; wiring them up is a separate change.
+
 ## Certificate file permissions
 
 `get-cert` writes the private key with the mode passed by `--key-mode`. The

--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -136,6 +136,7 @@ data:
                 {{- if eq $backendProtocol "https" }}
                 {{- include "tls-lb.proxySSLDirectives" (dict "protocol" $backendProtocol "tls" $backendTLS "serverName" $backendServerName "trustedCAPath" $backendTrustedCAPath "tlsMountPath" $.Values.tlsLb.tlsMountPath) | nindent 16 }}
                 {{- end }}
+                {{- include "tls-lb.proxyStreamingDirectives" $ | nindent 16 }}
                 proxy_pass {{ $backendProtocol }}://route_{{ $i }};
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
@@ -182,7 +183,9 @@ data:
             # c8s-verify/v1 attestation + over-encryption sidecar (loopback).
             # nginx serves the static cert(s) via discovery above; the dynamic
             # per-session attestation challenge and PQ handshake are proxied to
-            # the in-pod `cds-attest` sidecar.
+            # the in-pod `cds-attest` sidecar. Deliberately not streamed: the
+            # tunnel seals one complete response envelope per request, so there
+            # is nothing to hand over incrementally.
             location /.well-known/c8s/ {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}
@@ -203,6 +206,7 @@ data:
                 {{- if eq .Values.tlsLb.upstream.protocol "https" }}
                 {{- include "tls-lb.proxySSLDirectives" (dict "protocol" .Values.tlsLb.upstream.protocol "tls" .Values.tlsLb.upstream.tls "serverName" $upstreamServerName "trustedCAPath" $upstreamTrustedCAPath "tlsMountPath" .Values.tlsLb.tlsMountPath) | nindent 16 }}
                 {{- end }}
+                {{- include "tls-lb.proxyStreamingDirectives" $ | nindent 16 }}
                 set $backend_addr {{ $upstreamAddress }};
                 proxy_pass {{ .Values.tlsLb.upstream.protocol }}://$backend_addr;
                 proxy_set_header Host $host;

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -149,6 +149,28 @@ proxy_ssl_verify off;
 {{- end -}}
 
 {{/*
+Render the directives that hand a response to the client as the upstream
+produces it. nginx's defaults are store-and-forward: `proxy_buffering on`
+accumulates the body until a proxy buffer fills, which turns an SSE token
+stream into bursts, and the HTTP/1.0 upstream hop cannot carry a chunked
+response at all. Setting HTTP/1.1 requires clearing `Connection`, which nginx
+otherwise sends upstream as `close`.
+
+An upstream keeps per-response control: `X-Accel-Buffering: yes` re-enables
+buffering for that response, sized by the server-level proxy_buffers.
+
+Takes no input; caller nindents it into a `location {}` block. These cannot be
+hoisted to server level: a location that sets any proxy_set_header of its own
+discards the inherited set, and every proxied location here sets
+Host/X-Forwarded-*.
+*/}}
+{{- define "tls-lb.proxyStreamingDirectives" -}}
+proxy_buffering off;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+{{- end -}}
+
+{{/*
 Validate the global CORS configuration. Skips when disabled.
 */}}
 {{- define "tls-lb.validateCORS" -}}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2154,6 +2154,48 @@ func TestTLSLBTypedHTTPSRouteCustomTrustedCAPathDoesNotMountMeshCA(t *testing.T)
 	assertNoTLSLBMeshCAVolume(t, out)
 }
 
+// TestTLSLBProxiedLocationsStreamUnbuffered pins the SSE delivery fix. On
+// nginx's defaults the front door is store-and-forward: proxy_buffering
+// accumulates the body until a proxy buffer fills, so an inference token
+// stream reaches the client in bursts rather than at generation rate, and the
+// default HTTP/1.0 upstream hop cannot carry a chunked response at all. Every
+// proxied application location, the catch-all upstream and each configured
+// route alike, must hand bytes over as they arrive.
+func TestTLSLBProxiedLocationsStreamUnbuffered(t *testing.T) {
+	out, err := helmTemplateTLSLB(t,
+		"--set-string", "routes[0].path=/allowlist",
+		"--set-string", "routes[0].backend.address=cds.c8s-system.svc.cluster.local:8080",
+		"--set-string", "routes[0].backend.protocol=https",
+		"--set", "routes[0].backend.tls.verify=true",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+
+	for _, loc := range []struct {
+		name string
+		path string
+	}{
+		{"catch-all upstream", "/"},
+		{"route", "/allowlist"},
+	} {
+		t.Run(loc.name, func(t *testing.T) {
+			block := cfg.location(t, "prefix", loc.path)
+			block.assertDirective(t, "proxy_buffering", "off")
+			block.assertDirective(t, "proxy_http_version", "1.1")
+			// Clearing Connection is what makes the 1.1 hop legal: nginx
+			// otherwise sends `close` upstream on every request.
+			block.assertDirective(t, "proxy_set_header", "Connection", `""`)
+		})
+	}
+
+	// The over-encryption sidecar seals one complete response envelope per
+	// request, so it has nothing to deliver incrementally. Leaving that
+	// location on nginx's defaults is deliberate, not an oversight.
+	cfg.location(t, "prefix", "/.well-known/c8s/").assertNoDirective(t, "proxy_buffering")
+}
+
 func renderedTLSLBNginxConf(t *testing.T, manifest string) string {
 	t.Helper()
 	cm := renderedConfigMap(t, manifest, "c8s-tls-lb-nginx")
@@ -4452,6 +4494,9 @@ func Example_tlsLBConfig() {
 	//             proxy_ssl_verify on;
 	//             proxy_ssl_verify_depth 2;
 	//             proxy_ssl_trusted_certificate /tls/ca.pem;
+	//             proxy_buffering off;
+	//             proxy_http_version 1.1;
+	//             proxy_set_header Connection "";
 	//             proxy_pass https://route_0;
 	//             proxy_set_header Host $host;
 	//             proxy_set_header X-Real-IP $remote_addr;
@@ -4466,6 +4511,9 @@ func Example_tlsLBConfig() {
 	//             proxy_ssl_verify on;
 	//             proxy_ssl_verify_depth 2;
 	//             proxy_ssl_trusted_certificate /tls/ca.pem;
+	//             proxy_buffering off;
+	//             proxy_http_version 1.1;
+	//             proxy_set_header Connection "";
 	//             proxy_pass https://route_1;
 	//             proxy_set_header Host $host;
 	//             proxy_set_header X-Real-IP $remote_addr;
@@ -4481,6 +4529,9 @@ func Example_tlsLBConfig() {
 	//             proxy_ssl_verify on;
 	//             proxy_ssl_verify_depth 2;
 	//             proxy_ssl_trusted_certificate /tls/cert.pem;
+	//             proxy_buffering off;
+	//             proxy_http_version 1.1;
+	//             proxy_set_header Connection "";
 	//             set $backend_addr vllm:8000;
 	//             proxy_pass https://$backend_addr;
 	//             proxy_set_header Host $host;


### PR DESCRIPTION
Fixes #140.

`tls-lb`'s proxied locations ran on nginx's defaults, which are store-and-forward. `proxy_buffering on` accumulates the response body until a proxy buffer fills, so an SSE token stream reaches the client in clumps rather than at generation rate, and the default HTTP/1.0 upstream hop cannot carry a chunked response at all.

Every proxied application location (the catch-all `location /` and each `tlsLb.routes[]` entry) now renders:

```nginx
proxy_buffering off;
proxy_http_version 1.1;
proxy_set_header Connection "";
```

## Reproduced and verified

An SSE upstream emitting 20 events, one every 100 ms, behind the chart-rendered config from `origin/main` and from this branch. Same upstream container, same nginx image, same client:

| | first event | last event | spread | gaps < 5 ms |
|---|---:|---:|---:|---:|
| before (`origin/main`) | 2027.6 ms | 2027.6 ms | **0.0 ms** | 19/19 |
| after (this branch) | 0.9 ms | 1934.9 ms | **1934.0 ms** | 0/19 |

Before, all 20 events land in a single burst at the moment the upstream finishes. After, they arrive as produced. That zero-spread burst is the same signature as the ITL inversion in the issue.

## Unconditional, not opt-in

The issue asks whether this should be per-route. It is unconditional and there is no value to turn it off:

- There is nothing route-specific about buffering. A route can front a streaming backend as easily as the catch-all can.
- An upstream that would rather be buffered keeps per-response control: `X-Accel-Buffering: yes` re-enables buffering for that response, and the server-level `proxy_buffers` still applies when it does. That is a better escape hatch than a chart value, because it is per-response rather than per-install.
- A value can be added later without breaking anyone if a real need shows up.

The trade-off is stated in the docs: unbuffered proxying stops nginx from shielding the backend from slow clients, so a slow reader holds the upstream connection (and an inference engine's generation slot) for as long as it takes.

## Deliberately not covered

- **`/.well-known/c8s/`** keeps nginx's defaults. `cds-attest`'s `handleTunnel` seals one complete `TunnelResponse` envelope per request, so a response through the post-quantum over-encryption channel cannot stream regardless of proxy settings. Streaming clients ride the validated TLS path. The exclusion is recorded in the template comment and asserted in the test, so it does not read as an oversight later.
- **WebSocket upgrades** are still not proxied. They did not work on nginx's defaults either (upgrade proxying needs HTTP/1.1 plus `Upgrade`/`Connection` forwarding), so nothing regressed here; wiring them up is a separate change.
- **`proxy_read_timeout`** stays at nginx's 60 s. It applies between successive upstream reads with buffering on or off, so this change does not move it. Worth revisiting separately if queue waits before first token get long.

## Note on upstream keepalive

The issue suggests HTTP/1.1 plus an empty `Connection` also buys upstream keepalive. It does not on its own: nginx only pools upstream connections when the `upstream {}` block carries a `keepalive` directive. The catch-all cannot have one, because it dials through a variable (`set $backend_addr`) precisely so nginx re-resolves a headless Service per record TTL instead of pinning pod IPs at startup. Route upstreams could take `keepalive`, but holding connections to statically pinned pod IPs makes pod churn worse there, so this PR does not add it. HTTP/1.1 is still the right hop version regardless.

## Changes

- `tls-lb-helpers.tpl`: new `tls-lb.proxyStreamingDirectives`, with the rationale and the reason it cannot be hoisted to server level (a location that sets any `proxy_set_header` of its own discards the inherited set).
- `tls-lb-configmap.yaml`: called from the route loop and the catch-all.
- `chart_test.go`: `TestTLSLBProxiedLocationsStreamUnbuffered` pins the directives on both, and pins the tunnel's exclusion. `Example_tlsLBConfig` golden output updated.
- `docs/operator.md`: new "Response streaming" section under tls-lb upstream.

`make lint` and `go test -race ./internal/helmchart/...` pass; `helm lint` is clean.
