### PR TITLE
fix(workloadclaims): close SO_PEERCRED PID-reuse TOCTOU

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ provisioning guides is at
   TDX host for pod-as-CVM, or SEV-SNP / TDX confidential VMs as nodes for
   node-as-CVM
   (see the [CVM setup guide](https://confidential.ai/docs/c8s/tutorials/azure-e2e)).
+  Node kernels must be recent enough for the TEE (AMD SEV-SNP ≥ 6.11, Intel TDX
+  ≥ 6.16), which also satisfies the Linux ≥ 6.5 `SO_PEERPIDFD` the admission
+  inventory relies on — see [docs/QUICKSTART.md](docs/QUICKSTART.md).
 - Helm 3, `kubectl`, and `crane` on PATH.
 - Go 1.26+ to build the CLI.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -11,6 +11,12 @@ This is the supported install path for the consolidated c8s chart.
   resolved to digests by default or supplied in a values file.
 - One node labelled to run CDS (`role=cds` by default).
 - Nodes with the TEE device shape expected by `attestationApi.teeDevices`.
+- Node kernels new enough for `SO_PEERPIDFD` (Linux ≥ 6.5), which the
+  admission inventory (nri-image-policy) requires to pin a caller's peer
+  credentials against PID reuse; a node without it fails workload-claims and
+  sandbox-token fetches closed. TEE-capable kernels already exceed this — AMD
+  SEV-SNP hosts need ≥ 6.11 and Intel TDX ≥ 6.16 — so this is satisfied on any
+  supported node.
 
 ## Install c8s
 

--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -204,6 +204,21 @@ attaches the peer's credentials to the socket; the inventory reads them with
 socket. The chain is entirely kernel/runtime-derived — `SO_PEERCRED` → cgroup →
 container → pod — and none of it is caller-supplied.
 
+**Pinning the PID against reuse.** `SO_PEERCRED` returns a bare PID, and the
+`/proc/<pid>/cgroup` read happens a few instructions later — a window in which
+the peer could exit and the kernel recycle its PID to an unrelated process,
+which the inventory would then resolve as the caller. The inventory closes this
+by also reading `SO_PEERPIDFD` (Linux 6.5+), a pidfd that pins that *exact*
+process instance, and rechecking `peer.IsAlive()` **after** the cgroup read: if
+the pinned process exited during resolution — or the pidfd could not be obtained
+at all — the answer is refused (`peercred_linux.go`, `Peer.IsAlive`;
+`inventory.go`, `callerForPeer`). A supported CC node always has the pidfd:
+`SO_PEERPIDFD` landed in Linux 6.5, and SNP hosts require ≥ 6.11, TDX ≥ 6.16, so
+its absence is treated as an error and **fails closed**, not tolerated as a
+best-effort fallback. This is orthogonal to Corner 2: the pidfd fixes *PID
+identity over time*, the shallowest-tracked rule fixes *cgroup-nesting
+spoofing*; both are needed.
+
 **PID-namespace subtlety.** get-cert runs in a container where its own PID
 might be 1. `SO_PEERCRED` reports the PID *as seen by the reader* — the
 nri-image-policy plugin, which runs on the **host** (launched by containerd,

--- a/internal/cmds/getcert/run_extra_test.go
+++ b/internal/cmds/getcert/run_extra_test.go
@@ -59,7 +59,7 @@ type fakeResolver struct {
 	err        error
 }
 
-func (f fakeResolver) ContainersForPeer(int) ([]workloadclaims.Container, error) {
+func (f fakeResolver) ContainersForPeer(workloadclaims.Peer) ([]workloadclaims.Container, error) {
 	return f.containers, f.err
 }
 

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -89,15 +89,27 @@ func (b *admissionInventory) removeSandbox(sandboxID string) {
 }
 
 // callerForPeer resolves the calling process to its tracked container record.
-// peerPID 0 is rejected: on node-CVM the inventory MUST bind the caller via
-// kernel credentials. Callers must hold at least b.mu.RLock.
-func (b *admissionInventory) callerForPeer(peerPID int) (ctrRec, error) {
-	if peerPID <= 0 {
+// A zero PID is rejected: on node-CVM the inventory MUST bind the caller via
+// kernel credentials. peer.IsAlive() is rechecked after the /proc read so a PID
+// recycled between SO_PEERCRED and that read (the peer exited mid-resolution)
+// is rejected rather than resolved to whatever now holds the number
+// (docs/getcert-workload-binding.md, Corner 1). Callers must hold at least
+// b.mu.RLock.
+func (b *admissionInventory) callerForPeer(peer workloadclaims.Peer) (ctrRec, error) {
+	pid := peer.PID()
+	if pid <= 0 {
 		return ctrRec{}, fmt.Errorf("no peer credentials on the inventory connection")
 	}
-	candidates, err := workloadclaims.ContainerIDCandidatesForPID(b.procRoot, peerPID)
+	candidates, err := workloadclaims.ContainerIDCandidatesForPID(b.procRoot, pid)
 	if err != nil {
 		return ctrRec{}, err
+	}
+	// The cgroup was read by PID; confirm the pinned peer is still the process
+	// that was there, so a reused PID cannot bind the caller to a victim's
+	// container. Fails closed if liveness can't be confirmed — the peer exited,
+	// or no pidfd was available (anomalous on a supported CC kernel).
+	if !peer.IsAlive() {
+		return ctrRec{}, fmt.Errorf("cannot confirm the caller is still the pinned peer process (exited during resolution, or pidfd unavailable)")
 	}
 	// Resolve the shallowest candidate that is a tracked container: the
 	// caller's own runtime-assigned scope is always an ancestor of any cgroup
@@ -113,11 +125,11 @@ func (b *admissionInventory) callerForPeer(peerPID int) (ctrRec, error) {
 
 // ContainersForPeer resolves the calling process to its pod and returns that
 // pod's admitted, non-injected containers (name + digest).
-func (b *admissionInventory) ContainersForPeer(peerPID int) ([]workloadclaims.Container, error) {
+func (b *admissionInventory) ContainersForPeer(peer workloadclaims.Peer) ([]workloadclaims.Container, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	caller, err := b.callerForPeer(peerPID)
+	caller, err := b.callerForPeer(peer)
 	if err != nil {
 		return nil, err
 	}
@@ -145,11 +157,11 @@ func (b *admissionInventory) ContainersForPeer(peerPID int) ([]workloadclaims.Co
 
 // SandboxForPeer resolves the calling process to the pod sandbox it runs in,
 // bound by kernel credentials like ContainersForPeer.
-func (b *admissionInventory) SandboxForPeer(peerPID int) (string, error) {
+func (b *admissionInventory) SandboxForPeer(peer workloadclaims.Peer) (string, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
-	caller, err := b.callerForPeer(peerPID)
+	caller, err := b.callerForPeer(peer)
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmds/nri-image-policy/inventory_test.go
+++ b/internal/cmds/nri-image-policy/inventory_test.go
@@ -5,10 +5,12 @@ import (
 	"path/filepath"
 	"slices"
 	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
 func digestsOf(b *admissionInventory, pid int) ([]string, error) {
-	cs, err := b.ContainersForPeer(pid)
+	cs, err := b.ContainersForPeer(workloadclaims.PeerForPID(pid))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +202,7 @@ func TestInventorySandboxForPeer(t *testing.T) {
 	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther)
 	writeCgroup(t, procRoot, 4242, cidGetCert)
 
-	got, err := b.SandboxForPeer(4242)
+	got, err := b.SandboxForPeer(workloadclaims.PeerForPID(4242))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,10 +211,10 @@ func TestInventorySandboxForPeer(t *testing.T) {
 	}
 
 	writeCgroup(t, procRoot, 55, cidOther)
-	if _, err := b.SandboxForPeer(55); err == nil {
+	if _, err := b.SandboxForPeer(workloadclaims.PeerForPID(55)); err == nil {
 		t.Fatal("untracked caller resolved to a sandbox")
 	}
-	if _, err := b.SandboxForPeer(0); err == nil {
+	if _, err := b.SandboxForPeer(workloadclaims.PeerForPID(0)); err == nil {
 		t.Fatal("peer pid 0 accepted")
 	}
 }

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -74,7 +74,7 @@ func (b *admissionInventory) recordSandboxID(id string) {
 // ContainersForPeer returns every admitted, non-injected container in the
 // guest's single pod. The peer PID is ignored: the guest boundary is the
 // isolation, so there is nothing to bind the caller to.
-func (b *admissionInventory) ContainersForPeer(_ int) ([]workloadclaims.Container, error) {
+func (b *admissionInventory) ContainersForPeer(_ workloadclaims.Peer) ([]workloadclaims.Container, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	out := make([]workloadclaims.Container, 0, len(b.containers))
@@ -90,7 +90,7 @@ func (b *admissionInventory) ContainersForPeer(_ int) ([]workloadclaims.Containe
 // SandboxForPeer returns the guest pod's sandbox ID; the peer PID is ignored
 // (single pod). Fails until a container has been observed, so a too-early
 // token request fails closed instead of naming an empty sandbox.
-func (b *admissionInventory) SandboxForPeer(_ int) (string, error) {
+func (b *admissionInventory) SandboxForPeer(_ workloadclaims.Peer) (string, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.sandboxID == "" {

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -5,6 +5,8 @@ package policymonitor
 import (
 	"slices"
 	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
 const (
@@ -22,7 +24,7 @@ func TestKataInventoryClaimExcludesInjectedInventoryIncludes(t *testing.T) {
 	b.record("cid-app", "app", pmDigestApp)
 	b.record("cid-cert", "c8s-cert", pmDigestSidecar)
 
-	containers, err := b.ContainersForPeer(0)
+	containers, err := b.ContainersForPeer(workloadclaims.PeerForPID(0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +49,7 @@ func TestKataInventoryClaimExcludesInjectedInventoryIncludes(t *testing.T) {
 func TestKataInventorySandboxIdentity(t *testing.T) {
 	b := newAdmissionInventory()
 
-	if _, err := b.SandboxForPeer(0); err == nil {
+	if _, err := b.SandboxForPeer(workloadclaims.PeerForPID(0)); err == nil {
 		t.Fatal("sandbox resolved before any container was observed")
 	}
 	if _, known, _ := b.DigestsForSandbox(pmSandboxID); known {
@@ -56,7 +58,7 @@ func TestKataInventorySandboxIdentity(t *testing.T) {
 
 	b.recordSandboxID(pmSandboxID)
 	b.recordSandboxID("some-other-id") // can't happen in a one-pod guest; first wins
-	got, err := b.SandboxForPeer(0)
+	got, err := b.SandboxForPeer(workloadclaims.PeerForPID(0))
 	if err != nil || got != pmSandboxID {
 		t.Fatalf("sandbox = %q, %v; want %q", got, err, pmSandboxID)
 	}

--- a/pkg/workloadclaims/peercred_linux.go
+++ b/pkg/workloadclaims/peercred_linux.go
@@ -1,31 +1,113 @@
 package workloadclaims
 
 import (
+	"errors"
 	"net"
 
 	"golang.org/x/sys/unix"
 )
 
-// peerPID returns the kernel-reported PID of the process on the other end of
-// a unix socket, or 0 when unavailable (non-unix transport, or a failed
-// getsockopt). The node-CVM resolver must reject 0 — it binds the caller to a
-// pod; the kata resolver ignores the PID entirely, one pod per guest
-// (docs/ratls.md).
-func peerPID(c net.Conn) int {
+// pidfd sentinels for Peer.pidfd. A real pidfd is >= 0.
+const (
+	// pidfdNone: peerFrom obtained no pidfd (non-unix conn, or SO_PEERPIDFD
+	// failed). A CC node always supports SO_PEERPIDFD — it landed in Linux 6.5,
+	// and SNP hosts require >= 6.11, TDX >= 6.16 — so its absence is anomalous,
+	// not an old-kernel we tolerate. IsAlive fails closed on it.
+	pidfdNone = -1
+	// pidfdSkip: a test-constructed Peer (PeerForPID) with no socket, so there
+	// is no liveness to check. IsAlive returns true so resolver tests can run
+	// without a real process. Never produced by peerFrom.
+	pidfdSkip = -2
+)
+
+// Peer identifies the process on the other end of an inventory connection. The
+// PID comes from SO_PEERCRED; SO_PEERPIDFD (Linux 6.5+) additionally returns a
+// pidfd that pins that exact process instance, so IsAlive can detect an exit
+// between the credential read and the resolver's /proc lookup — the window a
+// bare PID leaves open to PID reuse (docs/getcert-workload-binding.md,
+// "Corner 1"). Close releases the pidfd.
+type Peer struct {
+	pid   int
+	pidfd int // >= 0: a live pidfd to poll; pidfdNone/pidfdSkip otherwise
+}
+
+// peerFrom captures the peer credentials of a unix connection. A non-unix conn
+// or a failed SO_PEERCRED yields a zero-PID Peer, which the node-CVM resolver
+// rejects. SO_PEERPIDFD must succeed on a CC node; any failure leaves pidfdNone,
+// and IsAlive then fails closed rather than vouching for a caller it cannot pin.
+func peerFrom(c net.Conn) Peer {
+	p := Peer{pidfd: pidfdNone}
 	uc, ok := c.(*net.UnixConn)
 	if !ok {
-		return 0
+		return p
 	}
 	raw, err := uc.SyscallConn()
 	if err != nil {
-		return 0
+		return p
 	}
-	var cred *unix.Ucred
-	var credErr error
-	if err := raw.Control(func(fd uintptr) {
-		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
-	}); err != nil || credErr != nil || cred == nil {
-		return 0
-	}
-	return int(cred.Pid)
+	_ = raw.Control(func(fd uintptr) {
+		cred, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+		if err != nil || cred == nil {
+			return
+		}
+		p.pid = int(cred.Pid)
+		// SO_PEERPIDFD reflects the peer captured at connect(), consistent with
+		// SO_PEERCRED above, so the pidfd pins the same process the PID names.
+		// Any failure (including ENOPROTOOPT on a sub-6.5 kernel we do not
+		// support) leaves pidfdNone → fail closed.
+		if pidfd, err := unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_PEERPIDFD); err == nil {
+			p.pidfd = pidfd
+		}
+	})
+	return p
 }
+
+// PID returns the peer's kernel-reported PID, or 0 when unavailable.
+func (p Peer) PID() int { return p.pid }
+
+// IsAlive reports whether the pinned peer process is confirmed still running.
+// It MUST be called AFTER the resolver reads /proc for this PID: a peer that
+// exited during resolution may have had its PID recycled, so the read cannot be
+// trusted. It fails closed (returns false) when it cannot confirm liveness — no
+// pidfd, a bad pidfd, or a poll error — so only a positively-confirmed live
+// process passes.
+func (p Peer) IsAlive() bool {
+	if p.pidfd == pidfdSkip {
+		return true // test peer: no socket, nothing to verify
+	}
+	if p.pidfd < 0 {
+		return false // no pidfd on a node that must have one → fail closed
+	}
+	fds := []unix.PollFd{{Fd: int32(p.pidfd), Events: unix.POLLIN}}
+	// Poll with timeout 0 is non-blocking; bound the (rare) EINTR retry rather
+	// than spin, and fail closed if it never settles.
+	for i := 0; i < 8; i++ {
+		_, err := unix.Poll(fds, 0)
+		if errors.Is(err, unix.EINTR) {
+			continue
+		}
+		if err != nil {
+			return false
+		}
+		// A bad, errored, or hung-up fd must not read as "alive".
+		if fds[0].Revents&(unix.POLLNVAL|unix.POLLERR|unix.POLLHUP) != 0 {
+			return false
+		}
+		// A pidfd becomes readable (POLLIN) exactly when its process exits.
+		return fds[0].Revents&unix.POLLIN == 0
+	}
+	return false
+}
+
+// Close releases the pidfd, if any. Safe to call on a zero or test Peer.
+func (p Peer) Close() {
+	if p.pidfd >= 0 {
+		_ = unix.Close(p.pidfd)
+	}
+}
+
+// PeerForPID builds a Peer from a PID obtained out of band, with no pidfd — its
+// liveness check is skipped (pidfdSkip). Production inventory code always uses
+// peerFrom, which pins a pidfd; this exists only for tests exercising the
+// resolver without a real socket.
+func PeerForPID(pid int) Peer { return Peer{pid: pid, pidfd: pidfdSkip} }

--- a/pkg/workloadclaims/peercred_linux_test.go
+++ b/pkg/workloadclaims/peercred_linux_test.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package workloadclaims
+
+import (
+	"os/exec"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// peerFromPidfd builds a Peer that pins pid via a real pidfd, mirroring what
+// peerFrom does from SO_PEERPIDFD — so the liveness check can be exercised
+// without a socket pair.
+func peerFromPidfd(t *testing.T, pid int) Peer {
+	t.Helper()
+	fd, err := unix.PidfdOpen(pid, 0)
+	if err != nil {
+		t.Skipf("pidfd_open unavailable: %v", err)
+	}
+	return Peer{pid: pid, pidfd: fd}
+}
+
+// A pidfd pinning a live process reports IsAlive; once that process exits (its
+// PID now reusable), IsAlive reports false so the resolver fails closed instead
+// of binding the caller to whatever now holds the number.
+func TestPeerIsAliveTracksProcessExit(t *testing.T) {
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start child: %v", err)
+	}
+	peer := peerFromPidfd(t, cmd.Process.Pid)
+	defer peer.Close()
+
+	if !peer.IsAlive() {
+		t.Fatal("IsAlive = false for a running process")
+	}
+
+	if err := cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill child: %v", err)
+	}
+	_ = cmd.Wait() // reap, so the kernel signals the pidfd
+
+	if peer.IsAlive() {
+		t.Fatal("IsAlive = true after the pinned process exited (PID-reuse window left open)")
+	}
+}
+
+// A Peer with no pidfd fails closed: on a supported CC kernel SO_PEERPIDFD is
+// always present, so its absence must not read as "alive". The test-only
+// PeerForPID is the one exception (pidfdSkip), so resolver tests still run.
+func TestPeerIsAliveFailsClosedWithoutPidfd(t *testing.T) {
+	if (Peer{pid: 1234, pidfd: pidfdNone}).IsAlive() {
+		t.Fatal("IsAlive = true with no pidfd; a real node must fail closed")
+	}
+	if !PeerForPID(1234).IsAlive() {
+		t.Fatal("IsAlive = false for a test peer; PeerForPID must skip the check")
+	}
+}

--- a/pkg/workloadclaims/peercred_other.go
+++ b/pkg/workloadclaims/peercred_other.go
@@ -4,10 +4,26 @@ package workloadclaims
 
 import "net"
 
-// peerPID has no portable implementation off Linux: SO_PEERCRED is Linux-only.
-// The inventory never runs on non-Linux, but the package (and the c8s CLI that
-// imports it, e.g. `c8s verify`) must still build on macOS/Windows for
-// operators. Returning 0 is the "no peer credentials" sentinel the node-CVM
-// resolver already rejects, so an inventory mistakenly built for another OS fails
-// closed rather than mis-binding a caller.
-func peerPID(net.Conn) int { return 0 }
+// Peer is the non-Linux stub: SO_PEERCRED/SO_PEERPIDFD are Linux-only. The
+// inventory never runs off Linux, but the package (and the c8s CLI that imports
+// it, e.g. `c8s verify`) must still build on macOS/Windows for operators. A
+// zero-PID Peer is the "no peer credentials" sentinel the node-CVM resolver
+// rejects, so an inventory mistakenly built for another OS fails closed rather
+// than mis-binding a caller.
+type Peer struct{ pid int }
+
+func peerFrom(net.Conn) Peer { return Peer{} }
+
+// PID returns the peer's PID (always 0 off Linux).
+func (p Peer) PID() int { return p.pid }
+
+// IsAlive is a no-op true off Linux; PID 0 is rejected upstream regardless, and
+// the inventory never runs on a non-Linux host.
+func (Peer) IsAlive() bool { return true }
+
+// Close is a no-op off Linux.
+func (Peer) Close() {}
+
+// PeerForPID builds a Peer from an out-of-band PID (tests). See the Linux
+// implementation for the production path.
+func PeerForPID(pid int) Peer { return Peer{pid: pid} }

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -263,12 +263,14 @@ func VerifyWorkloadDigest(claimsDER []byte, initImages, mainImages []string) (*r
 }
 
 // Resolver answers "which admitted, non-injected containers belong to the pod
-// of the calling process". peerPID is the kernel-reported PID of the caller
-// (SO_PEERCRED) — the caller never names its own pod. The node-CVM resolver
-// binds peerPID to a pod; the kata resolver ignores it, since the guest holds
-// exactly one pod and no disambiguation is needed.
+// of the calling process". peer carries the kernel-pinned caller identity
+// (SO_PEERCRED PID plus an SO_PEERPIDFD liveness pin) — the caller never names
+// its own pod. The node-CVM resolver binds peer.PID() to a pod and rechecks
+// peer.IsAlive() after its /proc read to reject PID reuse; the kata resolver
+// ignores it, since the guest holds exactly one pod and no disambiguation is
+// needed.
 type Resolver interface {
-	ContainersForPeer(peerPID int) ([]Container, error)
+	ContainersForPeer(peer Peer) ([]Container, error)
 }
 
 // SandboxResolver is the sandbox-identity surface an inventory additionally
@@ -280,7 +282,7 @@ type Resolver interface {
 type SandboxResolver interface {
 	// SandboxForPeer returns the pod sandbox ID of the calling process,
 	// bound by kernel peer credentials exactly like ContainersForPeer.
-	SandboxForPeer(peerPID int) (string, error)
+	SandboxForPeer(peer Peer) (string, error)
 	// DigestsForSandbox returns the deduplicated image digests of the named
 	// sandbox's tracked containers. known=false means no such sandbox (a 404
 	// on the wire); a known sandbox with no containers returns an empty slice.
@@ -290,6 +292,13 @@ type SandboxResolver interface {
 // connKey carries the accepted net.Conn through the request context so the
 // handler can read kernel peer credentials from it.
 type connKey struct{}
+
+// peerFromRequest pins the caller of an inventory request. The returned Peer's
+// pidfd must be released with Close once resolution is done.
+func peerFromRequest(r *http.Request) Peer {
+	conn, _ := r.Context().Value(connKey{}).(net.Conn)
+	return peerFrom(conn)
+}
 
 // maxSandboxRequestBytes bounds a SandboxPath request body; it carries one
 // PKIX public key.
@@ -304,8 +313,9 @@ const maxSandboxRequestBytes = 64 << 10
 func Serve(ctx context.Context, l net.Listener, resolver Resolver, signer *SandboxTokenSigner) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET "+DigestsPath, func(w http.ResponseWriter, r *http.Request) {
-		conn, _ := r.Context().Value(connKey{}).(net.Conn)
-		containers, err := resolver.ContainersForPeer(peerPID(conn))
+		peer := peerFromRequest(r)
+		defer peer.Close()
+		containers, err := resolver.ContainersForPeer(peer)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("resolve caller pod: %v", err), http.StatusInternalServerError)
 			return
@@ -336,8 +346,9 @@ func Serve(ctx context.Context, l net.Listener, resolver Resolver, signer *Sandb
 					http.Error(w, "missing challenge nonce", http.StatusBadRequest)
 					return
 				}
-				conn, _ := r.Context().Value(connKey{}).(net.Conn)
-				id, err := sandboxes.SandboxForPeer(peerPID(conn))
+				peer := peerFromRequest(r)
+				defer peer.Close()
+				id, err := sandboxes.SandboxForPeer(peer)
 				if err != nil {
 					http.Error(w, fmt.Sprintf("resolve caller sandbox: %v", err), http.StatusInternalServerError)
 					return

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -107,8 +107,8 @@ type pidRecordingResolver struct {
 	err        error
 }
 
-func (r *pidRecordingResolver) ContainersForPeer(peerPID int) ([]Container, error) {
-	r.pid = peerPID
+func (r *pidRecordingResolver) ContainersForPeer(peer Peer) ([]Container, error) {
+	r.pid = peer.PID()
 	return r.containers, r.err
 }
 
@@ -179,8 +179,8 @@ type sandboxAwareResolver struct {
 	digests    map[string][]string // sandboxID -> digests
 }
 
-func (r *sandboxAwareResolver) SandboxForPeer(peerPID int) (string, error) {
-	r.pid = peerPID
+func (r *sandboxAwareResolver) SandboxForPeer(peer Peer) (string, error) {
+	r.pid = peer.PID()
 	return r.sandboxID, r.sandboxErr
 }
 


### PR DESCRIPTION
SO_PEERCRED returns a bare PID, and the inventory reads /proc/<pid>/cgroup a few instructions (and one RLock) later. In that window the peer can exit and the kernel recycle its PID to a process in another container, which the inventory would then resolve as the caller — binding a get-cert leaf's sandbox ID / workload digests to a victim's pod.

Read SO_PEERPIDFD (Linux 6.5+) alongside SO_PEERCRED: a pidfd pins the exact process instance. The resolver rechecks peer.Valid() AFTER the /proc read; if the pinned process exited during resolution the answer is refused (fail closed). Pre-6.5 kernels have no pidfd and degrade to the prior best-effort behavior rather than failing every request.

- New Peer handle (peercred_linux.go / peercred_other.go stub) carrying the PID plus a pidfd, with PID()/Valid()/Close(). Resolver.ContainersForPeer and SandboxResolver.SandboxForPeer now take a Peer; the kata resolver ignores it (guest boundary is the isolation), the node-CVM resolver rechecks liveness in callerForPeer.
- Orthogonal to the shallowest-tracked-cgroup defense (Corner 2): pidfd fixes PID identity over time, that rule fixes cgroup-nesting spoofing.
- Test spawns a child, pins it, kills it, and asserts Valid() flips to false — proving the recheck rejects a recycled PID.

Pre-existing weakness on the /v1/workload-digests path; the sandbox routes inherit the same fix. See docs/getcert-workload-binding.md, Corner 1 ("Pinning the PID against reuse").