### PR TITLE
feat(secrets): sidecar that stores secrets as file in pod

### DIFF
--- a/cmd/c8s/get_secret.go
+++ b/cmd/c8s/get_secret.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/getsecret"
+
+func init() {
+	rootCmd.AddCommand(getsecret.NewCmd())
+}

--- a/internal/cmds/getsecret/client_test.go
+++ b/internal/cmds/getsecret/client_test.go
@@ -1,0 +1,237 @@
+package getsecret
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeLeaf stages a certificate and key where the cert sidecar would leave
+// them.
+func writeLeaf(t *testing.T, dir string) (certPath, keyPath string, pub *ecdsa.PublicKey) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "workload"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath = filepath.Join(dir, "tls.crt")
+	keyPath = filepath.Join(dir, "tls.key")
+	write(t, certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	write(t, keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	return certPath, keyPath, &key.PublicKey
+}
+
+func write(t *testing.T, path string, b []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The sandbox token binds to the leaf's key, so newClient must return the key
+// of the certificate it presents — not a fresh one.
+func TestNewClientReturnsLeafKey(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath, want := writeLeaf(t, dir)
+	cfg := validConfig(t)
+	cfg.CertPath, cfg.KeyPath = certPath, keyPath
+
+	client, pub, err := newClient(cfg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client == nil {
+		t.Fatal("no client returned")
+	}
+	got, ok := pub.(*ecdsa.PublicKey)
+	if !ok {
+		t.Fatalf("public key is %T, want *ecdsa.PublicKey", pub)
+	}
+	if !got.Equal(want) {
+		t.Fatal("returned key is not the leaf's")
+	}
+}
+
+// A missing or unreadable leaf is a retryable failure, not a panic: the cert
+// sidecar may not have written it yet.
+func TestNewClientWithoutLeaf(t *testing.T) {
+	for _, tc := range []struct{ name, cert, key string }{
+		{"absent", "nope.crt", "nope.key"},
+		{"garbage", "bad.crt", "bad.key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			cfg := validConfig(t)
+			cfg.CertPath = filepath.Join(dir, tc.cert)
+			cfg.KeyPath = filepath.Join(dir, tc.key)
+			if tc.name == "garbage" {
+				write(t, cfg.CertPath, []byte("not a pem"))
+				write(t, cfg.KeyPath, []byte("not a pem"))
+			}
+			if _, _, err := newClient(cfg, nil); err == nil {
+				t.Fatal("a missing leaf was accepted")
+			}
+		})
+	}
+}
+
+// The provider reloads from disk, so a renewal written by the cert sidecar is
+// picked up without restarting this one.
+func TestLeafProviderReloads(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath, first := writeLeaf(t, dir)
+	p := leafProvider{certPath: certPath, keyPath: keyPath}
+
+	got, ttl, err := p.Provision(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl <= 0 {
+		t.Fatalf("ttl = %v, want positive", ttl)
+	}
+	parsed, _ := x509.ParseCertificate(got.Certificate[0])
+	if !parsed.PublicKey.(*ecdsa.PublicKey).Equal(first) {
+		t.Fatal("first provision returned the wrong key")
+	}
+
+	_, _, second := writeLeaf(t, dir) // renewal lands on the same paths
+	got, _, err = p.Provision(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed, _ = x509.ParseCertificate(got.Certificate[0])
+	if !parsed.PublicKey.(*ecdsa.PublicKey).Equal(second) {
+		t.Fatal("provision did not pick up the renewed leaf")
+	}
+}
+
+func TestFetchChallengeFailures(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"server refuses", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "no", http.StatusServiceUnavailable)
+		}},
+		{"not json", func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte("not json"))
+		}},
+		{"not base64", func(w http.ResponseWriter, _ *http.Request) {
+			w.Write([]byte(`{"challenge":"!!!"}`))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+			cfg := flowConfig(t, srv.URL)
+			if _, err := fetchChallenge(context.Background(), cfg, http.DefaultClient); err == nil {
+				t.Fatal("a bad challenge response was accepted")
+			}
+		})
+	}
+}
+
+// An unreachable CDS is an error, not a hang or a nil value.
+func TestFetchChallengeUnreachable(t *testing.T) {
+	cfg := flowConfig(t, "http://127.0.0.1:1")
+	cfg.RequestTimeout = 200 * time.Millisecond
+	if _, err := fetchChallenge(context.Background(), cfg, http.DefaultClient); err == nil {
+		t.Fatal("an unreachable CDS reported success")
+	}
+}
+
+// A malformed success body must not be mistaken for a secret.
+func TestSecretResponseMustBeDecodable(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"not json", "not json"},
+		{"value not base64", `{"value":"!!!"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			startInventory(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/secrets" {
+					w.Write([]byte(`{"challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`))
+					return
+				}
+				w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+			cfg := flowConfig(t, srv.URL)
+			_, _, err := do(context.Background(), cfg, http.DefaultClient, testKey(t), http.MethodGet, "/api/db")
+			if err == nil {
+				t.Fatal("an undecodable body was accepted as a secret")
+			}
+		})
+	}
+}
+
+// The inventory is where the sandbox token comes from; without it there is no
+// request to make.
+func TestUnreachableInventoryFails(t *testing.T) {
+	prev := inventoryEndpoint
+	inventoryEndpoint = func() string { return "unix://" + filepath.Join(t.TempDir(), "absent.sock") }
+	t.Cleanup(func() { inventoryEndpoint = prev })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`))
+	}))
+	defer srv.Close()
+	cfg := flowConfig(t, srv.URL)
+	_, _, err := do(context.Background(), cfg, http.DefaultClient, testKey(t), http.MethodGet, "/api/db")
+	if err == nil || !strings.Contains(err.Error(), "sandbox token") {
+		t.Fatalf("err = %v, want a sandbox-token failure", err)
+	}
+}
+
+// An unwritable output directory fails loudly rather than reporting success
+// with no file on disk.
+func TestWriteAllUnwritable(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.OutDir = filepath.Join(cfg.OutDir, "readonly", "secrets")
+	if err := os.MkdirAll(filepath.Dir(cfg.OutDir), 0o500); err != nil {
+		t.Fatal(err)
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root, which ignores the directory mode")
+	}
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
+		t.Fatal("an unwritable directory reported success")
+	}
+}
+
+func TestWriteAllRejectsBadMode(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.FileMode = "notamode"
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
+		t.Fatal("a bad file mode was accepted")
+	}
+}

--- a/internal/cmds/getsecret/cmd.go
+++ b/internal/cmds/getsecret/cmd.go
@@ -1,0 +1,57 @@
+package getsecret
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmd returns the cobra subcommand. Registered as a child of `c8s`.
+func NewCmd() *cobra.Command {
+	var (
+		cfg   config
+		specs []string
+	)
+	cmd := &cobra.Command{
+		Use:   "get-secret",
+		Short: "Fetch this pod's secrets from CDS and write them into the pod",
+		Long: `get-secret fetches the secrets a workload is granted and writes each one
+to a file for the pod's other containers to read.
+
+It authenticates with the pod's CDS-issued certificate and a sandbox token
+redeemed from the node's admission inventory, and CDS releases only when the
+containers running in the sandbox match a workload entry holding a grant for
+the requested path. That is only true once every main container is running, so
+early attempts are refused and get-secret retries — the files appear shortly
+after the workload starts, and a consumer must wait for them.
+
+A path the store does not hold yet is created, so the first pod of a workload
+to ask is the one that defines the value. The value is generated inside CDS and
+does not survive a CDS restart; nothing durable may be keyed on it.`,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			for _, spec := range specs {
+				s, err := parseSecretSpec(spec)
+				if err != nil {
+					return err
+				}
+				cfg.Secrets = append(cfg.Secrets, s)
+			}
+			return run(cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cfg.CDSURL, "cds-url", "", "https base URL of CDS")
+	f.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "local attestation-api used to verify CDS's RA-TLS certificate")
+	f.StringSliceVar(&cfg.Measurements, "measurements", nil, "SHA-384 hex launch measurement(s) CDS must present (repeatable; empty pins none, UNSAFE)")
+	f.StringVar(&cfg.CertPath, "cert", "/run/c8s/certs/tls.crt", "the pod's CDS-issued certificate, presented to CDS")
+	f.StringVar(&cfg.KeyPath, "key", "/run/c8s/certs/tls.key", "private key for --cert")
+	f.StringSliceVar(&specs, "secret", nil, "NAME=/store/path to fetch; NAME is the filename written under --out-dir (repeatable)")
+	f.StringVar(&cfg.OutDir, "out-dir", "/run/c8s/secrets", "directory the secret files are written to; must be memory-backed")
+	f.StringVar(&cfg.FileMode, "file-mode", "0640", "octal mode for the written files")
+	f.IntVar(&cfg.Attempts, "attempts", 60, "how many times to try before failing; release is refused until every main container is running, so retries are expected")
+	f.DurationVar(&cfg.RetryInterval, "retry-interval", 5*time.Second, "wait between attempts")
+	f.DurationVar(&cfg.RequestTimeout, "request-timeout", 10*time.Second, "per-request timeout against CDS")
+	f.DurationVar(&cfg.InventoryTimeout, "inventory-timeout", 5*time.Second, "timeout for redeeming a sandbox token from the node's admission inventory")
+	return cmd
+}

--- a/internal/cmds/getsecret/cmd_test.go
+++ b/internal/cmds/getsecret/cmd_test.go
@@ -1,0 +1,74 @@
+package getsecret
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The webhook renders these flags, so a malformed --secret has to fail at parse
+// rather than reaching CDS.
+func TestNewCmdRejectsBadSecretSpec(t *testing.T) {
+	cmd := NewCmd()
+	cmd.SetArgs([]string{
+		"--cds-url=https://cds.example",
+		"--attestation-api-url=http://127.0.0.1:8080",
+		"--secret=notaspec",
+	})
+	cmd.SetOut(nil)
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "NAME=/store/path") {
+		t.Fatalf("err = %v, want a spec-parse failure", err)
+	}
+}
+
+func TestNewCmdRejectsMissingCDSURL(t *testing.T) {
+	cmd := NewCmd()
+	cmd.SetArgs([]string{"--secret=DB=/api/db"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--cds-url") {
+		t.Fatalf("err = %v, want a missing --cds-url failure", err)
+	}
+}
+
+func TestNewCmdDefaults(t *testing.T) {
+	cmd := NewCmd()
+	for flag, want := range map[string]string{
+		"cert":      "/run/c8s/certs/tls.crt",
+		"key":       "/run/c8s/certs/tls.key",
+		"out-dir":   "/run/c8s/secrets",
+		"file-mode": "0640",
+	} {
+		if got := cmd.Flags().Lookup(flag).DefValue; got != want {
+			t.Fatalf("--%s default = %q, want %q", flag, got, want)
+		}
+	}
+}
+
+// A malformed measurement is a typo in rendered config, and pinning nothing is
+// not an acceptable fallback for it.
+func TestRunRejectsBadMeasurements(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.Measurements = []string{"not-hex"}
+	if err := run(cfg); err == nil || !strings.Contains(err.Error(), "--measurements") {
+		t.Fatalf("err = %v, want a measurement-parse failure", err)
+	}
+}
+
+func TestRunRejectsInvalidConfig(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.CDSURL = ""
+	if err := run(cfg); err == nil {
+		t.Fatal("an invalid config was accepted")
+	}
+}
+
+// fetchAll builds the client before it asks for anything, so a leaf that is not
+// on disk yet surfaces there.
+func TestFetchAllWithoutLeaf(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.CertPath = filepath.Join(t.TempDir(), "absent.crt")
+	cfg.KeyPath = filepath.Join(t.TempDir(), "absent.key")
+	if _, err := fetchAll(context.Background(), cfg, nil); err == nil {
+		t.Fatal("a missing leaf was accepted")
+	}
+}

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -1,0 +1,297 @@
+package getsecret
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+const flowSandbox = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// stubResolver is an inventory that vouches for one sandbox. The token route
+// binds its caller by peer credentials, which a unix socket supplies; nothing
+// here needs to disambiguate.
+type stubResolver struct{}
+
+func (stubResolver) SandboxForPeer(workloadclaims.Peer) (string, error) { return flowSandbox, nil }
+func (stubResolver) DigestsForSandbox(string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
+	return nil, nil, false, nil
+}
+
+// startInventory serves the real token route on a unix socket and points the
+// sidecar at it.
+func startInventory(t *testing.T) {
+	t.Helper()
+	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sock := filepath.Join(t.TempDir(), "wc.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	t.Cleanup(func() { cancel(); l.Close() })
+
+	prev := inventoryEndpoint
+	inventoryEndpoint = func() string { return "unix://" + sock }
+	t.Cleanup(func() { inventoryEndpoint = prev })
+}
+
+// fakeCDS records what it was asked and answers from a scripted sequence.
+type fakeCDS struct {
+	mu         sync.Mutex
+	challenges int
+	requests   []string // "METHOD /path"
+	tokens     []string // the Authorization header of each secret request
+	replies    map[string][]reply
+}
+
+type reply struct {
+	status int
+	value  string // raw value; encoded as base64 in the response
+}
+
+func newFakeCDS(t *testing.T, replies map[string][]reply) (*fakeCDS, string) {
+	t.Helper()
+	f := &fakeCDS{replies: replies}
+	srv := httptest.NewServer(f)
+	t.Cleanup(srv.Close)
+	return f, srv.URL
+}
+
+func (f *fakeCDS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if r.Method == http.MethodPost && r.URL.Path == secrets.ChallengeRoute {
+		f.challenges++
+		nonce := make([]byte, 32)
+		rand.Read(nonce)
+		json.NewEncoder(w).Encode(types.ChallengeResponse{Challenge: base64.StdEncoding.EncodeToString(nonce)})
+		return
+	}
+
+	key := r.Method + " " + r.URL.Path
+	f.requests = append(f.requests, key)
+	f.tokens = append(f.tokens, r.Header.Get("Authorization"))
+	if r.Header.Get(secrets.ChallengeHeader) == "" {
+		http.Error(w, "no challenge", http.StatusBadRequest)
+		return
+	}
+
+	queue := f.replies[key]
+	if len(queue) == 0 {
+		http.Error(w, "unscripted", http.StatusTeapot)
+		return
+	}
+	next := queue[0]
+	f.replies[key] = queue[1:]
+	if next.status != http.StatusOK && next.status != http.StatusCreated {
+		w.WriteHeader(next.status)
+		return
+	}
+	w.WriteHeader(next.status)
+	json.NewEncoder(w).Encode(map[string]string{"value": base64.StdEncoding.EncodeToString([]byte(next.value))})
+}
+
+func flowConfig(t *testing.T, url string) config {
+	t.Helper()
+	cfg := validConfig(t)
+	cfg.CDSURL = url
+	return cfg
+}
+
+func testKey(t *testing.T) *ecdsa.PublicKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &k.PublicKey
+}
+
+// An existing secret is read and returned without a create.
+func TestFetchOneReadsExisting(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db": {{status: http.StatusOK, value: "existing"}},
+	})
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "existing" {
+		t.Fatalf("value = %q, want %q", got, "existing")
+	}
+	if len(cds.requests) != 1 || cds.requests[0] != "GET /secrets/api/db" {
+		t.Fatalf("requests = %v, want a single GET", cds.requests)
+	}
+}
+
+// A path the store does not hold yet is created by the workload that finds it
+// empty.
+func TestFetchOneCreatesWhenAbsent(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db":  {{status: http.StatusNotFound}},
+		"POST /secrets/api/db": {{status: http.StatusCreated, value: "minted"}},
+	})
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "minted" {
+		t.Fatalf("value = %q, want %q", got, "minted")
+	}
+	if want := []string{"GET /secrets/api/db", "POST /secrets/api/db"}; !equal(cds.requests, want) {
+		t.Fatalf("requests = %v, want %v", cds.requests, want)
+	}
+}
+
+// The replica that loses the create race is told 409 with no value, and
+// recovers by reading — otherwise it would hold nothing while its sibling holds
+// the secret.
+func TestFetchOneRereadsAfterLosingCreateRace(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db":  {{status: http.StatusNotFound}, {status: http.StatusOK, value: "winner"}},
+		"POST /secrets/api/db": {{status: http.StatusConflict}},
+	})
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "winner" {
+		t.Fatalf("value = %q, want the winning replica's value", got)
+	}
+	want := []string{"GET /secrets/api/db", "POST /secrets/api/db", "GET /secrets/api/db"}
+	if !equal(cds.requests, want) {
+		t.Fatalf("requests = %v, want %v", cds.requests, want)
+	}
+}
+
+// A denial is not a create: only 404 means the path is free.
+func TestFetchOneDoesNotCreateOnDenial(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db": {{status: http.StatusForbidden}},
+	})
+	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db"); err == nil {
+		t.Fatal("a denial was treated as success")
+	}
+	for _, r := range cds.requests {
+		if strings.HasPrefix(r, "POST") {
+			t.Fatalf("a denial triggered a create: %v", cds.requests)
+		}
+	}
+}
+
+// Every request takes its own challenge and its own token: both are single-use,
+// so reusing either would be refused by CDS.
+func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db":  {{status: http.StatusNotFound}, {status: http.StatusOK, value: "v"}},
+		"POST /secrets/api/db": {{status: http.StatusConflict}},
+	})
+	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db"); err != nil {
+		t.Fatal(err)
+	}
+	if cds.challenges != len(cds.requests) {
+		t.Fatalf("%d challenges for %d requests, want one each", cds.challenges, len(cds.requests))
+	}
+	seen := map[string]bool{}
+	for _, tok := range cds.tokens {
+		if tok == "" || !strings.HasPrefix(tok, secrets.AuthScheme) {
+			t.Fatalf("request carried no sandbox token: %q", tok)
+		}
+		if seen[tok] {
+			t.Fatal("a sandbox token was reused across requests")
+		}
+		seen[tok] = true
+	}
+}
+
+// Retries are the normal case — release is refused until every main container
+// is running — so a denial that later clears must succeed rather than fail the
+// pod.
+func TestFetchWithRetryRecoversOnceReleased(t *testing.T) {
+	startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db": {
+			{status: http.StatusForbidden},
+			{status: http.StatusForbidden},
+			{status: http.StatusOK, value: "released"},
+		},
+	})
+	cfg := flowConfig(t, url)
+	cfg.RetryInterval = time.Millisecond
+	cfg.Attempts = 5
+	pub := testKey(t)
+	values, err := fetchWithRetry(context.Background(), cfg, func(ctx context.Context) (map[string][]byte, error) {
+		return fetchAllWith(ctx, cfg, http.DefaultClient, pub)
+	})
+	if err != nil {
+		t.Fatalf("never released: %v", err)
+	}
+	if string(values["DB"]) != "released" {
+		t.Fatalf("value = %q", values["DB"])
+	}
+	if cds.challenges < 3 {
+		t.Fatalf("challenges = %d, want one per attempt", cds.challenges)
+	}
+}
+
+// A bounded run that never gets released fails rather than idling in a Running
+// pod with no secret.
+func TestFetchWithRetryGivesUp(t *testing.T) {
+	startInventory(t)
+	_, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db": {{status: http.StatusForbidden}, {status: http.StatusForbidden}},
+	})
+	cfg := flowConfig(t, url)
+	cfg.RetryInterval = time.Millisecond
+	cfg.Attempts = 2
+	pub := testKey(t)
+	attempts := 0
+	_, err := fetchWithRetry(context.Background(), cfg, func(ctx context.Context) (map[string][]byte, error) {
+		attempts++
+		return fetchAllWith(ctx, cfg, http.DefaultClient, pub)
+	})
+	if err == nil {
+		t.Fatal("a permanently refused release reported success")
+	}
+	if attempts != cfg.Attempts {
+		t.Fatalf("tried %d times, want %d", attempts, cfg.Attempts)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -1,0 +1,402 @@
+// Package getsecret implements the get-secret subcommand: the sidecar that
+// fetches a workload's secrets from CDS and writes them into the pod.
+//
+// It runs as a native sidecar rather than an init container because CDS only
+// releases once every main container is running — release is gated on the whole
+// container set matching a workload entry, and an init container would be
+// asking before its siblings exist (docs/secrets.md). So it starts alongside the
+// workload, retries while the set completes, and writes when it does. The
+// consumer must therefore tolerate the file appearing shortly after it starts.
+package getsecret
+
+import (
+	"context"
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/secrets"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// inventoryEndpoint is where the sandbox token is redeemed. A package variable
+// only so tests can point it at a socket they control; production always uses
+// the compiled path, which is what stops a control-plane value redirecting the
+// redemption to a rogue inventory (docs/getcert-workload-binding.md, Corner 5).
+var inventoryEndpoint = workloadclaims.InventoryEndpoint
+
+// config is everything the sidecar needs. The webhook renders all of it.
+type config struct {
+	CDSURL            string
+	AttestationApiURL string
+	Measurements      []string
+
+	CertPath string
+	KeyPath  string
+
+	Secrets  []secretRequest
+	OutDir   string
+	FileMode string
+
+	Attempts         int
+	RetryInterval    time.Duration
+	RequestTimeout   time.Duration
+	InventoryTimeout time.Duration
+}
+
+// secretRequest is one NAME=/store/path pair: which secret to fetch and what to
+// call the file it lands in.
+type secretRequest struct {
+	Name string
+	Path string
+}
+
+// parseSecretSpec parses a NAME=/store/path pair. The name becomes a filename,
+// so it may not contain a separator.
+func parseSecretSpec(spec string) (secretRequest, error) {
+	name, path, ok := strings.Cut(spec, "=")
+	if !ok {
+		return secretRequest{}, fmt.Errorf("secret %q must be NAME=/store/path", spec)
+	}
+	name = strings.TrimSpace(name)
+	if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return secretRequest{}, fmt.Errorf("secret name %q must be non-empty and not a path", name)
+	}
+	// Canonicalised with the same code CDS matches grants against, so a path
+	// this sidecar accepts is one the server can answer for.
+	canonical, err := pkgallowlist.CanonicalSecretPath(strings.TrimSpace(path))
+	if err != nil {
+		return secretRequest{}, fmt.Errorf("secret %q: %w", name, err)
+	}
+	return secretRequest{Name: name, Path: canonical}, nil
+}
+
+func run(cfg config) error {
+	if err := validate(&cfg); err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	measurements, err := ratls.ParseHexMeasurementsList(cfg.Measurements)
+	if err != nil {
+		return fmt.Errorf("--measurements: %w", err)
+	}
+	if len(measurements) == 0 {
+		slog.Warn("--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development.")
+	}
+
+	values, err := fetchWithRetry(ctx, cfg, func(ctx context.Context) (map[string][]byte, error) {
+		return fetchAll(ctx, cfg, measurements)
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeAll(cfg, values); err != nil {
+		return err
+	}
+	slog.Info("secrets written", "count", len(values), "dir", cfg.OutDir)
+
+	// A native sidecar that exits is restarted by the kubelet for the pod's
+	// life, re-running the whole release check each time. Idling until the pod
+	// is torn down leaves its status reflecting the workload rather than this
+	// sidecar.
+	<-ctx.Done()
+	return nil
+}
+
+// fetchWithRetry gets every requested secret, retrying the whole set.
+//
+// Retrying is expected, not exceptional: until every main container is running
+// the sandbox does not match its workload entry, so early attempts are denied
+// by design. The bound turns a genuinely stuck release into a visible failure
+// instead of an idle sidecar in a Running pod.
+func fetchWithRetry(ctx context.Context, cfg config, fetch func(context.Context) (map[string][]byte, error)) (map[string][]byte, error) {
+	var lastErr error
+	for attempt := 1; attempt <= cfg.Attempts; attempt++ {
+		values, err := fetch(ctx)
+		if err == nil {
+			return values, nil
+		}
+		lastErr = err
+		if attempt == cfg.Attempts {
+			break
+		}
+		slog.Info("secret not released yet; retrying",
+			"attempt", attempt, "of", cfg.Attempts, "retry_in", cfg.RetryInterval, "error", err)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(cfg.RetryInterval):
+		}
+	}
+	return nil, fmt.Errorf("giving up after %d attempts: %w", cfg.Attempts, lastErr)
+}
+
+// fetchAll gets every secret in one pass. All-or-nothing: a partial set is not
+// written, so a consumer never sees some of its secrets and waits forever for
+// the rest.
+func fetchAll(ctx context.Context, cfg config, measurements [][]byte) (map[string][]byte, error) {
+	client, pub, err := newClient(cfg, measurements)
+	if err != nil {
+		return nil, err
+	}
+	return fetchAllWith(ctx, cfg, client, pub)
+}
+
+// fetchAllWith is fetchAll once the client and the key it is bound to exist.
+func fetchAllWith(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(cfg.Secrets))
+	for _, s := range cfg.Secrets {
+		value, err := fetchOne(ctx, cfg, client, pub, s.Path)
+		if err != nil {
+			return nil, fmt.Errorf("secret %s: %w", s.Path, err)
+		}
+		out[s.Name] = value
+	}
+	return out, nil
+}
+
+// fetchOne reads a secret, creating it if the store holds nothing yet.
+//
+// A workload that starts and finds its path empty is the one that creates it,
+// so 404 means "create". A 409 on that create means another replica won the
+// race, and the value is read back rather than returned by the create.
+func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, path string) ([]byte, error) {
+	value, status, err := do(ctx, cfg, client, pub, http.MethodGet, path)
+	switch {
+	case err != nil && status != http.StatusNotFound:
+		return nil, err
+	case status == http.StatusOK:
+		return value, nil
+	}
+
+	value, status, err = do(ctx, cfg, client, pub, http.MethodPost, path)
+	switch {
+	case status == http.StatusCreated:
+		return value, nil
+	case status != http.StatusConflict:
+		return nil, err
+	}
+
+	value, status, err = do(ctx, cfg, client, pub, http.MethodGet, path)
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("created by another replica but not readable: %w", err)
+	}
+	return value, nil
+}
+
+// do performs one secret request: a fresh challenge, a sandbox token bound to
+// it and to this pod's leaf key, then the request itself. Both are single-use,
+// so every call takes its own.
+func do(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, method, path string) ([]byte, int, error) {
+	challenge, err := fetchChallenge(ctx, cfg, client)
+	if err != nil {
+		return nil, 0, err
+	}
+	token, err := workloadclaims.FetchSandboxToken(ctx, inventoryEndpoint(), cfg.InventoryTimeout, pub, challenge)
+	if err != nil {
+		return nil, 0, fmt.Errorf("redeem sandbox token: %w", err)
+	}
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, method, cfg.CDSURL+"/secrets"+path, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set(secrets.ChallengeHeader, base64.StdEncoding.EncodeToString(challenge))
+	req.Header.Set("Authorization", secrets.AuthScheme+base64.StdEncoding.EncodeToString(tokenJSON))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		var body struct {
+			Value string `json:"value"`
+		}
+		if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+			return nil, resp.StatusCode, fmt.Errorf("decode secret response: %w", err)
+		}
+		value, err := base64.StdEncoding.DecodeString(body.Value)
+		if err != nil {
+			return nil, resp.StatusCode, fmt.Errorf("secret value is not base64: %w", err)
+		}
+		return value, resp.StatusCode, nil
+	default:
+		// The body is deliberately opaque; the reason is in the CDS log.
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, resp.StatusCode, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(detail)))
+	}
+}
+
+func fetchChallenge(ctx context.Context, cfg config, client *http.Client) ([]byte, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, cfg.CDSURL+secrets.ChallengeRoute, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch challenge: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch challenge: %s", resp.Status)
+	}
+	var out types.ChallengeResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<16)).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode challenge: %w", err)
+	}
+	challenge, err := base64.StdEncoding.DecodeString(out.Challenge)
+	if err != nil {
+		return nil, fmt.Errorf("challenge is not base64: %w", err)
+	}
+	return challenge, nil
+}
+
+// leafProvider presents the pod's CDS-issued leaf as the client certificate.
+// It reloads from disk on each provision, so a renewal written by the cert
+// sidecar is picked up without restarting this one.
+type leafProvider struct{ certPath, keyPath string }
+
+func (p leafProvider) Provision(context.Context) (*tls.Certificate, time.Duration, error) {
+	cert, err := tls.LoadX509KeyPair(p.certPath, p.keyPath)
+	if err != nil {
+		return nil, 0, fmt.Errorf("load leaf %s: %w", p.certPath, err)
+	}
+	return &cert, time.Hour, nil
+}
+
+// newClient builds the mTLS client to CDS and returns the leaf's public key,
+// which the sandbox token is bound to.
+func newClient(cfg config, measurements [][]byte) (*http.Client, crypto.PublicKey, error) {
+	provider := leafProvider{certPath: cfg.CertPath, keyPath: cfg.KeyPath}
+	leaf, _, err := provider.Provision(context.Background())
+	if err != nil {
+		return nil, nil, err
+	}
+	parsed, err := x509.ParseCertificate(leaf.Certificate[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse leaf: %w", err)
+	}
+	tlsCfg, _, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
+		Policy:       &ratls.VerifyPolicy{Measurements: measurements, AttestationApiURL: cfg.AttestationApiURL},
+		CertProvider: provider,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("build CDS client: %w", err)
+	}
+	return &http.Client{
+		Timeout:   cfg.RequestTimeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}, parsed.PublicKey, nil
+}
+
+// writeAll writes every value, then verifies nothing was left behind. Each
+// write is atomic (temp file then rename) so a consumer polling for the file
+// never reads a torn one.
+func writeAll(cfg config, values map[string][]byte) error {
+	mode, err := parseFileMode(cfg.FileMode)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cfg.OutDir, 0o750); err != nil {
+		return fmt.Errorf("create %s: %w", cfg.OutDir, err)
+	}
+	for name, value := range values {
+		dest := filepath.Join(cfg.OutDir, name)
+		tmp, err := os.CreateTemp(cfg.OutDir, "."+name+".*")
+		if err != nil {
+			return fmt.Errorf("create temp for %s: %w", dest, err)
+		}
+		if err := writeAndClose(tmp, value, mode); err != nil {
+			os.Remove(tmp.Name())
+			return fmt.Errorf("write %s: %w", dest, err)
+		}
+		if err := os.Rename(tmp.Name(), dest); err != nil {
+			os.Remove(tmp.Name())
+			return fmt.Errorf("rename into %s: %w", dest, err)
+		}
+	}
+	return nil
+}
+
+func writeAndClose(f *os.File, value []byte, mode os.FileMode) error {
+	// Chmod before the content lands, so the value is never briefly readable
+	// under the temp file's default mode.
+	if err := f.Chmod(mode); err != nil {
+		f.Close()
+		return err
+	}
+	if _, err := f.Write(value); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+func parseFileMode(s string) (os.FileMode, error) {
+	var mode uint32
+	if _, err := fmt.Sscanf(s, "%o", &mode); err != nil || mode == 0 || mode > 0o777 {
+		return 0, fmt.Errorf("--file-mode %q must be an octal file mode like 0640", s)
+	}
+	return os.FileMode(mode), nil
+}
+
+func validate(cfg *config) error {
+	if cfg.CDSURL == "" {
+		return fmt.Errorf("--cds-url is required")
+	}
+	cfg.CDSURL = strings.TrimRight(cfg.CDSURL, "/")
+	if !strings.HasPrefix(cfg.CDSURL, "https://") {
+		return fmt.Errorf("--cds-url must be https (RA-TLS)")
+	}
+	if cfg.AttestationApiURL == "" {
+		return fmt.Errorf("--attestation-api-url is required to verify CDS")
+	}
+	if len(cfg.Secrets) == 0 {
+		return fmt.Errorf("at least one --secret NAME=/store/path is required")
+	}
+	seen := map[string]bool{}
+	for _, s := range cfg.Secrets {
+		if seen[s.Name] {
+			return fmt.Errorf("--secret name %q is repeated; each names a distinct file", s.Name)
+		}
+		seen[s.Name] = true
+	}
+	if cfg.Attempts <= 0 {
+		return fmt.Errorf("--attempts must be positive")
+	}
+	if cfg.RetryInterval <= 0 || cfg.RequestTimeout <= 0 || cfg.InventoryTimeout <= 0 {
+		return fmt.Errorf("--retry-interval, --request-timeout and --inventory-timeout must be positive")
+	}
+	if _, err := parseFileMode(cfg.FileMode); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cmds/getsecret/run_test.go
+++ b/internal/cmds/getsecret/run_test.go
@@ -1,0 +1,222 @@
+package getsecret
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSecretSpec(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		spec     string
+		wantName string
+		wantPath string
+		wantErr  bool
+	}{
+		{name: "simple", spec: "DB=/api/db", wantName: "DB", wantPath: "/api/db"},
+		{name: "spaces are trimmed", spec: " DB = /api/db ", wantName: "DB", wantPath: "/api/db"},
+		{name: "nested path", spec: "K=/a/b/c", wantName: "K", wantPath: "/a/b/c"},
+		{name: "no separator", spec: "/api/db", wantErr: true},
+		{name: "empty name", spec: "=/api/db", wantErr: true},
+		// The name becomes a filename, so anything path-shaped is refused
+		// rather than resolved.
+		{name: "name is a path", spec: "a/b=/api/db", wantErr: true},
+		{name: "name escapes the dir", spec: "..=/api/db", wantErr: true},
+		{name: "relative store path", spec: "DB=api/db", wantErr: true},
+		{name: "unclean store path", spec: "DB=/api/../etc", wantErr: true},
+		{name: "wildcard store path", spec: "DB=/api/**", wantErr: true},
+		{name: "percent-encoded store path", spec: "DB=/api%2Fdb", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSecretSpec(tc.spec)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseSecretSpec(%q) = %+v, want an error", tc.spec, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseSecretSpec(%q): %v", tc.spec, err)
+			}
+			if got.Name != tc.wantName || got.Path != tc.wantPath {
+				t.Fatalf("parseSecretSpec(%q) = %+v, want {%s %s}", tc.spec, got, tc.wantName, tc.wantPath)
+			}
+		})
+	}
+}
+
+func validConfig(t *testing.T) config {
+	t.Helper()
+	return config{
+		CDSURL:            "https://cds.example",
+		AttestationApiURL: "http://127.0.0.1:8080",
+		Secrets:           []secretRequest{{Name: "DB", Path: "/api/db"}},
+		OutDir:            t.TempDir(),
+		FileMode:          "0640",
+		Attempts:          3,
+		RetryInterval:     time.Second,
+		RequestTimeout:    time.Second,
+		InventoryTimeout:  time.Second,
+	}
+}
+
+func TestValidate(t *testing.T) {
+	if err := validate(ptr(validConfig(t))); err != nil {
+		t.Fatalf("a valid config was refused: %v", err)
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*config)
+		want   string
+	}{
+		{"no cds url", func(c *config) { c.CDSURL = "" }, "--cds-url"},
+		{"plaintext cds url", func(c *config) { c.CDSURL = "http://cds.example" }, "https"},
+		{"no attestation api", func(c *config) { c.AttestationApiURL = "" }, "--attestation-api-url"},
+		{"no secrets", func(c *config) { c.Secrets = nil }, "--secret"},
+		{"zero attempts", func(c *config) { c.Attempts = 0 }, "--attempts"},
+		{"zero retry interval", func(c *config) { c.RetryInterval = 0 }, "--retry-interval"},
+		{"bad file mode", func(c *config) { c.FileMode = "rw-r-----" }, "--file-mode"},
+		{"file mode out of range", func(c *config) { c.FileMode = "7777" }, "--file-mode"},
+		{
+			"repeated secret name",
+			func(c *config) {
+				c.Secrets = append(c.Secrets, secretRequest{Name: "DB", Path: "/api/other"})
+			},
+			"repeated",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := validConfig(t)
+			tc.mutate(&cfg)
+			err := validate(&cfg)
+			if err == nil {
+				t.Fatal("expected an error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A trailing slash on --cds-url must not produce a double slash in the request
+// path, which the server would reject as non-canonical.
+func TestValidateTrimsURL(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.CDSURL = "https://cds.example/"
+	if err := validate(&cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.CDSURL != "https://cds.example" {
+		t.Fatalf("CDSURL = %q, want the trailing slash trimmed", cfg.CDSURL)
+	}
+}
+
+func TestWriteAll(t *testing.T) {
+	cfg := validConfig(t)
+	values := map[string][]byte{
+		"DB":    []byte("s3cret"),
+		"OTHER": {0x00, 0xff, '\n', '"'}, // raw bytes, not text
+	}
+	if err := writeAll(cfg, values); err != nil {
+		t.Fatal(err)
+	}
+	for name, want := range values {
+		path := filepath.Join(cfg.OutDir, name)
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("%s = %q, want %q", name, got, want)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o640 {
+			t.Fatalf("%s mode = %o, want 640", name, info.Mode().Perm())
+		}
+	}
+}
+
+// Nothing is left behind by the atomic write: a consumer polling the directory
+// must not find a temp file and mistake it for its secret.
+func TestWriteAllLeavesNoTempFiles(t *testing.T) {
+	cfg := validConfig(t)
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(cfg.OutDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "DB" {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("directory holds %v, want just [DB]", names)
+	}
+}
+
+// Rewriting is how a renewal or a re-fetch lands, so it must replace rather
+// than fail or append.
+func TestWriteAllOverwrites(t *testing.T) {
+	cfg := validConfig(t)
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("first")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("second")}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(cfg.OutDir, "DB"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "second" {
+		t.Fatalf("value = %q, want the rewritten one", got)
+	}
+}
+
+func TestWriteAllCreatesDir(t *testing.T) {
+	cfg := validConfig(t)
+	cfg.OutDir = filepath.Join(cfg.OutDir, "nested", "secrets")
+	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(cfg.OutDir, "DB")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseFileMode(t *testing.T) {
+	for _, tc := range []struct {
+		in      string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{in: "0640", want: 0o640},
+		{in: "640", want: 0o640},
+		{in: "0400", want: 0o400},
+		{in: "0", wantErr: true},
+		{in: "1000", wantErr: true},
+		{in: "notamode", wantErr: true},
+	} {
+		got, err := parseFileMode(tc.in)
+		if tc.wantErr {
+			if err == nil {
+				t.Fatalf("parseFileMode(%q) = %o, want an error", tc.in, got)
+			}
+			continue
+		}
+		if err != nil || got != tc.want {
+			t.Fatalf("parseFileMode(%q) = %o, %v; want %o", tc.in, got, err, tc.want)
+		}
+	}
+}
+
+func ptr(c config) *config { return &c }

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -30,10 +30,14 @@ const Route = "/secrets/*"
 // match, so no store path is shadowed by it.
 const ChallengeRoute = "/secrets"
 
-// authScheme prefixes the sandbox token in the Authorization header. The token
-// travels in a header rather than the URL so it is covered by the server's
-// header bound and never reaches a request log.
-const authScheme = "SandboxToken "
+// AuthScheme prefixes the sandbox token in the Authorization header, and
+// ChallengeHeader carries the nonce. The token travels in a header rather than
+// the URL so it is covered by the server's header bound and never reaches a
+// request log.
+const (
+	AuthScheme      = "SandboxToken "
+	ChallengeHeader = "X-C8s-Challenge"
+)
 
 // InjectedEntrypoints are the argv[0] values the admission webhook injects the
 // c8s image with: get-cert for the cert sidecar, /c8s for the probe-file gate,
@@ -227,7 +231,7 @@ func (h Handler) consumeChallenge(r *http.Request) ([]byte, error) {
 	if h.Challenges == nil {
 		return nil, fmt.Errorf("no challenge store configured")
 	}
-	raw := r.Header.Get("X-C8s-Challenge")
+	raw := r.Header.Get(ChallengeHeader)
 	if raw == "" {
 		return nil, fmt.Errorf("missing challenge")
 	}
@@ -298,7 +302,7 @@ func verifiedLeaf(r *http.Request) (*x509.Certificate, error) {
 }
 
 func (h Handler) parseToken(r *http.Request) (*workloadclaims.SignedSandboxToken, error) {
-	raw, ok := strings.CutPrefix(r.Header.Get("Authorization"), authScheme)
+	raw, ok := strings.CutPrefix(r.Header.Get("Authorization"), AuthScheme)
 	if !ok || raw == "" {
 		return nil, fmt.Errorf("missing sandbox token")
 	}

--- a/internal/secrets/handler_errors_test.go
+++ b/internal/secrets/handler_errors_test.go
@@ -80,9 +80,9 @@ func TestTokenHeaderRejections(t *testing.T) {
 	}{
 		{"missing", ""},
 		{"wrong scheme", "Bearer " + base64.StdEncoding.EncodeToString([]byte(`{"token":"","signature":""}`))},
-		{"not base64", authScheme + "!!!"},
-		{"not json", authScheme + base64.StdEncoding.EncodeToString([]byte("not json"))},
-		{"unknown field", authScheme + base64.StdEncoding.EncodeToString([]byte(`{"token":"AA==","signature":"AA==","extra":1}`))},
+		{"not base64", AuthScheme + "!!!"},
+		{"not json", AuthScheme + base64.StdEncoding.EncodeToString([]byte("not json"))},
+		{"unknown field", AuthScheme + base64.StdEncoding.EncodeToString([]byte(`{"token":"AA==","signature":"AA==","extra":1}`))},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			hn := newHarness(t)

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -205,7 +205,7 @@ func (hn *harness) requestWith(t *testing.T, method, path string, leaf *x509.Cer
 
 	r := httptest.NewRequest(method, "/secrets"+path, nil)
 	r.Header.Set("X-C8s-Challenge", base64.StdEncoding.EncodeToString(nonce))
-	r.Header.Set("Authorization", authScheme+base64.StdEncoding.EncodeToString(body))
+	r.Header.Set("Authorization", AuthScheme+base64.StdEncoding.EncodeToString(body))
 	r.TLS = &tls.ConnectionState{
 		PeerCertificates: []*x509.Certificate{leaf},
 		VerifiedChains:   [][]*x509.Certificate{{leaf}},


### PR DESCRIPTION
Native sidecar. Per secret: fetch a challenge → redeem a sandbox token from the node's inventory bound to that challenge and the pod's leaf key → request with mTLS. 404 means the path is free, so it creates; 409 means another replica won the race, so it re-reads. Every request takes its own challenge and its own token, since both are single-use.

Values are written all-or-nothing to --out-dir, atomically (temp + rename, chmod before content lands) so a consumer polling for the file never sees a torn or half-populated set. On success it idles rather than exiting — a native sidecar that exits gets restarted for the pod's life, re-running the whole release check each time.

Design decisions worth flagging

Retries are the normal path, not error handling. Release is refused until every main container is running, so early denials are expected. Default is 60 attempts at 5s. The bound is what turns a genuinely stuck release into a visible failure instead of an idle sidecar in a Running pod.

The inventory endpoint stays compiled. I made it a package var so tests can point at a socket they control, following the dialPort/listenPort precedent in digests.go — but deliberately not a flag, since a control-plane-settable value would let the redemption be redirected to a rogue inventory (getcert-workload-binding.md Corner 5).

Two small changes outside the package: secrets.AuthScheme and secrets.ChallengeHeader are now exported so client and server can't drift on the header contract, and CanonicalSecretPath is reused for --secret parsing so a path the sidecar accepts is one CDS can answer for.

The tests use the real token route over a unix socket rather than faking it, so the token construction is exercised end to end. Notable assertions: a denial doesn't trigger a create (only 404 does), tokens are never reused across requests, and the provider picks up a renewed leaf without a restart.