### PR TITLE
feat(secrets): sandbox-bound release policy and the in-CDS secret store

### DIFF
--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -32,14 +32,8 @@ type ctrRec struct {
 }
 
 // sbxRec is a sandbox's admission high-water mark: every distinct (digest,
-// argv) admitted in it, keyed for dedup. It is never pruned while the sandbox
-// lives.
-//
-// containers alone cannot answer /digests. A container is removed and recreated
-// across a CrashLoopBackOff, so a live view lets a pod arrange for a container
-// to be absent at the moment it is asked and present a set it does not have —
-// the release check would then see only the containers of an entry it is not
-// (docs/secrets.md). Admission is monotone; membership here is too.
+// argv) admitted in it, keyed for dedup, never pruned while the sandbox lives.
+// See docs/secrets.md — "The report is a high-water mark".
 type sbxRec struct {
 	byKey      map[string]workloadclaims.SandboxContainer
 	unresolved bool // some admitted container never resolved a digest
@@ -89,9 +83,9 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 	b.sandboxes[sandboxID] = struct{}{}
 }
 
-// remove evicts a stopped container from caller resolution. It deliberately
-// does NOT touch the sandbox's admission record: what ran there is what ran
-// there, and forgetting it is the TOCTOU sbxRec exists to close.
+// remove evicts a stopped container from caller resolution only. The sandbox's
+// admission record keeps it: a stopped container must not bind a caller, but it
+// still ran here (sbxRec).
 func (b *admissionInventory) remove(containerID string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -60,9 +60,8 @@ func (b *admissionInventory) record(cid, digest string, argv []string) {
 }
 
 // remove evicts a container whose bundle kata-agent has torn down. The
-// admission record is deliberately kept: a container is removed and recreated
-// across a CrashLoopBackOff, and forgetting it would let a pod present a
-// container set it does not have (docs/secrets.md).
+// admission record keeps it — it still ran in this guest. See docs/secrets.md,
+// "The report is a high-water mark".
 func (b *admissionInventory) remove(cid string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/sandboxledger/ledger.go
+++ b/internal/sandboxledger/ledger.go
@@ -1,0 +1,135 @@
+// Package sandboxledger records which node's admission inventory vouched for a
+// pod sandbox, so a later decision about that sandbox asks the same inventory
+// rather than one the requester names.
+//
+// A sandbox token carries the host that signed it, and CDS reads that host to
+// find the key that verifies the signature. That is sound for issuance — a wrong
+// host simply yields a key the signature fails under — but it makes the
+// requester the one choosing which inventory is asked. Anything able to answer
+// on the inventory port inside the operator's node CIDRs could otherwise sign a
+// token for someone else's sandbox ID, be believed about what that sandbox runs,
+// and have the answer used to release that sandbox's secrets.
+//
+// The binding is therefore taken once, at issuance, and is first-write-wins:
+// the first inventory to be believed about a sandbox is the only one believed
+// about it. See docs/secrets.md.
+package sandboxledger
+
+import (
+	"sync"
+	"time"
+)
+
+// binding is what the ledger holds for one sandbox: the node address whose
+// inventory vouched for it, and when that stops being believed.
+type binding struct {
+	host    string
+	expires time.Time
+}
+
+// Ledger maps a sandbox ID to the inventory that vouched for it.
+//
+// Entries expire so a ledger cannot outlive the certificates it describes, and
+// the total is capped so sandbox churn — or an inventory minting tokens for
+// fabricated IDs — cannot grow it without bound. CDS is a single in-memory
+// process whose OOM costs the cluster its mesh CA, so an unbounded map here
+// would be a denial primitive.
+type Ledger struct {
+	mu       sync.Mutex
+	bindings map[string]binding
+	ttl      time.Duration
+	max      int
+	now      func() time.Time
+}
+
+// New builds a ledger. ttl should be the maximum leaf lifetime: a binding is
+// only useful while a certificate carrying that sandbox ID could still be
+// presented.
+func New(ttl time.Duration, max int) *Ledger {
+	return &Ledger{
+		bindings: make(map[string]binding),
+		ttl:      ttl,
+		max:      max,
+		now:      time.Now,
+	}
+}
+
+// Record binds sandboxID to inventoryHost, reporting whether the binding holds.
+//
+// It returns false only when a *different*, unexpired host already owns the
+// sandbox. The same host re-recording is a refresh, not a conflict: a workload
+// renews its certificate on an interval and re-presents the same pair, so
+// once-only would refuse a pod its own renewal.
+//
+// A caller must not deny issuance on false. get-cert has no token-less retry, so
+// refusing there would let one pre-claim wedge a pod for a full certificate
+// lifetime — a worse outcome than the theft it prevents. False means the sandbox
+// is unsafe to answer questions about, not that the requester is unauthorized.
+func (l *Ledger) Record(sandboxID, inventoryHost string) bool {
+	if sandboxID == "" || inventoryHost == "" {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := l.now()
+	if b, ok := l.bindings[sandboxID]; ok && now.Before(b.expires) {
+		if b.host != inventoryHost {
+			return false
+		}
+	}
+	if _, ok := l.bindings[sandboxID]; !ok && len(l.bindings) >= l.max {
+		l.evictExpiredLocked(now)
+		if len(l.bindings) >= l.max {
+			return false
+		}
+	}
+	l.bindings[sandboxID] = binding{host: inventoryHost, expires: now.Add(l.ttl)}
+	return true
+}
+
+// Lookup returns the inventory host bound to sandboxID. An expired or absent
+// binding reports false, which callers must treat as fail-closed: without it
+// there is no inventory this process is willing to believe about the sandbox.
+func (l *Ledger) Lookup(sandboxID string) (string, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b, ok := l.bindings[sandboxID]
+	if !ok || !l.now().Before(b.expires) {
+		return "", false
+	}
+	return b.host, true
+}
+
+// Len reports the number of live bindings, for metrics and tests.
+func (l *Ledger) Len() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.evictExpiredLocked(l.now())
+	return len(l.bindings)
+}
+
+func (l *Ledger) evictExpiredLocked(now time.Time) {
+	for id, b := range l.bindings {
+		if !now.Before(b.expires) {
+			delete(l.bindings, id)
+		}
+	}
+}
+
+// EvictionLoop drops expired bindings on each tick until done is closed.
+func (l *Ledger) EvictionLoop(done <-chan struct{}, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			l.mu.Lock()
+			l.evictExpiredLocked(l.now())
+			l.mu.Unlock()
+		}
+	}
+}

--- a/internal/sandboxledger/ledger_test.go
+++ b/internal/sandboxledger/ledger_test.go
@@ -1,0 +1,122 @@
+package sandboxledger
+
+import (
+	"testing"
+	"time"
+)
+
+func testLedger(t *testing.T, ttl time.Duration, max int) (*Ledger, *time.Time) {
+	t.Helper()
+	clock := time.Unix(1_700_000_000, 0)
+	l := New(ttl, max)
+	l.now = func() time.Time { return clock }
+	return l, &clock
+}
+
+func TestRecordFirstWriteWins(t *testing.T) {
+	l, _ := testLedger(t, time.Hour, 10)
+
+	if !l.Record("sandbox-1", "10.0.0.1") {
+		t.Fatal("first binding refused")
+	}
+	if l.Record("sandbox-1", "10.0.0.2") {
+		t.Fatal("a second inventory claimed a bound sandbox")
+	}
+	host, ok := l.Lookup("sandbox-1")
+	if !ok || host != "10.0.0.1" {
+		t.Fatalf("lookup = %q %v, want the original host", host, ok)
+	}
+}
+
+// A workload renews on an interval and re-presents the same pair, so the same
+// host re-recording must refresh rather than conflict.
+func TestRecordSameHostRefreshes(t *testing.T) {
+	l, clock := testLedger(t, time.Hour, 10)
+	l.Record("sandbox-1", "10.0.0.1")
+
+	*clock = clock.Add(50 * time.Minute)
+	if !l.Record("sandbox-1", "10.0.0.1") {
+		t.Fatal("the bound host was refused its own refresh")
+	}
+
+	// The refresh extended the binding past the original expiry.
+	*clock = clock.Add(30 * time.Minute)
+	if _, ok := l.Lookup("sandbox-1"); !ok {
+		t.Fatal("binding expired despite being refreshed")
+	}
+}
+
+func TestExpiredBindingIsReclaimable(t *testing.T) {
+	l, clock := testLedger(t, time.Hour, 10)
+	l.Record("sandbox-1", "10.0.0.1")
+
+	*clock = clock.Add(time.Hour + time.Second)
+	if _, ok := l.Lookup("sandbox-1"); ok {
+		t.Fatal("expired binding still resolved")
+	}
+	if !l.Record("sandbox-1", "10.0.0.2") {
+		t.Fatal("an expired binding blocked a new host")
+	}
+}
+
+func TestLookupUnknown(t *testing.T) {
+	l, _ := testLedger(t, time.Hour, 10)
+	if _, ok := l.Lookup("nope"); ok {
+		t.Fatal("unknown sandbox resolved")
+	}
+}
+
+func TestRecordRejectsEmpty(t *testing.T) {
+	l, _ := testLedger(t, time.Hour, 10)
+	if l.Record("", "10.0.0.1") || l.Record("sandbox-1", "") {
+		t.Fatal("an empty sandbox or host was bound")
+	}
+}
+
+// The cap bounds a rogue inventory minting tokens for fabricated sandbox IDs.
+// Expired entries are reclaimed first, so ordinary churn does not hit it.
+func TestCapBoundsGrowth(t *testing.T) {
+	l, clock := testLedger(t, time.Hour, 2)
+	if !l.Record("a", "10.0.0.1") || !l.Record("b", "10.0.0.1") {
+		t.Fatal("bindings within the cap were refused")
+	}
+	if l.Record("c", "10.0.0.1") {
+		t.Fatal("the cap did not bound growth")
+	}
+	// An existing binding still refreshes at the cap.
+	if !l.Record("a", "10.0.0.1") {
+		t.Fatal("refresh refused at the cap")
+	}
+
+	*clock = clock.Add(time.Hour + time.Second)
+	if !l.Record("c", "10.0.0.1") {
+		t.Fatal("expired entries were not reclaimed to make room")
+	}
+}
+
+func TestLenEvictsExpired(t *testing.T) {
+	l, clock := testLedger(t, time.Hour, 10)
+	l.Record("a", "10.0.0.1")
+	l.Record("b", "10.0.0.1")
+	if got := l.Len(); got != 2 {
+		t.Fatalf("Len = %d, want 2", got)
+	}
+	*clock = clock.Add(time.Hour + time.Second)
+	if got := l.Len(); got != 0 {
+		t.Fatalf("Len after expiry = %d, want 0", got)
+	}
+}
+
+func TestEvictionLoopStops(t *testing.T) {
+	l := New(time.Millisecond, 10)
+	l.Record("a", "10.0.0.1")
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() { l.EvictionLoop(done, time.Millisecond); close(stopped) }()
+	close(done)
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("EvictionLoop did not return when done closed")
+	}
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -1,0 +1,398 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"slices"
+	"strings"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// Route is the path prefix the handler serves. The trailing wildcard is
+// required: a store path has slashes in it, and a single-segment pattern would
+// only ever match a top-level path.
+const Route = "/secrets/*"
+
+// authScheme prefixes the sandbox token in the Authorization header. The token
+// travels in a header rather than the URL so it is covered by the server's
+// header bound and never reaches a request log.
+const authScheme = "SandboxToken "
+
+// challengeSource issues and consumes the single-use nonces that make a request
+// fresh. The secrets listener holds its own, so a nonce minted for issuance
+// cannot be redeemed here.
+type challengeSource interface {
+	Consume(challenge []byte) bool
+}
+
+// inventorySource is the callback to a node's admission inventory: its
+// sandbox-token signing key, and what a sandbox has run.
+type inventorySource interface {
+	InventoryKey(ctx context.Context, host string) (*ecdsa.PublicKey, error)
+	FetchSandbox(ctx context.Context, host, sandboxID string) (workloadclaims.SandboxDigestsResponse, error)
+}
+
+// bindingSource resolves which inventory this process is willing to believe
+// about a sandbox.
+type bindingSource interface {
+	Lookup(sandboxID string) (host string, ok bool)
+}
+
+// policySource supplies the current allowlist.
+type policySource interface {
+	Allowlist() (*pkgallowlist.Allowlist, error)
+}
+
+// Handler serves GET and POST on Route.
+type Handler struct {
+	Store      Store
+	Challenges challengeSource
+	Inventory  inventorySource
+	Bindings   bindingSource
+	Policy     policySource
+
+	// InventoryHosts bounds the addresses the callback may dial. Empty refuses
+	// every request: without it a workload could name its own pod.
+	InventoryHosts workloadclaims.InventoryHosts
+
+	// InjectedDigests are the images the platform injects into every
+	// confidential pod. Containers running one are not part of a workload's
+	// declared set, so they are dropped before matching.
+	//
+	// It is a set, not a single digest, for two reasons: the injected
+	// containers need not all share an image, and an image bump changes the
+	// digest while pods created before it keep running the old one. A CDS that
+	// knew only the current digest would find an undroppable container in every
+	// older pod and refuse it a secret until it was recreated, so both digests
+	// belong here for the length of an upgrade.
+	//
+	// InjectedArgv0 are the entrypoints those images are injected with. A
+	// container must match a digest AND an entrypoint to be dropped: these
+	// images are argv-unconstrained allowlist floor entries, so dropping on the
+	// digest alone would let a pod add a container running one of them as
+	// anything at all and have it ignored.
+	InjectedDigests []string
+	InjectedArgv0   []string
+
+	Logger *slog.Logger
+}
+
+// denial is a refusal to release. The reason reaches the CDS log; the client is
+// told only that it was refused, because the detail describes the state of a
+// pod the caller may not be entitled to learn about.
+type denial struct {
+	status int
+	reason string
+}
+
+func (d denial) Error() string { return d.reason }
+
+func deny(reason string, args ...any) denial {
+	return denial{status: http.StatusForbidden, reason: fmt.Sprintf(reason, args...)}
+}
+
+func (h Handler) logger() *slog.Logger {
+	if h.Logger != nil {
+		return h.Logger
+	}
+	return slog.Default()
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	path, err := requestPath(r)
+	if err != nil {
+		http.Error(w, "invalid secret path", http.StatusBadRequest)
+		return
+	}
+
+	// The challenge is consumed unconditionally and first, exactly as issuance
+	// does: a nonce that survives an early error path is a nonce that can be
+	// replayed against another path.
+	nonce, err := h.consumeChallenge(r)
+	if err != nil {
+		h.logger().Warn("secret request rejected", "path", path, "error", err)
+		http.Error(w, "invalid or expired challenge", http.StatusBadRequest)
+		return
+	}
+
+	grant, err := h.authorize(ctx, r, nonce)
+	if err != nil {
+		var d denial
+		if !errors.As(err, &d) {
+			d = denial{status: http.StatusForbidden, reason: err.Error()}
+		}
+		h.logger().Warn("secret request denied", "path", path, "reason", d.reason)
+		http.Error(w, "not authorized for this secret", d.status)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		h.serveGet(ctx, w, grant, path)
+	case http.MethodPost:
+		h.servePost(ctx, w, grant, path)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h Handler) serveGet(ctx context.Context, w http.ResponseWriter, grant *pkgallowlist.SecretsPolicy, path string) {
+	if !grant.Allows(path, pkgallowlist.OpRead) {
+		// Indistinguishable from a path that does not exist: telling a caller
+		// which of its ungranted guesses are real would enumerate the store.
+		h.logger().Warn("secret read denied", "path", path)
+		http.Error(w, "no such secret", http.StatusNotFound)
+		return
+	}
+	value, err := h.Store.Get(ctx, path)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			http.Error(w, "no such secret", http.StatusNotFound)
+			return
+		}
+		h.logger().Error("secret read failed", "path", path, "error", err)
+		http.Error(w, "secret unavailable", http.StatusInternalServerError)
+		return
+	}
+	writeValue(w, value, http.StatusOK)
+}
+
+func (h Handler) servePost(ctx context.Context, w http.ResponseWriter, grant *pkgallowlist.SecretsPolicy, path string) {
+	if !grant.Allows(path, pkgallowlist.OpWrite) {
+		h.logger().Warn("secret create denied", "path", path)
+		http.Error(w, "no such secret", http.StatusNotFound)
+		return
+	}
+	// The value is minted here and never supplied by the caller, so no client
+	// chooses what another client will later read.
+	candidate, err := Generate()
+	if err != nil {
+		h.logger().Error("generate secret failed", "path", path, "error", err)
+		http.Error(w, "secret unavailable", http.StatusInternalServerError)
+		return
+	}
+	_, created, err := h.Store.PutIfAbsent(ctx, path, candidate)
+	if err != nil {
+		h.logger().Error("secret create failed", "path", path, "error", err)
+		http.Error(w, "secret unavailable", http.StatusInternalServerError)
+		return
+	}
+	if !created {
+		// The existing value is withheld: returning it here would make a write
+		// grant a read grant. A caller that also holds read re-reads with GET,
+		// which is how the replica that loses this race recovers.
+		w.WriteHeader(http.StatusConflict)
+		return
+	}
+	writeValue(w, candidate, http.StatusCreated)
+}
+
+// valueResponse carries a secret value. Base64 because a generated value is raw
+// bytes.
+type valueResponse struct {
+	Value string `json:"value"`
+}
+
+func writeValue(w http.ResponseWriter, value []byte, status int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(valueResponse{Value: base64.StdEncoding.EncodeToString(value)})
+}
+
+// requestPath returns the canonical store path a request names.
+//
+// It reads the escaped form and refuses anything not already canonical rather
+// than repairing it, so the bytes matched against a grant, and the bytes used as
+// a store key, are the bytes the client sent. Chi routes on the raw or the
+// decoded path depending on whether the URL contained escapes, so deriving from
+// one source and rejecting "%" removes that difference.
+func requestPath(r *http.Request) (string, error) {
+	raw := r.URL.EscapedPath()
+	rest, ok := strings.CutPrefix(raw, "/secrets")
+	if !ok {
+		return "", fmt.Errorf("path %q is not under /secrets", raw)
+	}
+	return pkgallowlist.CanonicalSecretPath(rest)
+}
+
+func (h Handler) consumeChallenge(r *http.Request) ([]byte, error) {
+	if h.Challenges == nil {
+		return nil, fmt.Errorf("no challenge store configured")
+	}
+	raw := r.Header.Get("X-C8s-Challenge")
+	if raw == "" {
+		return nil, fmt.Errorf("missing challenge")
+	}
+	nonce, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("challenge is not base64")
+	}
+	if !h.Challenges.Consume(nonce) {
+		return nil, fmt.Errorf("challenge is unknown, expired, or already used")
+	}
+	return nonce, nil
+}
+
+// authorize establishes which workload is calling and returns the secret grant
+// that workload holds. Every failure is fail-closed.
+func (h Handler) authorize(ctx context.Context, r *http.Request, nonce []byte) (*pkgallowlist.SecretsPolicy, error) {
+	leaf, err := verifiedLeaf(r)
+	if err != nil {
+		return nil, deny("%v", err)
+	}
+	sandboxID, err := ratls.SandboxIDFromCert(leaf)
+	if err != nil || sandboxID == "" {
+		return nil, deny("client certificate carries no sandbox ID")
+	}
+
+	// The token re-proves, against this request's own challenge, that the
+	// caller is still in that sandbox, and names the inventory that says so.
+	token, err := h.parseToken(r)
+	if err != nil {
+		return nil, deny("%v", err)
+	}
+	host, err := h.verifyToken(ctx, token, leaf.PublicKey, nonce, sandboxID)
+	if err != nil {
+		return nil, deny("%v", err)
+	}
+
+	containers, err := h.runningContainers(ctx, host, sandboxID)
+	if err != nil {
+		return nil, deny("%v", err)
+	}
+
+	al, err := h.Policy.Allowlist()
+	if err != nil {
+		return nil, fmt.Errorf("load allowlist: %w", err)
+	}
+	name, workload, err := al.MatchWorkload(containers)
+	if err != nil {
+		return nil, deny("sandbox %s: %v", sandboxID, err)
+	}
+	if workload.Secrets == nil {
+		return nil, deny("workload %q holds no secret grant", name)
+	}
+	return workload.Secrets, nil
+}
+
+// verifiedLeaf returns the client certificate, requiring that crypto/tls
+// verified it against the configured roots. VerifiedChains is empty unless the
+// listener both asked for a certificate and had roots to check it against, so
+// this refuses a listener misconfigured to accept a self-signed peer — whose
+// sandbox-ID extension would be whatever it chose.
+func verifiedLeaf(r *http.Request) (*x509.Certificate, error) {
+	if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+		return nil, fmt.Errorf("no client certificate")
+	}
+	if len(r.TLS.VerifiedChains) == 0 {
+		return nil, fmt.Errorf("client certificate was not verified against the mesh CA")
+	}
+	return r.TLS.PeerCertificates[0], nil
+}
+
+func (h Handler) parseToken(r *http.Request) (*workloadclaims.SignedSandboxToken, error) {
+	raw, ok := strings.CutPrefix(r.Header.Get("Authorization"), authScheme)
+	if !ok || raw == "" {
+		return nil, fmt.Errorf("missing sandbox token")
+	}
+	der, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("sandbox token is not base64")
+	}
+	var token workloadclaims.SignedSandboxToken
+	dec := json.NewDecoder(bytes.NewReader(der))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&token); err != nil {
+		return nil, fmt.Errorf("decode sandbox token: %w", err)
+	}
+	return &token, nil
+}
+
+// verifyToken checks the token against the inventory this process already
+// believes owns the sandbox, and returns that inventory's host.
+func (h Handler) verifyToken(ctx context.Context, token *workloadclaims.SignedSandboxToken, requesterPub crypto.PublicKey, nonce []byte, sandboxID string) (string, error) {
+	if h.Inventory == nil || h.Bindings == nil {
+		return "", fmt.Errorf("secrets are not configured to reach an inventory")
+	}
+	if len(h.InventoryHosts) == 0 {
+		return "", fmt.Errorf("no inventory CIDRs are configured to bound the callback")
+	}
+	// The binding, not the token, decides who is asked. The token names a host
+	// too, but that is the requester's choice; taking it would let anything able
+	// to answer on the inventory port vouch for someone else's sandbox.
+	host, ok := h.Bindings.Lookup(sandboxID)
+	if !ok {
+		return "", fmt.Errorf("no inventory is bound to sandbox %s", sandboxID)
+	}
+	if !h.InventoryHosts.Contains(host) {
+		return "", fmt.Errorf("bound inventory is outside the configured node CIDRs")
+	}
+	claimed, err := workloadclaims.UnverifiedInventoryHost(token.Token)
+	if err != nil {
+		return "", err
+	}
+	if claimed != host {
+		return "", fmt.Errorf("sandbox token names an inventory other than the one bound to this sandbox")
+	}
+	key, err := h.Inventory.InventoryKey(ctx, host)
+	if err != nil {
+		return "", fmt.Errorf("resolve inventory key: %w", err)
+	}
+	verified, err := token.Verify(key, requesterPub, nonce)
+	if err != nil {
+		return "", err
+	}
+	if verified.SandboxID != sandboxID {
+		return "", fmt.Errorf("sandbox token names a different sandbox than the certificate")
+	}
+	return host, nil
+}
+
+// runningContainers asks the bound inventory what the sandbox has run, and
+// drops the platform's own injected containers so a workload entry need not
+// enumerate them.
+func (h Handler) runningContainers(ctx context.Context, host, sandboxID string) ([]pkgallowlist.RunningContainer, error) {
+	resp, err := h.Inventory.FetchSandbox(ctx, host, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox containers: %w", err)
+	}
+	reported, err := resp.RequireContainers()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]pkgallowlist.RunningContainer, 0, len(reported))
+	for _, c := range reported {
+		if h.isInjected(c) {
+			continue
+		}
+		out = append(out, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("sandbox %s reports no workload containers", sandboxID)
+	}
+	return out, nil
+}
+
+// isInjected reports whether a reported container is one the platform injected.
+// Both the image and the entrypoint must match — see InjectedDigests.
+func (h Handler) isInjected(c workloadclaims.SandboxContainer) bool {
+	if len(c.Argv) == 0 || !slices.Contains(h.InjectedDigests, c.Digest) {
+		return false
+	}
+	return slices.Contains(h.InjectedArgv0, c.Argv[0])
+}

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -1,0 +1,432 @@
+package secrets
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+const (
+	testSandbox  = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testHost     = "10.0.0.7"
+	testAppImg   = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testInjected = "sha256:9999999999999999999999999999999999999999999999999999999999999999"
+	testOther    = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
+	// testInjectedOld is the previous release's injected image, still running in
+	// pods created before an upgrade.
+	testInjectedOld = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+)
+
+// --- fakes ---
+
+type fakeChallenges struct{ used map[string]bool }
+
+func (f *fakeChallenges) Consume(c []byte) bool {
+	k := string(c)
+	if f.used[k] {
+		return false
+	}
+	if f.used == nil {
+		f.used = map[string]bool{}
+	}
+	f.used[k] = true
+	return true
+}
+
+type fakeInventory struct {
+	key        *ecdsa.PublicKey
+	containers []workloadclaims.SandboxContainer
+	err        error
+}
+
+func (f *fakeInventory) InventoryKey(context.Context, string) (*ecdsa.PublicKey, error) {
+	return f.key, nil
+}
+func (f *fakeInventory) FetchSandbox(context.Context, string, string) (workloadclaims.SandboxDigestsResponse, error) {
+	if f.err != nil {
+		return workloadclaims.SandboxDigestsResponse{}, f.err
+	}
+	digests := make([]string, 0, len(f.containers))
+	for _, c := range f.containers {
+		digests = append(digests, c.Digest)
+	}
+	return workloadclaims.SandboxDigestsResponse{Digests: digests, Containers: f.containers}, nil
+}
+
+type fakeBindings struct{ host string }
+
+func (f fakeBindings) Lookup(string) (string, bool) {
+	if f.host == "" {
+		return "", false
+	}
+	return f.host, true
+}
+
+type fakePolicy struct{ al *pkgallowlist.Allowlist }
+
+func (f fakePolicy) Allowlist() (*pkgallowlist.Allowlist, error) { return f.al, nil }
+
+// --- scaffolding ---
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// leafFor mints a client certificate carrying sandboxID, as CDS stamps it.
+func leafFor(t *testing.T, sandboxID string) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "workload"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	if sandboxID != "" {
+		ext, err := ratls.MarshalSandboxIDExtension(sandboxID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tmpl.ExtraExtensions = append(tmpl.ExtraExtensions, ext)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, key
+}
+
+type harness struct {
+	h          Handler
+	signer     *workloadclaims.SandboxTokenSigner
+	leaf       *x509.Certificate
+	challenges *fakeChallenges
+	inv        *fakeInventory
+	store      *MemoryStore
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	signer, err := workloadclaims.NewSandboxTokenSigner(testHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, _ := leafFor(t, testSandbox)
+	cidrs, err := workloadclaims.ParseInventoryHosts([]string{"10.0.0.0/24"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: map[string]pkgallowlist.Workload{
+		"api": {
+			Containers: []pkgallowlist.Container{{
+				Digest:  mustDigest(t, testAppImg),
+				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/serve"}},
+				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+			}},
+			Secrets: &pkgallowlist.SecretsPolicy{
+				Policy: pkgallowlist.PolicyAllow,
+				Read:   []string{"/api/**"},
+				Write:  []string{"/api/**"},
+			},
+		},
+	}}
+	inv := &fakeInventory{
+		key: signer.PublicKey(),
+		containers: []workloadclaims.SandboxContainer{
+			{Digest: testAppImg, Argv: []string{"/serve"}},
+			{Digest: testInjected, Argv: []string{"get-cert", "--san=x"}},
+		},
+	}
+	challenges := &fakeChallenges{used: map[string]bool{}}
+	store := NewMemoryStore(16, 64)
+	return &harness{
+		h: Handler{
+			Store:           store,
+			Challenges:      challenges,
+			Inventory:       inv,
+			Bindings:        fakeBindings{host: testHost},
+			Policy:          fakePolicy{al: al},
+			InventoryHosts:  cidrs,
+			InjectedDigests: []string{testInjected, testInjectedOld},
+			InjectedArgv0:   []string{"get-cert", "get-secret", "/c8s"},
+		},
+		signer: signer, leaf: leaf, challenges: challenges, inv: inv, store: store,
+	}
+}
+
+// request builds a request as the fetcher would send it.
+func (hn *harness) request(t *testing.T, method, path string) *http.Request {
+	t.Helper()
+	return hn.requestWith(t, method, path, hn.leaf, testSandbox, []byte("nonce-"+path+method))
+}
+
+func (hn *harness) requestWith(t *testing.T, method, path string, leaf *x509.Certificate, tokenSandbox string, nonce []byte) *http.Request {
+	t.Helper()
+	keyDigest, err := workloadclaims.RequesterKeyDigest(leaf.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := hn.signer.Sign(tokenSandbox, keyDigest, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := json.Marshal(token)
+
+	r := httptest.NewRequest(method, "/secrets"+path, nil)
+	r.Header.Set("X-C8s-Challenge", base64.StdEncoding.EncodeToString(nonce))
+	r.Header.Set("Authorization", authScheme+base64.StdEncoding.EncodeToString(body))
+	r.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{leaf},
+		VerifiedChains:   [][]*x509.Certificate{{leaf}},
+	}
+	return r
+}
+
+func do(h Handler, r *http.Request) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	return w
+}
+
+func decodeValue(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var v valueResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &v); err != nil {
+		t.Fatalf("decode response %q: %v", w.Body.String(), err)
+	}
+	return v.Value
+}
+
+// --- tests ---
+
+func TestCreateThenRead(t *testing.T) {
+	hn := newHarness(t)
+
+	w := do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("POST = %d (%s), want 201", w.Code, w.Body)
+	}
+	created := decodeValue(t, w)
+
+	w = do(hn.h, hn.request(t, http.MethodGet, "/api/db"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET = %d (%s), want 200", w.Code, w.Body)
+	}
+	if got := decodeValue(t, w); got != created {
+		t.Fatal("GET returned a different value than POST created")
+	}
+}
+
+// The replica that loses the create race is told 409 with no value, and
+// recovers by reading.
+func TestCreateOnExistingConflicts(t *testing.T) {
+	hn := newHarness(t)
+	do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
+
+	w := do(hn.h, hn.requestWith(t, http.MethodPost, "/api/db", hn.leaf, testSandbox, []byte("n2")))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("second POST = %d, want 409", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "value") {
+		t.Fatalf("409 leaked a value: %s", w.Body)
+	}
+}
+
+func TestUngrantedPathIsNotFound(t *testing.T) {
+	hn := newHarness(t)
+	w := do(hn.h, hn.request(t, http.MethodGet, "/other/db"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("ungranted GET = %d, want 404 (indistinguishable from absent)", w.Code)
+	}
+}
+
+func TestChallengeIsSingleUse(t *testing.T) {
+	hn := newHarness(t)
+	nonce := []byte("reused")
+	if w := do(hn.h, hn.requestWith(t, http.MethodPost, "/api/db", hn.leaf, testSandbox, nonce)); w.Code != http.StatusCreated {
+		t.Fatalf("first = %d", w.Code)
+	}
+	if w := do(hn.h, hn.requestWith(t, http.MethodGet, "/api/db", hn.leaf, testSandbox, nonce)); w.Code != http.StatusBadRequest {
+		t.Fatalf("replayed challenge = %d, want 400", w.Code)
+	}
+}
+
+// An unverified chain must never be trusted for the sandbox ID: a self-signed
+// leaf's extension is whatever its minter chose.
+func TestUnverifiedChainRefused(t *testing.T) {
+	hn := newHarness(t)
+	r := hn.request(t, http.MethodGet, "/api/db")
+	r.TLS.VerifiedChains = nil
+	if w := do(hn.h, r); w.Code != http.StatusForbidden {
+		t.Fatalf("unverified chain = %d, want 403", w.Code)
+	}
+}
+
+func TestNoClientCertRefused(t *testing.T) {
+	hn := newHarness(t)
+	r := hn.request(t, http.MethodGet, "/api/db")
+	r.TLS = &tls.ConnectionState{}
+	if w := do(hn.h, r); w.Code != http.StatusForbidden {
+		t.Fatalf("certless = %d, want 403", w.Code)
+	}
+}
+
+func TestCertWithoutSandboxIDRefused(t *testing.T) {
+	hn := newHarness(t)
+	bare, _ := leafFor(t, "")
+	r := hn.requestWith(t, http.MethodGet, "/api/db", bare, testSandbox, []byte("n"))
+	if w := do(hn.h, r); w.Code != http.StatusForbidden {
+		t.Fatalf("no sandbox ID = %d, want 403", w.Code)
+	}
+}
+
+// A token for a sandbox other than the certificate's must not be redeemable.
+func TestTokenSandboxMustMatchCert(t *testing.T) {
+	hn := newHarness(t)
+	other := strings.Repeat("a", 64)
+	r := hn.requestWith(t, http.MethodGet, "/api/db", hn.leaf, other, []byte("n"))
+	if w := do(hn.h, r); w.Code != http.StatusForbidden {
+		t.Fatalf("mismatched sandbox = %d, want 403", w.Code)
+	}
+}
+
+// Without a ledger binding there is no inventory this process will believe.
+func TestUnboundSandboxRefused(t *testing.T) {
+	hn := newHarness(t)
+	hn.h.Bindings = fakeBindings{}
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("unbound sandbox = %d, want 403", w.Code)
+	}
+}
+
+// A token naming an inventory other than the bound one is refused even though
+// its signature verifies: the binding, not the token, chooses who is asked.
+func TestTokenHostMustMatchBinding(t *testing.T) {
+	hn := newHarness(t)
+	hn.h.Bindings = fakeBindings{host: "10.0.0.9"}
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("host mismatch = %d, want 403", w.Code)
+	}
+}
+
+// An image the entry does not declare means this pod is not that workload —
+// even though the extra image is itself allowlisted elsewhere.
+func TestForeignContainerRefused(t *testing.T) {
+	hn := newHarness(t)
+	hn.inv.containers = append(hn.inv.containers,
+		workloadclaims.SandboxContainer{Digest: testOther, Argv: []string{"/bin/sh"}})
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("foreign container = %d, want 403", w.Code)
+	}
+}
+
+// The injected image is an argv-unconstrained floor entry, so it is dropped
+// only when running an injected entrypoint. A pod that adds it running a shell
+// must not have that container ignored.
+func TestInjectedImageWithForeignArgvIsNotDropped(t *testing.T) {
+	hn := newHarness(t)
+	hn.inv.containers = append(hn.inv.containers,
+		workloadclaims.SandboxContainer{Digest: testInjected, Argv: []string{"/bin/sh", "-c", "cat /run/c8s/secrets/*"}})
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("smuggled injected-image container = %d, want 403", w.Code)
+	}
+}
+
+// An inventory too old to report per-container detail cannot support a
+// (digest, argv) decision, so it is refused rather than silently matched on
+// digests alone.
+func TestInventoryWithoutContainerDetailRefused(t *testing.T) {
+	hn := newHarness(t)
+	hn.inv.containers = nil
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("detail-less inventory = %d, want 403", w.Code)
+	}
+}
+
+func TestEntryWithoutGrantRefused(t *testing.T) {
+	hn := newHarness(t)
+	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: map[string]pkgallowlist.Workload{
+		"api": {Containers: []pkgallowlist.Container{{
+			Digest:  mustDigest(t, testAppImg),
+			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/serve"}},
+			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+		}}},
+	}}
+	hn.h.Policy = fakePolicy{al: al}
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("grantless entry = %d, want 403", w.Code)
+	}
+}
+
+func TestNonCanonicalPathRejected(t *testing.T) {
+	hn := newHarness(t)
+	for _, p := range []string{"/api/../etc", "/api/db/", "/api%2Fdb", ""} {
+		r := hn.request(t, http.MethodGet, "/api/db")
+		r.URL.Path = "/secrets" + p
+		r.URL.RawPath = "/secrets" + p
+		if w := do(hn.h, r); w.Code != http.StatusBadRequest {
+			t.Fatalf("path %q = %d, want 400", p, w.Code)
+		}
+	}
+}
+
+func TestMethodNotAllowed(t *testing.T) {
+	hn := newHarness(t)
+	r := hn.request(t, http.MethodDelete, "/api/db")
+	if w := do(hn.h, r); w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE = %d, want 405", w.Code)
+	}
+}
+
+// A pod created before a c8s image bump still runs the previous injected image.
+// Both digests are configured for the length of an upgrade, so such a pod is
+// not refused its secret until it happens to be recreated.
+func TestInjectedImageFromPreviousReleaseIsDropped(t *testing.T) {
+	hn := newHarness(t)
+	hn.inv.containers = []workloadclaims.SandboxContainer{
+		{Digest: testAppImg, Argv: []string{"/serve"}},
+		{Digest: testInjectedOld, Argv: []string{"get-cert", "--san=x"}},
+	}
+	if w := do(hn.h, hn.request(t, http.MethodPost, "/api/db")); w.Code != http.StatusCreated {
+		t.Fatalf("pod running the previous injected image = %d, want 201", w.Code)
+	}
+}
+
+// An unconfigured drop set refuses everything rather than dropping nothing
+// quietly — which is why it is a startup requirement, not a runtime default.
+func TestNoInjectedDigestsRefuses(t *testing.T) {
+	hn := newHarness(t)
+	hn.h.InjectedDigests = nil
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("unconfigured drop set = %d, want 403", w.Code)
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -1,0 +1,100 @@
+// Package secrets holds the CDS secret store and the policy that gates access
+// to it. See docs/secrets.md.
+package secrets
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// ErrNotFound reports a path the store does not hold.
+var ErrNotFound = errors.New("secrets: no such path")
+
+// Store is the secret backend.
+//
+// Generation lives above the store, not inside it: a backing store generates in
+// its own way — a KMS wraps a key, a vault mints its own — so a store that also
+// chose values would force every backend to reimplement or contradict this
+// one's policy. PutIfAbsent is a compare-and-set, which every real key-value
+// store offers.
+type Store interface {
+	Get(ctx context.Context, path string) ([]byte, error)
+	// PutIfAbsent stores value at path if nothing is there, returning what the
+	// path holds afterwards and whether this call is what put it there.
+	PutIfAbsent(ctx context.Context, path string, value []byte) (current []byte, created bool, err error)
+}
+
+// GeneratedValueBytes is the size of a value CDS mints for a workload that
+// finds its path empty. 32 bytes is a symmetric key's worth of entropy, which
+// is what these values are used as.
+const GeneratedValueBytes = 32
+
+// Generate returns a fresh secret value.
+func Generate() ([]byte, error) {
+	b := make([]byte, GeneratedValueBytes)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("secrets: generate value: %w", err)
+	}
+	return b, nil
+}
+
+// MemoryStore keeps secrets in the CDS process and nowhere else. They do not
+// survive a restart — see docs/secrets.md, "Restarts".
+//
+// Both bounds are fail-closed. CDS is a single in-memory process holding the
+// mesh CA, so a workload able to grow this map without limit could OOM it and
+// take every certificate in the cluster with it.
+type MemoryStore struct {
+	mu       sync.RWMutex
+	values   map[string][]byte
+	maxPaths int
+	maxValue int
+}
+
+// NewMemoryStore builds the store. maxPaths bounds distinct paths; maxValue
+// bounds one value.
+func NewMemoryStore(maxPaths, maxValue int) *MemoryStore {
+	return &MemoryStore{
+		values:   make(map[string][]byte),
+		maxPaths: maxPaths,
+		maxValue: maxValue,
+	}
+}
+
+func (s *MemoryStore) Get(_ context.Context, path string) ([]byte, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	v, ok := s.values[path]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	// Copy: the caller must not be able to mutate stored state through the
+	// slice it is handed.
+	return append([]byte(nil), v...), nil
+}
+
+func (s *MemoryStore) PutIfAbsent(_ context.Context, path string, value []byte) ([]byte, bool, error) {
+	if len(value) > s.maxValue {
+		return nil, false, fmt.Errorf("secrets: value is %d bytes, limit is %d", len(value), s.maxValue)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if v, ok := s.values[path]; ok {
+		return append([]byte(nil), v...), false, nil
+	}
+	if len(s.values) >= s.maxPaths {
+		return nil, false, fmt.Errorf("secrets: store holds %d paths, limit is %d", len(s.values), s.maxPaths)
+	}
+	s.values[path] = append([]byte(nil), value...)
+	return append([]byte(nil), value...), true, nil
+}
+
+// Len reports how many paths the store holds, for metrics and tests.
+func (s *MemoryStore) Len() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.values)
+}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -1,0 +1,100 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestMemoryStoreGetMissing(t *testing.T) {
+	s := NewMemoryStore(10, 64)
+	if _, err := s.Get(context.Background(), "/nope"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("err = %v, want ErrNotFound", err)
+	}
+}
+
+// The first writer defines the value; a later one is told what is there and
+// that it did not create it — which is how a losing replica recovers.
+func TestMemoryStorePutIfAbsent(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(10, 64)
+
+	got, created, err := s.PutIfAbsent(ctx, "/a", []byte("first"))
+	if err != nil || !created || !bytes.Equal(got, []byte("first")) {
+		t.Fatalf("first put: %q %v %v", got, created, err)
+	}
+	got, created, err = s.PutIfAbsent(ctx, "/a", []byte("second"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatal("second put reported that it created the value")
+	}
+	if !bytes.Equal(got, []byte("first")) {
+		t.Fatalf("second put = %q, want the original value", got)
+	}
+}
+
+// A caller must not be able to reach into stored state through a returned
+// slice.
+func TestMemoryStoreCopiesValues(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(10, 64)
+	original := []byte("secret")
+	if _, _, err := s.PutIfAbsent(ctx, "/a", original); err != nil {
+		t.Fatal(err)
+	}
+	original[0] = 'X' // mutate the caller's slice after storing
+
+	got, err := s.Get(ctx, "/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, []byte("secret")) {
+		t.Fatalf("stored value = %q, want it unaffected by the caller's slice", got)
+	}
+	got[0] = 'Y' // mutate what Get handed back
+	again, _ := s.Get(ctx, "/a")
+	if !bytes.Equal(again, []byte("secret")) {
+		t.Fatalf("stored value = %q, want it unaffected by a mutated result", again)
+	}
+}
+
+func TestMemoryStoreBounds(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(2, 4)
+
+	if _, _, err := s.PutIfAbsent(ctx, "/big", []byte("toolong")); err == nil {
+		t.Fatal("an oversized value was stored")
+	}
+	for _, p := range []string{"/a", "/b"} {
+		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok")); err != nil {
+			t.Fatalf("put %s: %v", p, err)
+		}
+	}
+	if _, _, err := s.PutIfAbsent(ctx, "/c", []byte("ok")); err == nil {
+		t.Fatal("the path cap did not bound the store")
+	}
+	// An existing path still resolves at the cap.
+	if _, created, err := s.PutIfAbsent(ctx, "/a", []byte("ok")); err != nil || created {
+		t.Fatalf("existing path at the cap: created=%v err=%v", created, err)
+	}
+	if s.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", s.Len())
+	}
+}
+
+func TestGenerate(t *testing.T) {
+	a, err := Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(a) != GeneratedValueBytes {
+		t.Fatalf("len = %d, want %d", len(a), GeneratedValueBytes)
+	}
+	b, _ := Generate()
+	if bytes.Equal(a, b) {
+		t.Fatal("two generated values were identical")
+	}
+}

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -50,11 +50,9 @@ type Allowlist struct {
 }
 
 // Workload is a named policy entry. Label is an informational image reference.
-// Secrets is nil when the entry grants nothing, which is also what a "deny"
-// grant normalizes to — so an entry without a grant serializes exactly as it
-// did before the field existed. That is what lets a CDS carrying this field be
-// deployed ahead of the enforcing consumers baked into node and guest images:
-// they only ever see "secrets" once an operator writes a real grant.
+// Secrets is nil when the entry grants nothing, which is what a "deny" grant
+// normalizes to: an entry that releases nothing carries no "secrets" key at
+// all, so a consumer that does not know the field never sees it.
 type Workload struct {
 	Label          string         `json:"label,omitempty"`
 	InitContainers []Container    `json:"initContainers"`
@@ -101,15 +99,9 @@ func ParseJSON(data []byte) (*Allowlist, error) {
 }
 
 // ParseServedJSON decodes a document served by CDS, ignoring fields it does not
-// know.
-//
-// The enforcing consumers (nri-image-policy, policy-monitor) are baked into node
-// and guest images, so their launch measurement pins which schema version they
-// understand. Rejecting unknown fields there would mean a CDS serving any newer
-// field silently freezes every un-upgraded node's policy — refreshOnce keeps the
-// previous allowlist on a parse error — and unfreezing it would cost a node
-// image rebuild and a measurement change. Consumers enforce the fields they
-// know; ignoring the rest is what lets the document grow without a flag day.
+// know. Its consumers pin a schema version in a launch measurement, so a strict
+// parse would make any newer field freeze their policy until a node-image
+// rebuild. See docs/secrets.md — "Upgrading".
 func ParseServedJSON(data []byte) (*Allowlist, error) {
 	return parseJSON(data, false)
 }

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -1,0 +1,117 @@
+package allowlist
+
+import "fmt"
+
+// RunningContainer is one container an inventory reports: the bytes, and the
+// effective argv they were told to run.
+//
+// A local type rather than the inventory's own keeps this package a pure
+// function of the allowlist — the caller converts.
+type RunningContainer struct {
+	Digest string
+	Argv   []string
+}
+
+// ErrNoMatch reports that no entry describes the running set; ErrAmbiguous that
+// more than one does. Both are refusals, but they say different things to an
+// operator: the first is a set that matches nothing, the second a pair of
+// entries that cannot be told apart.
+var (
+	ErrNoMatch   = fmt.Errorf("allowlist: no workload entry matches the running containers")
+	ErrAmbiguous = fmt.Errorf("allowlist: more than one workload entry matches the running containers")
+)
+
+// MatchWorkload resolves a running container set to the single entry that
+// describes it.
+//
+// An entry matches when every running container is one it declares (digest and
+// argv), and every main container it declares is running. It is deliberately not
+// set equality: a declared init container may have exited, and a declared native
+// sidecar keeps running, so demanding the two sets be equal would refuse
+// ordinary pods outright. "Nothing foreign, every main present" admits both
+// while still refusing a set containing anything the entry does not name.
+//
+// running must already have had injected-component containers removed — this
+// package does not know which images the platform injects.
+//
+// Argv is matched against the entry's own policies rather than via Index, whose
+// admission is a union across every entry listing a digest: an entry pinning an
+// exact command guarantees nothing here if another entry widens the same digest.
+func (a *Allowlist) MatchWorkload(running []RunningContainer) (string, Workload, error) {
+	if len(running) == 0 {
+		// A pod always runs at least the container that is asking, so an empty
+		// set is no evidence rather than a set that happens to match an entry
+		// declaring nothing.
+		return "", Workload{}, ErrNoMatch
+	}
+	var (
+		foundName string
+		found     Workload
+		matches   int
+	)
+	for name, w := range a.Workloads {
+		if !w.describes(running) {
+			continue
+		}
+		matches++
+		if matches > 1 {
+			return "", Workload{}, ErrAmbiguous
+		}
+		foundName, found = name, w
+	}
+	if matches == 0 {
+		return "", Workload{}, ErrNoMatch
+	}
+	return foundName, found, nil
+}
+
+// describes reports whether the entry admits everything running and has all its
+// main containers present.
+func (w Workload) describes(running []RunningContainer) bool {
+	declared := make([]Container, 0, len(w.Containers)+len(w.InitContainers))
+	declared = append(declared, w.Containers...)
+	declared = append(declared, w.InitContainers...)
+
+	for _, r := range running {
+		if !admittedBy(declared, r) {
+			return false
+		}
+	}
+	for _, c := range w.Containers {
+		if !anyRunning(running, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// admittedBy reports whether some declared container permits this running
+// container's digest and argv.
+func admittedBy(declared []Container, r RunningContainer) bool {
+	for _, c := range declared {
+		if c.admits(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// anyRunning reports whether a declared container is satisfied by something
+// running.
+func anyRunning(running []RunningContainer, c Container) bool {
+	for _, r := range running {
+		if c.admits(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// admits reports whether this declared container permits the running one.
+func (c Container) admits(r RunningContainer) bool {
+	if c.Digest.String() != r.Digest {
+		return false
+	}
+	rest, ok := c.Command.matchCommand(r.Argv)
+	return ok && c.Args.matchArgs(rest)
+}

--- a/pkg/allowlist/match_test.go
+++ b/pkg/allowlist/match_test.go
@@ -1,0 +1,166 @@
+package allowlist
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	dApp     = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	dSidecar = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	dInit    = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	dOther   = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+)
+
+func dig(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatalf("ParseDigest(%q): %v", s, err)
+	}
+	return d
+}
+
+// exactly builds a container pinned to one digest and argv.
+func exactly(t *testing.T, digest string, argv ...string) Container {
+	t.Helper()
+	c := Container{Digest: dig(t, digest), Command: ArgvPolicy{Policy: PolicyAny}, Args: ArgvPolicy{Policy: PolicyAny}}
+	if len(argv) > 0 {
+		c.Command = ArgvPolicy{Policy: PolicyExact, Argv: argv}
+		c.Args = ArgvPolicy{Policy: PolicyDeny}
+	}
+	return c
+}
+
+func run(digest string, argv ...string) RunningContainer {
+	return RunningContainer{Digest: digest, Argv: argv}
+}
+
+func TestMatchWorkload(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{
+		"api": {
+			InitContainers: []Container{exactly(t, dInit, "/migrate")},
+			Containers:     []Container{exactly(t, dApp, "/serve"), exactly(t, dSidecar, "/proxy")},
+		},
+	}}
+
+	for _, tc := range []struct {
+		name    string
+		running []RunningContainer
+		want    string
+		wantErr error
+	}{
+		{
+			name:    "every main present",
+			running: []RunningContainer{run(dApp, "/serve"), run(dSidecar, "/proxy")},
+			want:    "api",
+		},
+		{
+			// A declared init container that has not been reaped is not foreign.
+			name:    "lingering init is admitted",
+			running: []RunningContainer{run(dApp, "/serve"), run(dSidecar, "/proxy"), run(dInit, "/migrate")},
+			want:    "api",
+		},
+		{
+			name:    "missing main is refused",
+			running: []RunningContainer{run(dApp, "/serve")},
+			wantErr: ErrNoMatch,
+		},
+		{
+			// The whole point: an extra image, even one that has since stopped,
+			// means this pod is not the entry.
+			name:    "foreign container is refused",
+			running: []RunningContainer{run(dApp, "/serve"), run(dSidecar, "/proxy"), run(dOther, "/sh")},
+			wantErr: ErrNoMatch,
+		},
+		{
+			name:    "wrong argv on a declared digest is refused",
+			running: []RunningContainer{run(dApp, "/bin/sh", "-c", "cat /run/secrets/*"), run(dSidecar, "/proxy")},
+			wantErr: ErrNoMatch,
+		},
+		{
+			name:    "empty running set is refused",
+			running: nil,
+			wantErr: ErrNoMatch,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			name, _, err := al.MatchWorkload(tc.running)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if name != tc.want {
+				t.Fatalf("matched %q, want %q", name, tc.want)
+			}
+		})
+	}
+}
+
+// Two entries that the running set cannot tell apart are refused rather than
+// resolved by iteration order.
+func TestMatchWorkloadAmbiguous(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{
+		"a": {Containers: []Container{exactly(t, dApp, "/serve")}},
+		"b": {Containers: []Container{exactly(t, dApp, "/serve")}},
+	}}
+	if _, _, err := al.MatchWorkload([]RunningContainer{run(dApp, "/serve")}); !errors.Is(err, ErrAmbiguous) {
+		t.Fatalf("err = %v, want ErrAmbiguous", err)
+	}
+}
+
+// Two entries sharing a digest but pinning different argv are distinguishable
+// here, even though Index admits either argv for that digest (a union across
+// entries). That difference is the reason argv is matched per entry.
+func TestMatchWorkloadDistinguishesByArgv(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{
+		"model-a": {Containers: []Container{exactly(t, dApp, "/serve", "--model", "a")}},
+		"model-b": {Containers: []Container{exactly(t, dApp, "/serve", "--model", "b")}},
+	}}
+	name, _, err := al.MatchWorkload([]RunningContainer{run(dApp, "/serve", "--model", "b")})
+	if err != nil || name != "model-b" {
+		t.Fatalf("matched %q (%v), want model-b", name, err)
+	}
+
+	idx := al.BuildIndex()
+	if !idx.AdmitsContainer(dApp, []string{"/serve", "--model", "a"}) {
+		t.Fatal("precondition: Index should admit either argv for the shared digest")
+	}
+}
+
+// A digest declared with an "any" command in one entry does not let that entry
+// swallow a pod whose real workload is another entry.
+func TestMatchWorkloadWideEntryDoesNotStealNarrowPod(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{
+		"prod":  {Containers: []Container{exactly(t, dApp, "/serve"), exactly(t, dSidecar, "/proxy")}},
+		"debug": {Containers: []Container{exactly(t, dApp)}}, // command: any
+	}}
+	// The sidecar is foreign to "debug", so only "prod" matches.
+	name, _, err := al.MatchWorkload([]RunningContainer{run(dApp, "/serve"), run(dSidecar, "/proxy")})
+	if err != nil || name != "prod" {
+		t.Fatalf("matched %q (%v), want prod", name, err)
+	}
+}
+
+func TestMatchWorkloadEmptyAllowlist(t *testing.T) {
+	al := &Allowlist{Schema: Schema}
+	if _, _, err := al.MatchWorkload([]RunningContainer{run(dApp, "/serve")}); !errors.Is(err, ErrNoMatch) {
+		t.Fatalf("err = %v, want ErrNoMatch", err)
+	}
+}
+
+func TestDigestConstantsAreWellFormed(t *testing.T) {
+	for _, d := range []string{dApp, dSidecar, dInit, dOther} {
+		if !strings.HasPrefix(d, "sha256:") || len(d) != len("sha256:")+64 {
+			t.Fatalf("malformed test digest %q", d)
+		}
+	}
+}

--- a/pkg/ratls/tls.go
+++ b/pkg/ratls/tls.go
@@ -65,6 +65,26 @@ type ServerConfig struct {
 	// When nil, the server does not request client certificates.
 	ClientPolicy *VerifyPolicy
 
+	// ClientCAs, when set, has crypto/tls verify a presented client
+	// certificate against these roots, with no RA-TLS branch: a leaf that does
+	// not chain is rejected in the handshake. Mutually exclusive with
+	// ClientPolicy, whose dual verifier accepts a self-signed RA-TLS peer as a
+	// fallback — for a handler that reads a CDS-stamped field out of the leaf
+	// (the sandbox ID), that fallback would let any attested TEE assert an
+	// arbitrary value.
+	//
+	// Pair it with ClientAuth to choose whether a certificate is required.
+	// Because the chain is verified here, r.TLS.VerifiedChains is populated and
+	// a handler need not re-verify.
+	ClientCAs []*x509.Certificate
+
+	// ClientAuth selects how a client certificate is demanded when ClientCAs is
+	// set; it defaults to tls.VerifyClientCertIfGiven, which lets a certless
+	// caller still reach the routes that need no identity while holding any
+	// certificate that IS presented to the ClientCAs roots. Ignored unless
+	// ClientCAs is set.
+	ClientAuth tls.ClientAuthType
+
 	// RotationTimeout is the maximum time allowed for background certificate
 	// rotation. If the attestation binary doesn't respond within this duration,
 	// rotation is aborted and retried on the next handshake past rotateAt.
@@ -436,7 +456,21 @@ func NewServerTLSConfig(cfg *ServerConfig) (*tls.Config, *CertManager, error) {
 
 	// mTLS: require and verify client certificates.
 	var sharedCA *sharedCACerts
-	if cfg.ClientPolicy != nil {
+	switch {
+	case len(cfg.ClientCAs) > 0:
+		if cfg.ClientPolicy != nil {
+			return nil, nil, fmt.Errorf("ratls: ClientCAs and ClientPolicy are mutually exclusive (ClientPolicy admits a self-signed RA-TLS peer, which ClientCAs exists to refuse)")
+		}
+		pool := x509.NewCertPool()
+		for _, c := range cfg.ClientCAs {
+			pool.AddCert(c)
+		}
+		tlsCfg.ClientCAs = pool
+		tlsCfg.ClientAuth = cfg.ClientAuth
+		if tlsCfg.ClientAuth == tls.NoClientCert {
+			tlsCfg.ClientAuth = tls.VerifyClientCertIfGiven
+		}
+	case cfg.ClientPolicy != nil:
 		tlsCfg.ClientAuth = tls.RequireAnyClientCert
 		if len(cfg.CACert) > 0 || cfg.DynamicCACert {
 			sharedCA = newSharedCACerts(cfg.CACert) // empty slice is fine — falls through to RA-TLS

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -144,20 +144,13 @@ type SandboxTokenRequest struct {
 	Nonce []byte `json:"nonce"`
 }
 
-// SandboxDigestsResponse is the SandboxDigestsPrefix answer.
+// SandboxDigestsResponse is the SandboxDigestsPrefix answer. Both fields
+// describe every container ever admitted in the sandbox, not only those running
+// now — see docs/secrets.md, "The report is a high-water mark".
 //
-// Digests is the deduplicated image-digest set, and is what cert issuance gates
-// on (membership). Containers is the per-container detail secret release needs:
-// it is NOT deduplicated, and it carries each container's effective argv, so a
-// consumer can hold a sandbox to a whole workload entry — the same (digest,
-// argv) pair admission evaluated — rather than to a digest set that says nothing
-// about what those images were told to run.
-//
-// Both describe every container ever admitted in the sandbox, not only those
-// running now: a container is removed and recreated across a CrashLoopBackOff,
-// so a live snapshot would let a pod present a set it does not really have by
-// arranging for a container to be absent at the moment it is asked (see
-// docs/secrets.md).
+// Digests is the deduplicated digest set cert issuance gates on. Containers
+// carries each container's effective argv and is not deduplicated, so a consumer
+// can hold a sandbox to the same (digest, argv) pair admission evaluated.
 //
 // Digests is [] (never null) for a known sandbox with no containers. Containers
 // is absent on an inventory that predates it, which consumers must treat as


### PR DESCRIPTION
secret store and policy but not hooked up to anything live

pkg/ratls — ServerConfig.ClientCAs + ClientAuth. Chain verification is done by crypto/tls against the mesh CA with no RA-TLS branch, so a self-signed leaf is refused in the handshake and VerifiedChains is populated for the handler. It's mutually exclusive with ClientPolicy (whose dual verifier admits a self-signed peer as fallback) and returns an error if both are set. Defaults to VerifyClientCertIfGiven, so certless callers on the existing routes are unaffected.

internal/sandboxledger — first-write-wins sandbox→inventory binding, TTL'd and capped. Same host refreshes (a pod renews every 6h and re-presents the same pair, so once-only would refuse a pod its own renewal); a different host conflicts. The doc comment is explicit that a caller must not deny issuance on a conflict — get-cert has no token-less retry, so refusing there would wedge a pod for a full cert lifetime, worse than the theft it prevents.

pkg/allowlist.MatchWorkload — "nothing foreign, every main present", matching argv against the entry's own policies rather than via Index. There's a test that pins exactly why: it asserts Index.AdmitsContainer admits either argv for a shared digest (the union across entries) while MatchWorkload still distinguishes model-a from model-b.

internal/secrets — store (PutIfAbsent CAS, generation above the store, bounded, defensive copies both directions) and the handler: challenge consumed first and unconditionally, verified-chain requirement, token cross-checked against both the cert's sandbox ID and the ledger's host, injected containers dropped on (digest, argv0) not digest alone, ungranted paths 404 rather than 403, 409 with no body on create-conflict.