### PR TITLE
test(helmchart): assert on decoded manifests instead of rendered text

### DIFF
--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -164,17 +164,17 @@ func TestChartDefaultRendersReplacementStack(t *testing.T) {
 	if !renderedManifestHasKind(t, out, "MutatingWebhookConfiguration") {
 		t.Fatalf("default chart missing MutatingWebhookConfiguration\n%s", out)
 	}
-	for _, want := range []string{
-		"app.kubernetes.io/component: cds",
-		"app.kubernetes.io/name: ratls-mesh",
-		"app.kubernetes.io/name: nri-image-policy",
-		"app.kubernetes.io/name: tls-lb",
-		"server_name c8s-tls-lb.c8s-system.svc;",
+	for _, label := range [][2]string{
+		{"app.kubernetes.io/component", "cds"},
+		{"app.kubernetes.io/name", "ratls-mesh"},
+		{"app.kubernetes.io/name", "nri-image-policy"},
+		{"app.kubernetes.io/name", "tls-lb"},
 	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("default chart missing %q\n%s", want, out)
+		if !renderedManifestHasLabel(t, out, label[0], label[1]) {
+			t.Fatalf("default chart missing a manifest labelled %s: %s", label[0], label[1])
 		}
 	}
+	renderedTLSLBNginxConfig(t, out).server(t).assertDirective(t, "server_name", "c8s-tls-lb.c8s-system.svc")
 	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
 	assertContainerArgs(t, cert,
 		"get-cert",
@@ -842,8 +842,9 @@ func TestChartRendersOperatorKeysPEM(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "operator-keys") || !strings.Contains(out, "BEGIN PUBLIC KEY") {
-		t.Fatalf("rendered output missing the operator-keys ConfigMap with PEM content")
+	cm := renderedConfigMap(t, out, "c8s-cds-operator-keys")
+	if got := cm.Data["keys.pem"]; got != pemText {
+		t.Fatalf("operator-keys ConfigMap keys.pem = %q, want the PEM content %q", got, pemText)
 	}
 }
 
@@ -961,11 +962,22 @@ func TestChartRendersRATLSCustomOutboundPortConsistently(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if got := strings.Count(out, "- --outbound-port\n            - \"16001\""); got != 2 {
-		t.Fatalf("expected iptables-sync and ratls-mesh to use outbound port 16001, got %d occurrences\n%s", got, out)
+	ds := findRATLSMeshDaemonSet(t, out)
+	sync, ok := findContainer(ds.Spec.Template.Spec.InitContainers, "iptables-sync")
+	if !ok {
+		t.Fatalf("iptables-sync init container missing; have %v", containerNames(ds.Spec.Template.Spec.InitContainers))
 	}
-	if strings.Contains(out, "- --outbound-port\n            - \"15001\"") {
-		t.Fatalf("ratls-mesh rendered the default outbound port despite override\n%s", out)
+	if !argvContainsFlagValue(sync.Command, "--outbound-port", "16001") {
+		t.Fatalf("iptables-sync missing --outbound-port 16001; command=%q", sync.Command)
+	}
+	meshArgs := containerArgs(t, ds, "ratls-mesh")
+	if got, ok := containerArgValue(meshArgs, "--outbound-port"); !ok || got != "16001" {
+		t.Fatalf("ratls-mesh --outbound-port = (%q, %v), want (\"16001\", true)", got, ok)
+	}
+	for _, c := range allContainers(ds) {
+		if argvContainsFlagValue(c.Command, "--outbound-port", "15001") || argvContainsFlagValue(c.Args, "--outbound-port", "15001") {
+			t.Fatalf("container %q rendered the default outbound port despite override", c.Name)
+		}
 	}
 }
 
@@ -974,17 +986,13 @@ func TestChartCanDisableStatusMirror(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "--status-mirror-enabled=true") {
-		t.Fatalf("default chart should enable status mirror\n%s", out)
-	}
+	assertContainerHasArg(t, "operator", renderedOperatorArgs(t, out), "--status-mirror-enabled=true")
 
 	out, err = helmTemplate(t, "--set", "statusMirror.enabled=false")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "--status-mirror-enabled=false") {
-		t.Fatalf("statusMirror.enabled=false should disable status mirror\n%s", out)
-	}
+	assertContainerHasArg(t, "operator", renderedOperatorArgs(t, out), "--status-mirror-enabled=false")
 }
 
 func TestChartWebhookInjectsWorkloadsAndExcludesSystemNamespaces(t *testing.T) {
@@ -1333,6 +1341,114 @@ func assertContainerNoArgPrefix(t *testing.T, container string, args []string, p
 	}
 }
 
+func assertContainerHasArgPrefix(t *testing.T, container string, args []string, prefix string) {
+	t.Helper()
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return
+		}
+	}
+	t.Fatalf("%s container missing arg with prefix %q\nargs: %v", container, prefix, args)
+}
+
+// renderedManifestHasLabel reports whether any rendered doc carries the label,
+// on its own metadata or its pod template.
+func renderedManifestHasLabel(t *testing.T, manifest, key, value string) bool {
+	t.Helper()
+	found := false
+	iterateManifests(t, manifest, func(doc []byte) bool {
+		var obj struct {
+			Metadata struct {
+				Labels map[string]string `json:"labels"`
+			} `json:"metadata"`
+			Spec struct {
+				Template struct {
+					Metadata struct {
+						Labels map[string]string `json:"labels"`
+					} `json:"metadata"`
+				} `json:"template"`
+			} `json:"spec"`
+		}
+		if err := sigsyaml.Unmarshal(doc, &obj); err != nil {
+			return false
+		}
+		if obj.Metadata.Labels[key] == value || obj.Spec.Template.Metadata.Labels[key] == value {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+// renderedWorkload is a pod-bearing manifest (Deployment, DaemonSet,
+// StatefulSet, Job) with its decoded pod spec.
+type renderedWorkload struct {
+	kind, name string
+	spec       corev1.PodSpec
+}
+
+func renderedPodSpecs(t *testing.T, manifest string) []renderedWorkload {
+	t.Helper()
+	var out []renderedWorkload
+	iterateManifests(t, manifest, func(doc []byte) bool {
+		var obj struct {
+			docMeta
+			Spec struct {
+				Template corev1.PodTemplateSpec `json:"template"`
+			} `json:"spec"`
+		}
+		if err := sigsyaml.Unmarshal(doc, &obj); err != nil {
+			return false
+		}
+		switch obj.Kind {
+		case "Deployment", "DaemonSet", "StatefulSet", "Job":
+			out = append(out, renderedWorkload{obj.Kind, obj.Metadata.Name, obj.Spec.Template.Spec})
+		}
+		return false
+	})
+	return out
+}
+
+// kataEnforcementExpressions returns the joined CEL validation expressions of
+// the c8s-kata-enforcement policy; the runtime-class allowlist lives there.
+func kataEnforcementExpressions(t *testing.T, manifest string) string {
+	t.Helper()
+	var policy admissionregv1.ValidatingAdmissionPolicy
+	if !findDoc(t, manifest, "ValidatingAdmissionPolicy", "c8s-kata-enforcement", &policy) {
+		t.Fatalf("missing c8s-kata-enforcement ValidatingAdmissionPolicy\n%s", manifest)
+	}
+	var sb strings.Builder
+	for _, v := range policy.Spec.Validations {
+		sb.WriteString(v.Expression)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+// findKey returns a dotted path to the first occurrence of key anywhere in a
+// decoded YAML tree, or "" if absent.
+func findKey(node any, key string) string {
+	switch v := node.(type) {
+	case map[string]any:
+		for k, child := range v {
+			if k == key {
+				return k
+			}
+			if p := findKey(child, key); p != "" {
+				return k + "." + p
+			}
+		}
+	case []any:
+		for i, child := range v {
+			if p := findKey(child, key); p != "" {
+				return fmt.Sprintf("[%d].%s", i, p)
+			}
+		}
+	}
+	return ""
+}
+
 func TestChartWebhookRendersSecurityKnobs(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set", "webhook.certVolume.fsGroup=4242",
@@ -1385,25 +1501,32 @@ func TestChartIntValuesFromValuesFileRenderPlain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template -f: %v\n%s", err, out)
 	}
-	// No value anywhere may render in scientific notation.
-	if strings.Contains(out, "e+0") {
-		for _, line := range strings.Split(out, "\n") {
-			if strings.Contains(line, "e+0") {
-				t.Errorf("scientific-notation int leaked: %q", strings.TrimSpace(line))
-			}
-		}
+	// Each affected field is asserted through its decoded typed value; a
+	// scientific-notation render (7e+06) fails the int decode loudly.
+	args := renderedOperatorArgs(t, out)
+	assertContainerHasArg(t, "operator", args, "--cert-fs-group=1500000")
+	assertContainerHasArg(t, "operator", args, "--get-cert-run-as-user=2000000000")
+	nginx := renderedDeploymentContainer(t, out, "c8s-tls-lb", "nginx")
+	if got := nginx.SecurityContext.RunAsUser; got == nil || *got != 7000000 {
+		t.Errorf("nginx runAsUser = %v, want 7000000", got)
 	}
-	// Spot-check the plain-integer renders, including the CEL admission policy
-	// (where int != double would be an uninstallable compile error).
-	for _, want := range []string{
-		"--cert-fs-group=1500000",
-		"--get-cert-run-as-user=2000000000",
-		"runAsUser: 7000000",
-		"runAsUser != 7000000",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("render missing %q", want)
-		}
+	if got := nginx.SecurityContext.RunAsGroup; got == nil || *got != 7000000 {
+		t.Errorf("nginx runAsGroup = %v, want 7000000", got)
+	}
+	mesh := renderedDaemonSetContainer(t, out, "c8s-ratls-mesh", "ratls-mesh")
+	if got := mesh.SecurityContext.RunAsUser; got == nil || *got != 7000000 {
+		t.Errorf("ratls-mesh runAsUser = %v, want 7000000", got)
+	}
+	// The CEL admission policy, where int != double would be an uninstallable
+	// compile error.
+	var policy admissionregv1.ValidatingAdmissionPolicy
+	if !findDoc(t, out, "ValidatingAdmissionPolicy", "deny-ratls-mesh-uid", &policy) {
+		t.Fatalf("missing deny-ratls-mesh-uid ValidatingAdmissionPolicy\n%s", out)
+	}
+	if !slices.ContainsFunc(policy.Spec.Validations, func(v admissionregv1.Validation) bool {
+		return strings.Contains(v.Expression, "runAsUser != 7000000")
+	}) {
+		t.Errorf("uid policy expression missing the plain-integer comparison: %+v", policy.Spec.Validations)
 	}
 }
 
@@ -1571,8 +1694,14 @@ func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
 			}
 			cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
 			assertContainerArgs(t, cds, "--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400")
-			if strings.Contains(out, "name: HOST_IP") {
-				t.Errorf("cvmMode=%s must not render any HOST_IP env\n%s", mode, out)
+			for _, w := range renderedPodSpecs(t, out) {
+				for _, c := range append(append([]corev1.Container{}, w.spec.InitContainers...), w.spec.Containers...) {
+					for _, e := range c.Env {
+						if e.Name == "HOST_IP" {
+							t.Errorf("cvmMode=%s must not render any HOST_IP env; %s %s container %s carries it", mode, w.kind, w.name, c.Name)
+						}
+					}
+				}
 			}
 		})
 	}
@@ -1586,15 +1715,20 @@ func TestChartRendersManagedClusterKnobs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "imagePullSecrets:\n- name: ghcr-secret") {
-		t.Fatalf("render missing chart-wide imagePullSecrets\n%s", out)
+	var sa corev1.ServiceAccount
+	if !findDoc(t, out, "ServiceAccount", "c8s-operator", &sa) {
+		t.Fatalf("render missing ServiceAccount c8s-operator\n%s", out)
 	}
-	// aks → privileged attestation-api (assert the two fields without pinning
-	// the exact line spacing, which carries explanatory comments).
-	for _, want := range []string{"privileged: true", "readOnlyRootFilesystem: true"} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("render missing %q\n%s", want, out)
-		}
+	if !hasPullSecret(sa.ImagePullSecrets, "ghcr-secret") {
+		t.Fatalf("operator ServiceAccount missing chart-wide pull secret ghcr-secret: %v", sa.ImagePullSecrets)
+	}
+	// aks → privileged attestation-api with a read-only root filesystem.
+	sc := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attestation-api").SecurityContext
+	if sc == nil || sc.Privileged == nil || !*sc.Privileged {
+		t.Fatalf("attestation-api must be privileged under aks; got %+v", sc)
+	}
+	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Fatalf("attestation-api must set readOnlyRootFilesystem: true; got %+v", sc)
 	}
 }
 
@@ -1644,33 +1778,47 @@ func TestChartRendersTLSLBPublicTLSAndDiscovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	for _, want := range []string{
-		"ssl_certificate     /edge-tls/public.crt;",
-		"ssl_certificate_key /edge-tls/public.key;",
-		"ECDHE-RSA-AES128-GCM-SHA256",
-		"location = /v1/discovery",
-		"alias /discovery/discovery.json;",
-		"location = /.well-known/cds-cert.pem",
-		"alias /tls/cert.pem;",
-		"location = /.well-known/mesh-ca.pem",
-		"alias /tls/ca.pem;",
-		"proxy_ssl_certificate /tls/cert.pem;",
-		"proxy_ssl_certificate_key /tls/key.pem;",
-		"proxy_ssl_name my-backend.other-ns.svc.cluster.local;",
-		"proxy_ssl_verify on;",
-		"proxy_ssl_trusted_certificate /tls/cert.pem;",
-		"proxy_pass https://$backend_addr;",
-		"name: tls-certs",
-		"name: public-tls",
-		"mountPath: /edge-tls",
-		"secretName: tls-lb-public-tls",
-		"key: public.crt",
-		"path: public.key",
-		"name: discovery",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("render missing %q\n%s", want, out)
-		}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	server := cfg.server(t)
+	server.assertDirective(t, "ssl_certificate", "/edge-tls/public.crt")
+	server.assertDirective(t, "ssl_certificate_key", "/edge-tls/public.key")
+	ciphers := server.directives["ssl_ciphers"]
+	if len(ciphers) != 1 || len(ciphers[0]) != 1 ||
+		!slices.Contains(strings.Split(ciphers[0][0], ":"), "ECDHE-RSA-AES128-GCM-SHA256") {
+		t.Fatalf("ssl_ciphers missing ECDHE-RSA-AES128-GCM-SHA256; got %v", ciphers)
+	}
+	cfg.location(t, "exact", "/v1/discovery").assertDirective(t, "alias", "/discovery/discovery.json")
+	cfg.location(t, "exact", "/.well-known/cds-cert.pem").assertDirective(t, "alias", "/tls/cert.pem")
+	cfg.location(t, "exact", "/.well-known/mesh-ca.pem").assertDirective(t, "alias", "/tls/ca.pem")
+	defaultRoute := cfg.location(t, "prefix", "/")
+	defaultRoute.assertDirective(t, "proxy_ssl_certificate", "/tls/cert.pem")
+	defaultRoute.assertDirective(t, "proxy_ssl_certificate_key", "/tls/key.pem")
+	defaultRoute.assertDirective(t, "proxy_ssl_name", "my-backend.other-ns.svc.cluster.local")
+	defaultRoute.assertDirective(t, "proxy_ssl_verify", "on")
+	defaultRoute.assertDirective(t, "proxy_ssl_trusted_certificate", "/tls/cert.pem")
+	defaultRoute.assertDirective(t, "proxy_pass", "https://$backend_addr")
+
+	spec := renderedDeployment(t, out, "c8s-tls-lb").Spec.Template.Spec
+	if _, ok := podVolume(spec, "tls-certs"); !ok {
+		t.Fatalf("tls-lb missing tls-certs volume; volumes=%v", spec.Volumes)
+	}
+	pub, ok := podVolume(spec, "public-tls")
+	if !ok || pub.Secret == nil || pub.Secret.SecretName != "tls-lb-public-tls" {
+		t.Fatalf("tls-lb public-tls volume must source Secret tls-lb-public-tls; got %+v", pub)
+	}
+	wantItems := []corev1.KeyToPath{
+		{Key: "public.crt", Path: "public.crt"},
+		{Key: "public.key", Path: "public.key"},
+	}
+	if !reflect.DeepEqual(pub.Secret.Items, wantItems) {
+		t.Fatalf("public-tls secret items = %v, want %v", pub.Secret.Items, wantItems)
+	}
+	if _, ok := podVolume(spec, "discovery"); !ok {
+		t.Fatalf("tls-lb missing discovery volume; volumes=%v", spec.Volumes)
+	}
+	nginx := renderedDeploymentContainer(t, out, "c8s-tls-lb", "nginx")
+	if m, ok := containerVolumeMount(nginx, "public-tls"); !ok || m.MountPath != "/edge-tls" {
+		t.Fatalf("nginx public-tls mount = (%+v, %v), want mountPath /edge-tls", m, ok)
 	}
 	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
 	assertContainerArgs(t, cert,
@@ -1769,27 +1917,20 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	if len(sidecar.Args) == 0 || sidecar.Args[0] != "cds-attest" {
 		t.Fatalf("cds-attest args = %v, want first arg 'cds-attest'", sidecar.Args)
 	}
-	joined := strings.Join(sidecar.Args, " ")
-	for _, want := range []string{
+	assertContainerArgs(t, sidecar,
 		"--host=127.0.0.1",
 		"--port=8800",
 		"--generation=milan",
-		"--attestation-api-url=http://",
 		"--mesh-identity-cert-file=/tls/cert.pem",
 		"--mesh-identity-key-file=/tls/key.pem",
 		"--mesh-identity-ca-file=/tls/ca.pem",
 		// The baseline mesh-wrapped upstream is a plain-HTTP workload upstream;
 		// the mTLS args render only for an https upstream.
 		"--upstream=http://c8s-infer.c8s-system.svc.cluster.local:8000",
-	} {
-		if !strings.Contains(joined, want) {
-			t.Fatalf("cds-attest args missing %q: %v", want, sidecar.Args)
-		}
-	}
+	)
+	assertContainerHasArgPrefix(t, "cds-attest", sidecar.Args, "--attestation-api-url=http://")
 	for _, banned := range []string{"--upstream-ca", "--upstream-cert", "--upstream-key", "--upstream-server-name"} {
-		if strings.Contains(joined, banned) {
-			t.Fatalf("cds-attest must not set %s for the default http upstream: %v", banned, sidecar.Args)
-		}
+		assertContainerNoArgPrefix(t, "cds-attest", sidecar.Args, banned)
 	}
 	// The sidecar must not mount the mesh-CA for the default cert.pem trust path.
 	if _, ok := containerVolumeMount(sidecar, "mesh-ca"); ok {
@@ -1800,14 +1941,9 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	}
 
 	// nginx reverse-proxies the dynamic well-known prefix to the sidecar.
-	for _, want := range []string{
-		"location /.well-known/c8s/ {",
-		"proxy_pass http://127.0.0.1:8800;",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("nginx config missing %q\n%s", want, out)
-		}
-	}
+	renderedTLSLBNginxConfig(t, out).
+		location(t, "prefix", "/.well-known/c8s/").
+		assertDirective(t, "proxy_pass", "http://127.0.0.1:8800")
 
 	// An https upstream: the sidecar presents the CDS client cert and
 	// verifies the upstream against the CA chain get-cert writes to
@@ -1821,18 +1957,13 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 		t.Fatalf("helm template (https upstream): %v\n%s", err, httpsOut)
 	}
 	httpsSidecar := renderedDeploymentContainer(t, httpsOut, "c8s-tls-lb", "cds-attest")
-	httpsJoined := strings.Join(httpsSidecar.Args, " ")
-	for _, want := range []string{
+	assertContainerArgs(t, httpsSidecar,
 		"--upstream=https://my-backend.other-ns.svc:8443",
 		"--upstream-ca=/tls/cert.pem",
 		"--upstream-cert=/tls/cert.pem",
 		"--upstream-key=/tls/key.pem",
 		"--upstream-server-name=my-backend.other-ns.svc",
-	} {
-		if !strings.Contains(httpsJoined, want) {
-			t.Fatalf("cds-attest args missing %q: %v", want, httpsSidecar.Args)
-		}
-	}
+	)
 
 	// Default on: the sidecar and its well-known proxy render without any
 	// attest override.
@@ -1840,8 +1971,13 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template (defaults): %v\n%s", err, defOut)
 	}
-	if !strings.Contains(defOut, "name: cds-attest") || !strings.Contains(defOut, "location /.well-known/c8s/ {") {
+	wellKnown := nginxLocationKey{match: "prefix", path: "/.well-known/c8s/"}
+	defContainers := renderedDeployment(t, defOut, "c8s-tls-lb").Spec.Template.Spec.Containers
+	if _, ok := findContainer(defContainers, "cds-attest"); !ok {
 		t.Fatal("cds-attest sidecar should render by default (tlsLb.attest.enabled defaults true)")
+	}
+	if _, ok := renderedTLSLBNginxConfig(t, defOut).locations[wellKnown]; !ok {
+		t.Fatal("well-known proxy location should render by default (tlsLb.attest.enabled defaults true)")
 	}
 
 	// Explicit opt-out: no sidecar, no well-known proxy.
@@ -1849,8 +1985,12 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template (attest disabled): %v\n%s", err, offOut)
 	}
-	if strings.Contains(offOut, "name: cds-attest") || strings.Contains(offOut, "location /.well-known/c8s/ {") {
+	offContainers := renderedDeployment(t, offOut, "c8s-tls-lb").Spec.Template.Spec.Containers
+	if _, ok := findContainer(offContainers, "cds-attest"); ok {
 		t.Fatal("cds-attest sidecar should not render when tlsLb.attest.enabled=false")
+	}
+	if _, ok := renderedTLSLBNginxConfig(t, offOut).locations[wellKnown]; ok {
+		t.Fatal("well-known proxy location should not render when tlsLb.attest.enabled=false")
 	}
 }
 
@@ -1961,24 +2101,17 @@ func TestChartTLSLBMeshWrappedUpstreamIsWorkloadDirect(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	cfg := renderedTLSLBNginxConf(t, out)
-	for _, want := range []string{
-		"resolver kube-dns.kube-system.svc.cluster.local;",
-		// The baseline mesh-wrapped upstream is the operator-managed headless
-		// Service, so the pod-IP hop is mesh-wrapped.
-		"set $backend_addr c8s-infer.c8s-system.svc.cluster.local:8000;",
-		"proxy_pass http://$backend_addr;",
-	} {
-		if !strings.Contains(cfg, want) {
-			t.Fatalf("tls-lb nginx config missing %q\n%s", want, cfg)
-		}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	cfg.http.assertDirective(t, "resolver", "kube-dns.kube-system.svc.cluster.local")
+	defaultRoute := cfg.location(t, "prefix", "/")
+	// The baseline mesh-wrapped upstream is the operator-managed headless
+	// Service, so the pod-IP hop is mesh-wrapped.
+	defaultRoute.assertDirective(t, "set", "$backend_addr", "c8s-infer.c8s-system.svc.cluster.local:8000")
+	defaultRoute.assertDirective(t, "proxy_pass", "http://$backend_addr")
+	if len(cfg.upstreams) != 0 {
+		t.Fatalf("catch-all upstream must be a variable dial, not a static upstream block (it would pin headless pod IPs at startup); got %v", cfg.upstreams)
 	}
-	if strings.Contains(cfg, "upstream backend {") {
-		t.Fatalf("catch-all upstream must be a variable dial, not a static upstream block (it would pin headless pod IPs at startup)\n%s", cfg)
-	}
-	if strings.Contains(cfg, "proxy_ssl_") {
-		t.Fatalf("default http upstream must not render proxy_ssl_ directives\n%s", cfg)
-	}
+	cfg.assertNoDirectivePrefix(t, "proxy_ssl_")
 }
 
 // nginx exits at startup on a resolver name that does not resolve, and RKE2
@@ -1995,12 +2128,12 @@ func TestChartTLSLBResolverDerivesFromDistro(t *testing.T) {
 		{
 			name: "rke2 via kata.distro",
 			args: []string{"--set-string", "kata.distro=rke2"},
-			want: "resolver rke2-coredns-rke2-coredns.kube-system.svc.cluster.local;",
+			want: "rke2-coredns-rke2-coredns.kube-system.svc.cluster.local",
 		},
 		{
 			name: "rke2 via nriImagePolicy.distro",
 			args: []string{"--set-string", "nriImagePolicy.distro=rke2"},
-			want: "resolver rke2-coredns-rke2-coredns.kube-system.svc.cluster.local;",
+			want: "rke2-coredns-rke2-coredns.kube-system.svc.cluster.local",
 		},
 		{
 			name: "explicit resolver wins over distro",
@@ -2008,7 +2141,7 @@ func TestChartTLSLBResolverDerivesFromDistro(t *testing.T) {
 				"--set-string", "kata.distro=rke2",
 				"--set-string", "tlsLb.nginx.resolver=my-dns.dns-ns.svc.cluster.local",
 			},
-			want: "resolver my-dns.dns-ns.svc.cluster.local;",
+			want: "my-dns.dns-ns.svc.cluster.local",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2016,10 +2149,11 @@ func TestChartTLSLBResolverDerivesFromDistro(t *testing.T) {
 			if err != nil {
 				t.Fatalf("helm template: %v\n%s", err, out)
 			}
-			cfg := renderedTLSLBNginxConf(t, out)
-			if !strings.Contains(cfg, tc.want) {
-				t.Fatalf("tls-lb nginx config missing %q\n%s", tc.want, cfg)
+			cfg := renderedTLSLBNginxConfig(t, out)
+			if cfg.http == nil {
+				t.Fatal("nginx config missing http block")
 			}
+			cfg.http.assertDirective(t, "resolver", tc.want)
 		})
 	}
 }
@@ -2049,8 +2183,9 @@ func TestTLSLBCORSAllowsSessionHeaderByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if !strings.Contains(out, "X-C8s-Session") {
-		t.Fatalf("CORS Access-Control-Allow-Headers missing X-C8s-Session:\n%s", out)
+	conf := renderedTLSLBNginxConf(t, out)
+	if !strings.Contains(conf, "X-C8s-Session") {
+		t.Fatalf("CORS Access-Control-Allow-Headers missing X-C8s-Session:\n%s", conf)
 	}
 }
 
@@ -2356,6 +2491,8 @@ type nginxConfig struct {
 	maps      map[nginxMapKey]*nginxBlock
 	locations map[nginxLocationKey]*nginxBlock
 	http      *nginxBlock
+	servers   []*nginxBlock
+	all       []*nginxBlock
 }
 
 type nginxMapKey struct {
@@ -2394,8 +2531,12 @@ func parseNginxConfig(t *testing.T, conf string) nginxConfig {
 		if strings.HasSuffix(trimmed, "{") {
 			fields := strings.Fields(strings.TrimSpace(strings.TrimSuffix(trimmed, "{")))
 			block := &nginxBlock{directives: make(map[string][][]string)}
+			cfg.all = append(cfg.all, block)
 			if len(fields) == 1 && fields[0] == "http" {
 				cfg.http = block
+			}
+			if len(fields) == 1 && fields[0] == "server" {
+				cfg.servers = append(cfg.servers, block)
 			}
 			if len(fields) == 2 && fields[0] == "upstream" {
 				cfg.upstreams[fields[1]] = block
@@ -2453,6 +2594,27 @@ func (cfg nginxConfig) location(t *testing.T, match, path string) *nginxBlock {
 		t.Fatalf("nginx config missing location %#v; got %v", key, cfg.locations)
 	}
 	return location
+}
+
+func (cfg nginxConfig) server(t *testing.T) *nginxBlock {
+	t.Helper()
+	if len(cfg.servers) != 1 {
+		t.Fatalf("nginx config has %d server blocks, want 1", len(cfg.servers))
+	}
+	return cfg.servers[0]
+}
+
+// assertNoDirectivePrefix fails if any block in the config carries a directive
+// whose name starts with prefix.
+func (cfg nginxConfig) assertNoDirectivePrefix(t *testing.T, prefix string) {
+	t.Helper()
+	for _, block := range cfg.all {
+		for name, args := range block.directives {
+			if strings.HasPrefix(name, prefix) {
+				t.Fatalf("nginx directive %s %v present, want no %s* directives", name, args, prefix)
+			}
+		}
+	}
 }
 
 func (cfg nginxConfig) mapBlock(t *testing.T, source, target string) *nginxBlock {
@@ -2897,7 +3059,7 @@ func TestTLSLBRollsOnNginxConfigChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template default config: %v\n%s", err, defaultOut)
 	}
-	defaultChecksum := renderedValue(t, defaultOut, "checksum/nginx-config")
+	defaultChecksum := renderedDeployment(t, defaultOut, "c8s-tls-lb").Spec.Template.Annotations["checksum/nginx-config"]
 	if defaultChecksum == "" {
 		t.Fatalf("default checksum/nginx-config is empty\n%s", defaultOut)
 	}
@@ -2908,7 +3070,7 @@ func TestTLSLBRollsOnNginxConfigChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template changed config: %v\n%s", err, changedOut)
 	}
-	changedChecksum := renderedValue(t, changedOut, "checksum/nginx-config")
+	changedChecksum := renderedDeployment(t, changedOut, "c8s-tls-lb").Spec.Template.Annotations["checksum/nginx-config"]
 	if changedChecksum == defaultChecksum {
 		t.Fatalf("checksum/nginx-config did not change after changing upstream: %s", defaultChecksum)
 	}
@@ -2919,25 +3081,26 @@ func TestChartOperatorRBACIsScoped(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	for _, want := range []string{
-		"resources: [confidentialworkloads]",
-		"verbs: [get, list, watch]",
-		"resources: [confidentialworkloads/status]",
-		"verbs: [get, update, patch]",
-		"resources: [pods]",
-		"resources: [leases]",
-		"resources: [mutatingwebhookconfigurations]",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("render missing %q\n%s", want, out)
-		}
-	}
-	// The event recorder needs events, but only create/patch (recorder
-	// aggregation), never read or delete across the cluster. Decode the
-	// ClusterRole and assert the verbs exactly so a broadened grant fails.
+	// Decode the ClusterRole and assert the verbs exactly so a broadened
+	// grant fails. The event recorder needs events, but only create/patch
+	// (recorder aggregation), never read or delete across the cluster.
 	var role rbacv1.ClusterRole
 	if !findDoc(t, out, "ClusterRole", "c8s-operator", &role) {
 		t.Fatalf("render missing ClusterRole c8s-operator\n%s", out)
+	}
+	for _, tc := range []struct {
+		apiGroup, resource string
+		verbs              []string
+	}{
+		{"confidential.ai", "confidentialworkloads", []string{"get", "list", "watch"}},
+		{"confidential.ai", "confidentialworkloads/status", []string{"get", "update", "patch"}},
+		{"", "pods", []string{"get", "list", "watch", "delete"}},
+		{"coordination.k8s.io", "leases", []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
+		{"admissionregistration.k8s.io", "mutatingwebhookconfigurations", []string{"get", "update", "patch"}},
+	} {
+		if got := operatorVerbsFor(role, tc.apiGroup, tc.resource); !slices.Equal(got, tc.verbs) {
+			t.Fatalf("operator %s verbs = %v, want %v", tc.resource, got, tc.verbs)
+		}
 	}
 	if got := operatorVerbsFor(role, "", "events"); !slices.Equal(got, []string{"create", "patch"}) {
 		t.Fatalf("operator events verbs = %v, want [create patch]", got)
@@ -2952,17 +3115,28 @@ func TestChartOperatorRBACIsScoped(t *testing.T) {
 	if got := operatorVerbsFor(role, "", "services"); !slices.Equal(got, []string{"get", "list", "watch", "create", "update", "delete"}) {
 		t.Fatalf("operator services verbs = %v", got)
 	}
-	for _, unexpected := range []string{
-		"resources: [confidentialworkloads/finalizers]",
-		"resources: [replicasets]",
-		"resources: [secrets, configmaps]",
-		"resources: [nodes]",
-		"resources: [rolebindings]",
-	} {
-		if strings.Contains(out, unexpected) {
-			t.Fatalf("render contained broad RBAC rule %q\n%s", unexpected, out)
+	// No rendered Role/ClusterRole may grant any of these resources at all.
+	banned := []string{"confidentialworkloads/finalizers", "replicasets", "secrets", "configmaps", "nodes", "rolebindings"}
+	iterateManifests(t, out, func(doc []byte) bool {
+		var head docMeta
+		if err := sigsyaml.Unmarshal(doc, &head); err != nil || (head.Kind != "ClusterRole" && head.Kind != "Role") {
+			return false
 		}
-	}
+		var r struct {
+			Rules []rbacv1.PolicyRule `json:"rules"`
+		}
+		if err := sigsyaml.Unmarshal(doc, &r); err != nil {
+			t.Fatalf("decode %s %s rules: %v", head.Kind, head.Metadata.Name, err)
+		}
+		for _, rule := range r.Rules {
+			for _, resource := range banned {
+				if slices.Contains(rule.Resources, resource) {
+					t.Errorf("%s %s grants broad RBAC resource %q", head.Kind, head.Metadata.Name, resource)
+				}
+			}
+		}
+		return false
+	})
 }
 
 // operatorVerbsFor returns the verbs the ClusterRole grants on (apiGroup,
@@ -2983,13 +3157,12 @@ func TestChartWebhookAddsCABundleRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	for _, want := range []string{
-		"resources: [mutatingwebhookconfigurations]",
-		"verbs: [get, update, patch]",
-	} {
-		if !strings.Contains(out, want) {
-			t.Fatalf("render missing %q\n%s", want, out)
-		}
+	var role rbacv1.ClusterRole
+	if !findDoc(t, out, "ClusterRole", "c8s-operator", &role) {
+		t.Fatalf("render missing ClusterRole c8s-operator\n%s", out)
+	}
+	if got := operatorVerbsFor(role, "admissionregistration.k8s.io", "mutatingwebhookconfigurations"); !slices.Equal(got, []string{"get", "update", "patch"}) {
+		t.Fatalf("operator mutatingwebhookconfigurations verbs = %v, want [get update patch]", got)
 	}
 }
 
@@ -2998,7 +3171,7 @@ func TestChartRollsAttestationApiOnConfigChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template default config: %v\n%s", err, defaultOut)
 	}
-	defaultChecksum := renderedValue(t, defaultOut, "checksum/config")
+	defaultChecksum := renderedDaemonSet(t, defaultOut, "c8s-attestation-api").Spec.Template.Annotations["checksum/config"]
 	if defaultChecksum == "" {
 		t.Fatalf("default checksum/config is empty\n%s", defaultOut)
 	}
@@ -3009,7 +3182,7 @@ func TestChartRollsAttestationApiOnConfigChange(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template changed config: %v\n%s", err, changedOut)
 	}
-	changedChecksum := renderedValue(t, changedOut, "checksum/config")
+	changedChecksum := renderedDaemonSet(t, changedOut, "c8s-attestation-api").Spec.Template.Annotations["checksum/config"]
 	if changedChecksum == defaultChecksum {
 		t.Fatalf("checksum/config did not change after changing platforms: %s", defaultChecksum)
 	}
@@ -3082,8 +3255,9 @@ func TestChartKataEnabledRendersDeployStack(t *testing.T) {
 	}
 	// The enforcement allowlist is platform-scoped too: a TDX class name must
 	// not be admissible on an SNP install.
-	if strings.Contains(out, "'kata-qemu-tdx'") || strings.Contains(out, "'kata-qemu-tdx-nvidia'") {
-		t.Errorf("kata-enforcement allowlist must not accept TDX classes on an SNP install\n%s", out)
+	expr := kataEnforcementExpressions(t, out)
+	if strings.Contains(expr, "'kata-qemu-tdx'") || strings.Contains(expr, "'kata-qemu-tdx-nvidia'") {
+		t.Errorf("kata-enforcement allowlist must not accept TDX classes on an SNP install\n%s", expr)
 	}
 }
 
@@ -3194,8 +3368,8 @@ func TestChartKataRendersGpuStack(t *testing.T) {
 	}
 
 	// Enforcement allowlist accepts the class.
-	if !strings.Contains(out, "'kata-qemu-snp-nvidia'") {
-		t.Errorf("kata-enforcement allowlist must accept kata-qemu-snp-nvidia\n%s", out)
+	if expr := kataEnforcementExpressions(t, out); !strings.Contains(expr, "'kata-qemu-snp-nvidia'") {
+		t.Errorf("kata-enforcement allowlist must accept kata-qemu-snp-nvidia\n%s", expr)
 	}
 
 	// GPU image puller: pulls the -nvidia tag and patches the GPU config.
@@ -3268,8 +3442,9 @@ func TestChartKataRendersGpuStackTdx(t *testing.T) {
 		t.Errorf("SNAPSHOTTER_HANDLER_MAPPING_X86_64 = %q must route qemu-nvidia-gpu-tdx through nydus", v)
 	}
 
-	if !strings.Contains(out, "'kata-qemu-tdx-nvidia'") {
-		t.Errorf("kata-enforcement allowlist must accept kata-qemu-tdx-nvidia\n%s", out)
+	expr := kataEnforcementExpressions(t, out)
+	if !strings.Contains(expr, "'kata-qemu-tdx-nvidia'") {
+		t.Errorf("kata-enforcement allowlist must accept kata-qemu-tdx-nvidia\n%s", expr)
 	}
 
 	puller := renderedDaemonSet(t, out, "c8s-kata-deploy-image-puller-nvidia")
@@ -3291,11 +3466,11 @@ func TestChartKataRendersGpuStackTdx(t *testing.T) {
 	if v := envValue(kube.Env, "SHIMS_X86_64"); strings.Contains(v, "-snp") {
 		t.Errorf("SHIMS_X86_64 = %q must not register SNP shims on a TDX install", v)
 	}
-	if strings.Contains(out, "'kata-qemu-snp'") || strings.Contains(out, "'kata-qemu-snp-nvidia'") {
-		t.Errorf("kata-enforcement allowlist must not accept SNP classes on a TDX install\n%s", out)
+	if strings.Contains(expr, "'kata-qemu-snp'") || strings.Contains(expr, "'kata-qemu-snp-nvidia'") {
+		t.Errorf("kata-enforcement allowlist must not accept SNP classes on a TDX install\n%s", expr)
 	}
-	if !strings.Contains(out, "'kata-qemu-tdx'") {
-		t.Errorf("kata-enforcement allowlist must accept kata-qemu-tdx on a TDX install\n%s", out)
+	if !strings.Contains(expr, "'kata-qemu-tdx'") {
+		t.Errorf("kata-enforcement allowlist must accept kata-qemu-tdx on a TDX install\n%s", expr)
 	}
 
 	// Webhook injection follows the platform.
@@ -3559,7 +3734,7 @@ func TestChartKataShapeDropsHostSideComponents(t *testing.T) {
 		t.Errorf("kata shape still renders the host attestation-api DaemonSet")
 	}
 	for _, component := range []string{"ratls-mesh", "nri-image-policy"} {
-		if strings.Contains(out, "app.kubernetes.io/name: "+component) {
+		if renderedManifestHasLabel(t, out, "app.kubernetes.io/name", component) {
 			t.Errorf("kata shape still renders %s manifests", component)
 		}
 	}
@@ -3797,19 +3972,6 @@ func helmTemplate(t *testing.T, args ...string) (string, error) {
 // default, for tests exercising the manual tlsLb.upstream paths.
 func noUpstreamArgs(args ...string) []string {
 	return append([]string{"--set-string", "tlsLb.upstream.address="}, args...)
-}
-
-func renderedValue(t *testing.T, manifest, key string) string {
-	t.Helper()
-	prefix := key + ": "
-	for _, line := range strings.Split(manifest, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, prefix) {
-			return strings.TrimSpace(strings.TrimPrefix(trimmed, prefix))
-		}
-	}
-	t.Fatalf("rendered manifest missing %q\n%s", key, manifest)
-	return ""
 }
 
 // docMeta is the minimum we decode from each YAML doc to dispatch by kind+name.
@@ -5013,8 +5175,9 @@ func TestChartServesAllowlistSeedInNodeMode(t *testing.T) {
 		t.Errorf("node-mode seed missing tls-lb nginx self-entry\nseed: %v", seed.Digests)
 	}
 	// The flag/mount must be present so CDS actually loads the seed.
-	if !strings.Contains(out, "--allowlist-seed=/etc/cds/allowlist-seed.json") {
-		t.Errorf("node-mode CDS missing --allowlist-seed flag; seed rendered but not loaded")
+	cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+	if !slices.Contains(cds.Args, "--allowlist-seed=/etc/cds/allowlist-seed.json") {
+		t.Errorf("node-mode CDS missing --allowlist-seed flag; seed rendered but not loaded\nargs: %v", cds.Args)
 	}
 }
 
@@ -5506,9 +5669,18 @@ func TestChartDefaultRendersNoPullSecretRefs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	if strings.Contains(out, "imagePullSecrets") {
-		t.Errorf("default render carries an imagePullSecrets block\n%s", out)
-	}
+	iterateManifests(t, out, func(doc []byte) bool {
+		var raw map[string]any
+		if err := yaml.Unmarshal(doc, &raw); err != nil {
+			t.Fatalf("decode manifest: %v", err)
+		}
+		if path := findKey(raw, "imagePullSecrets"); path != "" {
+			var meta docMeta
+			_ = sigsyaml.Unmarshal(doc, &meta)
+			t.Errorf("default render carries an imagePullSecrets block: %s %s at %s", meta.Kind, meta.Metadata.Name, path)
+		}
+		return false
+	})
 }
 
 // pullerDockercfgSecret returns the Secret name the kata-image-puller's


### PR DESCRIPTION
## What

chart_test.go pinned rendered output with substring matches against the raw YAML stream (60 `strings.Contains` plus exact-text checks), so key reordering, indentation, or a rename in an intermediate value broke tests with zero behavior change. Every raw-stream assertion now decodes the rendered manifests into typed structs and asserts on fields: container argv and env, RBAC verb tables per resource, parsed nginx directives and server blocks, VAP CEL expressions, ConfigMap data entries, pod-template checksum annotations, and a recursive decoded-tree sweep for pull-secret refs.

Deliberately kept as strings: `helm template` failure messages (user-visible contracts), Contains against already-decoded field values (script bodies, CEL text, the quoted CORS header list), and the tee-proxy-remnant name sweep (a pure name search cannot false-positive on formatting).

New helpers extend the file's existing typed patterns: `renderedWorkload`/`renderedPodSpecs`, `renderedManifestHasLabel`, `kataEnforcementExpressions`, `findKey`, and nginx server-block parsing with `assertNoDirectivePrefix`.

## Verification
- `go test -count=1 ./internal/helmchart/` green, also with `-race`
- 16 assertions checked by mutating the corresponding chart template (image, flag, verb, annotation, secret ref), confirming the typed test fails, then reverting; helmchart is excluded from mutation runs so this manual pass stands in for the gremlins check
- chart templates untouched: the diff is one test file