### PR TITLE
chore(image): bump CONFOS_REF for the attestation-api GPU DeviceAllow fix

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -33,7 +33,7 @@ env:
   # SHA (checkout fetches it as a ref). Pinned, not main: bumping it changes
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main.
-  CONFOS_REF: "f7cbadcf179f580d465fa28753a9821655dd60f3" # confos main (#68)
+  CONFOS_REF: "1180707d8c862ba0c1368f48c15ed6d82817ea52" # confos main (#73)
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Bumps the pinned confos build tree from f7cbadc (#68) to 1180707 (confidential-dot-ai/confidential-os-builder#73).

## Why

The baked `attestation-api.service` used `DeviceAllow=char-nvidia-frontend`, which no longer names the major-195 device group on current drivers (`/proc/devices` registers it as `nvidia`). The device cgroup therefore denied `/dev/nvidia0..7`, NVML enumerated zero GPUs, and every GPU-evidence `/attest` request failed with `no CC GPUs or switches reported by NVAT SDK`. The bumped tree allows `char-nvidia` instead.

Verified end-to-end on b300-node-2 / sglang-cvm with a runtime drop-in of the same change: `confai verify --require-nvidia-gpu` passes with 8 nonce-bound Blackwell GPUs.

## Notes

- Changes the image's TDX measurement, as any CONFOS_REF bump does — launches from the rebuilt image dir carry their own refreshed `manifest.json`.
- Merging triggers the usual Docker → c8s-image chain, publishing a new `c8s-base:rke2-cdi`.