### PR TITLE
fix(install): repair #168 fresh-install regressions

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -707,6 +707,17 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		if installKataDebug {
 			fmt.Fprintln(os.Stdout, "+ kata guest image: DEBUG variant — container logs/exec are host-readable; SNP launch measurement differs from the locked image")
 		}
+		// The sandbox-digests callback dials node addresses and nothing else.
+		// Resolve them here, where the cluster is reachable, so a default
+		// install does not quietly ship with sandbox identity disabled. Must
+		// run before buildValueArgs, which folds the resolved CIDRs into the
+		// computed values.
+		resolved, err := resolveInventoryCIDRs(cmd.Context(), installInventoryCIDRs)
+		if err != nil {
+			return err
+		}
+		installInventoryCIDRs = resolved
+
 		// The computed values are shared with `c8s render-values` via
 		// buildValueArgs, then written to one values file rather than passed as a
 		// pile of --set flags. The contract that the CLI's flag-derived values
@@ -797,15 +808,6 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 				return err
 			}
 		}
-
-		// The sandbox-digests callback dials node addresses and nothing else.
-		// Resolve them here, where the cluster is reachable, so a default
-		// install does not quietly ship with sandbox identity disabled.
-		resolved, err := resolveInventoryCIDRs(cmd.Context(), installInventoryCIDRs)
-		if err != nil {
-			return err
-		}
-		installInventoryCIDRs = resolved
 
 		// The install always ships pods that exceed the restricted pod-security
 		// profile: nri-image-policy runs privileged unconditionally, ratls-mesh's

--- a/internal/helmchart/c8s/templates/host-namespace-policy.yaml
+++ b/internal/helmchart/c8s/templates/host-namespace-policy.yaml
@@ -12,6 +12,11 @@ reason at the filesystem layer — the inventory's socket directory is root-owne
 c8s's own node-level components (the nri-image-policy installer, ratls-mesh)
 legitimately use both and run in the release namespace, which is exempt along
 with kube-system and any operator-supplied additions.
+
+One hostPath is carved out: the webhook injects a read-only mount of the
+inventory socket directory (nriImagePolicy.hostPaths.runtimeDir) into every
+CW pod's cert sidecar, so the policy admits exactly that dir, type Directory,
+with every referencing mount readOnly.
 */}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -52,8 +57,14 @@ spec:
       message: "hostIPC is denied for tenant pods."
     - expression: >-
         !has(object.spec.volumes) ||
-        object.spec.volumes.all(v, !has(v.hostPath))
-      message: "hostPath volumes are denied: a writable mount of the node filesystem could swap the admission inventory's socket (docs/getcert-workload-binding.md, Corner 7)."
+        object.spec.volumes.all(v, !has(v.hostPath) ||
+          (v.hostPath.path == {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }} &&
+           has(v.hostPath.type) && v.hostPath.type == 'Directory' &&
+           object.spec.containers.all(c, !has(c.volumeMounts) ||
+             c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))) &&
+           (!has(object.spec.initContainers) || object.spec.initContainers.all(c, !has(c.volumeMounts) ||
+             c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))))))
+      message: "hostPath volumes are denied, except a read-only mount of the admission inventory socket directory (the webhook-injected claims volume): a writable mount of the node filesystem could swap the inventory's socket (docs/getcert-workload-binding.md, Corner 7)."
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
@@ -66,15 +66,6 @@ spec:
           securityContext:
             privileged: true
           env:
-            # The address CDS dials for this node's sandbox-digests endpoint.
-            # The plugin is a host process with no downward API of its own, so
-            # the installer hands it down through a file (see the install
-            # script). Inferring it from the route to CDS does not work: the
-            # chart points the plugin at the CDS NodePort on loopback.
-            - name: NODE_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
             - name: HOST_CONTAINERD_DIR
               value: {{ include "nri-image-policy.containerdConfigDir" . | quote }}
             # The literal RKE2 base-config include, written verbatim into a
@@ -96,6 +87,16 @@ spec:
           imagePullPolicy: {{ .Values.nriImagePolicy.image.pullPolicy }}
           securityContext:
             privileged: true
+          env:
+            # The address CDS dials for this node's sandbox-digests endpoint.
+            # The plugin is a host process with no downward API of its own, so
+            # the install script hands it down through a file. Inferring it
+            # from the route to CDS does not work: the chart points the plugin
+            # at the CDS NodePort on loopback.
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           command: ["/bin/sh", "-c"]
           args:
             - |

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -595,6 +595,63 @@ func TestChartNriInstallerRendersSinglePullDaemonSet(t *testing.T) {
 	if got, want := worker.Spec.Template.Labels["app.kubernetes.io/component"], "nri-installer-worker"; got != want {
 		t.Errorf("worker installer pod component label = %q, want %q", got, want)
 	}
+	// The install script writes ${NODE_IP:?} to the node-ip file the plugin
+	// reads, so the env var must sit on the install container itself, not on
+	// the rke2-only containerd-prep sibling.
+	install, ok := findContainer(worker.Spec.Template.Spec.InitContainers, "install")
+	if !ok {
+		t.Fatalf("install init container missing; have %v", containerNames(worker.Spec.Template.Spec.InitContainers))
+	}
+	if !hasNodeIPEnv(install) {
+		t.Errorf("install init container missing NODE_IP downward-API env; have %+v", install.Env)
+	}
+}
+
+// The webhook injects a read-only hostPath mount of the inventory socket dir
+// (nriImagePolicy.hostPaths.runtimeDir) into every CW pod, so the
+// deny-host-namespaces VAP must carve out exactly that dir — a blanket
+// hostPath deny rejects every confidential workload the platform itself
+// mutates.
+func TestChartHostNamespacePolicyCarvesOutClaimsDir(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	var vap admissionregv1.ValidatingAdmissionPolicy
+	if !findDoc(t, out, "ValidatingAdmissionPolicy", "c8s-deny-host-namespaces", &vap) {
+		t.Fatal("ValidatingAdmissionPolicy c8s-deny-host-namespaces not rendered")
+	}
+	var hostPathExpr string
+	for _, v := range vap.Spec.Validations {
+		if strings.Contains(v.Expression, "hostPath") {
+			hostPathExpr = v.Expression
+		}
+	}
+	if hostPathExpr == "" {
+		t.Fatal("no hostPath validation in c8s-deny-host-namespaces")
+	}
+	for _, want := range []string{
+		`"/var/run/nri-image-policy"`, // the claims dir, and nothing wider
+		`'Directory'`,                 // the exact type the webhook injects
+		"m.readOnly",                  // every referencing mount must be read-only
+	} {
+		if !strings.Contains(hostPathExpr, want) {
+			t.Errorf("hostPath validation missing %s; expression=%q", want, hostPathExpr)
+		}
+	}
+}
+
+// hasNodeIPEnv reports whether the container carries a NODE_IP env var sourced
+// from the status.hostIP downward-API field — the sandbox-digests callback
+// address the installer writes down for the host-process plugin.
+func hasNodeIPEnv(c corev1.Container) bool {
+	for _, e := range c.Env {
+		if e.Name == "NODE_IP" && e.ValueFrom != nil && e.ValueFrom.FieldRef != nil &&
+			e.ValueFrom.FieldRef.FieldPath == "status.hostIP" {
+			return true
+		}
+	}
+	return false
 }
 
 // Single-node (empty cds.node.selector) renders the installer identically to


### PR DESCRIPTION
Found by an end-to-end install test on an Azure CVM (RKE2, cvm-mode=aks):

- chart: move the NODE_IP env from containerd-prep to the install init container that consumes it; without it the NRI installer crash-loops and a fresh install never becomes ready
- install: resolve sandbox-digests callback CIDRs before buildValueArgs freezes the computed values; a default install deployed CDS without --sandbox-inventory-cidr, refusing every sandbox-token cert request
- chart: carve the webhook-injected read-only workload-claims mount out of the deny-host-namespaces VAP, which denied every CW pod the platform itself mutates