### PR TITLE
fix(tls-lb): stream SSE instead of buffering it

### DIFF
--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -209,6 +209,28 @@ data:
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                 proxy_set_header X-Forwarded-Proto $scheme;
+                {{- /*
+                  Stream responses through instead of accumulating them.
+
+                  nginx defaults to proxy_buffering on and HTTP/1.0 upstream, so
+                  a Server-Sent Events body is buffered and released in clumps.
+                  For token streaming that turns a smooth generation into
+                  bursts: measured on an 8xB300 TDX node-as-CVM, TTFT p50 rose
+                  22.4ms -> 287.2ms through this proxy while inter-token latency
+                  *fell* 5.49ms -> 1.58ms. ITL improving across an extra hop is
+                  the tell -- chunks arriving together compress measured ITL
+                  while first-token latency rises.
+
+                  proxy_http_version 1.1 is required alongside it: HTTP/1.0
+                  upstream has no chunked transfer-encoding, so nginx must read
+                  to EOF to know the body length, which re-buffers regardless of
+                  proxy_buffering.
+
+                  Both are safe for non-streaming responses -- they change when
+                  bytes are forwarded, not what is sent.
+                */}}
+                proxy_buffering off;
+                proxy_http_version 1.1;
             }
             {{- end }}
 

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2006,6 +2006,22 @@ func TestTLSLBVerifyDerivesProxySSLNameFromUpstream(t *testing.T) {
 	defaultRoute.assertDirective(t, "proxy_ssl_name", "my-backend.other-ns.svc.cluster.local")
 }
 
+func TestTLSLBCORSAllowsSessionHeaderByDefault(t *testing.T) {
+	// Browser clients send X-C8s-Session on the /tunnel request, so the default
+	// CORS allow-headers must include it or the over-encrypted channel breaks
+	// cross-origin.
+	out, err := helmTemplateTLSLB(t,
+		"--set", "cors.enabled=true",
+		"--set", "cors.allowOrigins={https://example.github.io}",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "X-C8s-Session") {
+		t.Fatalf("CORS Access-Control-Allow-Headers missing X-C8s-Session:\n%s", out)
+	}
+}
+
 func TestTLSLBAdditionalRoutesConfigureNginxLocations(t *testing.T) {
 	// Route backends must be secured (https + verify); the location/upstream
 	// wiring under test is protocol-independent.
@@ -5292,34 +5308,6 @@ func TestChartKataGuestImageDebugSelectsDebugTag(t *testing.T) {
 	}
 	if got := pullerEnv(t, out, "TAG"); got != "main-debug" {
 		t.Errorf("debug puller TAG = %q, want main-debug", got)
-	}
-}
-
-// GPU in-guest registry auth: "" inherits the non-GPU setting (the GPU guest
-// bakes the same auth.json), "none" forces anonymous, anything else wins
-// verbatim — the contract documented on kata.gpu.guestImage.registryAuth.
-func TestChartKataGpuRegistryAuthInheritance(t *testing.T) {
-	gpuAuth := func(t *testing.T, args ...string) string {
-		t.Helper()
-		out, err := helmTemplateKata(t, args...)
-		if err != nil {
-			t.Fatalf("helm template: %v\n%s", err, out)
-		}
-		puller := renderedDaemonSet(t, out, "c8s-kata-deploy-image-puller-nvidia")
-		pc, ok := findContainer(puller.Spec.Template.Spec.Containers, "reconcile")
-		if !ok {
-			t.Fatalf("GPU puller missing reconcile container")
-		}
-		return envValue(pc.Env, "REGISTRY_AUTH")
-	}
-	if got := gpuAuth(t); got != "file:///run/image-security/auth.json" {
-		t.Errorf("default GPU REGISTRY_AUTH = %q, want the inherited non-GPU baked-auth path", got)
-	}
-	if got := gpuAuth(t, "--set-string", "kata.gpu.guestImage.registryAuth=none"); got != "" {
-		t.Errorf(`registryAuth=none GPU REGISTRY_AUTH = %q, want "" (anonymous)`, got)
-	}
-	if got := gpuAuth(t, "--set-string", "kata.gpu.guestImage.registryAuth=kbs:///default/creds/gpu"); got != "kbs:///default/creds/gpu" {
-		t.Errorf("explicit registryAuth GPU REGISTRY_AUTH = %q, want the verbatim override", got)
 	}
 }
 

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2006,22 +2006,6 @@ func TestTLSLBVerifyDerivesProxySSLNameFromUpstream(t *testing.T) {
 	defaultRoute.assertDirective(t, "proxy_ssl_name", "my-backend.other-ns.svc.cluster.local")
 }
 
-func TestTLSLBCORSAllowsSessionHeaderByDefault(t *testing.T) {
-	// Browser clients send X-C8s-Session on the /tunnel request, so the default
-	// CORS allow-headers must include it or the over-encrypted channel breaks
-	// cross-origin.
-	out, err := helmTemplateTLSLB(t,
-		"--set", "cors.enabled=true",
-		"--set", "cors.allowOrigins={https://example.github.io}",
-	)
-	if err != nil {
-		t.Fatalf("helm template: %v\n%s", err, out)
-	}
-	if !strings.Contains(out, "X-C8s-Session") {
-		t.Fatalf("CORS Access-Control-Allow-Headers missing X-C8s-Session:\n%s", out)
-	}
-}
-
 func TestTLSLBAdditionalRoutesConfigureNginxLocations(t *testing.T) {
 	// Route backends must be secured (https + verify); the location/upstream
 	// wiring under test is protocol-independent.
@@ -4487,6 +4471,8 @@ func Example_tlsLBConfig() {
 	//             proxy_set_header X-Real-IP $remote_addr;
 	//             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 	//             proxy_set_header X-Forwarded-Proto $scheme;
+	//             proxy_buffering off;
+	//             proxy_http_version 1.1;
 	//         }
 	//
 	//         location /healthz {
@@ -5306,6 +5292,34 @@ func TestChartKataGuestImageDebugSelectsDebugTag(t *testing.T) {
 	}
 	if got := pullerEnv(t, out, "TAG"); got != "main-debug" {
 		t.Errorf("debug puller TAG = %q, want main-debug", got)
+	}
+}
+
+// GPU in-guest registry auth: "" inherits the non-GPU setting (the GPU guest
+// bakes the same auth.json), "none" forces anonymous, anything else wins
+// verbatim — the contract documented on kata.gpu.guestImage.registryAuth.
+func TestChartKataGpuRegistryAuthInheritance(t *testing.T) {
+	gpuAuth := func(t *testing.T, args ...string) string {
+		t.Helper()
+		out, err := helmTemplateKata(t, args...)
+		if err != nil {
+			t.Fatalf("helm template: %v\n%s", err, out)
+		}
+		puller := renderedDaemonSet(t, out, "c8s-kata-deploy-image-puller-nvidia")
+		pc, ok := findContainer(puller.Spec.Template.Spec.Containers, "reconcile")
+		if !ok {
+			t.Fatalf("GPU puller missing reconcile container")
+		}
+		return envValue(pc.Env, "REGISTRY_AUTH")
+	}
+	if got := gpuAuth(t); got != "file:///run/image-security/auth.json" {
+		t.Errorf("default GPU REGISTRY_AUTH = %q, want the inherited non-GPU baked-auth path", got)
+	}
+	if got := gpuAuth(t, "--set-string", "kata.gpu.guestImage.registryAuth=none"); got != "" {
+		t.Errorf(`registryAuth=none GPU REGISTRY_AUTH = %q, want "" (anonymous)`, got)
+	}
+	if got := gpuAuth(t, "--set-string", "kata.gpu.guestImage.registryAuth=kbs:///default/creds/gpu"); got != "kbs:///default/creds/gpu" {
+		t.Errorf("explicit registryAuth GPU REGISTRY_AUTH = %q, want the verbatim override", got)
 	}
 }
 


### PR DESCRIPTION
Closes #140.

nginx defaults to `proxy_buffering on` and HTTP/1.0 to the upstream, so `tls-lb`'s catch-all `location /` accumulates a Server-Sent Events body and releases it in clumps. Any streaming inference workload behind the attested front door is affected — which today means every token-streaming endpoint.

## Evidence

Measured on an 8×B300 TDX node-as-CVM (`--cvm-mode node`), Dynamo + vLLM serving `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8`, identical build and load on both paths:

| path | TTFT p50 | ITL p50 | tok/s @ c32 |
|---|---:|---:|---:|
| in-pod, direct to upstream | 22.4 ms | **5.49 ms** | 3294 |
| through `tls-lb` | 287.2 ms | **1.58 ms** | 2235 |

The tell is inter-token latency *falling* across an extra hop. Real generation latency cannot improve by adding a proxy — chunks are arriving together, which compresses measured ITL while first-token latency rises.

## Why both directives

`proxy_buffering off` alone is not enough. HTTP/1.0 upstream has no chunked transfer-encoding, so nginx must read to EOF to learn the body length and re-buffers regardless. `proxy_http_version 1.1` is what makes the response streamable in the first place.

Both are safe for non-streaming responses: they change *when* bytes are forwarded, not *what* is sent. No behaviour change for a JSON body that arrives in one piece.

## Scope

One `location` block in `internal/helmchart/c8s/templates/tls-lb-configmap.yaml`. Not exposed as a value — buffering an SSE stream is never the desired behaviour for this proxy, so a toggle would only be a way to reintroduce the bug. Happy to add one if you disagree.

Verified rendering with `helm template` that both directives land inside the `location /` block and that the explanatory Go-template comment is stripped from the rendered nginx config.

## Testing note

I have not re-run the A/B through a patched `tls-lb` — the numbers above are the pre-fix measurement that motivated the change. If you would like the post-fix half before merging, say so and I will bring a node up; I would expect ITL to rise toward the in-pod 5.49 ms and TTFT to fall sharply.
