### PR TITLE
feat(image): rke2-ci variant input for the CI runner-node image

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: false
+      ci:
+        description: "Build the rke2-ci variant (NRI admission floor stripped, C8S_NO_GPU: for CI runner clusters, e.g. the GPU-less OVH TDX host). Mutually exclusive with dev."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -33,6 +38,8 @@ env:
   # SHA (checkout fetches it as a ref). Pinned, not main: bumping it changes
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main.
+  # TODO(rke2-ci): bump to the confos merge that adds mkosi.profiles/rke2-ci
+  # before dispatching ci=true (the profile must exist at this ref).
   CONFOS_REF: "f7cbadcf179f580d465fa28753a9821655dd60f3" # confos main (#68)
 
 jobs:
@@ -58,6 +65,9 @@ jobs:
           path: c8s
 
       - name: Checkout attestation-rs (for the gpu-attest binary)
+        # rke2-ci composes the stock CPU attest profile (C8S_NO_GPU=1) and
+        # never stages the locally built gpu-attest binary.
+        if: github.event.inputs.ci != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: confidential-dot-ai/attestation-rs
@@ -76,9 +86,17 @@ jobs:
         # VARIANT drives C8S_NAME (-> output/$VARIANT/) and the push tags.
         run: |
           echo "IMAGE=${REGISTRY}/confidential-dot-ai/c8s-base" >> "$GITHUB_ENV"
+          if [ "${{ github.event.inputs.dev }}" = "true" ] && [ "${{ github.event.inputs.ci }}" = "true" ]; then
+            echo "::error::dev and ci are mutually exclusive; dispatch one variant at a time."
+            exit 1
+          fi
           if [ "${{ github.event.inputs.dev }}" = "true" ]; then
             echo "VARIANT=rke2-dev" >> "$GITHUB_ENV"
             echo "C8S_DEV=1" >> "$GITHUB_ENV"
+          elif [ "${{ github.event.inputs.ci }}" = "true" ]; then
+            echo "VARIANT=rke2-ci" >> "$GITHUB_ENV"
+            echo "C8S_CI=1" >> "$GITHUB_ENV"
+            echo "C8S_NO_GPU=1" >> "$GITHUB_ENV"
           else
             echo "VARIANT=rke2" >> "$GITHUB_ENV"
             echo "C8S_DEV=0" >> "$GITHUB_ENV"


### PR DESCRIPTION
**Draft, paired with confidential-os-builder#70** (the `rke2-ci` overlay profile). Requesting review from @joaosa. Nothing merges without sign-off, and the first `ci=true` dispatch waits for the confos merge plus the `CONFOS_REF` bump (the file carries a TODO at the pin).

## What

A `ci=true` workflow_dispatch input mirroring `dev=true`:

- `VARIANT=rke2-ci`, publishing `c8s-base:rke2-ci-cdi` / `:rke2-ci-cdi-<sha>` + the oras artifact, with the existing per-variant roothash skip
- `C8S_CI=1`: composes the confos `rke2-ci` overlay profile, which strips the NRI admission floor (see the paired PR for the full trust rationale: CI clusters must admit arbitrary job images, and CI infrastructure must not enter the CDS allowlist to coexist with the floor)
- `C8S_NO_GPU=1`: stock CPU attest profile; CI runner hosts are GPU-less (OVH Scale-i1), and the gpu-attest checkout step is skipped for this variant
- `dev` and `ci` are mutually exclusive per dispatch; `workflow_run` builds are untouched (always the production `rke2` variant)

## Why

The TDX CI runner host (`tdx-gh-runner`, provisioned and attesting this week: quote verified against Intel roots, `tcb_status: UpToDate`) needs a node image for its standing `tdx-metal-cvm` ARC runner. The SNP twin boots the June plain-rke2 image; no TDX equivalent exists, and the product image's fail-closed floor denies ARC pods by design.

## Consumption plan (separate follow-up in confidential-ci)

CDI-import `rke2-ci-cdi` into a rootdisk PVC, boot via plain KubeVirt manifest with an `opkeydata` Secret volume, `c8s get-kubeconfig --operator-key` over RA-TLS for guest cluster-admin, ARC scale set over that kubeconfig. No serial console anywhere in the path; the GitHub App PEM never transits a loggable channel, which retires the documented secret-in-console gap for this lane.

Offer: once both PRs merge and the first `ci=true` build publishes, I validate end to end on `tdx-gh-runner` (boot, quote verify, `get-kubeconfig`, ARC listener registered) and post the evidence before anything else consumes it.