### PR TITLE
feat(secrets): operator-supplied values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: latest
+          # A full major.minor.patch is resolved in-process; anything less is
+          # looked up over the network before the linter runs.
+          version: v2.12.2
 
   test:
     name: Build & Test

--- a/cmd/c8s/secrets.go
+++ b/cmd/c8s/secrets.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/secrets"
+
+func init() {
+	rootCmd.AddCommand(secrets.NewCmd())
+}

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -149,7 +149,9 @@ for what the admission inventory contributes to a release decision.
 
 CDS enforces this grant at `GET`/`POST /secrets/*`. Writing a grant is what
 turns release on: an entry without one releases nothing
-([`secrets.md`](secrets.md#when-it-is-served)).
+([`secrets.md`](secrets.md#when-it-is-served)). An operator supplying a value at
+`PUT /secrets/*` is authorized by the operator key instead
+([`secrets.md`](secrets.md#operator-supplied-values)).
 
 Filesystem location is not an authorization boundary — a workload owns its own
 filesystem once a value is inside it — so a grant names store paths only. An

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -3,10 +3,6 @@
 How a workload is authorized to read a secret, and what the allowlist and the
 admission inventory contribute to that decision.
 
-> **Status.** Delivery works end to end. Still missing: an operator diagnostic
-> for a denied release (`c8s secrets explain`) and the lint checks that catch an
-> ambiguous or under-declared entry.
-
 ## When it is served
 
 Release is gated on an allowlist entry carrying a grant, which is operator-signed
@@ -89,6 +85,9 @@ GET  /secrets/<store path>         → 200 {"value": "<base64>"} | 404 | 403
 POST /secrets/<store path>         → 201 {"value": "<base64>"} | 409 | 403
 ```
 
+`PUT` on the same paths is the operator's, authorized by the operator key
+instead — see "Operator-supplied values".
+
 `POST /secrets` is the challenge route; the wildcard can never match it, so no
 store path is shadowed by it — a secret at `/challenge` still resolves.
 
@@ -118,6 +117,57 @@ Paths must arrive already canonical: absolute, clean, no trailing slash, and no
 percent-encoding. They are rejected rather than repaired, so the bytes matched
 against a grant and the bytes used as a store key are the bytes the client
 sent.
+
+## Operator-supplied values
+
+CDS generates a value it is asked for and finds missing, which covers a session
+key but not an API token, a database password, or a wrapped key. Those come from
+an operator:
+
+```sh
+c8s secrets put /tenant-a/hf-token --url "$CDS" --measurements "$M" \
+  --operator-key operator.key < token.txt
+```
+
+The value is read from stdin or `--from-file`, and the bytes are stored exactly
+as read — a trailing newline is part of the value. The byte count is printed to
+confirm which one was sent.
+
+```
+PUT /secrets/<store path>   {"value": "<base64>", "overwrite": <bool>}
+                            → 201 {"created": true}
+                            → 409 {"existing": "workload"|"operator"}
+                            → 200 {"existing": "workload"|"operator"}
+```
+
+Authorization is the operator key that CDS already pins for allowlist writes
+(`cds --operator-keys`) — the same key the `secrets` grants are rooted in. Its
+token binds the method, path, and body, so a captured one cannot be replayed
+against a different path or a different value. `overwrite` travels in the body
+for that reason: a query parameter is outside what the token covers.
+
+### Replacing a value
+
+A path that already holds a value answers `409` and names what put it there —
+a workload that found the path empty, or an earlier operator write. Nothing is
+written. `--overwrite` replaces it, and the CLI prints what it is replacing
+before it does:
+
+```
+$ c8s secrets put /tenant-a/db --overwrite < db.txt
+~ /tenant-a/db (replaces a workload-generated value)
+wrote 24 bytes to /tenant-a/db
+```
+
+The store has no versioning and no delete, so a displaced value is gone.
+
+**A workload reads its secret into a file once, at startup.** Replacing a value
+reaches a pod when that pod next restarts, so a Deployment holding the old value
+keeps it until it is rolled. Replacing a path a workload created is worth
+pausing over for that reason: the pods that generated the value go on using it.
+
+Revoking a value means restarting CDS, which empties the whole store — see
+"Restarts".
 
 ## What CDS checks
 

--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -13,29 +13,19 @@ package allowlist
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"net/http"
-	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/confidential-dot-ai/c8s/internal/lbdiscovery"
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
 	"github.com/confidential-dot-ai/c8s/internal/localverify"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
-	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
-
-// envOperatorKey supplies the operator private key when --operator-key is unset.
-// The flag takes precedence.
-const envOperatorKey = "C8S_OPERATOR_KEY"
 
 // defaultRequiredComponents are the core c8s components an allowlist is expected
 // to cover. `upload` warns (and requires --force) when an uploaded file names
@@ -58,18 +48,9 @@ var defaultRequiredComponents = []string{
 
 // options holds the flags shared by every subcommand.
 type options struct {
-	url              string
-	measurements     []string
-	measurementsFile string
-	timeout          time.Duration
+	cdsconn.Options
 
-	operatorKey string
-
-	output   string // "text" | "json"
-	insecure bool
-
-	// verify is the evidence verifier; a stub in tests.
-	verify localverify.VerifyFunc
+	output string // "text" | "json"
 }
 
 // NewCmd returns the `c8s allowlist` command tree.
@@ -79,7 +60,7 @@ func NewCmd() *cobra.Command {
 
 // newCmd is the injectable constructor behind NewCmd.
 func newCmd(verify localverify.VerifyFunc) *cobra.Command {
-	o := &options{verify: verify}
+	o := &options{Options: cdsconn.Options{Verify: verify}}
 	cmd := &cobra.Command{
 		Use:   "allowlist",
 		Short: "Manage the CDS image allowlist",
@@ -108,13 +89,8 @@ allowlist").`,
 	}
 
 	pf := cmd.PersistentFlags()
-	pf.StringVar(&o.url, "url", "", "CDS-issued-TLS tls-lb or direct CDS base URL (required); WebPKI tls-lb URLs are not attestation-bound")
-	pf.StringSliceVar(&o.measurements, "measurements", nil, "trusted endpoint build ID(s) (repeatable/comma-separated); use the tls-lb value for CDS-issued public TLS or the CDS value for a direct URL; empty trusts any attested build (UNSAFE)")
-	pf.StringVar(&o.measurementsFile, "measurements-file", "", "file of trusted endpoint build IDs, one per line")
-	pf.DurationVar(&o.timeout, "timeout", 15*time.Second, "per-request timeout")
-	pf.StringVar(&o.operatorKey, "operator-key", "", "operator EC private key PEM file, whose public key is pinned on CDS via --operator-keys (env "+envOperatorKey+"); required for writes")
+	cdsconn.BindFlags(pf, &o.Options)
 	pf.StringVarP(&o.output, "output", "o", "text", "output format: text or json")
-	pf.BoolVar(&o.insecure, "insecure", false, "dev/test only: allow a plaintext http:// CDS URL, skipping RA-TLS attestation of CDS")
 
 	cmd.AddCommand(
 		newListCmd(o),
@@ -132,8 +108,8 @@ allowlist").`,
 
 // validate checks the flags every subcommand needs.
 func (o *options) validate() error {
-	if strings.TrimSpace(o.url) == "" {
-		return fmt.Errorf("--url is required")
+	if err := o.Validate(); err != nil {
+		return err
 	}
 	if o.output != "text" && o.output != "json" {
 		return fmt.Errorf("--output must be text or json, got %q", o.output)
@@ -141,95 +117,17 @@ func (o *options) validate() error {
 	return nil
 }
 
-// client builds an HTTP client for CDS. An https URL is verified via RA-TLS
-// (CDS proves its TEE attestation). Plaintext http is refused unless --insecure
-// is set, so a typo'd or downgraded URL never silently writes the allowlist to
-// an unauthenticated endpoint.
+// client builds the allowlist API client over the attested channel to CDS.
 func (o *options) client(ctx context.Context) (allowlistclient.Client, error) {
-	u, err := url.Parse(o.url)
-	if err != nil || u.Host == "" {
-		return allowlistclient.Client{}, fmt.Errorf("invalid --url %q", o.url)
-	}
-
-	switch u.Scheme {
-	case "http":
-		if !o.insecure {
-			return allowlistclient.Client{}, fmt.Errorf("refusing plaintext http:// for CDS (no attestation): use https:// (RA-TLS), or pass --insecure for a dev/test endpoint")
-		}
-		fmt.Fprintln(os.Stderr, "warning: --url is http:// with --insecure; CDS attestation is NOT verified (dev/test only)")
-		return allowlistclient.NewClientWithHTTP(o.url, &http.Client{Timeout: o.timeout}), nil
-	case "https":
-		measurements, err := o.loadMeasurements()
-		if err != nil {
-			return allowlistclient.Client{}, err
-		}
-		if len(measurements) == 0 {
-			fmt.Fprintln(os.Stderr, "warning: no --measurements set; accepting any attested endpoint build (UNSAFE)")
-		}
-		hc, err := o.httpsClient(ctx, measurements)
-		if err != nil {
-			return allowlistclient.Client{}, err
-		}
-		hc.Timeout = o.timeout
-		return allowlistclient.NewClientWithHTTP(o.url, hc), nil
-	default:
-		return allowlistclient.Client{}, fmt.Errorf("--url scheme must be http or https, got %q", u.Scheme)
-	}
-}
-
-// httpsClient builds the attestation-verifying HTTP client. A tls-lb front
-// door serves a CDS-issued cert with no RA-TLS extension; its trust path is
-// the discovery document, so probe for that first and fall back to direct
-// RA-TLS serving-cert verification (a port-forwarded CDS) when the target
-// serves none — the same routing `c8s verify` uses in auto mode. A
-// discovery document that fails verification is a hard error, never a
-// fallback.
-func (o *options) httpsClient(ctx context.Context, measurements [][]byte) (*http.Client, error) {
-	probeCtx, cancel := context.WithTimeout(ctx, o.timeout)
-	defer cancel()
-	hc, err := lbdiscovery.NewVerifiedHTTPClient(probeCtx, o.url, measurements, o.verify)
-	switch {
-	case err == nil:
-		fmt.Fprintln(os.Stderr, "note: target is a tls-lb front door; verified its discovery attestation and bound this session to the attested connection")
-		return hc, nil
-	case errors.Is(err, lbdiscovery.ErrNoDiscovery):
-		return localverify.NewRATLSHTTPClient(measurements, o.verify, o.timeout), nil
-	default:
-		return nil, err
-	}
-}
-
-// loadMeasurements combines --measurements and --measurements-file into the raw
-// digest byte form RA-TLS verification expects.
-func (o *options) loadMeasurements() ([][]byte, error) {
-	hexes := append([]string{}, o.measurements...)
-	if o.measurementsFile != "" {
-		data, err := os.ReadFile(o.measurementsFile)
-		if err != nil {
-			return nil, fmt.Errorf("read --measurements-file: %w", err)
-		}
-		hexes = append(hexes, strings.Split(string(data), "\n")...)
-	}
-	return ratls.ParseHexMeasurementsList(hexes)
-}
-
-// signer builds the operator credential from the flags or environment. Required
-// only for write subcommands.
-func (o *options) signer() (*operatorauth.Signer, error) {
-	keyPath := coalesce(o.operatorKey, os.Getenv(envOperatorKey))
-	if keyPath == "" {
-		return nil, fmt.Errorf("operator key required: set --operator-key or %s", envOperatorKey)
-	}
-	keyPEM, err := os.ReadFile(keyPath)
+	hc, err := o.HTTPClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("read operator key: %w", err)
+		return allowlistclient.Client{}, err
 	}
-	signer, err := operatorauth.NewSignerFromKeyPEM(keyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("load operator key: %w", err)
-	}
-	return signer, nil
+	return allowlistclient.NewClientWithHTTP(o.URL, hc), nil
 }
+
+// signer builds the operator credential. Required only for write subcommands.
+func (o *options) signer() (*operatorauth.Signer, error) { return o.Signer() }
 
 // matchedComponents returns the required component identifiers that appear as a
 // (case-insensitive) substring of image — the same name-based signal the upload
@@ -290,14 +188,6 @@ func missingComponents(images map[string]string, required []string) []string {
 		}
 	}
 	return missing
-}
-
-// coalesce returns a if non-empty, else b (which may itself be empty).
-func coalesce(a, b string) string {
-	if a != "" {
-		return a
-	}
-	return b
 }
 
 // sortedKeys returns the map keys sorted, for stable output.

--- a/internal/cmds/allowlist/cmd_test.go
+++ b/internal/cmds/allowlist/cmd_test.go
@@ -17,6 +17,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -323,7 +324,7 @@ func TestAddRejectsWildcardImage(t *testing.T) {
 func TestWriteRequiresOperatorCredential(t *testing.T) {
 	url, _ := recordingCDS(t)
 	// No key and no env: a real (non-dry-run) add must fail before writing.
-	t.Setenv(envOperatorKey, "")
+	t.Setenv(cdsconn.EnvOperatorKey, "")
 	_, _, err := runCmd("add", digA, "registry/app@"+digA, "--url", url, "--insecure")
 	if err == nil {
 		t.Fatal("expected add without an operator key to fail")
@@ -333,9 +334,9 @@ func TestWriteRequiresOperatorCredential(t *testing.T) {
 func TestSignerPrefersFlagOverEnv(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeOperatorKey(t, dir)
-	t.Setenv(envOperatorKey, filepath.Join(dir, "nonexistent.key"))
+	t.Setenv(cdsconn.EnvOperatorKey, filepath.Join(dir, "nonexistent.key"))
 
-	o := &options{operatorKey: keyPath}
+	o := &options{Options: cdsconn.Options{OperatorKey: keyPath}}
 	if _, err := o.signer(); err != nil {
 		t.Fatalf("flag should take precedence over (broken) env, got %v", err)
 	}
@@ -344,7 +345,7 @@ func TestSignerPrefersFlagOverEnv(t *testing.T) {
 func TestSignerFallsBackToEnv(t *testing.T) {
 	dir := t.TempDir()
 	keyPath := writeOperatorKey(t, dir)
-	t.Setenv(envOperatorKey, keyPath)
+	t.Setenv(cdsconn.EnvOperatorKey, keyPath)
 
 	o := &options{} // no flags
 	if _, err := o.signer(); err != nil {

--- a/internal/cmds/allowlist/read_write_test.go
+++ b/internal/cmds/allowlist/read_write_test.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
-	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
 // servingCDS is an httptest server that serves the given digests on GET (as a
@@ -89,66 +89,10 @@ func TestClientRejectsUnknownScheme(t *testing.T) {
 	}
 }
 
-// --- loadMeasurements ---
-
-func TestLoadMeasurementsFromFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "measurements.txt")
-	m1 := strings.Repeat("42", ratls.SNPMeasurementSize)
-	m2 := strings.Repeat("ab", ratls.SNPMeasurementSize)
-	// blank lines and surrounding whitespace must be tolerated
-	if err := os.WriteFile(path, []byte(m1+"\n\n  "+m2+"  \n"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	o := &options{measurementsFile: path}
-	got, err := o.loadMeasurements()
-	if err != nil {
-		t.Fatalf("loadMeasurements: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("expected 2 measurements, got %d", len(got))
-	}
-}
-
-func TestLoadMeasurementsCombinesFlagAndFile(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "measurements.txt")
-	if err := os.WriteFile(path, []byte(strings.Repeat("ab", ratls.SNPMeasurementSize)+"\n"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	o := &options{
-		measurements:     []string{strings.Repeat("42", ratls.SNPMeasurementSize)},
-		measurementsFile: path,
-	}
-	got, err := o.loadMeasurements()
-	if err != nil {
-		t.Fatalf("loadMeasurements: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("expected flag+file to combine into 2 measurements, got %d", len(got))
-	}
-}
-
-func TestLoadMeasurementsFileMissing(t *testing.T) {
-	o := &options{measurementsFile: filepath.Join(t.TempDir(), "nope.txt")}
-	if _, err := o.loadMeasurements(); err == nil || !strings.Contains(err.Error(), "read --measurements-file") {
-		t.Fatalf("expected a read error, got %v", err)
-	}
-}
-
-func TestLoadMeasurementsRejectsBadHex(t *testing.T) {
-	o := &options{measurements: []string{"not-hex"}}
-	if _, err := o.loadMeasurements(); err == nil {
-		t.Fatal("expected invalid hex to be rejected")
-	}
-}
-
 // --- signer error paths ---
 
 func TestSignerMissingKeyFile(t *testing.T) {
-	o := &options{operatorKey: filepath.Join(t.TempDir(), "nope.key")}
+	o := &options{Options: cdsconn.Options{OperatorKey: filepath.Join(t.TempDir(), "nope.key")}}
 	if _, err := o.signer(); err == nil || !strings.Contains(err.Error(), "read operator key") {
 		t.Fatalf("expected a read error, got %v", err)
 	}
@@ -160,7 +104,7 @@ func TestSignerRejectsGarbagePEM(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a pem"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	o := &options{operatorKey: path}
+	o := &options{Options: cdsconn.Options{OperatorKey: path}}
 	if _, err := o.signer(); err == nil || !strings.Contains(err.Error(), "load operator key") {
 		t.Fatalf("expected a key-parse error, got %v", err)
 	}

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -30,6 +30,7 @@ type dependencies struct {
 	MaxRequestSize    int64                 // applied to write endpoints; must be > 0
 	SecretsHandler    *secrets.Handler      // nil leaves /secrets unrouted (--secrets off)
 	SecretsChallenges *attestation.ChallengeStore
+	SecretsOperator   *secrets.OperatorHandler // operator-supplied values; routed with SecretsHandler
 }
 
 func newRouter(deps dependencies) http.Handler {
@@ -70,10 +71,17 @@ func newRouter(deps dependencies) http.Handler {
 	r.Method(http.MethodPut, "/allowlist/workloads/{name}", deps.allowlistWrite(http.HandlerFunc(deps.AllowlistHandler.HandlePutWorkload)))
 	r.Method(http.MethodDelete, "/allowlist/workloads/{name}", deps.allowlistWrite(http.HandlerFunc(deps.AllowlistHandler.HandleDeleteWorkload)))
 
+	// GET and POST are the workload's, authenticated by mesh leaf and sandbox
+	// token. PUT is the operator's, on allowlistWrite so it carries the same
+	// body-bound operator token an allowlist mutation does.
 	if deps.SecretsHandler != nil {
+		if deps.SecretsOperator == nil {
+			panic("cds: dependencies.SecretsOperator must be set alongside SecretsHandler")
+		}
 		r.Method(http.MethodPost, secrets.ChallengeRoute, deps.protected(attestation.HandleAuthenticate(deps.SecretsChallenges)))
 		r.Method(http.MethodGet, secrets.Route, deps.protected(deps.SecretsHandler))
 		r.Method(http.MethodPost, secrets.Route, deps.protected(deps.SecretsHandler))
+		r.Method(http.MethodPut, secrets.Route, deps.allowlistWrite(deps.SecretsOperator))
 	}
 
 	r.Get("/ca", handleCA(deps.CACertPEM))

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -1,8 +1,11 @@
 package cds
 
 import (
+	"bytes"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -31,6 +34,7 @@ func secretsRouter(t *testing.T, enabled bool) http.Handler {
 		// reaches it is refused for want of a client certificate.
 		deps.SecretsHandler = &secrets.Handler{}
 		deps.SecretsChallenges = &secretsCS
+		deps.SecretsOperator = &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)}
 	}
 	return newRouter(deps)
 }
@@ -68,6 +72,7 @@ func TestRouter_SecretsUnroutedWhenDisabled(t *testing.T) {
 		{http.MethodPost, "/secrets"},
 		{http.MethodGet, "/secrets/api/db"},
 		{http.MethodPost, "/secrets/api/db"},
+		{http.MethodPut, "/secrets/api/db"},
 	} {
 		if code := get(t, r, tc.method, tc.path); code != http.StatusNotFound {
 			t.Fatalf("%s %s = %d with secrets disabled, want 404", tc.method, tc.path, code)
@@ -91,6 +96,7 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 		MaxRequestSize:    65536,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
+		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)},
 	}
 	_ = newRouter(deps)
 
@@ -101,5 +107,52 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 	secretsIssued := secretsCS.Create()
 	if cs.Consume(secretsIssued[:]) {
 		t.Fatal("a secrets challenge was redeemable against the issuance pool")
+	}
+}
+
+// PUT is the operator's door onto the same paths, so it is authorized by the
+// pinned operator key rather than by a mesh leaf and sandbox token. With no
+// authorizer wired, it refuses.
+func TestRouter_SecretsPutIsOperatorAuthorized(t *testing.T) {
+	r := secretsRouter(t, true)
+	if code := get(t, r, http.MethodPut, "/secrets/api/db"); code != http.StatusUnauthorized {
+		t.Fatalf("PUT /secrets/api/db = %d, want 401", code)
+	}
+}
+
+// The operator body cap is the allowlist one, not MaxRequestSize: a secret
+// value is base64 inside JSON and would not fit the attestation-sized bound.
+func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
+	limiter, err := issuer.NewIPRateLimiter(rate.Limit(1000), 1000, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := attestation.NewChallengeStore(time.Minute)
+	secretsCS := attestation.NewChallengeStore(time.Minute)
+	var seen int
+	deps := dependencies{
+		AttestHandler:     AttestHandler{Challenges: &cs},
+		ReadyFn:           func() bool { return true },
+		RateLimiter:       limiter,
+		MaxRequestSize:    8,
+		SecretsHandler:    &secrets.Handler{},
+		SecretsChallenges: &secretsCS,
+		SecretsOperator: &secrets.OperatorHandler{
+			Store:        secrets.NewMemoryStore(8, 4096),
+			MaxBodyBytes: allowlistWriteBodyCap,
+			Authorize:    func(_ *http.Request, body []byte) error { seen = len(body); return nil },
+		},
+	}
+	r := newRouter(deps)
+
+	value := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte("x"), 512))
+	body := `{"value":"` + value + `"}`
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/secrets/api/db", strings.NewReader(body)))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body)
+	}
+	if seen != len(body) {
+		t.Fatalf("authorizer saw %d bytes, want the whole %d-byte body", seen, len(body))
 	}
 }

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -67,7 +67,7 @@ func run(cfg config) error {
 	// canonical hash is committed to REPORTDATA by both replicas and compared
 	// before any CA or allowlist state is released.
 	var writeAuthorizer allowlist.WriteAuthorizer = func(*http.Request, []byte) error {
-		return fmt.Errorf("allowlist writes are disabled: set --operator-keys")
+		return fmt.Errorf("operator writes are disabled: set --operator-keys")
 	}
 	var operatorKeysPEM []byte
 	var operatorKeysHash string
@@ -85,9 +85,9 @@ func run(cfg config) error {
 			Keys:      keys,
 			ClockSkew: time.Duration(cfg.jwtClockSkew) * time.Second,
 		}.Authorize
-		slog.Info("allowlist write authorization enabled (pinned operator keys)", "operator_keys", cfg.operatorKeys, "count", len(keys), "key_set_hash", operatorKeysHash)
+		slog.Info("operator write authorization enabled (pinned operator keys)", "operator_keys", cfg.operatorKeys, "count", len(keys), "key_set_hash", operatorKeysHash)
 	} else {
-		slog.Warn("--operator-keys empty: allowlist writes are disabled (reads still served)")
+		slog.Warn("--operator-keys empty: allowlist and secret writes are disabled (reads still served)")
 	}
 
 	allowlistStore, err := allowlist.OpenStore(cfg.allowlistDB)
@@ -261,16 +261,28 @@ func run(cfg config) error {
 	sandboxBindings := sandboxledger.New(issuer.CapTTL(cfg.certTTL, issuer.MaxLeafTTL), cfg.sandboxLedgerMax)
 	go sandboxBindings.EvictionLoop(ctx.Done(), cfg.rateLimiterEvictInterval)
 
-	var secretsHandler *secrets.Handler
+	var (
+		secretsHandler  *secrets.Handler
+		secretsOperator *secrets.OperatorHandler
+	)
 	if enabled, why := secretsEnabled(cfg, sandboxDigests, inventoryHosts); enabled {
+		// One store behind both handlers: an operator write and a workload read
+		// are two doors onto the same paths.
+		store := secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxValueBytes)
 		secretsHandler = &secrets.Handler{
-			Store:          secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxValueBytes),
+			Store:          store,
 			Challenges:     &secretsChallenges,
 			Inventory:      sandboxDigests,
 			Bindings:       sandboxBindings,
 			Policy:         secrets.NewCachedPolicy(&allowlistStore),
 			InventoryHosts: inventoryHosts,
 			Logger:         slog.Default(),
+		}
+		secretsOperator = &secrets.OperatorHandler{
+			Store:        store,
+			Authorize:    writeAuthorizer,
+			MaxBodyBytes: allowlistWriteBodyCap,
+			Logger:       slog.Default(),
 		}
 		slog.Info("serving /secrets; release is gated on an allowlist entry carrying a secrets grant")
 	} else {
@@ -320,6 +332,7 @@ func run(cfg config) error {
 		MaxRequestSize:    cfg.maxRequestSize,
 		SecretsHandler:    secretsHandler,
 		SecretsChallenges: &secretsChallenges,
+		SecretsOperator:   secretsOperator,
 	}
 	if cfg.rotationInterval > 0 {
 		go rotator.Run(ctx)

--- a/internal/cmds/cdsconn/cdsconn.go
+++ b/internal/cmds/cdsconn/cdsconn.go
@@ -1,0 +1,166 @@
+// Package cdsconn builds what an operator CLI needs to reach CDS: an HTTP
+// client that has verified the endpoint's attestation, and the operator
+// credential that signs a write.
+//
+// It is shared by `c8s allowlist` and `c8s secrets`, which authorize against the
+// same pinned operator keys and reach CDS the same way. The attestation
+// decisions — that plaintext http needs --insecure, that a tls-lb front door is
+// trusted through its discovery document, that a direct URL is verified by
+// RA-TLS — belong in one place, since each is a way to talk to an unattested
+// endpoint by mistake.
+package cdsconn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/confidential-dot-ai/c8s/internal/lbdiscovery"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// EnvOperatorKey supplies the operator private key when the flag is unset.
+const EnvOperatorKey = "C8S_OPERATOR_KEY"
+
+// Options are the connection and credential flags an operator CLI carries.
+// Embed it in a command's option struct and bind Flags to its persistent flags.
+type Options struct {
+	URL              string
+	Measurements     []string
+	MeasurementsFile string
+	Timeout          time.Duration
+	OperatorKey      string
+	Insecure         bool
+
+	// Verify is the evidence verifier; a stub in tests. Zero means
+	// localverify.Verify.
+	Verify localverify.VerifyFunc
+}
+
+// BindFlags registers the connection and credential flags on a command's
+// persistent flag set, so every operator CLI spells them the same way.
+func BindFlags(pf *pflag.FlagSet, o *Options) {
+	pf.StringVar(&o.URL, "url", "", "CDS-issued-TLS tls-lb or direct CDS base URL (required); WebPKI tls-lb URLs are not attestation-bound")
+	pf.StringSliceVar(&o.Measurements, "measurements", nil, "trusted endpoint build ID(s) (repeatable/comma-separated); use the tls-lb value for CDS-issued public TLS or the CDS value for a direct URL; empty trusts any attested build (UNSAFE)")
+	pf.StringVar(&o.MeasurementsFile, "measurements-file", "", "file of trusted endpoint build IDs, one per line")
+	pf.DurationVar(&o.Timeout, "timeout", 15*time.Second, "per-request timeout")
+	pf.StringVar(&o.OperatorKey, "operator-key", "", "operator EC private key PEM file, whose public key is pinned on CDS via --operator-keys (env "+EnvOperatorKey+"); required for writes")
+	pf.BoolVar(&o.Insecure, "insecure", false, "dev/test only: allow a plaintext http:// CDS URL, skipping RA-TLS attestation of CDS")
+}
+
+// Validate checks the flags every subcommand needs.
+func (o *Options) Validate() error {
+	if strings.TrimSpace(o.URL) == "" {
+		return fmt.Errorf("--url is required")
+	}
+	return nil
+}
+
+// HTTPClient builds a client for CDS. An https URL is verified via RA-TLS (CDS
+// proves its TEE attestation). Plaintext http is refused unless Insecure is
+// set, so a typo'd or downgraded URL never silently writes to an
+// unauthenticated endpoint.
+func (o *Options) HTTPClient(ctx context.Context) (*http.Client, error) {
+	u, err := url.Parse(o.URL)
+	if err != nil || u.Host == "" {
+		return nil, fmt.Errorf("invalid --url %q", o.URL)
+	}
+
+	switch u.Scheme {
+	case "http":
+		if !o.Insecure {
+			return nil, fmt.Errorf("refusing plaintext http:// for CDS (no attestation): use https:// (RA-TLS), or pass --insecure for a dev/test endpoint")
+		}
+		fmt.Fprintln(os.Stderr, "warning: --url is http:// with --insecure; CDS attestation is NOT verified (dev/test only)")
+		return &http.Client{Timeout: o.Timeout}, nil
+	case "https":
+		measurements, err := o.loadMeasurements()
+		if err != nil {
+			return nil, err
+		}
+		if len(measurements) == 0 {
+			fmt.Fprintln(os.Stderr, "warning: no --measurements set; accepting any attested endpoint build (UNSAFE)")
+		}
+		hc, err := o.httpsClient(ctx, measurements)
+		if err != nil {
+			return nil, err
+		}
+		hc.Timeout = o.Timeout
+		return hc, nil
+	default:
+		return nil, fmt.Errorf("--url scheme must be http or https, got %q", u.Scheme)
+	}
+}
+
+// httpsClient builds the attestation-verifying client. A tls-lb front door
+// serves a CDS-issued cert with no RA-TLS extension; its trust path is the
+// discovery document, so probe for that first and fall back to direct RA-TLS
+// serving-cert verification (a port-forwarded CDS) when the target serves none
+// — the same routing `c8s verify` uses in auto mode. A discovery document that
+// fails verification is a hard error, never a fallback.
+func (o *Options) httpsClient(ctx context.Context, measurements [][]byte) (*http.Client, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+	hc, err := lbdiscovery.NewVerifiedHTTPClient(probeCtx, o.URL, measurements, o.verifyFunc())
+	switch {
+	case err == nil:
+		fmt.Fprintln(os.Stderr, "note: target is a tls-lb front door; verified its discovery attestation and bound this session to the attested connection")
+		return hc, nil
+	case errors.Is(err, lbdiscovery.ErrNoDiscovery):
+		return localverify.NewRATLSHTTPClient(measurements, o.verifyFunc(), o.Timeout), nil
+	default:
+		return nil, err
+	}
+}
+
+// loadMeasurements combines Measurements and MeasurementsFile into the raw
+// digest byte form RA-TLS verification expects.
+func (o *Options) loadMeasurements() ([][]byte, error) {
+	hexes := append([]string{}, o.Measurements...)
+	if o.MeasurementsFile != "" {
+		data, err := os.ReadFile(o.MeasurementsFile)
+		if err != nil {
+			return nil, fmt.Errorf("read --measurements-file: %w", err)
+		}
+		hexes = append(hexes, strings.Split(string(data), "\n")...)
+	}
+	return ratls.ParseHexMeasurementsList(hexes)
+}
+
+// Signer builds the operator credential from the flag or the environment. The
+// private key never leaves the CLI: it signs a short-lived token bound to the
+// exact method, path, and body of one write.
+func (o *Options) Signer() (*operatorauth.Signer, error) {
+	keyPath := o.OperatorKey
+	if keyPath == "" {
+		keyPath = os.Getenv(EnvOperatorKey)
+	}
+	if keyPath == "" {
+		return nil, fmt.Errorf("operator key required: set --operator-key or %s", EnvOperatorKey)
+	}
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read operator key: %w", err)
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(keyPEM)
+	if err != nil {
+		return nil, fmt.Errorf("load operator key: %w", err)
+	}
+	return signer, nil
+}
+
+func (o *Options) verifyFunc() localverify.VerifyFunc {
+	if o.Verify != nil {
+		return o.Verify
+	}
+	return localverify.Verify
+}

--- a/internal/cmds/cdsconn/cdsconn_test.go
+++ b/internal/cmds/cdsconn/cdsconn_test.go
@@ -1,0 +1,229 @@
+package cdsconn
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+func TestValidateRequiresURL(t *testing.T) {
+	var o Options
+	if err := o.Validate(); err == nil || !strings.Contains(err.Error(), "--url is required") {
+		t.Fatalf("expected a --url error, got %v", err)
+	}
+	o.URL = "  "
+	if err := o.Validate(); err == nil {
+		t.Fatal("whitespace-only --url was accepted")
+	}
+	o.URL = "https://cds.example"
+	if err := o.Validate(); err != nil {
+		t.Fatalf("a real --url was rejected: %v", err)
+	}
+}
+
+// Plaintext http reaches an endpoint that has proved nothing, so it needs
+// --insecure. This is the gate both operator CLIs depend on.
+func TestHTTPClientRefusesPlaintextWithoutInsecure(t *testing.T) {
+	o := Options{URL: "http://cds.example:8080"}
+	if _, err := o.HTTPClient(context.Background()); err == nil || !strings.Contains(err.Error(), "refusing plaintext") {
+		t.Fatalf("expected a plaintext refusal, got %v", err)
+	}
+
+	o.Insecure = true
+	if _, err := o.HTTPClient(context.Background()); err != nil {
+		t.Fatalf("--insecure should allow http, got %v", err)
+	}
+}
+
+// A target that serves no discovery document is a direct CDS URL, which is
+// verified by RA-TLS on its serving certificate rather than through a front
+// door. Nothing is dialled until a request is made, so the fallback yields a
+// client rather than an error.
+func TestHTTPClientFallsBackToRATLS(t *testing.T) {
+	o := Options{
+		URL:     "https://" + closedAddr(t),
+		Timeout: time.Second,
+		Verify: func(context.Context, string, json.RawMessage, localverify.Params) (*teetypes.VerificationResult, error) {
+			return nil, nil
+		},
+	}
+	hc, err := o.HTTPClient(context.Background())
+	if err != nil {
+		t.Fatalf("HTTPClient: %v", err)
+	}
+	if hc.Timeout != time.Second {
+		t.Fatalf("Timeout = %s, want the --timeout value", hc.Timeout)
+	}
+}
+
+// closedAddr returns a host:port nothing is listening on.
+func closedAddr(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	l.Close()
+	return addr
+}
+
+func TestHTTPClientRejectsBadURL(t *testing.T) {
+	for _, tc := range []struct{ name, url, want string }{
+		{"no host", "https://", "invalid --url"},
+		{"unknown scheme", "ftp://cds.example", "scheme must be http or https"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o := Options{URL: tc.url}
+			_, err := o.HTTPClient(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want one containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadMeasurementsFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "measurements.txt")
+	m1 := strings.Repeat("42", ratls.SNPMeasurementSize)
+	m2 := strings.Repeat("ab", ratls.SNPMeasurementSize)
+	// blank lines and surrounding whitespace must be tolerated
+	if err := os.WriteFile(path, []byte(m1+"\n\n  "+m2+"  \n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	o := Options{MeasurementsFile: path}
+	got, err := o.loadMeasurements()
+	if err != nil {
+		t.Fatalf("loadMeasurements: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 measurements, got %d", len(got))
+	}
+}
+
+func TestLoadMeasurementsCombinesFlagAndFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "measurements.txt")
+	if err := os.WriteFile(path, []byte(strings.Repeat("ab", ratls.SNPMeasurementSize)+"\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	o := Options{
+		Measurements:     []string{strings.Repeat("42", ratls.SNPMeasurementSize)},
+		MeasurementsFile: path,
+	}
+	got, err := o.loadMeasurements()
+	if err != nil {
+		t.Fatalf("loadMeasurements: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected flag+file to combine into 2 measurements, got %d", len(got))
+	}
+}
+
+func TestLoadMeasurementsFileMissing(t *testing.T) {
+	o := Options{MeasurementsFile: filepath.Join(t.TempDir(), "nope.txt")}
+	if _, err := o.loadMeasurements(); err == nil || !strings.Contains(err.Error(), "read --measurements-file") {
+		t.Fatalf("expected a read error, got %v", err)
+	}
+}
+
+func TestLoadMeasurementsRejectsBadHex(t *testing.T) {
+	o := Options{Measurements: []string{"not-hex"}}
+	if _, err := o.loadMeasurements(); err == nil {
+		t.Fatal("expected invalid hex to be rejected")
+	}
+}
+
+func TestSignerRequiresAKey(t *testing.T) {
+	t.Setenv(EnvOperatorKey, "")
+	var o Options
+	if _, err := o.Signer(); err == nil || !strings.Contains(err.Error(), "operator key required") {
+		t.Fatalf("expected a missing-key error, got %v", err)
+	}
+}
+
+// The env var is the fallback so an operator does not repeat the path on every
+// write; the flag wins when both are set.
+func TestSignerReadsTheEnvAndPrefersTheFlag(t *testing.T) {
+	key := writeTestKey(t)
+	t.Setenv(EnvOperatorKey, key)
+
+	var o Options
+	if _, err := o.Signer(); err != nil {
+		t.Fatalf("env fallback: %v", err)
+	}
+	o.OperatorKey = filepath.Join(t.TempDir(), "nonexistent.key")
+	if _, err := o.Signer(); err == nil {
+		t.Fatal("the flag did not take precedence over the env var")
+	}
+}
+
+func writeTestKey(t *testing.T) string {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "operator.key")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestSignerMissingKeyFile(t *testing.T) {
+	o := Options{OperatorKey: filepath.Join(t.TempDir(), "nope.key")}
+	if _, err := o.Signer(); err == nil || !strings.Contains(err.Error(), "read operator key") {
+		t.Fatalf("expected a read error, got %v", err)
+	}
+}
+
+func TestSignerRejectsGarbagePEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.key")
+	if err := os.WriteFile(path, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	o := Options{OperatorKey: path}
+	if _, err := o.Signer(); err == nil || !strings.Contains(err.Error(), "load operator key") {
+		t.Fatalf("expected a key-parse error, got %v", err)
+	}
+}
+
+// Both operator CLIs bind these, so the names are part of the interface.
+func TestBindFlagsNamesEveryOption(t *testing.T) {
+	var o Options
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	BindFlags(fs, &o)
+	for _, name := range []string{"url", "measurements", "measurements-file", "timeout", "operator-key", "insecure"} {
+		if fs.Lookup(name) == nil {
+			t.Errorf("--%s is not bound", name)
+		}
+	}
+	if err := fs.Parse([]string{"--url", "https://cds.example", "--operator-key", "/k.pem"}); err != nil {
+		t.Fatal(err)
+	}
+	if o.URL != "https://cds.example" || o.OperatorKey != "/k.pem" {
+		t.Fatalf("parsed into %+v", o)
+	}
+}

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -1,0 +1,97 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// client writes secrets to CDS over an attested channel.
+type client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// authorizer mints the operator Authorization header for one write, bound to
+// its method, path, and body. Implemented by operatorauth.Signer.
+type authorizer interface {
+	Authorization(method, path string, body []byte) (string, error)
+}
+
+// result is what a write did. Created reports a path that held nothing;
+// Existing names what put the value the write displaced, or on a refusal what
+// is still there.
+type result struct {
+	Created  bool
+	Existing intsecrets.Origin
+	// Refused reports that the path already held a value and the write did not
+	// carry overwrite intent, so nothing changed.
+	Refused bool
+}
+
+// put sends one value. overwrite travels in the body rather than the URL so the
+// operator token's body binding covers it.
+func (c client) put(ctx context.Context, path string, value []byte, overwrite bool, auth authorizer) (result, error) {
+	body, err := json.Marshal(intsecrets.PutRequest{
+		Value:     base64.StdEncoding.EncodeToString(value),
+		Overwrite: overwrite,
+	})
+	if err != nil {
+		return result{}, err
+	}
+
+	url := c.baseURL + "/secrets" + path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		return result{}, err
+	}
+	authz, err := auth.Authorization(http.MethodPut, req.URL.Path, body)
+	if err != nil {
+		return result{}, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authz)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return result{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return result{}, fmt.Errorf("read response: %w", err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusCreated,
+		resp.StatusCode == http.StatusConflict,
+		resp.StatusCode == http.StatusOK && overwrite:
+		var pr intsecrets.PutResponse
+		if err := json.Unmarshal(raw, &pr); err != nil {
+			return result{}, fmt.Errorf("decode response: %w", err)
+		}
+		return result{
+			Created:  pr.Created,
+			Existing: pr.Existing,
+			Refused:  resp.StatusCode == http.StatusConflict,
+		}, nil
+	case resp.StatusCode == http.StatusOK:
+		// 200 answers a replacement. Reading it as anything else would let the
+		// CLI report a refusal for a write that landed.
+		return result{}, fmt.Errorf("cds replaced a value for a request that did not ask to: %s", path)
+	default:
+		return result{}, fmt.Errorf("cds returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+// maxResponseBytes bounds a CDS reply. The body is a three-field status
+// object; anything approaching this is a wrong endpoint.
+const maxResponseBytes = 64 * 1024

--- a/internal/cmds/secrets/cmd.go
+++ b/internal/cmds/secrets/cmd.go
@@ -1,0 +1,80 @@
+// Package secrets implements the `c8s secrets` operator CLI for the CDS secret
+// store.
+//
+// Writes are authorized by an operator EC private key whose public key CDS pins
+// (cds --operator-keys) — the same credential that signs an allowlist mutation,
+// and the same key the `secrets` grants in that allowlist are rooted in. The
+// private key never leaves the CLI: it signs a short-lived token bound to the
+// method, path, and body of one request.
+package secrets
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+)
+
+// options holds the flags shared by every subcommand.
+type options struct {
+	cdsconn.Options
+}
+
+// NewCmd returns the `c8s secrets` command tree.
+func NewCmd() *cobra.Command {
+	return newCmd(localverify.Verify)
+}
+
+// newCmd is the injectable constructor behind NewCmd.
+func newCmd(verify localverify.VerifyFunc) *cobra.Command {
+	o := &options{Options: cdsconn.Options{Verify: verify}}
+	cmd := &cobra.Command{
+		Use:   "secrets",
+		Short: "Manage the CDS secret store",
+		Long: `Put operator-supplied values into the CDS secret store — an API token, a
+database password, a wrapped key: anything CDS cannot generate for itself.
+
+A value is released to a pod when the images running in that pod's sandbox match
+an allowlist entry whose 'secrets' grant covers the path. Write the grant with
+'c8s allowlist workload apply'; this command supplies the value.
+
+Writes are signed with an operator EC private key you supply via --operator-key
+(or C8S_OPERATOR_KEY), whose public half CDS pins separately via
+'c8s install --operator-keys'.
+
+Values live in the CDS process and nowhere else, so a CDS restart clears the
+store and every workload holding a secret has to be rolled (see
+docs/secrets.md).`,
+		SilenceUsage: true,
+	}
+
+	cdsconn.BindFlags(cmd.PersistentFlags(), &o.Options)
+	cmd.AddCommand(newPutCmd(o))
+	return cmd
+}
+
+// client builds the secrets API client over the attested channel to CDS.
+func (o *options) client(ctx context.Context) (client, error) {
+	hc, err := o.HTTPClient(ctx)
+	if err != nil {
+		return client{}, err
+	}
+	return client{baseURL: trimSlash(o.URL), http: hc}, nil
+}
+
+func trimSlash(u string) string {
+	for len(u) > 0 && u[len(u)-1] == '/' {
+		u = u[:len(u)-1]
+	}
+	return u
+}
+
+// cmdCtx returns the command context or a background context as a fallback.
+func cmdCtx(cmd *cobra.Command) context.Context {
+	if c := cmd.Context(); c != nil {
+		return c
+	}
+	return context.Background()
+}

--- a/internal/cmds/secrets/put.go
+++ b/internal/cmds/secrets/put.go
@@ -1,0 +1,132 @@
+package secrets
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+func newPutCmd(o *options) *cobra.Command {
+	var (
+		fromFile  string
+		overwrite bool
+		dryRun    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "put <path>",
+		Short: "Store an operator-supplied value at a secret path",
+		Long: `Store a value at <path> in the CDS secret store, reading it from stdin or from
+--from-file. The bytes are stored exactly as read, including any trailing
+newline; the byte count is printed so you can confirm which bytes were sent.
+
+A path that already holds a value needs --overwrite, and the value it holds is
+named before it is replaced.
+
+A workload reads its secret into a file once, at startup. Replacing a value
+reaches a running pod when that pod next restarts.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			path, err := pkgallowlist.CanonicalSecretPath(args[0])
+			if err != nil {
+				return err
+			}
+			value, err := readValue(cmd, fromFile)
+			if err != nil {
+				return err
+			}
+
+			if dryRun {
+				fmt.Fprintf(cmd.OutOrStdout(), "would write %d bytes to %s\n", len(value), path)
+				return nil
+			}
+
+			signer, err := o.Signer()
+			if err != nil {
+				return err
+			}
+			c, err := o.client(cmdCtx(cmd))
+			if err != nil {
+				return err
+			}
+
+			// Ask to create first, whatever --overwrite says. A path that already
+			// holds a value comes back refused with what is there, so the line
+			// naming what a replacement destroys is printed before it happens —
+			// the store has no versioning and no delete.
+			res, err := c.put(cmdCtx(cmd), path, value, false, signer)
+			if err != nil {
+				return err
+			}
+			if res.Created {
+				fmt.Fprintf(cmd.OutOrStdout(), "+ %s (new)\n", path)
+				fmt.Fprintf(cmd.OutOrStdout(), "wrote %d bytes to %s\n", len(value), path)
+				return nil
+			}
+			if !overwrite {
+				return fmt.Errorf("%s already holds %s; re-run with --overwrite to replace it", path, describe(res.Existing))
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "~ %s (replaces %s)\n", path, describe(res.Existing))
+			res, err = c.put(cmdCtx(cmd), path, value, true, signer)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "wrote %d bytes to %s\n", len(value), path)
+			if res.Existing == intsecrets.OriginWorkload {
+				fmt.Fprintf(cmd.ErrOrStderr(),
+					"note: pods already holding the workload-generated value keep it until they restart\n")
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&fromFile, "from-file", "", "read the value from this file instead of stdin")
+	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "replace a value already at the path")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print the intended change without calling CDS")
+	return cmd
+}
+
+// describe names a stored value by what put it there, for the line an operator
+// reads before replacing it.
+func describe(o intsecrets.Origin) string {
+	switch o {
+	case intsecrets.OriginWorkload:
+		return "a workload-generated value"
+	case intsecrets.OriginOperator:
+		return "an operator-supplied value"
+	default:
+		return "a value"
+	}
+}
+
+// readValue reads the secret from a file or stdin. The bytes are passed through
+// unmodified: a PEM key ends in a newline and a token usually must not, so
+// neither can be trimmed on the CLI's guess.
+func readValue(cmd *cobra.Command, fromFile string) ([]byte, error) {
+	var (
+		value []byte
+		err   error
+	)
+	if fromFile != "" {
+		value, err = os.ReadFile(fromFile)
+		if err != nil {
+			return nil, fmt.Errorf("read --from-file: %w", err)
+		}
+	} else {
+		value, err = io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("read value from stdin: %w", err)
+		}
+	}
+	if len(value) == 0 {
+		return nil, fmt.Errorf("value is empty: supply it on stdin or with --from-file")
+	}
+	return value, nil
+}

--- a/internal/cmds/secrets/put_test.go
+++ b/internal/cmds/secrets/put_test.go
@@ -1,0 +1,320 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// fakeCDS serves PUT /secrets/* with the create-safe semantics the real handler
+// has, recording each request so a test can assert on what the CLI sent.
+type fakeCDS struct {
+	mu      sync.Mutex
+	values  map[string]intsecrets.Origin
+	seen    []intsecrets.PutRequest
+	authz   []string
+	paths   []string
+	failAll bool
+}
+
+func newFakeCDS(t *testing.T) (*fakeCDS, string) {
+	t.Helper()
+	f := &fakeCDS{values: map[string]intsecrets.Origin{}}
+	srv := httptest.NewServer(http.HandlerFunc(f.serve))
+	t.Cleanup(srv.Close)
+	return f, srv.URL
+}
+
+func (f *fakeCDS) serve(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.failAll {
+		http.Error(w, "nope", http.StatusInternalServerError)
+		return
+	}
+	var req intsecrets.PutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/secrets")
+	f.seen = append(f.seen, req)
+	f.authz = append(f.authz, r.Header.Get("Authorization"))
+	f.paths = append(f.paths, r.URL.Path)
+
+	existing, held := f.values[path]
+	resp := intsecrets.PutResponse{Path: path}
+	status := http.StatusCreated
+	switch {
+	case !held:
+		f.values[path] = intsecrets.OriginOperator
+		resp.Created = true
+	case !req.Overwrite:
+		status = http.StatusConflict
+		resp.Existing = existing
+	default:
+		f.values[path] = intsecrets.OriginOperator
+		status = http.StatusOK
+		resp.Existing = existing
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (f *fakeCDS) seed(path string, by intsecrets.Origin) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.values[path] = by
+}
+
+func writeOperatorKey(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "operator.key")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// run drives the command tree the way a shell would, with stdin supplied.
+func run(t *testing.T, stdin string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	cmd := newCmd(func(context.Context, string, json.RawMessage, localverify.Params) (*teetypes.VerificationResult, error) {
+		return nil, nil
+	})
+	var out, errb bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errb.String(), err
+}
+
+func TestPutCreates(t *testing.T) {
+	f, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "hunter2", "put", "/tenant-a/db", "--url", url, "--insecure", "--operator-key", key)
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !strings.Contains(out, "+ /tenant-a/db (new)") || !strings.Contains(out, "wrote 7 bytes to /tenant-a/db") {
+		t.Fatalf("output = %q", out)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+	if f.seen[0].Overwrite {
+		t.Fatal("a plain put carried overwrite intent")
+	}
+	if got, _ := base64.StdEncoding.DecodeString(f.seen[0].Value); string(got) != "hunter2" {
+		t.Fatalf("value = %q", got)
+	}
+	if f.paths[0] != "/secrets/tenant-a/db" {
+		t.Fatalf("path = %q", f.paths[0])
+	}
+	if !strings.HasPrefix(f.authz[0], "Bearer ") {
+		t.Fatalf("Authorization = %q, want an operator bearer token", f.authz[0])
+	}
+}
+
+// The refusal names what is there and leaves it alone, which is the whole point
+// of asking to create before asking to replace.
+func TestPutRefusesOccupiedPathWithoutOverwrite(t *testing.T) {
+	f, url := newFakeCDS(t)
+	f.seed("/tenant-a/db", intsecrets.OriginWorkload)
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "hunter2", "put", "/tenant-a/db", "--url", url, "--insecure", "--operator-key", key)
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(err.Error(), "a workload-generated value") || !strings.Contains(err.Error(), "--overwrite") {
+		t.Fatalf("err = %v", err)
+	}
+	if strings.Contains(out, "wrote") {
+		t.Fatalf("the refusal claimed to have written: %q", out)
+	}
+	if len(f.seen) != 1 || f.seen[0].Overwrite {
+		t.Fatalf("sent %+v, want a single create attempt", f.seen)
+	}
+}
+
+// --overwrite still asks to create first, so the line naming what is destroyed
+// is printed before the write that destroys it.
+func TestPutOverwriteNamesWhatItReplaces(t *testing.T) {
+	f, url := newFakeCDS(t)
+	f.seed("/tenant-a/db", intsecrets.OriginWorkload)
+	key := writeOperatorKey(t)
+
+	out, errOut, err := run(t, "hunter2", "put", "/tenant-a/db", "--url", url, "--insecure", "--operator-key", key, "--overwrite")
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !strings.Contains(out, "~ /tenant-a/db (replaces a workload-generated value)") {
+		t.Fatalf("output = %q", out)
+	}
+	if idx, wrote := strings.Index(out, "~ /tenant-a/db"), strings.Index(out, "wrote 7 bytes"); idx < 0 || wrote < idx {
+		t.Fatalf("the replacement line did not precede the write: %q", out)
+	}
+	if !strings.Contains(errOut, "keep it until they restart") {
+		t.Fatalf("stderr = %q, want the restart note", errOut)
+	}
+	if len(f.seen) != 2 || f.seen[0].Overwrite || !f.seen[1].Overwrite {
+		t.Fatalf("sent %+v, want a create attempt then an overwrite", f.seen)
+	}
+}
+
+// Replacing an operator value is routine rotation, so it says so rather than
+// warning about pods that generated it.
+func TestPutOverwriteOfOperatorValue(t *testing.T) {
+	f, url := newFakeCDS(t)
+	f.seed("/tenant-a/db", intsecrets.OriginOperator)
+	key := writeOperatorKey(t)
+
+	out, errOut, err := run(t, "v2", "put", "/tenant-a/db", "--url", url, "--insecure", "--operator-key", key, "--overwrite")
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !strings.Contains(out, "replaces an operator-supplied value") {
+		t.Fatalf("output = %q", out)
+	}
+	if strings.Contains(errOut, "keep it until they restart") {
+		t.Fatalf("stderr warned about a workload value it did not replace: %q", errOut)
+	}
+}
+
+// --overwrite onto an empty path is a creation and reports as one.
+func TestPutOverwriteOnEmptyPath(t *testing.T) {
+	f, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "v", "put", "/a", "--url", url, "--insecure", "--operator-key", key, "--overwrite")
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !strings.Contains(out, "+ /a (new)") {
+		t.Fatalf("output = %q", out)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}
+
+func TestPutFromFile(t *testing.T) {
+	f, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+	path := filepath.Join(t.TempDir(), "token")
+	if err := os.WriteFile(path, []byte("hf_abc\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := run(t, "", "put", "/a", "--url", url, "--insecure", "--operator-key", key, "--from-file", path); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	got, _ := base64.StdEncoding.DecodeString(f.seen[0].Value)
+	if string(got) != "hf_abc\n" {
+		t.Fatalf("value = %q, want the file's bytes unmodified including the newline", got)
+	}
+}
+
+func TestPutDryRunDoesNotCallCDS(t *testing.T) {
+	f, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "hunter2", "put", "/a", "--url", url, "--insecure", "--operator-key", key, "--dry-run")
+	if err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if !strings.Contains(out, "would write 7 bytes to /a") {
+		t.Fatalf("output = %q", out)
+	}
+	if len(f.seen) != 0 {
+		t.Fatal("--dry-run reached CDS")
+	}
+}
+
+func TestPutRejectsBadInput(t *testing.T) {
+	_, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+	base := []string{"--url", url, "--insecure", "--operator-key", key}
+
+	for _, tc := range []struct {
+		name  string
+		stdin string
+		args  []string
+		want  string
+	}{
+		{"relative path", "v", []string{"put", "tenant/db"}, "must be absolute"},
+		{"wildcard path", "v", []string{"put", "/tenant/**"}, "must not contain wildcards"},
+		{"uncanonical path", "v", []string{"put", "/tenant/../db"}, "not clean"},
+		{"empty stdin", "", []string{"put", "/a"}, "value is empty"},
+		{"missing file", "", []string{"put", "/a", "--from-file", "/nope/nothing"}, "read --from-file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := run(t, tc.stdin, append(tc.args, base...)...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want one containing %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A URL with no attestation must be refused unless the operator asked for it.
+func TestPutRefusesPlaintextWithoutInsecure(t *testing.T) {
+	_, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+	_, _, err := run(t, "v", "put", "/a", "--url", url, "--operator-key", key)
+	if err == nil || !strings.Contains(err.Error(), "refusing plaintext") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPutRequiresURLAndKey(t *testing.T) {
+	t.Setenv("C8S_OPERATOR_KEY", "")
+	if _, _, err := run(t, "v", "put", "/a"); err == nil || !strings.Contains(err.Error(), "--url is required") {
+		t.Fatalf("err = %v, want a --url error", err)
+	}
+	_, url := newFakeCDS(t)
+	if _, _, err := run(t, "v", "put", "/a", "--url", url, "--insecure"); err == nil ||
+		!strings.Contains(err.Error(), "operator key required") {
+		t.Fatalf("err = %v, want an operator-key error", err)
+	}
+}
+
+func TestPutSurfacesServerErrors(t *testing.T) {
+	f, url := newFakeCDS(t)
+	f.failAll = true
+	key := writeOperatorKey(t)
+	_, _, err := run(t, "v", "put", "/a", "--url", url, "--insecure", "--operator-key", key)
+	if err == nil || !strings.Contains(err.Error(), "cds returned 500") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -182,13 +182,13 @@ func (h Handler) servePost(ctx context.Context, w http.ResponseWriter, grant *pk
 		http.Error(w, "secret unavailable", http.StatusInternalServerError)
 		return
 	}
-	_, created, err := h.Store.PutIfAbsent(ctx, path, candidate)
+	_, held, err := h.Store.PutIfAbsent(ctx, path, candidate, OriginWorkload)
 	if err != nil {
 		h.logger().Error("secret create failed", "path", path, "error", err)
 		http.Error(w, "secret unavailable", http.StatusInternalServerError)
 		return
 	}
-	if !created {
+	if held.Exists {
 		// The existing value is withheld: returning it here would make a write
 		// grant a read grant. A caller that also holds read re-reads with GET,
 		// which is how the replica that loses this race recovers.

--- a/internal/secrets/handler_errors_test.go
+++ b/internal/secrets/handler_errors_test.go
@@ -16,8 +16,11 @@ import (
 type failingStore struct{ err error }
 
 func (f failingStore) Get(context.Context, string) ([]byte, error) { return nil, f.err }
-func (f failingStore) PutIfAbsent(context.Context, string, []byte) ([]byte, bool, error) {
-	return nil, false, f.err
+func (f failingStore) PutIfAbsent(context.Context, string, []byte, Origin) ([]byte, Held, error) {
+	return nil, Held{}, f.err
+}
+func (f failingStore) Put(context.Context, string, []byte, Origin) (Held, error) {
+	return Held{}, f.err
 }
 
 // A store failure is not a policy denial: the caller is told the secret is

--- a/internal/secrets/operator.go
+++ b/internal/secrets/operator.go
@@ -1,0 +1,161 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/confidential-dot-ai/c8s/internal/httputil"
+)
+
+// DefaultMaxOperatorBodyBytes caps a PUT body when OperatorHandler.MaxBodyBytes
+// is zero. The value arrives base64-encoded inside a JSON envelope, so the body
+// runs well ahead of the store's own per-value bound.
+const DefaultMaxOperatorBodyBytes int64 = 64 * 1024
+
+// PutRequest is the body of PUT /secrets/*.
+type PutRequest struct {
+	// Value is the secret, base64. Operator values are arbitrary bytes — a
+	// wrapped key, a PEM, a token — so they are not representable raw.
+	Value string `json:"value"`
+	// Overwrite permits replacing a value already at the path. It lives in the
+	// body rather than a query parameter so the operator token's body binding
+	// covers it; htu binds only the path.
+	Overwrite bool `json:"overwrite"`
+}
+
+// PutResponse reports what a PUT did, or on 409 what stopped it. Existing names
+// what put the value that was already there and is empty when there was none.
+type PutResponse struct {
+	Path     string `json:"path"`
+	Created  bool   `json:"created"`
+	Existing Origin `json:"existing,omitempty"`
+}
+
+// OperatorHandler serves PUT on Route: an operator supplying a value CDS cannot
+// generate — an API token, a database password, a wrapped key.
+//
+// Authorization is the operator key that already roots the secrets grants, via
+// the same verifier the allowlist writes use. Its token binds method, path and
+// body, so a captured one cannot be replayed against another path or value.
+type OperatorHandler struct {
+	Store Store
+	// Authorize is operatorauth.Verifier.Authorize. Nil rejects every request.
+	Authorize func(r *http.Request, body []byte) error
+	// MaxBodyBytes caps the request body; zero means DefaultMaxOperatorBodyBytes.
+	MaxBodyBytes int64
+
+	Logger *slog.Logger
+}
+
+func (h OperatorHandler) logger() *slog.Logger {
+	if h.Logger != nil {
+		return h.Logger
+	}
+	return slog.Default()
+}
+
+func (h OperatorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Authorization runs before anything is read off the request, so an
+	// unauthenticated caller learns nothing, not even whether a path parses.
+	body, ok := h.authorize(w, r)
+	if !ok {
+		return
+	}
+
+	path, err := requestPath(r)
+	if err != nil {
+		http.Error(w, "invalid secret path", http.StatusBadRequest)
+		return
+	}
+
+	var req PutRequest
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+	value, err := base64.StdEncoding.DecodeString(req.Value)
+	if err != nil {
+		http.Error(w, "value is not base64", http.StatusUnprocessableEntity)
+		return
+	}
+	if len(value) == 0 {
+		http.Error(w, "value is empty", http.StatusUnprocessableEntity)
+		return
+	}
+
+	if req.Overwrite {
+		h.replace(w, r, path, value)
+		return
+	}
+	h.create(w, r, path, value)
+}
+
+// create refuses a path that already holds something, naming what put it there
+// so the operator can decide before anything is destroyed. The store has no
+// versioning and no delete, so a displaced value is gone.
+func (h OperatorHandler) create(w http.ResponseWriter, r *http.Request, path string, value []byte) {
+	_, held, err := h.Store.PutIfAbsent(r.Context(), path, value, OriginOperator)
+	if err != nil {
+		h.logger().Error("operator secret write failed", "path", path, "error", err)
+		http.Error(w, "secret write failed", http.StatusInternalServerError)
+		return
+	}
+	if held.Exists {
+		writeResult(w, http.StatusConflict, PutResponse{Path: path, Existing: held.Origin})
+		return
+	}
+	h.logger().Info("operator secret created", "path", path, "bytes", len(value))
+	writeResult(w, http.StatusCreated, PutResponse{Path: path, Created: true})
+}
+
+func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path string, value []byte) {
+	held, err := h.Store.Put(r.Context(), path, value, OriginOperator)
+	if err != nil {
+		h.logger().Error("operator secret write failed", "path", path, "error", err)
+		http.Error(w, "secret write failed", http.StatusInternalServerError)
+		return
+	}
+	if !held.Exists {
+		h.logger().Info("operator secret created", "path", path, "bytes", len(value))
+		writeResult(w, http.StatusCreated, PutResponse{Path: path, Created: true})
+		return
+	}
+	h.logger().Info("operator secret replaced", "path", path, "bytes", len(value), "existing", held.Origin)
+	writeResult(w, http.StatusOK, PutResponse{Path: path, Existing: held.Origin})
+}
+
+// authorize reads the body under the cap and runs the operator check against
+// those exact bytes, so the token's body binding is checked against what the
+// handler goes on to decode.
+func (h OperatorHandler) authorize(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	if h.Authorize == nil {
+		http.Error(w, "operator writes are not configured", http.StatusUnauthorized)
+		return nil, false
+	}
+	cap := h.MaxBodyBytes
+	if cap <= 0 {
+		cap = DefaultMaxOperatorBodyBytes
+	}
+	body, ok := httputil.ReadCappedBody(w, r, cap)
+	if !ok {
+		return nil, false
+	}
+	if err := h.Authorize(r, body); err != nil {
+		h.logger().Warn("operator secret write rejected", "remote", r.RemoteAddr, "reason", err)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return nil, false
+	}
+	return body, true
+}
+
+func writeResult(w http.ResponseWriter, status int, resp PutResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/internal/secrets/operator_test.go
+++ b/internal/secrets/operator_test.go
@@ -1,0 +1,318 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// operatorHarness wires the handler to a real store and a recording authorizer,
+// so a test can assert on what the authorizer was handed as well as on the
+// response.
+type operatorHarness struct {
+	h        OperatorHandler
+	store    *MemoryStore
+	seenBody []byte
+	authErr  error
+}
+
+func newOperatorHarness(t *testing.T) *operatorHarness {
+	t.Helper()
+	oh := &operatorHarness{store: NewMemoryStore(8, 64)}
+	oh.h = OperatorHandler{
+		Store: oh.store,
+		Authorize: func(_ *http.Request, body []byte) error {
+			oh.seenBody = append([]byte(nil), body...)
+			return oh.authErr
+		},
+	}
+	return oh
+}
+
+func putRequest(t *testing.T, path string, value []byte, overwrite bool) *http.Request {
+	t.Helper()
+	body, err := json.Marshal(PutRequest{
+		Value:     base64.StdEncoding.EncodeToString(value),
+		Overwrite: overwrite,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return httptest.NewRequest(http.MethodPut, "/secrets"+path, bytes.NewReader(body))
+}
+
+func doPut(h OperatorHandler, r *http.Request) (*httptest.ResponseRecorder, PutResponse) {
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	var resp PutResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	return w, resp
+}
+
+func TestOperatorPutCreates(t *testing.T) {
+	oh := newOperatorHarness(t)
+	w, resp := doPut(oh.h, putRequest(t, "/tenant-a/db", []byte("hunter2"), false))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body)
+	}
+	if !resp.Created || resp.Existing != "" {
+		t.Fatalf("resp = %+v, want a bare creation", resp)
+	}
+	got, err := oh.store.Get(context.Background(), "/tenant-a/db")
+	if err != nil || !bytes.Equal(got, []byte("hunter2")) {
+		t.Fatalf("stored %q %v", got, err)
+	}
+}
+
+// The whole point of the create-first shape: a path holding a value is reported
+// back untouched, so the operator sees what a replacement would destroy before
+// it happens.
+func TestOperatorPutRefusesToDisplaceWithoutOverwrite(t *testing.T) {
+	oh := newOperatorHarness(t)
+	ctx := context.Background()
+	if _, _, err := oh.store.PutIfAbsent(ctx, "/tenant-a/db", []byte("generated"), OriginWorkload); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := doPut(oh.h, putRequest(t, "/tenant-a/db", []byte("hunter2"), false))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", w.Code)
+	}
+	if resp.Created || resp.Existing != OriginWorkload {
+		t.Fatalf("resp = %+v, want the workload origin", resp)
+	}
+	got, _ := oh.store.Get(ctx, "/tenant-a/db")
+	if !bytes.Equal(got, []byte("generated")) {
+		t.Fatalf("a refused write changed the value to %q", got)
+	}
+}
+
+// A 409 names what put the value there and nothing else: the value itself must
+// never reach a write-only caller.
+func TestOperatorPutConflictWithholdsTheValue(t *testing.T) {
+	oh := newOperatorHarness(t)
+	if _, _, err := oh.store.PutIfAbsent(context.Background(), "/a", []byte("topsecret"), OriginWorkload); err != nil {
+		t.Fatal(err)
+	}
+	w, _ := doPut(oh.h, putRequest(t, "/a", []byte("new"), false))
+	if strings.Contains(w.Body.String(), "topsecret") ||
+		strings.Contains(w.Body.String(), base64.StdEncoding.EncodeToString([]byte("topsecret"))) {
+		t.Fatalf("the conflict response carried the stored value: %s", w.Body)
+	}
+}
+
+func TestOperatorPutOverwriteReplaces(t *testing.T) {
+	oh := newOperatorHarness(t)
+	ctx := context.Background()
+	if _, _, err := oh.store.PutIfAbsent(ctx, "/a", []byte("generated"), OriginWorkload); err != nil {
+		t.Fatal(err)
+	}
+
+	w, resp := doPut(oh.h, putRequest(t, "/a", []byte("chosen"), true))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	if resp.Created || resp.Existing != OriginWorkload {
+		t.Fatalf("resp = %+v, want the displaced workload origin", resp)
+	}
+	got, _ := oh.store.Get(ctx, "/a")
+	if !bytes.Equal(got, []byte("chosen")) {
+		t.Fatalf("value = %q, want the operator's", got)
+	}
+}
+
+// An overwrite onto an empty path is a creation, not a replacement, so the CLI
+// does not claim to have destroyed something that was never there.
+func TestOperatorPutOverwriteOnEmptyPathCreates(t *testing.T) {
+	oh := newOperatorHarness(t)
+	w, resp := doPut(oh.h, putRequest(t, "/a", []byte("chosen"), true))
+	if w.Code != http.StatusCreated || !resp.Created || resp.Existing != "" {
+		t.Fatalf("status = %d resp = %+v, want a plain creation", w.Code, resp)
+	}
+}
+
+// Overwrite intent rides in the body so the operator token's pbh claim covers
+// it; a query parameter would be outside both htu and pbh.
+func TestOperatorPutAuthorizesTheExactBody(t *testing.T) {
+	oh := newOperatorHarness(t)
+	req := putRequest(t, "/a", []byte("v"), true)
+	body, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("v")), Overwrite: true})
+	doPut(oh.h, req)
+	if !bytes.Equal(oh.seenBody, body) {
+		t.Fatalf("authorizer saw %q, want the exact request body %q", oh.seenBody, body)
+	}
+}
+
+func TestOperatorPutRejectsUnauthorized(t *testing.T) {
+	oh := newOperatorHarness(t)
+	oh.authErr = fmt.Errorf("no token")
+	w, _ := doPut(oh.h, putRequest(t, "/a", []byte("v"), false))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+	if oh.store.Len() != 0 {
+		t.Fatal("an unauthorized request reached the store")
+	}
+}
+
+// Nil means no operator keys are pinned, which must reject rather than admit.
+func TestOperatorPutWithoutAuthorizerRejects(t *testing.T) {
+	h := OperatorHandler{Store: NewMemoryStore(8, 64)}
+	w, _ := doPut(h, putRequest(t, "/a", []byte("v"), false))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+// Authorization runs before the path is parsed, so an unauthenticated caller
+// cannot even learn which paths are well-formed.
+func TestOperatorPutChecksAuthBeforeThePath(t *testing.T) {
+	oh := newOperatorHarness(t)
+	oh.authErr = fmt.Errorf("no token")
+	req := httptest.NewRequest(http.MethodPut, "/secrets/../etc", strings.NewReader(`{"value":"AA=="}`))
+	w := httptest.NewRecorder()
+	oh.h.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 rather than a path error", w.Code)
+	}
+}
+
+func TestOperatorPutRejectsBadRequests(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+		body string
+		want int
+	}{
+		{"uncanonical path", "/secrets/a/../b", `{"value":"dg=="}`, http.StatusBadRequest},
+		{"percent-encoded path", "/secrets/a%2Fb", `{"value":"dg=="}`, http.StatusBadRequest},
+		{"trailing slash", "/secrets/a/", `{"value":"dg=="}`, http.StatusBadRequest},
+		{"outside the prefix", "/other/a", `{"value":"dg=="}`, http.StatusBadRequest},
+		{"unknown field", "/secrets/a", `{"value":"dg==","ttl":5}`, http.StatusUnprocessableEntity},
+		{"not json", "/secrets/a", `nonsense`, http.StatusUnprocessableEntity},
+		{"value not base64", "/secrets/a", `{"value":"not base64!"}`, http.StatusUnprocessableEntity},
+		{"empty value", "/secrets/a", `{"value":""}`, http.StatusUnprocessableEntity},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oh := newOperatorHarness(t)
+			req := httptest.NewRequest(http.MethodPut, tc.path, strings.NewReader(tc.body))
+			w := httptest.NewRecorder()
+			oh.h.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d: %s", w.Code, tc.want, w.Body)
+			}
+			if oh.store.Len() != 0 {
+				t.Fatal("a rejected request reached the store")
+			}
+		})
+	}
+}
+
+func TestOperatorPutCapsTheBody(t *testing.T) {
+	oh := newOperatorHarness(t)
+	oh.h.MaxBodyBytes = 16
+	req := putRequest(t, "/a", bytes.Repeat([]byte("x"), 64), false)
+	w := httptest.NewRecorder()
+	oh.h.ServeHTTP(w, req)
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want 413", w.Code)
+	}
+}
+
+// The store's per-value bound is a fail-closed limit on process memory, so
+// exceeding it is a server error rather than a silent truncation.
+func TestOperatorPutRespectsTheStoreValueBound(t *testing.T) {
+	oh := newOperatorHarness(t)
+	w, _ := doPut(oh.h, putRequest(t, "/a", bytes.Repeat([]byte("x"), 65), false))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+	if oh.store.Len() != 0 {
+		t.Fatal("an oversized value was stored")
+	}
+}
+
+func TestOperatorPutStoreFailureIsFiveHundred(t *testing.T) {
+	for _, overwrite := range []bool{false, true} {
+		h := OperatorHandler{
+			Store:     failingStore{err: fmt.Errorf("backend down")},
+			Authorize: func(*http.Request, []byte) error { return nil },
+		}
+		w, _ := doPut(h, putRequest(t, "/a", []byte("v"), overwrite))
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("overwrite=%v: status = %d, want 500", overwrite, w.Code)
+		}
+	}
+}
+
+// --- against the real operator credential ---
+
+// The claim the body-bound token makes has to hold against the real verifier,
+// not just a stub: a captured write must not be replayable against another path,
+// and must not be editable into an overwrite.
+func TestOperatorPutAgainstRealOperatorAuth(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewMemoryStore(8, 64)
+	h := OperatorHandler{
+		Store:     store,
+		Authorize: operatorauth.Verifier{Keys: []*ecdsa.PublicKey{&key.PublicKey}}.Authorize,
+	}
+
+	create, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("v1"))})
+	authz, err := signer.Authorization(http.MethodPut, "/secrets/a", create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	send := func(path string, body []byte, header string) int {
+		req := httptest.NewRequest(http.MethodPut, path, bytes.NewReader(body))
+		req.Header.Set("Authorization", header)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := send("/secrets/a", create, authz); code != http.StatusCreated {
+		t.Fatalf("a properly signed write = %d, want 201", code)
+	}
+	if code := send("/secrets/b", create, authz); code != http.StatusUnauthorized {
+		t.Fatalf("the same token against another path = %d, want 401", code)
+	}
+
+	// Editing the captured body into an overwrite breaks the pbh binding, which
+	// is why the flag rides in the body rather than the query string.
+	escalated, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("v1")), Overwrite: true})
+	if code := send("/secrets/a", escalated, authz); code != http.StatusUnauthorized {
+		t.Fatalf("an edited body = %d, want 401", code)
+	}
+	if code := send("/secrets/a", create, authz); code != http.StatusConflict {
+		t.Fatalf("replaying the create = %d, want 409 (nothing displaced)", code)
+	}
+	got, _ := store.Get(context.Background(), "/a")
+	if !bytes.Equal(got, []byte("v1")) {
+		t.Fatalf("value = %q, want the one write that was authorized", got)
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -13,6 +13,25 @@ import (
 // ErrNotFound reports a path the store does not hold.
 var ErrNotFound = errors.New("secrets: no such path")
 
+// Origin records what put a value at a path.
+type Origin string
+
+const (
+	// OriginWorkload marks a value CDS generated for a workload that found its
+	// path empty.
+	OriginWorkload Origin = "workload"
+	// OriginOperator marks a value an operator supplied over PUT /secrets/*.
+	OriginOperator Origin = "operator"
+)
+
+// Held describes what a path already contained when a write arrived. It carries
+// the origin and never the value: the operator write path reports what it is
+// about to displace, and that report must not turn a write into a read.
+type Held struct {
+	Exists bool
+	Origin Origin
+}
+
 // Store is the secret backend.
 //
 // Generation lives above the store, not inside it: a backing store generates in
@@ -23,8 +42,12 @@ var ErrNotFound = errors.New("secrets: no such path")
 type Store interface {
 	Get(ctx context.Context, path string) ([]byte, error)
 	// PutIfAbsent stores value at path if nothing is there, returning what the
-	// path holds afterwards and whether this call is what put it there.
-	PutIfAbsent(ctx context.Context, path string, value []byte) (current []byte, created bool, err error)
+	// path holds afterwards and what was already there. held.Exists reports that
+	// the write did not happen.
+	PutIfAbsent(ctx context.Context, path string, value []byte, by Origin) (current []byte, held Held, err error)
+	// Put stores value at path, replacing anything already there, and reports
+	// what it displaced.
+	Put(ctx context.Context, path string, value []byte, by Origin) (Held, error)
 }
 
 // GeneratedValueBytes is the size of a value CDS mints for a workload that
@@ -49,16 +72,21 @@ func Generate() ([]byte, error) {
 // take every certificate in the cluster with it.
 type MemoryStore struct {
 	mu       sync.RWMutex
-	values   map[string][]byte
+	values   map[string]entry
 	maxPaths int
 	maxValue int
+}
+
+type entry struct {
+	value  []byte
+	origin Origin
 }
 
 // NewMemoryStore builds the store. maxPaths bounds distinct paths; maxValue
 // bounds one value.
 func NewMemoryStore(maxPaths, maxValue int) *MemoryStore {
 	return &MemoryStore{
-		values:   make(map[string][]byte),
+		values:   make(map[string]entry),
 		maxPaths: maxPaths,
 		maxValue: maxValue,
 	}
@@ -67,29 +95,62 @@ func NewMemoryStore(maxPaths, maxValue int) *MemoryStore {
 func (s *MemoryStore) Get(_ context.Context, path string) ([]byte, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	v, ok := s.values[path]
+	e, ok := s.values[path]
 	if !ok {
 		return nil, ErrNotFound
 	}
 	// Copy: the caller must not be able to mutate stored state through the
 	// slice it is handed.
-	return append([]byte(nil), v...), nil
+	return append([]byte(nil), e.value...), nil
 }
 
-func (s *MemoryStore) PutIfAbsent(_ context.Context, path string, value []byte) ([]byte, bool, error) {
-	if len(value) > s.maxValue {
-		return nil, false, fmt.Errorf("secrets: value is %d bytes, limit is %d", len(value), s.maxValue)
+func (s *MemoryStore) PutIfAbsent(_ context.Context, path string, value []byte, by Origin) ([]byte, Held, error) {
+	if err := s.checkValue(value); err != nil {
+		return nil, Held{}, err
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if v, ok := s.values[path]; ok {
-		return append([]byte(nil), v...), false, nil
+	if e, ok := s.values[path]; ok {
+		return append([]byte(nil), e.value...), Held{Exists: true, Origin: e.origin}, nil
 	}
+	if err := s.checkRoom(); err != nil {
+		return nil, Held{}, err
+	}
+	s.values[path] = entry{value: append([]byte(nil), value...), origin: by}
+	return append([]byte(nil), value...), Held{}, nil
+}
+
+func (s *MemoryStore) Put(_ context.Context, path string, value []byte, by Origin) (Held, error) {
+	if err := s.checkValue(value); err != nil {
+		return Held{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	prior, existed := s.values[path]
+	if !existed {
+		if err := s.checkRoom(); err != nil {
+			return Held{}, err
+		}
+	}
+	s.values[path] = entry{value: append([]byte(nil), value...), origin: by}
+	return Held{Exists: existed, Origin: prior.origin}, nil
+}
+
+func (s *MemoryStore) checkValue(value []byte) error {
+	if len(value) > s.maxValue {
+		return fmt.Errorf("secrets: value is %d bytes, limit is %d", len(value), s.maxValue)
+	}
+	return nil
+}
+
+// checkRoom guards the path bound. Callers hold the lock and have established
+// the path is absent, so this is only ever asked about a write that grows the
+// map.
+func (s *MemoryStore) checkRoom() error {
 	if len(s.values) >= s.maxPaths {
-		return nil, false, fmt.Errorf("secrets: store holds %d paths, limit is %d", len(s.values), s.maxPaths)
+		return fmt.Errorf("secrets: store holds %d paths, limit is %d", len(s.values), s.maxPaths)
 	}
-	s.values[path] = append([]byte(nil), value...)
-	return append([]byte(nil), value...), true, nil
+	return nil
 }
 
 // Len reports how many paths the store holds, for metrics and tests.

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -20,19 +20,78 @@ func TestMemoryStorePutIfAbsent(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(10, 64)
 
-	got, created, err := s.PutIfAbsent(ctx, "/a", []byte("first"))
-	if err != nil || !created || !bytes.Equal(got, []byte("first")) {
-		t.Fatalf("first put: %q %v %v", got, created, err)
+	got, held, err := s.PutIfAbsent(ctx, "/a", []byte("first"), OriginWorkload)
+	if err != nil || held.Exists || !bytes.Equal(got, []byte("first")) {
+		t.Fatalf("first put: %q %+v %v", got, held, err)
 	}
-	got, created, err = s.PutIfAbsent(ctx, "/a", []byte("second"))
+	got, held, err = s.PutIfAbsent(ctx, "/a", []byte("second"), OriginOperator)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if created {
+	if !held.Exists {
 		t.Fatal("second put reported that it created the value")
+	}
+	if held.Origin != OriginWorkload {
+		t.Fatalf("held origin = %q, want the first writer's", held.Origin)
 	}
 	if !bytes.Equal(got, []byte("first")) {
 		t.Fatalf("second put = %q, want the original value", got)
+	}
+}
+
+// Put replaces whatever is there and reports what that was, which is the only
+// thing the operator write path learns about a value it did not write.
+func TestMemoryStorePut(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(10, 64)
+
+	held, err := s.Put(ctx, "/a", []byte("operator"), OriginOperator)
+	if err != nil || held.Exists {
+		t.Fatalf("put onto an empty path: %+v %v", held, err)
+	}
+
+	if _, _, err := s.PutIfAbsent(ctx, "/b", []byte("generated"), OriginWorkload); err != nil {
+		t.Fatal(err)
+	}
+	held, err = s.Put(ctx, "/b", []byte("operator"), OriginOperator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !held.Exists || held.Origin != OriginWorkload {
+		t.Fatalf("held = %+v, want the displaced workload value", held)
+	}
+	got, err := s.Get(ctx, "/b")
+	if err != nil || !bytes.Equal(got, []byte("operator")) {
+		t.Fatalf("after replace: %q %v", got, err)
+	}
+
+	// The replacement carries its own origin forward.
+	held, err = s.Put(ctx, "/b", []byte("again"), OriginOperator)
+	if err != nil || held.Origin != OriginOperator {
+		t.Fatalf("held = %+v %v, want the operator value it replaced", held, err)
+	}
+}
+
+// Put is bounded by the same caps as PutIfAbsent, and replacing a path does not
+// consume room the store does not have.
+func TestMemoryStorePutBounds(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(1, 4)
+
+	if _, err := s.Put(ctx, "/a", []byte("toolong"), OriginOperator); err == nil {
+		t.Fatal("an oversized value was stored")
+	}
+	if _, err := s.Put(ctx, "/a", []byte("ok"), OriginOperator); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(ctx, "/b", []byte("ok"), OriginOperator); err == nil {
+		t.Fatal("the path cap did not bound Put")
+	}
+	if _, err := s.Put(ctx, "/a", []byte("new"), OriginOperator); err != nil {
+		t.Fatalf("replacing an existing path at the cap: %v", err)
+	}
+	if s.Len() != 1 {
+		t.Fatalf("Len = %d, want 1", s.Len())
 	}
 }
 
@@ -42,7 +101,7 @@ func TestMemoryStoreCopiesValues(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(10, 64)
 	original := []byte("secret")
-	if _, _, err := s.PutIfAbsent(ctx, "/a", original); err != nil {
+	if _, _, err := s.PutIfAbsent(ctx, "/a", original, OriginWorkload); err != nil {
 		t.Fatal(err)
 	}
 	original[0] = 'X' // mutate the caller's slice after storing
@@ -65,20 +124,20 @@ func TestMemoryStoreBounds(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(2, 4)
 
-	if _, _, err := s.PutIfAbsent(ctx, "/big", []byte("toolong")); err == nil {
+	if _, _, err := s.PutIfAbsent(ctx, "/big", []byte("toolong"), OriginWorkload); err == nil {
 		t.Fatal("an oversized value was stored")
 	}
 	for _, p := range []string{"/a", "/b"} {
-		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok")); err != nil {
+		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok"), OriginWorkload); err != nil {
 			t.Fatalf("put %s: %v", p, err)
 		}
 	}
-	if _, _, err := s.PutIfAbsent(ctx, "/c", []byte("ok")); err == nil {
+	if _, _, err := s.PutIfAbsent(ctx, "/c", []byte("ok"), OriginWorkload); err == nil {
 		t.Fatal("the path cap did not bound the store")
 	}
 	// An existing path still resolves at the cap.
-	if _, created, err := s.PutIfAbsent(ctx, "/a", []byte("ok")); err != nil || created {
-		t.Fatalf("existing path at the cap: created=%v err=%v", created, err)
+	if _, held, err := s.PutIfAbsent(ctx, "/a", []byte("ok"), OriginWorkload); err != nil || !held.Exists {
+		t.Fatalf("existing path at the cap: held=%+v err=%v", held, err)
 	}
 	if s.Len() != 2 {
 		t.Fatalf("Len = %d, want 2", s.Len())


### PR DESCRIPTION
CDS generates a value it is asked for and finds missing, which covers a session key but not an API token, a database password, or a wrapped DEK. Those have to come from an operator.

PUT /secrets/* is served behind the allowlistWrite middleware and verified by the same operatorauth.Verifier the allowlist mutations use — the key CDS already pins, and the key the `secrets` grants are rooted in. Its token binds method, path and body, so a captured one is not replayable against a different path or a different value. The store gains an unconditional Put alongside Get/PutIfAbsent, and both handlers share one MemoryStore.

`c8s secrets put <path>` reads the value from stdin or --from-file and sends it base64 in a JSON envelope. The bytes are stored exactly as read: trimming a trailing newline would corrupt a PEM and keeping one corrupts a token, so neither is guessed at and the byte count is printed instead.

Resolving the open question in SECRETS_DESIGN.md §4 — what PUT does over a path a workload created — the write is create-safe by default. A path that already holds a value answers 409 naming what put it there, and nothing is written; --overwrite replaces it, and the CLI prints the line describing what it is destroying before it does. That is what makes it diff-first without an operator read path: an endpoint that returned a stored value would turn the operator key into a read capability over every secret in the cluster, which it is not today. The store has no versioning and no delete, so an accidental clobber is unrecoverable and worth one flag.

Overwrite intent travels in the request body rather than a query parameter because operatorauth binds htu to r.URL.Path, which excludes the query string — a captured create token with ?overwrite=true appended would otherwise displace another value. TestOperatorPutAgainstRealOperatorAuth pins that against the real signer and verifier.

Overwriting is not live rotation: a workload reads its secret into a file once at startup, so a replacement reaches a pod when that pod next restarts, and the pods that generated a value go on using it. The CLI says so on the workload-generated path. There is no DELETE; revocation stays "restart CDS", which empties the store.

Origin is tracked per path so the refusal can distinguish a value a workload generated from an earlier operator write. It is metadata only — Held never carries the value, so reporting what a write would displace cannot become a way to read it.

internal/cmds/cdsconn extracts what the two operator CLIs share: the attested HTTP client and the operator credential. The --insecure plaintext gate, the tls-lb discovery probe and the RA-TLS fallback are each a way to reach an unattested endpoint by mistake, and duplicating them for a second CLI is how the two drift.