### PR TITLE
feat(allowlist,secrets): argv-matched path grants and the secret-brok…

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -130,6 +130,13 @@ entry widens a shared digest to `any`, because that becomes the effective
 container-level policy for the digest everywhere. The narrower, entry-scoped
 guarantee is recovered at [cert issuance](#where-its-enforced).
 
+**`paths` does not take the union.** A grant is attributed only to the entries
+whose `command`/`args` the effective argv actually satisfied
+(`Index.PathGrants`). Admission and entitlement would otherwise come from
+different entries: a digest listed once with a strict argv and a grant, and once
+with `command: any` and none, could be run as `/bin/sh -c …` — admitted by the
+second entry, granted by the first.
+
 ## Path policy (`paths`)
 
 `paths` grants filesystem access for a coming key-management integration: a
@@ -140,17 +147,25 @@ is entitled to.
 "paths": { "policy": "allow", "read": ["/secrets/model/**"], "write": ["/secrets/session"] }
 ```
 
-- `deny` (default) grants nothing; `any` is unconstrained; `allow` lists `read`
-  and `write` globs.
-- A `write` grant implies create and update.
+- `deny` (the default) and `any` both grant nothing; only `allow` grants, and
+  only the `read`/`write` globs it lists. (`any` is the unconstrained sentinel
+  for argv; for paths it normalizes to empty lists, so it is `deny` with a
+  different name. `lint` says so.)
+- A `write` grant implies create and update. There is no delete.
 - Paths are absolute and clean (no `.`/`..`); the only wildcard is a trailing
-  `/**` (subtree). These rules exist so a grant cannot be widened by path
-  trickery once an enforcer consumes it.
+  `/**`, matching strictly below its base on a segment boundary — `/a/b/**`
+  covers `/a/b/c` but neither `/a/bc` nor `/a/b` itself. A bare `/**` is
+  rejected: it grants the whole keyspace.
+- A digest in the **floor** may not carry a grant, and the document is rejected
+  if one does. The floor admits by digest alone, so no argv is ever matched and
+  the grant would be held whatever the container ran.
 
-**No enforcer consumes `paths` yet.** It is carried, validated, canonicalized,
-and attested (it is part of the seed digest), so the schema and the operator
-tooling are ready — but it grants nothing until the secret-release component
-exists. When that component lands, a grant's subject must be bound to the
+**No enforcer consumes `paths` yet.** Resolution exists — `Index.PathGrants`
+turns an attested digest plus its effective argv into the grants it holds — but
+nothing calls it, so no secret is released. It is carried, validated,
+canonicalized, and attested (it is part of the seed digest), so the schema and
+the operator tooling are ready — but it grants nothing until the secret-release
+component exists. When that component lands, a grant's subject must be bound to the
 **attested workload digest**, never to a self-asserted image reference, or any
 allowlisted workload could claim another's grant. The field is inert-with-a-spec
 by design; it is not a live capability.
@@ -306,10 +321,12 @@ confirm loop, and the signed write is always a separate, reviewed `apply`.
 `lint` catches the semantic traps before a write: an entry that admits nothing
 (both lists empty), a `command: deny` container that can never start, a
 shared digest whose union is widened to `any` by some entry, a digest that is
-floor-listed while also carrying a workload policy — the floor admits it by
-digest alone, so the argv/paths policy is silently not enforced — tag-form labels
-(which can move under the operator), and a summary of how many `any` policies a
-document carries. `--online` cross-checks digests against the registry with
+floor-listed while also carrying a workload argv policy — the floor admits it by
+digest alone, so that policy is silently not enforced — a `paths: any` that reads
+like a grant but is not, tag-form labels (which can move under the operator), and
+a summary of how many `any` policies a document carries. The two path traps that
+are *errors* rather than warnings — a bare `/**`, and a floor digest carrying a
+grant — are rejected by `ParseJSON`, so they never reach `lint`. `--online` cross-checks digests against the registry with
 `crane`; `--strict` turns warnings into a non-zero exit for CI.
 
 ## Operator credentials

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -136,14 +136,10 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 			}
 			if c.Paths.Policy == pkgallowlist.PolicyAny {
 				anyCount++
+				warnings = append(warnings, fmt.Sprintf("workload %q container %s paths policy is 'any'; it grants no secrets (only 'allow' with explicit read/write paths does)", name, d))
 			}
 			if c.Image != "" && isTagForm(c.Image) {
 				warnings = append(warnings, fmt.Sprintf("workload %q container %s image %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, d, c.Image))
-			}
-			for _, g := range append(append([]string{}, c.Paths.Read...), c.Paths.Write...) {
-				if g == "/**" {
-					warnings = append(warnings, fmt.Sprintf("workload %q container %s grants a root-subtree path %q (whole filesystem)", name, d, g))
-				}
 			}
 		}
 	}
@@ -155,10 +151,12 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 	}
 
 	// A floor digest is admitted by digest alone, so it short-circuits any argv
-	// or paths policy an operator also wrote for the same digest in a workload.
+	// policy an operator also wrote for the same digest in a workload. A paths
+	// grant on such a digest is rejected outright by ParseJSON, so it cannot
+	// reach here.
 	for _, d := range sortedKeys(al.Digests) {
 		if names := entriesByDigest[d]; len(names) > 0 {
-			warnings = append(warnings, fmt.Sprintf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv/paths policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
+			warnings = append(warnings, fmt.Sprintf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
 		}
 	}
 

--- a/internal/secrets/broker.go
+++ b/internal/secrets/broker.go
@@ -1,0 +1,96 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// Subject is who a release is authorized for: the image digest a container was
+// admitted as, and the effective argv it was admitted with.
+//
+// INVARIANT: both fields come from the component that made the admission
+// decision — nri-image-policy's CreateContainer record on node-CVM, the guest
+// monitor's bundle read under kata — and NEVER from the request being served.
+// The broker cannot verify them and does not try. A caller that fills a Subject
+// from its own request body has authorized nothing: it has let the requester
+// name its own entitlement.
+type Subject struct {
+	Digest types.Digest
+	Argv   []string
+}
+
+// Broker resolves a Subject's grants and moves secrets through a Provider.
+//
+// Index.PathGrants attributes a grant only to an entry whose argv policy the
+// subject's argv matched, so a digest shared with a permissive entry cannot
+// borrow a strict entry's paths. Floor digests hold no grants, which is what
+// keeps every c8s-injected component unentitled.
+type Broker struct {
+	Provider Provider
+	// Index returns the allowlist projection to resolve against. It is a
+	// function because the served allowlist is swapped on every operator write.
+	Index func() (*allowlist.Index, error)
+}
+
+// Grants returns the read and write paths subj holds.
+func (b *Broker) Grants(subj Subject) (allowlist.PathPolicy, error) {
+	idx, err := b.Index()
+	if err != nil {
+		return allowlist.PathPolicy{}, fmt.Errorf("load allowlist: %w", err)
+	}
+	return idx.PathGrants(subj.Digest.String(), subj.Argv), nil
+}
+
+// Fetch returns the secrets at refs. Every ref must satisfy a read grant subj
+// holds; one denial fails the whole call, so a partial result is never mistaken
+// for a complete one.
+//
+// refs must be non-empty: a grant may name a subtree, which no provider can be
+// asked to enumerate cheaply or consistently, so a caller always names the exact
+// paths it wants.
+func (b *Broker) Fetch(ctx context.Context, subj Subject, refs []Ref) ([]Secret, error) {
+	if len(refs) == 0 {
+		return nil, fmt.Errorf("secrets: fetch requires at least one path")
+	}
+	idx, err := b.Index()
+	if err != nil {
+		return nil, fmt.Errorf("load allowlist: %w", err)
+	}
+	for _, r := range refs {
+		if !idx.AdmitsRead(subj.Digest.String(), subj.Argv, r.Path) {
+			return nil, ErrDenied
+		}
+	}
+	out, err := b.Provider.GetMany(ctx, refs)
+	if err != nil {
+		return nil, err
+	}
+	// Only the requested paths were authorized, so a provider answering with any
+	// other path — or with a short list — must fail the call rather than hand
+	// back material nothing granted.
+	if len(out) != len(refs) {
+		return nil, fmt.Errorf("secrets: provider returned %d of %d requested secrets", len(out), len(refs))
+	}
+	for i, s := range out {
+		if s.Path != refs[i].Path {
+			return nil, fmt.Errorf("secrets: provider returned %q for requested path %q", s.Path, refs[i].Path)
+		}
+	}
+	return out, nil
+}
+
+// Put writes data at path, which must satisfy a write grant subj holds. A write
+// grant implies create and update.
+func (b *Broker) Put(ctx context.Context, subj Subject, path string, data []byte) (Secret, error) {
+	idx, err := b.Index()
+	if err != nil {
+		return Secret{}, fmt.Errorf("load allowlist: %w", err)
+	}
+	if !idx.AdmitsWrite(subj.Digest.String(), subj.Argv, path) {
+		return Secret{}, ErrDenied
+	}
+	return b.Provider.Put(ctx, path, data)
+}

--- a/internal/secrets/broker_test.go
+++ b/internal/secrets/broker_test.go
@@ -1,0 +1,195 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	digestApp    = "sha256:" + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	digestFloor  = "sha256:" + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	appArgv0     = "/app/serve"
+	grantedPath  = "/secret/model/key"
+	deniedPath   = "/secret/other/key"
+	writablePath = "/secret/session"
+)
+
+// brokerFor builds a broker over an allowlist granting digestApp read on
+// /secret/model/** and write on /secret/session, only when it runs /app/serve.
+func brokerFor(t *testing.T, seed map[string][]byte) *Broker {
+	t.Helper()
+	doc, err := allowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","digests":{"` + digestFloor + `":"get-cert"},
+		"workloads":{"app":{"containers":[{"digest":"` + digestApp + `",
+		 "command":{"policy":"exact","argv":["` + appArgv0 + `"]},"args":{"policy":"any"},
+		 "paths":{"policy":"allow","read":["/secret/model/**"],"write":["` + writablePath + `"]}}]}}}`))
+	if err != nil {
+		t.Fatalf("parse allowlist: %v", err)
+	}
+	idx := doc.BuildIndex()
+	return &Broker{
+		Provider: NewMemProvider(seed),
+		Index:    func() (*allowlist.Index, error) { return idx, nil },
+	}
+}
+
+// subj builds the Subject the admission component would supply. In production
+// neither field is caller-supplied; here the test plays that component.
+func subj(t *testing.T, digest string, argv ...string) Subject {
+	t.Helper()
+	d, err := types.ParseDigest(digest)
+	if err != nil {
+		t.Fatalf("parse digest: %v", err)
+	}
+	return Subject{Digest: d, Argv: argv}
+}
+
+func TestBrokerFetchHonorsReadGrant(t *testing.T) {
+	b := brokerFor(t, map[string][]byte{grantedPath: []byte("weights"), deniedPath: []byte("other")})
+	argv := []string{appArgv0, "--port=8080"}
+
+	got, err := b.Fetch(context.Background(), subj(t, digestApp, argv...), []Ref{{Path: grantedPath}})
+	if err != nil {
+		t.Fatalf("fetch granted path: %v", err)
+	}
+	if len(got) != 1 || string(got[0].Data) != "weights" || got[0].Version != "1" {
+		t.Fatalf("got %+v, want one v1 secret with the seeded data", got)
+	}
+
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp, argv...), []Ref{{Path: deniedPath}}); !errors.Is(err, ErrDenied) {
+		t.Fatalf("ungranted path: err = %v, want ErrDenied", err)
+	}
+}
+
+// One denial fails the whole call, so a partial answer can never be mistaken
+// for the caller's complete entitled set.
+func TestBrokerFetchIsAllOrNothing(t *testing.T) {
+	b := brokerFor(t, map[string][]byte{grantedPath: []byte("weights"), deniedPath: []byte("other")})
+	refs := []Ref{{Path: grantedPath}, {Path: deniedPath}}
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp, appArgv0), refs); !errors.Is(err, ErrDenied) {
+		t.Fatalf("mixed request: err = %v, want ErrDenied", err)
+	}
+}
+
+// The grant is pinned to the argv the entry allows, so the same bytes run any
+// other way hold nothing.
+func TestBrokerFetchDeniesUnmatchedArgv(t *testing.T) {
+	b := brokerFor(t, map[string][]byte{grantedPath: []byte("weights")})
+	argv := []string{"/bin/sh", "-c", "cat " + grantedPath}
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp, argv...), []Ref{{Path: grantedPath}}); !errors.Is(err, ErrDenied) {
+		t.Fatalf("unmatched argv: err = %v, want ErrDenied", err)
+	}
+}
+
+func TestBrokerFetchDeniesFloorDigest(t *testing.T) {
+	b := brokerFor(t, map[string][]byte{grantedPath: []byte("weights")})
+	if _, err := b.Fetch(context.Background(), subj(t, digestFloor), []Ref{{Path: grantedPath}}); !errors.Is(err, ErrDenied) {
+		t.Fatalf("floor digest: err = %v, want ErrDenied", err)
+	}
+}
+
+func TestBrokerFetchRequiresPaths(t *testing.T) {
+	b := brokerFor(t, nil)
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp, appArgv0), nil); err == nil {
+		t.Fatal("an empty fetch must be rejected, not enumerate the grant")
+	}
+}
+
+func TestBrokerPutHonorsWriteGrant(t *testing.T) {
+	b := brokerFor(t, nil)
+	argv := []string{appArgv0}
+
+	s, err := b.Put(context.Background(), subj(t, digestApp, argv...), writablePath, []byte("v1"))
+	if err != nil {
+		t.Fatalf("put granted path: %v", err)
+	}
+	if s.Version != "1" {
+		t.Fatalf("version = %q, want 1", s.Version)
+	}
+	if s, err = b.Put(context.Background(), subj(t, digestApp, argv...), writablePath, []byte("v2")); err != nil || s.Version != "2" {
+		t.Fatalf("second put: %+v, %v — want version 2", s, err)
+	}
+
+	// A read grant must not imply write.
+	if _, err := b.Put(context.Background(), subj(t, digestApp, argv...), grantedPath, []byte("x")); !errors.Is(err, ErrDenied) {
+		t.Fatalf("write to a read-only path: err = %v, want ErrDenied", err)
+	}
+}
+
+// An init container writes a secret the main container then reads. The two are
+// separate grants on separate digests in a real workload; here the point is
+// that a fresh Put is what a later Fetch sees.
+func TestBrokerWriteThenRead(t *testing.T) {
+	doc, err := allowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","workloads":{"app":{
+		"initContainers":[{"digest":"` + digestApp + `","command":{"policy":"exact","argv":["/init"]},
+		 "args":{"policy":"any"},"paths":{"policy":"allow","write":["` + writablePath + `"]}}],
+		"containers":[{"digest":"` + digestFloor + `","command":{"policy":"exact","argv":["/main"]},
+		 "args":{"policy":"any"},"paths":{"policy":"allow","read":["` + writablePath + `"]}}]}}}`))
+	if err != nil {
+		t.Fatalf("parse allowlist: %v", err)
+	}
+	idx := doc.BuildIndex()
+	b := &Broker{Provider: NewMemProvider(nil), Index: func() (*allowlist.Index, error) { return idx, nil }}
+
+	if _, err := b.Put(context.Background(), subj(t, digestApp, "/init"), writablePath, []byte("session")); err != nil {
+		t.Fatalf("init write: %v", err)
+	}
+	got, err := b.Fetch(context.Background(), subj(t, digestFloor, "/main"), []Ref{{Path: writablePath}})
+	if err != nil {
+		t.Fatalf("main read: %v", err)
+	}
+	if string(got[0].Data) != "session" {
+		t.Fatalf("data = %q, want the value the init container wrote", got[0].Data)
+	}
+	// The reader holds no write grant on the same path.
+	if _, err := b.Put(context.Background(), subj(t, digestFloor, "/main"), writablePath, []byte("x")); !errors.Is(err, ErrDenied) {
+		t.Fatalf("reader write: err = %v, want ErrDenied", err)
+	}
+}
+
+func TestBrokerGrants(t *testing.T) {
+	b := brokerFor(t, nil)
+	g, err := b.Grants(subj(t, digestApp, appArgv0))
+	if err != nil {
+		t.Fatalf("grants: %v", err)
+	}
+	if g.Policy != allowlist.PolicyAllow || len(g.Read) != 1 || len(g.Write) != 1 {
+		t.Fatalf("grants = %+v, want one read and one write glob", g)
+	}
+	if g, _ = b.Grants(subj(t, digestApp, "/bin/sh")); g.Policy != allowlist.PolicyDeny {
+		t.Fatalf("unmatched argv grants = %+v, want deny", g)
+	}
+}
+
+func TestBrokerIndexError(t *testing.T) {
+	b := &Broker{
+		Provider: NewMemProvider(nil),
+		Index:    func() (*allowlist.Index, error) { return nil, errors.New("store down") },
+	}
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp), []Ref{{Path: grantedPath}}); err == nil {
+		t.Fatal("an unavailable allowlist must fail closed")
+	}
+	if _, err := b.Put(context.Background(), subj(t, digestApp), writablePath, nil); err == nil {
+		t.Fatal("an unavailable allowlist must fail closed")
+	}
+}
+
+// wrongPathProvider answers a granted request with a different path — a bug or a
+// hostile adapter. Only the requested paths were authorized, so the call must
+// fail rather than hand back material nothing granted.
+type wrongPathProvider struct{ Provider }
+
+func (wrongPathProvider) GetMany(context.Context, []Ref) ([]Secret, error) {
+	return []Secret{{Path: deniedPath, Version: "1", Data: []byte("other")}}, nil
+}
+
+func TestBrokerFetchRejectsProviderPathMismatch(t *testing.T) {
+	b := brokerFor(t, map[string][]byte{grantedPath: []byte("weights")})
+	b.Provider = wrongPathProvider{b.Provider}
+	if _, err := b.Fetch(context.Background(), subj(t, digestApp, appArgv0), []Ref{{Path: grantedPath}}); err == nil {
+		t.Fatal("a provider answering with an unrequested path must fail the call")
+	}
+}

--- a/internal/secrets/memprovider.go
+++ b/internal/secrets/memprovider.go
@@ -1,0 +1,81 @@
+package secrets
+
+import (
+	"context"
+	"strconv"
+	"sync"
+)
+
+// memProvider is the in-memory Provider used by tests and the e2e lane until a
+// real adapter lands. Versions are a per-path counter starting at 1.
+type memProvider struct {
+	mu     sync.RWMutex
+	byPath map[string][]Secret // path -> versions, oldest first
+}
+
+// NewMemProvider returns a Provider seeded with the given values, each at
+// version 1. The seed is copied, so a caller cannot mutate stored data.
+func NewMemProvider(seed map[string][]byte) Provider {
+	p := &memProvider{byPath: make(map[string][]Secret, len(seed))}
+	for path, data := range seed {
+		p.byPath[path] = []Secret{{Path: path, Version: "1", Data: copyOf(data)}}
+	}
+	return p
+}
+
+func (p *memProvider) Get(_ context.Context, path, version string) (Secret, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.get(path, version)
+}
+
+func (p *memProvider) GetMany(_ context.Context, refs []Ref) ([]Secret, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]Secret, 0, len(refs))
+	for _, r := range refs {
+		s, err := p.get(r.Path, r.Version)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (p *memProvider) Put(_ context.Context, path string, data []byte) (Secret, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	s := Secret{
+		Path:    path,
+		Version: strconv.Itoa(len(p.byPath[path]) + 1),
+		Data:    copyOf(data),
+	}
+	p.byPath[path] = append(p.byPath[path], s)
+	return Secret{Path: s.Path, Version: s.Version, Data: copyOf(s.Data)}, nil
+}
+
+func (p *memProvider) Close() error { return nil }
+
+// get resolves one path/version under the caller's lock. Version "" is the
+// latest.
+func (p *memProvider) get(path, version string) (Secret, error) {
+	versions := p.byPath[path]
+	if len(versions) == 0 {
+		return Secret{}, ErrNotFound
+	}
+	if version == "" {
+		s := versions[len(versions)-1]
+		return Secret{Path: s.Path, Version: s.Version, Data: copyOf(s.Data)}, nil
+	}
+	for _, s := range versions {
+		if s.Version == version {
+			return Secret{Path: s.Path, Version: s.Version, Data: copyOf(s.Data)}, nil
+		}
+	}
+	return Secret{}, ErrNotFound
+}
+
+func copyOf(b []byte) []byte {
+	return append([]byte(nil), b...)
+}

--- a/internal/secrets/memprovider_test.go
+++ b/internal/secrets/memprovider_test.go
@@ -1,0 +1,63 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMemProviderVersionsAndIsolation(t *testing.T) {
+	seed := []byte("v1")
+	p := NewMemProvider(map[string][]byte{"/a": seed})
+	ctx := context.Background()
+
+	// The seed is copied, so mutating the caller's slice cannot alter the store.
+	seed[0] = 'X'
+	got, err := p.Get(ctx, "/a", "")
+	if err != nil || string(got.Data) != "v1" {
+		t.Fatalf("get seeded: %+v, %v — want the original bytes", got, err)
+	}
+
+	// Nor can mutating a returned slice.
+	got.Data[0] = 'Y'
+	if again, _ := p.Get(ctx, "/a", ""); string(again.Data) != "v1" {
+		t.Fatalf("returned data aliases the store: %q", again.Data)
+	}
+
+	if _, err := p.Put(ctx, "/a", []byte("v2")); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	latest, _ := p.Get(ctx, "/a", "")
+	if latest.Version != "2" || string(latest.Data) != "v2" {
+		t.Fatalf("latest = %+v, want v2 at version 2", latest)
+	}
+	pinned, err := p.Get(ctx, "/a", "1")
+	if err != nil || string(pinned.Data) != "v1" {
+		t.Fatalf("pinned read: %+v, %v — want the first version", pinned, err)
+	}
+}
+
+func TestMemProviderNotFound(t *testing.T) {
+	p := NewMemProvider(nil)
+	ctx := context.Background()
+	if _, err := p.Get(ctx, "/missing", ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing path: err = %v, want ErrNotFound", err)
+	}
+	if _, err := p.Get(ctx, "/missing", "7"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing version: err = %v, want ErrNotFound", err)
+	}
+	if _, err := p.GetMany(ctx, []Ref{{Path: "/missing"}}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetMany must fail whole rather than return a short list: %v", err)
+	}
+}
+
+func TestMemProviderGetManyOrder(t *testing.T) {
+	p := NewMemProvider(map[string][]byte{"/a": []byte("A"), "/b": []byte("B")})
+	got, err := p.GetMany(context.Background(), []Ref{{Path: "/b"}, {Path: "/a"}})
+	if err != nil {
+		t.Fatalf("GetMany: %v", err)
+	}
+	if len(got) != 2 || string(got[0].Data) != "B" || string(got[1].Data) != "A" {
+		t.Fatalf("got %+v, want results in request order", got)
+	}
+}

--- a/internal/secrets/provider.go
+++ b/internal/secrets/provider.go
@@ -1,0 +1,60 @@
+// Package secrets brokers attested secret release: it resolves the path grants
+// a container holds from the allowlist and reads or writes them through a
+// backing provider. Providers are dumb — no policy, no attestation, no caching;
+// every authorization decision is made here, keyed on the attested container
+// digest and the argv that digest was admitted with.
+//
+// A provider maps c8s's absolute, POSIX-shaped paths onto its own namespace
+// (Vault mounts, AWS ARNs, Key Vault names). That mapping belongs to the
+// provider and must be explicit; nothing here assumes the two coincide.
+package secrets
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// ErrNotFound is returned by a provider when no secret exists at a path.
+var ErrNotFound = errors.New("secrets: not found")
+
+// ErrDenied is returned by the broker when the caller's grants do not cover a
+// requested path. It is deliberately indistinguishable from ErrNotFound to a
+// caller, so a denied request does not reveal whether the secret exists.
+var ErrDenied = errors.New("secrets: not granted")
+
+// Secret is one stored value. Version is the provider's own generation
+// identifier, empty when the provider is unversioned.
+type Secret struct {
+	Path    string
+	Version string
+	Data    []byte
+}
+
+// Ref names one secret to read. An empty Version means the latest.
+type Ref struct {
+	Path    string
+	Version string
+}
+
+// Provider is the adapter contract an external key-management system
+// implements. There is no delete: the allowlist grants read and write only.
+type Provider interface {
+	// Get returns the secret at path. Version "" is the latest.
+	Get(ctx context.Context, path, version string) (Secret, error)
+	// GetMany returns the secrets for refs, in order. A single round trip is
+	// what keeps release off a per-secret latency budget.
+	GetMany(ctx context.Context, refs []Ref) ([]Secret, error)
+	// Put writes data at path, creating or replacing it, and returns the
+	// resulting version. Last write wins.
+	Put(ctx context.Context, path string, data []byte) (Secret, error)
+	// Close releases whatever leases or renewable tokens the provider holds.
+	io.Closer
+}
+
+// Health is implemented by providers that can report backend reachability, so
+// a serving process can fail readiness rather than accept requests it cannot
+// satisfy. Providers that cannot are treated as always healthy.
+type Health interface {
+	Ping(ctx context.Context) error
+}

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -184,6 +184,27 @@ func (a *Allowlist) normalize() error {
 		sortContainers(w.Containers)
 		a.Workloads[name] = w
 	}
+	return a.rejectFloorGrants()
+}
+
+// rejectFloorGrants fails a document where a floor digest also carries a path
+// grant. The floor admits by digest alone — no argv is ever matched — so the
+// grant would be held whatever the container ran. Index.PathGrants enforces the
+// same rule at query time; this makes it a write-time error too.
+func (a *Allowlist) rejectFloorGrants() error {
+	if len(a.Digests) == 0 {
+		return nil
+	}
+	for name, w := range a.Workloads {
+		for _, c := range append(append([]Container{}, w.InitContainers...), w.Containers...) {
+			if c.Paths.Policy != PolicyAllow {
+				continue
+			}
+			if _, isFloor := a.Digests[c.Digest.String()]; isFloor {
+				return fmt.Errorf("workload %q container %s is floor-listed and carries a paths grant: the floor admits it by digest alone, so the grant would be held whatever it ran", name, c.Digest)
+			}
+		}
+	}
 	return nil
 }
 
@@ -266,10 +287,10 @@ func normalizeGlobs(globs []string) ([]string, error) {
 		if !strings.HasPrefix(g, "/") {
 			return nil, fmt.Errorf("path %q must be absolute", g)
 		}
-		base := strings.TrimSuffix(g, "/**")
-		if base == "" {
-			base = "/"
+		if g == "/**" {
+			return nil, fmt.Errorf(`path "/**" grants the whole keyspace; name the subtrees instead`)
 		}
+		base := strings.TrimSuffix(g, "/**")
 		if strings.Contains(base, "*") {
 			return nil, fmt.Errorf("path %q: the only wildcard is a trailing /**", g)
 		}

--- a/pkg/allowlist/allowlist_test.go
+++ b/pkg/allowlist/allowlist_test.go
@@ -131,3 +131,32 @@ func mustParse(t *testing.T, s string) *Allowlist {
 	}
 	return al
 }
+
+// A floor digest is admitted by digest alone, so a paths grant on it would be
+// held whatever the container ran. Reject the document rather than store it.
+func TestParseJSON_RejectsFloorDigestWithGrant(t *testing.T) {
+	body := `{"schema":"c8s.allowlist/v1","digests":{"` + digestA + `":"base"},
+		"workloads":{"w":{"containers":[{"digest":"` + digestA + `",
+		 "command":{"policy":"any"},"args":{"policy":"any"},
+		 "paths":{"policy":"allow","read":["/s/**"]}}]}}}`
+	if _, err := ParseJSON([]byte(body)); err == nil {
+		t.Fatal("expected a floor-digest-with-grant rejection")
+	}
+
+	// The same digest in the floor without a grant stays legal (the argv policy
+	// is simply unenforced, which lint warns about).
+	ok := `{"schema":"c8s.allowlist/v1","digests":{"` + digestA + `":"base"},
+		"workloads":{"w":{"containers":[{"digest":"` + digestA + `",
+		 "command":{"policy":"any"},"args":{"policy":"any"}}]}}}`
+	if _, err := ParseJSON([]byte(ok)); err != nil {
+		t.Fatalf("floor digest without a grant should parse: %v", err)
+	}
+}
+
+func TestParseJSON_RejectsRootSubtreeGrant(t *testing.T) {
+	body := `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[{"digest":"` +
+		digestA + `","paths":{"policy":"allow","read":["/**"]}}]}}}`
+	if _, err := ParseJSON([]byte(body)); err == nil {
+		t.Fatal("expected a whole-keyspace grant rejection")
+	}
+}

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -1,6 +1,13 @@
 package allowlist
 
-import "github.com/confidential-dot-ai/c8s/pkg/types"
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
 
 // Index answers admission queries for enforcers in O(1). Build it once from a
 // normalized Allowlist.
@@ -63,6 +70,101 @@ func (i *Index) AdmitsContainer(digest string, argv []string) bool {
 		}
 	}
 	return false
+}
+
+// PathGrants returns the filesystem grants held by a container running this
+// digest with this effective argv: the union over the entries whose command and
+// args policies that argv satisfied. Grants are attributed only to a policy the
+// argv actually matched, so a digest that also appears under a permissive entry
+// cannot borrow a strict entry's grants. A floor digest holds none — the floor
+// admits by digest alone, so no argv was checked and no entry can be attributed.
+func (i *Index) PathGrants(digest string, argv []string) PathPolicy {
+	d, err := types.ParseDigest(digest)
+	if err != nil || i.floor[d.String()] {
+		return PathPolicy{Policy: PolicyDeny}
+	}
+	granted := PathPolicy{Policy: PolicyDeny}
+	for _, c := range i.byDigest[d.String()] {
+		if c.Paths.Policy != PolicyAllow {
+			continue
+		}
+		rest, ok := c.Command.matchCommand(argv)
+		if !ok || !c.Args.matchArgs(rest) {
+			continue
+		}
+		granted.Policy = PolicyAllow
+		granted.Read = append(granted.Read, c.Paths.Read...)
+		granted.Write = append(granted.Write, c.Paths.Write...)
+	}
+	granted.Read = sortDedupe(granted.Read)
+	granted.Write = sortDedupe(granted.Write)
+	return granted
+}
+
+// AdmitsRead reports whether a container running digest with argv may read path.
+func (i *Index) AdmitsRead(digest string, argv []string, p string) bool {
+	return pathCovered(i.PathGrants(digest, argv).Read, p)
+}
+
+// AdmitsWrite reports whether a container running digest with argv may write
+// path. A write grant implies create and update; there is no delete.
+func (i *Index) AdmitsWrite(digest string, argv []string, p string) bool {
+	return pathCovered(i.PathGrants(digest, argv).Write, p)
+}
+
+// CleanPath canonicalizes a caller-supplied path. A request names one path,
+// never a pattern, so a wildcard is rejected rather than matched literally.
+func CleanPath(p string) (string, error) {
+	if !strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("path %q must be absolute", p)
+	}
+	if strings.Contains(p, "*") {
+		return "", fmt.Errorf("path %q must not contain a wildcard", p)
+	}
+	if path.Clean(p) != p {
+		return "", fmt.Errorf("path %q is not clean (no . or ..)", p)
+	}
+	return p, nil
+}
+
+// pathCovered reports whether p is covered by any glob. p is canonicalized
+// first, so an unclean or wildcard-bearing request matches nothing.
+func pathCovered(globs []string, p string) bool {
+	clean, err := CleanPath(p)
+	if err != nil {
+		return false
+	}
+	for _, g := range globs {
+		if matchGlob(g, clean) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob matches one normalized grant against a clean absolute path: an
+// exact path matches itself, and a trailing /** matches strictly below its base
+// on a segment boundary — so /a/b/** covers /a/b/c but neither /a/bc nor /a/b.
+func matchGlob(glob, p string) bool {
+	base, subtree := strings.CutSuffix(glob, "/**")
+	if !subtree {
+		return glob == p
+	}
+	return strings.HasPrefix(p, base+"/")
+}
+
+func sortDedupe(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	sort.Strings(in)
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // matchCommand matches a command policy against the front of argv. exact pins a

--- a/pkg/allowlist/policy_test.go
+++ b/pkg/allowlist/policy_test.go
@@ -78,3 +78,99 @@ func TestIndex_UnknownDigestDenied(t *testing.T) {
 		t.Fatal("unknown digest must be denied")
 	}
 }
+
+// The grant a container holds must come from a policy its argv actually
+// satisfied. A digest shared with a permissive entry would otherwise let any
+// argv borrow a strict entry's paths — admitted via one entry, granted via
+// another.
+func TestIndex_PathGrantsAreArgvMatched(t *testing.T) {
+	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{
+		"victim":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/app/serve"]},
+		 "paths":{"policy":"allow","read":["/secret/model/**"]}}]},
+		"debug":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"}}]}}}`).BuildIndex()
+
+	shell := []string{"/bin/sh", "-c", "cat /secret/model/key"}
+	if !idx.AdmitsContainer(digestA, shell) {
+		t.Fatal("the permissive entry should still admit the argv")
+	}
+	if idx.AdmitsRead(digestA, shell, "/secret/model/key") {
+		t.Fatal("an argv admitted only by the permissive entry must hold no grant")
+	}
+	if !idx.AdmitsRead(digestA, []string{"/app/serve"}, "/secret/model/key") {
+		t.Fatal("the argv the granting entry pins must hold the grant")
+	}
+}
+
+func TestIndex_FloorDigestHoldsNoGrant(t *testing.T) {
+	// A floor digest carrying a grant is rejected at parse time, so build the
+	// index from a document where the floor entry is added afterwards — the
+	// state a stale or hand-built index could still reach.
+	al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
+		{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},
+		 "paths":{"policy":"allow","read":["/s/**"]}}]}}}`)
+	al.Digests = map[string]string{digestA: "shared-base"}
+	idx := al.BuildIndex()
+
+	if idx.AdmitsRead(digestA, []string{"/bin/sh"}, "/s/x") {
+		t.Fatal("a floor digest must hold no grant — no argv was ever matched")
+	}
+}
+
+func TestIndex_PathGrantsUnionMatchingEntries(t *testing.T) {
+	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{
+		"a":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},
+		 "paths":{"policy":"allow","read":["/s/a"],"write":["/w/a"]}}]},
+		"b":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},
+		 "paths":{"policy":"allow","read":["/s/a","/s/b"]}}]}}}`).BuildIndex()
+
+	g := idx.PathGrants(digestA, []string{"/app"})
+	if g.Policy != PolicyAllow {
+		t.Fatalf("policy = %q, want allow", g.Policy)
+	}
+	if len(g.Read) != 2 || g.Read[0] != "/s/a" || g.Read[1] != "/s/b" {
+		t.Fatalf("read = %v, want deduped and sorted [/s/a /s/b]", g.Read)
+	}
+	if !idx.AdmitsWrite(digestA, []string{"/app"}, "/w/a") {
+		t.Fatal("write grant should be honored")
+	}
+	if idx.AdmitsWrite(digestA, []string{"/app"}, "/s/a") {
+		t.Fatal("a read grant must not imply write")
+	}
+}
+
+// paths:any normalizes to empty read/write lists, so it grants nothing.
+func TestIndex_PathsAnyGrantsNothing(t *testing.T) {
+	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
+		{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},
+		 "paths":{"policy":"any"}}]}}}`).BuildIndex()
+	if idx.AdmitsRead(digestA, []string{"/app"}, "/anything") {
+		t.Fatal("paths:any must grant nothing")
+	}
+}
+
+func TestMatchGlobAndCleanPath(t *testing.T) {
+	for _, tc := range []struct {
+		glob, path string
+		want       bool
+	}{
+		{"/s/model", "/s/model", true},
+		{"/s/model", "/s/model/key", false},
+		{"/s/model/**", "/s/model/key", true},
+		{"/s/model/**", "/s/model/sub/key", true},
+		{"/s/model/**", "/s/model", false},
+		{"/s/model/**", "/s/modelx/key", false},
+	} {
+		if got := matchGlob(tc.glob, tc.path); got != tc.want {
+			t.Errorf("matchGlob(%q, %q) = %v, want %v", tc.glob, tc.path, got, tc.want)
+		}
+	}
+
+	for _, bad := range []string{"relative/x", "/a/../b", "/a/*", "/a/"} {
+		if _, err := CleanPath(bad); err == nil {
+			t.Errorf("CleanPath(%q) accepted an invalid request path", bad)
+		}
+	}
+	if _, err := CleanPath("/a/b"); err != nil {
+		t.Errorf("CleanPath(/a/b): %v", err)
+	}
+}


### PR DESCRIPTION
…er interface

Resolution for the paths policy shipped in #135, plus the adapter contract a secret broker will sit behind. No enforcer consumes either yet.

Grants are attributed only to entries whose command/args the effective argv satisfied. AdmitsContainer takes the union across every entry listing a digest, so attributing grants the same way would let admission and entitlement come from different entries: a digest listed once with a strict argv and a grant, and once with command:any and none, could run /bin/sh -c and hold the first entry's paths. Floor digests hold no grants at all — the floor admits by digest alone, so no argv is ever matched.

Two new validation errors: a bare /** grant (the whole keyspace), and a floor digest carrying a grant (held whatever it ran). lint gains a paths:any warning.

internal/secrets defines Provider (versioned Get, GetMany, Put, Close) and an in-memory stub. No List: subtree grants cannot be enumerated cheaply or consistently on Vault KV v2, Secrets Manager or Key Vault, so callers name exact paths — which also keeps an existence oracle off the future endpoint. Fetch is all-or-nothing and ErrDenied is indistinguishable from ErrNotFound.