### PR TITLE
feat(secrets): injection annotations

### DIFF
--- a/cmd/c8s/operator.go
+++ b/cmd/c8s/operator.go
@@ -41,6 +41,7 @@ by this command.`,
 			GetCertImage:            getCertImage,
 			CDSURL:                  cdsURL,
 			AttestationApiURL:       attestationApiURL,
+			CDSMeasurements:         cdsMeasurements,
 			ExcludeNamespaces:       excludeNamespaces,
 			WebhookConfigName:       webhookConfigName,
 			WebhookServiceName:      webhookServiceName,
@@ -68,6 +69,7 @@ var (
 	getCertImage            string
 	cdsURL                  string
 	attestationApiURL       string
+	cdsMeasurements         []string
 	webhookConfigName       string
 	webhookServiceName      string
 	webhookServiceNamespace string
@@ -94,6 +96,7 @@ func init() {
 	operatorCmd.Flags().StringVar(&getCertImage, "get-cert-image", "", "image reference the admission webhook injects for get-cert containers (empty = webhook disabled)")
 	operatorCmd.Flags().StringVar(&cdsURL, "cds-url", "", "CDS Service URL the injected get-cert containers POST to")
 	operatorCmd.Flags().StringVar(&attestationApiURL, "attestation-api-url", "", "attestation-api endpoint (empty = no verification)")
+	operatorCmd.Flags().StringSliceVar(&cdsMeasurements, "cds-measurements", nil, "SHA-384 hex launch measurement(s) the injected secret fetcher requires CDS to present (repeatable; empty pins none)")
 	operatorCmd.Flags().StringSliceVar(&excludeNamespaces, "exclude-namespaces", nil, "extra namespaces the startup reinject sweep skips (mirrors webhook.extraExcluded)")
 	operatorCmd.Flags().StringVar(&webhookConfigName, "webhook-config-name", "", "MutatingWebhookConfiguration to patch caBundle (empty = skip)")
 	operatorCmd.Flags().StringVar(&webhookServiceName, "webhook-service-name", "", "webhook Service name (defaults to c8s)")

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -3,9 +3,9 @@
 How a workload is authorized to read a secret, and what the allowlist and the
 admission inventory contribute to that decision.
 
-> **Status.** Nothing fetches from the endpoint yet — the injected fetcher and
-> its webhook wiring are not implemented, so a workload today must call the API
-> itself.
+> **Status.** Delivery works end to end. Still missing: an operator diagnostic
+> for a denied release (`c8s secrets explain`) and the lint checks that catch an
+> ambiguous or under-declared entry.
 
 ## When it is served
 
@@ -34,10 +34,54 @@ measurement requirement above is unmeetable there. Two other reasons stand
 independently: the kata sandbox ID comes from a host-written CRI annotation, and
 argv enforcement in the guest is watch-and-kill rather than synchronous.
 
+## Asking for a secret
+
+Annotate the pod alongside `confidential.ai/cw`:
+
+| Annotation | |
+|---|---|
+| `confidential.ai/c8s-secrets` | comma-separated `NAME=/store/path`; `NAME` is the file each value is written to |
+| `confidential.ai/c8s-secret-dir` | where the files land; default `/run/c8s/secrets` |
+
+```yaml
+annotations:
+  confidential.ai/cw: api
+  confidential.ai/c8s-secrets: "DB=/tenant-a/db,HF=/tenant-a/hf-token"
+```
+
+The webhook injects a `c8s-secret` sidecar and a memory-backed volume. Every
+container in the pod mounts that volume **read-only**; only the fetcher may
+write it. The volume and the container name are reserved — a pod declaring
+either is rejected, since a `hostPath` there would write a released secret to
+host-visible storage, and an ephemeral container mounting it would read one out
+of a running pod.
+
+### The file appears after your container starts
+
+This is the part to design around. CDS releases only once **every** main
+container is running, because that is when the sandbox matches a whole workload
+entry. The fetcher therefore starts alongside the workload, is refused while the
+set is incomplete, and writes when it completes. A consumer must wait for its
+file rather than read it at startup:
+
+```sh
+until [ -f /run/c8s/secrets/DB ]; do sleep 1; done
+```
+
+Nothing can remove this. An init container would be asking before its siblings
+exist and would deadlock the pod it gates. The consequence is that a terminal
+fetch failure leaves a `Running` pod with no secret and an
+`Init:CrashLoopBackOff` sub-status — there is no fail-closed delivery gate to be
+had under combination gating.
+
+A workload that finds its path empty creates it, so the first pod of a workload
+to ask defines the value.
+
 ## The API
 
-Every request needs a single-use challenge and a fresh sandbox token, so a
-release is bound to one caller and cannot be replayed.
+The injected fetcher speaks this; a workload does not have to. Every request
+needs a single-use challenge and a fresh sandbox token, so a release is bound to
+one caller and cannot be replayed.
 
 ```
 POST /secrets                      → {"challenge": "<base64>"}
@@ -221,7 +265,7 @@ reports this. A partially-rolled Deployment ends up with two different values
 for one path.
 
 So after a CDS restart, restart every secret-consuming workload rather than
-letting them recover piecemeal. Treat a released value as ephemeral for the
+letting them recover piecemeal — a rolling restart of each Deployment. Treat a released value as ephemeral for the
 lifetime of the CDS process; nothing durable may be keyed on one.
 
 The sandbox ledger is process memory too, so a leaf that outlives a restart has

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -55,6 +55,10 @@ type Options struct {
 	// AttestationApiURL points at the attestation-api.
 	AttestationApiURL string
 
+	// CDSMeasurements are the launch measurements the injected secret fetcher
+	// requires CDS to present. Empty pins none.
+	CDSMeasurements []string
+
 	// WebhookConfigName is the MutatingWebhookConfiguration to patch.
 	WebhookConfigName string
 
@@ -234,6 +238,7 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 			GetCertImage:          opts.GetCertImage,
 			CDSURL:                opts.CDSURL,
 			AttestationApiURL:     opts.AttestationApiURL,
+			CDSMeasurements:       opts.CDSMeasurements,
 			CertFSGroup:           int64Ptr(opts.CertFSGroup),
 			CertKeyMode:           opts.CertKeyMode,
 			CertRenewInterval:     opts.CertRenewInterval,

--- a/internal/helmchart/c8s/templates/operator.yaml
+++ b/internal/helmchart/c8s/templates/operator.yaml
@@ -51,6 +51,12 @@ spec:
             - --webhook-service-name={{ include "c8s.operatorName" . }}
             - --webhook-service-namespace={{ .Release.Namespace }}
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
+            {{- /* The same measurements CDS is pinned to elsewhere: the
+                   injected secret fetcher verifies CDS before handing it a
+                   sandbox token and taking a value back. */}}
+            {{- range .Values.cds.measurements }}
+            - --cds-measurements={{ . }}
+            {{- end }}
             {{- range .Values.webhook.extraExcluded }}
             - --exclude-namespaces={{ . }}
             {{- end }}

--- a/internal/helmchart/c8s/templates/webhook.yaml
+++ b/internal/helmchart/c8s/templates/webhook.yaml
@@ -44,6 +44,15 @@ webhooks:
         apiVersions: [v1]
         resources: [pods]
         scope: Namespaced
+      # Ephemeral containers attach to a running pod and are stripped from a
+      # CREATE, so they are only visible on this subresource. Without it,
+      # `kubectl debug` could mount the volume holding a released secret or the
+      # pod's private key and read it out (docs/secrets.md).
+      - operations: [UPDATE]
+        apiGroups: [""]
+        apiVersions: [v1]
+        resources: [pods/ephemeralcontainers]
+        scope: Namespaced
     clientConfig:
       service:
         namespace: {{ .Release.Namespace }}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -6115,3 +6115,36 @@ func TestAttestationApiSeccomp(t *testing.T) {
 		t.Fatalf("attestation-api must set seccompProfile.type: RuntimeDefault; got %+v", sc.SeccompProfile)
 	}
 }
+
+// The injected secret fetcher verifies CDS before handing it a sandbox token
+// and taking a value back, so cds.measurements has to reach the operator that
+// renders the fetcher's args. Each hop is unit-tested; this asserts the chart
+// end of the chain, which nothing else covers.
+func TestChartOperatorCarriesCDSMeasurementsForSecretFetcher(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set-string", "cds.measurements[0]=aa11",
+		"--set-string", "cds.measurements[1]=bb22",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	args := strings.Join(renderedDeploymentContainer(t, out, "c8s-operator", "operator").Args, " ")
+	for _, want := range []string{"--cds-measurements=aa11", "--cds-measurements=bb22"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("operator args missing %q; the fetcher would pin no measurement and accept any CDS: %s", want, args)
+		}
+	}
+}
+
+// With no measurements configured the flag is absent rather than empty, so the
+// fetcher falls back to its own unpinned warning instead of parsing "".
+func TestChartOperatorOmitsCDSMeasurementsWhenUnset(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	args := strings.Join(renderedDeploymentContainer(t, out, "c8s-operator", "operator").Args, " ")
+	if strings.Contains(args, "--cds-measurements") {
+		t.Errorf("operator carries --cds-measurements with none configured: %s", args)
+	}
+}

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -73,6 +74,13 @@ const (
 	AnnotationGetCertRunAsGroup      = "confidential.ai/c8s-get-cert-run-as-group"
 	AnnotationGetCertRunAsNonRoot    = "confidential.ai/c8s-get-cert-run-as-non-root"
 	AnnotationGetCertVerbose         = "confidential.ai/c8s-get-cert-verbose"
+
+	// AnnotationSecrets requests secrets for the pod, as a comma-separated
+	// list of NAME=/store/path. NAME is the file each value is written to
+	// under AnnotationSecretDir. Setting it injects the fetcher sidecar.
+	AnnotationSecrets = "confidential.ai/c8s-secrets"
+	// AnnotationSecretDir overrides where the files land.
+	AnnotationSecretDir = "confidential.ai/c8s-secret-dir"
 )
 
 var errInvalidInjectionAnnotation = errors.New("invalid c8s injection annotation")
@@ -94,6 +102,27 @@ const discoveryPublicTLSModeWebPKI = "webpki"
 // webhook rebuilds the sidecar every call (injectInitContainers) and rejects
 // the name in the regular/ephemeral lists (rejectReservedCertContainer); the
 // cw-label-integrity VAP enforces its presence in the API server.
+// reservedSecretContainerName is the injected secret fetcher. Reserved like
+// the cert containers: a pod that declared the name itself would have the
+// webhook's container silently replace or collide with it.
+const reservedSecretContainerName = "c8s-secret"
+
+// defaultCertVolumeName is the injected cert volume when a pod does not name
+// its own with AnnotationCertVolume.
+const defaultCertVolumeName = "c8s-certs"
+
+// secretsVolumeName is the memory-backed volume the fetcher writes to and the
+// workload reads from.
+const secretsVolumeName = "c8s-secrets"
+
+// defaultSecretDir is where the fetcher writes, matching its own default.
+const defaultSecretDir = "/run/c8s/secrets"
+
+// secretsVolumeSizeLimit bounds the tmpfs. It is charged to the pod's memory
+// (the guest's, under kata), so an unbounded one would let a workload's own
+// writes into the shared directory pressure the pod rather than fail.
+const secretsVolumeSizeLimit = "1Mi"
+
 const reservedCertContainerName = "c8s-cert"
 
 // reservedCertWaitContainerName is the injected gate init container that blocks
@@ -144,6 +173,11 @@ type Config struct {
 
 	// AttestationApiURL points at the node-local attestation-api.
 	AttestationApiURL string
+
+	// CDSMeasurements are the launch measurements the secret fetcher requires
+	// CDS to present. Empty pins none, which leaves an impostor CDS able to
+	// answer with a value of its choosing.
+	CDSMeasurements []string
 
 	// CertDir is the mount path for the shared cert volume.
 	CertDir string
@@ -222,7 +256,15 @@ type injection struct {
 	Reload    reloadSpec
 	Discovery discoverySpec
 	Security  getCertSecuritySpec
+	Secrets   secretsSpec
 	Verbose   bool
+}
+
+// secretsSpec is the pod's secret request: which secrets, and where the files
+// land. Empty Specs means no fetcher is injected.
+type secretsSpec struct {
+	Specs []string
+	Dir   string
 }
 
 type certSpec struct {
@@ -278,6 +320,10 @@ func parseAnnotations(pod *corev1.Pod) (*injection, error) {
 		Reload: reloadSpec{
 			WatchVolume:    annotations[AnnotationReloadWatchVolume],
 			WatchMountPath: annotations[AnnotationReloadWatchMountPath],
+		},
+		Secrets: secretsSpec{
+			Specs: listAnnotation(annotations, AnnotationSecrets),
+			Dir:   strings.TrimSpace(annotations[AnnotationSecretDir]),
 		},
 		Discovery: discoverySpec{
 			Volume:        annotations[AnnotationDiscoveryVolume],
@@ -398,6 +444,8 @@ func hasInjectionDetailAnnotations(annotations map[string]string) bool {
 		AnnotationGetCertRunAsGroup,
 		AnnotationGetCertRunAsNonRoot,
 		AnnotationGetCertVerbose,
+		AnnotationSecrets,
+		AnnotationSecretDir,
 	} {
 		if annotations[name] != "" {
 			return true
@@ -495,6 +543,17 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	// An ephemeral container is attached to a running pod, so nothing here is
+	// injected — the only decision is whether it may reach what the injected
+	// containers already put on that pod.
+	if req.SubResource == "ephemeralcontainers" {
+		if err := rejectEphemeralReservedMounts(pod); err != nil {
+			l.Info("denying ephemeral container", "reason", err.Error())
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		return admission.Allowed("ephemeral container mounts no reserved c8s volume")
+	}
+
 	if err := validateWorkloadLabel(pod); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
@@ -555,6 +614,11 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		// to persistent, host-visible storage outside the TEE memory boundary.
 		// Reject anything but the expected memory-backed emptyDir.
 		if err := rejectReservedCertVolume(pod, inj.withDefaults(m.cfg).Cert.Volume); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		// Same reasoning for the released secrets: a hostPath here would write
+		// them to host-visible storage.
+		if err := rejectReservedSecretsVolume(pod); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		l.Info("injecting c8s get-cert containers", "workload", inj.WorkloadID)
@@ -759,8 +823,20 @@ func mutatePod(pod *corev1.Pod, inj *injection, cfg Config) {
 		pod.Spec.ShareProcessNamespace = boolPtr(true)
 	}
 
-	pod.Spec.InitContainers = injectInitContainers(pod.Spec.InitContainers,
-		certContainer(&effective, cfg), certWaitContainer(&effective, cfg))
+	injected := []corev1.Container{certContainer(&effective, cfg), certWaitContainer(&effective, cfg)}
+	if len(effective.Secrets.Specs) > 0 {
+		ensureVolume(pod, secretsVolume())
+		// Read-only for the workload, and mounted before the fetcher is built
+		// so mountAll (which skips a container that already has the mount)
+		// leaves the fetcher's own read-write mount alone.
+		mountAll(pod, corev1.VolumeMount{
+			Name:      secretsVolumeName,
+			MountPath: effective.Secrets.Dir,
+			ReadOnly:  true,
+		})
+		injected = append(injected, secretContainer(&effective, cfg))
+	}
+	pod.Spec.InitContainers = injectInitContainers(pod.Spec.InitContainers, injected...)
 
 	if pod.Annotations == nil {
 		pod.Annotations = map[string]string{}
@@ -940,7 +1016,7 @@ func (inj *injection) withDefaults(cfg Config) injection {
 		effective.SAN = effective.WorkloadID
 	}
 	if effective.Cert.Volume == "" {
-		effective.Cert.Volume = "c8s-certs"
+		effective.Cert.Volume = defaultCertVolumeName
 	}
 	if effective.Cert.Dir == "" {
 		effective.Cert.Dir = cfg.CertDir
@@ -953,6 +1029,9 @@ func (inj *injection) withDefaults(cfg Config) injection {
 	}
 	if effective.Cert.RenewInterval <= 0 {
 		effective.Cert.RenewInterval = cfg.CertRenewInterval
+	}
+	if effective.Secrets.Dir == "" {
+		effective.Secrets.Dir = defaultSecretDir
 	}
 	if effective.Security.RunAsUser == nil {
 		effective.Security.RunAsUser = cfg.GetCertRunAsUser
@@ -1016,6 +1095,118 @@ func boolPtr(v bool) *bool {
 
 func int64Ptr(v int64) *int64 {
 	return &v
+}
+
+// secretsVolume is the memory-backed volume released values are written to.
+// Bounded: it is charged to the pod's memory, so an unbounded tmpfs would let
+// writes into the shared directory pressure the pod instead of failing.
+func secretsVolume() corev1.Volume {
+	limit := resource.MustParse(secretsVolumeSizeLimit)
+	return corev1.Volume{
+		Name: secretsVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+				Medium:    corev1.StorageMediumMemory,
+				SizeLimit: &limit,
+			},
+		},
+	}
+}
+
+// rejectEphemeralReservedMounts denies an ephemeral container that mounts a
+// volume holding c8s material — the released secrets, or the pod's private key.
+//
+// The release check cannot help here: it gates the fetch, and by the time an
+// ephemeral container is attached the file already exists. Without this,
+// `kubectl debug` with any allowlisted image and a volumeMount reads a secret
+// straight out of a live pod.
+//
+// Reserved container names are checked too. The pod-CREATE path already does
+// that, but Kubernetes strips spec.ephemeralContainers at CREATE, so that check
+// only ever runs against an empty list.
+func rejectEphemeralReservedMounts(pod *corev1.Pod) error {
+	certVolume := strings.TrimSpace(pod.Annotations[AnnotationCertVolume])
+	if certVolume == "" {
+		certVolume = defaultCertVolumeName
+	}
+	reserved := map[string]bool{secretsVolumeName: true, certVolume: true}
+	for _, c := range pod.Spec.EphemeralContainers {
+		if isReservedCertName(c.Name) {
+			return fmt.Errorf("%w: ephemeral container name %q is reserved for the injected c8s containers",
+				errInvalidInjectionAnnotation, c.Name)
+		}
+		for _, m := range c.VolumeMounts {
+			if reserved[m.Name] {
+				return fmt.Errorf("%w: ephemeral container %q may not mount %q, which holds c8s-released material",
+					errInvalidInjectionAnnotation, c.Name, m.Name)
+			}
+		}
+	}
+	return nil
+}
+
+// rejectReservedSecretsVolume denies a pod that pre-declares the secrets volume
+// as anything but the expected memory-backed emptyDir. ensureVolume keeps an
+// existing same-named volume rather than overwriting it, so without this a pod
+// spec could point it at a hostPath and have a CDS-released secret written to
+// persistent, host-visible storage outside the TEE boundary. Omitting it is
+// fine — the webhook injects it.
+func rejectReservedSecretsVolume(pod *corev1.Pod) error {
+	for i := range pod.Spec.Volumes {
+		v := &pod.Spec.Volumes[i]
+		if v.Name != secretsVolumeName {
+			continue
+		}
+		if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumMemory {
+			return fmt.Errorf("%w: volume %q is reserved for released secrets; it must be a memory-backed emptyDir (medium: Memory) or omitted",
+				errInvalidInjectionAnnotation, secretsVolumeName)
+		}
+	}
+	return nil
+}
+
+// secretContainer is the workload's secret fetcher.
+//
+// A native sidecar (restartPolicy: Always), and ordered after c8s-cert-wait so
+// the leaf it authenticates with is already on disk. It cannot be a plain init
+// container: CDS releases only once every main container is running, so an init
+// container would be asking before its siblings exist and would deadlock the
+// pod it is gating (docs/secrets.md).
+func secretContainer(inj *injection, cfg Config) corev1.Container {
+	args := []string{
+		"get-secret",
+		"--cds-url=" + cfg.CDSURL,
+		"--attestation-api-url=" + cfg.AttestationApiURL,
+		"--cert=" + certPath(inj.Cert.Dir, inj.Cert.CertFile),
+		"--key=" + certPath(inj.Cert.Dir, inj.Cert.KeyFile),
+		"--out-dir=" + inj.Secrets.Dir,
+	}
+	for _, spec := range inj.Secrets.Specs {
+		args = append(args, "--secret="+spec)
+	}
+	for _, m := range cfg.CDSMeasurements {
+		args = append(args, "--measurements="+m)
+	}
+
+	always := corev1.ContainerRestartPolicyAlways
+	return corev1.Container{
+		Name:            reservedSecretContainerName,
+		Image:           cfg.GetCertImage,
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		RestartPolicy:   &always,
+		Args:            args,
+		Env:             getCertEnv(inj),
+		// The only container with write access: the shared directory is
+		// readable pod-wide by design, but a workload able to write it could
+		// replace a value another container has yet to read.
+		VolumeMounts: append(
+			append(getCertVolumeMounts(inj, false), corev1.VolumeMount{
+				Name:      secretsVolumeName,
+				MountPath: inj.Secrets.Dir,
+			}),
+			workloadClaimsMounts(cfg)...),
+		SecurityContext: getCertSecurityContext(inj),
+	}
 }
 
 func certsVolume(name string) corev1.Volume {
@@ -1141,7 +1332,9 @@ func rejectReservedCertContainer(pod *corev1.Pod) error {
 }
 
 func isReservedCertName(name string) bool {
-	return name == reservedCertContainerName || name == reservedCertWaitContainerName
+	return name == reservedCertContainerName ||
+		name == reservedCertWaitContainerName ||
+		name == reservedSecretContainerName
 }
 
 // rejectReservedCertVolume denies a pod that pre-declares the reserved cert

--- a/internal/webhook/pod_mutator_secrets_test.go
+++ b/internal/webhook/pod_mutator_secrets_test.go
@@ -1,0 +1,290 @@
+package webhook
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func secretsConfig() Config {
+	return Config{
+		GetCertImage:      "ghcr.io/confidential-dot-ai/c8s-operator:test",
+		CDSURL:            "https://cds.c8s-system.svc:8443",
+		AttestationApiURL: "http://attestation-api.c8s-system.svc:8400",
+		CertDir:           "/etc/c8s/certs",
+	}
+}
+
+func podWithApp() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "api", Namespace: "tenant"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+}
+
+func mutateWithSecrets(t *testing.T, pod *corev1.Pod, specs []string, dir string) {
+	t.Helper()
+	mutatePod(pod, &injection{
+		WorkloadID: "api",
+		Secrets:    secretsSpec{Specs: specs, Dir: dir},
+	}, secretsConfig())
+}
+
+func containerNamed(pod *corev1.Pod, name string) *corev1.Container {
+	for i := range pod.Spec.InitContainers {
+		if pod.Spec.InitContainers[i].Name == name {
+			return &pod.Spec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+// No annotation, no fetcher: a pod that asks for nothing gets the cert
+// containers only.
+func TestNoSecretsRequestedInjectsNothing(t *testing.T) {
+	pod := podWithApp()
+	mutateWithSecrets(t, pod, nil, "")
+	if c := containerNamed(pod, reservedSecretContainerName); c != nil {
+		t.Fatal("the fetcher was injected without a secrets annotation")
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == secretsVolumeName {
+			t.Fatal("the secrets volume was injected without a secrets annotation")
+		}
+	}
+}
+
+// The fetcher must run alongside the workload, not before it: CDS releases only
+// once every main container is running, so an ordinary init container would
+// deadlock the pod it gates.
+func TestFetcherIsANativeSidecarOrderedAfterCertWait(t *testing.T) {
+	pod := podWithApp()
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+
+	names := make([]string, 0, len(pod.Spec.InitContainers))
+	for _, c := range pod.Spec.InitContainers {
+		names = append(names, c.Name)
+	}
+	want := []string{reservedCertContainerName, reservedCertWaitContainerName, reservedSecretContainerName}
+	if !slices.Equal(names[:3], want) {
+		t.Fatalf("init containers = %v, want %v first", names, want)
+	}
+
+	fetcher := containerNamed(pod, reservedSecretContainerName)
+	if fetcher.RestartPolicy == nil || *fetcher.RestartPolicy != corev1.ContainerRestartPolicyAlways {
+		t.Fatal("the fetcher is not a native sidecar; exiting would restart it for the pod's life")
+	}
+	if len(pod.Spec.Containers) != 1 {
+		t.Fatalf("main containers = %d, want the workload's own only", len(pod.Spec.Containers))
+	}
+}
+
+func TestFetcherArgs(t *testing.T) {
+	pod := podWithApp()
+	cfg := secretsConfig()
+	cfg.CDSMeasurements = []string{"aa", "bb"}
+	mutatePod(pod, &injection{
+		WorkloadID: "api",
+		Secrets:    secretsSpec{Specs: []string{"DB=/api/db", "HF=/api/hf"}},
+	}, cfg)
+
+	args := strings.Join(containerNamed(pod, reservedSecretContainerName).Args, " ")
+	for _, want := range []string{
+		"get-secret",
+		"--cds-url=https://cds.c8s-system.svc:8443",
+		"--secret=DB=/api/db",
+		"--secret=HF=/api/hf",
+		"--out-dir=" + defaultSecretDir,
+		"--measurements=aa",
+		"--measurements=bb",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("args %q missing %q", args, want)
+		}
+	}
+}
+
+func TestSecretDirOverride(t *testing.T) {
+	pod := podWithApp()
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "/var/run/app-secrets")
+
+	fetcher := containerNamed(pod, reservedSecretContainerName)
+	if !strings.Contains(strings.Join(fetcher.Args, " "), "--out-dir=/var/run/app-secrets") {
+		t.Fatalf("args = %v, want the overridden dir", fetcher.Args)
+	}
+	for _, c := range pod.Spec.Containers {
+		for _, m := range c.VolumeMounts {
+			if m.Name == secretsVolumeName && m.MountPath != "/var/run/app-secrets" {
+				t.Fatalf("workload mount path = %q, want the overridden dir", m.MountPath)
+			}
+		}
+	}
+}
+
+// The directory is readable pod-wide by design, but only the fetcher may write
+// it: a workload able to write could replace a value a sibling has yet to read.
+func TestOnlyTheFetcherMountsSecretsWritable(t *testing.T) {
+	pod := podWithApp()
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, corev1.Container{Name: "user-init"})
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+
+	check := func(c corev1.Container) {
+		for _, m := range c.VolumeMounts {
+			if m.Name != secretsVolumeName {
+				continue
+			}
+			wantRO := c.Name != reservedSecretContainerName
+			if m.ReadOnly != wantRO {
+				t.Fatalf("container %q mounts secrets ReadOnly=%v, want %v", c.Name, m.ReadOnly, wantRO)
+			}
+		}
+	}
+	for _, c := range pod.Spec.Containers {
+		check(c)
+	}
+	for _, c := range pod.Spec.InitContainers {
+		check(c)
+	}
+}
+
+// A hostPath here would write a released secret to host-visible storage,
+// outside the TEE boundary.
+func TestReservedSecretsVolumeMustBeMemoryBacked(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source corev1.VolumeSource
+		wantOK bool
+	}{
+		{"memory emptyDir", corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}}, true},
+		{"hostPath", corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/var/lib/exfil"}}, false},
+		{"disk emptyDir", corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}, false},
+		{"pvc", corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "c"}}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := podWithApp()
+			pod.Spec.Volumes = []corev1.Volume{{Name: secretsVolumeName, VolumeSource: tc.source}}
+			err := rejectReservedSecretsVolume(pod)
+			if tc.wantOK && err != nil {
+				t.Fatalf("rejected a valid volume: %v", err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Fatal("accepted a volume that would leave the TEE boundary")
+			}
+		})
+	}
+}
+
+// The injected volume is memory-backed and bounded: it is charged to the pod's
+// memory, so an unbounded tmpfs would let writes pressure the pod.
+func TestInjectedSecretsVolumeIsBoundedTmpfs(t *testing.T) {
+	pod := podWithApp()
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+
+	var found *corev1.Volume
+	for i := range pod.Spec.Volumes {
+		if pod.Spec.Volumes[i].Name == secretsVolumeName {
+			found = &pod.Spec.Volumes[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("no secrets volume was injected")
+	}
+	if found.EmptyDir == nil || found.EmptyDir.Medium != corev1.StorageMediumMemory {
+		t.Fatalf("volume = %+v, want a memory-backed emptyDir", found.VolumeSource)
+	}
+	if found.EmptyDir.SizeLimit == nil || found.EmptyDir.SizeLimit.IsZero() {
+		t.Fatal("the tmpfs is unbounded")
+	}
+}
+
+// A pod declaring the fetcher's name would collide with the injected one.
+func TestFetcherNameIsReserved(t *testing.T) {
+	pod := podWithApp()
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{Name: reservedSecretContainerName})
+	if err := rejectReservedCertContainer(pod); err == nil {
+		t.Fatal("a pod claiming the fetcher's container name was accepted")
+	}
+}
+
+// The secrets annotations are injection detail, so setting one without opting
+// the pod in must fail loudly rather than be ignored.
+func TestSecretsAnnotationsRequireOptIn(t *testing.T) {
+	for _, name := range []string{AnnotationSecrets, AnnotationSecretDir} {
+		pod := podWithApp()
+		pod.Annotations = map[string]string{name: "DB=/api/db"}
+		if _, err := parseAnnotations(pod); err == nil {
+			t.Fatalf("%s without %s was silently ignored", name, AnnotationWorkload)
+		}
+	}
+}
+
+func TestSecretsAnnotationParsing(t *testing.T) {
+	pod := podWithApp()
+	pod.Annotations = map[string]string{
+		AnnotationWorkload:  "api",
+		AnnotationSecrets:   " DB=/api/db , HF=/api/hf ",
+		AnnotationSecretDir: "/var/run/app-secrets",
+	}
+	inj, err := parseAnnotations(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(inj.Secrets.Specs, []string{"DB=/api/db", "HF=/api/hf"}) {
+		t.Fatalf("specs = %v", inj.Secrets.Specs)
+	}
+	if inj.Secrets.Dir != "/var/run/app-secrets" {
+		t.Fatalf("dir = %q", inj.Secrets.Dir)
+	}
+}
+
+// An ephemeral container attaches to a running pod, so the release check cannot
+// help: the file already exists. Without this guard `kubectl debug` reads a
+// secret straight out of a live pod.
+func TestEphemeralContainerCannotMountReservedVolumes(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		certVolume string
+		mount      string
+		ctrName    string
+		wantOK     bool
+	}{
+		{name: "mounts secrets", mount: secretsVolumeName},
+		{name: "mounts certs", mount: defaultCertVolumeName},
+		{name: "mounts a renamed cert volume", certVolume: "my-certs", mount: "my-certs"},
+		{name: "claims a reserved name", ctrName: reservedSecretContainerName, mount: "scratch"},
+		{name: "mounts something else", mount: "scratch", wantOK: true},
+		{name: "mounts nothing", wantOK: true},
+		// The pod renamed its cert volume, so the default name is no longer
+		// the one holding its key.
+		{name: "default name after a rename", certVolume: "my-certs", mount: defaultCertVolumeName, wantOK: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := podWithApp()
+			if tc.certVolume != "" {
+				pod.Annotations = map[string]string{AnnotationCertVolume: tc.certVolume}
+			}
+			name := tc.ctrName
+			if name == "" {
+				name = "debugger"
+			}
+			ec := corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: name},
+			}
+			if tc.mount != "" {
+				ec.VolumeMounts = []corev1.VolumeMount{{Name: tc.mount, MountPath: "/x"}}
+			}
+			pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{ec}
+
+			err := rejectEphemeralReservedMounts(pod)
+			if tc.wantOK && err != nil {
+				t.Fatalf("rejected a harmless ephemeral container: %v", err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Fatal("accepted an ephemeral container that could read c8s material")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two annotations - confidential.ai/c8s-secrets (NAME=/path list, reusing the existing listAnnotation helper) and confidential.ai/c8s-secret-dir. Both added to hasInjectionDetailAnnotations, so setting either without confidential.ai/cw errors rather than being silently ignored.

The fetcher injects as a native sidecar ordered c8s-cert → c8s-cert-wait → c8s-secret, so the leaf it authenticates with is already on disk. There's a test pinning that order and the restartPolicy: Always.

Guards, each mirroring shipped cert-path precedent:

- rejectReservedSecretsVolume — ensureVolume keeps a pre-declared same-named volume, so without this a pod spec pointing c8s-secrets at a hostPath would have CDS-released secrets written outside the TEE. Table test covers hostPath, disk-backed emptyDir, and PVC.
- c8s-secret added to isReservedCertName — covers both regular and (existing) ephemeral-container checks.
- RW for the fetcher, RO for everyone else. This works because mountAll skips a container that already has the mount, so ordering the pod-wide RO mount before building the fetcher leaves its own RW mount intact. Worth knowing that's load-bearing, not incidental.
- sizeLimit on the tmpfs — it's charged to the pod's memory (the guest's, under kata).

One new Config field: CDSMeasurements, rendered into the fetcher's --measurements. Empty pins nothing, which leaves an impostor CDS able to answer with a value of its choosing — get-cert has the same posture today, but it matters more here, so it's documented on the field.

Handler — Handle now branches on req.SubResource == "ephemeralcontainers" before anything else. That request shape is different: the pod already exists, nothing is injected, and the only decision is whether the new containers may reach what the injected ones put there. rejectEphemeralReservedMounts denies any ephemeral container mounting the secrets volume or the pod's cert volume, and any claiming a reserved container name.

The cert volume name is derived from the pod's own c8s-cert-volume annotation, not a constant — a pod that renamed its cert volume must have that name protected, and the default name is then no longer sensitive. There's a test for both directions.

Chart — added a second rule to the mutating webhook for pods/ephemeralcontainers on UPDATE. Confirmed with helm template that it renders; the whole rule block is above.

**Caveat:**
I did not add pods/ephemeralcontainers to the deny-host-namespaces VAP, which the earlier review had suggested. Its CEL targets host namespaces and hostPath volumes, and an ephemeral container can introduce neither — it can only mount volumes the pod already declares. So the mutating webhook is the correct place, and widening the VAP would have meant re-reasoning about CEL that doesn't apply.

Also worth noting the guard protects the cert volume too, not just secrets. That gap predates this work — kubectl debug mounting c8s-certs could read the pod's mesh private key  — and closing it here was free.