### PR TITLE
fix(ci): grant actions: read so the CVM reaper can read run status

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -20,6 +20,15 @@ on:
 # Least privilege: the wrapper only reads the repo to dispatch the reusable lane.
 permissions:
   contents: read
+  # actions: read is LOAD-BEARING, not boilerplate. cvm-e2e.yml's reap step calls
+  #   gh api repos/<owner>/actions/runs/$rid -q .status
+  # to tell a genuinely orphaned CVM from one a live run still owns. GitHub sets
+  # every unlisted scope to `none` when a permissions block is present, so with
+  # `contents: read` alone that call 403s, `2>/dev/null` swallows it, $st is
+  # empty, and every decision falls through to the age-only branch:
+  #   elif [ -z "$st" ] && [ "$age" -gt 10800 ]
+  # which means a leaked CVM squats a finite bare-metal host for up to 3 hours.
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha }}


### PR DESCRIPTION
`cvm-e2e.yml`'s reap step tells a genuinely orphaned CVM from one a live run still owns by calling:

```
gh api repos/<owner>/actions/runs/$rid -q .status
```

That needs `actions: read`. This workflow declares only `contents: read`, and GitHub's documented behaviour is:

> If you specify the access for any of these permissions, all of those that are not specified are set to `none`.

So the call **403s**, `2>/dev/null` hides it, `$st` is empty, and every decision falls through to the age-only branch:

```bash
elif [ -z "$st" ] && [ "$age" -gt 10800 ]
```

A leaked CVM therefore squats a **finite bare-metal host for up to three hours** instead of being reaped the moment its owning run finishes. The run-status check that exists to prevent exactly that has never been able to work from this repo.

Permissions flow down to called workflows and can only be reduced, never elevated, so the vendored `cvm-e2e.yml` cannot grant this for itself. It has to be here.

## Honesty about the evidence

Verified **structurally** (the call, the fallback branch, the declared permissions) and against the permissions documentation. **Not observed live**: reaching the failing branch requires a leaked CVM to be present at the start of a run, and none of the runs available to me had one. So this is a proven-by-construction fix rather than a reproduced-failure fix.

One line of actual change; the rest is a comment explaining why it is not boilerplate, since a future tidy-up would otherwise delete it.