### PR TITLE
feat(tls-lb): wide-open CORS on protocol endpoints by default

### DIFF
--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -211,6 +211,8 @@ data:
             location = {{ .Values.tlsLb.discovery.path }} {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}
+                {{- else if eq (include "tls-lb.protocolCorsEnabled" .) "true" }}
+                {{- include "tls-lb.protocolCorsLocationDirectives" . | nindent 16 }}
                 {{- end }}
                 access_log off;
                 default_type application/json;
@@ -221,6 +223,8 @@ data:
             location = {{ .Values.tlsLb.discovery.cdsCertPath }} {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}
+                {{- else if eq (include "tls-lb.protocolCorsEnabled" .) "true" }}
+                {{- include "tls-lb.protocolCorsLocationDirectives" . | nindent 16 }}
                 {{- end }}
                 access_log off;
                 default_type application/x-pem-file;
@@ -232,6 +236,8 @@ data:
             location = {{ .Values.tlsLb.discovery.meshCAPath }} {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}
+                {{- else if eq (include "tls-lb.protocolCorsEnabled" .) "true" }}
+                {{- include "tls-lb.protocolCorsLocationDirectives" . | nindent 16 }}
                 {{- end }}
                 access_log off;
                 default_type application/x-pem-file;
@@ -249,6 +255,8 @@ data:
             location /.well-known/c8s/ {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}
+                {{- else if eq (include "tls-lb.protocolCorsEnabled" .) "true" }}
+                {{- include "tls-lb.protocolCorsLocationDirectives" . | nindent 16 }}
                 {{- end }}
                 proxy_pass http://127.0.0.1:{{ .Values.tlsLb.attest.port }};
                 proxy_set_header Host $host;

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -194,6 +194,8 @@ readBurst — the numeric args arrive pre-validated by the configmap prologue.
 location{{ if .exact }} ={{ end }} {{ .path }} {
     {{- if default false $root.Values.tlsLb.cors.enabled }}
     {{- include "tls-lb.corsLocationDirectives" $root.Values.tlsLb.cors | nindent 4 }}
+    {{- else if eq (include "tls-lb.protocolCorsEnabled" $root) "true" }}
+    {{- include "tls-lb.protocolCorsLocationDirectives" $root | nindent 4 }}
     {{- end }}
     # These run before nginx collapses callers onto the loopback proxy source.
     # Each zone's map key is empty for the methods it does not cover, so
@@ -219,6 +221,11 @@ Validate the global CORS configuration. Skips when disabled.
 {{- if hasKey $cors "enabled" -}}
 {{- if not (kindIs "bool" $cors.enabled) -}}
 {{- fail (printf "tlsLb.cors.enabled must be a boolean; do not set it via --set-string, got: %v" $cors.enabled) -}}
+{{- end -}}
+{{- end -}}
+{{- if hasKey $cors "protocolEndpoints" -}}
+{{- if not (kindIs "bool" $cors.protocolEndpoints) -}}
+{{- fail (printf "tlsLb.cors.protocolEndpoints must be a boolean; do not set it via --set-string, got: %v" $cors.protocolEndpoints) -}}
 {{- end -}}
 {{- end -}}
 {{- if default false $cors.enabled -}}
@@ -382,6 +389,52 @@ add_header Access-Control-Allow-Methods     $cors_out_methods always;
 add_header Access-Control-Allow-Headers     $cors_out_headers always;
 add_header Access-Control-Allow-Credentials $cors_out_credentials always;
 add_header Access-Control-Expose-Headers    $cors_out_expose always;
+{{- end -}}
+
+{{/*
+Whether the c8s protocol-owned locations get the built-in wide-open CORS
+block: tlsLb.cors.protocolEndpoints (default true), unless the operator's
+global CORS block is enabled — an explicit policy already covers every
+location, so the built-in one steps aside. hasKey instead of `default`
+because sprig's default treats an explicit false as unset.
+*/}}
+{{- define "tls-lb.protocolCorsEnabled" -}}
+{{- $cors := default dict .Values.tlsLb.cors -}}
+{{- $pe := true -}}
+{{- if hasKey $cors "protocolEndpoints" -}}{{- $pe = $cors.protocolEndpoints -}}{{- end -}}
+{{- and $pe (not (default false $cors.enabled)) -}}
+{{- end -}}
+
+{{/*
+Render wide-open CORS directives for a c8s protocol-owned location (the
+attestation/handshake/tunnel namespace, the discovery document and
+certificate endpoints, the built-in allowlist route). These endpoints exist
+to be verified by any browser anywhere: every response is either
+self-authenticating (hardware evidence, CDS-signed certificates, sealed
+tunnel records) or public by design, and no request relies on ambient
+browser credentials (allowlist mutations are operator-signed over method,
+path, and body). An origin allowlist here cannot protect anything and only
+breaks third-party verifiers, so the policy is a constant: any origin, no
+credentials. Self-contained on purpose — no http-level maps and no
+upstream pass-through; these endpoints are c8s-owned end to end, so tls-lb
+states their CORS policy itself. Caller nindents into a `location {}`
+block.
+*/}}
+{{- define "tls-lb.protocolCorsLocationDirectives" -}}
+proxy_hide_header Access-Control-Allow-Origin;
+proxy_hide_header Access-Control-Allow-Methods;
+proxy_hide_header Access-Control-Allow-Headers;
+proxy_hide_header Access-Control-Allow-Credentials;
+proxy_hide_header Access-Control-Expose-Headers;
+if ($request_method = 'OPTIONS') {
+    add_header Access-Control-Allow-Origin  "*" always;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Authorization, Content-Type, X-C8s-Session" always;
+    add_header Access-Control-Max-Age       "600" always;
+    add_header Content-Length 0;
+    return 204;
+}
+add_header Access-Control-Allow-Origin "*" always;
 {{- end -}}
 
 {{/*

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1138,8 +1138,26 @@ tlsLb:
   # `routes[i].cors.enabled: false` to disable CORS on that route while
   # leaving the global block enabled. Only the `enabled` key is honored on a
   # per-route cors block.
+  #
+  # Independent of this block, the c8s protocol-owned endpoints
+  # (/.well-known/c8s/*, the discovery document and certificate endpoints,
+  # and the built-in /allowlist route) serve wide-open CORS by default —
+  # see `protocolEndpoints` below.
   cors:
     enabled: false
+    # -- Wide-open CORS (Access-Control-Allow-Origin "*", no credentials) on
+    # the c8s protocol-owned endpoints only: /.well-known/c8s/*, the
+    # discovery document and certificate endpoints, and the built-in
+    # /allowlist route. On by default because those endpoints exist to be
+    # verified by any browser anywhere: responses are self-authenticating
+    # (hardware evidence, CDS-signed certificates, sealed tunnel records) or
+    # public by design, and no request relies on ambient browser credentials
+    # (allowlist mutations are operator-signed). An origin allowlist there
+    # cannot protect anything and only breaks third-party verifiers. Workload
+    # locations (`routes` and the catch-all upstream) are never affected by
+    # this flag. Ignored while `enabled` is true — the operator policy below
+    # then covers every location, protocol endpoints included.
+    protocolEndpoints: true
     # -- Allowed Origin values. Use ["*"] to allow any origin (cannot be
     # combined with allowCredentials: true; browsers reject that pairing).
     # Otherwise list exact origins; the request Origin header is echoed back

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2246,6 +2246,84 @@ func TestTLSLBCORSAllowsSessionHeaderByDefault(t *testing.T) {
 	}
 }
 
+// protocolCORSLocations are the c8s protocol-owned nginx locations that serve
+// wide-open CORS by default: their responses are self-authenticating or
+// public by design, and browser verifiers on any origin must be able to
+// reach them.
+var protocolCORSLocations = []struct{ match, path string }{
+	{"exact", "/allowlist"},
+	{"prefix", "/allowlist/"},
+	{"exact", "/v1/discovery"},
+	{"exact", "/.well-known/cds-cert.pem"},
+	{"exact", "/.well-known/mesh-ca.pem"},
+	{"prefix", "/.well-known/c8s/"},
+}
+
+func TestTLSLBProtocolEndpointsCORSByDefault(t *testing.T) {
+	// With no CORS configuration at all, the protocol-owned endpoints must be
+	// callable from a browser on any origin — that is the whole point of
+	// in-browser attestation — while workload locations stay untouched.
+	out, err := helmTemplateTLSLB(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	for _, loc := range protocolCORSLocations {
+		block := cfg.location(t, loc.match, loc.path)
+		block.assertDirective(t, "add_header", "Access-Control-Allow-Origin", `"*"`, "always")
+	}
+	// The workload catch-all inherits nothing from the protocol default.
+	cfg.location(t, "prefix", "/").assertNoDirective(t, "add_header")
+	// The built-in policy is self-contained: none of the global CORS
+	// http-level maps are rendered.
+	if _, ok := cfg.maps[nginxMapKey{source: "$http_origin", target: "$cors_origin"}]; ok {
+		t.Fatal("global CORS maps rendered without tlsLb.cors.enabled")
+	}
+}
+
+func TestTLSLBProtocolEndpointsCORSOptOut(t *testing.T) {
+	out, err := helmTemplateTLSLB(t, "--set", "cors.protocolEndpoints=false")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	conf := renderedTLSLBNginxConf(t, out)
+	if strings.Contains(conf, "Access-Control") {
+		t.Fatalf("CORS directives rendered with cors.protocolEndpoints=false:\n%s", conf)
+	}
+}
+
+func TestTLSLBGlobalCORSCoversProtocolEndpoints(t *testing.T) {
+	// An enabled global CORS block is an explicit operator policy; it covers
+	// the protocol endpoints too (as it always has), and the built-in
+	// wide-open block steps aside rather than double-emitting headers.
+	out, err := helmTemplateTLSLB(t,
+		"--set", "cors.enabled=true",
+		"--set", "cors.allowOrigins={https://example.github.io}",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	for _, loc := range protocolCORSLocations {
+		block := cfg.location(t, loc.match, loc.path)
+		block.assertDirective(t, "add_header", "Access-Control-Allow-Origin", "$cors_out_origin", "always")
+	}
+	if conf := renderedTLSLBNginxConf(t, out); strings.Contains(conf, `Access-Control-Allow-Origin  "*"`) ||
+		strings.Contains(conf, `Access-Control-Allow-Origin "*"`) {
+		t.Fatalf("wide-open protocol CORS rendered alongside an enabled global block:\n%s", conf)
+	}
+}
+
+func TestTLSLBRejectsStringProtocolEndpoints(t *testing.T) {
+	out, err := helmTemplateTLSLB(t, "--set-string", "cors.protocolEndpoints=false")
+	if err == nil {
+		t.Fatal("helm template succeeded with string cors.protocolEndpoints, want error")
+	}
+	if !strings.Contains(out, "tlsLb.cors.protocolEndpoints must be a boolean") {
+		t.Fatalf("unexpected error output:\n%s", out)
+	}
+}
+
 func TestTLSLBExposesAllowlistThroughCDSByDefault(t *testing.T) {
 	out, err := helmTemplateTLSLB(t)
 	if err != nil {


### PR DESCRIPTION
## Why

Browser verifiers are dead on arrival against a default install. The protocol endpoints — `/.well-known/c8s/*`, the discovery document and certificate endpoints, and the built-in `/allowlist` route — send no CORS headers unless the operator enables the global `tlsLb.cors` block, which also requires choosing an origin allowlist and applies to every workload location. So the endpoints whose whole purpose is *any browser anywhere can verify this cluster* are exactly the ones a cross-origin page cannot reach (we just hit this deploying the static c8s-verify demo page, and had to add CORS at the WebPKI front door instead).

An origin allowlist on those endpoints protects nothing:

- every response is self-authenticating (hardware evidence, CDS-signed certificates, sealed tunnel records) or public by design;
- no request relies on ambient browser credentials — allowlist mutations are operator-signed over method, path, and body;
- the client-side c8s-verify flow fails closed on substitution.

It only breaks third-party verifiers — and third parties verifying your cluster from origins you never heard of is the point of publishing attestation.

## What

New `tlsLb.cors.protocolEndpoints` (default **true**): the protocol-owned locations serve `Access-Control-Allow-Origin: *` (no credentials, preflight short-circuited at nginx) via a self-contained directive set — no http-level maps and no upstream pass-through, since these endpoints are c8s-owned end to end.

Scope and precedence:

- **Workload locations** (`routes` and the catch-all upstream) are never affected by this flag; they keep the opt-in global block.
- **An enabled global `cors` block behaves exactly as today** and covers the protocol endpoints with the operator's policy; the built-in wide-open block steps aside (no double headers, no behavior change for existing CORS users).
- `protocolEndpoints: false` restores the previous no-CORS default.
- Preflight `OPTIONS` on `/allowlist` returns 204 before the rate limiter, which already exempted it.

## Testing

- New chart tests: default render carries `ACAO *` on all six protocol locations and nothing on the catch-all; opt-out renders no CORS at all; an enabled global block uses the `$cors_out_*` machinery on protocol locations with no literal `*` anywhere; `--set-string` booleans are rejected.
- `go test -race ./...`, `golangci-lint run` (0 issues), `gofmt`, and `.github/scripts/chart-verify.sh` all clean.