### PR TITLE
feat(cds): secrets broker — store, attestation-gated fetch, broker identity, operator CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,9 @@ The direction of travel, beyond closing the gaps above:
 
 - **Key management system.** Attestation-gated secret release, so application
   secrets are brokered to workloads only after their measurement verifies.
+  The CDS broker, store interface, and operator CLI ship in
+  [`docs/secrets-broker.md`](docs/secrets-broker.md); workload-side injection
+  and external KMS adapters are the next milestones.
 
 - **IGVM support for Kata.** Move the per-pod runtime's measured boot to
   IGVM, unifying pod-as-CVM and node-as-CVM on one measured-boot format.

--- a/cmd/c8s/secrets.go
+++ b/cmd/c8s/secrets.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/secrets"
+
+func init() {
+	rootCmd.AddCommand(secrets.NewCmd())
+}

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -39,6 +39,12 @@ Infrastructure assets whose integrity the above depend on:
    values** — what the platform will admit and attest.
 7. **Operator keys** and **per-session channel keys** (RA-TLS leaves, the
    browser over-encryption keys).
+8. **Brokered application secrets** — tenant DEKs, credentials, and signing
+   keys held by the CDS secrets broker in attested CVM memory and released
+   only to attested workloads under per-(entry, digest, path) grants
+   (`docs/secrets-broker.md`). At rest they exist only in CDS process memory;
+   in transit only wrapped inside an attested channel; at rest in pods only
+   in tmpfs (in-TEE RAM).
 
 ---
 
@@ -53,7 +59,7 @@ TEE is the trust boundary.** "It works on a normal cluster" is not the bar.
 | Physical host operator (in its *physical* role) | Trusted | Not to mount memory-bus probing / DIMM substitution / JTAG. The same company is distrusted in its hypervisor role. |
 | Code measured into the TEE (guest stack, CDS) | Trusted | Correct iff its launch measurement is pinned by the relying party. |
 | Hypervisor / host OS / BIOS / drivers / kubelet / containerd | **Untrusted** | Full control of the node: can read/modify anything outside a CVM, schedule pods, set pod annotations, inject kernel cmdline (§5), serve its own TEE attestation on the pod network. |
-| Kubernetes control plane / etcd | **Untrusted** | Sees only ciphertext and public material for the **TEE-held privates** — CDS mesh CA / EAR issuer / handoff signer, RA-TLS leaf keys, browser over-encryption session keys — which never enter etcd. Ordinary Kubernetes Secrets **are visible in plaintext** to whoever reads etcd: image-pull dockerconfigjson (`imagePullSecrets`, `kata.guestImage.pullerAuthSecret`), the webhook TLS `caBundle`, and any tenant workload Secrets. Attestation-gated application-secret release is deferred (§7). CRDs are not security inputs. |
+| Kubernetes control plane / etcd | **Untrusted** | Sees only ciphertext and public material for the **TEE-held privates** — CDS mesh CA / EAR issuer / handoff signer, RA-TLS leaf keys, browser over-encryption session keys, and brokered application secrets — which never enter etcd. Ordinary Kubernetes Secrets **are visible in plaintext** to whoever reads etcd: image-pull dockerconfigjson (`imagePullSecrets`, `kata.guestImage.pullerAuthSecret`), the webhook TLS `caBundle`, and any tenant workload Secrets. The secrets broker's store is CDS-memory only for the same reason (`docs/secrets-broker.md`). CRDs are not security inputs. |
 | Pod-network attacker (compromised CNI, malicious sidecar, DNS hijack) | **Untrusted** | Can stand up its own genuine TEE attestation and try to impersonate CDS / a mesh peer at bootstrap. |
 | Co-tenant workload | **Untrusted** | Multi-tenant isolation is not yet solved (§7). Node-as-CVM pods are only kernel-isolated. |
 | Supply chain — CI (GitHub Actions), ghcr.io, npm/CDN, the fleet GitOps repo | **Partially trusted, unenumerated risk** | Produces the measurements, allowlists, and digests that make attestation meaningful — all from *outside* the TEE. See §5 (Open) and §6. |
@@ -108,6 +114,7 @@ surface; a workload can be injected without a CR.
 | TEE evidence is valid | attestation-api and CDS | hardware evidence verification (verdict unsigned — see §6) |
 | A CSR can be signed | CDS | EAR JWT, plus `cds.measurements` when configured |
 | Image digest is allowed | nri-image-policy (host, base mode); **in-guest `policy-monitor` SIGKILL under kata** (the load-bearing enforcer on a locked confidential guest — the host-side plugin is untrusted there) | CDS-served allowlist + baked seed |
+| Application-secret release | CDS secrets broker (`/secrets/fetch`) | TEE evidence + launch-measurement pin (**fail-closed when empty**, unlike `/attest`) + claimed-set → workload-entry resolution (ambiguous ⇒ 403) + per-(digest, path) PathPolicy grants; response wrapped to the requester's evidence-bound key and signed by the mesh-CA-anchored broker identity (docs/secrets-broker.md) |
 | Mesh peer cert chains to the mesh CA | ratls-mesh | mesh CA bundle (chain only; peer measurement **not** pinned — §5) |
 | Workload is injection candidate | admission webhook | pod annotation `confidential.ai/cw` |
 | LB attestation + session key are TEE-bound | `c8s cds-attest` sidecar | SNP report `report_data = SHA-384(x25519 \|\| mlkem768 \|\| nonce)` (default PQ; does not yet bind the mesh identity, §5 Addressable) or `SHA-384(serving_leaf_spki \|\| nonce)` (`pq=false`, no PQ tunnel) |
@@ -146,6 +153,7 @@ fix) · **Accepted** (deliberate non-goal, §7).
 |---|---|---|---|
 | A control-plane **config swap-restart** on CDS is detected only by pin-holding verifiers, never prevented at boot. The operator-key list and allowlist seed are attested: CDS binds their canonical digests into its serving-cert evidence (config-claims, `docs/ratls.md`), verifiers pin them (`c8s cds verify --operator-keys/--allowlist-seed`, `ratls.VerifyPolicy`), and `/handoff` releases the mesh CA only on a byte-equal operator-key-set hash (the seed digest is not checked at handoff, so a seed-only swap is caught by pinned verifies, not by handoff). Residual: the **CDS pod arguments** stay host-supplied — dropping `--operator-keys` downgrades to the attested empty key set — and enforcers/in-cluster clients pin nothing (their config is host-supplied too), so between a swap-restart and the next pinned verify the cluster serves and enforces the attacker's allowlist. Revocation of op-keys is coarse (no CRL/OCSP). | control plane / host | Run pinned verifies continuously (CI gate on `c8s verify` exit codes), not only at bootstrap; expose public ingress only behind a passing verify. Move op-keys to a CA + short-lived operator certs (`x5c`), CA-based revocation. Detection by pinning verifiers — not boot-time prevention — is the accepted posture. | `docs/ratls.md` (Config-claims); pitfalls "Operator key-pinning"; decision 2026-07-01 |
 | The **workload-image pin** (`c8s verify --workload-image`) distinguishes honest workloads only. A CDS-issued leaf commits the pod's container-image digest (config-claims), but CDS binds the claim to nothing the pod actually runs: it checks only that the forwarded list hashes to the evidence-bound digest and that every image is allowlisted. Any admitted workload can run the attest flow itself (the attestation-api binds caller-chosen REPORTDATA) and assert **any allowlisted image set** — a victim workload's included — satisfying a pin against that victim. It can never assert a *non-allowlisted* image, and image integrity is untouched (everything running is still independently allowlisted). So the pin detects an honest workload drifting or a config swap, not a lying workload asserting another's identity. | admitted (allowlisted) workload | Per-workload measurement enforced at `/attest` (bind the claim to the pod's admitted/measured images). Interim: treat the pin as honest-workload detection, not identity. | `docs/getcert-workload-binding.md` (Corner 5/6); `docs/ratls.md` (Config-claims) |
+| **Secrets fetch forgery (same class as the row above, escalated impact).** The `/secrets/fetch` gate has the same structural gap: any admitted workload — including a floor or `argv:any` image the control plane schedules with no tenant cooperation — can claim another entry's digest set and **receive that entry's secrets** (confidentiality), and once workload writes ship, **overwrite them** (integrity). The broker hardens the channel (response wrap to the evidence-bound key, mesh-CA-anchored broker identity, fail-closed measurement pin), which closes fake/relay brokers — but the requester *is* the unwrap target, so direct claim forgery stands. Impact escalates from "satisfies a verifier pin" to "exfiltrates secret material". | admitted (allowlisted) workload / control plane | Measured-digest consumption at CDS (TDX RTMR3 event-log verification) and/or SPIFFE-style agent identity; SNP has no runtime-extend register, so the SNP close is the identity work. Interim: keep floor/permissive-argv images minimal (any is a fetch proxy), and treat the lint "grants require exact argv" warning as an error. | `docs/secrets-broker.md` §security posture; `docs/getcert-workload-binding.md` (Corner 5) |
 | Bootstrap allowlist is baked from whatever the floating `:main` tag resolved to at guest-build time; an unpinned `:main`-everywhere deploy can bake a seed that rejects the deployed CDS. | CI / whoever moves `:main` | Atomic floating-tag promotion (roll `:main`/`:latest` only after Docker **and** kata-guest-base succeed for one commit); `oras pull @digest` for `kata.guestImage`. Runtime mitigation: policy-monitor grow-only CDS refresh. | pitfalls "bootstrap allowlist … floating :main" |
 | In-guest CDS allowlist refresh is **disabled on every default kata install**: policy-monitor fail-closed refuses to run without `C8S_CDS_MEASUREMENTS`, and no shipping path can deliver the pin — baking it is self-referential (CDS runs from the same guest image the pin would be baked into, so the value would change the launch measurement it pins) and per-pod cloud-init is host-controlled (a host-chosen pin defeats the point). Guests therefore enforce the baked seed alone; operator `c8s allowlist add` reaches host-side enforcement and CDS but **not running guests**. Also: the SNP launch digest covers the VMSA set, so even a correct pin is per-VM-shape (vCPU count). Stricter than ratls-mesh (which warns and proceeds on an empty pin) by intent — for the refresh, "any attested TEE" is not enough because the host can boot its own CVM from the same guest image and pass "attested" while serving an attacker-chosen allowlist, and grow-only merging is no defence when additions are the attack. | host / operator drift | Operator-signed allowlist entries verified in-guest against a baked operator public key (candidate design). Interim: the deliberate fail-closed posture — guests enforce the measured seed and nothing else. | kata-image-policy.md; GAPS §Trust model |
 | GPU guest boots **kata's** GPU kernel with NVIDIA modules grafted from kata's rootfs — kernel/driver provenance is the kata release, not the c8s build. | supply chain | A confos GPU kernel flavor (`CONFIG_MODULES=y` + `CONFIG_MODULE_SIG_FORCE=y`, ephemeral build key) compiling/signing the NVIDIA modules. Interim: module loading locked after bring-up (`kernel.modules_disabled=1`). | pitfalls; GAPS §Confidential GPU |
@@ -254,9 +262,10 @@ If any of these is false, the corresponding guarantee does not hold.
 ### Deferred this milestone (expected to close)
 
 - Pod-spec integrity beyond image digest; per-workload peer allowlists and measurement
-  pinning in the mesh; attestation-gated application secret release (the whitepaper's
-  Secrets Manager Proxy / wrapped-vs-direct key brokering); active/active CDS HA;
-  multi-tenant isolation and federated multi-cluster control planes.
+  pinning in the mesh; attestation-gated application secret release **for workload
+  runtime writes and external-KMS backends** (read-path release shipped — see
+  `docs/secrets-broker.md`; the claim-forgery residual is §5 Addressable);
+  active/active CDS HA; multi-tenant isolation and federated multi-cluster control planes.
 
 ### Accepted / permanent non-goals (whitepaper §3.4, §9)
 
@@ -407,7 +416,8 @@ In that model:
 - planned replica adoption transfers the current allowlist version and digests
   inside the recipient-encrypted handoff payload. A write racing after the
   snapshot can still be missed by the joining singleton.
-- secret release is gated by workload attestation (designed; see GAPS §Trust model);
+- secret release is gated by workload attestation (read path shipped —
+  `docs/secrets-broker.md`; runtime writes and wrapped/external-KMS modes remain designed);
 - recovery from total CDS outage means re-bootstrap and re-issue certificates.
 
 ### CDS is a stateful singleton until handoff is enabled

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -132,8 +132,8 @@ guarantee is recovered at [cert issuance](#where-its-enforced).
 
 ## Path policy (`paths`)
 
-`paths` grants filesystem access for a coming key-management integration: a
-workload attests, and a secret broker releases material into paths the workload
+`paths` grants filesystem access for key-management integration: a workload
+attests, and the CDS secrets broker releases material into paths the workload
 is entitled to.
 
 ```json
@@ -147,13 +147,20 @@ is entitled to.
   `/**` (subtree). These rules exist so a grant cannot be widened by path
   trickery once an enforcer consumes it.
 
-**No enforcer consumes `paths` yet.** It is carried, validated, canonicalized,
-and attested (it is part of the seed digest), so the schema and the operator
-tooling are ready — but it grants nothing until the secret-release component
-exists. When that component lands, a grant's subject must be bound to the
-**attested workload digest**, never to a self-asserted image reference, or any
-allowlisted workload could claim another's grant. The field is inert-with-a-spec
-by design; it is not a live capability.
+**Consumed by the CDS secrets broker** (`docs/secrets-broker.md`) for read
+grants: `/secrets/fetch` resolves the requester's claimed container set to
+exactly one workload entry and releases only paths that entry grants to each
+claimed digest, entry-scoped (never the per-digest union). A grant binds to
+the attested workload digest, never to a self-asserted image reference. Workload
+runtime *writes* are not yet delivered (no in-pod write path ships); the grant
+model already carries them.
+
+Grant-writing rules lint enforces as warnings (treat the first two as errors):
+a paths-bearing container should pin argv `exact`+`exact` (any invocation of
+permissive bytes can read the granted secrets); grant paths should live under
+`/secrets/` (the staging root); identical-set entries carrying grants fail
+closed at the broker (ambiguous entry resolution); a same-entry duplicate that
+widens a digest's paths to `any` silently grants every requested path.
 
 ## Where it's enforced
 
@@ -317,5 +324,7 @@ document carries. `--online` cross-checks digests against the registry with
 Generating an operator key and pinning its public half is unchanged; see the
 README and [`operator.md`](operator.md). Rotating the pinned set rolls CDS, and
 the pinned set's digest is attested, so a verifier detects a changed write policy.
-The path grants (`paths`) will, when their enforcer lands, be managed with the
-same `workload edit`/`apply` flow and bound to the attested workload digest.
+Path grants (`paths`) are managed with the same `workload edit`/`apply` flow and
+are released to attested workload digests by the secrets broker
+([`secrets-broker.md`](secrets-broker.md)); deposits use the same operator
+credential via `c8s secrets`.

--- a/docs/secrets-broker.md
+++ b/docs/secrets-broker.md
@@ -1,0 +1,213 @@
+# Secrets broker
+
+How c8s releases application secrets to attested workloads: the CDS brokers
+secrets from an internal store to pods whose **attested container-digest set**
+is granted them by the allowlist's path policy (`paths`, see
+[`allowlist-and-capabilities.md`](allowlist-and-capabilities.md)). This is the
+consumer of the `PathPolicy` field the allowlist has carried since
+`eb8e4b3`.
+
+> **Trust model.** Unchanged: the host, hypervisor, and Kubernetes control
+> plane are untrusted; the trust boundary is the TEE. Two consequences drive
+> every choice below. Control-plane data (annotations, pod specs, sidecar
+> args) is a *request*, never a grant — grants come only from the attested
+> allowlist. And ordinary Kubernetes Secrets/ConfigMaps/PVs are plaintext to
+> the control plane, so secrets never touch them: not in etcd, not in env,
+> not on a host-readable disk.
+
+## What ships in this PR (and what does not)
+
+Ships: the store interface and an in-memory store, the CDS broker endpoints,
+the broker identity, and the `c8s secrets` operator CLI (deposit / read-back /
+delete). Adapters to external key managers (openbao, vault, AWS KMS)
+implement `secretstore.Store` in their own PRs. Workload-side delivery (the
+injected `c8s-secrets` init container and webhook machinery) is the next PR;
+the fetch endpoint is exercised by the CLI and tests until then. Workload
+runtime **writes** are deferred with their first consumer — the write grants
+in policy already have meaning, but no in-pod write path ships yet.
+
+This supersedes the unmerged `split/secret-broker` standalone-broker branch
+family (`c8s-secret-broker` Service, `internal/cmds/secretbroker`,
+`confidential.ai/secrets-inject`): the broker logic lives **in the CDS**, so
+the platform's existing root of trust stays the only root of trust.
+
+## The model
+
+Secrets are scoped by **(workload entry, path)**. A workload entry is the
+allowlist's named init/main container set with per-container policy; the
+path is a filesystem path the entry grants to a given container digest.
+
+- **Deposit** is operator-only: `c8s secrets put <entry> <path> <value>`,
+  authorized by the pinned operator key (the same credential as allowlist
+  writes) and wrapped to the broker encryption key in transit.
+- **Release** is attestation-gated: a pod proves its TEE, claims its
+  init/main container digest set, and receives exactly the paths the
+  resolved entry grants to each claimed digest.
+- **Grant precision is entry-scoped**, never the per-digest union: the fetch
+  gate resolves the claimed set to exactly one entry, mirroring the
+  combination gate at cert issuance.
+
+**Tenant rule.** Two entries with identical container sets are one security
+domain — anything running that set may claim either entry's secrets.
+Per-tenant secrets therefore require a per-tenant digest in the workload set
+(e.g. a per-tenant loader image). Identical-set entries with grants are a
+configuration error: the broker fails closed (403 `entry_ambiguous`), and
+`c8s allowlist lint` flags them at write time.
+
+## The fetch flow
+
+```
+pod (c8s-secrets init)                 CDS
+─────────────────────                  ───
+GET /secrets/broker-identity  ──────►  signing leaf (mesh-CA-issued)
+                                       + encryption pubkey (bound by signature)
+verify chain against mesh CA
+(from get-cert's CA bundle)
+
+POST /authenticate            ──────►  challenge (single-use, 60 s TTL)
+ephemeral X25519 keypair
+evidence := TEE(REPORTDATA =
+  transcript(challenge, request))
+POST /secrets/fetch           ──────►  consume challenge
+  {challenge, evidence,                VerifyEnforced(evidence, transcript)
+   init/main digests,                  measurement pin — FAIL CLOSED when empty
+   response_pubkey, requests}          resolve set → exactly one entry
+                                       per request: digest ∈ entry,
+                                         path ∈ entry's read grants
+                                       store.Get(entry, path)
+                            ◄──────    wrap to response_pubkey
+                                       + sign with broker signing leaf
+verify signature; unwrap; stage
+```
+
+The transcript mirrors `/attest` (`ratls.ReportDataForKeyAndClaims`): a
+domain-separated, length-framed SHA-384
+`SHA-384("c8s/secrets-fetch/v1\0" ‖ framed(challenge) ‖ framed(canonical(request)))`,
+so the evidence binds the whole release decision — claimed set, response
+key, and requested paths.
+
+Grant resolution per `(entry, digest, path)` is the union across the
+entry's containers with that digest (the `AdmitsContainer` semantic):
+`deny` (default) grants nothing, `any` grants any requested path, `allow`
+glob-matches (`/**` is a subtree). Empty `paths: []` yields an empty result.
+
+## Why the broker identity and the wrap exist
+
+`/attest` binds the response to the requester's key: a relayed certificate
+is useless to anyone but the keyholder, and a fake CDS's certificates fail
+loudly at first mesh use. A secrets fetch has no equivalent by default —
+and the default client posture today is TOFU (`--cds-measurements` unset
+accepts any attested endpoint), where a fake or relaying CDS would read
+every secret and could fabricate responses silently. So:
+
+1. **Response wrap.** The fetch request carries an ephemeral X25519 public
+   key bound into the evidence transcript; the response is sealed to it
+   (X25519 → HKDF-SHA256 → AES-256-GCM, `pkg/secrets`). A relay learns
+   nothing — only the pod holding the ephemeral private key unwraps.
+2. **Broker identity.** At startup CDS issues itself a signing leaf from
+   the mesh CA (in-process) plus an X25519 encryption key bound to that
+   leaf, served at `GET /secrets/broker-identity`. Clients verify the chain
+   to the mesh CA (the pod's get-cert bundle; the CLI's `/ca` read) before
+   trusting responses or depositing values. A same-measurement fake CDS can
+   copy config, but it cannot hold the mesh CA key, so it cannot mint this
+   identity.
+3. **Hard measurement pin.** `/secrets/fetch` fails closed when
+   `cds.measurements` is empty — unlike `/attest`, where the documented
+   "pin nothing yet" posture degrades to loud failures, secrets degrade
+   silently.
+
+Deposits are likewise wrapped to the broker encryption key, so a fake
+broker never sees operator plaintext either.
+
+## The store
+
+`internal/secretstore.Store`:
+
+```go
+type Ref struct{ Entry, Path string }
+type Store interface {
+    Get(ctx context.Context, ref Ref, requester types.Digest) ([]byte, error)
+    Set(ctx context.Context, ref Ref, value []byte) error
+    Delete(ctx context.Context, ref Ref) error
+}
+```
+
+`Get` receives the requesting container digest so per-caller backends
+(leased credentials) are expressible; single-value stores ignore it. The
+shipped implementation is in-memory, last-write-wins.
+
+**Durability posture.** The store is deliberately not persisted: a PV of
+plaintext is host-readable, and etcd is plaintext to the control plane.
+Consequences, by design: a CDS restart loses deposited secrets (re-deposit
+with the CLI); secrets do not ride `/handoff`; staged pods keep what they
+staged. A durable, attested-backend store is an adapter-PR concern.
+
+## Endpoints
+
+| Route | Caller | Gate |
+|---|---|---|
+| `POST /secrets/fetch` | workload init container | challenge + evidence + measurement pin (fail-closed empty) + entry resolution + per-(digest, path) grant |
+| `GET /secrets/broker-identity` | any client | none — integrity from the chain to the mesh CA |
+| `PUT /secrets/entries/{entry}/paths/{path}` | operator CLI | operator JWT (body-bound), value wrapped to broker encryption key |
+| `GET /secrets/entries/{entry}/paths/{path}?pubkey=` | operator CLI | operator JWT; response wrapped to the query's ephemeral key |
+| `DELETE /secrets/entries/{entry}/paths/{path}` | operator CLI | operator JWT |
+
+Errors use the standard envelope with these codes: `invalid_challenge`,
+`verification_failed`, `measurement_denied`, `measurement_not_configured`,
+`grant_denied`, `entry_ambiguous`, `secret_not_found`. Metrics:
+`c8s_cds_secrets_fetch_total{result}`, `c8s_cds_secrets_operator_total{op,result}`.
+Audit logs record entry, path, caller digest, launch digest, decision, and
+value *size* — never values.
+
+## Security posture
+
+**Strong.** Fake/relay brokers read nothing and fabricate nothing (wrap +
+mesh-CA-anchored identity + hard pin). The control plane cannot fetch with
+its own identity — it has no TEE evidence. Non-allowlisted code can never
+run and therefore never fetch. Grants are entry-scoped per (digest, path);
+annotations and specs are requests only. Plaintext exists only in CDS
+process memory (the release hop), pod tmpfs (in-TEE RAM), and the
+requester's view — never etcd, env, or PV.
+
+**Residual — claim forgery (Corner-5 class).** Any admitted workload can
+run the fetch flow itself and claim *any allowlisted digest set*: CDS
+verifies the evidence and the allowlist membership of the claim, not that
+the claim reflects what the pod runs (the same gap as
+[`getcert-workload-binding.md`](getcert-workload-binding.md) Corner 5, and
+the allowlisted-image fetch-proxy vector is exercisable by the control
+plane with no workload cooperation). The impact escalates from "satisfies a
+verifier pin" to "exfiltrates secret material" — and write-poisoning joins
+it when workload writes ship. The closes are measured-digest consumption
+(TDX RTMR3 event-log verification at CDS) and/or SPIFFE-style agent
+identity, both tracked follow-ons; SNP has no runtime-extend register, so
+the SNP close is the identity work. This residual is catalogued in
+[`THREAT_MODEL.md`](THREAT_MODEL.md) §5 (Addressable).
+
+**Operator mitigations today.** Keep the allowlist tight: floor images
+admit argv-blind, and any permissive-argv image is a potential fetch
+proxy. Secrets-bearing containers should pin argv exactly (lint enforces a
+warning; treat it as an error). Pin `cds.measurements` — the broker
+refuses to serve without it.
+
+## CLI
+
+```
+c8s secrets put <entry> <path> <value|@file|->   # deposit (wrapped, operator-signed)
+c8s secrets get <entry> <path>                   # read-back (stdout raw; -o json for base64)
+c8s secrets delete <entry> <path>                # remove
+```
+
+Persistent flags mirror `c8s allowlist`: `--url`, `--measurements` /
+`--measurements-file`, `--timeout`, `--operator-key` (or
+`C8S_OPERATOR_KEY`), `-o text|json`, `--insecure`. The CLI verifies the
+broker identity against the `/ca` bundle before any value crosses the
+wire.
+
+## Operator checklist
+
+1. Add path grants to the workload entry (`c8s allowlist workload edit`):
+   `paths: {policy: allow, read: ["/secrets/model/**"]}`. Keep argv exact;
+   lint warns otherwise.
+2. Deposit: `c8s secrets put vllm-llama /secrets/model/dek @dek.bin`.
+3. (Next PR) annotate pods: `confidential.ai/c8s-secrets-read-vllm:
+   /secrets/model/dek`, all images digest-pinned.

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -162,10 +162,88 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 		}
 	}
 
+	warnings = append(warnings, lintSecretsGrants(al)...)
+
 	if anyCount > 0 {
 		warnings = append(warnings, fmt.Sprintf("%d 'any' (unconstrained) policy value(s) across all entries", anyCount))
 	}
 	return warnings
+}
+
+// lintSecretsGrants reports secrets-broker grant traps (docs/secrets-broker.md):
+// grants behind permissive argv, grants outside the /secrets/ staging root,
+// identical-set entries the broker must fail closed on, and within-entry
+// duplicates that widen a digest's paths to 'any'.
+func lintSecretsGrants(al *pkgallowlist.Allowlist) []string {
+	var warnings []string
+
+	setKeys := map[string][]string{} // canonical container-set key -> entry names
+	grantsByEntry := map[string]bool{}
+	for _, name := range sortedWorkloadNames(al.Workloads) {
+		w := al.Workloads[name]
+		entryHasGrants := false
+		seenPerDigest := map[string][]pkgallowlist.Container{}
+		for _, c := range allContainers(w) {
+			d := c.Digest.String()
+			seenPerDigest[d] = append(seenPerDigest[d], c)
+			if c.Paths.Policy == pkgallowlist.PolicyDeny {
+				continue
+			}
+			entryHasGrants = true
+			if c.Command.Policy != pkgallowlist.PolicyExact || c.Args.Policy != pkgallowlist.PolicyExact {
+				warnings = append(warnings, fmt.Sprintf("workload %q container %s carries path grants but its argv policy is not exact+exact — any invocation of these bytes can read the granted secrets", name, d))
+			}
+			for _, g := range append(append([]string{}, c.Paths.Read...), c.Paths.Write...) {
+				if g != "/secrets/**" && !strings.HasPrefix(g, "/secrets/") {
+					warnings = append(warnings, fmt.Sprintf("workload %q container %s grants path %q outside /secrets/ — the broker stages secrets only under /secrets/", name, d, g))
+				}
+			}
+		}
+		for d, cs := range seenPerDigest {
+			if len(cs) > 1 {
+				for _, c := range cs {
+					if c.Paths.Policy == pkgallowlist.PolicyAny {
+						warnings = append(warnings, fmt.Sprintf("workload %q duplicates digest %s and one occurrence widens paths to 'any'; the effective grant for that digest is any requested path (union within the entry)", name, d))
+						break
+					}
+				}
+			}
+		}
+		grantsByEntry[name] = entryHasGrants
+		setKeys[containerSetKey(al, w)] = append(setKeys[containerSetKey(al, w)], name)
+	}
+
+	for _, names := range setKeys {
+		if len(names) < 2 {
+			continue
+		}
+		anyGrants := false
+		for _, n := range names {
+			anyGrants = anyGrants || grantsByEntry[n]
+		}
+		if anyGrants {
+			warnings = append(warnings, fmt.Sprintf("entries [%s] share an identical container set while at least one carries path grants; the secrets broker fails closed on ambiguous entry resolution (403) for every pod of that set — differentiate the sets", strings.Join(names, ", ")))
+		}
+	}
+	return warnings
+}
+
+// containerSetKey renders an entry's non-floor init/main digest sets as one
+// comparable string. Entries with equal keys have identical claimed sets.
+func containerSetKey(al *pkgallowlist.Allowlist, w pkgallowlist.Workload) string {
+	set := func(cs []pkgallowlist.Container) []string {
+		var out []string
+		for _, c := range cs {
+			d := c.Digest.String()
+			if _, isFloor := al.Digests[d]; isFloor {
+				continue
+			}
+			out = append(out, d)
+		}
+		sort.Strings(out)
+		return out
+	}
+	return strings.Join(set(w.InitContainers), ",") + "|" + strings.Join(set(w.Containers), ",")
 }
 
 // lintOnline checks each workload container digest is resolvable in its

--- a/internal/cmds/allowlist/lint_secrets_test.go
+++ b/internal/cmds/allowlist/lint_secrets_test.go
@@ -1,0 +1,83 @@
+package allowlist
+
+import (
+	"strings"
+	"testing"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+func secretsLintWarnings(t *testing.T, doc string) []string {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return lintSecretsGrants(al)
+}
+
+func TestLintGrantsRequireExactArgv(t *testing.T) {
+	warnings := secretsLintWarnings(t, `{"schema":"c8s.allowlist/v1",
+		"workloads":{"w":{"containers":[
+			{"digest":"`+digA+`","command":{"policy":"any"},"args":{"policy":"exact","argv":["run"]},
+			 "paths":{"policy":"allow","read":["/secrets/model/**"]}}]}}}`)
+	if !anyContains(warnings, "not exact+exact") {
+		t.Fatalf("expected an argv warning, got: %v", warnings)
+	}
+}
+
+func TestLintGrantsOutsideSecretsRoot(t *testing.T) {
+	warnings := secretsLintWarnings(t, `{"schema":"c8s.allowlist/v1",
+		"workloads":{"w":{"containers":[
+			{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+			 "paths":{"policy":"allow","read":["/etc/ssl/key"]}}]}}}`)
+	if !anyContains(warnings, "outside /secrets/") {
+		t.Fatalf("expected a root warning, got: %v", warnings)
+	}
+}
+
+func TestLintIdenticalSetEntriesWithGrants(t *testing.T) {
+	entry := func(read string) string {
+		return `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+			"paths":{"policy":"allow","read":["` + read + `"]}}`
+	}
+	warnings := secretsLintWarnings(t, `{"schema":"c8s.allowlist/v1",
+		"workloads":{
+			"a":{"containers":[`+entry("/secrets/a")+`]},
+			"b":{"containers":[`+entry("/secrets/b")+`]}}}`)
+	if !anyContains(warnings, "identical container set") {
+		t.Fatalf("expected an ambiguity warning, got: %v", warnings)
+	}
+}
+
+func TestLintIdenticalSetWithoutGrantsIsQuiet(t *testing.T) {
+	entry := `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}`
+	warnings := secretsLintWarnings(t, `{"schema":"c8s.allowlist/v1",
+		"workloads":{
+			"a":{"containers":[`+entry+`]},
+			"b":{"containers":[`+entry+`]}}}`)
+	if anyContains(warnings, "identical container set") {
+		t.Fatalf("grant-free identical sets must not warn, got: %v", warnings)
+	}
+}
+
+func TestLintSameEntryDuplicateWidenedToAny(t *testing.T) {
+	warnings := secretsLintWarnings(t, `{"schema":"c8s.allowlist/v1",
+		"workloads":{"w":{"containers":[
+			{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+			 "paths":{"policy":"allow","read":["/secrets/a"]}},
+			{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app","--debug"]},"args":{"policy":"deny"},
+			 "paths":{"policy":"any"}}]}}}`)
+	if !anyContains(warnings, "widens paths to 'any'") {
+		t.Fatalf("expected a widening warning, got: %v", warnings)
+	}
+}
+
+func anyContains(ss []string, sub string) bool {
+	for _, s := range ss {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmds/cds/brokeridentity.go
+++ b/internal/cmds/cds/brokeridentity.go
@@ -1,0 +1,74 @@
+package cds
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/pkg/secrets"
+)
+
+// brokerIdentity holds the CDS's secrets-broker identity: an ECDSA signing
+// leaf issued by the mesh CA and an X25519 encryption key bound to that leaf.
+// A same-measurement fake CDS can copy config, but it cannot hold the mesh CA
+// key, so it cannot mint this identity — clients that verify it defuse fake
+// and relay CDSes (docs/secrets-broker.md).
+type brokerIdentity struct {
+	doc        secrets.BrokerIdentity
+	signingKey *ecdsa.PrivateKey
+	encPriv    []byte
+}
+
+// newBrokerIdentity issues the broker identity from the mesh CA. The leaf
+// lives only in process memory and dies with the CA on restart, so its TTL is
+// capped by the CA's own lifetime.
+func newBrokerIdentity(ca *issuer.CA, caChainPEM []byte) (*brokerIdentity, error) {
+	signingKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("broker identity: generate signing key: %w", err)
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "c8s-secrets-broker"},
+	}, signingKey)
+	if err != nil {
+		return nil, fmt.Errorf("broker identity: create CSR: %w", err)
+	}
+	csr, err := x509.ParseCertificateRequest(csrDER)
+	if err != nil {
+		return nil, fmt.Errorf("broker identity: parse CSR: %w", err)
+	}
+	ttl := time.Until(ca.Cert.NotAfter)
+	if ttl <= 0 {
+		return nil, fmt.Errorf("broker identity: mesh CA already expired")
+	}
+	leafPEM, _, err := ca.SignCSR(issuer.SignCSRParams{CSR: csr, TTL: ttl})
+	if err != nil {
+		return nil, fmt.Errorf("broker identity: sign leaf: %w", err)
+	}
+
+	encPriv, encPub, err := secrets.GenerateX25519()
+	if err != nil {
+		return nil, err
+	}
+	encSig, err := secrets.SignEncryptionPubkey(signingKey, encPub)
+	if err != nil {
+		return nil, err
+	}
+
+	return &brokerIdentity{
+		doc: secrets.BrokerIdentity{
+			SigningLeafPEM:      leafPEM,
+			CAChainPEM:          caChainPEM,
+			EncryptionPubkey:    base64.StdEncoding.EncodeToString(encPub),
+			EncryptionPubkeySig: encSig,
+		},
+		signingKey: signingKey,
+		encPriv:    encPriv,
+	}, nil
+}

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -19,6 +19,7 @@ type dependencies struct {
 	AttestKeyHandler attestation.Handler
 	SignCSRHandler   SignCSRHandler
 	AllowlistHandler allowlist.Handler
+	SecretsHandler   SecretsHandler
 	HandoffHandler   *issuer.HandoffHandler // nil disables /handoff (no --handoff-measurements)
 	ReadyFn          attestation.ReadinessFunc
 	EarIssuer        ear.Issuer
@@ -66,6 +67,16 @@ func newRouter(deps dependencies) http.Handler {
 	r.Method(http.MethodDelete, "/allowlist/digests", deps.allowlistWrite(http.HandlerFunc(deps.AllowlistHandler.HandleDeleteDigests)))
 	r.Method(http.MethodPut, "/allowlist/workloads/{name}", deps.allowlistWrite(http.HandlerFunc(deps.AllowlistHandler.HandlePutWorkload)))
 	r.Method(http.MethodDelete, "/allowlist/workloads/{name}", deps.allowlistWrite(http.HandlerFunc(deps.AllowlistHandler.HandleDeleteWorkload)))
+
+	// The secrets broker. /secrets/fetch is attestation-gated like /attest;
+	// the operator deposit routes take the allowlist write middleware;
+	// /secrets/broker-identity is an unauthenticated read like /ca — integrity
+	// comes from the chain to the mesh CA.
+	r.Method(http.MethodPost, "/secrets/fetch", deps.protected(http.HandlerFunc(deps.SecretsHandler.HandleFetch)))
+	r.Get("/secrets/broker-identity", deps.SecretsHandler.HandleBrokerIdentity)
+	r.Method(http.MethodPut, "/secrets/entries/{entry}/paths/*", deps.allowlistWrite(http.HandlerFunc(deps.SecretsHandler.HandleOperatorPut)))
+	r.Method(http.MethodGet, "/secrets/entries/{entry}/paths/*", deps.allowlistWrite(http.HandlerFunc(deps.SecretsHandler.HandleOperatorGet)))
+	r.Method(http.MethodDelete, "/secrets/entries/{entry}/paths/*", deps.allowlistWrite(http.HandlerFunc(deps.SecretsHandler.HandleOperatorDelete)))
 
 	r.Get("/ca", handleCA(deps.CACertPEM))
 	r.Get("/operator-keys", handleOperatorKeys(deps.OperatorKeysPEM))

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/ear"
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
 	"github.com/confidential-dot-ai/c8s/internal/readiness"
+	"github.com/confidential-dot-ai/c8s/internal/secretstore"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
@@ -123,6 +124,15 @@ func run(cfg config) error {
 		"not_after", mesh.Cert.NotAfter.Format(time.RFC3339),
 	)
 	caChainPEM := certutil.EncodeCertPEM(mesh.Cert.Raw)
+
+	// The secrets broker identity rides the mesh CA: it is the one key a
+	// same-measurement fake CDS cannot hold, so clients that verify it defuse
+	// fake and relay brokers (docs/secrets-broker.md).
+	brokerId, err := newBrokerIdentity(mesh, caChainPEM)
+	if err != nil {
+		return fmt.Errorf("issue secrets broker identity: %w", err)
+	}
+	secretStore := secretstore.NewMemStore()
 
 	measurements := parseMeasurementAllowlist(cfg.measurements)
 	if len(measurements) == 0 {
@@ -251,6 +261,16 @@ func run(cfg config) error {
 			Store:             &allowlistStore,
 			WriteAuthorizer:   writeAuthorizer,
 			MaxWriteBodyBytes: allowlistWriteBodyCap,
+		},
+		SecretsHandler: SecretsHandler{
+			Challenges:        &challengeStore,
+			AttestationClient: asClient,
+			RequestTimeout:    cfg.requestTimeout,
+			Measurements:      measurements,
+			AllowlistStore:    &allowlistStore,
+			Store:             secretStore,
+			Identity:          brokerId,
+			WriteAuthorizer:   writeAuthorizer,
 		},
 		AttestKeyHandler: attestKeyHandler,
 		HandoffHandler:   handoffHandler,

--- a/internal/cmds/cds/secretgrants.go
+++ b/internal/cmds/cds/secretgrants.go
@@ -1,0 +1,98 @@
+package cds
+
+import (
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// resolveEntries returns the names of workload entries whose non-floor
+// init/main digest sets exactly equal the claimed sets, sorted for
+// determinism. It mirrors enforceWorkloadCombination (attest.go) but returns
+// the matches: the fetch gate needs the granting entry, and more than one
+// match is an ambiguity the caller must fail closed on (docs/secrets-broker.md).
+func resolveEntries(doc *pkgallowlist.Allowlist, initDigests, mainDigests []string) []string {
+	floor := doc.Digests
+	claimInit := nonFloorSet(initDigests, floor)
+	claimMain := nonFloorSet(mainDigests, floor)
+	if len(claimInit) == 0 && len(claimMain) == 0 {
+		return nil
+	}
+	var matches []string
+	for name, w := range doc.Workloads {
+		if setsEqual(claimInit, nonFloorSet(digestStrings(w.InitContainers), floor)) &&
+			setsEqual(claimMain, nonFloorSet(digestStrings(w.Containers), floor)) {
+			matches = append(matches, name)
+		}
+	}
+	slices.Sort(matches)
+	return matches
+}
+
+// grantFor reports whether the entry grants op access to path for digest.
+// Grants are the union across the entry's containers with that digest (the
+// per-container semantic of AdmitsContainer). deny grants nothing; any grants
+// any requested path; allow glob-matches (trailing /** is a subtree).
+func grantFor(entry *pkgallowlist.Workload, digest types.Digest, p string, write bool) bool {
+	for _, c := range slices.Concat(entry.InitContainers, entry.Containers) {
+		if c.Digest != digest {
+			continue
+		}
+		switch c.Paths.Policy {
+		case pkgallowlist.PolicyAny:
+			return true
+		case pkgallowlist.PolicyAllow:
+			globs := c.Paths.Read
+			if write {
+				globs = c.Paths.Write
+			}
+			for _, g := range globs {
+				if pathMatches(g, p) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// entryHasDigest reports whether the digest appears anywhere in the entry.
+func entryHasDigest(entry *pkgallowlist.Workload, digest types.Digest) bool {
+	for _, c := range slices.Concat(entry.InitContainers, entry.Containers) {
+		if c.Digest == digest {
+			return true
+		}
+	}
+	return false
+}
+
+// validRequestPath enforces the request-side path form: absolute and clean,
+// no wildcards (grants carry the globs, requests name concrete files).
+func validRequestPath(p string) error {
+	if !strings.HasPrefix(p, "/") {
+		return fmt.Errorf("path %q must be absolute", p)
+	}
+	if strings.Contains(p, "*") {
+		return fmt.Errorf("path %q: wildcards belong in policy, not requests", p)
+	}
+	if path.Clean(p) != p {
+		return fmt.Errorf("path %q is not clean (no . or ..)", p)
+	}
+	return nil
+}
+
+// pathMatches matches a policy glob against a request path: a trailing "/**"
+// is a subtree match, anything else is exact.
+func pathMatches(glob, p string) bool {
+	if base, ok := strings.CutSuffix(glob, "/**"); ok {
+		if base == "" {
+			return strings.HasPrefix(p, "/")
+		}
+		return p == base || strings.HasPrefix(p, base+"/")
+	}
+	return glob == p
+}

--- a/internal/cmds/cds/secrets.go
+++ b/internal/cmds/cds/secrets.go
@@ -1,0 +1,376 @@
+package cds
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/confidential-dot-ai/c8s/internal/attestation"
+	"github.com/confidential-dot-ai/c8s/internal/httputil"
+	"github.com/confidential-dot-ai/c8s/internal/secretstore"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// SecretsHandler serves the secrets broker: POST /secrets/fetch for attested
+// workloads, GET /secrets/broker-identity for clients anchoring the broker,
+// and the operator deposit routes. The release gate mirrors /attest
+// (docs/secrets-broker.md).
+type SecretsHandler struct {
+	Challenges        *attestation.ChallengeStore
+	AttestationClient attestationclient.Client
+	// RequestTimeout caps one fetch's attestation round-trip. Zero = none.
+	RequestTimeout time.Duration
+	// Measurements pins which launch digests may fetch. Unlike /attest, an
+	// empty map FAILS CLOSED: secrets degrade silently where a fake-issued
+	// cert fails loudly at first mesh use.
+	Measurements   map[string]bool
+	AllowlistStore allowlistGate
+	Store          secretstore.Store
+	Identity       *brokerIdentity
+	// WriteAuthorizer authorizes operator deposits (operatorauth), nil = off.
+	WriteAuthorizer func(r *http.Request, body []byte) error
+}
+
+// operatorWriteBodyCap bounds a deposit body — the same 1 MiB as allowlist writes.
+const operatorWriteBodyCap int64 = 1 << 20
+
+var secretsFetchTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "c8s_cds_secrets_fetch_total",
+	Help: "Secrets broker fetch decisions by result.",
+}, []string{"result"})
+
+var secretsOperatorTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: "c8s_cds_secrets_operator_total",
+	Help: "Secrets broker operator deposit decisions by operation and result.",
+}, []string{"op", "result"})
+
+// HandleBrokerIdentity serves GET /secrets/broker-identity. Unauthenticated
+// like /ca: integrity comes from the chain to the mesh CA, which the client
+// anchors out of band (the pod's get-cert bundle).
+func (h SecretsHandler) HandleBrokerIdentity(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(h.Identity.doc)
+}
+
+// HandleFetch serves POST /secrets/fetch: the attestation-gated release of the
+// calling pod's entitled secrets, wrapped to its evidence-bound response key
+// and signed by the broker identity.
+func (h SecretsHandler) HandleFetch(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	if h.RequestTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, h.RequestTimeout)
+		defer cancel()
+	}
+
+	var req secrets.FetchRequest
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		secretsFetchTotal.WithLabelValues("invalid_request").Inc()
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+		return
+	}
+
+	challengeBytes, err := base64.StdEncoding.DecodeString(req.Challenge)
+	if err != nil || !h.Challenges.Consume(challengeBytes) {
+		secretsFetchTotal.WithLabelValues("invalid_challenge").Inc()
+		attestation.WriteError(w, http.StatusBadRequest, types.ErrorCodeInvalidChallenge, "invalid or expired challenge")
+		return
+	}
+
+	responsePub, err := base64.StdEncoding.DecodeString(req.ResponsePubkey)
+	if err != nil || len(responsePub) != 32 {
+		secretsFetchTotal.WithLabelValues("invalid_request").Inc()
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest,
+			"response_pubkey must be a base64 raw X25519 public key")
+		return
+	}
+
+	expectedReportData, err := secrets.ReportDataForFetch(challengeBytes, req)
+	if err != nil {
+		secretsFetchTotal.WithLabelValues("invalid_request").Inc()
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+		return
+	}
+	verifyResp, err := h.AttestationClient.VerifyEnforced(ctx, secrets.VerifyReportData(req.Evidence, expectedReportData))
+	if err != nil {
+		status, code, msg := classifyVerifyError(err)
+		slog.Warn("secrets fetch: attestation verification failed", "status", status, "error", err)
+		secretsFetchTotal.WithLabelValues("verification_failed").Inc()
+		attestation.WriteError(w, status, code, msg)
+		return
+	}
+
+	if len(h.Measurements) == 0 {
+		slog.Error("secrets fetch rejected: no measurements pinned", "remote", r.RemoteAddr)
+		secretsFetchTotal.WithLabelValues("measurement_not_configured").Inc()
+		attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementNotConfigured,
+			"secrets fetch requires cds.measurements to pin at least one launch digest")
+		return
+	}
+	launchDigest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest)
+	if !h.Measurements[launchDigest] {
+		slog.Warn("secrets fetch: measurement not in allowlist", "launch_digest", launchDigest)
+		secretsFetchTotal.WithLabelValues("measurement_denied").Inc()
+		attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
+		return
+	}
+
+	doc, _, err := h.AllowlistStore.LoadAll()
+	if err != nil {
+		slog.Error("secrets fetch: load allowlist", "error", err)
+		secretsFetchTotal.WithLabelValues("internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "allowlist unavailable")
+		return
+	}
+	matches := resolveEntries(doc, req.InitContainerDigests, req.ContainerDigests)
+	if len(matches) == 0 {
+		slog.Warn("secrets fetch: claimed container set matches no workload entry",
+			"init", req.InitContainerDigests, "main", req.ContainerDigests)
+		secretsFetchTotal.WithLabelValues("grant_denied").Inc()
+		attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeGrantDenied,
+			"claimed container set matches no workload entry")
+		return
+	}
+	if len(matches) > 1 {
+		// Identical-set entries are one security domain, but the store scopes
+		// values by entry name — answering would pick one silently. Fail loud.
+		slog.Warn("secrets fetch: ambiguous workload entry", "matches", matches)
+		secretsFetchTotal.WithLabelValues("entry_ambiguous").Inc()
+		attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeEntryAmbiguous,
+			fmt.Sprintf("claimed container set matches multiple workload entries: %s", strings.Join(matches, ", ")))
+		return
+	}
+	entryName := matches[0]
+	entry := doc.Workloads[entryName]
+
+	values := map[string]string{}
+	for _, sr := range req.Requests {
+		digest, err := types.ParseDigest(sr.Digest)
+		if err != nil {
+			secretsFetchTotal.WithLabelValues("invalid_request").Inc()
+			attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+			return
+		}
+		if !entryHasDigest(&entry, digest) {
+			slog.Warn("secrets fetch: digest not in resolved entry", "entry", entryName, "digest", digest)
+			secretsFetchTotal.WithLabelValues("grant_denied").Inc()
+			attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeGrantDenied,
+				fmt.Sprintf("digest %s is not in workload entry %q", digest, entryName))
+			return
+		}
+		for _, p := range sr.Paths {
+			if err := validRequestPath(p); err != nil {
+				secretsFetchTotal.WithLabelValues("invalid_request").Inc()
+				attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+				return
+			}
+			if !grantFor(&entry, digest, p, false) {
+				slog.Warn("secrets fetch: path not granted", "entry", entryName, "digest", digest, "path", p)
+				secretsFetchTotal.WithLabelValues("grant_denied").Inc()
+				attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeGrantDenied,
+					fmt.Sprintf("path %q is not granted to %s in workload entry %q", p, digest, entryName))
+				return
+			}
+			value, err := h.Store.Get(ctx, secretstore.Ref{Entry: entryName, Path: p}, digest)
+			if errors.Is(err, secretstore.ErrNotFound) {
+				secretsFetchTotal.WithLabelValues("not_found").Inc()
+				attestation.WriteError(w, http.StatusNotFound, types.ErrorCodeSecretNotFound,
+					fmt.Sprintf("no secret at %q in workload entry %q", p, entryName))
+				return
+			}
+			if err != nil {
+				slog.Error("secrets fetch: store get", "entry", entryName, "path", p, "error", err)
+				secretsFetchTotal.WithLabelValues("internal").Inc()
+				attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "store error")
+				return
+			}
+			values[p] = base64.StdEncoding.EncodeToString(value)
+		}
+	}
+
+	payloadJSON, err := json.Marshal(values)
+	if err != nil {
+		secretsFetchTotal.WithLabelValues("internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "marshal response")
+		return
+	}
+	payload, err := secrets.Wrap(responsePub, payloadJSON, []byte(secrets.FetchAAD))
+	if err != nil {
+		slog.Error("secrets fetch: wrap response", "error", err)
+		secretsFetchTotal.WithLabelValues("internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "wrap response")
+		return
+	}
+	signature, err := secrets.SignResponse(h.Identity.signingKey, payload)
+	if err != nil {
+		secretsFetchTotal.WithLabelValues("internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "sign response")
+		return
+	}
+
+	var totalBytes int
+	for _, v := range values {
+		totalBytes += len(v)
+	}
+	slog.Info("secrets released",
+		"entry", entryName,
+		"launch_digest", launchDigest,
+		"paths", len(values),
+		"value_bytes", totalBytes,
+		"remote", r.RemoteAddr,
+	)
+	secretsFetchTotal.WithLabelValues("released").Inc()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(secrets.FetchResponse{Payload: payload, Signature: signature})
+}
+
+// HandleOperatorPut serves PUT /secrets/entries/{entry}/paths/* : deposit a
+// secret, wrapped to the broker encryption key. Operator-JWT authorized.
+func (h SecretsHandler) HandleOperatorPut(w http.ResponseWriter, r *http.Request) {
+	entry, p := chi.URLParam(r, "entry"), "/"+chi.URLParam(r, "*")
+	body, ok := h.authorizeOperator(w, r)
+	if !ok {
+		return
+	}
+	var req secrets.Wrapped
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		secretsOperatorTotal.WithLabelValues("put", "invalid_request").Inc()
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+		return
+	}
+	if err := h.checkEntry(entry, p); err != nil {
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
+		return
+	}
+	value, err := secrets.Unwrap(h.Identity.encPriv, secrets.DepositAAD(entry, p), req)
+	if err != nil {
+		slog.Warn("secrets deposit: unwrap failed", "entry", entry, "path", p, "remote", r.RemoteAddr)
+		secretsOperatorTotal.WithLabelValues("put", "unwrap_failed").Inc()
+		attestation.WriteError(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "value does not unwrap for this broker")
+		return
+	}
+	if err := h.Store.Set(r.Context(), secretstore.Ref{Entry: entry, Path: p}, value); err != nil {
+		slog.Error("secrets deposit: store set", "entry", entry, "path", p, "error", err)
+		secretsOperatorTotal.WithLabelValues("put", "internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "store error")
+		return
+	}
+	slog.Info("secret deposited", "entry", entry, "path", p, "value_bytes", len(value), "remote", r.RemoteAddr)
+	secretsOperatorTotal.WithLabelValues("put", "ok").Inc()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// HandleOperatorGet serves GET /secrets/entries/{entry}/paths/*?pubkey= :
+// operator read-back, wrapped to the ephemeral key in the query.
+func (h SecretsHandler) HandleOperatorGet(w http.ResponseWriter, r *http.Request) {
+	entry, p := chi.URLParam(r, "entry"), "/"+chi.URLParam(r, "*")
+	if _, ok := h.authorizeOperator(w, r); !ok {
+		return
+	}
+	pub, err := base64.StdEncoding.DecodeString(r.URL.Query().Get("pubkey"))
+	if err != nil || len(pub) != 32 {
+		secretsOperatorTotal.WithLabelValues("get", "invalid_request").Inc()
+		attestation.WriteError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest,
+			"pubkey query parameter must be a base64 raw X25519 public key")
+		return
+	}
+	value, err := h.Store.Get(r.Context(), secretstore.Ref{Entry: entry, Path: p}, types.Digest{})
+	if errors.Is(err, secretstore.ErrNotFound) {
+		secretsOperatorTotal.WithLabelValues("get", "not_found").Inc()
+		attestation.WriteError(w, http.StatusNotFound, types.ErrorCodeSecretNotFound, "no secret at this path")
+		return
+	}
+	if err != nil {
+		slog.Error("secrets read-back: store get", "entry", entry, "path", p, "error", err)
+		secretsOperatorTotal.WithLabelValues("get", "internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "store error")
+		return
+	}
+	wrapped, err := secrets.Wrap(pub, value, secrets.DepositAAD(entry, p))
+	if err != nil {
+		secretsOperatorTotal.WithLabelValues("get", "internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "wrap response")
+		return
+	}
+	// Sign like a fetch response: the wrap alone only proves the sender knew
+	// the public encryption key; the signature is what a fake broker cannot mint.
+	signature, err := secrets.SignResponse(h.Identity.signingKey, wrapped)
+	if err != nil {
+		secretsOperatorTotal.WithLabelValues("get", "internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "sign response")
+		return
+	}
+	slog.Info("secret read back", "entry", entry, "path", p, "value_bytes", len(value), "remote", r.RemoteAddr)
+	secretsOperatorTotal.WithLabelValues("get", "ok").Inc()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(secrets.FetchResponse{Payload: wrapped, Signature: signature})
+}
+
+// HandleOperatorDelete serves DELETE /secrets/entries/{entry}/paths/* .
+func (h SecretsHandler) HandleOperatorDelete(w http.ResponseWriter, r *http.Request) {
+	entry, p := chi.URLParam(r, "entry"), "/"+chi.URLParam(r, "*")
+	if _, ok := h.authorizeOperator(w, r); !ok {
+		return
+	}
+	if err := h.Store.Delete(r.Context(), secretstore.Ref{Entry: entry, Path: p}); err != nil {
+		slog.Error("secrets delete: store delete", "entry", entry, "path", p, "error", err)
+		secretsOperatorTotal.WithLabelValues("delete", "internal").Inc()
+		attestation.WriteError(w, http.StatusInternalServerError, types.ErrorCodeInternal, "store error")
+		return
+	}
+	slog.Info("secret deleted", "entry", entry, "path", p, "remote", r.RemoteAddr)
+	secretsOperatorTotal.WithLabelValues("delete", "ok").Inc()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// authorizeOperator gates an operator mutation on the pinned-key JWT, the same
+// shape as allowlist writes.
+func (h SecretsHandler) authorizeOperator(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if h.WriteAuthorizer == nil {
+		attestation.WriteError(w, http.StatusUnauthorized, types.ErrorCodeInvalidToken, "operator writes disabled")
+		return nil, false
+	}
+	body, ok := httputil.ReadCappedBody(w, r, operatorWriteBodyCap)
+	if !ok {
+		return nil, false
+	}
+	if err := h.WriteAuthorizer(r, body); err != nil {
+		slog.Warn("secrets operator write rejected", "method", r.Method, "remote", r.RemoteAddr, "reason", err)
+		attestation.WriteError(w, http.StatusUnauthorized, types.ErrorCodeInvalidToken, "operator authorization failed")
+		return nil, false
+	}
+	return body, true
+}
+
+// checkEntry validates a deposit destination: the workload entry must exist
+// and the path must be a well-formed request path.
+func (h SecretsHandler) checkEntry(entry, p string) error {
+	if entry == "" {
+		return fmt.Errorf("entry is required")
+	}
+	doc, _, err := h.AllowlistStore.LoadAll()
+	if err != nil {
+		return fmt.Errorf("load allowlist: %w", err)
+	}
+	if _, ok := doc.Workloads[entry]; !ok {
+		return fmt.Errorf("workload entry %q does not exist", entry)
+	}
+	return validRequestPath(p)
+}

--- a/internal/cmds/cds/secrets_test.go
+++ b/internal/cmds/cds/secrets_test.go
@@ -1,0 +1,362 @@
+package cds
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/confidential-dot-ai/c8s/internal/attestation"
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/internal/secretstore"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// ctxWithChiParams stubs chi URL parameters for direct handler invocation.
+func ctxWithChiParams(r *http.Request, params map[string]string) context.Context {
+	rctx := chi.NewRouteContext()
+	for k, v := range params {
+		rctx.URLParams.Add(k, v)
+	}
+	return context.WithValue(r.Context(), chi.RouteCtxKey, rctx)
+}
+
+func mustRootPool(t *testing.T, caPEM []byte) *x509.CertPool {
+	t.Helper()
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(caPEM) {
+		t.Fatalf("append CA PEM")
+	}
+	return pool
+}
+
+const (
+	secDigestVLLM   = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	secDigestOther  = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	secLaunchDigest = "abcd1234"
+)
+
+func vllmEntry() pkgallowlist.Workload {
+	return pkgallowlist.Workload{
+		Label: "docker.io/vllm/vllm-openai:v0.6.3",
+		Containers: []pkgallowlist.Container{
+			{
+				Digest:  mustParseDigest(secDigestVLLM),
+				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"python3"}},
+				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"-m", "vllm.entrypoints.openai.api_server"}},
+				Paths: pkgallowlist.PathPolicy{
+					Policy: pkgallowlist.PolicyAllow,
+					Read:   []string{"/secrets/model/**"},
+					Write:  []string{"/secrets/session"},
+				},
+			},
+		},
+	}
+}
+
+func mustParseDigest(s string) types.Digest {
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func newTestSecretsHandler(t *testing.T, measurements map[string]bool, workloads map[string]pkgallowlist.Workload) SecretsHandler {
+	t.Helper()
+	ca, err := issuer.NewCA("test ca", 2*issuer.MaxLeafTTL)
+	if err != nil {
+		t.Fatalf("new ca: %v", err)
+	}
+	id, err := newBrokerIdentity(ca, certutil.EncodeCertPEM(ca.Cert.Raw))
+	if err != nil {
+		t.Fatalf("broker identity: %v", err)
+	}
+	mock := newMockAttestationApi(t, secLaunchDigest)
+	store := attestation.NewChallengeStore(30 * time.Second)
+	secretsStore := secretstore.NewMemStore()
+	return SecretsHandler{
+		Challenges:        &store,
+		AttestationClient: attestationclient.NewClient(mock.URL),
+		Measurements:      measurements,
+		AllowlistStore:    fakeStore{floor: map[string]bool{}, workloads: workloads},
+		Store:             secretsStore,
+		Identity:          id,
+	}
+}
+
+func fetchBody(t *testing.T, h SecretsHandler, req secrets.FetchRequest) ([]byte, secrets.FetchRequest) {
+	t.Helper()
+	c := h.Challenges.Create()
+	req.Challenge = base64.StdEncoding.EncodeToString(c[:])
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return body, req
+}
+
+func doFetch(t *testing.T, h SecretsHandler, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/secrets/fetch", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleFetch(w, req)
+	return w
+}
+
+func goodFetchRequest(t *testing.T) secrets.FetchRequest {
+	t.Helper()
+	_, pub, err := secrets.GenerateX25519()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	return secrets.FetchRequest{
+		ContainerDigests: []string{secDigestVLLM},
+		ResponsePubkey:   base64.StdEncoding.EncodeToString(pub),
+		Requests:         []secrets.SecretRequest{{Digest: secDigestVLLM, Paths: []string{"/secrets/model/dek"}}},
+	}
+}
+
+func TestFetchHappyPath(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	if err := h.Store.Set(t.Context(), secretstore.Ref{Entry: "vllm-llama", Path: "/secrets/model/dek"}, []byte("supersecret")); err != nil {
+		t.Fatalf("seed store: %v", err)
+	}
+
+	priv, pub, _ := secrets.GenerateX25519()
+	req := goodFetchRequest(t)
+	req.ResponsePubkey = base64.StdEncoding.EncodeToString(pub)
+	body, canonicalReq := fetchBody(t, h, req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp secrets.FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	// The transcript must be computable by the client for its own request —
+	// this is what the evidence would have bound on a real TEE.
+	if _, err := secrets.ReportDataForFetch(mustChallengeBytes(t, canonicalReq.Challenge), canonicalReq); err != nil {
+		t.Fatalf("transcript: %v", err)
+	}
+
+	// Verify the broker identity chains to the mesh CA, then the signature,
+	// then unwrap.
+	signingPub, _, err := h.Identity.doc.Verify(mustRootPool(t, h.Identity.doc.CAChainPEM))
+	if err != nil {
+		t.Fatalf("verify identity: %v", err)
+	}
+	if err := secrets.VerifyResponseSignature(signingPub, resp.Payload, resp.Signature); err != nil {
+		t.Fatalf("response signature: %v", err)
+	}
+	payloadJSON, err := secrets.Unwrap(priv, []byte(secrets.FetchAAD), resp.Payload)
+	if err != nil {
+		t.Fatalf("unwrap: %v", err)
+	}
+	var values map[string]string
+	if err := json.Unmarshal(payloadJSON, &values); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	got, err := base64.StdEncoding.DecodeString(values["/secrets/model/dek"])
+	if err != nil || string(got) != "supersecret" {
+		t.Fatalf("got %q (err %v)", got, err)
+	}
+}
+
+func mustChallengeBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		t.Fatalf("challenge: %v", err)
+	}
+	return b
+}
+
+func TestFetchFailsClosedOnEmptyMeasurements(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	body, _ := fetchBody(t, h, goodFetchRequest(t))
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeMeasurementNotConfigured) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchMeasurementDenied(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{"someone-else": true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	body, _ := fetchBody(t, h, goodFetchRequest(t))
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeMeasurementDenied) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchNoMatchingEntry(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	req := goodFetchRequest(t)
+	req.ContainerDigests = []string{secDigestOther}
+	body, _ := fetchBody(t, h, req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeGrantDenied) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchAmbiguousEntries(t *testing.T) {
+	// Two entries with identical container sets but different grants.
+	e2 := vllmEntry()
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{
+		"vllm-a": vllmEntry(),
+		"vllm-b": e2,
+	})
+	body, _ := fetchBody(t, h, goodFetchRequest(t))
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeEntryAmbiguous) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchDigestNotInEntry(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	req := goodFetchRequest(t)
+	req.Requests = []secrets.SecretRequest{{Digest: secDigestOther, Paths: []string{"/secrets/model/dek"}}}
+	body, _ := fetchBody(t, h, req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeGrantDenied) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchPathNotGranted(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	req := goodFetchRequest(t)
+	req.Requests = []secrets.SecretRequest{{Digest: secDigestVLLM, Paths: []string{"/secrets/other/key"}}}
+	body, _ := fetchBody(t, h, req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusForbidden || !strings.Contains(w.Body.String(), types.ErrorCodeGrantDenied) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchSecretNotFound(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	body, _ := fetchBody(t, h, goodFetchRequest(t))
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusNotFound || !strings.Contains(w.Body.String(), types.ErrorCodeSecretNotFound) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchInvalidChallenge(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	req := goodFetchRequest(t)
+	req.Challenge = base64.StdEncoding.EncodeToString([]byte("bogus-bogus-bogus-bogus-bogus-bogus-bo"))
+	body, _ := json.Marshal(req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusBadRequest || !strings.Contains(w.Body.String(), types.ErrorCodeInvalidChallenge) {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestFetchPathGlobMatching(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	_ = h.Store.Set(t.Context(), secretstore.Ref{Entry: "vllm-llama", Path: "/secrets/model/v2/key"}, []byte("v2"))
+	req := goodFetchRequest(t)
+	req.Requests = []secrets.SecretRequest{{Digest: secDigestVLLM, Paths: []string{"/secrets/model/v2/key"}}}
+	body, _ := fetchBody(t, h, req)
+	w := doFetch(t, h, body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("subtree glob not honored: got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOperatorPutGetDelete(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	h.WriteAuthorizer = func(*http.Request, []byte) error { return nil }
+
+	// PUT wrapped to the broker encryption key.
+	signingPub, encPub, err := h.Identity.doc.Verify(mustRootPool(t, h.Identity.doc.CAChainPEM))
+	if err != nil {
+		t.Fatalf("verify identity: %v", err)
+	}
+	wrapped, err := secrets.Wrap(encPub, []byte("deposit-value"), secrets.DepositAAD("vllm-llama", "/secrets/model/dek"))
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	body, _ := json.Marshal(wrapped)
+	putReq := httptest.NewRequest(http.MethodPut, "/secrets/entries/vllm-llama/paths/secrets/model/dek", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleOperatorPut(w, putReq.WithContext(ctxWithChiParams(putReq, map[string]string{"entry": "vllm-llama", "*": "secrets/model/dek"})))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("put got %d: %s", w.Code, w.Body.String())
+	}
+
+	// GET read-back wrapped to an ephemeral key.
+	priv, pub, _ := secrets.GenerateX25519()
+	getReq := httptest.NewRequest(http.MethodGet, "/secrets/entries/vllm-llama/paths/secrets/model/dek?pubkey="+base64.StdEncoding.EncodeToString(pub), nil)
+	w = httptest.NewRecorder()
+	h.HandleOperatorGet(w, getReq.WithContext(ctxWithChiParams(getReq, map[string]string{"entry": "vllm-llama", "*": "secrets/model/dek"})))
+	if w.Code != http.StatusOK {
+		t.Fatalf("get got %d: %s", w.Code, w.Body.String())
+	}
+	var wrappedResp secrets.FetchResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &wrappedResp); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if err := secrets.VerifyResponseSignature(signingPub, wrappedResp.Payload, wrappedResp.Signature); err != nil {
+		t.Fatalf("get response signature: %v", err)
+	}
+	value, err := secrets.Unwrap(priv, secrets.DepositAAD("vllm-llama", "/secrets/model/dek"), wrappedResp.Payload)
+	if err != nil || string(value) != "deposit-value" {
+		t.Fatalf("read-back got %q (err %v)", value, err)
+	}
+
+	// DELETE.
+	delReq := httptest.NewRequest(http.MethodDelete, "/secrets/entries/vllm-llama/paths/secrets/model/dek", nil)
+	w = httptest.NewRecorder()
+	h.HandleOperatorDelete(w, delReq.WithContext(ctxWithChiParams(delReq, map[string]string{"entry": "vllm-llama", "*": "secrets/model/dek"})))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("delete got %d: %s", w.Code, w.Body.String())
+	}
+	if _, err := h.Store.Get(t.Context(), secretstore.Ref{Entry: "vllm-llama", Path: "/secrets/model/dek"}, types.Digest{}); err == nil {
+		t.Fatal("secret survived delete")
+	}
+}
+
+func TestOperatorPutRejectsUnknownEntry(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	h.WriteAuthorizer = func(*http.Request, []byte) error { return nil }
+	_, encPub, _ := h.Identity.doc.Verify(mustRootPool(t, h.Identity.doc.CAChainPEM))
+	wrapped, _ := secrets.Wrap(encPub, []byte("v"), secrets.DepositAAD("nope", "/secrets/x"))
+	body, _ := json.Marshal(wrapped)
+	putReq := httptest.NewRequest(http.MethodPut, "/secrets/entries/nope/paths/secrets/x", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	h.HandleOperatorPut(w, putReq.WithContext(ctxWithChiParams(putReq, map[string]string{"entry": "nope", "*": "secrets/x"})))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestOperatorUnauthorizedWhenNoKeys(t *testing.T) {
+	h := newTestSecretsHandler(t, map[string]bool{secLaunchDigest: true}, map[string]pkgallowlist.Workload{"vllm-llama": vllmEntry()})
+	putReq := httptest.NewRequest(http.MethodPut, "/secrets/entries/vllm-llama/paths/secrets/x", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	h.HandleOperatorPut(w, putReq.WithContext(ctxWithChiParams(putReq, map[string]string{"entry": "vllm-llama", "*": "secrets/x"})))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -1,0 +1,147 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	pkgsecrets "github.com/confidential-dot-ai/c8s/pkg/secrets"
+)
+
+// brokerClient is a broker-identity-verified CDS client: values cross the
+// wire wrapped to the broker encryption key, so a same-measurement fake CDS
+// (which cannot hold the mesh CA key and therefore cannot mint this identity)
+// never sees plaintext.
+type brokerClient struct {
+	hc      *http.Client
+	baseURL string
+	encPub  []byte
+	signing *ecdsa.PublicKey
+}
+
+func newBrokerClient(hc *http.Client, baseURL string, roots *x509.CertPool, identityJSON []byte) (*brokerClient, error) {
+	var bi pkgsecrets.BrokerIdentity
+	dec := json.NewDecoder(bytes.NewReader(identityJSON))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&bi); err != nil {
+		return nil, fmt.Errorf("decode broker identity: %w", err)
+	}
+	signing, encPub, err := bi.Verify(roots)
+	if err != nil {
+		return nil, err
+	}
+	return &brokerClient{hc: hc, baseURL: baseURL, encPub: encPub, signing: signing}, nil
+}
+
+// authorizer signs one request, mirroring allowlistclient.Authorizer.
+type authorizer interface {
+	Authorization(method, path string, body []byte) (string, error)
+}
+
+// put wraps value to the broker encryption key and deposits it at (entry, path).
+func (c *brokerClient) put(ctx context.Context, entry, path string, value []byte, auth authorizer) error {
+	wrapped, err := pkgsecrets.Wrap(c.encPub, value, pkgsecrets.DepositAAD(entry, path))
+	if err != nil {
+		return fmt.Errorf("wrap value: %w", err)
+	}
+	body, err := json.Marshal(wrapped)
+	if err != nil {
+		return err
+	}
+	return c.mutate(ctx, http.MethodPut, secretPath(entry, path), body, auth)
+}
+
+// get reads back (entry, path), unwrapping to a fresh ephemeral key.
+func (c *brokerClient) get(ctx context.Context, entry, path string, auth authorizer) ([]byte, error) {
+	priv, pub, err := pkgsecrets.GenerateX25519()
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		c.baseURL+secretPath(entry, path)+"?pubkey="+url.QueryEscape(base64.StdEncoding.EncodeToString(pub)), nil)
+	if err != nil {
+		return nil, err
+	}
+	authz, err := auth.Authorization(http.MethodGet, req.URL.Path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Authorization", authz)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, statusError(resp)
+	}
+	var fetchResp pkgsecrets.FetchResponse
+	dec := json.NewDecoder(io.LimitReader(resp.Body, 2<<20))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&fetchResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if err := pkgsecrets.VerifyResponseSignature(c.signing, fetchResp.Payload, fetchResp.Signature); err != nil {
+		return nil, err
+	}
+	value, err := pkgsecrets.Unwrap(priv, pkgsecrets.DepositAAD(entry, path), fetchResp.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("unwrap response: %w", err)
+	}
+	return value, nil
+}
+
+// del removes (entry, path).
+func (c *brokerClient) del(ctx context.Context, entry, path string, auth authorizer) error {
+	return c.mutate(ctx, http.MethodDelete, secretPath(entry, path), nil, auth)
+}
+
+// secretPath builds the route path for a (entry, path) ref: the entry is one
+// path segment; the secret path keeps its slashes under /paths/.
+func secretPath(entry, p string) string {
+	return "/secrets/entries/" + url.PathEscape(entry) + "/paths" + p
+}
+
+// mutate sends a body-bound, authorized write (mirrors allowlistclient).
+func (c *brokerClient) mutate(ctx context.Context, method, path string, body []byte, auth authorizer) error {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	if err != nil {
+		return err
+	}
+	authz, err := auth.Authorization(method, req.URL.Path, body)
+	if err != nil {
+		return fmt.Errorf("authorize request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", authz)
+
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return statusError(resp)
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func statusError(resp *http.Response) error {
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(msg)))
+}

--- a/internal/cmds/secrets/client_test.go
+++ b/internal/cmds/secrets/client_test.go
@@ -1,0 +1,244 @@
+package secrets
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	pkgsecrets "github.com/confidential-dot-ai/c8s/pkg/secrets"
+)
+
+// fakeBroker is a self-contained fake CDS secrets broker: its own CA, a
+// broker signing leaf, an encryption key, and a map store. It speaks the real
+// wire protocol so the CLI client is tested end to end.
+type fakeBroker struct {
+	caPEM      []byte
+	identity   pkgsecrets.BrokerIdentity
+	encPriv    []byte
+	signingKey *ecdsa.PrivateKey
+
+	mu    sync.Mutex
+	store map[string][]byte
+}
+
+func newFakeBroker(t *testing.T) *fakeBroker {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test mesh CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, caKey.Public(), caKey)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	caCert, _ := x509.ParseCertificate(caDER)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "c8s-secrets-broker"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, leafKey.Public(), caKey)
+	if err != nil {
+		t.Fatalf("leaf: %v", err)
+	}
+
+	encPriv, encPub, err := pkgsecrets.GenerateX25519()
+	if err != nil {
+		t.Fatalf("enc key: %v", err)
+	}
+	encSig, err := pkgsecrets.SignEncryptionPubkey(leafKey, encPub)
+	if err != nil {
+		t.Fatalf("enc sig: %v", err)
+	}
+
+	return &fakeBroker{
+		caPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		identity: pkgsecrets.BrokerIdentity{
+			SigningLeafPEM:      pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafDER}),
+			CAChainPEM:          pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+			EncryptionPubkey:    base64.StdEncoding.EncodeToString(encPub),
+			EncryptionPubkeySig: encSig,
+		},
+		encPriv:    encPriv,
+		signingKey: leafKey,
+		store:      map[string][]byte{},
+	}
+}
+
+func (f *fakeBroker) handler(t *testing.T) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/ca", func(w http.ResponseWriter, _ *http.Request) { w.Write(f.caPEM) })
+	r.Get("/secrets/broker-identity", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(f.identity)
+	})
+	r.Put("/secrets/entries/{entry}/paths/*", func(w http.ResponseWriter, req *http.Request) {
+		entry, p := chi.URLParam(req, "entry"), "/"+chi.URLParam(req, "*")
+		var wrapped pkgsecrets.Wrapped
+		if err := json.NewDecoder(req.Body).Decode(&wrapped); err != nil {
+			http.Error(w, "bad body", http.StatusUnprocessableEntity)
+			return
+		}
+		value, err := pkgsecrets.Unwrap(f.encPriv, pkgsecrets.DepositAAD(entry, p), wrapped)
+		if err != nil {
+			http.Error(w, "unwrap failed", http.StatusBadRequest)
+			return
+		}
+		f.mu.Lock()
+		f.store[entry+"\x00"+p] = value
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	r.Get("/secrets/entries/{entry}/paths/*", func(w http.ResponseWriter, req *http.Request) {
+		entry, p := chi.URLParam(req, "entry"), "/"+chi.URLParam(req, "*")
+		pub, err := base64.StdEncoding.DecodeString(req.URL.Query().Get("pubkey"))
+		if err != nil {
+			http.Error(w, "bad pubkey", http.StatusUnprocessableEntity)
+			return
+		}
+		f.mu.Lock()
+		value, ok := f.store[entry+"\x00"+p]
+		f.mu.Unlock()
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		wrapped, err := pkgsecrets.Wrap(pub, value, pkgsecrets.DepositAAD(entry, p))
+		if err != nil {
+			http.Error(w, "wrap failed", http.StatusInternalServerError)
+			return
+		}
+		sig, err := pkgsecrets.SignResponse(f.signingKey, wrapped)
+		if err != nil {
+			http.Error(w, "sign failed", http.StatusInternalServerError)
+			return
+		}
+		json.NewEncoder(w).Encode(pkgsecrets.FetchResponse{Payload: wrapped, Signature: sig})
+	})
+	r.Delete("/secrets/entries/{entry}/paths/*", func(w http.ResponseWriter, req *http.Request) {
+		entry, p := chi.URLParam(req, "entry"), "/"+chi.URLParam(req, "*")
+		f.mu.Lock()
+		delete(f.store, entry+"\x00"+p)
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	return r
+}
+
+func testOperatorSigner(t *testing.T) *operatorauth.Signer {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("operator key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+	return signer
+}
+
+// TestCLIRoundTrip drives the real CLI client against a fake broker: identity
+// verify → put → get → delete, end to end over the real wire protocol.
+func TestCLIRoundTrip(t *testing.T) {
+	fake := newFakeBroker(t)
+	srv := httptest.NewServer(fake.handler(t))
+	t.Cleanup(srv.Close)
+	signer := testOperatorSigner(t)
+
+	caPEM, err := getBytes(context.Background(), srv.Client(), srv.URL+"/ca")
+	if err != nil {
+		t.Fatalf("fetch ca: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("parse ca")
+	}
+	identityJSON, err := getBytes(context.Background(), srv.Client(), srv.URL+"/secrets/broker-identity")
+	if err != nil {
+		t.Fatalf("fetch identity: %v", err)
+	}
+	bc, err := newBrokerClient(srv.Client(), srv.URL, roots, identityJSON)
+	if err != nil {
+		t.Fatalf("broker client: %v", err)
+	}
+
+	if err := bc.put(context.Background(), "vllm-llama", "/secrets/model/dek", []byte("the-dek"), signer); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, err := bc.get(context.Background(), "vllm-llama", "/secrets/model/dek", signer)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "the-dek" {
+		t.Fatalf("got %q", got)
+	}
+	if err := bc.del(context.Background(), "vllm-llama", "/secrets/model/dek", signer); err != nil {
+		t.Fatalf("del: %v", err)
+	}
+	if _, err := bc.get(context.Background(), "vllm-llama", "/secrets/model/dek", signer); err == nil {
+		t.Fatal("get after delete succeeded")
+	}
+}
+
+// TestBrokerClientRejectsWrongCA: an identity chained to a different root must fail.
+func TestBrokerClientRejectsWrongCA(t *testing.T) {
+	fake := newFakeBroker(t)
+	other := newFakeBroker(t)
+	identityJSON, _ := json.Marshal(fake.identity)
+	roots := x509.NewCertPool()
+	roots.AppendCertsFromPEM(other.caPEM)
+	if _, err := newBrokerClient(&http.Client{}, "http://x", roots, identityJSON); err == nil {
+		t.Fatal("identity from the wrong CA accepted")
+	}
+}
+
+func TestReadValueArg(t *testing.T) {
+	if v, _ := readValueArg("literal"); string(v) != "literal" {
+		t.Fatalf("got %q", v)
+	}
+	f := t.TempDir() + "/v"
+	if err := os.WriteFile(f, []byte("from-file"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	v, err := readValueArg("@" + f)
+	if err != nil || string(v) != "from-file" {
+		t.Fatalf("got %q err %v", v, err)
+	}
+}

--- a/internal/cmds/secrets/cmd.go
+++ b/internal/cmds/secrets/cmd.go
@@ -1,0 +1,214 @@
+// Package secrets implements the `c8s secrets` operator CLI: deposit, read
+// back, and delete the secrets the CDS broker releases to attested workloads
+// (docs/secrets-broker.md). Every command verifies the broker identity against
+// the mesh CA served by the target CDS before any value crosses the wire, and
+// values always travel wrapped to the broker encryption key — never as
+// plaintext a same-measurement fake CDS could read.
+package secrets
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/lbdiscovery"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// envOperatorKey supplies the operator private key when --operator-key is unset.
+const envOperatorKey = "C8S_OPERATOR_KEY"
+
+// options holds the flags shared by every subcommand.
+type options struct {
+	url              string
+	measurements     []string
+	measurementsFile string
+	timeout          time.Duration
+	operatorKey      string
+	output           string
+	insecure         bool
+
+	verify localverify.VerifyFunc
+}
+
+// NewCmd returns the `c8s secrets` command tree.
+func NewCmd() *cobra.Command {
+	return newCmd(localverify.Verify)
+}
+
+func newCmd(verify localverify.VerifyFunc) *cobra.Command {
+	o := &options{verify: verify}
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Deposit and inspect CDS-brokered secrets",
+		Long: `Deposit, read back, and delete the secrets the CDS broker releases to
+attested workloads. Secrets are scoped by workload entry and path; a workload
+receives exactly the paths its attested container digests are granted by the
+allowlist entry's path policy (docs/secrets-broker.md).
+
+Values are wrapped to the broker encryption key before they leave this CLI and
+every write is signed with an operator EC key (--operator-key or
+C8S_OPERATOR_KEY), the same credential that authorizes allowlist writes.`,
+		SilenceUsage: true,
+	}
+
+	pf := cmd.PersistentFlags()
+	pf.StringVar(&o.url, "url", "", "CDS base URL (required). CDS has no public ingress: reach it via 'kubectl port-forward svc/c8s-cds 8443:8443' then --url https://localhost:8443, or via the tls-lb")
+	pf.StringSliceVar(&o.measurements, "measurements", nil, "allowed SHA-384 hex launch measurement(s) of the attested endpoint (repeatable/comma-separated); empty = no pinning (UNSAFE)")
+	pf.StringVar(&o.measurementsFile, "measurements-file", "", "file of allowed launch measurements, one hex digest per line")
+	pf.DurationVar(&o.timeout, "timeout", 15*time.Second, "per-request timeout")
+	pf.StringVar(&o.operatorKey, "operator-key", "", "operator EC private key PEM file, whose public key is pinned on CDS via --operator-keys (env "+envOperatorKey+"); required")
+	pf.StringVarP(&o.output, "output", "o", "text", "output format: text or json")
+	pf.BoolVar(&o.insecure, "insecure", false, "dev/test only: allow a plaintext http:// CDS URL, skipping RA-TLS attestation of CDS")
+
+	cmd.AddCommand(
+		newPutCmd(o),
+		newGetCmd(o),
+		newDeleteCmd(o),
+	)
+	return cmd
+}
+
+// validate checks the flags every subcommand needs.
+func (o *options) validate() error {
+	if strings.TrimSpace(o.url) == "" {
+		return fmt.Errorf("--url is required")
+	}
+	if o.output != "text" && o.output != "json" {
+		return fmt.Errorf("--output must be text or json, got %q", o.output)
+	}
+	return nil
+}
+
+// httpClient builds the CDS HTTP client: RA-TLS verified for https, plaintext
+// only with --insecure (mirrors `c8s allowlist`).
+func (o *options) httpClient(ctx context.Context) (*http.Client, error) {
+	u, err := url.Parse(o.url)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("invalid --url %q", o.url)
+	}
+	switch u.Scheme {
+	case "http":
+		if !o.insecure {
+			return nil, fmt.Errorf("refusing plaintext http:// for CDS (no attestation): use https:// (RA-TLS), or pass --insecure for a dev/test endpoint")
+		}
+		fmt.Fprintln(os.Stderr, "warning: --url is http:// with --insecure; CDS attestation is NOT verified (dev/test only)")
+		return &http.Client{Timeout: o.timeout}, nil
+	case "https":
+		measurements, err := o.loadMeasurements()
+		if err != nil {
+			return nil, err
+		}
+		if len(measurements) == 0 {
+			fmt.Fprintln(os.Stderr, "warning: no --measurements set; accepting any RA-TLS-attested CDS (UNSAFE)")
+		}
+		probeCtx, cancel := context.WithTimeout(ctx, o.timeout)
+		defer cancel()
+		hc, err := lbdiscovery.NewVerifiedHTTPClient(probeCtx, o.url, measurements, o.verify)
+		switch {
+		case err == nil:
+			fmt.Fprintln(os.Stderr, "note: target is a tls-lb front door; verified its discovery attestation and bound this session to the attested connection")
+			return hc, nil
+		case errors.Is(err, lbdiscovery.ErrNoDiscovery):
+			return localverify.NewRATLSHTTPClient(measurements, o.verify, o.timeout), nil
+		default:
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("--url scheme must be http or https, got %q", u.Scheme)
+	}
+}
+
+func (o *options) loadMeasurements() ([][]byte, error) {
+	hexes := append([]string{}, o.measurements...)
+	if o.measurementsFile != "" {
+		data, err := os.ReadFile(o.measurementsFile)
+		if err != nil {
+			return nil, fmt.Errorf("read --measurements-file: %w", err)
+		}
+		hexes = append(hexes, strings.Split(string(data), "\n")...)
+	}
+	return ratls.ParseHexMeasurementsList(hexes)
+}
+
+// signer builds the operator credential from the flags or environment.
+func (o *options) signer() (*operatorauth.Signer, error) {
+	keyPath := o.operatorKey
+	if keyPath == "" {
+		keyPath = os.Getenv(envOperatorKey)
+	}
+	if keyPath == "" {
+		return nil, fmt.Errorf("operator key required: set --operator-key or %s", envOperatorKey)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read operator key: %w", err)
+	}
+	return operatorauth.NewSignerFromKeyPEM(keyPEM)
+}
+
+// brokerIdentity fetches /ca and /secrets/broker-identity and returns the
+// verified (signing, encryption) public keys. The CA bundle rides the same
+// RA-TLS channel, so this inherits its pinning — pin --measurements, and run
+// `c8s cds verify` out of band for governance, as with every CDS client.
+func (o *options) brokerIdentity(ctx context.Context, hc *http.Client) (*brokerClient, error) {
+	caPEM, err := getBytes(ctx, hc, o.url+"/ca")
+	if err != nil {
+		return nil, fmt.Errorf("fetch mesh CA: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parse mesh CA bundle")
+	}
+	identityJSON, err := getBytes(ctx, hc, o.url+"/secrets/broker-identity")
+	if err != nil {
+		return nil, fmt.Errorf("fetch broker identity: %w", err)
+	}
+	return newBrokerClient(hc, o.url, roots, identityJSON)
+}
+
+func getBytes(ctx context.Context, hc *http.Client, u string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", u, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+}
+
+// readValueArg reads a secret value: literal, @file, or - for stdin.
+func readValueArg(arg string) ([]byte, error) {
+	switch {
+	case arg == "-":
+		return io.ReadAll(io.LimitReader(os.Stdin, 1<<20))
+	case strings.HasPrefix(arg, "@"):
+		return os.ReadFile(strings.TrimPrefix(arg, "@"))
+	default:
+		return []byte(arg), nil
+	}
+}
+
+func ctx(cmd *cobra.Command) context.Context {
+	if c := cmd.Context(); c != nil {
+		return c
+	}
+	return context.Background()
+}

--- a/internal/cmds/secrets/subcommands.go
+++ b/internal/cmds/secrets/subcommands.go
@@ -1,0 +1,118 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func newPutCmd(o *options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "put <entry> <path> <value|@file|->",
+		Short: "Deposit a secret for a workload entry",
+		Long: `Deposit a secret the CDS broker may release to workloads attested as
+the given entry. The value is read from the argument, an @file, or stdin (-),
+and is wrapped to the broker encryption key before it leaves this CLI.`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			entry, path := args[0], args[1]
+			value, err := readValueArg(args[2])
+			if err != nil {
+				return fmt.Errorf("read value: %w", err)
+			}
+			signer, err := o.signer()
+			if err != nil {
+				return err
+			}
+			hc, err := o.httpClient(ctx(cmd))
+			if err != nil {
+				return err
+			}
+			bc, err := o.brokerIdentity(ctx(cmd), hc)
+			if err != nil {
+				return err
+			}
+			if err := bc.put(ctx(cmd), entry, path, value, signer); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "deposited %s %s (%d bytes)\n", entry, path, len(value))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newGetCmd(o *options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <entry> <path>",
+		Short: "Read back a deposited secret",
+		Long: `Read back a secret from the broker store. The raw value is written to
+stdout; use -o json for base64. This is an operator debugging path — workloads
+receive secrets through the attested fetch flow, not this endpoint.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			signer, err := o.signer()
+			if err != nil {
+				return err
+			}
+			hc, err := o.httpClient(ctx(cmd))
+			if err != nil {
+				return err
+			}
+			bc, err := o.brokerIdentity(ctx(cmd), hc)
+			if err != nil {
+				return err
+			}
+			value, err := bc.get(ctx(cmd), args[0], args[1], signer)
+			if err != nil {
+				return err
+			}
+			if o.output == "json" {
+				fmt.Println(base64.StdEncoding.EncodeToString(value))
+				return nil
+			}
+			_, err = os.Stdout.Write(value)
+			return err
+		},
+	}
+	return cmd
+}
+
+func newDeleteCmd(o *options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <entry> <path>",
+		Short: "Delete a deposited secret",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.validate(); err != nil {
+				return err
+			}
+			signer, err := o.signer()
+			if err != nil {
+				return err
+			}
+			hc, err := o.httpClient(ctx(cmd))
+			if err != nil {
+				return err
+			}
+			bc, err := o.brokerIdentity(ctx(cmd), hc)
+			if err != nil {
+				return err
+			}
+			if err := bc.del(ctx(cmd), args[0], args[1], signer); err != nil {
+				return err
+			}
+			fmt.Fprintf(os.Stderr, "deleted %s %s\n", args[0], args[1])
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/secretstore/json.go
+++ b/internal/secretstore/json.go
@@ -1,0 +1,51 @@
+package secretstore
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// jsonDoc is the test-helper dump format: entry -> path -> base64 value. It is
+// used by unit and integration tests to seed and inspect a MemStore; nothing in
+// the CDS runtime reads it (deposit is the operator CLI).
+type jsonDoc map[string]map[string]string
+
+// DumpJSON serializes the store for test assertions.
+func (m *MemStore) DumpJSON() ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	doc := jsonDoc{}
+	for ref, v := range m.secrets {
+		if doc[ref.Entry] == nil {
+			doc[ref.Entry] = map[string]string{}
+		}
+		doc[ref.Entry][ref.Path] = base64.StdEncoding.EncodeToString(v)
+	}
+	return json.Marshal(doc)
+}
+
+// LoadJSON replaces the store's contents from a DumpJSON document.
+func (m *MemStore) LoadJSON(data []byte) error {
+	var doc jsonDoc
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&doc); err != nil {
+		return fmt.Errorf("decode secret store dump: %w", err)
+	}
+	next := make(map[Ref][]byte)
+	for entry, paths := range doc {
+		for p, b64 := range paths {
+			v, err := base64.StdEncoding.DecodeString(b64)
+			if err != nil {
+				return fmt.Errorf("entry %q path %q: invalid base64: %w", entry, p, err)
+			}
+			next[Ref{Entry: entry, Path: p}] = v
+		}
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secrets = next
+	return nil
+}

--- a/internal/secretstore/secretstore.go
+++ b/internal/secretstore/secretstore.go
@@ -1,0 +1,85 @@
+// Package secretstore backs the CDS secrets broker: the interface between the
+// attestation-gated release endpoints and whatever holds the secrets. This PR
+// ships the interface and in-memory implementations; adapters to external key
+// managers (openbao, vault, AWS KMS) implement Store in their own PRs.
+//
+// Secrets are scoped by Ref{Entry, Path}: the workload entry (an allowlist
+// workload whose container set a pod attested) plus the policy path granted to
+// that entry. Entry scoping lets two tenants share a mount path with different
+// values, provided their workload sets differ — see docs/secrets-broker.md.
+package secretstore
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// ErrNotFound is returned by Get when no secret exists at the ref.
+var ErrNotFound = errors.New("secretstore: not found")
+
+// Ref identifies a secret: the workload entry it belongs to and its policy path.
+type Ref struct {
+	Entry string
+	Path  string
+}
+
+// Store is the broker's backend. Get receives the requesting container digest
+// so per-caller backends (leased credentials) are expressible; single-value
+// implementations ignore it. The zero digest means "no workload requester"
+// (operator paths).
+type Store interface {
+	Get(ctx context.Context, ref Ref, requester types.Digest) ([]byte, error)
+	Set(ctx context.Context, ref Ref, value []byte) error
+	Delete(ctx context.Context, ref Ref) error
+}
+
+// MemStore is an in-memory Store: one value per ref, last write wins. It loses
+// everything on CDS restart — that is the intended direct-mode posture
+// (re-deposit after a total CDS loss, docs/secrets-broker.md), never a PV of
+// plaintext.
+type MemStore struct {
+	mu      sync.RWMutex
+	secrets map[Ref][]byte
+}
+
+// NewMemStore returns an empty in-memory store.
+func NewMemStore() *MemStore {
+	return &MemStore{secrets: make(map[Ref][]byte)}
+}
+
+// Get returns a copy of the stored value, or ErrNotFound.
+func (m *MemStore) Get(_ context.Context, ref Ref, _ types.Digest) ([]byte, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	v, ok := m.secrets[ref]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return append([]byte(nil), v...), nil
+}
+
+// Set stores a copy of value at ref, replacing any previous value.
+func (m *MemStore) Set(_ context.Context, ref Ref, value []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.secrets[ref] = append([]byte(nil), value...)
+	return nil
+}
+
+// Delete removes ref. Deleting an absent ref is not an error.
+func (m *MemStore) Delete(_ context.Context, ref Ref) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.secrets, ref)
+	return nil
+}
+
+// Len reports how many refs hold a value. Test and metrics helper.
+func (m *MemStore) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.secrets)
+}

--- a/internal/secretstore/secretstore_test.go
+++ b/internal/secretstore/secretstore_test.go
@@ -1,0 +1,129 @@
+package secretstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func mustDigest(t *testing.T, hexChar byte) types.Digest {
+	t.Helper()
+	hex := make([]byte, 64)
+	for i := range hex {
+		hex[i] = hexChar
+	}
+	d, err := types.ParseDigest("sha256:" + string(hex))
+	if err != nil {
+		t.Fatalf("parse digest: %v", err)
+	}
+	return d
+}
+
+func TestMemStoreGetSetDelete(t *testing.T) {
+	s := NewMemStore()
+	ctx := context.Background()
+	ref := Ref{Entry: "vllm-llama", Path: "/secrets/model/dek"}
+	requester := mustDigest(t, 'a')
+
+	if _, err := s.Get(ctx, ref, requester); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("empty store: got %v, want ErrNotFound", err)
+	}
+
+	if err := s.Set(ctx, ref, []byte("key-material")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := s.Get(ctx, ref, requester)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(got) != "key-material" {
+		t.Fatalf("got %q", got)
+	}
+
+	// Last write wins.
+	if err := s.Set(ctx, ref, []byte("rotated")); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, _ = s.Get(ctx, ref, requester)
+	if string(got) != "rotated" {
+		t.Fatalf("after rewrite got %q", got)
+	}
+
+	if err := s.Delete(ctx, ref); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := s.Get(ctx, ref, requester); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("after delete: got %v, want ErrNotFound", err)
+	}
+	// Deleting an absent ref is fine.
+	if err := s.Delete(ctx, ref); err != nil {
+		t.Fatalf("delete absent: %v", err)
+	}
+}
+
+func TestMemStoreCopiesValues(t *testing.T) {
+	s := NewMemStore()
+	ctx := context.Background()
+	ref := Ref{Entry: "e", Path: "/secrets/x"}
+
+	in := []byte("abc")
+	_ = s.Set(ctx, ref, in)
+	in[0] = 'z'
+	got, _ := s.Get(ctx, ref, types.Digest{})
+	if string(got) != "abc" {
+		t.Fatalf("store aliased the input slice: got %q", got)
+	}
+
+	got[0] = 'y'
+	again, _ := s.Get(ctx, ref, types.Digest{})
+	if string(again) != "abc" {
+		t.Fatalf("store aliased the returned slice: got %q", again)
+	}
+}
+
+func TestMemStoreEntryScoping(t *testing.T) {
+	s := NewMemStore()
+	ctx := context.Background()
+	_ = s.Set(ctx, Ref{Entry: "tenant-a", Path: "/secrets/model/key"}, []byte("a"))
+	_ = s.Set(ctx, Ref{Entry: "tenant-b", Path: "/secrets/model/key"}, []byte("b"))
+
+	a, _ := s.Get(ctx, Ref{Entry: "tenant-a", Path: "/secrets/model/key"}, types.Digest{})
+	b, _ := s.Get(ctx, Ref{Entry: "tenant-b", Path: "/secrets/model/key"}, types.Digest{})
+	if string(a) != "a" || string(b) != "b" {
+		t.Fatalf("entry scoping broken: a=%q b=%q", a, b)
+	}
+}
+
+func TestMemStoreJSONRoundTrip(t *testing.T) {
+	s := NewMemStore()
+	ctx := context.Background()
+	_ = s.Set(ctx, Ref{Entry: "e1", Path: "/secrets/a"}, []byte{1, 2, 3})
+	_ = s.Set(ctx, Ref{Entry: "e1", Path: "/secrets/b"}, []byte{4})
+	_ = s.Set(ctx, Ref{Entry: "e2", Path: "/secrets/c"}, []byte{})
+
+	dump, err := s.DumpJSON()
+	if err != nil {
+		t.Fatalf("dump: %v", err)
+	}
+
+	restored := NewMemStore()
+	if err := restored.LoadJSON(dump); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if restored.Len() != 3 {
+		t.Fatalf("restored %d secrets, want 3", restored.Len())
+	}
+	got, err := restored.Get(ctx, Ref{Entry: "e1", Path: "/secrets/a"}, types.Digest{})
+	if err != nil || len(got) != 3 || got[2] != 3 {
+		t.Fatalf("restored value wrong: %v %v", got, err)
+	}
+
+	if err := restored.LoadJSON([]byte(`{"e": {"/p": "not-base64!!"}}`)); err == nil {
+		t.Fatal("invalid base64 accepted")
+	}
+	if err := restored.LoadJSON([]byte(`{"e": {"/p": "AAE="}, "x-unknown": 1}`)); err == nil {
+		t.Fatal("unknown field accepted")
+	}
+}

--- a/pkg/secrets/identity.go
+++ b/pkg/secrets/identity.go
@@ -1,0 +1,106 @@
+package secrets
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+)
+
+// Domain separators for the broker-identity binding signature and response
+// signatures. Bump with the wire version.
+const (
+	encBindingDomainSep  = "c8s/secrets-broker-enc/v1\x00"
+	responseSigDomainSep = "c8s/secrets-response/v1\x00"
+)
+
+// SignEncryptionPubkey produces the binding signature a broker signing key
+// makes over its encryption pubkey, proving the CA-issued leaf endorses this
+// encryption key.
+func SignEncryptionPubkey(signingPriv *ecdsa.PrivateKey, encPub []byte) (string, error) {
+	digest := sha512.Sum384(append([]byte(encBindingDomainSep), encPub...))
+	sig, err := ecdsa.SignASN1(rand.Reader, signingPriv, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("secrets identity: sign encryption pubkey: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// Verify checks the broker identity's chain to a mesh CA root and returns the
+// verified (signing, encryption) public keys.
+func (bi BrokerIdentity) Verify(caRoots *x509.CertPool) (*ecdsa.PublicKey, []byte, error) {
+	leaf, err := parseOneCert(bi.SigningLeafPEM)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secrets identity: parse signing leaf: %w", err)
+	}
+	intermediates := x509.NewCertPool()
+	for block, rest := pem.Decode(bi.CAChainPEM); block != nil; block, rest = pem.Decode(rest) {
+		c, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("secrets identity: parse CA chain: %w", err)
+		}
+		intermediates.AddCert(c)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: caRoots, Intermediates: intermediates}); err != nil {
+		return nil, nil, fmt.Errorf("secrets identity: signing leaf does not chain to the mesh CA: %w", err)
+	}
+	signingPub, ok := leaf.PublicKey.(*ecdsa.PublicKey)
+	if !ok {
+		return nil, nil, errors.New("secrets identity: signing leaf is not ECDSA")
+	}
+
+	encPub, err := base64.StdEncoding.DecodeString(bi.EncryptionPubkey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secrets identity: encryption pubkey: %w", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(bi.EncryptionPubkeySig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secrets identity: encryption pubkey signature: %w", err)
+	}
+	digest := sha512.Sum384(append([]byte(encBindingDomainSep), encPub...))
+	if !ecdsa.VerifyASN1(signingPub, digest[:], sig) {
+		return nil, nil, errors.New("secrets identity: encryption pubkey not bound to the signing leaf")
+	}
+	return signingPub, encPub, nil
+}
+
+// SignResponse signs a wrapped fetch payload with the broker signing key.
+func SignResponse(signingPriv *ecdsa.PrivateKey, payload Wrapped) (string, error) {
+	digest := responseDigest(payload)
+	sig, err := ecdsa.SignASN1(rand.Reader, signingPriv, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("secrets: sign response: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(sig), nil
+}
+
+// VerifyResponseSignature checks a fetch response signature. It deliberately
+// does not verify the payload contents — that is Unwrap's job, and it only
+// succeeds for the holder of the request key.
+func VerifyResponseSignature(signingPub *ecdsa.PublicKey, payload Wrapped, signature string) error {
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		return fmt.Errorf("secrets: response signature encoding: %w", err)
+	}
+	digest := responseDigest(payload)
+	if !ecdsa.VerifyASN1(signingPub, digest[:], sig) {
+		return errors.New("secrets: response signature invalid")
+	}
+	return nil
+}
+
+func responseDigest(payload Wrapped) [48]byte {
+	return sha512.Sum384([]byte(responseSigDomainSep + payload.EphemeralPubkey + payload.Nonce + payload.Ciphertext))
+}
+
+func parseOneCert(certPEM []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, errors.New("no PEM block")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -1,0 +1,198 @@
+package secrets
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func pemEncode(blockType string, der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+}
+
+func TestReportDataForFetch(t *testing.T) {
+	req := FetchRequest{
+		InitContainerDigests: []string{"sha256:aaaa"},
+		ResponsePubkey:       "cHVi",
+		Requests:             []SecretRequest{{Digest: "sha256:x", Paths: []string{"/secrets/a"}}},
+	}
+	rd1, err := ReportDataForFetch([]byte("challenge-1"), req)
+	if err != nil {
+		t.Fatalf("report data: %v", err)
+	}
+	rd2, _ := ReportDataForFetch([]byte("challenge-1"), req)
+	if rd1 != rd2 {
+		t.Fatal("not deterministic")
+	}
+	rd3, _ := ReportDataForFetch([]byte("challenge-2"), req)
+	if rd1 == rd3 {
+		t.Fatal("challenge not bound")
+	}
+	req2 := req
+	req2.Requests[0].Paths = []string{"/secrets/b"}
+	rd4, _ := ReportDataForFetch([]byte("challenge-1"), req2)
+	if rd1 == rd4 {
+		t.Fatal("request body not bound")
+	}
+	req3 := req
+	req3.ResponsePubkey = "b3RoZXI"
+	rd5, _ := ReportDataForFetch([]byte("challenge-1"), req3)
+	if rd1 == rd5 {
+		t.Fatal("response pubkey not bound")
+	}
+}
+
+func TestWrapRoundTrip(t *testing.T) {
+	priv, pub, err := GenerateX25519()
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	blob, err := Wrap(pub, []byte("model-dek"), []byte("aad-context"))
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	out, err := Unwrap(priv, []byte("aad-context"), blob)
+	if err != nil {
+		t.Fatalf("unwrap: %v", err)
+	}
+	if string(out) != "model-dek" {
+		t.Fatalf("got %q", out)
+	}
+
+	// Wrong AAD fails.
+	if _, err := Unwrap(priv, []byte("other"), blob); err == nil {
+		t.Fatal("unwrap succeeded with wrong AAD")
+	}
+	// Wrong key fails.
+	priv2, _, _ := GenerateX25519()
+	if _, err := Unwrap(priv2, []byte("aad-context"), blob); err == nil {
+		t.Fatal("unwrap succeeded with wrong key")
+	}
+	// Tampered ciphertext fails.
+	blob.Ciphertext = base64.StdEncoding.EncodeToString([]byte("tampered-tampered"))
+	if _, err := Unwrap(priv, []byte("aad-context"), blob); err == nil {
+		t.Fatal("unwrap succeeded with tampered ciphertext")
+	}
+}
+
+func newTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("ca key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test mesh CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
+	if err != nil {
+		t.Fatalf("ca cert: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse ca: %v", err)
+	}
+	return cert, key
+}
+
+func issueBrokerLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatalf("leaf key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "c8s-secrets-broker"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, key.Public(), caKey)
+	if err != nil {
+		t.Fatalf("leaf: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	pemBytes := pemEncode("CERTIFICATE", der)
+	return cert, key, pemBytes
+}
+
+func TestBrokerIdentityVerify(t *testing.T) {
+	ca, caKey := newTestCA(t)
+	_, leafKey, leafPEM := issueBrokerLeaf(t, ca, caKey)
+	caPEM := pemEncode("CERTIFICATE", ca.Raw)
+
+	_, encPub, err := GenerateX25519()
+	if err != nil {
+		t.Fatalf("enc key: %v", err)
+	}
+	sig, err := SignEncryptionPubkey(leafKey, encPub)
+	if err != nil {
+		t.Fatalf("sign enc: %v", err)
+	}
+	bi := BrokerIdentity{
+		SigningLeafPEM:      leafPEM,
+		CAChainPEM:          caPEM,
+		EncryptionPubkey:    base64.StdEncoding.EncodeToString(encPub),
+		EncryptionPubkeySig: sig,
+	}
+
+	roots := x509.NewCertPool()
+	roots.AddCert(ca)
+	signingPub, gotEnc, err := bi.Verify(roots)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if string(gotEnc) != string(encPub) {
+		t.Fatal("encryption pubkey mismatch")
+	}
+
+	// Response sign/verify round trip.
+	blob, err := Wrap(encPub, []byte("payload"), nil)
+	if err != nil {
+		t.Fatalf("wrap: %v", err)
+	}
+	rsig, err := SignResponse(leafKey, blob)
+	if err != nil {
+		t.Fatalf("sign response: %v", err)
+	}
+	if err := VerifyResponseSignature(signingPub, blob, rsig); err != nil {
+		t.Fatalf("verify response: %v", err)
+	}
+	blob.Ciphertext = base64.StdEncoding.EncodeToString([]byte("tampered"))
+	if err := VerifyResponseSignature(signingPub, blob, rsig); err == nil {
+		t.Fatal("tampered payload passed signature check")
+	}
+
+	// Chain to a different root fails.
+	otherCA, _ := newTestCA(t)
+	otherRoots := x509.NewCertPool()
+	otherRoots.AddCert(otherCA)
+	if _, _, err := bi.Verify(otherRoots); err == nil {
+		t.Fatal("identity verified against the wrong CA")
+	}
+
+	// Swapped encryption key fails the binding.
+	_, encPub2, _ := GenerateX25519()
+	bi.EncryptionPubkey = base64.StdEncoding.EncodeToString(encPub2)
+	if _, _, err := bi.Verify(roots); err == nil {
+		t.Fatal("swapped encryption pubkey passed")
+	}
+}

--- a/pkg/secrets/transcript.go
+++ b/pkg/secrets/transcript.go
@@ -1,0 +1,62 @@
+package secrets
+
+import (
+	"crypto/sha512"
+	"encoding/binary"
+	"encoding/json"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// fetchDomainSep domain-separates the fetch transcript. Bump with the wire version.
+const fetchDomainSep = "c8s/secrets-fetch/v1\x00"
+
+// transcriptInput is the canonical form folded into the attestation
+// REPORTDATA alongside the challenge: everything the release decision is made
+// on, so a tampered claim, response key, or requested path fails evidence
+// verification. List order is significant — both sides marshal the same value.
+type transcriptInput struct {
+	InitContainerDigests []string        `json:"init_container_digests"`
+	ContainerDigests     []string        `json:"container_digests"`
+	ResponsePubkey       string          `json:"response_pubkey"`
+	Requests             []SecretRequest `json:"requests"`
+}
+
+// ReportDataForFetch computes the expected attestation REPORTDATA for a fetch
+// request, mirroring ratls.ReportDataForKeyAndClaims: a domain-separated,
+// length-framed SHA-384 transcript so no two distinct (challenge, request)
+// pairs share a preimage:
+//
+//	SHA-384(domainSep || framed(challenge) || framed(canonical(request)))
+//	  where framed(x) = uint64-BE(len(x)) || x
+//	  canonical(request) = json.Marshal of the request sans evidence
+func ReportDataForFetch(challenge []byte, req FetchRequest) ([64]byte, error) {
+	canonical, err := json.Marshal(transcriptInput{
+		InitContainerDigests: req.InitContainerDigests,
+		ContainerDigests:     req.ContainerDigests,
+		ResponsePubkey:       req.ResponsePubkey,
+		Requests:             req.Requests,
+	})
+	if err != nil {
+		return [64]byte{}, err
+	}
+
+	var out [64]byte
+	h := sha512.New384()
+	h.Write([]byte(fetchDomainSep))
+	for _, field := range [][]byte{challenge, canonical} {
+		var size [8]byte
+		binary.BigEndian.PutUint64(size[:], uint64(len(field)))
+		h.Write(size[:])
+		h.Write(field)
+	}
+	copy(out[:], h.Sum(nil))
+	return out, nil
+}
+
+// VerifyReportData wraps the fetch transcript into the attestation-api verify
+// request, the same shape /attest uses.
+func VerifyReportData(evidence types.AttestationEvidence, reportData [64]byte) types.VerifyRequest {
+	rd := types.NewBase64Bytes(reportData[:sha512.Size384])
+	return types.VerifyReportData(evidence, rd)
+}

--- a/pkg/secrets/types.go
+++ b/pkg/secrets/types.go
@@ -1,0 +1,70 @@
+// Package secrets carries the wire contract between the CDS secrets broker
+// and its clients (the c8s-secrets init container, the operator CLI): request
+// and response types, the attestation transcript, the response wrap, and the
+// broker-identity document. The broker itself lives in internal/cmds/cds; the
+// store interface in internal/secretstore. See docs/secrets-broker.md.
+package secrets
+
+import (
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// SecretRequest asks for the values at the given paths on behalf of one
+// container digest. Grants are resolved per (entry, digest, path) at CDS.
+type SecretRequest struct {
+	Digest string   `json:"digest"`
+	Paths  []string `json:"paths"`
+}
+
+// FetchRequest is the body of POST /secrets/fetch. The init/main digest lists
+// are the pod's claimed non-injected container set (the webhook passes them
+// from the digest-pinned pod spec); CDS resolves them to exactly one workload
+// entry and grants only that entry's per-digest paths.
+type FetchRequest struct {
+	Challenge string                    `json:"challenge"`
+	Evidence  types.AttestationEvidence `json:"evidence"`
+
+	InitContainerDigests []string `json:"init_container_digests,omitempty"`
+	ContainerDigests     []string `json:"container_digests,omitempty"`
+
+	// ResponsePubkey is the standard-base64 raw X25519 public key the
+	// response is wrapped to. It rides the attestation transcript, so a
+	// relay cannot swap it without failing evidence verification.
+	ResponsePubkey string `json:"response_pubkey"`
+
+	Requests []SecretRequest `json:"requests"`
+}
+
+// FetchResponse is the success body of POST /secrets/fetch. Payload is the
+// wrapped canonical JSON of map[path]base64(value); Signature is the broker
+// signing leaf's ECDSA over it. Clients verify the signature against the
+// broker identity (which chains to the mesh CA) before unwrapping.
+type FetchResponse struct {
+	Payload   Wrapped `json:"payload"`
+	Signature string  `json:"signature"`
+}
+
+// Wrapped is a one-shot X25519 + HKDF-SHA256 + AES-256-GCM sealed message:
+// the sender's ephemeral public key, the nonce, and the ciphertext. See wrap.go.
+type Wrapped struct {
+	EphemeralPubkey string `json:"ephemeral_pubkey"`
+	Nonce           string `json:"nonce"`
+	Ciphertext      string `json:"ciphertext"`
+}
+
+// BrokerIdentity is served at GET /secrets/broker-identity. It proves the
+// endpoint holds the mesh CA key (the one secret a same-measurement fake CDS
+// lacks): the signing leaf chains to the mesh CA, and the encryption pubkey is
+// bound to the leaf by signature. See docs/secrets-broker.md.
+type BrokerIdentity struct {
+	// SigningLeafPEM is the broker's ECDSA P-384 leaf issued by the mesh CA.
+	SigningLeafPEM []byte `json:"signing_leaf_pem"`
+	// CAChainPEM is the mesh CA chain the leaf verifies against.
+	CAChainPEM []byte `json:"ca_chain_pem"`
+	// EncryptionPubkey is the standard-base64 raw X25519 public key deposit
+	// values are wrapped to.
+	EncryptionPubkey string `json:"encryption_pubkey"`
+	// EncryptionPubkeySig is the standard-base64 ECDSA signature by the
+	// signing leaf over the encryption pubkey (domain-separated, identity.go).
+	EncryptionPubkeySig string `json:"encryption_pubkey_signature"`
+}

--- a/pkg/secrets/wrap.go
+++ b/pkg/secrets/wrap.go
@@ -1,0 +1,118 @@
+package secrets
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+)
+
+// wrapHKDFInfo domain-separates the key derivation. Bump with the wire version.
+const wrapHKDFInfo = "c8s/secrets-wrap/v1"
+
+// FetchAAD binds a wrapped fetch payload to the fetch flow.
+const FetchAAD = "c8s/secrets-fetch-response/v1"
+
+// DepositAAD binds a wrapped operator deposit to its destination ref.
+func DepositAAD(entry, path string) []byte {
+	return []byte("c8s/secrets-deposit/v1\x00" + entry + "\x00" + path)
+}
+
+// Wrap seals plaintext to a recipient's raw X25519 public key with a fresh
+// ephemeral key: ECDH(ephemeral, recipient) → HKDF-SHA256 → AES-256-GCM. The
+// construction mirrors pkg/overenc's channel derivation, shrunk to one shot.
+// AAD binds the ciphertext to purpose, so a blob cut from one flow cannot be
+// replayed into another.
+func Wrap(recipientPub, plaintext, aad []byte) (Wrapped, error) {
+	pub, err := ecdh.X25519().NewPublicKey(recipientPub)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: parse recipient key: %w", err)
+	}
+	eph, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: generate ephemeral key: %w", err)
+	}
+	shared, err := eph.ECDH(pub)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: ECDH: %w", err)
+	}
+	nonce := make([]byte, 12)
+	if _, err := rand.Read(nonce); err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: nonce: %w", err)
+	}
+	key, err := hkdf.Key(sha256.New, shared, nonce, wrapHKDFInfo, 32)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: HKDF: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: AES: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return Wrapped{}, fmt.Errorf("secrets wrap: GCM: %w", err)
+	}
+	return Wrapped{
+		EphemeralPubkey: base64.StdEncoding.EncodeToString(eph.PublicKey().Bytes()),
+		Nonce:           base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext:      base64.StdEncoding.EncodeToString(aead.Seal(nil, nonce, plaintext, aad)),
+	}, nil
+}
+
+// Unwrap opens a Wrapped blob with the recipient's raw X25519 private key.
+func Unwrap(recipientPriv, aad []byte, blob Wrapped) ([]byte, error) {
+	priv, err := ecdh.X25519().NewPrivateKey(recipientPriv)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: parse private key: %w", err)
+	}
+	ephPubBytes, err := base64.StdEncoding.DecodeString(blob.EphemeralPubkey)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: ephemeral key: %w", err)
+	}
+	ephPub, err := ecdh.X25519().NewPublicKey(ephPubBytes)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: parse ephemeral key: %w", err)
+	}
+	nonce, err := base64.StdEncoding.DecodeString(blob.Nonce)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: nonce: %w", err)
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(blob.Ciphertext)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: ciphertext: %w", err)
+	}
+	shared, err := priv.ECDH(ephPub)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: ECDH: %w", err)
+	}
+	key, err := hkdf.Key(sha256.New, shared, nonce, wrapHKDFInfo, 32)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: HKDF: %w", err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: AES: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: GCM: %w", err)
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		return nil, fmt.Errorf("secrets unwrap: open: %w", err)
+	}
+	return plaintext, nil
+}
+
+// GenerateX25519 returns a fresh raw (private, public) key pair.
+func GenerateX25519() (priv, pub []byte, err error) {
+	k, err := ecdh.X25519().GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("secrets: generate X25519 key: %w", err)
+	}
+	return k.Bytes(), k.PublicKey().Bytes(), nil
+}

--- a/pkg/types/error_codes.go
+++ b/pkg/types/error_codes.go
@@ -18,4 +18,8 @@ const (
 	ErrorCodeInternal                  = "internal"
 	ErrorCodeAttestationUnavailable    = "attestation_unavailable"
 	ErrorCodeBindingUnavailable        = "binding_unavailable"
+	ErrorCodeMeasurementNotConfigured  = "measurement_not_configured"
+	ErrorCodeGrantDenied               = "grant_denied"
+	ErrorCodeEntryAmbiguous            = "entry_ambiguous"
+	ErrorCodeSecretNotFound            = "secret_not_found"
 )


### PR DESCRIPTION
The CDS now brokers application secrets to attested workloads, consuming the allowlist PathPolicy field (#135):

- internal/secretstore: Store interface (Get/Set/Delete on Ref{Entry,Path}) and an in-memory implementation; KMS adapters (openbao/vault/AWS KMS) implement it in follow-ups.
- POST /secrets/fetch: challenge + evidence + launch-measurement pin (fail-closed when empty, unlike /attest) + claimed-set → workload-entry resolution (ambiguous ⇒ 403) + per-(digest, path) grant checks.
- Broker identity: mesh-CA-issued signing leaf + bound X25519 encryption key at GET /secrets/broker-identity. Responses are wrapped to the requester's evidence-bound ephemeral key and signed, so a fake or relay CDS — including a same-measurement one — can neither read nor fabricate.
- Operator routes (operator-JWT, wrapped values): PUT/GET/DELETE /secrets/entries/{entry}/paths/{path}, plus `c8s secrets put|get|delete`.
- lint: grants require exact argv, /secrets/ root, identical-set entries with grants fail closed, same-entry 'any' widening warned.
- Docs: docs/secrets-broker.md (design), THREAT_MODEL §1/§4/§5/§7, allowlist-and-capabilities paths section, README roadmap.

Workload-side delivery (c8s-secrets init container + webhook injection) and kata wiring land in follow-up PRs. The claim-forgery residual (Corner-5 class) is documented in THREAT_MODEL §5 as Addressable.