### PR TITLE
feat(ci): run the TDX bare-metal lane on merge alongside SNP

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -1,4 +1,21 @@
 # ═══════════════════════════════════════════════════════════════════════════
+# VENDORED FILE. SOURCE OF TRUTH LIVES IN confidential-ci.
+# ═══════════════════════════════════════════════════════════════════════════
+# UPSTREAM: confidential-dot-ai/confidential-ci  .github/workflows/cvm-e2e.yml
+# THIS FILE: confidential-dot-ai/c8s             .github/workflows/cvm-e2e.yml
+#
+# WHY A COPY: c8s is PUBLIC and confidential-ci is PRIVATE, and a public repo
+# cannot `uses:` a private repo's reusable workflow. Vendoring is the stopgap.
+#
+# THESE TWO COPIES HAVE ALREADY DIVERGED, and it went unnoticed: upstream grew
+# a tdx-metal arm this copy never had, then had it removed again. Neither file
+# referenced the other, so nothing could detect it. Reconciling them is separate
+# work; this banner exists so the next person knows to look.
+#
+# WHEN CHANGING THIS FILE: change the upstream copy too, or say in the PR why the
+# two must differ. A silent one-sided edit is how the drift above happened.
+#
+# ═══════════════════════════════════════════════════════════════════════════
 # THE PRIMITIVE — "run CI inside a CVM", reusable across the whole stack.
 # ═══════════════════════════════════════════════════════════════════════════
 #

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -1,4 +1,20 @@
 # ═══════════════════════════════════════════════════════════════════════════
+# VENDORED FILE. SOURCE OF TRUTH LIVES IN confidential-ci.
+# ═══════════════════════════════════════════════════════════════════════════
+# UPSTREAM: confidential-dot-ai/confidential-ci  .github/workflows/e2e-c8s.yml
+# THIS FILE: confidential-dot-ai/c8s             .github/workflows/e2e-c8s.yml
+#
+# WHY A COPY: c8s is PUBLIC and confidential-ci is PRIVATE, and a public repo
+# cannot `uses:` a private repo's reusable workflow. Vendoring is the stopgap.
+#
+# This copy and its upstream have diverged over time. Treat upstream as the
+# reference when they disagree, and reconcile deliberately rather than by
+# copying whichever was edited most recently.
+#
+# WHEN CHANGING THIS FILE: change the upstream copy too, or say in the PR why the
+# two must differ. A silent one-sided edit is how the drift above happened.
+#
+# ═══════════════════════════════════════════════════════════════════════════
 # CONSUMER: c8s — the flagship payload ("install c8s + prove a cw workload runs")
 # ═══════════════════════════════════════════════════════════════════════════
 #
@@ -297,3 +313,20 @@ jobs:
       runner: ${{ matrix.runner }}
       flavor: rke2-node
       payload_b64: ${{ needs.payload.outputs.b64 }}
+
+
+  # TDX metal, a SIBLING JOB rather than another row of the matrix above.
+  # A reusable-workflow `uses:` must be a static literal, so it cannot be driven
+  # by ${{ matrix }} (confidential-ci research/ADR-matrix-architecture-2026-07-20).
+  # It would want to be a separate job regardless: the two lanes use different
+  # transports, console for SNP and RA-TLS for TDX, and folding them into one
+  # reusable workflow is exactly the two-drivers-in-one-file shape that was just
+  # removed from cvm-e2e.yml.
+  # Same trigger as `e2e` above, so one merge exercises both lanes.
+  tdx:
+    # No `needs: payload`. The TDX lane is self-contained and does not consume
+    # payload_b64, and it boots on a different host from the SNP lane, so the
+    # two run in parallel rather than one waiting on the other.
+    uses: ./.github/workflows/tdx-metal-e2e.yml
+    with:
+      c8s_ref: ${{ inputs.c8s_ref }}

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -327,6 +327,23 @@ jobs:
     # No `needs: payload`. The TDX lane is self-contained and does not consume
     # payload_b64, and it boots on a different host from the SNP lane, so the
     # two run in parallel rather than one waiting on the other.
+    #
+    # DELIBERATELY PASSES NO c8s_ref, AND THAT MATTERS. Read before "fixing" it.
+    # The TDX node image bakes its NRI admission floor from the c8s ref it was
+    # BUILT from (currently 64b6d7a, published in the tdx-rke2-image-refs
+    # ConfigMap). That floor is fail-closed, so installing any OTHER c8s ref
+    # means that ref's own components are not in the floor and get denied. The
+    # lane warns about exactly this: "the floor is fail-closed, so an unpaired
+    # ref is the likeliest cause of a red run". Passing the merge head here
+    # would turn TDX red on every single merge.
+    #
+    # SO BE CLEAR ABOUT WHAT THIS JOB PROVES. It boots a real TD, attests it,
+    # installs the PAIRED c8s, asserts the components converge, and asserts the
+    # baked floor denies a non-allowlisted image. That is a full health check of
+    # the confidential stack, the host, the node image and the runner. It does
+    # NOT test the code in the merge that triggered it. The SNP lane does that.
+    #
+    # TO GET REAL MERGE-CODE COVERAGE ON TDX, a TDX node image has to be built
+    # per c8s merge so its floor pairs with the merge head. That is the actual
+    # blocker, and it lives in the image pipeline, not here.
     uses: ./.github/workflows/tdx-metal-e2e.yml
-    with:
-      c8s_ref: ${{ inputs.c8s_ref }}

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -324,6 +324,9 @@ jobs:
   # removed from cvm-e2e.yml.
   # Same trigger as `e2e` above, so one merge exercises both lanes.
   tdx:
+    # Mirrors the SNP path's matrix-derived label, `e2e (snp-metal, cvm-launcher)`,
+    # so the two lanes line up in the run tree instead of reading as unrelated.
+    name: tdx (tdx-metal, cvm-launcher-tdx)
     # No `needs: payload`. The TDX lane is self-contained and does not consume
     # payload_b64, and it boots on a different host from the SNP lane, so the
     # two run in parallel rather than one waiting on the other.

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -90,7 +90,9 @@ env:
 
 jobs:
   e2e:
-    name: c8s on TDX metal
+    # Named to match the SNP primitive's leaf, `cvm (<platform>/<flavor>)`,
+    # so both lanes read the same way in the run tree.
+    name: cvm (tdx-metal/rke2-node)
     # The HOST-side launcher runner on tdx-gh-runner. Its bm-e2e SA is scoped to
     # confai-images (baremetal/kubevirt-rbac.yaml); kubectl uses the in-cluster
     # token, so there is no kubeconfig to manage for the OUTER cluster.

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -1,0 +1,435 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# VENDORED FILE, TWO COPIES, KEEP THEM BYTE-IDENTICAL.
+# ═══════════════════════════════════════════════════════════════════════════
+# SOURCE OF TRUTH:
+#   confidential-dot-ai/confidential-ci  .github/workflows/tdx-metal-e2e.yml
+# VENDORED COPY:
+#   confidential-dot-ai/c8s              .github/workflows/tdx-metal-e2e.yml
+#
+# WHY A COPY EXISTS AT ALL: c8s is PUBLIC and confidential-ci is PRIVATE, and a
+# public repo cannot `uses:` a private repo's reusable workflow. Vendoring is
+# the workaround, the same one cvm-e2e.yml and e2e-c8s.yml already use. It is a
+# stopgap, not a design: see confidential-ci research/ADR-matrix-architecture.
+#
+# THE DRIFT HAZARD IS REAL, NOT THEORETICAL. c8s's vendored cvm-e2e.yml silently
+# fell 121 lines behind its confidential-ci original and lost an entire platform
+# arm. Nothing detected it, because neither copy referenced the other.
+#
+# THE RULE: edit the source of truth, then copy the WHOLE file across unchanged.
+# Both copies carry both triggers (workflow_call and workflow_dispatch) precisely
+# so that no per-repo edit is ever needed and a plain checksum can prove they
+# match. If you find yourself wanting to change only one copy, that is the signal
+# to stop vendoring and solve it properly instead.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# c8s on TDX BARE METAL: the product lane
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Boots the PUBLISHED, UNMODIFIED c8s node image as an Intel TDX CVM on
+# tdx-gh-runner, installs the c8s bundle into it, and asserts the product's
+# security guarantee: the baked NRI floor DENIES a non-allowlisted image.
+#
+# Proven by hand on hardware 2026-07-26 before this lane existed: image
+# imported via CDI, CVM booted, operator-key-bound kubeconfig obtained over
+# RA-TLS, `c8s install` deployed cds/operator/ratls-mesh/tls-lb, and busybox
+# was denied with "image not in allowlist".
+#
+# WHY THIS LANE HAS NO SERIAL CONSOLE (and the SNP lane does): the c8s node
+# image is console-dead by design (hardened kernel, no CONFIG_SERIAL_8250, no
+# sshd, root locked). Its supported entrypoint is the network: attestation-api
+# on :8400, kube-apiserver on :6443, cred-release on :8443. That works here
+# only because this host's OUTER cluster was renumbered to 172.20/172.21, so a
+# guest running rke2's default 10.42/10.43 no longer collides with it. The SNP
+# lane cannot do this: its cluster is live on 10.42 and RKE2 CIDRs are fixed at
+# init. Consequence worth keeping: no secret ever transits a loggable channel
+# here, so this lane is free of the console PEM-leak gap the SNP lane carries.
+#
+# DISPATCH-ONLY for v1 (no schedule/merge trigger until it has a green history).
+name: tdx-metal-e2e
+
+on:
+  # workflow_call so the vendored copy can be invoked as a job by c8s's
+  # e2e-c8s.yml. workflow_dispatch so either copy stays runnable by hand.
+  # Both copies carry both, so the two files remain byte-identical.
+  workflow_call:
+    inputs:
+      c8s_ref:
+        description: 'c8s ref to test. Defaults to the ref paired with the node image.'
+        required: false
+        type: string
+        default: ''
+      keep_cvm:
+        description: 'leave the CVM running for debugging instead of tearing it down'
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      c8s_ref:
+        description: 'c8s git ref to install + test. Empty = the c8sRef pinned in the tdx-rke2-image-refs CM (VERSION PAIRING: the node image bakes an admission floor containing the bootstrap digests from ITS build ref, so a mismatched CLI gets its own components denied).'
+        required: false
+        default: ''
+      keep_cvm:
+        description: 'Skip teardown to debug a failure. The reaper still clears it after 3h.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # One at a time: the lane boots a CVM off a shared RWO rootdisk PVC.
+  group: tdx-metal-e2e
+  cancel-in-progress: false
+
+env:
+  NS: confai-images
+  REFS_CM: tdx-rke2-image-refs
+  VM: c8s-tdx-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  e2e:
+    name: c8s on TDX metal
+    # The HOST-side launcher runner on tdx-gh-runner. Its bm-e2e SA is scoped to
+    # confai-images (baremetal/kubevirt-rbac.yaml); kubectl uses the in-cluster
+    # token, so there is no kubeconfig to manage for the OUTER cluster.
+    runs-on: cvm-launcher-tdx
+    # CDI import is pre-staged, so: boot ~1m + guest first boot ~3m + c8s CLI
+    # build ~3m + install/converge ~3m + asserts. Headroom for a cold go cache.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: tools (kubectl, go, crane, helm)
+        run: |
+          set -euo pipefail
+          mkdir -p "$PWD/bin"
+          curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl
+          chmod +x bin/kubectl
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+          if ! command -v go >/dev/null; then
+            GOVER="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -1 | sed 's/^go//')"
+            [ -n "$GOVER" ] || GOVER=1.26.3
+            curl -fsSL "https://go.dev/dl/go${GOVER}.linux-amd64.tar.gz" | sudo tar -C /usr/local -xz
+          fi
+          # $GITHUB_PATH only affects LATER steps, so `go` is still not on PATH
+          # inside THIS one. `go install crane` below needs it here and now.
+          export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          # crane: `c8s install --resolve-digests=true` below shells out to it.
+          # Pinned rather than fetched through the GitHub releases API, which
+          # rate-limits by IP on a shared self-hosted host.
+          command -v crane >/dev/null || go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+          # helm: c8s install shells out to it too. The ephemeral ARC pod has
+          # neither binary, unlike the host, so install rather than assume.
+          if ! command -v helm >/dev/null; then
+            curl -fsSL https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz \
+              | tar -xz -C "$PWD/bin" --strip-components=1 linux-amd64/helm
+          fi
+
+      # reap-before-provision: a killed run leaks a CVM (and its scratch PVC).
+      # Fail SAFE: only reap on a positive "completed", or on age. An unknown
+      # status (403/404/no token) KEEPS the CVM rather than killing a live run.
+      - name: reap leaked CVMs from finished runs
+        run: |
+          set +e +o pipefail
+          NOW=$(date -u +%s)
+          for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
+            rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
+            standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
+            [ "$standing" = "true" ] && { echo "keeping $vm (standing runner)"; continue; }
+            [ -z "$rid" ] && continue
+            [ "$rid" = "${{ github.run_id }}" ] && continue
+            ct=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null)
+            age=$(( NOW - $(date -u -d "$ct" +%s 2>/dev/null || echo "$NOW") ))
+            if [ "$age" -gt 10800 ]; then
+              echo "reaping $vm (age ${age}s > 3h)"
+              kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+              kubectl -n "$NS" delete pvc "${vm#virtualmachine.kubevirt.io/}-scratch" --ignore-not-found --wait=false
+            fi
+          done
+          exit 0
+
+      - name: resolve image refs + the paired c8s ref
+        run: |
+          set -euo pipefail
+          for k in image rootPvc mrtd c8sRef; do
+            v=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath="{.data.$k}" 2>/dev/null)
+            [ -n "$v" ] || { echo "::error::$REFS_CM missing '$k'. The TDX refs CM is the single source of truth for image+measurement+paired ref"; exit 1; }
+            echo "$k=$v" >> "$GITHUB_ENV"
+          done
+          # An explicit input overrides the pin, but say so loudly: the floor is
+          # fail-closed, so an unpaired ref is the likeliest cause of a red run.
+          if [ -n '${{ inputs.c8s_ref }}' ]; then
+            echo "::warning title=version pairing::testing c8s_ref='${{ inputs.c8s_ref }}' against an image built from '$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.c8sRef}')': components may be denied by the baked floor"
+            echo "c8sRef=${{ inputs.c8s_ref }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: preflight, TDX device capacity
+        # KubeVirt's socket device-plugin probes the QGS socket ONLY at
+        # virt-handler startup and never re-checks. After a host reboot or a
+        # qgsd/bridge restart it advertises 0 forever and every TDX VM fails to
+        # schedule with a misleading "Insufficient devices". Seen in the wild
+        # 2026-07-26 on a 26h-old virt-handler while QGS was perfectly healthy.
+        # Cheap to detect here; the remedy needs cluster-scoped rights the
+        # bm-e2e SA deliberately lacks, so this reports rather than fixes.
+        run: |
+          set -uo pipefail
+          if kubectl auth can-i get nodes >/dev/null 2>&1; then
+            N=$(kubectl get node -l kubevirt.io/tdx=true -o jsonpath='{.items[0].status.allocatable.devices\.kubevirt\.io/tdx}' 2>/dev/null)
+            echo "devices.kubevirt.io/tdx = ${N:-unknown}"
+            if [ "${N:-0}" = "0" ]; then
+              echo "::error title=TDX devices exhausted::virt-handler is advertising 0 TDX devices. Fix on the host: kubectl -n kubevirt rollout restart daemonset/virt-handler"
+              exit 1
+            fi
+          else
+            echo "no node read permission (expected: bm-e2e is namespace-scoped); relying on the scheduling gate below"
+          fi
+
+      - name: per-run operator key + opkeydata secret
+        # The initrd mounts the ISO labelled "opkeydata", SHA-384s the file
+        # named `pubkey`, and extends that into RTMR[3]. cred-release then
+        # refuses to serve if the on-disk key does not match RTMR[3], so the
+        # kubeconfig we fetch is cryptographically bound to THIS keypair.
+        run: |
+          set -euo pipefail
+          umask 077
+          openssl ecparam -name prime256v1 -genkey -noout -out /tmp/op.key
+          openssl ec -in /tmp/op.key -pubout -out /tmp/op.pub 2>/dev/null
+          kubectl -n "$NS" create secret generic "$VM-opkey" \
+            --from-file=pubkey=/tmp/op.pub --dry-run=client -o yaml | kubectl apply -f -
+          echo "operator key bound (sha384 $(sha384sum < /tmp/op.pub | cut -c1-16)...)"
+
+      - name: boot the TDX CVM
+        run: |
+          set -euo pipefail
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: $VM-scratch
+            namespace: $NS
+            labels: {ci.confidential.ai/managed: "true"}
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources: {requests: {storage: 80Gi}}
+            storageClassName: local-path
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata: {name: $VM-cloudinit, namespace: $NS}
+          type: Opaque
+          stringData:
+            userdata: |
+              #cloud-config
+              hostname: ${VM}
+          ---
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: $VM
+            namespace: $NS
+            labels:
+              ci.confidential.ai/managed: "true"
+              ci.confidential.ai/run-id: "${{ github.run_id }}"
+            annotations:
+              ci.confidential.ai/repo: "${{ github.repository }}"
+              ci.confidential.ai/run-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          spec:
+            runStrategy: Always
+            template:
+              metadata:
+                labels: {kubevirt.io/domain: $VM}
+              spec:
+                nodeSelector:
+                  kubevirt.io/tdx: "true"
+                domain:
+                  cpu:
+                    # host-passthrough is MANDATORY: QEMU rejects a named model
+                    # for TDX ("Named cpu model is not supported for TDX yet!").
+                    model: host-passthrough
+                    cores: 4
+                  devices:
+                    autoattachVSOCK: true
+                    disks:
+                      - name: rootdisk
+                        # dm-verity rootfs: never written. readonly takes a
+                        # SHARED qemu lock so concurrent CVMs coexist; a
+                        # writable open takes an EXCLUSIVE one and starves every
+                        # other guest on the same PVC (cost the SNP lane a day).
+                        # NB: readonly is a field of `disk`, not a sibling of it;
+                        # KubeVirt's strict decoder rejects the sibling form.
+                        disk: {bus: virtio, readonly: true}
+                      - name: scratch
+                        disk: {bus: virtio}
+                        # HARD requirement: the initrd keys the encrypted
+                        # overlay off this exact serial. Without it the guest
+                        # falls back to a 2G tmpfs and rke2 wedges when full.
+                        serial: confai-scratch
+                      - name: opkey
+                        disk: {bus: virtio}
+                      - name: cloudinit
+                        disk: {bus: virtio}
+                    interfaces: [{name: default, masquerade: {}}]
+                    rng: {}
+                  firmware: {bootloader: {efi: {secureBoot: false}}}
+                  # Empty object: TDX takes no per-VM policy. Cluster config
+                  # lives in the KubeVirt CR (confidentialCompute.tdx.attestation).
+                  launchSecurity: {tdx: {}}
+                  memory: {guest: 16Gi}
+                  resources: {requests: {memory: 16Gi}}
+                networks: [{name: default, pod: {}}]
+                volumes:
+                  - name: rootdisk
+                    persistentVolumeClaim: {claimName: $rootPvc}
+                  - name: scratch
+                    persistentVolumeClaim: {claimName: $VM-scratch}
+                  - name: opkey
+                    secret: {secretName: $VM-opkey, volumeLabel: opkeydata}
+                  - name: cloudinit
+                    cloudInitNoCloud: {secretRef: {name: $VM-cloudinit}}
+          EOF
+          for i in $(seq 1 60); do
+            PHASE=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+            [ "$PHASE" = Running ] && break
+            sleep 5
+          done
+          if [ "${PHASE:-}" != Running ]; then
+            kubectl -n "$NS" describe vmi "$VM" | tail -25
+            echo "::error::VMI not Running (phase=${PHASE:-none}). 'Insufficient devices.kubevirt.io/tdx' means virt-handler latched 0: rollout restart daemonset/virt-handler -n kubevirt"
+            exit 1
+          fi
+          IP=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.interfaces[0].ipAddress}')
+          [ -n "$IP" ] || { echo "::error::no guest IP"; exit 1; }
+          echo "GUEST_IP=$IP" >> "$GITHUB_ENV"
+          echo "VMI Running at $IP"
+
+      - name: assert genuine TDX launch
+        run: |
+          set -euo pipefail
+          POD=$(kubectl -n "$NS" get pods -l kubevirt.io/domain="$VM" -o name | head -1)
+          kubectl -n "$NS" exec "$POD" -c compute -- \
+            bash -c 'tr "\0" "\n" < /proc/$(pgrep -f qemu-system | head -1)/cmdline | grep -c "tdx-guest"' | tee /tmp/tdx.cnt
+          [ "$(cat /tmp/tdx.cnt)" -ge 1 ] || { echo "::error::qemu has no tdx-guest object: not a genuine trust domain"; exit 1; }
+          echo "OK: qemu launched with -object tdx-guest"
+
+      - name: wait for guest services (attestation-api, apiserver, cred-release)
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 90); do
+            H=$(curl -s --connect-timeout 2 --max-time 4 "http://$GUEST_IP:8400/health" 2>/dev/null || true)
+            [ -n "$H" ] && { echo "attestation-api: $H"; break; }
+            sleep 10
+          done
+          echo "$H" | grep -q '"platform":"tdx"' || { echo "::error::attestation-api did not report platform=tdx"; exit 1; }
+          for i in $(seq 1 60); do
+            C=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$GUEST_IP:6443/livez" 2>/dev/null || true)
+            case "$C" in 200|401|403) echo "kube-apiserver: HTTP $C"; break;; esac
+            sleep 5
+          done
+          for i in $(seq 1 60); do
+            C=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$GUEST_IP:8443/" 2>/dev/null || true)
+            [ -n "$C" ] && [ "$C" != 000 ] && { echo "cred-release: HTTP $C"; break; }
+            sleep 5
+          done
+
+      - name: build the c8s CLI at the paired ref
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/c8s-src
+          git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src
+          git -C /tmp/c8s-src checkout -q "$c8sRef" || { echo "::error::bad c8s ref '$c8sRef': refusing to silently test main"; exit 1; }
+          echo "c8s ref sha: $(git -C /tmp/c8s-src rev-parse HEAD)"
+          ( cd /tmp/c8s-src && go install ./cmd/c8s )
+          # An unstamped build reports "dev", which is exactly why --image-tag
+          # is passed explicitly at install rather than trusting build metadata.
+          c8s --version || true
+
+      - name: get an attested, operator-key-bound kubeconfig (RA-TLS)
+        run: |
+          set -euo pipefail
+          c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --out /tmp/guest.kubeconfig --timeout 180s
+          [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }
+          WHO=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+          [ "$WHO" = operator ] || { echo "::error::unexpected identity '$WHO'"; exit 1; }
+          echo "OK: attested kubeconfig, identity=$WHO"
+          KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes
+
+      - name: install the c8s bundle under test
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          c8s install --cvm-mode node --single-node --hardware-platform tdx \
+            --image-tag "$c8sRef" \
+            --operator-keys /tmp/op.pub \
+            --measurements "$mrtd" \
+            --resolve-digests=true
+          kubectl -n c8s-system get pods -o wide
+
+      - name: assert components converged
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          # awk, not a regex backreference: `$2 !~ /^([0-9]+)\/\1$/` looks right
+          # and is not (awk has no backreferences), so it silently only ever
+          # matches 1/1 and calls every sidecar-bearing pod not-ready.
+          for i in $(seq 1 40); do
+            NOTREADY=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | awk '{split($2,a,"/"); if (a[1]!=a[2] || $3!="Running") n++} END {print n+0}')
+            TOTAL=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | wc -l)
+            [ "$TOTAL" -gt 0 ] && [ "$NOTREADY" -eq 0 ] && { echo "all $TOTAL components Running"; break; }
+            sleep 15
+          done
+          kubectl -n c8s-system get pods --no-headers
+          [ "${NOTREADY:-1}" -eq 0 ] || { echo "::error::components did not converge"; kubectl -n c8s-system describe pods | tail -40; exit 1; }
+
+      - name: NEGATIVE, the baked floor must deny a non-allowlisted image
+        # The product's core guarantee, asserted rather than worked around.
+        # Uses the `default` namespace deliberately: the node image bakes a
+        # restricted PSA default and exempts `default` for smoke pods, so a
+        # denial here is unambiguously the IMAGE floor, not PodSecurity.
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          kubectl -n default delete pod denied --ignore-not-found >/dev/null 2>&1 || true
+          kubectl -n default run denied --image=busybox:1.36 --restart=Never --command -- sleep 300
+          for i in $(seq 1 24); do
+            R=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+            [ -n "$R" ] && [ "$R" != ContainerCreating ] && break
+            sleep 5
+          done
+          MSG=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.message}' 2>/dev/null || true)
+          echo "reason=$R"
+          echo "message=$MSG"
+          echo "$MSG" | grep -q 'image not in allowlist' || {
+            echo "::error title=SECURITY REGRESSION::the baked NRI floor did NOT deny a non-allowlisted image (reason=$R). The product's fail-closed admission guarantee is not holding on this image."
+            kubectl -n default describe pod denied | tail -20
+            exit 1
+          }
+          echo "OK: floor denied busybox:1.36 at container creation"
+          kubectl -n default delete pod denied --wait=false >/dev/null 2>&1 || true
+
+      - name: summary
+        if: always()
+        run: |
+          {
+            echo "### c8s on TDX metal"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| image | \`${image:-?}\` |"
+            echo "| rootPvc | \`${rootPvc:-?}\` |"
+            echo "| c8s ref | \`${c8sRef:-?}\` |"
+            echo "| MRTD | \`${mrtd:0:32}...\` |"
+            echo "| guest | \`${GUEST_IP:-?}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: teardown
+        if: always() && inputs.keep_cvm != true
+        run: |
+          set +e
+          kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true --timeout=120s
+          kubectl -n "$NS" delete secret "$VM-opkey" "$VM-cloudinit" --ignore-not-found
+          kubectl -n "$NS" delete pvc "$VM-scratch" --ignore-not-found --wait=false
+          exit 0


### PR DESCRIPTION
Makes a merge to main exercise **TDX bare metal** as well as SEV-SNP. Depends on confidential-ci PR (adds `workflow_call` to the source lane).

## Why a sibling job, not a matrix row

A reusable-workflow `uses:` must be a static literal and cannot be driven by `${{ matrix }}` (confidential-ci `research/ADR-matrix-architecture-2026-07-20.md`, line 29). So TDX cannot be `- { platform: tdx-metal, ... }` in the existing matrix.

It would want to be a separate job regardless: the two lanes use genuinely different transports, console for SNP and RA-TLS for TDX. Folding them into one reusable workflow is exactly the two-drivers-in-one-file shape that was just removed from the upstream `cvm-e2e.yml`.

It carries no `needs: payload`, since the TDX lane is self-contained and boots on a different host, so the two lanes run in parallel rather than one waiting on the other.

## The lane is proven, not aspirational

confidential-ci run [30238209289](https://github.com/confidential-dot-ai/confidential-ci/actions/runs/30238209289): **all 17 steps green** — boot, genuine-TDX assertion (`qemu -object tdx-guest`), attestation-api reporting `"platform":"tdx"`, RA-TLS operator-key-bound kubeconfig, `c8s install`, converge, the **negative** floor-denies-unlisted-image assertion, and teardown.

That negative test is the valuable one: it proves the product's fail-closed admission floor actually denies an unlisted image, on real TDX hardware, per run.

## Vendoring and drift, which you asked about

c8s is public and confidential-ci is private, so a public repo cannot `uses:` the private reusable workflow. A copy is unavoidable.

To stop the copies silently separating:

- **Both copies of `tdx-metal-e2e.yml` carry both triggers** (`workflow_call` + `workflow_dispatch`), so no per-repo edit is ever needed and a plain checksum can prove they match.
- **A provenance banner** names the source of truth, the vendored copy, and the rule: edit upstream, then copy the whole file across.

This PR also puts banners on the **two files that were already vendored with no pointer home at all**: `cvm-e2e.yml` and `e2e-c8s.yml`. That absence is precisely why this repo's `cvm-e2e.yml` fell **121 lines** behind its upstream and lost an entire platform arm with nothing detecting it.

I did **not** force those two back into sync. They have diverged over real time and reconciling them is separate, deliberate work; the banners exist so the next person knows to look rather than assuming the files are the same.

## Verification

YAML parses for all three files, every `run:` block passes `bash -n`, and the caller passes only inputs the callee declares (`c8s_ref`).

**Not yet exercised end to end from this repo.** A PR cannot trigger the merge path, and `runs-on: cvm-launcher-tdx` is org self-hosted hardware which must never be exposed to `pull_request`. Worth dispatching `e2e-c8s.yml` on this branch before merging.

## Interaction with the trigger fix

With the current path gate, this new job inherits the same hole: a merge touching no source paths fires neither lane. #143 fixes that at the head of the chain.
