### PR TITLE
feat(allowlist): entry-level secret grants, and argv in the admission inventory

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -26,7 +26,8 @@ The allowlist has two layers.
 
 - **Workloads** — `workloads`: named entries, each pinning an init/main
   container set. Every container binds a **digest** to the process policy
-  (`command`, `args`) and path policy (`paths`) permitted for those bytes. The
+  (`command`, `args`) permitted for those bytes, and the entry as a whole may
+  carry a secret-store grant (`secrets`). The
   entry name is operator-chosen; the entry `label` and per-container `image` are
   informational. Policy is always resolved by container digest.
 
@@ -53,8 +54,7 @@ semantics](#a-digest-may-run-many-ways).
           "digest": "sha256:<vllm>",
           "image":  "docker.io/vllm/vllm-openai:v0.6.3",
           "command": { "policy": "exact", "argv": ["python3"] },
-          "args":    { "policy": "exact", "argv": ["-m", "vllm.entrypoints.openai.api_server", "--model", "/models/llama-3.1-8b"] },
-          "paths":   { "policy": "deny" }
+          "args":    { "policy": "exact", "argv": ["-m", "vllm.entrypoints.openai.api_server", "--model", "/models/llama-3.1-8b"] }
         }
       ]
     }
@@ -130,30 +130,32 @@ entry widens a shared digest to `any`, because that becomes the effective
 container-level policy for the digest everywhere. The narrower, entry-scoped
 guarantee is recovered at [cert issuance](#where-its-enforced).
 
-## Path policy (`paths`)
+## Secret grants (`secrets`)
 
-`paths` grants filesystem access for a coming key-management integration: a
-workload attests, and a secret broker releases material into paths the workload
-is entitled to.
+An entry may grant secret-store paths to the workload it names. The subject is
+the **entry**, not a container — see [`secrets.md`](secrets.md) for the model and
+for what the admission inventory contributes to a release decision.
 
 ```json
-"paths": { "policy": "allow", "read": ["/secrets/model/**"], "write": ["/secrets/session"] }
+"secrets": { "policy": "allow", "read": ["/tenant-a/**"], "write": ["/tenant-a/session"] }
 ```
 
-- `deny` (default) grants nothing; `any` is unconstrained; `allow` lists `read`
-  and `write` globs.
-- A `write` grant implies create and update.
+- `allow` or `deny` only; there is deliberately no `any`.
+- `write` requires `read`.
 - Paths are absolute and clean (no `.`/`..`); the only wildcard is a trailing
-  `/**` (subtree). These rules exist so a grant cannot be widened by path
-  trickery once an enforcer consumes it.
+  `/**` (subtree), which matches strictly beneath its base.
+- A grant that releases nothing is omitted from the canonical document, so an
+  entry without one serializes exactly as it did before the field existed.
 
-**No enforcer consumes `paths` yet.** It is carried, validated, and
-canonicalized, so the schema and the operator tooling are ready — but it grants
-nothing until the secret-release component exists. When that component lands, a
-grant's subject must be bound to the leaf's CDS-stamped **sandbox identity**
-(`docs/ratls.md`, "Sandbox identity"), never to a self-asserted image reference,
-or any allowlisted workload could claim another's grant. The field is
-inert-with-a-spec by design; it is not a live capability.
+**No enforcer consumes `secrets` yet** — the CDS secret store and its release
+endpoint are not implemented, so a grant releases nothing today. It is carried,
+validated, and canonicalized so the schema and the operator tooling are ready.
+
+This replaces the per-container `paths` field, which named filesystem locations
+and never had an enforcer. Filesystem location is not an authorization boundary
+— a workload owns its own filesystem once a value is inside it — so only the
+store path is policy. Upgrading an install that still sets `paths` is covered in
+[`secrets.md`](secrets.md#upgrading).
 
 ## Where it's enforced
 
@@ -239,7 +241,7 @@ failure modes:
 - The **workload policy overlay swaps wholesale, gated by a monotonic epoch**
   (the version counter). A consumer applies a pulled overlay only if its version
   is greater than the last applied, and ignores a regression. This matters
-  because workload policy can *tighten* (narrow `args`, revoke a `paths` grant);
+  because workload policy can *tighten* (narrow `args`, revoke a `secrets` grant);
   a plain additive merge would let a host that withholds an update keep a laxer
   policy live forever. Epoch-gated replacement makes a withheld or rolled-back
   update fail toward the last-known-good policy, not toward the laxest one. The
@@ -313,7 +315,7 @@ confirm loop, and the signed write is always a separate, reviewed `apply`.
 (both lists empty), a `command: deny` container that can never start, a
 shared digest whose union is widened to `any` by some entry, a digest that is
 floor-listed while also carrying a workload policy — the floor admits it by
-digest alone, so the argv/paths policy is silently not enforced — tag-form labels
+digest alone, so the argv policy is silently not enforced — tag-form labels
 (which can move under the operator), and a summary of how many `any` policies a
 document carries. `--online` cross-checks digests against the registry with
 `crane`; `--strict` turns warnings into a non-zero exit for CI.
@@ -323,6 +325,5 @@ document carries. `--online` cross-checks digests against the registry with
 Generating an operator key and pinning its public half is unchanged; see the
 README and [`operator.md`](operator.md). Rotating the pinned set rolls CDS, and
 a verifier detects a changed write policy by comparing the served
-`/operator-keys` list against its own bundle. The path grants (`paths`) will,
-when their enforcer lands, be managed with the same `workload edit`/`apply` flow
-and bound to the leaf's sandbox identity.
+`/operator-keys` list against its own bundle. Secret grants (`secrets`) are
+managed with the same `workload edit`/`apply` flow.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,89 @@
+# Secret release
+
+How a workload is authorized to read a secret, and what the allowlist and the
+admission inventory contribute to that decision.
+
+> **Status.** This document describes the parts that have landed: the
+> entry-level `secrets` grant, and the inventory reporting that release will be
+> evaluated against. The CDS secrets store and its release endpoint are not
+> implemented yet, so **no grant releases anything today**.
+
+## The grant
+
+A secret grant belongs to a **workload entry**, not a container:
+
+```json
+"vllm-llama": {
+  "containers": [ { "digest": "sha256:…", "command": {…}, "args": {…} } ],
+  "secrets": { "policy": "allow", "read": ["/tenant-a/**"], "write": ["/tenant-a/session"] }
+}
+```
+
+The subject is the entry because the value is delivered on a volume every
+container in the pod can read — a per-container grant would not describe what is
+actually released.
+
+- `policy` is `allow` or `deny`. There is deliberately **no `any`**: an unbounded
+  secret grant is never what an operator means.
+- Paths are absolute, clean, and the only wildcard is a trailing `/**`, which
+  matches strictly beneath its base — `/a/**` does not grant `/a`.
+- `write` requires `read`. The only client creates with `POST`, then re-reads;
+  a write-only grant would strand every replica that loses the create race.
+- A grant that releases nothing is **omitted** from the canonical document, so an
+  entry without one serializes exactly as it did before the field existed.
+
+`paths`, the per-container filesystem field this replaces, never had an enforcer
+and is gone. The in-pod destination of a secret is **not** an authorization
+boundary — the workload owns its own filesystem once the value is inside it — so
+only the store path is policy.
+
+### Upgrading
+
+CDS parses its seed with unknown fields rejected and fails closed, so a values
+file still carrying per-container `paths` would stop CDS booting. The chart
+rejects it at `helm upgrade` (`VALIDATION_ERROR kind=allowlist_container_paths`).
+Move the grant up to the entry; a `deny` grant is simply dropped.
+
+Serving the field is safe ahead of the consumers: `secrets` appears only once an
+operator writes a real grant, and the pull path
+(`allowlist.ParseServedJSON`) ignores fields it does not know. Strict parsing is
+kept for operator-authored input, where an unknown field is a typo.
+
+## What the inventory reports
+
+`GET /digests/{sandboxID}` answers with two views of the same sandbox:
+
+| field | shape | used by |
+|---|---|---|
+| `digests` | deduplicated digest set | cert issuance (membership) |
+| `containers` | `[{digest, argv}]`, **not** deduplicated | secret release |
+
+`argv` is the effective OCI `process.args` that admission evaluated, so release
+can hold a sandbox to the same `(digest, argv)` pair the allowlist matched rather
+than to a digest set that says nothing about what those images were told to run.
+Without it, two entries differing only in argv are indistinguishable, and the
+argv admission enforces is a **union across every entry listing the digest** — so
+an entry that pins `command: exact` gives no guarantee at release time if another
+entry widens the same digest.
+
+`containers` is absent on an inventory older than the field. A consumer that
+needs it must treat that as "cannot answer" rather than "no containers"
+(`RequireContainers`).
+
+### The report is a high-water mark
+
+Both views describe every container **ever admitted** in the sandbox, not those
+running now. The inventory is otherwise "created and not yet removed", and
+kubelet removes and recreates a container across a `CrashLoopBackOff` — so a live
+snapshot lets a pod arrange for a container to be absent at the moment it is
+asked and present a set it does not have. A pod could then declare a victim
+entry's containers plus one extra image that exits immediately, be handed the
+secret during a backoff window, and read it when the extra container restarts.
+
+Admission is monotone, so membership here is too. A container that stops leaves
+caller resolution — a stopped container must not bind a caller — but stays in the
+sandbox's record until the sandbox itself is torn down.
+
+The cost is that a pod which ever ran an image outside its entry never receives a
+secret, even after that image is gone. That is the correct direction for a
+release decision.

--- a/internal/cmds/allowlist/diff_test.go
+++ b/internal/cmds/allowlist/diff_test.go
@@ -14,7 +14,6 @@ func TestDiffAllowlistsWorkloads(t *testing.T) {
 			Digest:  mustDigest(t, digB),
 			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{argv}},
 			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			Paths:   pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyDeny},
 		}
 	}
 	live := &pkgallowlist.Allowlist{
@@ -88,7 +87,6 @@ func TestPrintDiffTextSectionPlaceholders(t *testing.T) {
 			Digest:  mustDigest(t, digB),
 			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{argv}},
 			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			Paths:   pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyDeny},
 		}
 	}
 	base := func(ctr pkgallowlist.Container, digests map[string]string) *pkgallowlist.Allowlist {

--- a/internal/cmds/allowlist/integration_test.go
+++ b/internal/cmds/allowlist/integration_test.go
@@ -283,7 +283,6 @@ func TestWorkloadApplyGetRoundTrip(t *testing.T) {
 				"image":   "registry.example.com/team/api@" + digA,
 				"command": map[string]any{"policy": "exact", "argv": []string{"/app/server"}},
 				"args":    map[string]any{"policy": "exact", "argv": []string{"--port=8080"}},
-				"paths":   map[string]any{"policy": "deny"},
 			}},
 		},
 	}

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -134,15 +134,14 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 			if c.Args.Policy == pkgallowlist.PolicyAny {
 				anyCount++
 			}
-			if c.Paths.Policy == pkgallowlist.PolicyAny {
-				anyCount++
-			}
 			if c.Image != "" && isTagForm(c.Image) {
 				warnings = append(warnings, fmt.Sprintf("workload %q container %s image %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, d, c.Image))
 			}
-			for _, g := range append(append([]string{}, c.Paths.Read...), c.Paths.Write...) {
+		}
+		if w.Secrets != nil {
+			for _, g := range append(append([]string{}, w.Secrets.Read...), w.Secrets.Write...) {
 				if g == "/**" {
-					warnings = append(warnings, fmt.Sprintf("workload %q container %s grants a root-subtree path %q (whole filesystem)", name, d, g))
+					warnings = append(warnings, fmt.Sprintf("workload %q grants the root secret subtree %q (every secret in the store)", name, g))
 				}
 			}
 		}
@@ -155,10 +154,12 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 	}
 
 	// A floor digest is admitted by digest alone, so it short-circuits any argv
-	// or paths policy an operator also wrote for the same digest in a workload.
+	// policy an operator also wrote for the same digest in a workload — and for
+	// a secrets-bearing entry it also makes the entry unmatchable, since the
+	// digest is dropped from the candidate set.
 	for _, d := range sortedKeys(al.Digests) {
 		if names := entriesByDigest[d]; len(names) > 0 {
-			warnings = append(warnings, fmt.Sprintf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv/paths policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
+			warnings = append(warnings, fmt.Sprintf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
 		}
 	}
 

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -8,7 +8,7 @@ import (
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
 
-// A digest on the floor is admitted by digest alone, so any argv/paths policy an
+// A digest on the floor is admitted by digest alone, so any argv policy an
 // operator also wrote for it in a workload is silently not enforced. lint must
 // surface that overlap — and only for the overlapping digest.
 func TestLintFloorWorkloadOverlap(t *testing.T) {
@@ -56,7 +56,7 @@ func TestLintCleanAllowlistReportsOK(t *testing.T) {
 }
 
 // The any-count warning tallies each unconstrained segment (command, args,
-// paths) per container; a fully-any container in a single entry produces no
+// per container; a fully-any container in a single entry produces no
 // other warning, so the output is pinned exactly.
 func TestLintAnyCountWarning(t *testing.T) {
 	cases := []struct {
@@ -65,13 +65,13 @@ func TestLintAnyCountWarning(t *testing.T) {
 		want string
 	}{
 		{
-			name: "fully unconstrained counts all three segments",
-			ctr:  `{"digest":"` + digA + `","command":{"policy":"any"},"args":{"policy":"any"},"paths":{"policy":"any"}}`,
-			want: "warning: 3 'any' (unconstrained) policy value(s) across all entries\n",
+			name: "fully unconstrained counts both argv segments",
+			ctr:  `{"digest":"` + digA + `","command":{"policy":"any"},"args":{"policy":"any"}}`,
+			want: "warning: 2 'any' (unconstrained) policy value(s) across all entries\n",
 		},
 		{
 			name: "single any segment counts once",
-			ctr:  `{"digest":"` + digA + `","command":{"policy":"any"},"args":{"policy":"exact","argv":["/x"]},"paths":{"policy":"allow","read":["/data"]}}`,
+			ctr:  `{"digest":"` + digA + `","command":{"policy":"any"},"args":{"policy":"exact","argv":["/x"]}}`,
 			want: "warning: 1 'any' (unconstrained) policy value(s) across all entries\n",
 		},
 	}

--- a/internal/cmds/allowlist/read.go
+++ b/internal/cmds/allowlist/read.go
@@ -176,27 +176,15 @@ func printWorkloadTable(w io.Writer, workloads map[string]pkgallowlist.Workload)
 	tw.Flush()
 }
 
-// summarizeWorkload aggregates the command policies, args policies, and path
-// grant/deny counts across every container (init and main) in an entry.
-func summarizeWorkload(w pkgallowlist.Workload) (command, args, paths string) {
+// summarizeWorkload aggregates the command and args policies across every
+// container (init and main) in an entry, alongside the entry's secret grant.
+func summarizeWorkload(w pkgallowlist.Workload) (command, args, secrets string) {
 	commandSet, argsSet := map[string]bool{}, map[string]bool{}
-	var readN, writeN, anyN int
 	for _, c := range allContainers(w) {
 		commandSet[argvPolicyName(c.Command)] = true
 		argsSet[argvPolicyName(c.Args)] = true
-		switch c.Paths.Policy {
-		case pkgallowlist.PolicyAllow:
-			readN += len(c.Paths.Read)
-			writeN += len(c.Paths.Write)
-		case pkgallowlist.PolicyAny:
-			anyN++
-		}
 	}
-	pathStr := fmt.Sprintf("R=%d W=%d", readN, writeN)
-	if anyN > 0 {
-		pathStr += fmt.Sprintf(" any=%d", anyN)
-	}
-	return joinSet(commandSet), joinSet(argsSet), pathStr
+	return joinSet(commandSet), joinSet(argsSet), secretsSummary(w.Secrets)
 }
 
 // allContainers returns the init containers followed by the main containers.
@@ -242,21 +230,17 @@ func argvSummary(p pkgallowlist.ArgvPolicy) string {
 	}
 }
 
-func pathSummary(p pkgallowlist.PathPolicy) string {
-	switch p.Policy {
-	case pkgallowlist.PolicyAny:
-		return "any"
-	case pkgallowlist.PolicyAllow:
-		return fmt.Sprintf("allow(r=%d,w=%d)", len(p.Read), len(p.Write))
-	default:
+func secretsSummary(p *pkgallowlist.SecretsPolicy) string {
+	if p == nil || p.Policy != pkgallowlist.PolicyAllow {
 		return "deny"
 	}
+	return fmt.Sprintf("allow(r=%d,w=%d)", len(p.Read), len(p.Write))
 }
 
-// containerSummary renders one container's policy triple, e.g.
-// "command=exact[/bin/sh -c] args=any paths=deny".
+// containerSummary renders one container's argv policy pair, e.g.
+// "command=exact[/bin/sh -c] args=any".
 func containerSummary(c pkgallowlist.Container) string {
-	return fmt.Sprintf("command=%s args=%s paths=%s", argvSummary(c.Command), argvSummary(c.Args), pathSummary(c.Paths))
+	return fmt.Sprintf("command=%s args=%s", argvSummary(c.Command), argvSummary(c.Args))
 }
 
 func shellJoin(argv []string) string {

--- a/internal/cmds/allowlist/read_write_test.go
+++ b/internal/cmds/allowlist/read_write_test.go
@@ -186,30 +186,33 @@ func TestListJSONOutput(t *testing.T) {
 
 // TestListTextWorkloadTable pins the text rendering of the workload summary
 // table: init/main counts, the aggregated command/args policy sets, and the
-// path grant tallies (with the any counter only when nonzero).
+// entry-level secret grant tallies.
 func TestListTextWorkloadTable(t *testing.T) {
-	web := pkgallowlist.Workload{Containers: []pkgallowlist.Container{
-		{
-			Digest:  mustDigest(t, digA),
-			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/app"}},
-			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			Paths:   pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/a", "/b"}, Write: []string{"/w"}},
+	web := pkgallowlist.Workload{
+		Containers: []pkgallowlist.Container{
+			{
+				Digest:  mustDigest(t, digA),
+				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/app"}},
+				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+			},
+			{
+				Digest:  mustDigest(t, digB),
+				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny},
+				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny},
+			},
 		},
-		{
-			Digest:  mustDigest(t, digB),
-			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny},
-			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny},
-			Paths:   pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyAny},
+		Secrets: &pkgallowlist.SecretsPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/a", "/b"}, Write: []string{"/w"}},
+	}
+	plain := pkgallowlist.Workload{
+		Containers: []pkgallowlist.Container{
+			{
+				Digest:  mustDigest(t, digC),
+				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/p"}},
+				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+			},
 		},
-	}}
-	plain := pkgallowlist.Workload{Containers: []pkgallowlist.Container{
-		{
-			Digest:  mustDigest(t, digC),
-			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/p"}},
-			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			Paths:   pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/r"}},
-		},
-	}}
+		Secrets: &pkgallowlist.SecretsPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/r"}},
+	}
 	al := &pkgallowlist.Allowlist{
 		Schema:    pkgallowlist.Schema,
 		Digests:   map[string]string{digD: "floor-img"},
@@ -232,8 +235,8 @@ func TestListTextWorkloadTable(t *testing.T) {
 		}
 	}
 	want := map[string][]string{
-		"web":   {"web", "0", "2", "command=any,exact", "args=any,deny", "R=2", "W=1", "any=1"},
-		"plain": {"plain", "0", "1", "command=exact", "args=deny", "R=1", "W=0"},
+		"web":   {"web", "0", "2", "command=any,exact", "args=any,deny", "allow(r=2,w=1)"},
+		"plain": {"plain", "0", "1", "command=exact", "args=deny", "allow(r=1,w=0)"},
 	}
 	for name, wantRow := range want {
 		got, ok := rows[name]
@@ -470,10 +473,9 @@ func TestLintOfflineWarningSurface(t *testing.T) {
 		"empty":{},
 		"tagged":{"label":"docker.io/library/busybox:latest","containers":[
 			{"digest":"`+digA+`","image":"docker.io/library/busybox:latest",
-			 "command":{"policy":"any"},"args":{"policy":"any"},"paths":{"policy":"any"}}]},
-		"other":{"containers":[
-			{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
-			 "paths":{"policy":"allow","read":["/**"]}},
+			 "command":{"policy":"any"},"args":{"policy":"any"}}]},
+		"other":{"secrets":{"policy":"allow","read":["/**"]},"containers":[
+			{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}},
 			{"digest":"`+digB+`","command":{"policy":"deny"},"args":{"policy":"deny"}}]}}}`)
 
 	out, _, err := runCmd("lint", file)
@@ -485,7 +487,7 @@ func TestLintOfflineWarningSurface(t *testing.T) {
 		`workload "tagged" label "docker.io/library/busybox:latest" is a tag`,
 		`image "docker.io/library/busybox:latest" is a tag`,
 		"the container can never start",
-		`grants a root-subtree path "/**"`,
+		`grants the root secret subtree "/**"`,
 		"appears in 2 entries and one grants 'any'",
 		"'any' (unconstrained) policy value(s) across all entries",
 	} {

--- a/internal/cmds/allowlist/workload_test.go
+++ b/internal/cmds/allowlist/workload_test.go
@@ -388,14 +388,11 @@ func TestArgvSummary(t *testing.T) {
 	}
 }
 
-func TestPathSummary(t *testing.T) {
-	if got := pathSummary(pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyAny}); got != "any" {
-		t.Fatalf("any summary = %q", got)
-	}
-	if got := pathSummary(pkgallowlist.PathPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/a"}, Write: []string{"/b", "/c"}}); got != "allow(r=1,w=2)" {
+func TestSecretsSummary(t *testing.T) {
+	if got := secretsSummary(&pkgallowlist.SecretsPolicy{Policy: pkgallowlist.PolicyAllow, Read: []string{"/a"}, Write: []string{"/b", "/c"}}); got != "allow(r=1,w=2)" {
 		t.Fatalf("allow summary = %q", got)
 	}
-	if got := pathSummary(pkgallowlist.PathPolicy{}); got != "deny" {
+	if got := secretsSummary(&pkgallowlist.SecretsPolicy{}); got != "deny" {
 		t.Fatalf("deny summary = %q", got)
 	}
 }

--- a/internal/cmds/getcert/run_extra_test.go
+++ b/internal/cmds/getcert/run_extra_test.go
@@ -63,8 +63,8 @@ func (f fakeResolver) SandboxForPeer(workloadclaims.Peer) (string, error) {
 	return f.sandboxID, f.err
 }
 
-func (f fakeResolver) DigestsForSandbox(string) ([]string, bool, error) {
-	return nil, false, nil
+func (f fakeResolver) DigestsForSandbox(string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
+	return nil, nil, false, nil
 }
 
 // startFakeInventory serves the inventory token socket and returns its unix://

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -3,6 +3,7 @@ package nriimagepolicy
 import (
 	"fmt"
 	"slices"
+	"strings"
 	"sync"
 
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -17,7 +18,8 @@ import (
 // cgroup → container), never from the request.
 type admissionInventory struct {
 	mu         sync.RWMutex
-	containers map[string]ctrRec   // containerID -> record
+	containers map[string]ctrRec   // live containerID -> record (caller resolution)
+	admitted   map[string]sbxRec   // sandboxID -> everything ever admitted there
 	sandboxes  map[string]struct{} // live pod sandbox IDs
 	procRoot   string
 }
@@ -26,34 +28,70 @@ type ctrRec struct {
 	sandboxID string
 	name      string
 	digest    string // canonical sha256:<hex>; "" when unresolved
+	argv      []string
+}
+
+// sbxRec is a sandbox's admission high-water mark: every distinct (digest,
+// argv) admitted in it, keyed for dedup. It is never pruned while the sandbox
+// lives.
+//
+// containers alone cannot answer /digests. A container is removed and recreated
+// across a CrashLoopBackOff, so a live view lets a pod arrange for a container
+// to be absent at the moment it is asked and present a set it does not have —
+// the release check would then see only the containers of an entry it is not
+// (docs/secrets.md). Admission is monotone; membership here is too.
+type sbxRec struct {
+	byKey      map[string]workloadclaims.SandboxContainer
+	unresolved bool // some admitted container never resolved a digest
 }
 
 func newAdmissionInventory(procRoot string) *admissionInventory {
 	return &admissionInventory{
 		containers: map[string]ctrRec{},
+		admitted:   map[string]sbxRec{},
 		sandboxes:  map[string]struct{}{},
 		procRoot:   procRoot,
 	}
 }
 
+// admittedKey identifies a (digest, argv) pair for dedup. The unit separator
+// cannot appear in a digest and is not a shell-reachable argv byte in practice;
+// a collision would only merge two identical-looking containers anyway.
+func admittedKey(digest string, argv []string) string {
+	return digest + "\x1f" + strings.Join(argv, "\x1f")
+}
+
 // record notes an admitted container, injected sidecars included: /digests is
-// an inventory of what runs in the sandbox, and the injected images are
+// an inventory of what was admitted in the sandbox, and the injected images are
 // allowlist floor entries, so CDS drops them from workload matching itself.
-func (b *admissionInventory) record(containerID, sandboxID, name, digest string) {
+// argv is the effective OCI process.args the allowlist was evaluated against.
+func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string) {
 	if containerID == "" || sandboxID == "" {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	b.containers[containerID] = ctrRec{sandboxID: sandboxID, name: name, digest: digest}
+	b.containers[containerID] = ctrRec{sandboxID: sandboxID, name: name, digest: digest, argv: argv}
+
+	rec, ok := b.admitted[sandboxID]
+	if !ok {
+		rec = sbxRec{byKey: map[string]workloadclaims.SandboxContainer{}}
+	}
+	if digest == "" {
+		rec.unresolved = true
+	} else {
+		rec.byKey[admittedKey(digest, argv)] = workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
+	}
+	b.admitted[sandboxID] = rec
+
 	// A container implies its sandbox, so a record arriving before (or without)
 	// the pod event still leaves the sandbox resolvable.
 	b.sandboxes[sandboxID] = struct{}{}
 }
 
-// remove evicts a container that stopped, so its digest can't linger in a
-// later pod's answer (container IDs are unique, but eviction keeps the map
-// bounded and correct across pod churn).
+// remove evicts a stopped container from caller resolution. It deliberately
+// does NOT touch the sandbox's admission record: what ran there is what ran
+// there, and forgetting it is the TOCTOU sbxRec exists to close.
 func (b *admissionInventory) remove(containerID string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -79,6 +117,7 @@ func (b *admissionInventory) removeSandbox(sandboxID string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	delete(b.sandboxes, sandboxID)
+	delete(b.admitted, sandboxID)
 	for id, rec := range b.containers {
 		if rec.sandboxID == sandboxID {
 			delete(b.containers, id)
@@ -134,28 +173,36 @@ func (b *admissionInventory) SandboxForPeer(peer workloadclaims.Peer) (string, e
 	return caller.sandboxID, nil
 }
 
-// DigestsForSandbox returns the sorted, deduplicated image digests of every
-// tracked container in the sandbox, injected containers included: this is an
-// inventory of what runs there, and CDS drops the injected images itself (they
-// are allowlist floor entries). An unresolved digest fails the whole answer
-// rather than commit a subset as if it were the whole inventory.
-func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, bool, error) {
+// DigestsForSandbox reports every container ever admitted in the sandbox,
+// injected containers included: CDS drops the injected ones itself. Digests is
+// the sorted, deduplicated digest set (issuance); containers carries the
+// per-container (digest, argv) detail, sorted for a stable answer.
+//
+// An unresolved digest fails the whole answer rather than commit a subset as if
+// it were the whole inventory.
+func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	if _, ok := b.sandboxes[sandboxID]; !ok {
-		return nil, false, nil
+		return nil, nil, false, nil
+	}
+	rec := b.admitted[sandboxID]
+	if rec.unresolved {
+		return nil, nil, true, fmt.Errorf("sandbox %s admitted a container with no resolved image digest", sandboxID)
 	}
 	digests := []string{}
-	for _, rec := range b.containers {
-		if rec.sandboxID != sandboxID {
-			continue
-		}
-		if rec.digest == "" {
-			return nil, true, fmt.Errorf("container %q has no resolved image digest", rec.name)
-		}
-		digests = append(digests, rec.digest)
+	containers := make([]workloadclaims.SandboxContainer, 0, len(rec.byKey))
+	for _, c := range rec.byKey {
+		digests = append(digests, c.Digest)
+		containers = append(containers, c)
 	}
 	slices.Sort(digests)
-	return slices.Compact(digests), true, nil
+	slices.SortFunc(containers, func(a, b workloadclaims.SandboxContainer) int {
+		if a.Digest != b.Digest {
+			return strings.Compare(a.Digest, b.Digest)
+		}
+		return strings.Compare(strings.Join(a.Argv, "\x1f"), strings.Join(b.Argv, "\x1f"))
+	})
+	return slices.Compact(digests), containers, true, nil
 }

--- a/internal/cmds/nri-image-policy/inventory_test.go
+++ b/internal/cmds/nri-image-policy/inventory_test.go
@@ -17,7 +17,7 @@ func sandboxDigestsFor(b *admissionInventory, pid int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	digests, known, err := b.DigestsForSandbox(id)
+	digests, _, known, err := b.DigestsForSandbox(id)
 	if err != nil {
 		return nil, err
 	}
@@ -75,11 +75,11 @@ func TestInventoryResolvesPodAndIsolatesOtherPods(t *testing.T) {
 		pod2 = "sandbox-2"
 	)
 	// pod1: get-cert sidecar + two app containers.
-	b.record(cidGetCert, pod1, "c8s-cert", digestOther)
-	b.record(cidApp1, pod1, "app", digestApp)
-	b.record(cidApp2, pod1, "worker", digestApp2)
+	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil)
+	b.record(cidApp1, pod1, "app", digestApp, nil)
+	b.record(cidApp2, pod1, "worker", digestApp2, nil)
 	// pod2: a different app; must never appear in pod1's answer.
-	b.record(cidOther, pod2, "app", digestOther)
+	b.record(cidOther, pod2, "app", digestOther, nil)
 
 	// The caller is the get-cert process in pod1.
 	writeCgroup(t, procRoot, 4242, cidGetCert)
@@ -98,7 +98,7 @@ func TestInventoryResolvesPodAndIsolatesOtherPods(t *testing.T) {
 func TestInventoryRejectsUntrackedAndZeroPID(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidApp1, "sandbox-1", "app", digestApp)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
 
 	if _, err := sandboxDigestsFor(b, 0); err == nil {
 		t.Fatal("peer pid 0 accepted (node-CVM must bind the caller)")
@@ -118,9 +118,9 @@ func TestInventoryRejectsNestedVictimCgroup(t *testing.T) {
 	b := newAdmissionInventory(procRoot)
 
 	const pod1, pod2 = "sandbox-1", "sandbox-2"
-	b.record(cidApp1, pod1, "app", digestApp) // victim's app in pod1
-	b.record(cidGetCert, pod2, "c8s-cert", digestOther)
-	b.record(cidApp2, pod2, "app", digestApp2) // attacker's own app in pod2
+	b.record(cidApp1, pod1, "app", digestApp, nil) // victim's app in pod1
+	b.record(cidGetCert, pod2, "c8s-cert", digestOther, nil)
+	b.record(cidApp2, pod2, "app", digestApp2, nil) // attacker's own app in pod2
 
 	// Attacker's process: its real scope is cidGetCert (pod2), with a nested
 	// child cgroup named cidApp1 (pod1's container).
@@ -152,9 +152,9 @@ func TestInventoryRefusesUnresolvedDigest(t *testing.T) {
 	b := newAdmissionInventory(procRoot)
 
 	const pod1 = "sandbox-1"
-	b.record(cidGetCert, pod1, "c8s-cert", digestOther)
-	b.record(cidApp1, pod1, "app", digestApp)
-	b.record(cidApp2, pod1, "worker", "") // resolve failed at admission
+	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil)
+	b.record(cidApp1, pod1, "app", digestApp, nil)
+	b.record(cidApp2, pod1, "worker", "", nil) // resolve failed at admission
 	writeCgroup(t, procRoot, 4242, cidGetCert)
 
 	if _, err := sandboxDigestsFor(b, 4242); err == nil {
@@ -162,11 +162,15 @@ func TestInventoryRefusesUnresolvedDigest(t *testing.T) {
 	}
 }
 
-func TestInventoryEvicts(t *testing.T) {
+// A removed container leaves caller resolution but stays in the sandbox's
+// admission record. Dropping it would let a pod hide a container by arranging
+// for it to be absent when asked — kubelet removes and recreates a container
+// across a CrashLoopBackOff, so that window is free (docs/secrets.md).
+func TestInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther)
-	b.record(cidApp1, "sandbox-1", "app", digestApp)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
 	writeCgroup(t, procRoot, 77, cidGetCert)
 
 	b.remove(cidApp1)
@@ -174,8 +178,21 @@ func TestInventoryEvicts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !slices.Equal(got, []string{digestOther}) {
-		t.Fatalf("digests = %v, want only the surviving sidecar", got)
+	if !slices.Equal(got, slicesSorted([]string{digestOther, digestApp})) {
+		t.Fatalf("digests = %v, want the removed container still recorded", got)
+	}
+
+	// It is gone for caller resolution, though: a stopped container must not
+	// bind a caller.
+	writeCgroup(t, procRoot, 78, cidApp1)
+	if _, err := sandboxDigestsFor(b, 78); err == nil {
+		t.Fatal("a removed container still resolved a caller")
+	}
+
+	// Tearing the sandbox down does clear it.
+	b.removeSandbox("sandbox-1")
+	if _, _, known, _ := b.DigestsForSandbox("sandbox-1"); known {
+		t.Fatal("removed sandbox still known")
 	}
 }
 
@@ -184,7 +201,7 @@ func TestInventoryEvicts(t *testing.T) {
 func TestInventorySandboxForPeer(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
 	writeCgroup(t, procRoot, 4242, cidGetCert)
 
 	got, err := b.SandboxForPeer(workloadclaims.PeerForPID(4242))
@@ -207,13 +224,13 @@ func TestInventorySandboxForPeer(t *testing.T) {
 func TestInventoryDigestsForSandbox(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
 
-	if _, known, err := b.DigestsForSandbox("nope"); err != nil || known {
+	if _, _, known, err := b.DigestsForSandbox("nope"); err != nil || known {
 		t.Fatalf("unknown sandbox: known=%v err=%v, want known=false", known, err)
 	}
 
 	// A known sandbox with no containers answers an empty inventory.
 	b.recordSandbox("sandbox-empty")
-	got, known, err := b.DigestsForSandbox("sandbox-empty")
+	got, _, known, err := b.DigestsForSandbox("sandbox-empty")
 	if err != nil || !known {
 		t.Fatalf("empty sandbox: known=%v err=%v", known, err)
 	}
@@ -222,11 +239,11 @@ func TestInventoryDigestsForSandbox(t *testing.T) {
 	}
 
 	// The inventory includes injected containers, deduplicates, and sorts.
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther)
-	b.record(cidApp1, "sandbox-1", "app", digestApp)
-	b.record(cidApp2, "sandbox-1", "worker", digestApp)
-	b.record(cidOther, "sandbox-2", "app", digestApp2)
-	got, known, err = b.DigestsForSandbox("sandbox-1")
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	b.record(cidApp2, "sandbox-1", "worker", digestApp, nil)
+	b.record(cidOther, "sandbox-2", "app", digestApp2, nil)
+	got, _, known, err = b.DigestsForSandbox("sandbox-1")
 	if err != nil || !known {
 		t.Fatalf("known=%v err=%v", known, err)
 	}
@@ -245,10 +262,10 @@ func slicesSorted(in []string) []string {
 // the inventory covers every running container, injected ones included.
 func TestInventoryDigestsForSandboxRefusesUnresolved(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", "")
-	b.record(cidApp1, "sandbox-1", "app", digestApp)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", "", nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
 
-	if _, _, err := b.DigestsForSandbox("sandbox-1"); err == nil {
+	if _, _, _, err := b.DigestsForSandbox("sandbox-1"); err == nil {
 		t.Fatal("served a subset of the sandbox inventory")
 	}
 }
@@ -258,17 +275,17 @@ func TestInventoryDigestsForSandboxRefusesUnresolved(t *testing.T) {
 func TestInventorySandboxLifecycle(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
 
-	b.record(cidApp1, "sandbox-1", "app", digestApp)
-	if _, known, _ := b.DigestsForSandbox("sandbox-1"); !known {
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	if _, _, known, _ := b.DigestsForSandbox("sandbox-1"); !known {
 		t.Fatal("recorded container did not imply its sandbox")
 	}
 
-	b.record(cidOther, "sandbox-2", "app", digestApp2)
+	b.record(cidOther, "sandbox-2", "app", digestApp2, nil)
 	b.removeSandbox("sandbox-1")
-	if _, known, _ := b.DigestsForSandbox("sandbox-1"); known {
+	if _, _, known, _ := b.DigestsForSandbox("sandbox-1"); known {
 		t.Fatal("removed sandbox still known")
 	}
-	got, known, err := b.DigestsForSandbox("sandbox-2")
+	got, _, known, err := b.DigestsForSandbox("sandbox-2")
 	if err != nil || !known || !slices.Equal(got, []string{digestApp2}) {
 		t.Fatalf("sandbox-2 after removing sandbox-1: %v %v %v", got, known, err)
 	}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -249,7 +249,10 @@ func (p *plugin) recordForInventory(ctx context.Context, ctr *api.Container, ima
 			p.logger.Error("cannot resolve admitted image digest; the sandbox inventory will refuse to answer for this pod", "image", imageRef, "error", err)
 		}
 	}
-	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest)
+	// ctr.Args is the effective OCI process.args admission was evaluated
+	// against, so the inventory vouches for the same (digest, argv) pair the
+	// allowlist matched.
+	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest, ctr.GetArgs())
 }
 
 // evaluateRule checks whether a pod satisfies a compiled Kubernetes selector.

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -108,21 +108,21 @@ func TestPodSandboxEventsFeedInventory(t *testing.T) {
 	if _, err := p.Synchronize(context.Background(), pods, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, known, _ := p.inventory.DigestsForSandbox("pod1-id"); !known {
+	if _, _, known, _ := p.inventory.DigestsForSandbox("pod1-id"); !known {
 		t.Fatal("Synchronize did not seed the inventory sandbox set while deferring")
 	}
 
 	if err := p.RunPodSandbox(context.Background(), makePod("default", "pod2")); err != nil {
 		t.Fatal(err)
 	}
-	if _, known, _ := p.inventory.DigestsForSandbox("pod2-id"); !known {
+	if _, _, known, _ := p.inventory.DigestsForSandbox("pod2-id"); !known {
 		t.Fatal("RunPodSandbox did not record the sandbox")
 	}
 
 	if err := p.RemovePodSandbox(context.Background(), makePod("default", "pod2")); err != nil {
 		t.Fatal(err)
 	}
-	if _, known, _ := p.inventory.DigestsForSandbox("pod2-id"); known {
+	if _, _, known, _ := p.inventory.DigestsForSandbox("pod2-id"); known {
 		t.Fatal("RemovePodSandbox did not evict the sandbox")
 	}
 }

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -71,7 +71,7 @@ func TestPluginRun_StopsOnContextCancel(t *testing.T) {
 func TestRemoveContainer_EvictsFromInventory(t *testing.T) {
 	p := newTestPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}})
 	p.inventory = newAdmissionInventory(t.TempDir())
-	p.inventory.record(cidApp1, "sandbox-1", "app", digestApp)
+	p.inventory.record(cidApp1, "sandbox-1", "app", digestApp, nil)
 
 	ctr := &api.Container{Id: cidApp1, PodSandboxId: "sandbox-1", Name: "app"}
 	if err := p.RemoveContainer(context.Background(), &api.PodSandbox{Id: "sandbox-1"}, ctr); err != nil {

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"slices"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
@@ -33,27 +34,35 @@ var sandboxIDAnnotations = []string{
 // the guest boundary is the isolation, so no peer-credential check is needed.
 type admissionInventory struct {
 	mu         sync.RWMutex
-	containers map[string]string // container id -> image digest
-	sandboxID  string            // the guest's single pod sandbox
+	containers map[string]string                          // live container id -> image digest
+	admitted   map[string]workloadclaims.SandboxContainer // key -> everything ever admitted
+	sandboxID  string                                     // the guest's single pod sandbox
 }
 
 func newAdmissionInventory() *admissionInventory {
-	return &admissionInventory{containers: map[string]string{}}
+	return &admissionInventory{
+		containers: map[string]string{},
+		admitted:   map[string]workloadclaims.SandboxContainer{},
+	}
 }
 
-// record notes an admitted container's digest — injected sidecars included, so
-// the sandbox inventory is what actually runs in the guest.
-func (b *admissionInventory) record(cid, digest string) {
+// record notes an admitted container — injected sidecars included, so the
+// sandbox inventory is what actually ran in the guest. argv is the effective
+// OCI process.args the allowlist was evaluated against.
+func (b *admissionInventory) record(cid, digest string, argv []string) {
 	if digest == "" {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.containers[cid] = digest
+	b.admitted[digest+"\x1f"+strings.Join(argv, "\x1f")] = workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
 }
 
-// remove evicts a container whose bundle kata-agent has torn down, so a stopped
-// container's image cannot linger in a later /digests answer.
+// remove evicts a container whose bundle kata-agent has torn down. The
+// admission record is deliberately kept: a container is removed and recreated
+// across a CrashLoopBackOff, and forgetting it would let a pod present a
+// container set it does not have (docs/secrets.md).
 func (b *admissionInventory) remove(cid string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -87,20 +96,29 @@ func (b *admissionInventory) SandboxForPeer(_ workloadclaims.Peer) (string, erro
 }
 
 // DigestsForSandbox answers the sandbox inventory for the guest's single
-// sandbox: sorted, deduplicated digests of every recorded container, injected
-// sidecars included. Any other sandbox ID is unknown.
-func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, bool, error) {
+// sandbox: every container ever admitted there, injected sidecars included, as
+// a sorted deduplicated digest set plus per-container (digest, argv) detail.
+// Any other sandbox ID is unknown.
+func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.sandboxID == "" || sandboxID != b.sandboxID {
-		return nil, false, nil
+		return nil, nil, false, nil
 	}
 	digests := []string{}
-	for _, d := range b.containers {
-		digests = append(digests, d)
+	containers := make([]workloadclaims.SandboxContainer, 0, len(b.admitted))
+	for _, c := range b.admitted {
+		digests = append(digests, c.Digest)
+		containers = append(containers, c)
 	}
 	slices.Sort(digests)
-	return slices.Compact(digests), true, nil
+	slices.SortFunc(containers, func(x, y workloadclaims.SandboxContainer) int {
+		if x.Digest != y.Digest {
+			return strings.Compare(x.Digest, y.Digest)
+		}
+		return strings.Compare(strings.Join(x.Argv, "\x1f"), strings.Join(y.Argv, "\x1f"))
+	})
+	return slices.Compact(digests), containers, true, nil
 }
 
 // sandboxIDFromAnnotations extracts the pod sandbox ID from a container's OCI

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -21,10 +21,10 @@ const (
 func TestKataInventoryIncludesInjectedSidecars(t *testing.T) {
 	b := newAdmissionInventory()
 	b.recordSandboxID(pmSandboxID)
-	b.record("cid-app", pmDigestApp)
-	b.record("cid-cert", pmDigestSidecar)
+	b.record("cid-app", pmDigestApp, nil)
+	b.record("cid-cert", pmDigestSidecar, nil)
 
-	digests, known, err := b.DigestsForSandbox(pmSandboxID)
+	digests, _, known, err := b.DigestsForSandbox(pmSandboxID)
 	if err != nil || !known {
 		t.Fatalf("known=%v err=%v", known, err)
 	}
@@ -44,7 +44,7 @@ func TestKataInventorySandboxIdentity(t *testing.T) {
 	if _, err := b.SandboxForPeer(workloadclaims.PeerForPID(0)); err == nil {
 		t.Fatal("sandbox resolved before any container was observed")
 	}
-	if _, known, _ := b.DigestsForSandbox(pmSandboxID); known {
+	if _, _, known, _ := b.DigestsForSandbox(pmSandboxID); known {
 		t.Fatal("sandbox known before any container was observed")
 	}
 
@@ -54,10 +54,10 @@ func TestKataInventorySandboxIdentity(t *testing.T) {
 	if err != nil || got != pmSandboxID {
 		t.Fatalf("sandbox = %q, %v; want %q", got, err, pmSandboxID)
 	}
-	if _, known, _ := b.DigestsForSandbox("some-other-id"); known {
+	if _, _, known, _ := b.DigestsForSandbox("some-other-id"); known {
 		t.Fatal("foreign sandbox ID answered")
 	}
-	if digests, known, err := b.DigestsForSandbox(pmSandboxID); err != nil || !known || len(digests) != 0 {
+	if digests, _, known, err := b.DigestsForSandbox(pmSandboxID); err != nil || !known || len(digests) != 0 {
 		t.Fatalf("own sandbox: digests=%v known=%v err=%v, want empty inventory", digests, known, err)
 	}
 }
@@ -74,22 +74,25 @@ func TestSandboxIDFromAnnotations(t *testing.T) {
 	}
 }
 
-// The guest inventory must evict a container whose bundle kata-agent tore down,
-// or /digests reports everything the guest ever ran rather than what it runs.
-func TestKataInventoryEvictsRemovedContainer(t *testing.T) {
+// A container whose bundle kata-agent tore down stays in the guest's admission
+// record: /digests reports everything the guest ever ran, so a pod cannot hide
+// a container by arranging for it to be absent when asked (docs/secrets.md).
+func TestKataInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 	b := newAdmissionInventory()
 	b.recordSandboxID(pmSandboxID)
-	b.record("cid-app", pmDigestApp)
-	b.record("cid-gone", pmDigestSidecar)
+	b.record("cid-app", pmDigestApp, nil)
+	b.record("cid-gone", pmDigestSidecar, nil)
 
 	b.remove("cid-gone")
 
-	digests, known, err := b.DigestsForSandbox(pmSandboxID)
+	digests, _, known, err := b.DigestsForSandbox(pmSandboxID)
 	if err != nil || !known {
 		t.Fatalf("known=%v err=%v", known, err)
 	}
-	if !slices.Equal(digests, []string{pmDigestApp}) {
-		t.Fatalf("digests = %v, want only the surviving container", digests)
+	want := []string{pmDigestApp, pmDigestSidecar}
+	slices.Sort(want)
+	if !slices.Equal(digests, want) {
+		t.Fatalf("digests = %v, want the removed container still recorded (%v)", digests, want)
 	}
 }
 

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -474,7 +474,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 	if m.admits(digest, argv) {
 		m.logger.Info("allow container", "cid", cid, "digest", digest)
 		if m.inventory != nil {
-			m.inventory.record(cid, digest)
+			m.inventory.record(cid, digest, argv)
 		}
 		return
 	}

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -143,3 +143,19 @@
 {{- fail (printf "VALIDATION_ERROR kind=tlslb_allowlist_rate_budget: tlsLb.allowlist.rateLimit.totalBurst must be less than cds.rateBurst (%v), got: %d" .Values.cds.rateBurst $writeTotalBurst) -}}
 {{- end -}}
 {{- end -}}
+{{- /*
+  Per-container `paths` was replaced by an entry-level `secrets` grant. CDS
+  parses its seed with unknown fields rejected and fails closed on a parse
+  error, so a values file carried over from a release that used `paths` would
+  not misconfigure CDS — it would stop it booting, taking the mesh CA with it.
+  Catch it at upgrade time instead. See docs/secrets.md.
+*/ -}}
+{{- range $name, $entry := .Values.nriImagePolicy.bootstrapAllowlist.workloads -}}
+{{- range $field := (list "initContainers" "containers") -}}
+{{- range $ctr := (index $entry $field) -}}
+{{- if hasKey $ctr "paths" -}}
+{{- fail (printf "VALIDATION_ERROR kind=allowlist_container_paths: nriImagePolicy.bootstrapAllowlist.workloads.%s.%s has a container with a `paths` policy, which was replaced by an entry-level `secrets` grant. CDS rejects unknown fields in its seed and would fail to start. Move the grant up to the entry as `secrets: {policy: allow, read: [...], write: [...]}` (a deny grant is just omitted). See docs/secrets.md." $name $field) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -4,11 +4,12 @@
 // The allowlist has two layers. Digests is the floor: a digest -> image-label
 // map whose images are admitted by digest alone. The measured guest seed and
 // standalone/injected component images live here. Workloads carries policy:
-// each named entry pins an init/main container set, and every container carries
-// entrypoint/cmd (argv) and path policy. Policy is always looked up by container
-// digest — the entry name and image labels are informational, never a
-// trust-bearing key, because the image reference a pod presents is chosen by the
-// untrusted host while the digest is bound to the bytes that run.
+// each named entry pins an init/main container set, every container carries
+// entrypoint/cmd (argv) policy, and the entry as a whole carries a secret-store
+// grant. Policy is always looked up by container digest — the entry name and
+// image labels are informational, never a trust-bearing key, because the image
+// reference a pod presents is chosen by the untrusted host while the digest is
+// bound to the bytes that run.
 //
 // Canonical is Go's json.Marshal of the normalized struct: fixed field order,
 // map keys sorted by encoding/json, container and path lists sorted by
@@ -32,8 +33,8 @@ import (
 // canonical form.
 const Schema = "c8s.allowlist/v1"
 
-// Policy values. Argv policies use Deny/Any/Exact; path policies use
-// Deny/Any/Allow.
+// Policy values. Argv policies use Deny/Any/Exact; secrets grants use
+// Deny/Allow — never Any (normalizeSecrets).
 const (
 	PolicyDeny  = "deny"
 	PolicyAny   = "any"
@@ -49,19 +50,24 @@ type Allowlist struct {
 }
 
 // Workload is a named policy entry. Label is an informational image reference.
+// Secrets is nil when the entry grants nothing, which is also what a "deny"
+// grant normalizes to — so an entry without a grant serializes exactly as it
+// did before the field existed. That is what lets a CDS carrying this field be
+// deployed ahead of the enforcing consumers baked into node and guest images:
+// they only ever see "secrets" once an operator writes a real grant.
 type Workload struct {
-	Label          string      `json:"label,omitempty"`
-	InitContainers []Container `json:"initContainers"`
-	Containers     []Container `json:"containers"`
+	Label          string         `json:"label,omitempty"`
+	InitContainers []Container    `json:"initContainers"`
+	Containers     []Container    `json:"containers"`
+	Secrets        *SecretsPolicy `json:"secrets,omitempty"`
 }
 
-// Container binds a digest to the process and path policy permitted for it.
+// Container binds a digest to the process policy permitted for it.
 type Container struct {
 	Digest  types.Digest `json:"digest"`
 	Image   string       `json:"image,omitempty"`
 	Command ArgvPolicy   `json:"command"`
 	Args    ArgvPolicy   `json:"args"`
-	Paths   PathPolicy   `json:"paths"`
 }
 
 // ArgvPolicy governs part of a container's effective argv (the OCI process.args
@@ -74,22 +80,45 @@ type ArgvPolicy struct {
 	Argv   []string `json:"argv,omitempty"`
 }
 
-// PathPolicy grants filesystem read/write globs for key-management integration.
-// A write grant implies create and update. Carried and attested; no enforcer
-// consumes it yet. See docs/allowlist-and-capabilities.md.
-type PathPolicy struct {
+// SecretsPolicy grants secret-store read/write globs to a whole workload entry.
+// The subject is the entry, not a container: the value is delivered on a volume
+// every container in the pod can read, so a per-container grant would not
+// describe what is actually released. See docs/secrets.md.
+type SecretsPolicy struct {
 	Policy string   `json:"policy"`
 	Read   []string `json:"read,omitempty"`
 	Write  []string `json:"write,omitempty"`
 }
 
-// ParseJSON decodes and validates an allowlist, rejecting unknown fields so a
-// malformed or foreign document fails loud instead of parsing as empty. The
-// result is normalized (digests lowercased and deduplicated, container and path
-// lists sorted) so Canonical is a function of content alone.
+// ParseJSON decodes and validates an operator-authored allowlist, rejecting
+// unknown fields so a typo or a foreign document fails loud instead of parsing
+// as empty. The result is normalized (digests lowercased and deduplicated,
+// container and path lists sorted) so Canonical is a function of content alone.
+//
+// Use ParseServedJSON for a document pulled from CDS.
 func ParseJSON(data []byte) (*Allowlist, error) {
+	return parseJSON(data, true)
+}
+
+// ParseServedJSON decodes a document served by CDS, ignoring fields it does not
+// know.
+//
+// The enforcing consumers (nri-image-policy, policy-monitor) are baked into node
+// and guest images, so their launch measurement pins which schema version they
+// understand. Rejecting unknown fields there would mean a CDS serving any newer
+// field silently freezes every un-upgraded node's policy — refreshOnce keeps the
+// previous allowlist on a parse error — and unfreezing it would cost a node
+// image rebuild and a measurement change. Consumers enforce the fields they
+// know; ignoring the rest is what lets the document grow without a flag day.
+func ParseServedJSON(data []byte) (*Allowlist, error) {
+	return parseJSON(data, false)
+}
+
+func parseJSON(data []byte, strict bool) (*Allowlist, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.DisallowUnknownFields()
+	if strict {
+		dec.DisallowUnknownFields()
+	}
 	var a Allowlist
 	if err := dec.Decode(&a); err != nil {
 		return nil, fmt.Errorf("decode allowlist: %w", err)
@@ -115,6 +144,9 @@ func ParseWorkloadJSON(data []byte) (*Workload, error) {
 	}
 	if err := normalizeContainers("entry", "containers", w.Containers); err != nil {
 		return nil, err
+	}
+	if err := normalizeSecrets(&w.Secrets); err != nil {
+		return nil, fmt.Errorf("entry secrets: %w", err)
 	}
 	sortContainers(w.InitContainers)
 	sortContainers(w.Containers)
@@ -168,6 +200,9 @@ func (a *Allowlist) normalize() error {
 		if err := normalizeContainers(name, "containers", w.Containers); err != nil {
 			return err
 		}
+		if err := normalizeSecrets(&w.Secrets); err != nil {
+			return fmt.Errorf("workload %q secrets: %w", name, err)
+		}
 		sortContainers(w.InitContainers)
 		sortContainers(w.Containers)
 		a.Workloads[name] = w
@@ -186,9 +221,6 @@ func normalizeContainers(workload, field string, cs []Container) error {
 		}
 		if err := normalizeArgv(&c.Args); err != nil {
 			return fmt.Errorf("workload %q %s %s args: %w", workload, field, c.Digest, err)
-		}
-		if err := normalizePaths(&c.Paths); err != nil {
-			return fmt.Errorf("workload %q %s %s paths: %w", workload, field, c.Digest, err)
 		}
 	}
 	return nil
@@ -216,16 +248,23 @@ func normalizeArgv(p *ArgvPolicy) error {
 	return nil
 }
 
-func normalizePaths(p *PathPolicy) error {
+// normalizeSecrets validates an entry's secrets grant, canonicalizing "grants
+// nothing" to a nil grant so it does not appear on the wire at all.
+//
+// Unlike argv policy there is no "any": an unbounded secret grant is never what
+// an operator means, and the same three characters that are inert today would
+// otherwise become "every secret in the cluster".
+func normalizeSecrets(pp **SecretsPolicy) error {
+	p := *pp
+	if p == nil {
+		return nil
+	}
 	switch p.Policy {
 	case PolicyDeny, "":
 		if len(p.Read) != 0 || len(p.Write) != 0 {
 			return fmt.Errorf("deny policy grants no paths")
 		}
-		p.Policy = PolicyDeny
-		p.Read, p.Write = nil, nil
-	case PolicyAny:
-		p.Read, p.Write = nil, nil
+		*pp = nil
 	case PolicyAllow:
 		read, err := normalizeGlobs(p.Read)
 		if err != nil {
@@ -235,12 +274,15 @@ func normalizePaths(p *PathPolicy) error {
 		if err != nil {
 			return fmt.Errorf("write: %w", err)
 		}
-		if len(read) == 0 && len(write) == 0 {
-			return fmt.Errorf("allow policy requires at least one read or write path")
+		if len(read) == 0 {
+			// The only client creates with POST and then re-reads: a write-only
+			// grant leaves every replica that loses the create race permanently
+			// without the value.
+			return fmt.Errorf("allow policy requires at least one read path")
 		}
 		p.Read, p.Write = read, write
 	default:
-		return fmt.Errorf("unknown paths policy %q (want deny, any, or allow)", p.Policy)
+		return fmt.Errorf("unknown secrets policy %q (want deny or allow)", p.Policy)
 	}
 	return nil
 }
@@ -292,7 +334,7 @@ func sortContainers(cs []Container) {
 }
 
 func policyKey(c Container) string {
-	b, _ := json.Marshal([]any{c.Command, c.Args, c.Paths})
+	b, _ := json.Marshal([]any{c.Command, c.Args})
 	return string(b)
 }
 

--- a/pkg/allowlist/allowlist_test.go
+++ b/pkg/allowlist/allowlist_test.go
@@ -39,7 +39,7 @@ func TestParseJSON_RejectsBadFloorDigest(t *testing.T) {
 func TestParseJSON_AbsentPolicyDefaultsToDeny(t *testing.T) {
 	al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[{"digest":"`+digestA+`"}]}}}`)
 	c := al.Workloads["w"].Containers[0]
-	if c.Command.Policy != PolicyDeny || c.Args.Policy != PolicyDeny || c.Paths.Policy != PolicyDeny {
+	if c.Command.Policy != PolicyDeny || c.Args.Policy != PolicyDeny {
 		t.Fatalf("absent policies should default to deny, got %#v", c)
 	}
 }
@@ -67,10 +67,12 @@ func TestParseJSON_PathValidation(t *testing.T) {
 		{"dotdot", `"read":["/a/../b"]`, false},
 		{"midglob", `"read":["/a/*/b"]`, false},
 		{"subtree", `"read":["/a/**"]`, true},
-		{"literal", `"write":["/secret"]`, true},
+		{"literal", `"read":["/secret"]`, true},
+		{"write with read", `"read":["/r"],"write":["/secret"]`, true},
+		{"write without read", `"write":["/secret"]`, false},
 	} {
 		body := `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[{"digest":"` +
-			digestA + `","paths":{"policy":"allow",` + tc.body + `}}]}}}`
+			digestA + `"}],"secrets":{"policy":"allow",` + tc.body + `}}}}`
 		_, err := ParseJSON([]byte(body))
 		if tc.ok && err != nil {
 			t.Errorf("%s: unexpected error %v", tc.name, err)
@@ -109,7 +111,7 @@ func TestRoundTripCanonical(t *testing.T) {
 	al := mustParse(t, `{"schema":"c8s.allowlist/v1","digests":{"`+digestA+`":"cds"},
 		"workloads":{"w":{"label":"img","containers":[
 		{"digest":"`+digestB+`","command":{"policy":"exact","argv":["/app"]},
-		 "args":{"policy":"any"},"paths":{"policy":"allow","read":["/s/**"]}}]}}}`)
+		 "args":{"policy":"any"}}],"secrets":{"policy":"allow","read":["/s/**"]}}}}`)
 	canon, err := al.Canonical()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/allowlist/secrets.go
+++ b/pkg/allowlist/secrets.go
@@ -1,0 +1,90 @@
+// Secret-store path grants: canonicalization and matching.
+//
+// Grant globs and requested paths go through the same canonical form, in this
+// package, deliberately. They are compared for equality and prefix containment,
+// so any divergence between how a grant is stored and how a request is read is
+// a policy bypass rather than a mismatch — see docs/secrets.md.
+
+package allowlist
+
+import (
+	"fmt"
+	"path"
+	"strings"
+)
+
+// Op is the access a request needs.
+type Op int
+
+const (
+	OpRead Op = iota
+	OpWrite
+)
+
+// subtreeSuffix marks a grant that covers a path and everything beneath it.
+const subtreeSuffix = "/**"
+
+// CanonicalSecretPath validates and canonicalizes a requested store path.
+//
+// It rejects rather than repairs: a path that is not already canonical is an
+// error, never something silently rewritten into one. Percent-encoding is
+// refused outright so "%2F" cannot alias with "/" — the request path and the
+// store key must be the same bytes by construction.
+func CanonicalSecretPath(p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("secret path is empty")
+	}
+	if strings.Contains(p, "%") {
+		return "", fmt.Errorf("secret path %q must not be percent-encoded", p)
+	}
+	if !strings.HasPrefix(p, "/") {
+		return "", fmt.Errorf("secret path %q must be absolute", p)
+	}
+	if strings.Contains(p, "*") {
+		return "", fmt.Errorf("secret path %q must not contain wildcards", p)
+	}
+	if p != "/" && strings.HasSuffix(p, "/") {
+		return "", fmt.Errorf("secret path %q must not have a trailing slash", p)
+	}
+	if path.Clean(p) != p {
+		return "", fmt.Errorf("secret path %q is not clean (no . or ..)", p)
+	}
+	return p, nil
+}
+
+// Allows reports whether the grant permits op on a canonical path. Call
+// CanonicalSecretPath first; an uncanonicalized path is not matched.
+//
+// A nil grant — an entry that says nothing — allows nothing.
+func (p *SecretsPolicy) Allows(canonicalPath string, op Op) bool {
+	if p == nil || p.Policy != PolicyAllow {
+		return false
+	}
+	globs := p.Read
+	if op == OpWrite {
+		globs = p.Write
+	}
+	for _, g := range globs {
+		if matchGlob(g, canonicalPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchGlob matches one normalized grant glob against a canonical path. A bare
+// path matches only itself; a "/**" suffix matches the subtree strictly beneath
+// its base, not the base itself, so granting "/a/**" does not hand over "/a".
+func matchGlob(glob, p string) bool {
+	base, subtree := strings.CutSuffix(glob, subtreeSuffix)
+	if !subtree {
+		return glob == p
+	}
+	if base == "" {
+		base = "/"
+	}
+	if base == "/" {
+		return strings.HasPrefix(p, "/") && p != "/"
+	}
+	return strings.HasPrefix(p, base+"/")
+}

--- a/pkg/allowlist/secrets_test.go
+++ b/pkg/allowlist/secrets_test.go
@@ -1,0 +1,142 @@
+package allowlist
+
+import "testing"
+
+// A requested path is rejected unless it is already canonical: the request path
+// and the store key must be the same bytes, so nothing here may repair input.
+func TestCanonicalSecretPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   string
+		ok   bool
+	}{
+		{"simple", "/db/password", true},
+		{"single segment", "/token", true},
+		{"root", "/", true},
+		{"empty", "", false},
+		{"relative", "db/password", false},
+		{"trailing slash", "/db/", false},
+		{"double slash", "//db", false},
+		{"dotdot", "/db/../etc", false},
+		{"dot", "/db/./x", false},
+		{"percent encoded slash", "/db%2Fpassword", false},
+		{"percent encoded dot", "/db/%2e%2e/x", false},
+		{"wildcard", "/db/*", false},
+		{"subtree glob", "/db/**", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := CanonicalSecretPath(tc.in)
+			if tc.ok {
+				if err != nil {
+					t.Fatalf("CanonicalSecretPath(%q) = %v, want ok", tc.in, err)
+				}
+				if got != tc.in {
+					t.Fatalf("CanonicalSecretPath(%q) = %q, want it unchanged", tc.in, got)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("CanonicalSecretPath(%q) = %q, want an error", tc.in, got)
+			}
+		})
+	}
+}
+
+func TestSecretsPolicyAllows(t *testing.T) {
+	grant := &SecretsPolicy{
+		Policy: PolicyAllow,
+		Read:   []string{"/tenant/a/**", "/shared/token"},
+		Write:  []string{"/tenant/a/**"},
+	}
+	for _, tc := range []struct {
+		name  string
+		path  string
+		op    Op
+		allow bool
+	}{
+		{"exact read", "/shared/token", OpRead, true},
+		{"subtree read", "/tenant/a/db", OpRead, true},
+		{"nested subtree read", "/tenant/a/deep/nested/key", OpRead, true},
+		{"subtree base itself", "/tenant/a", OpRead, false},
+		{"sibling prefix", "/tenant/ab", OpRead, false},
+		{"other tenant", "/tenant/b/db", OpRead, false},
+		{"exact grant is not a subtree", "/shared/token/more", OpRead, false},
+		{"write inside subtree", "/tenant/a/db", OpWrite, true},
+		{"read-only path is not writable", "/shared/token", OpWrite, false},
+		{"unrelated", "/other", OpRead, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := grant.Allows(tc.path, tc.op); got != tc.allow {
+				t.Fatalf("Allows(%q, %v) = %v, want %v", tc.path, tc.op, got, tc.allow)
+			}
+		})
+	}
+}
+
+// A deny grant (the default for an entry that says nothing) allows nothing,
+// including paths that appear in its own lists.
+func TestSecretsPolicyDenyAllowsNothing(t *testing.T) {
+	deny := &SecretsPolicy{Policy: PolicyDeny, Read: []string{"/a"}}
+	if deny.Allows("/a", OpRead) {
+		t.Fatal("deny policy released a path")
+	}
+	if (&SecretsPolicy{}).Allows("/a", OpRead) {
+		t.Fatal("zero policy released a path")
+	}
+	var absent *SecretsPolicy
+	if absent.Allows("/a", OpRead) {
+		t.Fatal("absent policy released a path")
+	}
+}
+
+// The root subtree covers everything below it but not "/" itself, so a grant
+// cannot be widened by asking for the root.
+func TestSecretsPolicyRootSubtree(t *testing.T) {
+	root := &SecretsPolicy{Policy: PolicyAllow, Read: []string{"/**"}}
+	if !root.Allows("/anything/at/all", OpRead) {
+		t.Fatal("root subtree did not cover a nested path")
+	}
+	if root.Allows("/", OpRead) {
+		t.Fatal("root subtree covered / itself")
+	}
+}
+
+// normalizeSecrets is the write-time gate: "any" is not a secrets policy, and a
+// write grant with no read is unusable by the only client there is.
+func TestNormalizeSecretsRejects(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   SecretsPolicy
+	}{
+		{"any", SecretsPolicy{Policy: PolicyAny}},
+		{"unknown", SecretsPolicy{Policy: "sometimes"}},
+		{"write without read", SecretsPolicy{Policy: PolicyAllow, Write: []string{"/w"}}},
+		{"allow with nothing", SecretsPolicy{Policy: PolicyAllow}},
+		{"deny with paths", SecretsPolicy{Policy: PolicyDeny, Read: []string{"/a"}}},
+		{"relative glob", SecretsPolicy{Policy: PolicyAllow, Read: []string{"a/b"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := &tc.in
+			if err := normalizeSecrets(&p); err == nil {
+				t.Fatalf("normalizeSecrets(%+v) = nil, want an error", tc.in)
+			}
+		})
+	}
+}
+
+// An explicit deny, and an absent grant, both canonicalize to no grant at all,
+// so an entry that releases nothing serializes exactly as it did before the
+// field existed.
+func TestNormalizeSecretsDropsEmptyGrant(t *testing.T) {
+	p := &SecretsPolicy{Policy: PolicyDeny}
+	if err := normalizeSecrets(&p); err != nil {
+		t.Fatalf("normalizeSecrets: %v", err)
+	}
+	if p != nil {
+		t.Fatalf("deny grant = %+v, want it dropped to nil", p)
+	}
+	var absent *SecretsPolicy
+	if err := normalizeSecrets(&absent); err != nil || absent != nil {
+		t.Fatalf("absent grant: %v %+v", err, absent)
+	}
+}

--- a/pkg/allowlistclient/client.go
+++ b/pkg/allowlistclient/client.go
@@ -95,7 +95,7 @@ func (c Client) fetch(ctx context.Context, ifNoneMatch string) (*allowlist.Allow
 	if err != nil {
 		return nil, "", false, err
 	}
-	al, err := allowlist.ParseJSON(body)
+	al, err := allowlist.ParseServedJSON(body)
 	if err != nil {
 		return nil, "", false, err
 	}

--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -333,24 +333,59 @@ func (c *DigestsClient) get(ctx context.Context, host, route string) (*http.Resp
 // host comes from the verified sandbox token, so it names the inventory that
 // vouched for the sandbox.
 func (c *DigestsClient) Fetch(ctx context.Context, host, sandboxID string) ([]string, error) {
-	if err := ratls.ValidateSandboxID(sandboxID); err != nil {
-		return nil, err
-	}
-	resp, err := c.get(ctx, host, SandboxDigestsPrefix+sandboxID)
+	out, err := c.FetchSandbox(ctx, host, sandboxID)
 	if err != nil {
 		return nil, err
 	}
+	return out.Digests, nil
+}
+
+// ErrSandboxContainersUnsupported reports an inventory that answers with digests
+// but no per-container detail — one older than the field. Distinguished so a
+// caller that needs (digest, argv) fails closed on it instead of silently
+// matching on digests alone.
+var ErrSandboxContainersUnsupported = fmt.Errorf("workloadclaims: inventory does not report per-container detail")
+
+// FetchSandbox is Fetch with the per-container (digest, argv) detail secret
+// release needs. It fails closed when the inventory reports containers it could
+// not fully resolve, and when it reports none at all for a sandbox that has
+// digests.
+func (c *DigestsClient) FetchSandbox(ctx context.Context, host, sandboxID string) (SandboxDigestsResponse, error) {
+	var out SandboxDigestsResponse
+	if err := ratls.ValidateSandboxID(sandboxID); err != nil {
+		return out, err
+	}
+	resp, err := c.get(ctx, host, SandboxDigestsPrefix+sandboxID)
+	if err != nil {
+		return out, err
+	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, ErrSandboxUnknown
+		return out, ErrSandboxUnknown
 	}
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
-		return nil, fmt.Errorf("workloadclaims: inventory %s returned %d: %s", host, resp.StatusCode, strings.TrimSpace(string(body)))
+		return out, fmt.Errorf("workloadclaims: inventory %s returned %d: %s", host, resp.StatusCode, strings.TrimSpace(string(body)))
 	}
-	var out SandboxDigestsResponse
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&out); err != nil {
-		return nil, fmt.Errorf("workloadclaims: decode inventory response: %w", err)
+		return out, fmt.Errorf("workloadclaims: decode inventory response: %w", err)
 	}
-	return out.Digests, nil
+	return out, nil
+}
+
+// RequireContainers returns the per-container detail, refusing an answer that
+// cannot support a (digest, argv) decision.
+func (r SandboxDigestsResponse) RequireContainers() ([]SandboxContainer, error) {
+	if len(r.Containers) == 0 {
+		if len(r.Digests) == 0 {
+			return nil, fmt.Errorf("workloadclaims: inventory reports no containers")
+		}
+		return nil, ErrSandboxContainersUnsupported
+	}
+	for _, c := range r.Containers {
+		if c.Digest == "" {
+			return nil, fmt.Errorf("workloadclaims: inventory reported a container with no digest")
+		}
+	}
+	return r.Containers, nil
 }

--- a/pkg/workloadclaims/digests_integration_test.go
+++ b/pkg/workloadclaims/digests_integration_test.go
@@ -366,8 +366,8 @@ func TestDigestsClientTransportAndProtocolFailures(t *testing.T) {
 type erroringResolver struct{}
 
 func (erroringResolver) SandboxForPeer(Peer) (string, error) { return "", errTestAttest }
-func (erroringResolver) DigestsForSandbox(string) ([]string, bool, error) {
-	return nil, false, errTestAttest
+func (erroringResolver) DigestsForSandbox(string) ([]string, []SandboxContainer, bool, error) {
+	return nil, nil, false, errTestAttest
 }
 
 // clientAgainst points a DigestsClient at an arbitrary TLS handler, so the

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -144,11 +144,36 @@ type SandboxTokenRequest struct {
 	Nonce []byte `json:"nonce"`
 }
 
-// SandboxDigestsResponse is the SandboxDigestsPrefix answer: the image digests
-// of every tracked container in the named sandbox. Digests is [] (never null)
-// for a known sandbox with no containers.
+// SandboxDigestsResponse is the SandboxDigestsPrefix answer.
+//
+// Digests is the deduplicated image-digest set, and is what cert issuance gates
+// on (membership). Containers is the per-container detail secret release needs:
+// it is NOT deduplicated, and it carries each container's effective argv, so a
+// consumer can hold a sandbox to a whole workload entry — the same (digest,
+// argv) pair admission evaluated — rather than to a digest set that says nothing
+// about what those images were told to run.
+//
+// Both describe every container ever admitted in the sandbox, not only those
+// running now: a container is removed and recreated across a CrashLoopBackOff,
+// so a live snapshot would let a pod present a set it does not really have by
+// arranging for a container to be absent at the moment it is asked (see
+// docs/secrets.md).
+//
+// Digests is [] (never null) for a known sandbox with no containers. Containers
+// is absent on an inventory that predates it, which consumers must treat as
+// "cannot answer" rather than "no containers".
 type SandboxDigestsResponse struct {
-	Digests []string `json:"digests"`
+	Digests    []string           `json:"digests"`
+	Containers []SandboxContainer `json:"containers,omitempty"`
+}
+
+// SandboxContainer is one admitted container: the bytes, and what they were
+// told to run.
+type SandboxContainer struct {
+	Digest string `json:"digest"`
+	// Argv is the effective OCI process.args — the merged image-config and
+	// pod-spec command, which is what the argv policy is written against.
+	Argv []string `json:"argv,omitempty"`
 }
 
 // SandboxResolver is the surface an inventory implements — nri-image-policy on
@@ -166,10 +191,12 @@ type SandboxResolver interface {
 	// SandboxForPeer returns the pod sandbox ID of the calling process,
 	// bound by kernel peer credentials exactly like ContainersForPeer.
 	SandboxForPeer(peer Peer) (string, error)
-	// DigestsForSandbox returns the deduplicated image digests of the named
-	// sandbox's tracked containers. known=false means no such sandbox (a 404
-	// on the wire); a known sandbox with no containers returns an empty slice.
-	DigestsForSandbox(sandboxID string) (digests []string, known bool, err error)
+	// DigestsForSandbox returns every container ever admitted in the named
+	// sandbox — deduplicated digests for issuance, and the per-container
+	// (digest, argv) detail for secret release. known=false means no such
+	// sandbox (a 404 on the wire); a known sandbox with no containers returns
+	// empty slices.
+	DigestsForSandbox(sandboxID string) (digests []string, containers []SandboxContainer, known bool, err error)
 }
 
 // connKey carries the accepted net.Conn through the request context so the
@@ -249,7 +276,7 @@ func ServeDigests(ctx context.Context, l net.Listener, resolver SandboxResolver,
 		_ = json.NewEncoder(w).Encode(InventoryIdentity{PublicKey: identity})
 	})
 	mux.HandleFunc("GET "+SandboxDigestsPrefix+"{sandboxID}", func(w http.ResponseWriter, r *http.Request) {
-		digests, known, err := resolver.DigestsForSandbox(r.PathValue("sandboxID"))
+		digests, containers, known, err := resolver.DigestsForSandbox(r.PathValue("sandboxID"))
 		if err != nil {
 			http.Error(w, fmt.Sprintf("resolve sandbox digests: %v", err), http.StatusInternalServerError)
 			return
@@ -262,7 +289,7 @@ func ServeDigests(ctx context.Context, l net.Listener, resolver SandboxResolver,
 			digests = []string{}
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(SandboxDigestsResponse{Digests: digests})
+		_ = json.NewEncoder(w).Encode(SandboxDigestsResponse{Digests: digests, Containers: containers})
 	})
 	return serveUntil(ctx, l, mux)
 }

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -43,9 +43,13 @@ func (r *fakeResolver) SandboxForPeer(peer Peer) (string, error) {
 	return r.sandboxID, r.sandboxErr
 }
 
-func (r *fakeResolver) DigestsForSandbox(sandboxID string) ([]string, bool, error) {
+func (r *fakeResolver) DigestsForSandbox(sandboxID string) ([]string, []SandboxContainer, bool, error) {
 	d, ok := r.digests[sandboxID]
-	return d, ok, nil
+	cs := make([]SandboxContainer, 0, len(d))
+	for _, dg := range d {
+		cs = append(cs, SandboxContainer{Digest: dg})
+	}
+	return d, cs, ok, nil
 }
 
 // serveTokens runs the token socket and returns its path.


### PR DESCRIPTION


Prepares the allowlist and the admission inventory for secret release. No enforcer consumes any of this yet: the CDS secret store and its release endpoint are not implemented, so a grant releases nothing today.

Workload.Secrets replaces the per-container Container.Paths field, which named filesystem locations and never had an enforcer. Filesystem location is not an authorization boundary — a workload owns its own filesystem once a value is inside it — so only the store path is policy. The subject is the entry rather than a container because a released value lands on a volume every container in the pod can read; a per-container grant would not describe what is actually released, and a grant written on an initContainers member would apply pod-wide without that init ever running.

The grant is a pointer, and a deny grant normalizes to nil, so an entry that releases nothing serializes byte-identically to before the field existed. That is what lets a CDS carrying this field deploy ahead of the enforcing consumers baked into node and guest images: they only ever see "secrets" once an operator writes a real grant. The pull path (ParseServedJSON) also ignores unknown fields now — nri-image-policy and policy-monitor pin their schema version in a launch measurement, so a strict parse there means any newer field silently freezes a node's policy, with a node-image rebuild to unfreeze. Strict parsing is kept for operator-authored input, where an unknown field is a typo.

policy: "any" is rejected: an unbounded secret grant is never what an operator means, and the three characters that are inert under filesystem semantics would become "every secret in the cluster". A write grant requires read, because the only client creates with POST and then re-reads.

The admission inventory now records each container's effective argv alongside its digest and reports both. Release must re-check argv rather than inherit it from admission: Index.AdmitsContainer is a union across every entry listing a digest, so an entry pinning command: exact guarantees nothing at release time if another entry widens the same digest, and two entries differing only in argv are otherwise indistinguishable. SandboxDigestsResponse gains "containers" additively, leaving "digests" untouched so cert issuance and older inventories are unaffected; a consumer needing argv fails closed on an inventory without it rather than silently matching on digests alone.

That report is now a high-water mark — every container ever admitted in the sandbox, not those running now. The inventory was "created and not yet removed", and kubelet removes and recreates a container across a CrashLoopBackOff, so a live snapshot lets a pod arrange for a container to be absent when asked and present a set it does not have: declare a victim entry's containers plus one extra image that exits immediately, take the secret during a backoff window, and read it when the extra container restarts. A stopped container still leaves caller resolution — it must not bind a caller — but stays in the sandbox record until the sandbox is torn down.

The chart rejects a bootstrapAllowlist still carrying per-container paths at helm upgrade (VALIDATION_ERROR kind=allowlist_container_paths). CDS parses its seed strictly and fails closed, so without this the upgrade would not misconfigure CDS — it would stop it booting, taking the mesh CA with it.

See docs/secrets.md.