### PR TITLE
test: extract the reinject-sweep runnable body so its paths are testable

### DIFF
--- a/internal/controller/reinject_sweep_test.go
+++ b/internal/controller/reinject_sweep_test.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -165,4 +166,31 @@ func TestNeedsReinjectSkipsTerminatingPod(t *testing.T) {
 	if needsReinject(p, excluded) {
 		t.Fatal("terminating pod should not be swept")
 	}
+}
+
+func TestRunReinjectSweep(t *testing.T) {
+	mgr := newTestManager(t)
+	excluded := excludedNamespaceSet("c8s-system", nil)
+
+	t.Run("client build failure is wrapped", func(t *testing.T) {
+		stubDirectClient(t, nil, errors.New("boom"))
+		err := runReinjectSweep(context.Background(), mgr, excluded)
+		if err == nil || !strings.Contains(err.Error(), "build sweep client: boom") {
+			t.Fatalf("runReinjectSweep error = %v, want wrapped client-build error", err)
+		}
+	})
+
+	t.Run("sweeps through the built client", func(t *testing.T) {
+		cw := map[string]string{webhook.AnnotationWorkload: "wl"}
+		fc := fake.NewClientBuilder().WithObjects(pod("needs", "tenant", "ReplicaSet", cw)).Build()
+		stubDirectClient(t, fc, nil)
+		if err := runReinjectSweep(context.Background(), mgr, excluded); err != nil {
+			t.Fatalf("runReinjectSweep: %v", err)
+		}
+		var p corev1.Pod
+		err := fc.Get(context.Background(), client.ObjectKey{Namespace: "tenant", Name: "needs"}, &p)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("uninjected cw pod still present after sweep (get err = %v)", err)
+		}
+	})
 }

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -266,11 +266,7 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 		// Deletes at startup must not pin a cluster-wide pod informer for the
 		// operator's lifetime.
 		if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-			c, err := newDirectClient(mgr)
-			if err != nil {
-				return fmt.Errorf("build sweep client: %w", err)
-			}
-			return reinjectSweep(ctx, c, excluded)
+			return runReinjectSweep(ctx, mgr, excluded)
 		})); err != nil {
 			return fmt.Errorf("add reinject sweep: %w", err)
 		}
@@ -283,6 +279,16 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 		return fmt.Errorf("add readyz: %w", err)
 	}
 	return nil
+}
+
+// runReinjectSweep is the reinject-sweep runnable body; a named function so
+// its client-build failure path is testable without starting the manager.
+func runReinjectSweep(ctx context.Context, mgr manager.Manager, excluded map[string]struct{}) error {
+	c, err := newDirectClient(mgr)
+	if err != nil {
+		return fmt.Errorf("build sweep client: %w", err)
+	}
+	return reinjectSweep(ctx, c, excluded)
 }
 
 type serverResourcesForGroupVersion interface {


### PR DESCRIPTION
## What

The reinject sweep's client-build failure path was untestable: it lives in a `manager.RunnableFunc` closure that only `mgr.Start` against a live API server can invoke. The closure body moves verbatim into `runReinjectSweep(ctx, mgr, excluded)`; the closure now just calls it. Same extraction pattern as `snapshotAllowlist`.

Tests cover both paths: a client-build failure surfaces wrapped, and a successful build sweeps uninjected cw pods through the built client.

## Verification
- `go test -race -count=1 ./internal/controller/` green
- the error-path guard checked by inverting the condition and confirming the new test fails