### PR TITLE
feat(ci): run both metal lanes on merge, and reconcile the vendored drift

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -27,7 +27,7 @@ on:
   workflow_call:
     inputs:
       platform:
-        description: 'target cell: snp-metal | tdx-metal | gke-snp | gke-tdx'
+        description: 'target cell: snp-metal (the only wired cell). TDX metal is NOT here: it has its own console-free lane, tdx-metal-e2e.yml. gke-snp and gke-tdx are unwired stubs.'
         type: string
         required: true
       runner:
@@ -45,6 +45,18 @@ on:
       timeout_minutes:
         type: number
         default: 55
+      keep_alive:
+        description: 'leave the CVM running after PAYLOAD_OK (standing-runner provisioner) — skips teardown; the VM is labelled standing so the reaper spares it'
+        type: boolean
+        default: false
+      vm_name:
+        description: 'stable VM name for a standing CVM (default: cvm-<run_id>-<attempt>, ephemeral)'
+        type: string
+        default: ''
+      memory_override:
+        description: 'override the per-platform guest RAM (e.g. 48Gi for a standing multi-runner CVM). vCPU is NOT overridable — it is baked into the measured IGVM (smp4). RAM is not in the launch measurement, so this keeps the same golden digest. Empty = per-platform default.'
+        type: string
+        default: ''
     secrets:
       ghcr_user:
         required: false
@@ -65,7 +77,7 @@ jobs:
       measurement: ${{ steps.run.outputs.measurement }}
     env:
       NS: confai-images
-      VM: cvm-${{ github.run_id }}-${{ github.run_attempt }}
+      VM: ${{ inputs.vm_name || format('cvm-{0}-{1}', github.run_id, github.run_attempt) }}
     steps:
       - name: platform config
         run: |
@@ -75,11 +87,18 @@ jobs:
           # (attestation-api :8400, /dev/sev-guest, NO toolchain — verity rootfs).
           case '${{ inputs.platform }}/${{ inputs.flavor }}' in
             snp-metal/rke2-node) echo "REFS_CM=rke2-image-refs"; echo "CORES=4"; echo "MEMORY=16Gi";
-                                 echo "NODE_LABEL=confidential.ai/sev-snp" ;;
+                                 echo "NODE_LABEL=confidential.ai/sev-snp"; echo "GUEST_MARKER=sev-snp-guest" ;;
             snp-metal/base-cpu)  echo "REFS_CM=base-image-refs"; echo "CORES=4"; echo "MEMORY=8Gi";
-                                 echo "NODE_LABEL=confidential.ai/sev-snp" ;;
-            *) echo "::error::cell '${{ inputs.platform }}/${{ inputs.flavor }}' not wired yet (tdx-metal/gke-* are stubs)"; exit 1 ;;
+                                 echo "NODE_LABEL=confidential.ai/sev-snp"; echo "GUEST_MARKER=sev-snp-guest" ;;
+            *) echo "::error::cell '${{ inputs.platform }}/${{ inputs.flavor }}' not wired here (tdx-metal has its own lane: tdx-metal-e2e.yml; gke-* are stubs)" >&2; exit 1 ;;
           esac >> "$GITHUB_ENV"
+          # RAM override (standing multi-runner CVM). Overrides ONLY memory —
+          # CORES stays the measured smp4, or attestation breaks. Not in the
+          # launch digest, so the golden is unchanged.
+          if [ -n '${{ inputs.memory_override }}' ]; then
+            echo "MEMORY=${{ inputs.memory_override }}" >> "$GITHUB_ENV"
+            echo "guest RAM overridden to ${{ inputs.memory_override }} (cores unchanged: measured smp4)"
+          fi
 
       - name: tools (kubectl + virtctl pinned to host KubeVirt + expect)
         run: |
@@ -96,18 +115,16 @@ jobs:
           set -euo pipefail
           ROOTPVC=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.rootPvc}')
           [ -n "$ROOTPVC" ] || { echo "::error::$REFS_CM missing rootPvc — run c8s-e2e/cluster-prep/apply.sh"; exit 1; }
-          # rke2-image-refs pins one file (igvmFile); base-image-refs publishes a
-          # per-core-count pattern (igvmFilePattern: guest-smp{cores}.igvm)
-          IGVMFILE=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFile}')
-          if [ -z "$IGVMFILE" ]; then
-            PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
-            [ -n "$PAT" ] || { echo "::error::$REFS_CM has neither igvmFile nor igvmFilePattern"; exit 1; }
-            IGVMFILE=${PAT//\{cores\}/$CORES}
-          fi
-          {
-            echo "ROOTPVC=$ROOTPVC"
-            echo "IGVMFILE=$IGVMFILE"
-          } >> "$GITHUB_ENV"
+          echo "ROOTPVC=$ROOTPVC" >> "$GITHUB_ENV"
+            # rke2-image-refs pins one file (igvmFile); base-image-refs publishes a
+            # per-core-count pattern (igvmFilePattern: guest-smp{cores}.igvm)
+            IGVMFILE=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFile}')
+            if [ -z "$IGVMFILE" ]; then
+              PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
+              [ -n "$PAT" ] || { echo "::error::$REFS_CM has neither igvmFile nor igvmFilePattern"; exit 1; }
+              IGVMFILE=${PAT//\{cores\}/$CORES}
+            fi
+            echo "IGVMFILE=$IGVMFILE" >> "$GITHUB_ENV"
 
       # reap-before-provision: a killed run leaks its CVM + its rootdisk clone.
       # CROSS-REPO SAFE: this primitive is called from ANY org repo, so a CVM may be
@@ -122,11 +139,9 @@ jobs:
           for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
             rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
             orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
-            # Standing runner CVMs (booted with keep_alive) have a MANUAL
-            # lifecycle: they outlive the run that created them and serve jobs
-            # for other repos. Their provision run completes within minutes, so
-            # the run-status check below would see a live shared runner as an
-            # orphan and delete it mid-job. Skip them entirely.
+            # standing runner CVMs (provision-*-cvm.yml, keep_alive) have a manual
+            # lifecycle — never reap them, even though their owning provision run
+            # has long since "completed" (that check would otherwise kill the runner).
             standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
             [ "$standing" = "true" ] && { echo "keeping $vm (standing runner — manual lifecycle)"; continue; }
             [ -z "$rid" ] && continue
@@ -150,6 +165,16 @@ jobs:
       - name: boot the measured CVM
         run: |
           set -euo pipefail
+          # keep_alive re-provision: a standing VM already exists under this stable
+          # name. `kubectl apply` alone updates the VM template but never restarts the
+          # running VMI, so spec changes (e.g. rootdisk readonly) silently never take
+          # — the poll below just sees the old VMI already Running. Delete it first,
+          # waiting for the VMI and its exclusive disk lock to release, so the apply
+          # boots a fresh VM with the current spec. Ephemeral runs use unique names,
+          # so this is a no-op for them.
+          if [ '${{ inputs.keep_alive }}' = 'true' ]; then
+            kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true
+          fi
           kubectl apply -f - <<EOF
           apiVersion: kubevirt.io/v1
           kind: VirtualMachine
@@ -158,6 +183,7 @@ jobs:
             namespace: $NS
             labels:
               ci.confidential.ai/managed: "true"
+              ci.confidential.ai/standing: "${{ inputs.keep_alive }}"
               ci.confidential.ai/run-id: "${{ github.run_id }}"
               ci.confidential.ai/run-attempt: "${{ github.run_attempt }}"
               ci.confidential.ai/platform: "${{ inputs.platform }}"
@@ -199,16 +225,12 @@ jobs:
                       - name: rootdisk
                         disk:
                           bus: virtio
-                          # The rke2 rootfs is a read-only dm-verity image (writes
-                          # go to a tmpfs overlay), so the disk never needs write
-                          # access — and opening it writable takes an EXCLUSIVE
-                          # QEMU image lock. The standing snp-metal-cvm ARC runner
-                          # boots from this same RWO PVC and holds that lock 24/7,
-                          # so a writable ephemeral CVM here fails at qemu with
-                          # `Failed to get "write" lock` and never reaches Running.
-                          # readonly takes a SHARED lock that coexists with the
-                          # runner (verified: this is how the TDX dev host runs two
-                          # VMs off one rootdisk).
+                          # Golden rootfs is a SHARED ROX verity PVC — open it readonly
+                          # so QEMU takes a SHARED lock and the standing keep_alive runner
+                          # + any ephemeral c8s e2e CVM coexist on it. Writable takes an
+                          # EXCLUSIVE lock, so only the first VM boots and every other CVM
+                          # on the same node is blocked (empty console / VMI stuck
+                          # Scheduled). Matches confidential-metal manifests/examples/rke2-cvm.yaml.
                           readonly: true
                     interfaces:
                       - name: default
@@ -234,9 +256,11 @@ jobs:
       - name: assert genuine confidential boot
         run: |
           set -uo pipefail
+          # GUEST_MARKER = the qemu-cmdline token proving the confidential guest type
+          # (sev-snp-guest for SNP).
           kubectl -n "$NS" exec "$POD" -c compute -- sh -c \
-            "tr '\0' '\n' < /proc/\$(pgrep -f qemu-system | head -1)/cmdline | grep -cE 'sev-snp-guest'" | tee /tmp/snp.cnt
-          [ "$(cat /tmp/snp.cnt 2>/dev/null)" = "1" ] && echo 'OK: genuine sev-snp-guest' || { echo '::error::not a sev-snp-guest'; exit 1; }
+            "tr '\0' '\n' < /proc/\$(pgrep -f qemu-system | head -1)/cmdline | grep -cE '$GUEST_MARKER'" | tee /tmp/g.cnt
+          [ "$(cat /tmp/g.cnt 2>/dev/null)" = "1" ] && echo "OK: genuine $GUEST_MARKER" || { echo "::error::not a $GUEST_MARKER"; exit 1; }
 
       - name: run payload in the CVM
         id: run
@@ -304,12 +328,14 @@ jobs:
             \$K get nodes --no-headers 2>&1 | grep -q ' Ready' && say NODE_READY || { say FAIL_NODE; exit 0; }
           fi
           MEAS=""
-          TD=/sys/kernel/config/tsm/report/cvmci
-          if mkdir -p "\$TD" 2>/dev/null; then
-            head -c 64 /dev/urandom > "\$TD/inblob" 2>/dev/null
-            MEAS=\$(python3 -c "import binascii,sys; d=open('\$TD/outblob','rb').read(); sys.stdout.write(binascii.hexlify(d[144:192]).decode())" 2>/dev/null)
-            rmdir "\$TD" 2>/dev/null
-          fi
+          # SNP: runtime launch measurement = the SNP report's MEASUREMENT field
+          # (configfs-tsm outblob, offset 0x90/144, 48 bytes).
+            TD=/sys/kernel/config/tsm/report/cvmci
+            if mkdir -p "\$TD" 2>/dev/null; then
+              head -c 64 /dev/urandom > "\$TD/inblob" 2>/dev/null
+              MEAS=\$(python3 -c "import binascii,sys; d=open('\$TD/outblob','rb').read(); sys.stdout.write(binascii.hexlify(d[144:192]).decode())" 2>/dev/null)
+              rmdir "\$TD" 2>/dev/null
+            fi
           export MEAS
           echo "@@MEAS \${MEAS:-none}@@"
           export GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN'
@@ -418,5 +444,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: "teardown (always — tmpfs CVM: deleting the VM is total)"
-        if: always()
+        # keep_alive leaves the CVM Running as a standing runner (provisioner path);
+        # every other caller (c8s, ephemeral lib runs) tears down as before.
+        if: ${{ always() && !inputs.keep_alive }}
         run: kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -49,251 +49,49 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # ── WHAT: build the c8s payload (the only c8s-specific work) ──────────────
-  payload:
-    runs-on: ubuntu-latest
-    outputs:
-      b64: ${{ steps.build.outputs.b64 }}
-      short: ${{ steps.build.outputs.short }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          repository: confidential-dot-ai/c8s
-          ref: ${{ inputs.c8s_ref || 'main' }}   # push/schedule have no inputs
-          path: c8s
-          fetch-depth: 50                        # the image-tag resolver walks ancestors
+  # ── ONE JOB PER PLATFORM ─────────────────────────────────────────────────
+  # Vendored from confidential-ci. c8s is PUBLIC and confidential-ci is PRIVATE,
+  # so a public repo cannot `uses:` the private reusable workflows and must keep
+  # local copies. cvm-e2e.yml, snp-metal-e2e.yml and tdx-metal-e2e.yml here are
+  # byte-identical to their originals; edit the original, then copy across.
+  #
+  # NOT a `matrix:`. A reusable-workflow `uses:` takes no expressions, so a
+  # matrix would need an if-gated dispatcher, and because every row instantiates
+  # the whole dispatcher that costs rows x jobs entries in the run tree, growing
+  # quadratically. Plain jobs give one real entry each.
+  #
+  # THE AZURE ROWS ARE ABSENT ON PURPOSE, and this is the ONE way this file
+  # differs from its confidential-ci original. Two hard blockers, both outside
+  # CI: (1) the Entra federated credential trusts
+  # `repo:confidential-dot-ai/confidential-ci`, so an OIDC token minted here is
+  # rejected with AADSTS700213; granting c8s its own credential is an access
+  # change, not a code change. (2) azure-tdx-e2e.yml reads
+  # c8s-e2e/azure-tdx-driver.sh, which lives in confidential-ci and does not
+  # exist in this repo. Until both are resolved, azure-snp and azure-tdx run
+  # from confidential-ci on a schedule.
 
-      - id: build
-        run: |
-          set -euo pipefail
-          SHORT=$(cd c8s && git rev-parse --short=7 HEAD)
-          FULL=$(cd c8s && git rev-parse HEAD)
-          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
-
-          # IMAGE TAGS: docker.yml is path-gated too — a commit that touches no
-          # source paths triggers NO Docker run, so retag-unchanged never fires
-          # and :<short-sha> tags don't exist for it (found live: main 70aea72 had
-          # NO cds/c8s-operator tags -> ImagePullBackOff). The image a commit X
-          # would actually deploy is "the newest built tag at or before X" — so
-          # resolve each component by walking X's ancestry until a tag exists.
-          # Under the post-merge trigger (workflow_run off Docker) this resolves
-          # to $SHORT on the first probe. Anonymous pulls — the packages are public.
-          resolve_tag(){
-            local comp=$1 tok code
-            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
-            for sha in $(git -C c8s log --format=%h --abbrev=7 -50); do
-              code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $tok" \
-                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
-                "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${sha}")
-              [ "$code" = "200" ] && { echo "$sha"; return; }
-            done
-            echo "::warning::no sha tag found for ${comp} in the last 50 commits — falling back to :main (racy)" >&2
-            echo main
-          }
-          # PLATFORM digest (linux/amd64), not the index digest: the NRI allowlist
-          # floor matches what the runtime resolves — an index digest would reject
-          # the very image it pins (docs/attestation/allowlist multi-arch pitfall).
-          resolve_digest(){
-            local comp=$1 tag=$2 tok m d
-            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
-            m=$(curl -fsSL -H "Authorization: Bearer $tok"               -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json'               "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}")
-            d=$(printf '%s' "$m" | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest' | head -1)
-            if [ -z "$d" ]; then
-              d=$(curl -fsSI -H "Authorization: Bearer $tok" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}" | awk '{ gsub("\r","") } tolower($1)=="docker-content-digest:"{ print $2 }')
-            fi
-            [ -n "$d" ] || { echo "::error::no digest for ${comp}:${tag}"; exit 1; }
-            echo "$d"
-          }
-          OPTAG=$(resolve_tag c8s-operator)      # global image.tag: operator + tls-lb init
-          CDSTAG=$(resolve_tag cds)
-          NRITAG=$(resolve_tag nri-image-policy)
-          CDSDIG=$(resolve_digest cds "$CDSTAG")            # nriImagePolicy floor pins CDS by digest
-          NRIDIG=$(resolve_digest nri-image-policy "$NRITAG")  # installer self-allow needs its own
-          # The operator image is ALSO the injected get-cert/c8s-cert sidecar image,
-          # and deriveComponents below only derives components that carry a digest.
-          OPDIG=$(resolve_digest c8s-operator "$OPTAG")
-          # attestation-api is versioned by the attestation-rs repo, NOT c8s — a
-          # c8s-ancestry walk can never find its tags (learned the hard way:
-          # InvalidImageName, run 29473241754). :main is the canonical pointer the
-          # c8s-integration fleet uses; accepted race until c8s pins a digest.
-          # aa_ref lets a caller PIN it (tag or sha-<short>) — floating :main drifts
-          # (e.g. attestation-rs enforce-VMPL0/reject-debug-policy landed on :main and
-          # broke this dev-sandbox CVM while the boot image was unchanged).
-          AATAG="${{ inputs.aa_ref || 'main' }}"
-          echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
-
-          # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:
-          #  - cds.node.selector/tolerations null : the --single-node effect. The chart
-          #    default pins role=cds, so CDS sits Pending forever on a single node.
-          #  - measurements: RUNTIME_MEASUREMENT  : placeholder. The payload substitutes
-          #    the node's OWN runtime launch digest ($MEAS from the primitive). The image
-          #    manifest's snp_launch_digest is NOT that value (CDS -> measurement_denied).
-          #  - ratlsMesh disabled                 : the L4 mesh proxy needs kernel netfilter
-          #    modules the monolithic guest kernel lacks (base-images ask). nri-image-policy
-          #    is a containerd NRI hook — no netfilter — so it runs (audit mode for now).
-          VALS=$(cat <<EOF | base64 -w0
-          image:
-            tag: "$OPTAG"
-            digest: "$OPDIG"
-          cds:
-            image:
-              tag: "$CDSTAG"
-              digest: "$CDSDIG"
-            node:
-              selector: null      # null DELETES the key from the merged values (chart
-              tolerations: null   # default incl.) -> renders NO selector. {} counts as
-                                  # "empty" to the template's `default` -> role=cds
-                                  # resurfaces -> CDS Pending (run 29536583462).
-            ratlsPlatform: sev-snp
-            measurements: ["RUNTIME_MEASUREMENT"]
-          attestationApi:
-            image:
-              tag: "$AATAG"
-            cvmMode: node
-            # cvmMode=node points every consumer at $(HOST_IP):<port>, but the staged
-            # rke2 image bakes no host attestation-api and the chart's AA DaemonSet is
-            # pod-netns, so nothing listens on the node's :8400. When nriImagePolicy is
-            # on, the chart already publishes the AA as a NodePort for host-process
-            # components; aligning the port makes $(HOST_IP) reach the node's own AA
-            # pod (both traffic policies are Local, so it never leaves the node).
-            port: 30840
-            service:
-              nodePort: 30840
-            teeDevices:
-              sevGuest: true
-              tdxGuest: false
-              tpm: false
-          ratlsMesh:
-            enabled: false
-          nriImagePolicy:
-            enabled: true          # NRI hook needs no netfilter (that was ratls-mesh's constraint)
-            distro: rke2
-            image:
-              tag: "$NRITAG"
-              digest: "$NRIDIG"
-            bootstrapAllowlist:
-              # c8s.imageAllowlist self-seeds only cds and tls-lb nginx; every other
-              # component (including the operator, i.e. the injected c8s-cert sidecar)
-              # is derived only under this flag, which defaults to false. `c8s install
-              # --resolve-digests` turns it on; this lane writes raw values and bypasses
-              # the CLI. Without it c8s-cert is denied-but-admitted under audit and the
-              # workload-claims broker never records it, so get-cert cannot resolve its
-              # own caller and waits out the 6h renewal interval.
-              deriveComponents: true
-            policy:
-              mode: audit          # bring-up: log would-be denials, admit all (chart-blessed).
-                                   # enforce needs an operator-keyed allowlist first — roadmap.
-          tlsLb:
-            hostPort:
-              enabled: false
-          EOF
-          )
-          CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
-
-          # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
-          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' > /tmp/gate-vals.yaml
-          helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
-          echo "render gate: chart+values validate clean"
-
-          # ── THE PAYLOAD: runs in-guest as root. Given $K, $MEAS; emits PAYLOAD_OK.
-          cat > payload.sh <<PAYLOAD
-          dl(){ curl -fsSL --retry 3 "\$1" -o "\$2" 2>/dev/null || wget -qO "\$2" "\$1" 2>/dev/null || python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])" "\$1" "\$2"; }
-          dl "https://codeload.github.com/confidential-dot-ai/c8s/tar.gz/$FULL" /tmp/src.tgz || { say FAIL_CHART_FETCH; exit 0; }
-          tar -xzf /tmp/src.tgz -C /tmp || { say FAIL_CHART_EXTRACT; exit 0; }
-          CD=\$(echo /tmp/c8s-*/internal/helmchart)
-          tar -czf /tmp/chart.tgz -C "\$CD" c8s || { say FAIL_CHART_PACK; exit 0; }
-          CC=\$(base64 -w0 /tmp/chart.tgz)
-          say CHART_FROM_SOURCE
-          \$K create ns c8s-system >/dev/null 2>&1
-          \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
-          if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
-          { printf 'apiVersion: helm.cattle.io/v1\nkind: HelmChart\nmetadata:\n  name: c8s\n  namespace: kube-system\nspec:\n  chartContent: %s\n  targetNamespace: c8s-system\n  createNamespace: false\n  valuesContent: |\n' "\$CC"
-            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed 's/^/    /'
-          } | \$K apply -f - 2>&1 | sed 's/^/@@HCAPPLY /;s/\$/@@/'
-          say \$MMARK
-          HOK=0
-          for i in \$(seq 1 45); do
-            s=\$(\$K -n kube-system get job helm-install-c8s -o jsonpath='{.status.succeeded}' 2>/dev/null)
-            echo "@@HJOB \$i succ=\${s:-0}@@"
-            \$K -n kube-system logs job/helm-install-c8s --tail=2 2>/dev/null | sed 's/^/@@HLOG /;s/\$/@@/'
-            [ "\$s" = "1" ] && { HOK=1; say HELM_DONE; break; }
-            sleep 12
-          done
-          if [ "\$HOK" != "1" ]; then
-            \$K -n kube-system get helmchart c8s -o jsonpath='{.status}' 2>&1 | head -c 600 | sed 's/^/@@HCSTATUS /;s/\$/@@/'
-            \$K -n kube-system logs job/helm-install-c8s --tail=40 2>&1 | sed 's/^/@@HLOG /;s/\$/@@/'
-            say FAIL_HELM
-            exit 0
-          fi
-          CDSOK=0
-          for i in \$(seq 1 45); do
-            PODS=\$(\$K -n c8s-system get pods --no-headers 2>&1)
-            printf '%s\n' "\$PODS" | sed 's/^/@@POD /;s/\$/@@/'
-            CDS=\$(printf '%s\n' "\$PODS" | grep '^c8s-cds-' | head -1)
-            echo "@@CDSR \$i: \${CDS:-nopod}@@"
-            printf '%s' "\$CDS" | grep -qE ' 1/1 +Running' && { CDSOK=1; say CDS_READY; break; }
-            printf '%s\n' "\$PODS" | grep -q 'ImagePullBackOff' && IPB=\$((\${IPB:-0}+1)) || IPB=0
-            [ "\$IPB" -ge 5 ] && { \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'; say FAIL_IMAGEPULL; exit 0; }
-            sleep 12
-          done
-          # consumption proof: a cw workload must RUN with the CDS-issued cert injected.
-          # Under MEAS_ENFORCED that cert is only issued if the node attests the pinned
-          # measurement — so this IS the enforcement test, not a separate assertion.
-          WOK=0; COK=0
-          if [ "\$CDSOK" != "1" ]; then
-            \$K -n c8s-system logs deploy/c8s-cds --tail=15 2>&1 | sed 's/^/@@CDSLOG /;s/\$/@@/'
-            \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
-          fi
-          if [ "\$CDSOK" = "1" ]; then
-            # Gate on the POLICY plane, not just CDS. c8s-cert is only recorded by the
-            # broker if the NRI plugin is ready when its container is created, and CDS
-            # and the plugin become ready independently, so applying on CDS alone is a
-            # coin flip. The installer pod is not a usable signal: its 120s health gate
-            # can expire while the plugin is still completing its initial CDS pull.
-            NRIOK=0
-            for i in \$(seq 1 60); do
-              HC=\$(curl -s -o /dev/null -w '%{http_code}' --unix-socket /var/run/nri-image-policy/health.sock --max-time 3 http://localhost/healthz 2>/dev/null)
-              echo "@@NRIH \$i: \${HC:-none}@@"
-              [ "\$HC" = "200" ] && { NRIOK=1; say NRI_PLUGIN_READY; break; }
-              sleep 5
-            done
-            [ "\$NRIOK" = "1" ] || say WARN_NRI_NOT_READY
-            printf %s '$CW' | base64 -d | \$K apply -f - 2>&1 | sed 's/^/@@CWAPPLY /;s/\$/@@/'
-            for i in \$(seq 1 60); do
-              DP=\$(\$K -n default get deploy demo-nginx --no-headers 2>&1)
-              echo "@@CWDEP \$i: \$DP@@"
-              printf '%s' "\$DP" | grep -qE ' 1/1 ' && { WOK=1; say WORKLOAD_OK; break; }
-              sleep 10
-            done
-            IC=\$(\$K -n default get pods -l app=demo-nginx -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null)
-            echo "@@CWCONTAINERS \${IC:-none}@@"
-            printf '%s' "\$IC" | grep -q 'c8s-cert' && { COK=1; say CERT_INJECTED; }
-            [ "\$WOK" = "1" ] && [ "\$COK" = "1" ] && say PAYLOAD_OK
-            if [ "\$WOK" != "1" ]; then
-              \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
-              \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
-            fi
-          fi
-          \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | tail -10 | sed 's/^/@@EV /;s/\$/@@/'
-          PAYLOAD
-          echo "b64=$(base64 -w0 payload.sh)" >> "$GITHUB_OUTPUT"
-
-  # ── WHERE: one call per platform cell; the primitive boots/attests/tears down.
-  #    bare metal (power-cord customers: CW/Nebius/Humain) | cloud (rent-infra:
-  #    Baseten/Modal/RunPod). Adding a cell = adding a row.
-  e2e:
-    needs: payload
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: snp-metal
-            runner: cvm-launcher
-          # - { platform: tdx-metal, runner: cvm-launcher-tdx }  # needs a TDX rke2-node image
-          # - { platform: gke-snp,   runner: ubuntu-latest }        # needs the c8s-fleet provisioner seam
-    uses: ./.github/workflows/cvm-e2e.yml
+  snp-metal:
+    permissions:
+      contents: read
+      # The CVM reaper asks GitHub whether the owning run finished; without this
+      # it 403s silently and falls back to reaping on age alone.
+      actions: read
+    uses: ./.github/workflows/snp-metal-e2e.yml
     with:
-      platform: ${{ matrix.platform }}
-      runner: ${{ matrix.runner }}
-      flavor: rke2-node
-      payload_b64: ${{ needs.payload.outputs.b64 }}
+      c8s_ref: ${{ inputs.c8s_ref }}
+      aa_ref: ${{ inputs.aa_ref }}
+
+  tdx-metal:
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/tdx-metal-e2e.yml
+    with:
+      # DELIBERATELY EMPTY. The TDX node image bakes a fail-closed NRI floor
+      # from the c8s ref it was BUILT from, so installing any other ref gets
+      # that ref's own components denied. Empty means "use the paired ref".
+      # CONSEQUENCE: this lane proves the stack, the host, the image and the
+      # runner. It does NOT test the code in the merge that triggered it; that
+      # is snp-metal's job. Real merge-code coverage on TDX needs a node image
+      # built per merge, which is an image-pipeline problem.
+      c8s_ref: ''

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -1,0 +1,323 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# LANE: c8s on SEV-SNP BARE METAL
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# One lane workflow per platform, so e2e-c8s.yml can be nothing but the list of
+# platforms. This lane exists because cvm-e2e.yml is a GENERIC primitive: its
+# contract is "boot a measured CVM, hand a caller-supplied payload a way to run
+# commands inside it", and it is shared with probe-cvm.yml, tee-payload.yml and
+# provision-snp-metal-cvm.yml. The c8s-specific install-and-assert payload
+# therefore cannot live in the primitive, and it should not live in the platform
+# list either. It lives here, with the lane it belongs to.
+#
+# The other three platform lanes are already self-contained in this way. This
+# makes SNP match them, which is what lets every job in e2e-c8s.yml have the
+# same shape and lets this lane be dispatched on its own.
+name: snp-metal-e2e
+
+on:
+  workflow_call:
+    inputs:
+      c8s_ref:
+        description: 'c8s ref to test'
+        required: false
+        type: string
+        default: ''
+      aa_ref:
+        description: 'attestation-api image ref'
+        required: false
+        type: string
+        default: ''
+  workflow_dispatch:
+    inputs:
+      c8s_ref:
+        description: 'c8s ref to test'
+        required: false
+        default: ''
+      aa_ref:
+        description: 'attestation-api image ref'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  # The CVM reaper inside the primitive asks GitHub whether the owning run
+  # finished; without this it 403s silently and reaps on age alone.
+  actions: read
+
+jobs:
+  payload:
+    runs-on: ubuntu-latest
+    outputs:
+      b64: ${{ steps.build.outputs.b64 }}
+      short: ${{ steps.build.outputs.short }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: confidential-dot-ai/c8s
+          ref: ${{ inputs.c8s_ref || 'main' }}   # push/schedule have no inputs
+          path: c8s
+          fetch-depth: 50                        # the image-tag resolver walks ancestors
+
+      - id: build
+        run: |
+          set -euo pipefail
+          SHORT=$(cd c8s && git rev-parse --short=7 HEAD)
+          FULL=$(cd c8s && git rev-parse HEAD)
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+
+          # IMAGE TAGS: docker.yml is path-gated too — a commit that touches no
+          # source paths triggers NO Docker run, so retag-unchanged never fires
+          # and :<short-sha> tags don't exist for it (found live: main 70aea72 had
+          # NO cds/c8s-operator tags -> ImagePullBackOff). The image a commit X
+          # would actually deploy is "the newest built tag at or before X" — so
+          # resolve each component by walking X's ancestry until a tag exists.
+          # Under the post-merge trigger (workflow_run off Docker) this resolves
+          # to $SHORT on the first probe. Anonymous pulls — the packages are public.
+          resolve_tag(){
+            local comp=$1 tok code
+            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
+            for sha in $(git -C c8s log --format=%h --abbrev=7 -50); do
+              code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $tok" \
+                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+                "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${sha}")
+              [ "$code" = "200" ] && { echo "$sha"; return; }
+            done
+            echo "::warning::no sha tag found for ${comp} in the last 50 commits — falling back to :main (racy)" >&2
+            echo main
+          }
+          # PLATFORM digest (linux/amd64), not the index digest: the NRI allowlist
+          # floor matches what the runtime resolves — an index digest would reject
+          # the very image it pins (docs/attestation/allowlist multi-arch pitfall).
+          resolve_digest(){
+            local comp=$1 tag=$2 tok m d
+            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
+            m=$(curl -fsSL -H "Authorization: Bearer $tok"               -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json'               "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}")
+            d=$(printf '%s' "$m" | jq -r '.manifests[]? | select(.platform.architecture=="amd64" and .platform.os=="linux") | .digest' | head -1)
+            if [ -z "$d" ]; then
+              d=$(curl -fsSI -H "Authorization: Bearer $tok" -H 'Accept: application/vnd.oci.image.manifest.v1+json' "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${tag}" | awk '{ gsub("\r","") } tolower($1)=="docker-content-digest:"{ print $2 }')
+            fi
+            [ -n "$d" ] || { echo "::error::no digest for ${comp}:${tag}"; exit 1; }
+            echo "$d"
+          }
+          OPTAG=$(resolve_tag c8s-operator)      # global image.tag: operator + tls-lb init
+          CDSTAG=$(resolve_tag cds)
+          NRITAG=$(resolve_tag nri-image-policy)
+          CDSDIG=$(resolve_digest cds "$CDSTAG")            # nriImagePolicy floor pins CDS by digest
+          NRIDIG=$(resolve_digest nri-image-policy "$NRITAG")  # installer self-allow needs its own
+          # The operator image is ALSO the injected get-cert/c8s-cert sidecar image
+          # (operator.yaml passes --get-cert-image={{ c8s.image }}). c8s.imageAllowlist
+          # only derives a component into always_allow when it has a digest, so an
+          # un-pinned operator leaves that sidecar out of the floor AND out of the CDS
+          # seed. Under policy.mode=audit it is then denied-but-admitted, and the
+          # workload-claims broker records only on the allow path, so the sidecar is
+          # never tracked and get-cert dies with "caller cgroup names no tracked
+          # container". Pin it like cds and nri already are.
+          OPDIG=$(resolve_digest c8s-operator "$OPTAG")
+          # attestation-api is versioned by the attestation-rs repo, NOT c8s — a
+          # c8s-ancestry walk can never find its tags (learned the hard way:
+          # InvalidImageName, run 29473241754). :main is the canonical pointer the
+          # c8s-integration fleet uses; accepted race until c8s pins a digest.
+          # aa_ref lets a caller PIN it (tag or sha-<short>) — floating :main drifts
+          # (e.g. attestation-rs enforce-VMPL0/reject-debug-policy landed on :main and
+          # broke this dev-sandbox CVM while the boot image was unchanged).
+          AATAG="${{ inputs.aa_ref || 'main' }}"
+          echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
+
+          # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:
+          #  - cds.node.selector/tolerations null : the --single-node effect. The chart
+          #    default pins role=cds, so CDS sits Pending forever on a single node.
+          #  - measurements: RUNTIME_MEASUREMENT  : placeholder. The payload substitutes
+          #    the node's OWN runtime launch digest ($MEAS from the primitive). The image
+          #    manifest's snp_launch_digest is NOT that value (CDS -> measurement_denied).
+          #  - ratlsMesh disabled                 : the L4 mesh proxy needs kernel netfilter
+          #    modules the monolithic guest kernel lacks (base-images ask). nri-image-policy
+          #    is a containerd NRI hook — no netfilter — so it runs (audit mode for now).
+          VALS=$(cat <<EOF | base64 -w0
+          image:
+            tag: "$OPTAG"
+            digest: "$OPDIG"
+          cds:
+            image:
+              tag: "$CDSTAG"
+              digest: "$CDSDIG"
+            node:
+              selector: null      # null DELETES the key from the merged values (chart
+              tolerations: null   # default incl.) -> renders NO selector. {} counts as
+                                  # "empty" to the template's `default` -> role=cds
+                                  # resurfaces -> CDS Pending (run 29536583462).
+            ratlsPlatform: sev-snp
+            measurements: ["RUNTIME_MEASUREMENT"]
+          attestationApi:
+            image:
+              tag: "$AATAG"
+            # UN-PIN: keep cvmMode=node (what we actually ship on metal) and make
+            # $(HOST_IP) routing resolve. Our image predates the baked host
+            # attestation-api, but when nriImagePolicy is on the chart already
+            # publishes the AA as a NodePort for exactly this reason ("NodePort used
+            # by host-process components such as nri-image-policy"). Aligning the AA
+            # port with that NodePort makes $(HOST_IP):<port> hit the node's own AA
+            # pod (both traffic policies are Local, so it never leaves the node).
+            # Verified by helm template at HEAD: all 4 consumers (cds, operator, both
+            # tls-lb sidecars) render http://$(HOST_IP):30840, and the Service exposes
+            # port 30840 -> targetPort http -> containerPort 30840.
+            cvmMode: node
+            port: 30840
+            service:
+              nodePort: 30840
+            teeDevices:
+              sevGuest: true
+              tdxGuest: false
+              tpm: false
+          ratlsMesh:
+            enabled: false
+          nriImagePolicy:
+            enabled: true          # NRI hook needs no netfilter (that was ratls-mesh's constraint)
+            distro: rke2
+            image:
+              tag: "$NRITAG"
+              digest: "$NRIDIG"
+            bootstrapAllowlist:
+              # THE FIX. deriveComponents is off by default and `c8s install
+              # --resolve-digests` is what normally turns it on; this lane writes raw
+              # values into a HelmChart CR, so it never did. Without it only cds and
+              # tls-lb nginx get self-entries, so the OPERATOR image is absent from
+              # always_allow and from the CDS seed. That image is also the injected
+              # c8s-cert sidecar, so under policy.mode=audit it is denied-but-admitted,
+              # and the workload-claims broker records only on the ALLOW path. The
+              # sidecar therefore runs untracked and its own get-cert call fails with
+              # "caller cgroup names no tracked container", after which get-cert waits
+              # out the 6h renewal interval and the workload never becomes ready.
+              deriveComponents: true
+            policy:
+              mode: audit          # bring-up: log would-be denials, admit all (chart-blessed).
+                                   # enforce needs an operator-keyed allowlist first — roadmap.
+          tlsLb:
+            hostPort:
+              enabled: false
+          EOF
+          )
+          CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
+
+          # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
+          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' > /tmp/gate-vals.yaml
+          helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
+          echo "render gate: chart+values validate clean"
+
+          # ── THE PAYLOAD: runs in-guest as root. Given $K, $MEAS; emits PAYLOAD_OK.
+          cat > payload.sh <<PAYLOAD
+          dl(){ curl -fsSL --retry 3 "\$1" -o "\$2" 2>/dev/null || wget -qO "\$2" "\$1" 2>/dev/null || python3 -c "import urllib.request,sys; urllib.request.urlretrieve(sys.argv[1], sys.argv[2])" "\$1" "\$2"; }
+          dl "https://codeload.github.com/confidential-dot-ai/c8s/tar.gz/$FULL" /tmp/src.tgz || { say FAIL_CHART_FETCH; exit 0; }
+          tar -xzf /tmp/src.tgz -C /tmp || { say FAIL_CHART_EXTRACT; exit 0; }
+          CD=\$(echo /tmp/c8s-*/internal/helmchart)
+          tar -czf /tmp/chart.tgz -C "\$CD" c8s || { say FAIL_CHART_PACK; exit 0; }
+          CC=\$(base64 -w0 /tmp/chart.tgz)
+          say CHART_FROM_SOURCE
+          \$K create ns c8s-system >/dev/null 2>&1
+          \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
+          if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
+          { printf 'apiVersion: helm.cattle.io/v1\nkind: HelmChart\nmetadata:\n  name: c8s\n  namespace: kube-system\nspec:\n  chartContent: %s\n  targetNamespace: c8s-system\n  createNamespace: false\n  valuesContent: |\n' "\$CC"
+            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed 's/^/    /'
+          } | \$K apply -f - 2>&1 | sed 's/^/@@HCAPPLY /;s/\$/@@/'
+          say \$MMARK
+          HOK=0
+          for i in \$(seq 1 45); do
+            s=\$(\$K -n kube-system get job helm-install-c8s -o jsonpath='{.status.succeeded}' 2>/dev/null)
+            echo "@@HJOB \$i succ=\${s:-0}@@"
+            \$K -n kube-system logs job/helm-install-c8s --tail=2 2>/dev/null | sed 's/^/@@HLOG /;s/\$/@@/'
+            [ "\$s" = "1" ] && { HOK=1; say HELM_DONE; break; }
+            sleep 12
+          done
+          if [ "\$HOK" != "1" ]; then
+            \$K -n kube-system get helmchart c8s -o jsonpath='{.status}' 2>&1 | head -c 600 | sed 's/^/@@HCSTATUS /;s/\$/@@/'
+            \$K -n kube-system logs job/helm-install-c8s --tail=40 2>&1 | sed 's/^/@@HLOG /;s/\$/@@/'
+            say FAIL_HELM
+            exit 0
+          fi
+          CDSOK=0
+          for i in \$(seq 1 45); do
+            PODS=\$(\$K -n c8s-system get pods --no-headers 2>&1)
+            printf '%s\n' "\$PODS" | sed 's/^/@@POD /;s/\$/@@/'
+            CDS=\$(printf '%s\n' "\$PODS" | grep '^c8s-cds-' | head -1)
+            echo "@@CDSR \$i: \${CDS:-nopod}@@"
+            printf '%s' "\$CDS" | grep -qE ' 1/1 +Running' && { CDSOK=1; say CDS_READY; break; }
+            printf '%s\n' "\$PODS" | grep -q 'ImagePullBackOff' && IPB=\$((\${IPB:-0}+1)) || IPB=0
+            [ "\$IPB" -ge 5 ] && { \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'; say FAIL_IMAGEPULL; exit 0; }
+            sleep 12
+          done
+          # consumption proof: a cw workload must RUN with the CDS-issued cert injected.
+          # Under MEAS_ENFORCED that cert is only issued if the node attests the pinned
+          # measurement — so this IS the enforcement test, not a separate assertion.
+          WOK=0; COK=0
+          if [ "\$CDSOK" != "1" ]; then
+            \$K -n c8s-system logs deploy/c8s-cds --tail=15 2>&1 | sed 's/^/@@CDSLOG /;s/\$/@@/'
+            \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
+          fi
+          if [ "\$CDSOK" = "1" ]; then
+            # Gate on the POLICY plane, not just CDS. The injected c8s-cert sidecar
+            # can only be recorded by the workload-claims broker if the NRI plugin is
+            # ready when its container is created; otherwise get-cert cannot resolve
+            # its own caller ("caller cgroup names no tracked container"), gives up
+            # after ~16s and waits out the 6h renewal interval. CDS and the plugin
+            # become ready independently, so applying on CDS alone is a coin flip.
+            # The installer pod is NOT a usable signal (its 120s health gate can
+            # expire while the plugin is still doing its initial CDS pull), so poll
+            # the plugin's own health socket.
+            NRIOK=0
+            for i in \$(seq 1 60); do
+              HC=\$(curl -s -o /dev/null -w '%{http_code}' --unix-socket /var/run/nri-image-policy/health.sock --max-time 3 http://localhost/healthz 2>/dev/null)
+              echo "@@NRIH \$i: \${HC:-none}@@"
+              [ "\$HC" = "200" ] && { NRIOK=1; say NRI_PLUGIN_READY; break; }
+              sleep 5
+            done
+            [ "\$NRIOK" = "1" ] || say WARN_NRI_NOT_READY
+            printf %s '$CW' | base64 -d | \$K apply -f - 2>&1 | sed 's/^/@@CWAPPLY /;s/\$/@@/'
+            for i in \$(seq 1 60); do
+              DP=\$(\$K -n default get deploy demo-nginx --no-headers 2>&1)
+              echo "@@CWDEP \$i: \$DP@@"
+              printf '%s' "\$DP" | grep -qE ' 1/1 ' && { WOK=1; say WORKLOAD_OK; break; }
+              sleep 10
+            done
+            IC=\$(\$K -n default get pods -l app=demo-nginx -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null)
+            echo "@@CWCONTAINERS \${IC:-none}@@"
+            printf '%s' "\$IC" | grep -q 'c8s-cert' && { COK=1; say CERT_INJECTED; }
+            [ "\$WOK" = "1" ] && [ "\$COK" = "1" ] && say PAYLOAD_OK
+            if [ "\$WOK" != "1" ]; then
+              \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
+              \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
+            fi
+          fi
+          \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | tail -10 | sed 's/^/@@EV /;s/\$/@@/'
+          PAYLOAD
+          echo "b64=$(base64 -w0 payload.sh)" >> "$GITHUB_OUTPUT"
+
+  # ── WHERE: one call per platform cell; the primitive boots/attests/tears down.
+  #    bare metal (customers who run their own hardware) | cloud (customers who
+  #    rent infrastructure). Adding a cell = adding a row.
+  # ── ONE JOB PER PLATFORM ─────────────────────────────────────────────────
+  # Four platforms, four jobs, four leaves in the run tree. Deliberately NOT a
+  # `matrix:` calling a dispatcher.
+  #
+  # WHY NOT A MATRIX. A reusable-workflow `uses:` takes no expressions, so a
+  # matrix cannot point each row at a different lane. The only way to get one is
+  # a dispatcher whose jobs are `if:`-gated on the row, and because every matrix
+  # row instantiates the WHOLE dispatcher, that costs rows x jobs entries in the
+  # tree: at four platforms, 16 entries of which 12 are skipped, growing
+  # quadratically. That is pure overhead from resolving at RUNTIME something
+  # that is known when the file is written.
+  #
+  # Resolving it here instead gives four real entries and no phantoms, one file
+  # to edit rather than two, and each lane's arguments visible inline. Adding a
+  # platform is one job block below.
+
+  cvm:
+    needs: payload
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/cvm-e2e.yml
+    with:
+      platform: snp-metal
+      runner: cvm-launcher
+      flavor: rke2-node
+      payload_b64: ${{ needs.payload.outputs.b64 }}

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -1,0 +1,456 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# VENDORED FILE, TWO COPIES, KEEP THEM BYTE-IDENTICAL.
+# ═══════════════════════════════════════════════════════════════════════════
+# SOURCE OF TRUTH:
+#   confidential-dot-ai/confidential-ci  .github/workflows/tdx-metal-e2e.yml
+# VENDORED COPY:
+#   confidential-dot-ai/c8s              .github/workflows/tdx-metal-e2e.yml
+#
+# WHY A COPY EXISTS AT ALL: c8s is PUBLIC and confidential-ci is PRIVATE, and a
+# public repo cannot `uses:` a private repo's reusable workflow. Vendoring is
+# the workaround, the same one cvm-e2e.yml and e2e-c8s.yml already use. It is a
+# stopgap, not a design: see confidential-ci research/ADR-matrix-architecture.
+#
+# THE DRIFT HAZARD IS REAL, NOT THEORETICAL. c8s's vendored cvm-e2e.yml silently
+# fell 121 lines behind its confidential-ci original and lost an entire platform
+# arm. Nothing detected it, because neither copy referenced the other.
+#
+# THE RULE: edit the source of truth, then copy the WHOLE file across unchanged.
+# Both copies carry both triggers (workflow_call and workflow_dispatch) precisely
+# so that no per-repo edit is ever needed and a plain checksum can prove they
+# match. If you find yourself wanting to change only one copy, that is the signal
+# to stop vendoring and solve it properly instead.
+#
+# ═══════════════════════════════════════════════════════════════════════════
+# c8s on TDX BARE METAL: the product lane
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Boots the PUBLISHED, UNMODIFIED c8s node image as an Intel TDX CVM on
+# tdx-gh-runner, installs the c8s bundle into it, and asserts the product's
+# security guarantee: the baked NRI floor DENIES a non-allowlisted image.
+#
+# Proven by hand on hardware 2026-07-26 before this lane existed: image
+# imported via CDI, CVM booted, operator-key-bound kubeconfig obtained over
+# RA-TLS, `c8s install` deployed cds/operator/ratls-mesh/tls-lb, and busybox
+# was denied with "image not in allowlist".
+#
+# WHY THIS LANE HAS NO SERIAL CONSOLE (and the SNP lane does): the c8s node
+# image is console-dead by design (hardened kernel, no CONFIG_SERIAL_8250, no
+# sshd, root locked). Its supported entrypoint is the network: attestation-api
+# on :8400, kube-apiserver on :6443, cred-release on :8443. That works here
+# only because this host's OUTER cluster was renumbered to 172.20/172.21, so a
+# guest running rke2's default 10.42/10.43 no longer collides with it. The SNP
+# lane cannot do this: its cluster is live on 10.42 and RKE2 CIDRs are fixed at
+# init. Consequence worth keeping: no secret ever transits a loggable channel
+# here, so this lane is free of the console PEM-leak gap the SNP lane carries.
+#
+# DISPATCH-ONLY for v1 (no schedule/merge trigger until it has a green history).
+name: tdx-metal-e2e
+
+on:
+  # workflow_call so the vendored copy can be invoked as a job by c8s's
+  # e2e-c8s.yml. workflow_dispatch so either copy stays runnable by hand.
+  # Both copies carry both, so the two files remain byte-identical.
+  workflow_call:
+    inputs:
+      c8s_ref:
+        description: 'c8s ref to test. Defaults to the ref paired with the node image.'
+        required: false
+        type: string
+        default: ''
+      keep_cvm:
+        description: 'leave the CVM running for debugging instead of tearing it down'
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      c8s_ref:
+        description: 'c8s git ref to install + test. Empty = the c8sRef pinned in the tdx-rke2-image-refs CM (VERSION PAIRING: the node image bakes an admission floor containing the bootstrap digests from ITS build ref, so a mismatched CLI gets its own components denied).'
+        required: false
+        default: ''
+      keep_cvm:
+        description: 'Skip teardown to debug a failure. The reaper still clears it after 3h.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # One at a time: the lane boots a CVM off a shared RWO rootdisk PVC.
+  group: tdx-metal-e2e
+  cancel-in-progress: false
+
+env:
+  NS: confai-images
+  REFS_CM: tdx-rke2-image-refs
+  VM: c8s-tdx-${{ github.run_id }}-${{ github.run_attempt }}
+
+jobs:
+  e2e:
+    # Named to match the SNP primitive's leaf, `cvm (<platform>/<flavor>)`,
+    # so both lanes read the same way in the run tree.
+    name: cvm (tdx-metal/rke2-node)
+    # The HOST-side launcher runner on tdx-gh-runner. Its bm-e2e SA is scoped to
+    # confai-images (baremetal/kubevirt-rbac.yaml); kubectl uses the in-cluster
+    # token, so there is no kubeconfig to manage for the OUTER cluster.
+    runs-on: cvm-launcher-tdx
+    # CDI import is pre-staged, so: boot ~1m + guest first boot ~3m + c8s CLI
+    # build ~3m + install/converge ~3m + asserts. Headroom for a cold go cache.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: tools (kubectl, go, crane, helm)
+        run: |
+          set -euo pipefail
+          mkdir -p "$PWD/bin"
+          curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl
+          chmod +x bin/kubectl
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+          if ! command -v go >/dev/null; then
+            GOVER="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -1 | sed 's/^go//')"
+            [ -n "$GOVER" ] || GOVER=1.26.3
+            curl -fsSL "https://go.dev/dl/go${GOVER}.linux-amd64.tar.gz" | sudo tar -C /usr/local -xz
+          fi
+          # $GITHUB_PATH only affects LATER steps, so `go` is still not on PATH
+          # inside THIS one. `go install crane` below needs it here and now.
+          export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          # crane: `c8s install --resolve-digests=true` below shells out to it.
+          # Pinned rather than fetched through the GitHub releases API, which
+          # rate-limits by IP on a shared self-hosted host.
+          command -v crane >/dev/null || go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+          # helm: c8s install shells out to it too. The ephemeral ARC pod has
+          # neither binary, unlike the host, so install rather than assume.
+          if ! command -v helm >/dev/null; then
+            curl -fsSL https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz \
+              | tar -xz -C "$PWD/bin" --strip-components=1 linux-amd64/helm
+          fi
+
+      # reap-before-provision: a killed run leaks a CVM (and its scratch PVC).
+      # Fail SAFE: only reap on a positive "completed", or on age. An unknown
+      # status (403/404/no token) KEEPS the CVM rather than killing a live run.
+      - name: reap leaked CVMs from finished runs
+        run: |
+          set +e +o pipefail
+          NOW=$(date -u +%s)
+          for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
+            rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
+            standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
+            [ "$standing" = "true" ] && { echo "keeping $vm (standing runner)"; continue; }
+            [ -z "$rid" ] && continue
+            [ "$rid" = "${{ github.run_id }}" ] && continue
+            ct=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null)
+            age=$(( NOW - $(date -u -d "$ct" +%s 2>/dev/null || echo "$NOW") ))
+            # Ask GitHub whether the owning run is actually finished, rather than
+            # waiting out the 3h age fallback while a CVM squats a finite host.
+            # ANY org repo can invoke this lane, so the owning repo is read from
+            # the annotation (a label value cannot hold the '/' in owner/repo).
+            # Ported from cvm-e2e.yml, which has had this since the SNP lane
+            # started leaking CVMs on cancelled runs.
+            # NOTE: this needs `actions: read`. Without it the call 403s, $st is
+            # empty, and we degrade to exactly the age-only behaviour this
+            # replaces, which is safe but slow.
+            orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
+            st=$(gh api "repos/${orepo:-${{ github.repository }}}/actions/runs/$rid" -q .status 2>/dev/null)
+            if [ "$st" = "completed" ]; then
+              echo "reaping $vm (run ${orepo:-${{ github.repository }}}#$rid completed)"
+              kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+              kubectl -n "$NS" delete pvc "${vm#virtualmachine.kubevirt.io/}-scratch" --ignore-not-found --wait=false
+            elif [ -z "$st" ] && [ "$age" -gt 10800 ]; then
+              echo "reaping $vm (status unknown, age ${age}s > 3h -> orphaned)"
+              kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+              kubectl -n "$NS" delete pvc "${vm#virtualmachine.kubevirt.io/}-scratch" --ignore-not-found --wait=false
+            else
+              echo "keeping $vm (run ${orepo:-${{ github.repository }}}#$rid status=${st:-unknown} age=${age}s)"
+            fi
+          done
+          exit 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: resolve image refs + the paired c8s ref
+        run: |
+          set -euo pipefail
+          for k in image rootPvc mrtd c8sRef; do
+            v=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath="{.data.$k}" 2>/dev/null)
+            [ -n "$v" ] || { echo "::error::$REFS_CM missing '$k'. The TDX refs CM is the single source of truth for image+measurement+paired ref"; exit 1; }
+            echo "$k=$v" >> "$GITHUB_ENV"
+          done
+          # An explicit input overrides the pin, but say so loudly: the floor is
+          # fail-closed, so an unpaired ref is the likeliest cause of a red run.
+          if [ -n '${{ inputs.c8s_ref }}' ]; then
+            echo "::warning title=version pairing::testing c8s_ref='${{ inputs.c8s_ref }}' against an image built from '$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.c8sRef}')': components may be denied by the baked floor"
+            echo "c8sRef=${{ inputs.c8s_ref }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: preflight, TDX device capacity
+        # KubeVirt's socket device-plugin probes the QGS socket ONLY at
+        # virt-handler startup and never re-checks. After a host reboot or a
+        # qgsd/bridge restart it advertises 0 forever and every TDX VM fails to
+        # schedule with a misleading "Insufficient devices". Seen in the wild
+        # 2026-07-26 on a 26h-old virt-handler while QGS was perfectly healthy.
+        # Cheap to detect here; the remedy needs cluster-scoped rights the
+        # bm-e2e SA deliberately lacks, so this reports rather than fixes.
+        run: |
+          set -uo pipefail
+          if kubectl auth can-i get nodes >/dev/null 2>&1; then
+            N=$(kubectl get node -l kubevirt.io/tdx=true -o jsonpath='{.items[0].status.allocatable.devices\.kubevirt\.io/tdx}' 2>/dev/null)
+            echo "devices.kubevirt.io/tdx = ${N:-unknown}"
+            if [ "${N:-0}" = "0" ]; then
+              echo "::error title=TDX devices exhausted::virt-handler is advertising 0 TDX devices. Fix on the host: kubectl -n kubevirt rollout restart daemonset/virt-handler"
+              exit 1
+            fi
+          else
+            echo "no node read permission (expected: bm-e2e is namespace-scoped); relying on the scheduling gate below"
+          fi
+
+      - name: per-run operator key + opkeydata secret
+        # The initrd mounts the ISO labelled "opkeydata", SHA-384s the file
+        # named `pubkey`, and extends that into RTMR[3]. cred-release then
+        # refuses to serve if the on-disk key does not match RTMR[3], so the
+        # kubeconfig we fetch is cryptographically bound to THIS keypair.
+        run: |
+          set -euo pipefail
+          umask 077
+          openssl ecparam -name prime256v1 -genkey -noout -out /tmp/op.key
+          openssl ec -in /tmp/op.key -pubout -out /tmp/op.pub 2>/dev/null
+          kubectl -n "$NS" create secret generic "$VM-opkey" \
+            --from-file=pubkey=/tmp/op.pub --dry-run=client -o yaml | kubectl apply -f -
+          echo "operator key bound (sha384 $(sha384sum < /tmp/op.pub | cut -c1-16)...)"
+
+      - name: boot the TDX CVM
+        run: |
+          set -euo pipefail
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: PersistentVolumeClaim
+          metadata:
+            name: $VM-scratch
+            namespace: $NS
+            labels: {ci.confidential.ai/managed: "true"}
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources: {requests: {storage: 80Gi}}
+            storageClassName: local-path
+          ---
+          apiVersion: v1
+          kind: Secret
+          metadata: {name: $VM-cloudinit, namespace: $NS}
+          type: Opaque
+          stringData:
+            userdata: |
+              #cloud-config
+              hostname: ${VM}
+          ---
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: $VM
+            namespace: $NS
+            labels:
+              ci.confidential.ai/managed: "true"
+              ci.confidential.ai/run-id: "${{ github.run_id }}"
+            annotations:
+              ci.confidential.ai/repo: "${{ github.repository }}"
+              ci.confidential.ai/run-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          spec:
+            runStrategy: Always
+            template:
+              metadata:
+                labels: {kubevirt.io/domain: $VM}
+              spec:
+                nodeSelector:
+                  kubevirt.io/tdx: "true"
+                domain:
+                  cpu:
+                    # host-passthrough is MANDATORY: QEMU rejects a named model
+                    # for TDX ("Named cpu model is not supported for TDX yet!").
+                    model: host-passthrough
+                    cores: 4
+                  devices:
+                    autoattachVSOCK: true
+                    disks:
+                      - name: rootdisk
+                        # dm-verity rootfs: never written. readonly takes a
+                        # SHARED qemu lock so concurrent CVMs coexist; a
+                        # writable open takes an EXCLUSIVE one and starves every
+                        # other guest on the same PVC (cost the SNP lane a day).
+                        # NB: readonly is a field of `disk`, not a sibling of it;
+                        # KubeVirt's strict decoder rejects the sibling form.
+                        disk: {bus: virtio, readonly: true}
+                      - name: scratch
+                        disk: {bus: virtio}
+                        # HARD requirement: the initrd keys the encrypted
+                        # overlay off this exact serial. Without it the guest
+                        # falls back to a 2G tmpfs and rke2 wedges when full.
+                        serial: confai-scratch
+                      - name: opkey
+                        disk: {bus: virtio}
+                      - name: cloudinit
+                        disk: {bus: virtio}
+                    interfaces: [{name: default, masquerade: {}}]
+                    rng: {}
+                  firmware: {bootloader: {efi: {secureBoot: false}}}
+                  # Empty object: TDX takes no per-VM policy. Cluster config
+                  # lives in the KubeVirt CR (confidentialCompute.tdx.attestation).
+                  launchSecurity: {tdx: {}}
+                  memory: {guest: 16Gi}
+                  resources: {requests: {memory: 16Gi}}
+                networks: [{name: default, pod: {}}]
+                volumes:
+                  - name: rootdisk
+                    persistentVolumeClaim: {claimName: $rootPvc}
+                  - name: scratch
+                    persistentVolumeClaim: {claimName: $VM-scratch}
+                  - name: opkey
+                    secret: {secretName: $VM-opkey, volumeLabel: opkeydata}
+                  - name: cloudinit
+                    cloudInitNoCloud: {secretRef: {name: $VM-cloudinit}}
+          EOF
+          for i in $(seq 1 60); do
+            PHASE=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+            [ "$PHASE" = Running ] && break
+            sleep 5
+          done
+          if [ "${PHASE:-}" != Running ]; then
+            kubectl -n "$NS" describe vmi "$VM" | tail -25
+            echo "::error::VMI not Running (phase=${PHASE:-none}). 'Insufficient devices.kubevirt.io/tdx' means virt-handler latched 0: rollout restart daemonset/virt-handler -n kubevirt"
+            exit 1
+          fi
+          IP=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.interfaces[0].ipAddress}')
+          [ -n "$IP" ] || { echo "::error::no guest IP"; exit 1; }
+          echo "GUEST_IP=$IP" >> "$GITHUB_ENV"
+          echo "VMI Running at $IP"
+
+      - name: assert genuine TDX launch
+        run: |
+          set -euo pipefail
+          POD=$(kubectl -n "$NS" get pods -l kubevirt.io/domain="$VM" -o name | head -1)
+          kubectl -n "$NS" exec "$POD" -c compute -- \
+            bash -c 'tr "\0" "\n" < /proc/$(pgrep -f qemu-system | head -1)/cmdline | grep -c "tdx-guest"' | tee /tmp/tdx.cnt
+          [ "$(cat /tmp/tdx.cnt)" -ge 1 ] || { echo "::error::qemu has no tdx-guest object: not a genuine trust domain"; exit 1; }
+          echo "OK: qemu launched with -object tdx-guest"
+
+      - name: wait for guest services (attestation-api, apiserver, cred-release)
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 90); do
+            H=$(curl -s --connect-timeout 2 --max-time 4 "http://$GUEST_IP:8400/health" 2>/dev/null || true)
+            [ -n "$H" ] && { echo "attestation-api: $H"; break; }
+            sleep 10
+          done
+          echo "$H" | grep -q '"platform":"tdx"' || { echo "::error::attestation-api did not report platform=tdx"; exit 1; }
+          for i in $(seq 1 60); do
+            C=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$GUEST_IP:6443/livez" 2>/dev/null || true)
+            case "$C" in 200|401|403) echo "kube-apiserver: HTTP $C"; break;; esac
+            sleep 5
+          done
+          for i in $(seq 1 60); do
+            C=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$GUEST_IP:8443/" 2>/dev/null || true)
+            [ -n "$C" ] && [ "$C" != 000 ] && { echo "cred-release: HTTP $C"; break; }
+            sleep 5
+          done
+
+      - name: build the c8s CLI at the paired ref
+        run: |
+          set -euo pipefail
+          rm -rf /tmp/c8s-src
+          git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src
+          git -C /tmp/c8s-src checkout -q "$c8sRef" || { echo "::error::bad c8s ref '$c8sRef': refusing to silently test main"; exit 1; }
+          echo "c8s ref sha: $(git -C /tmp/c8s-src rev-parse HEAD)"
+          ( cd /tmp/c8s-src && go install ./cmd/c8s )
+          # An unstamped build reports "dev", which is exactly why --image-tag
+          # is passed explicitly at install rather than trusting build metadata.
+          c8s --version || true
+
+      - name: get an attested, operator-key-bound kubeconfig (RA-TLS)
+        run: |
+          set -euo pipefail
+          c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --out /tmp/guest.kubeconfig --timeout 180s
+          [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }
+          WHO=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+          [ "$WHO" = operator ] || { echo "::error::unexpected identity '$WHO'"; exit 1; }
+          echo "OK: attested kubeconfig, identity=$WHO"
+          KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes
+
+      - name: install the c8s bundle under test
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          c8s install --cvm-mode node --single-node --hardware-platform tdx \
+            --image-tag "$c8sRef" \
+            --operator-keys /tmp/op.pub \
+            --measurements "$mrtd" \
+            --resolve-digests=true
+          kubectl -n c8s-system get pods -o wide
+
+      - name: assert components converged
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          # awk, not a regex backreference: `$2 !~ /^([0-9]+)\/\1$/` looks right
+          # and is not (awk has no backreferences), so it silently only ever
+          # matches 1/1 and calls every sidecar-bearing pod not-ready.
+          for i in $(seq 1 40); do
+            NOTREADY=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | awk '{split($2,a,"/"); if (a[1]!=a[2] || $3!="Running") n++} END {print n+0}')
+            TOTAL=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | wc -l)
+            [ "$TOTAL" -gt 0 ] && [ "$NOTREADY" -eq 0 ] && { echo "all $TOTAL components Running"; break; }
+            sleep 15
+          done
+          kubectl -n c8s-system get pods --no-headers
+          [ "${NOTREADY:-1}" -eq 0 ] || { echo "::error::components did not converge"; kubectl -n c8s-system describe pods | tail -40; exit 1; }
+
+      - name: NEGATIVE, the baked floor must deny a non-allowlisted image
+        # The product's core guarantee, asserted rather than worked around.
+        # Uses the `default` namespace deliberately: the node image bakes a
+        # restricted PSA default and exempts `default` for smoke pods, so a
+        # denial here is unambiguously the IMAGE floor, not PodSecurity.
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          kubectl -n default delete pod denied --ignore-not-found >/dev/null 2>&1 || true
+          kubectl -n default run denied --image=busybox:1.36 --restart=Never --command -- sleep 300
+          for i in $(seq 1 24); do
+            R=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
+            [ -n "$R" ] && [ "$R" != ContainerCreating ] && break
+            sleep 5
+          done
+          MSG=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.message}' 2>/dev/null || true)
+          echo "reason=$R"
+          echo "message=$MSG"
+          echo "$MSG" | grep -q 'image not in allowlist' || {
+            echo "::error title=SECURITY REGRESSION::the baked NRI floor did NOT deny a non-allowlisted image (reason=$R). The product's fail-closed admission guarantee is not holding on this image."
+            kubectl -n default describe pod denied | tail -20
+            exit 1
+          }
+          echo "OK: floor denied busybox:1.36 at container creation"
+          kubectl -n default delete pod denied --wait=false >/dev/null 2>&1 || true
+
+      - name: summary
+        if: always()
+        run: |
+          {
+            echo "### c8s on TDX metal"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| image | \`${image:-?}\` |"
+            echo "| rootPvc | \`${rootPvc:-?}\` |"
+            echo "| c8s ref | \`${c8sRef:-?}\` |"
+            echo "| MRTD | \`${mrtd:0:32}...\` |"
+            echo "| guest | \`${GUEST_IP:-?}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: teardown
+        if: always() && inputs.keep_cvm != true
+        run: |
+          set +e
+          kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true --timeout=120s
+          kubectl -n "$NS" delete secret "$VM-opkey" "$VM-cloudinit" --ignore-not-found
+          kubectl -n "$NS" delete pvc "$VM-scratch" --ignore-not-found --wait=false
+          exit 0


### PR DESCRIPTION
A merge to c8s main runs **one** lane today. The four-lane work landed in confidential-ci's copy, and this repo runs its own vendored copy, which was never updated. This brings it across.

## Drift reconciled first, not buried

`cvm-e2e.yml` here was **422 lines against 450** upstream. I checked what that gap actually was before overwriting anything:

**This copy already had every safety fix** — the readonly ROX rootdisk, the configfs-tsm measurement read, the cross-repo reaper, the pinned igvm sidecar digest. The gap was upstream growing standing-runner features (`keep_alive`, `vm_name`, `memory_override`) that this repo never used.

All three are optional and default inert, and:

```yaml
VM: ${{ inputs.vm_name || format('cvm-{0}-{1}', github.run_id, github.run_attempt) }}
```

produces **exactly** the VM name this copy already produced when `vm_name` is unset. So the sync is behaviour-preserving, not just plausible.

The three vendored lanes are now **byte-identical** to their originals:

| file | sha256 |
|---|---|
| `cvm-e2e.yml` | `7439704ebad6` |
| `snp-metal-e2e.yml` | `dc0629dae1f4` |
| `tdx-metal-e2e.yml` | `85bae38ea62c` |

## Shape

`e2e-c8s.yml` goes 300 lines to 98 and becomes only the platform list. The SNP payload moves into `snp-metal-e2e.yml`, because `cvm-e2e.yml` is a **generic primitive** shared with other callers and the c8s payload does not belong inside it.

Not a `matrix:`: a reusable-workflow `uses:` takes no expressions, so a matrix needs an if-gated dispatcher, and since every row instantiates the whole dispatcher that costs `rows x jobs` tree entries, growing quadratically. Plain jobs give one real entry each.

## The azure rows are absent on purpose

This is the **one** intended difference from the upstream copy, and both blockers are outside CI:

1. The Entra federated credential trusts `repo:confidential-dot-ai/confidential-ci`. A token minted from this repo is rejected with `AADSTS700213`. **Observed, not assumed**: the same rejection happened on a confidential-ci feature branch, and succeeded once on main. Granting c8s its own credential is an access change, not a code change.
2. `azure-tdx-e2e.yml` reads `c8s-e2e/azure-tdx-driver.sh`, which lives in confidential-ci and returns 404 here.

Until both are resolved the azure lanes keep running from confidential-ci on a schedule, so coverage is unchanged, just not merge-triggered from here.

## Verification

Validated by dispatch on this branch, since a PR cannot exercise a self-hosted lane. Result in a comment below.

The gate is not a green check: the failure mode this system has hit before is a run that stays green while measurement enforcement silently degrades to `MEAS_ACCEPTANY`. The check is that the emitted digest still equals the recorded baseline `15bc9953...d19115`, which independently matches the cluster's own `rke2-image-refs.runtimeLaunchDigest`.

## Note on what this does and does not fix

This makes both metal lanes run **when the merge trigger fires**. It does not fix the trigger. `docker.yml`'s push path gate still means roughly a quarter of merges to main produce no Docker run and therefore no TEE integration at all. That is #143.
