### PR TITLE
feat(volume): key blob format and pure-Go image encryption

### DIFF
--- a/internal/cmds/volume/blob.go
+++ b/internal/cmds/volume/blob.go
@@ -1,0 +1,161 @@
+// Package volume implements the `c8s volume` operator CLI: building an
+// encrypted, integrity-protected block image and putting its key into the CDS
+// secret store.
+//
+// The image is plain dm-crypt with a dm-verity tree inside it. There is
+// deliberately no LUKS header: a LUKS2 header is on-disk metadata whose only
+// integrity is an unkeyed checksum the host can recompute, and it is parsed as
+// root inside the TEE on every open. Plain dm-crypt has no on-disk metadata at
+// all, so every parameter comes from the key blob, which travels over the
+// attested channel.
+package volume
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// BlobType identifies the key blob's format. It is the first thing checked on
+// decode, so a foreign or malformed document fails loudly rather than parsing
+// as a blob with zero-valued fields.
+const BlobType = "c8s.volume/v1"
+
+// KeyBytes is the XTS key length: two AES-256 keys, matching dm-crypt's
+// --key-size 512.
+const KeyBytes = 64
+
+// verityHashBytes is the length of a SHA-256 root hash. The hash algorithm is
+// fixed rather than carried in the blob — a field with one legal value is a
+// field an attacker gets to choose.
+const verityHashBytes = 32
+
+// Blob is what the store holds for one volume: everything needed to open it,
+// and nothing that could be taken from anywhere else. The verity root hash
+// rides here rather than in an annotation or the allowlist entry because it is
+// the integrity anchor; an anchor the host can edit anchors nothing.
+type Blob struct {
+	Type   string `json:"type"`
+	Key    string `json:"key"`
+	Verity Verity `json:"verity"`
+}
+
+// Verity is the geometry needed to open the hash tree without reading a
+// superblock off the device. Parsing an on-disk verity superblock would
+// reintroduce exactly the host-controlled metadata parse that omitting a LUKS
+// header removes, so the opener passes --no-superblock and takes all of this
+// from here.
+type Verity struct {
+	RootHash string `json:"root_hash"`
+	Salt     string `json:"salt"`
+	// DataBlocks is the number of 4096-byte data blocks the tree covers.
+	DataBlocks uint64 `json:"data_blocks"`
+	// HashOffset is the byte offset of the hash tree within the image.
+	HashOffset uint64 `json:"hash_offset"`
+}
+
+// NewBlob builds a blob from a freshly generated key and the verity output.
+func NewBlob(key []byte, v Verity) (Blob, error) {
+	if len(key) != KeyBytes {
+		return Blob{}, fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	b := Blob{
+		Type:   BlobType,
+		Key:    base64.StdEncoding.EncodeToString(key),
+		Verity: v,
+	}
+	if err := b.Validate(); err != nil {
+		return Blob{}, err
+	}
+	return b, nil
+}
+
+// DecodeBlob parses a stored value, rejecting unknown fields so a document
+// carrying more than this format describes is an error rather than a blob with
+// the extra silently dropped.
+func DecodeBlob(raw []byte) (Blob, error) {
+	var b Blob
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&b); err != nil {
+		return Blob{}, fmt.Errorf("volume: decode key blob: %w", err)
+	}
+	if err := b.Validate(); err != nil {
+		return Blob{}, err
+	}
+	return b, nil
+}
+
+// Validate checks every field before any of them can reach a command line or a
+// device-mapper table. The opener runs privileged, so a field it has not
+// checked is a field the caller chose for it.
+func (b Blob) Validate() error {
+	if b.Type != BlobType {
+		return fmt.Errorf("volume: key blob type is %q, want %q", b.Type, BlobType)
+	}
+	key, err := base64.StdEncoding.DecodeString(b.Key)
+	if err != nil {
+		return fmt.Errorf("volume: key is not base64: %w", err)
+	}
+	if len(key) != KeyBytes {
+		return fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	if err := validateHex("root_hash", b.Verity.RootHash, verityHashBytes); err != nil {
+		return err
+	}
+	// veritysetup accepts a range of salt lengths; the only requirement here is
+	// that it is hex and non-empty, so it can be passed through unaltered.
+	if err := validateHexAny("salt", b.Verity.Salt); err != nil {
+		return err
+	}
+	if b.Verity.DataBlocks == 0 {
+		return fmt.Errorf("volume: verity data_blocks is zero")
+	}
+	if want := b.Verity.DataBlocks * VerityBlockSize; b.Verity.HashOffset != want {
+		return fmt.Errorf("volume: verity hash_offset is %d, want %d (data_blocks * %d)",
+			b.Verity.HashOffset, want, VerityBlockSize)
+	}
+	return nil
+}
+
+// DecodeKey returns the raw XTS key. Validate has already run, so the only way
+// this fails is a caller that built a Blob without it.
+func (b Blob) DecodeKey() ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(b.Key)
+	if err != nil || len(key) != KeyBytes {
+		return nil, fmt.Errorf("volume: key blob holds no usable key")
+	}
+	return key, nil
+}
+
+// Marshal returns the stored representation.
+func (b Blob) Marshal() ([]byte, error) { return json.Marshal(b) }
+
+// validateHex requires lowercase hex of an exact byte length. Lowercase because
+// the value is compared and passed through verbatim; accepting both cases would
+// make two spellings of one hash.
+func validateHex(field, s string, wantBytes int) error {
+	if err := validateHexAny(field, s); err != nil {
+		return err
+	}
+	if len(s) != wantBytes*2 {
+		return fmt.Errorf("volume: verity %s is %d hex chars, want %d", field, len(s), wantBytes*2)
+	}
+	return nil
+}
+
+func validateHexAny(field, s string) error {
+	if s == "" {
+		return fmt.Errorf("volume: verity %s is empty", field)
+	}
+	if s != strings.ToLower(s) {
+		return fmt.Errorf("volume: verity %s must be lowercase hex", field)
+	}
+	if _, err := hex.DecodeString(s); err != nil {
+		return fmt.Errorf("volume: verity %s is not hex: %w", field, err)
+	}
+	return nil
+}

--- a/internal/cmds/volume/blob_test.go
+++ b/internal/cmds/volume/blob_test.go
@@ -1,0 +1,114 @@
+package volume
+
+import (
+	"strings"
+	"testing"
+)
+
+func validVerity() Verity {
+	return Verity{
+		RootHash:   strings.Repeat("ab", verityHashBytes),
+		Salt:       strings.Repeat("cd", 16),
+		DataBlocks: 4,
+		HashOffset: 4 * VerityBlockSize,
+	}
+}
+
+func validBlob(t *testing.T) Blob {
+	t.Helper()
+	b, err := NewBlob(testKey(), validVerity())
+	if err != nil {
+		t.Fatalf("new blob: %v", err)
+	}
+	return b
+}
+
+func TestBlobRoundTrips(t *testing.T) {
+	raw, err := validBlob(t).Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	key, err := got.DecodeKey()
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	if len(key) != KeyBytes {
+		t.Fatalf("key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	if got.Verity != validVerity() {
+		t.Fatalf("verity: got %+v, want %+v", got.Verity, validVerity())
+	}
+}
+
+func TestNewBlobRejectsWrongKeyLength(t *testing.T) {
+	if _, err := NewBlob(make([]byte, 32), validVerity()); err == nil {
+		t.Fatal("accepted a 32-byte key")
+	}
+}
+
+// A document carrying more than this format describes is an error: silently
+// dropping a field would let a future field be ignored by an old opener.
+func TestDecodeBlobRejectsUnknownFields(t *testing.T) {
+	if _, err := DecodeBlob([]byte(`{"type":"c8s.volume/v1","key":"","verity":{},"extra":1}`)); err == nil {
+		t.Fatal("accepted an unknown field")
+	}
+}
+
+func TestDecodeBlobRejectsWrongType(t *testing.T) {
+	b := validBlob(t)
+	b.Type = "c8s.volume/v2"
+	raw, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := DecodeBlob(raw); err == nil {
+		t.Fatal("accepted a foreign blob type")
+	}
+}
+
+func TestValidateRejectsMalformedVerity(t *testing.T) {
+	cases := map[string]func(*Blob){
+		"root hash too short":  func(b *Blob) { b.Verity.RootHash = "abcd" },
+		"root hash uppercase":  func(b *Blob) { b.Verity.RootHash = strings.ToUpper(b.Verity.RootHash) },
+		"root hash not hex":    func(b *Blob) { b.Verity.RootHash = strings.Repeat("zz", verityHashBytes) },
+		"salt empty":           func(b *Blob) { b.Verity.Salt = "" },
+		"salt not hex":         func(b *Blob) { b.Verity.Salt = "nothex" },
+		"zero data blocks":     func(b *Blob) { b.Verity.DataBlocks = 0 },
+		"hash offset mismatch": func(b *Blob) { b.Verity.HashOffset = 1 },
+	}
+	for name, mutate := range cases {
+		b := validBlob(t)
+		mutate(&b)
+		if err := b.Validate(); err == nil {
+			t.Errorf("%s: accepted", name)
+		}
+	}
+}
+
+// hash_offset is where the opener starts reading the tree. If it disagreed with
+// data_blocks the opener would hash the wrong bytes, so the two are checked
+// against each other rather than trusted independently.
+func TestValidateTiesHashOffsetToDataBlocks(t *testing.T) {
+	b := validBlob(t)
+	b.Verity.DataBlocks = 9
+	b.Verity.HashOffset = 9 * VerityBlockSize
+	if err := b.Validate(); err != nil {
+		t.Fatalf("consistent geometry rejected: %v", err)
+	}
+	b.Verity.DataBlocks = 10
+	if err := b.Validate(); err == nil {
+		t.Fatal("accepted data_blocks that disagree with hash_offset")
+	}
+}
+
+func TestDecodeKeyFailsOnCorruptKey(t *testing.T) {
+	b := validBlob(t)
+	b.Key = "not base64"
+	if _, err := b.DecodeKey(); err == nil {
+		t.Fatal("accepted a non-base64 key")
+	}
+}

--- a/internal/cmds/volume/crypt.go
+++ b/internal/cmds/volume/crypt.go
@@ -1,0 +1,91 @@
+package volume
+
+import (
+	"crypto/aes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/xts"
+)
+
+// SectorSize is the dm-crypt sector size, and therefore the unit the XTS tweak
+// counts in.
+//
+// 512 is dm-crypt's default, and the reason to keep it is the tweak. For
+// aes-xts-plain64 the IV is the sector index, but with a larger --sector-size
+// dm-crypt's numbering depends on whether iv_large_sectors is set — so a
+// mismatch between what wrote the image and what opens it yields a volume that
+// decrypts to noise with nothing to say why. At 512 there is one numbering and
+// no flag to agree on.
+const SectorSize = 512
+
+// VerityBlockSize is the dm-verity data block size. Independent of SectorSize:
+// verity sits above dm-crypt and counts in its own blocks.
+const VerityBlockSize = 4096
+
+// ErrUnaligned reports a payload that is not a whole number of sectors.
+var ErrUnaligned = errors.New("volume: payload is not a multiple of the sector size")
+
+// GenerateKey returns a fresh XTS key.
+//
+// Always fresh, never operator-supplied: AES-XTS is deterministic, so
+// re-encrypting a changed directory under a reused key tells the host exactly
+// which sectors changed between the two versions.
+func GenerateKey() ([]byte, error) {
+	key := make([]byte, KeyBytes)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("volume: generate key: %w", err)
+	}
+	return key, nil
+}
+
+// Encrypt writes the ciphertext of src to dst, one sector at a time, with each
+// sector's index as its XTS tweak. This is byte-for-byte what dm-crypt
+// aes-xts-plain64 with a 512-bit key produces for the same input, which is what
+// lets the image be built without root, a loop device, or cryptsetup.
+//
+// src must be sector-aligned. Padding it here would change the bytes dm-verity
+// was formatted over, so an unaligned payload is refused rather than fixed.
+func Encrypt(dst io.Writer, src io.Reader, key []byte) error {
+	return transform(dst, src, key, false)
+}
+
+// Decrypt is Encrypt's inverse, and exists so a build can prove its own output
+// round-trips before the plaintext is discarded.
+func Decrypt(dst io.Writer, src io.Reader, key []byte) error {
+	return transform(dst, src, key, true)
+}
+
+func transform(dst io.Writer, src io.Reader, key []byte, decrypt bool) error {
+	if len(key) != KeyBytes {
+		return fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	cipher, err := xts.NewCipher(aes.NewCipher, key)
+	if err != nil {
+		return fmt.Errorf("volume: init xts: %w", err)
+	}
+
+	in := make([]byte, SectorSize)
+	out := make([]byte, SectorSize)
+	for sector := uint64(0); ; sector++ {
+		n, err := io.ReadFull(src, in)
+		switch {
+		case errors.Is(err, io.EOF):
+			return nil
+		case errors.Is(err, io.ErrUnexpectedEOF):
+			return fmt.Errorf("%w: trailing %d bytes", ErrUnaligned, n)
+		case err != nil:
+			return fmt.Errorf("volume: read sector %d: %w", sector, err)
+		}
+		if decrypt {
+			cipher.Decrypt(out, in, sector)
+		} else {
+			cipher.Encrypt(out, in, sector)
+		}
+		if _, err := dst.Write(out); err != nil {
+			return fmt.Errorf("volume: write sector %d: %w", sector, err)
+		}
+	}
+}

--- a/internal/cmds/volume/crypt_test.go
+++ b/internal/cmds/volume/crypt_test.go
@@ -1,0 +1,144 @@
+package volume
+
+import (
+	"bytes"
+	"crypto/aes"
+	"errors"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/xts"
+)
+
+func sectors(n int) []byte {
+	b := make([]byte, n*SectorSize)
+	for i := range b {
+		b[i] = byte(i % 251)
+	}
+	return b
+}
+
+func testKey() []byte {
+	k := make([]byte, KeyBytes)
+	for i := range k {
+		k[i] = byte(i)
+	}
+	return k
+}
+
+func TestEncryptDecryptRoundTrips(t *testing.T) {
+	key := testKey()
+	for _, n := range []int{1, 2, 17} {
+		plain := sectors(n)
+		var ct, back bytes.Buffer
+		if err := Encrypt(&ct, bytes.NewReader(plain), key); err != nil {
+			t.Fatalf("%d sectors: encrypt: %v", n, err)
+		}
+		if ct.Len() != len(plain) {
+			t.Fatalf("%d sectors: ciphertext is %d bytes, want %d", n, ct.Len(), len(plain))
+		}
+		if bytes.Equal(ct.Bytes(), plain) {
+			t.Fatalf("%d sectors: ciphertext equals plaintext", n)
+		}
+		if err := Decrypt(&back, bytes.NewReader(ct.Bytes()), key); err != nil {
+			t.Fatalf("%d sectors: decrypt: %v", n, err)
+		}
+		if !bytes.Equal(back.Bytes(), plain) {
+			t.Fatalf("%d sectors: round trip differs", n)
+		}
+	}
+}
+
+// Each sector is tweaked by its own index, so identical plaintext sectors must
+// not produce identical ciphertext. If this fails the tweak is not advancing
+// and the image leaks which blocks are equal.
+func TestEncryptTweaksPerSector(t *testing.T) {
+	plain := make([]byte, 4*SectorSize) // all zero: every sector identical
+	var ct bytes.Buffer
+	if err := Encrypt(&ct, bytes.NewReader(plain), testKey()); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	out := ct.Bytes()
+	first := out[:SectorSize]
+	for i := 1; i < 4; i++ {
+		if bytes.Equal(first, out[i*SectorSize:(i+1)*SectorSize]) {
+			t.Fatalf("sector %d ciphertext equals sector 0: tweak is not advancing", i)
+		}
+	}
+}
+
+// The wire format is "XTS over 512-byte sectors, tweak = sector index", which
+// is what dm-crypt aes-xts-plain64 does. Pinning it against the library
+// directly means a change in our framing (sector size, tweak origin, ordering)
+// fails here rather than as an unopenable volume on a node.
+func TestEncryptMatchesRawXTSPerSectorTweak(t *testing.T) {
+	key := testKey()
+	plain := sectors(3)
+
+	var got bytes.Buffer
+	if err := Encrypt(&got, bytes.NewReader(plain), key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+
+	c, err := xts.NewCipher(aes.NewCipher, key)
+	if err != nil {
+		t.Fatalf("xts: %v", err)
+	}
+	want := make([]byte, len(plain))
+	for s := 0; s < 3; s++ {
+		lo, hi := s*SectorSize, (s+1)*SectorSize
+		c.Encrypt(want[lo:hi], plain[lo:hi], uint64(s))
+	}
+	if !bytes.Equal(got.Bytes(), want) {
+		t.Fatal("ciphertext does not match per-sector XTS with the sector index as tweak")
+	}
+}
+
+// Padding an unaligned payload would change the bytes dm-verity was formatted
+// over, so it is refused instead.
+func TestEncryptRejectsUnalignedPayload(t *testing.T) {
+	var out bytes.Buffer
+	err := Encrypt(&out, strings.NewReader(strings.Repeat("x", SectorSize+7)), testKey())
+	if !errors.Is(err, ErrUnaligned) {
+		t.Fatalf("got %v, want ErrUnaligned", err)
+	}
+}
+
+func TestEncryptRejectsWrongKeyLength(t *testing.T) {
+	var out bytes.Buffer
+	if err := Encrypt(&out, bytes.NewReader(sectors(1)), make([]byte, 32)); err == nil {
+		t.Fatal("accepted a 32-byte key")
+	}
+}
+
+func TestGenerateKeyIsFreshAndFullLength(t *testing.T) {
+	a, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	b, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	if len(a) != KeyBytes {
+		t.Fatalf("key is %d bytes, want %d", len(a), KeyBytes)
+	}
+	if bytes.Equal(a, b) {
+		t.Fatal("two generated keys are equal")
+	}
+}
+
+func TestDecryptWithWrongKeyDoesNotRecoverPlaintext(t *testing.T) {
+	plain := sectors(2)
+	var ct, back bytes.Buffer
+	if err := Encrypt(&ct, bytes.NewReader(plain), testKey()); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	wrong := make([]byte, KeyBytes)
+	if err := Decrypt(&back, bytes.NewReader(ct.Bytes()), wrong); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if bytes.Equal(back.Bytes(), plain) {
+		t.Fatal("wrong key recovered the plaintext")
+	}
+}


### PR DESCRIPTION
The artifact half of encrypted volumes: the c8s.volume/v1 key blob and the encryptor that produces the image it describes. No command wiring yet.

The image is plain dm-crypt, not LUKS. A LUKS2 header is on-disk metadata whose only integrity is an unkeyed checksum the host can recompute, parsed as root inside the TEE on every open (CVE-2021-4122 is that shape). What it would buy — keyslot rotation — is illusory against a host that keeps a snapshot of the old header. Plain dm-crypt has no on-disk metadata, so every parameter comes from the blob, which travels over the attested channel.

Sector size is 512 rather than 4096. For aes-xts-plain64 the tweak is the sector index, but at a larger sector size dm-crypt's numbering depends on iv_large_sectors, and a disagreement between writer and opener yields a volume that decrypts to noise with nothing to say why. At 512 there is one numbering and no flag to agree on.

That makes the image writable with x/crypto/xts, so building one needs no root, no loop device and no cryptsetup, and the encryption is testable off a node. A test pins the framing against the library so a change to sector size, tweak origin or ordering fails there rather than in the field.

The verity root hash rides in the blob rather than an annotation or the allowlist entry: it is the integrity anchor, and an anchor the host can edit anchors nothing. hash_offset is validated against data_blocks rather than trusted alongside it.