### PR TITLE
feat: getcert-fast-rebind

### DIFF
--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -296,10 +296,22 @@ plugin has not seen them — and the broker returns an **empty** set.
 
 get-cert handles that distinctly from an error: an empty broker result means
 "app containers not up yet," so it issues **without** a workload claim this
-round and binds the digests at the next renewal (re-attestation), once the app
-is running (`internal/cmds/getcert/run.go` `workloadClaims`). A *broker error*
+round and rebinds the digests once the app is running
+(`internal/cmds/getcert/run.go` `workloadClaims`). A *broker error*
 (unreachable, malformed) is fail-closed — issuance aborts. This is the
-"as of issuance, corrected at next renewal" semantics.
+"as of issuance, corrected shortly after" semantics.
+
+**Fast-rebind bounds the correction to seconds, not a renewal interval.** While
+the claim is pending, the renewal loop polls the broker at
+`--workload-claims-rebind-interval` (default 5s, on whenever
+`--workload-claims-broker` is set) and reissues the moment the admitted set
+appears, instead of waiting a full `--renew-interval` (hours). So a fresh pod's
+cert carries its workload claim within seconds of its app containers starting —
+which is what makes claim-consuming components (a secret broker; `c8s verify
+--workload-image`) usable at pod startup rather than only after the first
+hours-scale renewal. Set the interval to `0` to fall back to renewal-only
+binding. It is inert without the broker, so non-broker get-cert users (tls-lb,
+nginx sidecars) are unaffected.
 
 **Enforcement is on the verifier, not on issuance.** A relying party pinning
 `c8s verify --workload-image` fails closed against a pod that carries no or a
@@ -313,11 +325,14 @@ start from cert existence (letting them start and relying on the mesh being
 fail-closed for un-carted traffic) — a separate architecture change.
 
 **Staggered starts** can also bind a *partial* set: regular containers start
-~together, but a renewal fetch landing mid-startup could commit `{A}` and the
-next renewal rebind `{A,B,C}`. The workload digest is only *stable* once every
-container is steady-state, so a strict verifier could momentarily fail against
-a mid-startup leaf. Hardening this would mean waiting for an expected container
-count before binding — a deliberate follow-up, not baked in.
+~together, but a fetch landing mid-startup could commit `{A}` and a later fetch
+rebind `{A,B,C}`. The workload digest is only *stable* once every container is
+steady-state, so a strict verifier could momentarily fail against a mid-startup
+leaf. Fast-rebind keeps this window to seconds (the partial leaf is replaced on
+the next poll), and a claim-consuming enforcer that keys on a full workload
+entry simply fails closed against the partial set until it settles — but the
+binding is not itself gated on a *stable* set. Waiting for an expected container
+count before binding is the hardening — a deliberate follow-up, not baked in.
 
 **Init-container eviction churns the init set.** An init container runs to
 completion and exits; once the kubelet garbage-collects the exited container,

--- a/internal/cmds/getcert/fastrebind_test.go
+++ b/internal/cmds/getcert/fastrebind_test.go
@@ -1,0 +1,114 @@
+package getcert
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The renewal loop's fast-rebind state machine: a claim-free first issuance
+// (claimsPending) polls fast; once the claim binds (claimsBound) or the pod does
+// not use the broker (claimsNotApplicable) it settles to the renew interval.
+func TestShouldFastRebind(t *testing.T) {
+	cases := []struct {
+		name       string
+		fastRebind bool
+		state      claimState
+		want       bool
+	}{
+		{"disabled/pending", false, claimsPending, false},
+		{"disabled/bound", false, claimsBound, false},
+		{"enabled/pending", true, claimsPending, true},
+		{"enabled/bound", true, claimsBound, false},
+		{"enabled/notApplicable", true, claimsNotApplicable, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFastRebind(tc.fastRebind, tc.state); got != tc.want {
+				t.Fatalf("shouldFastRebind(%v, %v) = %v, want %v", tc.fastRebind, tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+// A pending claim is (re)issued only outside fast mode; in fast mode it is a
+// no-op so the claim-free cert is not rewritten every few seconds during startup.
+func TestShouldIssue(t *testing.T) {
+	cases := []struct {
+		name  string
+		fast  bool
+		state claimState
+		want  bool
+	}{
+		{"fast/pending is skipped", true, claimsPending, false},
+		{"fast/bound issues", true, claimsBound, true},
+		{"fast/notApplicable issues", true, claimsNotApplicable, true},
+		{"normal/pending issues", false, claimsPending, true},
+		{"normal/bound issues", false, claimsBound, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldIssue(tc.fast, tc.state); got != tc.want {
+				t.Fatalf("shouldIssue(%v, %v) = %v, want %v", tc.fast, tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenewCadence(t *testing.T) {
+	cfg := config{RenewInterval: 6 * time.Hour, WorkloadClaimsRebind: 5 * time.Second}
+	if got := renewCadence(true, cfg); got != cfg.WorkloadClaimsRebind {
+		t.Fatalf("fast cadence = %v, want %v", got, cfg.WorkloadClaimsRebind)
+	}
+	if got := renewCadence(false, cfg); got != cfg.RenewInterval {
+		t.Fatalf("normal cadence = %v, want %v", got, cfg.RenewInterval)
+	}
+}
+
+// The flag ships on by default so a pod that uses the broker binds its claim in
+// seconds without any operator wiring; the default is inert without the broker.
+func TestRebindFlagDefaultOn(t *testing.T) {
+	cmd := NewCmd()
+	got, err := cmd.Flags().GetDuration("workload-claims-rebind-interval")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 5*time.Second {
+		t.Fatalf("default --workload-claims-rebind-interval = %v, want 5s", got)
+	}
+}
+
+// Without the broker, a renewal tick always issues and reports the claim as not
+// applicable — the fast-rebind additions are inert for non-broker get-cert users
+// (tls-lb, nginx sidecars), which is the compatibility property this PR relies on.
+func TestRenewOnceWithoutBrokerIssues(t *testing.T) {
+	dir := t.TempDir()
+	chain := testIssuedChainPEM(t)
+	cdsURL, attURL := startFakeServers(t, chain)
+
+	cfg := config{
+		CDSURL:            cdsURL,
+		AttestationApiURL: attURL,
+		SAN:               "host.example.com",
+		OutPath:           filepath.Join(dir, "cert.pem"),
+	}
+	client := plaintextCDSClient(cfg.CDSURL)
+
+	// fast=true must not suppress issuance when the pod does not use the broker:
+	// state is claimsNotApplicable, so shouldIssue is true regardless.
+	state, issued, err := renewOnce(context.Background(), cfg, client, true)
+	if err != nil {
+		t.Fatalf("renewOnce: %v", err)
+	}
+	if state != claimsNotApplicable {
+		t.Fatalf("state = %v, want claimsNotApplicable", state)
+	}
+	if !issued {
+		t.Fatal("issued = false, want a certificate to be written")
+	}
+	if got, err := os.ReadFile(cfg.OutPath); err != nil || string(got) != chain {
+		t.Fatalf("written cert mismatch: err=%v", err)
+	}
+}

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -65,6 +65,7 @@ type config struct {
 	DiscoveryPublicTLSMode string
 	WorkloadClaimsBroker   bool
 	WorkloadClaimsTimeout  time.Duration
+	WorkloadClaimsRebind   time.Duration
 	WorkloadInitContainers []string
 }
 
@@ -125,6 +126,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags.StringVar(&cfg.DiscoveryPublicTLSMode, "discovery-public-tls-mode", "cds", "Public TLS mode to report in discovery metadata (cds or webpki)")
 	flags.BoolVar(&cfg.WorkloadClaimsBroker, "workload-claims-broker", false, "Bind a workload-digest claim by fetching this pod's admitted containers from the local broker at get-cert's compiled Unix socket path (docs/ratls.md) — nri-image-policy on node-CVM, policy-monitor in the kata guest. The path is baked in, not supplied, so the control plane cannot redirect the fetch; fail-closed if the broker is unreachable")
 	flags.DurationVar(&cfg.WorkloadClaimsTimeout, "workload-claims-timeout", 5*time.Second, "Timeout for the workload-claims broker fetch")
+	flags.DurationVar(&cfg.WorkloadClaimsRebind, "workload-claims-rebind-interval", 5*time.Second, "In renewal mode, while the workload claim is still pending (the pod's app containers are not yet admitted, so the first cert is claim-free), re-poll the broker at this cadence and rebind as soon as the admitted set appears, instead of waiting a full --renew-interval (docs/getcert-workload-binding.md, Corner 4). 0 disables fast-rebind. Inert without --workload-claims-broker")
 	flags.StringArrayVar(&cfg.WorkloadInitContainers, "workload-init-container", nil, "Name of a pod-spec init container (repeatable); the broker's containers are split into the init vs main image sets by these names for the workload digest (docs/ratls.md)")
 
 	_ = cmd.MarkFlagRequired("cds-url")
@@ -201,18 +203,27 @@ func run(cfg config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	if err := obtainCertWithRetry(ctx, cfg, client); err != nil {
+	initialState, err := obtainCertWithRetry(ctx, cfg, client)
+	if err != nil {
 		if cfg.RenewInterval <= 0 || !cfg.ContinueOnInitialError {
 			return err
 		}
 		slog.Error("initial certificate request failed, will retry next interval", "error", err)
+		initialState = claimsNotApplicable
 	} else if cfg.RenewInterval <= 0 {
 		return nil
 	}
 
-	// Daemon mode: renew certificate periodically with graceful shutdown.
-	slog.Info("entering renewal loop", "interval", cfg.RenewInterval)
-	ticker := time.NewTicker(cfg.RenewInterval)
+	// Daemon mode: renew the certificate periodically with graceful shutdown.
+	// Fast-rebind: the pod's first cert is issued before its app containers are
+	// admitted, so it is claim-free (docs/getcert-workload-binding.md, Corner 4).
+	// While the claim is pending, poll at WorkloadClaimsRebind and rebind as soon
+	// as the admitted set appears, then settle back to RenewInterval.
+	fastRebind := cfg.WorkloadClaimsBroker && cfg.WorkloadClaimsRebind > 0
+	fast := shouldFastRebind(fastRebind, initialState)
+	interval := renewCadence(fast, cfg)
+	slog.Info("entering renewal loop", "interval", interval, "fast_rebind", fast)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	var watchC <-chan time.Time
@@ -236,14 +247,21 @@ func run(cfg config) error {
 			slog.Info("shutting down cert renewer")
 			return nil
 		case <-ticker.C:
-			if err := obtainCert(ctx, cfg, client); err != nil {
+			state, issued, err := renewOnce(ctx, cfg, client, fast)
+			if err != nil {
 				slog.Error("certificate renewal failed, will retry next interval", "error", err)
 				continue
 			}
-			if cfg.ReloadNginx {
+			if issued && cfg.ReloadNginx {
 				if err := reloadNginx(); err != nil {
 					slog.Warn("certificate renewed but nginx reload failed", "error", err)
 				}
+			}
+			if wantFast := shouldFastRebind(fastRebind, state); wantFast != fast {
+				fast = wantFast
+				next := renewCadence(fast, cfg)
+				ticker.Reset(next)
+				slog.Info("certificate rebind cadence changed", "fast_rebind", fast, "interval", next)
 			}
 		case <-watchC:
 			changed, nextState, err := reloadWatchChanged(watchState, cfg.ReloadWatchPaths)
@@ -270,13 +288,13 @@ func run(cfg config) error {
 // container into kubelet's minutes-long CrashLoopBackOff. It still fails closed:
 // once the deadline passes the last error is returned and the pod does not
 // start without a real mesh cert.
-func obtainCertWithRetry(ctx context.Context, cfg config, client attestclient.Client) error {
+func obtainCertWithRetry(ctx context.Context, cfg config, client attestclient.Client) (claimState, error) {
 	if cfg.InitialRetryTimeout <= 0 {
 		return obtainCert(ctx, cfg, client)
 	}
 	bo := backoff.NewConstantBackOff(cfg.InitialRetryInterval)
-	_, err := backoff.Retry(ctx, func() (struct{}, error) {
-		return struct{}{}, obtainCert(ctx, cfg, client)
+	return backoff.Retry(ctx, func() (claimState, error) {
+		return obtainCert(ctx, cfg, client)
 	},
 		backoff.WithBackOff(bo),
 		backoff.WithMaxElapsedTime(cfg.InitialRetryTimeout),
@@ -284,16 +302,72 @@ func obtainCertWithRetry(ctx context.Context, cfg config, client attestclient.Cl
 			slog.Warn("certificate request failed, retrying", "retry_in", d, "error", err)
 		}),
 	)
-	return err
 }
 
-func obtainCert(ctx context.Context, cfg config, client attestclient.Client) error {
-	privateKey, keyPEM, err := loadOrGenerateKey(cfg)
+// obtainCert fetches the pod's workload claim (if the broker is enabled) and
+// issues one certificate, returning the resulting claim state so the renewal
+// loop can decide whether to keep polling fast for a not-yet-bound claim.
+func obtainCert(ctx context.Context, cfg config, client attestclient.Client) (claimState, error) {
+	wc, state, err := workloadClaims(ctx, cfg)
 	if err != nil {
-		return err
+		return claimsNotApplicable, err
 	}
+	if err := issueWithClaims(ctx, cfg, client, wc); err != nil {
+		return claimsNotApplicable, err
+	}
+	return state, nil
+}
 
-	wc, err := workloadClaims(ctx, cfg)
+// renewOnce is one renewal-loop tick: it re-fetches the workload claim and
+// issues, except that in fast-rebind mode a still-pending claim is a no-op — the
+// existing claim-free cert stands, so we do not re-issue (and SIGHUP nginx) every
+// few seconds while the app starts. It reports the claim state and whether a
+// certificate was written.
+func renewOnce(ctx context.Context, cfg config, client attestclient.Client, fast bool) (claimState, bool, error) {
+	wc, state, err := workloadClaims(ctx, cfg)
+	if err != nil {
+		return claimsNotApplicable, false, err
+	}
+	if !shouldIssue(fast, state) {
+		return state, false, nil
+	}
+	if err := issueWithClaims(ctx, cfg, client, wc); err != nil {
+		return state, false, err
+	}
+	return state, true, nil
+}
+
+// shouldIssue reports whether a renewal tick should (re)issue a certificate. In
+// fast-rebind mode a still-pending claim is skipped so the existing claim-free
+// cert is not reissued (and nginx not SIGHUP'd) every few seconds while the app
+// starts; every other case — a normal renewal, or a now-bindable claim — issues.
+func shouldIssue(fast bool, state claimState) bool {
+	return !fast || state != claimsPending
+}
+
+// shouldFastRebind reports whether the renewal loop should poll at the
+// fast-rebind cadence: only when fast-rebind is enabled and the last issuance's
+// workload claim is still pending (the app containers are not yet admitted).
+// Once the claim binds, or the pod does not use the broker, it returns false and
+// the loop settles back to the normal renew interval.
+func shouldFastRebind(fastRebind bool, state claimState) bool {
+	return fastRebind && state == claimsPending
+}
+
+// renewCadence is the ticker interval for the current mode: the fast-rebind
+// cadence while a claim is pending, otherwise the normal renew interval.
+func renewCadence(fast bool, cfg config) time.Duration {
+	if fast {
+		return cfg.WorkloadClaimsRebind
+	}
+	return cfg.RenewInterval
+}
+
+// issueWithClaims generates the leaf key, builds the CSR embedding the RA-TLS
+// attestation extension over wc's claims, drives the CDS attestation flow, and
+// writes the outputs.
+func issueWithClaims(ctx context.Context, cfg config, client attestclient.Client, wc workloadClaimsResult) error {
+	privateKey, keyPEM, err := loadOrGenerateKey(cfg)
 	if err != nil {
 		return err
 	}
@@ -323,6 +397,16 @@ func obtainCert(ctx context.Context, cfg config, client attestclient.Client) err
 	return writeOutputs(cfg, keyPEM, result)
 }
 
+// claimState is the outcome of a workload-claims fetch: whether the pod uses the
+// broker and, if so, whether a claim was bindable this issuance.
+type claimState int
+
+const (
+	claimsNotApplicable claimState = iota // --workload-claims-broker not set
+	claimsPending                         // broker set, but no app containers admitted yet
+	claimsBound                           // broker set, a workload claim was bound
+)
+
 // workloadClaimsResult carries the claims DER to bind plus the role-partitioned
 // digest lists to forward to CDS. All nil ⇒ the plain, claims-free flow.
 type workloadClaimsResult struct {
@@ -337,21 +421,21 @@ type workloadClaimsResult struct {
 // --workload-claims-broker it returns an empty (claims-free) result; with it a
 // broker error is fail-closed — issuance aborts rather than silently dropping
 // the workload binding.
-func workloadClaims(ctx context.Context, cfg config) (workloadClaimsResult, error) {
+func workloadClaims(ctx context.Context, cfg config) (workloadClaimsResult, claimState, error) {
 	if !cfg.WorkloadClaimsBroker {
-		return workloadClaimsResult{}, nil
+		return workloadClaimsResult{}, claimsNotApplicable, nil
 	}
 	containers, err := workloadclaims.Fetch(ctx, workloadclaims.BrokerEndpoint(), cfg.WorkloadClaimsTimeout)
 	if err != nil {
-		return workloadClaimsResult{}, fmt.Errorf("fetch workload claims: %w", err)
+		return workloadClaimsResult{}, claimsNotApplicable, fmt.Errorf("fetch workload claims: %w", err)
 	}
 	if len(containers) == 0 {
 		// Expected at first issuance: the c8s-cert native sidecar runs before
 		// the app containers, so the broker has admitted none yet. Issue
-		// without a claim now; a renewal (re-attestation) binds them once the
-		// app is up (docs/ratls.md).
-		slog.Info("workload-claims broker reports no app containers admitted yet; issuing without a workload claim (renewal will bind it)")
-		return workloadClaimsResult{}, nil
+		// without a claim now; fast-rebind binds them once the app is up
+		// (docs/getcert-workload-binding.md, Corner 4).
+		slog.Info("workload-claims broker reports no app containers admitted yet; issuing without a workload claim (fast-rebind will bind it)")
+		return workloadClaimsResult{}, claimsPending, nil
 	}
 
 	initNames := make(map[string]struct{}, len(cfg.WorkloadInitContainers))
@@ -362,13 +446,13 @@ func workloadClaims(ctx context.Context, cfg config) (workloadClaimsResult, erro
 
 	claims, err := workloadclaims.BuildConfigClaims(initDigests, mainDigests)
 	if err != nil {
-		return workloadClaimsResult{}, fmt.Errorf("build workload claims: %w", err)
+		return workloadClaimsResult{}, claimsNotApplicable, fmt.Errorf("build workload claims: %w", err)
 	}
 	ext, err := claims.MarshalExtension()
 	if err != nil {
-		return workloadClaimsResult{}, err
+		return workloadClaimsResult{}, claimsNotApplicable, err
 	}
-	return workloadClaimsResult{claimsDER: ext.Value, initDigests: initDigests, mainDigests: mainDigests}, nil
+	return workloadClaimsResult{claimsDER: ext.Value, initDigests: initDigests, mainDigests: mainDigests}, claimsBound, nil
 }
 
 // reloadNginx sends SIGHUP to the nginx master process to reload certs.

--- a/internal/cmds/getcert/run_more_test.go
+++ b/internal/cmds/getcert/run_more_test.go
@@ -461,12 +461,15 @@ func TestBrokerEndpointIsCompiledUnixPath(t *testing.T) {
 // Without --workload-claims-broker, workloadClaims is a no-op: it returns the
 // empty (claims-free) result without contacting any broker.
 func TestWorkloadClaimsWithoutFlagIsClaimFree(t *testing.T) {
-	res, err := workloadClaims(context.Background(), config{WorkloadClaimsBroker: false})
+	res, state, err := workloadClaims(context.Background(), config{WorkloadClaimsBroker: false})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if res.claimsDER != nil || res.initDigests != nil || res.mainDigests != nil {
 		t.Fatalf("no --workload-claims-broker but a claim was produced: %+v", res)
+	}
+	if state != claimsNotApplicable {
+		t.Fatalf("no --workload-claims-broker: got state %v, want claimsNotApplicable", state)
 	}
 }
 
@@ -602,7 +605,7 @@ func TestObtainCertEndToEnd(t *testing.T) {
 		OutPath:           filepath.Join(dir, "cert.pem"),
 	}
 	client := plaintextCDSClient(cfg.CDSURL)
-	if err := obtainCert(context.Background(), cfg, client); err != nil {
+	if _, err := obtainCert(context.Background(), cfg, client); err != nil {
 		t.Fatalf("obtainCert: %v", err)
 	}
 	got, err := os.ReadFile(cfg.OutPath)
@@ -626,7 +629,7 @@ func TestObtainCertCDSError(t *testing.T) {
 
 	cfg := config{CDSURL: cds.URL, AttestationApiURL: att.URL, SAN: "host.example.com"}
 	client := plaintextCDSClient(cfg.CDSURL)
-	if err := obtainCert(context.Background(), cfg, client); err == nil {
+	if _, err := obtainCert(context.Background(), cfg, client); err == nil {
 		t.Fatal("obtainCert succeeded, want error when CDS fails")
 	}
 }
@@ -669,7 +672,7 @@ func TestObtainCertWithRetrySucceedsAfterTransientFailure(t *testing.T) {
 		InitialRetryInterval: time.Millisecond,
 	}
 	client := plaintextCDSClient(cfg.CDSURL)
-	if err := obtainCertWithRetry(context.Background(), cfg, client); err != nil {
+	if _, err := obtainCertWithRetry(context.Background(), cfg, client); err != nil {
 		t.Fatalf("obtainCertWithRetry: %v", err)
 	}
 	if calls < 2 {
@@ -691,7 +694,7 @@ func TestObtainCertWithRetryNoTimeoutTriesOnce(t *testing.T) {
 
 	cfg := config{CDSURL: cds.URL, AttestationApiURL: att.URL, SAN: "host.example.com", InitialRetryTimeout: 0}
 	client := plaintextCDSClient(cfg.CDSURL)
-	if err := obtainCertWithRetry(context.Background(), cfg, client); err == nil {
+	if _, err := obtainCertWithRetry(context.Background(), cfg, client); err == nil {
 		t.Fatal("obtainCertWithRetry succeeded, want error")
 	}
 	if calls != 1 {
@@ -714,7 +717,7 @@ func TestRunOnceWritesCert(t *testing.T) {
 	// run() builds an https-only RA-TLS client via newCDSClient; drive the
 	// run-once path (obtainCertWithRetry then return) against the plaintext
 	// fake CDS with an injected client instead.
-	if err := obtainCertWithRetry(context.Background(), cfg, plaintextCDSClient(cfg.CDSURL)); err != nil {
+	if _, err := obtainCertWithRetry(context.Background(), cfg, plaintextCDSClient(cfg.CDSURL)); err != nil {
 		t.Fatalf("obtainCertWithRetry: %v", err)
 	}
 	if _, err := os.Stat(cfg.OutPath); err != nil {


### PR DESCRIPTION
the first cert requested by get-cert has no claims, because main containers haven't started yet. This PR re-requests a cert after the main containers have started in order to fetch the correct claims