### PR TITLE
fix(webhook): close two reserved-volume bypasses and fail closed on kata secrets

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -30,6 +30,13 @@ measurement requirement above is unmeetable there. Two other reasons stand
 independently: the kata sandbox ID comes from a host-written CRI annotation, and
 argv enforcement in the guest is watch-and-kill rather than synchronous.
 
+This is enforced, not just documented: the fetcher redeems its sandbox token
+over the mounted nri-image-policy socket and has no guest (loopback) endpoint,
+so an operator without `--workload-claims-host-dir` has nothing to mount. The
+webhook rejects `confidential.ai/c8s-secrets` at admission there rather than
+admitting a pod whose fetcher would CrashLoop while the workload blocked
+forever on a file that never lands.
+
 ## Asking for a secret
 
 Annotate the pod alongside `confidential.ai/cw`:

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -97,11 +97,6 @@ const defaultGetCertRunAsNonRoot = true
 const discoveryPublicTLSModeCDS = "cds"
 const discoveryPublicTLSModeWebPKI = "webpki"
 
-// reservedCertContainerName is the injected mesh-cert sidecar's name. It is
-// operator-reserved: a pod may not declare its own container under it. The
-// webhook rebuilds the sidecar every call (injectInitContainers) and rejects
-// the name in the regular/ephemeral lists (rejectReservedCertContainer); the
-// cw-label-integrity VAP enforces its presence in the API server.
 // reservedSecretContainerName is the injected secret fetcher. Reserved like
 // the cert containers: a pod that declared the name itself would have the
 // webhook's container silently replace or collide with it.
@@ -123,6 +118,11 @@ const defaultSecretDir = "/run/c8s/secrets"
 // writes into the shared directory pressure the pod rather than fail.
 const secretsVolumeSizeLimit = "1Mi"
 
+// reservedCertContainerName is the injected mesh-cert sidecar's name. It is
+// operator-reserved: a pod may not declare its own container under it. The
+// webhook rebuilds the sidecar every call (injectInitContainers) and rejects
+// the name in the regular/ephemeral lists (rejectReservedCertContainer); the
+// cw-label-integrity VAP enforces its presence in the API server.
 const reservedCertContainerName = "c8s-cert"
 
 // reservedCertWaitContainerName is the injected gate init container that blocks
@@ -570,6 +570,18 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
 			"%w: %s pods must not set hostNetwork — a hostNetwork pod shares the node IP and cannot be mesh-intercepted or protected by the cw inbound guard",
 			errInvalidInjectionAnnotation, AnnotationWorkload))
+	}
+	// The fetcher redeems a sandbox token from the node's inventory over the
+	// mounted nri-image-policy socket, and unlike get-cert it has no guest
+	// (kata loopback) endpoint. Without the host dir there is no socket to
+	// mount, so injecting it would produce a Running pod whose fetcher
+	// CrashLoops on a missing socket while the workload blocks forever waiting
+	// for a file that never lands. Refuse at admission instead — kata secrets
+	// are out of scope for further reasons too (see docs/secrets.md).
+	if inj != nil && len(inj.Secrets.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
+			"%w: %s needs the node inventory socket, which this operator is not configured with (kata, or nri-image-policy disabled); see docs/secrets.md",
+			errInvalidInjectionAnnotation, AnnotationSecrets))
 	}
 	if inj != nil && inj.SAN == "" {
 		// req.Namespace, not pod.Namespace: template-created pods reach
@@ -1125,11 +1137,7 @@ func secretsVolume() corev1.Volume {
 // that, but Kubernetes strips spec.ephemeralContainers at CREATE, so that check
 // only ever runs against an empty list.
 func rejectEphemeralReservedMounts(pod *corev1.Pod) error {
-	certVolume := strings.TrimSpace(pod.Annotations[AnnotationCertVolume])
-	if certVolume == "" {
-		certVolume = defaultCertVolumeName
-	}
-	reserved := map[string]bool{secretsVolumeName: true, certVolume: true}
+	reserved := reservedVolumeNames(pod)
 	for _, c := range pod.Spec.EphemeralContainers {
 		if isReservedCertName(c.Name) {
 			return fmt.Errorf("%w: ephemeral container name %q is reserved for the injected c8s containers",
@@ -1143,6 +1151,37 @@ func rejectEphemeralReservedMounts(pod *corev1.Pod) error {
 		}
 	}
 	return nil
+}
+
+// reservedVolumeNames is the set of volumes holding c8s material on this pod:
+// what the injected sidecars mount, plus the cert volume the annotation names.
+//
+// The sidecars' own mounts are what makes this sound. AnnotationCertVolume
+// stays mutable on a running pod — the mutating webhook intercepts CREATE and
+// pods/ephemeralcontainers but not a plain pod UPDATE, and the
+// cw-label-integrity VAP freezes only confidential.ai/cw — so a caller holding
+// `patch pods` can rewrite it to name a decoy and then attach an ephemeral
+// container mounting the volume that actually holds the leaf key. Reading the
+// mounts off spec.initContainers, immutable after CREATE, closes that: the
+// sidecar names the real volume whatever the annotation was rewritten to say.
+//
+// The annotation (or the default when unset) is still folded in, so a pod whose
+// sidecars were never injected is judged exactly as before.
+func reservedVolumeNames(pod *corev1.Pod) map[string]bool {
+	certVolume := strings.TrimSpace(pod.Annotations[AnnotationCertVolume])
+	if certVolume == "" {
+		certVolume = defaultCertVolumeName
+	}
+	reserved := map[string]bool{secretsVolumeName: true, certVolume: true}
+	for _, c := range pod.Spec.InitContainers {
+		if !isReservedCertName(c.Name) {
+			continue
+		}
+		for _, m := range c.VolumeMounts {
+			reserved[m.Name] = true
+		}
+	}
+	return reserved
 }
 
 // rejectReservedSecretsVolume denies a pod that pre-declares the secrets volume
@@ -1358,10 +1397,25 @@ func rejectReservedCertVolume(pod *corev1.Pod, volName string) error {
 	return nil
 }
 
+// mountAll gives every container in pod the mount, read-only.
+//
+// A container that already declares the volume keeps its own mount path, but
+// the mount is forced read-only: matching on the name alone and skipping would
+// let a pod pre-declare `{name: c8s-secrets}` with readOnly omitted (defaulting
+// to false) and keep write access to the shared directory, which is exactly the
+// invariant secretContainer relies on ("the only container with write access").
+// The same holds for the cert volume, where a writable mount means overwriting
+// the sidecar-managed leaf key.
+//
+// The fetcher's own read-write mount is unaffected: mountAll runs against the
+// pod's containers before the c8s sidecars are appended, and injectInitContainers
+// rebuilds them from scratch afterwards, so a coerced stale copy is discarded on
+// a webhook reinvocation.
 func mountAll(pod *corev1.Pod, mount corev1.VolumeMount) {
 	add := func(cs []corev1.Container) []corev1.Container {
 		for i := range cs {
-			if containerHasMount(cs[i], mount.Name) {
+			if existing := containerMount(&cs[i], mount.Name); existing != nil {
+				existing.ReadOnly = true
 				continue
 			}
 			cs[i].VolumeMounts = append(cs[i].VolumeMounts, mount)
@@ -1372,11 +1426,13 @@ func mountAll(pod *corev1.Pod, mount corev1.VolumeMount) {
 	pod.Spec.InitContainers = add(pod.Spec.InitContainers)
 }
 
-func containerHasMount(c corev1.Container, name string) bool {
-	for _, m := range c.VolumeMounts {
-		if m.Name == name {
-			return true
+// containerMount returns c's mount of the named volume, or nil. The pointer
+// aliases the container's slice so callers can amend the mount in place.
+func containerMount(c *corev1.Container, name string) *corev1.VolumeMount {
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == name {
+			return &c.VolumeMounts[i]
 		}
 	}
-	return false
+	return nil
 }

--- a/internal/webhook/pod_mutator_reserved_test.go
+++ b/internal/webhook/pod_mutator_reserved_test.go
@@ -196,4 +196,3 @@ func TestHandleAdmitsSecretsWithInventorySocket(t *testing.T) {
 		t.Fatalf("Handle denied a serviceable secrets pod: %v", resp.Result)
 	}
 }
-

--- a/internal/webhook/pod_mutator_reserved_test.go
+++ b/internal/webhook/pod_mutator_reserved_test.go
@@ -1,0 +1,199 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// TestPreDeclaredReservedMountIsForcedReadOnly covers a pod that declares its
+// own mount of a reserved volume with readOnly omitted (defaulting to false).
+// Matching on the name and skipping would leave that writable mount in place,
+// handing the workload write access to the shared secrets directory and to the
+// sidecar-managed leaf key — the invariant secretContainer depends on.
+func TestPreDeclaredReservedMountIsForcedReadOnly(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		volume string
+	}{
+		{"secrets", secretsVolumeName},
+		{"certs", defaultCertVolumeName},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := podWithApp()
+			pod.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+				Name:      tc.volume,
+				MountPath: "/attacker/chosen/path",
+			}}
+			pod.Spec.Volumes = []corev1.Volume{{
+				Name: tc.volume,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory},
+				},
+			}}
+
+			mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+
+			m := containerMount(&pod.Spec.Containers[0], tc.volume)
+			if m == nil {
+				t.Fatalf("workload container lost its %q mount", tc.volume)
+			}
+			if !m.ReadOnly {
+				t.Fatalf("pre-declared %q mount stayed writable: %+v", tc.volume, *m)
+			}
+			// Only the write bit is coerced; the pod keeps its mount path.
+			if m.MountPath != "/attacker/chosen/path" {
+				t.Fatalf("MountPath = %q, want the pod's own path", m.MountPath)
+			}
+		})
+	}
+}
+
+// The fetcher is the one container that must keep write access. It is appended
+// after mountAll runs and rebuilt by injectInitContainers on every call, so a
+// reinvocation over an already-injected pod must not leave it read-only.
+func TestFetcherKeepsWriteAccessAcrossReinvocation(t *testing.T) {
+	pod := podWithApp()
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
+
+	fetcher := containerNamed(pod, reservedSecretContainerName)
+	if fetcher == nil {
+		t.Fatal("fetcher not injected")
+	}
+	m := containerMount(fetcher, secretsVolumeName)
+	if m == nil {
+		t.Fatal("fetcher lost its secrets mount")
+	}
+	if m.ReadOnly {
+		t.Fatal("fetcher's secrets mount went read-only; it could no longer write released values")
+	}
+
+	// The workload's mount stays read-only across the same reinvocation.
+	if wm := containerMount(&pod.Spec.Containers[0], secretsVolumeName); wm == nil || !wm.ReadOnly {
+		t.Fatalf("workload secrets mount = %+v, want a read-only mount", wm)
+	}
+}
+
+// TestEphemeralGuardIgnoresAnnotationRewrite is the annotation-rewrite bypass:
+// annotations stay mutable on a running pod, so pointing AnnotationCertVolume
+// at a decoy must not free the volume that actually holds the leaf key.
+func TestEphemeralGuardIgnoresAnnotationRewrite(t *testing.T) {
+	pod := podWithApp()
+	pod.Annotations = map[string]string{AnnotationCertVolume: "my-certs"}
+	mutatePod(pod, &injection{
+		WorkloadID: "api",
+		Cert:       certSpec{Volume: "my-certs"},
+		Secrets:    secretsSpec{Specs: []string{"DB=/api/db"}},
+	}, secretsConfig())
+
+	// The attacker rewrites the annotation on the running pod, then attaches an
+	// ephemeral container mounting the real cert volume.
+	pod.Annotations[AnnotationCertVolume] = "decoy"
+	pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:         "debugger",
+			VolumeMounts: []corev1.VolumeMount{{Name: "my-certs", MountPath: "/x"}},
+		},
+	}}
+
+	if err := rejectEphemeralReservedMounts(pod); err == nil {
+		t.Fatal("annotation rewrite let an ephemeral container mount the real cert volume")
+	}
+
+	// The secrets volume has a fixed name, so it is reserved either way.
+	pod.Spec.EphemeralContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: secretsVolumeName, MountPath: "/x"}}
+	if err := rejectEphemeralReservedMounts(pod); err == nil {
+		t.Fatal("ephemeral container mounted the released secrets")
+	}
+
+	// A genuinely unrelated volume is still fine.
+	pod.Spec.EphemeralContainers[0].VolumeMounts = []corev1.VolumeMount{{Name: "scratch", MountPath: "/x"}}
+	if err := rejectEphemeralReservedMounts(pod); err != nil {
+		t.Fatalf("rejected a harmless ephemeral container: %v", err)
+	}
+}
+
+func TestReservedVolumeNamesCoversSidecarMounts(t *testing.T) {
+	pod := podWithApp()
+	pod.Spec.InitContainers = []corev1.Container{
+		{Name: reservedCertContainerName, VolumeMounts: []corev1.VolumeMount{
+			{Name: "my-certs"}, {Name: workloadClaimsVolumeName},
+		}},
+		{Name: "user-init", VolumeMounts: []corev1.VolumeMount{{Name: "user-scratch"}}},
+	}
+
+	reserved := reservedVolumeNames(pod)
+	for _, want := range []string{secretsVolumeName, defaultCertVolumeName, "my-certs", workloadClaimsVolumeName} {
+		if !reserved[want] {
+			t.Errorf("%q not reserved", want)
+		}
+	}
+	// A non-c8s init container's mounts are the pod's own business.
+	if reserved["user-scratch"] {
+		t.Error("a user init container's volume was reserved")
+	}
+}
+
+func handleSecretsPod(t *testing.T, cfg Config) admission.Response {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+			AnnotationWorkload: "api",
+			AnnotationSecrets:  "DB=/api/db",
+		}},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+	}
+	raw, err := json.Marshal(pod)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := &podMutator{decoder: admission.NewDecoder(scheme), cfg: cfg}
+	return m.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: "tenant",
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	})
+}
+
+// TestHandleRejectsSecretsWithoutInventorySocket covers the kata shape: the
+// fetcher redeems a sandbox token over the mounted inventory socket and has no
+// guest endpoint, so without a host dir there is nothing to mount. Injecting it
+// anyway produces a Running pod whose fetcher CrashLoops while the workload
+// blocks forever on a file that never lands — fail at admission instead.
+func TestHandleRejectsSecretsWithoutInventorySocket(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsGuest = true // kata: guest loopback, nothing mounted
+
+	resp := handleSecretsPod(t, cfg)
+	if resp.Allowed {
+		t.Fatal("admitted a secrets pod the fetcher could never serve")
+	}
+	if msg := resp.Result.Message; !strings.Contains(msg, AnnotationSecrets) {
+		t.Fatalf("denial %q does not name the offending annotation", msg)
+	}
+}
+
+// The same pod is admitted once the operator has the inventory socket, so the
+// guard rejects only the shape that cannot work.
+func TestHandleAdmitsSecretsWithInventorySocket(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsHostDir = "/run/c8s/nri"
+
+	if resp := handleSecretsPod(t, cfg); !resp.Allowed {
+		t.Fatalf("Handle denied a serviceable secrets pod: %v", resp.Result)
+	}
+}
+


### PR DESCRIPTION
## Summary

Three defects in the secrets/cert injection path added by #173/#175, plus a docstring fix. Each behavioural fix ships with a test that fails without it (verified by reverting each fix in turn and watching the matching test go red).

## The defects

**1. The ephemeral-mount guard read a mutable annotation.**
`rejectEphemeralReservedMounts` derived the reserved cert-volume name from `confidential.ai/c8s-cert-volume`. That annotation stays mutable on a running pod: the mutating webhook registers `CREATE` on pods and `UPDATE` on `pods/ephemeralcontainers` but not a plain pod `UPDATE`, and the `cw-label-integrity` VAP freezes only `confidential.ai/cw`. A caller holding `patch pods` + `update pods/ephemeralcontainers` (the `kubectl debug` bundle) could therefore point the annotation at a decoy, attach an ephemeral container mounting the volume that actually holds `tls.key`, and read the pod's mesh leaf private key — the exact scenario the guard's docstring says it prevents.

The reserved set is now also derived from what the injected sidecars mount, read off `spec.initContainers`, which is immutable after CREATE. The annotation fallback is unchanged, so a pod whose sidecars were never injected is judged exactly as before (including the existing "default name after a rename" case).

**2. Pre-declared reserved mounts kept `ReadOnly: false`.**
`mountAll` matched by volume name and skipped on a hit, so a pod that pre-declared its own `{name: c8s-secrets}` mount with `readOnly` omitted (defaulting to `false`) kept write access to the shared secrets directory. That contradicts the invariant `secretContainer` documents ("the only container with write access") and `docs/secrets.md` ("only the fetcher may write it") — a container could plant or overwrite a value a sibling has yet to read. The same shape applied to `c8s-certs`, giving write access to the sidecar-managed leaf key.

A pre-declared mount of a reserved volume is now forced read-only, keeping the pod's own mount path (only the write bit is coerced). The fetcher's read-write mount is unaffected: `mountAll` runs before the c8s sidecars are appended and `injectInitContainers` rebuilds them from scratch, so a coerced stale copy is discarded on a webhook reinvocation — covered by a test that mutates twice.

**3. Secrets on kata deadlocked silently.**
The fetcher redeems its sandbox token over the mounted nri-image-policy socket and, unlike `get-cert`, has no guest-loopback endpoint (`get-secret` defines no `--workload-claims-guest`). With `--workload-claims-guest` (kata) or neither flag, `workloadClaimsMounts` returns nil, so there is no socket to dial: the pod came up `Running` with the fetcher CrashLooping after 60 retries while the workload blocked forever on `until [ -f /run/c8s/secrets/NAME ]`.

`confidential.ai/c8s-secrets` is now rejected at admission when the operator has no `--workload-claims-host-dir`, mirroring the `hostNetwork` rejection just above it. `docs/secrets.md` already called kata out of scope for three independent reasons; this enforces it instead of only documenting it, and the doc is updated to say so.

**4. Docstring (nit).** The `reservedCertContainerName` paragraph had been separated from its declaration by five newer consts, so godoc bound it to `reservedSecretContainerName` and left `reservedCertContainerName` undocumented. Reattached.

## Testing

- `go test ./...` and `golangci-lint run ./...` clean.
- Total coverage 81.0%, matching `main` — the gate passes.
- Each fix was individually reverted to confirm the new tests fail without it.

Fixing forward on `main` rather than amending the original PRs, since that code is already merged.