### PR TITLE
docs(e2e): correct why the tdx lane pins its paired ref

### DIFF
--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -87,11 +87,37 @@ jobs:
       actions: read
     uses: ./.github/workflows/tdx-metal-e2e.yml
     with:
-      # DELIBERATELY EMPTY. The TDX node image bakes a fail-closed NRI floor
-      # from the c8s ref it was BUILT from, so installing any other ref gets
-      # that ref's own components denied. Empty means "use the paired ref".
-      # CONSEQUENCE: this lane proves the stack, the host, the image and the
-      # runner. It does NOT test the code in the merge that triggered it; that
-      # is snp-metal's job. Real merge-code coverage on TDX needs a node image
-      # built per merge, which is an image-pipeline problem.
+      # DELIBERATELY EMPTY. Empty means "use the ref the node image was built
+      # from", published in the tdx-rke2-image-refs ConfigMap.
+      #
+      # WHY, and the earlier comment here had this WRONG. It claimed the image
+      # bakes a floor "from its build ref, so installing any other ref gets that
+      # ref's own components denied". That is not the mechanism. The measured
+      # always_allow in the node image (confidential-os-builder
+      # mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in) holds exactly TWO
+      # entries, the nri-image-policy image and the cds image. It has never
+      # contained the operator, ratls-mesh, tls-lb, get-cert or attestation-api
+      # at any ref, so "that ref's components" were never in it to be missing.
+      #
+      # THE ACTUAL BINDING IS A BOOTSTRAP ORDERING. CDS serves the allowlist that
+      # admits everything else, so CDS itself has to be admitted first, and the
+      # only thing that can admit it before it is running is that two-entry
+      # measured floor, which pins ONE cds digest: the node image's. Install a
+      # different ref and its cds image is a different digest, so it is denied at
+      # container create in c8s-system (not an exempt namespace), never serves a
+      # seed, and helm --wait expires. Narrow in principle, since retag-unchanged
+      # preserves the digest whenever cds itself is untouched, but measured on
+      # 2026-07-27 it was 0 of the last 3 merge heads.
+      #
+      # Note --resolve-digests does NOT help here: it derives component digests
+      # into the CDS-SERVED seed, which is downstream of the bootstrap. That is
+      # why arbitrary third-party digests (the ARC images) can be seeded at
+      # install and admitted: those pods start after CDS is already serving.
+      #
+      # CONSEQUENCE, UNCHANGED: this lane proves the stack, the host, the image
+      # and the runner, not the code in the merge that triggered it. It is also
+      # the ONLY lane in either repo that runs nri-image-policy in ENFORCE mode
+      # and asserts a real admission denial; the snp-metal lane installs the
+      # merge head but with policy.mode: audit, so it tests newer code with
+      # enforcement off. The two are complementary, not redundant.
       c8s_ref: ''


### PR DESCRIPTION
Documentation only. The conclusion is unchanged; the stated reason for it was wrong.

## What I wrote, and why it is false

> DELIBERATELY EMPTY. The TDX node image bakes a fail-closed NRI floor from the c8s ref it was BUILT from, so installing any other ref gets that ref's own components denied.

The measured `always_allow` in the node image (`confidential-os-builder mkosi/base/mkosi.profiles/c8s/image-policy.yaml.in`) holds **exactly two entries**: the `nri-image-policy` image and the `cds` image.

It has never contained the operator, ratls-mesh, tls-lb, get-cert or attestation-api **at any ref**. So "that ref's own components" were never in the floor to be missing. The floor is also a pure union with no deny list and never compares refs.

## The actual constraint

A **bootstrap ordering**. CDS serves the allowlist that admits everything else, so CDS itself has to be admitted first, and the only thing that can admit it before it is running is that two-entry measured floor, which pins **one** cds digest: the node image's.

Install a different ref and its cds image is a different digest, so it is denied at container create in `c8s-system` (not an exempt namespace), never serves a seed, and `helm --wait` expires.

Narrow in principle, since retag-unchanged preserves the digest whenever `cds` itself is untouched. Not narrow in fact, measured 2026-07-27:

```
cds:64b6d7a  (baked in the node image)   sha256:10213e3a
cds:fd0547e                              a4c61848
cds:b16a501 = cds:6522581 = cds:main     6e37c1d1
```

**0 of the last 3 merge heads matched.**

## Also corrected

`--resolve-digests` does **not** rescue this. It derives component digests into the CDS-**served** seed, which is downstream of the bootstrap. That is precisely why arbitrary third-party digests (the ARC controller and runner images) seed fine at install and get admitted: those pods start *after* CDS is already serving.

## Why bother, if the behaviour does not change

A wrong stated reason is worse than no reason. This one points at the image pipeline ("needs a node image built per merge") when the actual lever is a single bootstrap digest. Someone acting on it would rebuild the wrong thing.

## One thing the comment now records that it should have all along

This lane is the **only one in either repo** running `nri-image-policy` in **enforce** mode, and the only place that asserts a real admission denial (`image not in allowlist` appears in exactly one workflow file across both repos). The `snp-metal` lane installs the merge head but with `policy.mode: audit`, so it tests newer code with enforcement **off**.

The two lanes are complementary rather than one being a weaker copy of the other: SNP varies the code and relaxes the platform, TDX fixes the code and enforces the platform. I had been describing TDX as the lesser of the two.
