### PR TITLE
feat(secrets): explain a release decision, error on entries that cann…

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -308,8 +308,8 @@ confirm loop, and the signed write is always a separate, reviewed `apply`.
   `remove` takes `sha256:` digests; a mixup fails validation instead of partially
   applying.
 - **Signed writes are diff-first and lint-first.** `upload`/`apply` run the
-  offline lint (errors block, warnings need `--force`) and print the diff before
-  the write.
+  offline lint and print the diff before the write. A lint error blocks the
+  write; `--strict` makes warnings block it too.
 
 ### lint
 
@@ -321,6 +321,17 @@ digest alone, so the argv policy is silently not enforced — tag-form labels
 (which can move under the operator), and a summary of how many `any` policies a
 document carries. `--online` cross-checks digests against the registry with
 `crane`; `--strict` turns warnings into a non-zero exit for CI.
+
+Two entries declaring the same containers with the same argv policy are an
+**error**, not a warning: release requires exactly one entry to describe a
+sandbox, so entries of the same shape either both match or neither does, and
+every pod resolving to them is refused whichever grant was meant. Nothing a
+workload can do resolves it. The shape compared is digests and argv policies per
+container list — the image label and the secret grant are excluded, since two
+entries alike but for their grants are exactly the case worth catching.
+
+`workload apply` runs that check against the served allowlist as well as the
+file, because the entry a new one collides with is usually one already there.
 
 ## Operator credentials
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -169,6 +169,47 @@ pausing over for that reason: the pods that generated the value go on using it.
 Revoking a value means restarting CDS, which empties the whole store — see
 "Restarts".
 
+## Diagnosing a refusal
+
+A refused pod is told only that it was refused, and the set that decides the
+matter — what the sandbox is running — is visible only to CDS. `explain` is
+where that is read:
+
+```sh
+c8s secrets explain --sandbox "$ID" --url "$CDS" --measurements "$M" \
+  --operator-key operator.key
+```
+
+```
+sandbox    0123456789abcdef…
+inventory  10.0.0.7
+reported   3 container(s)
+dropped    1 injected by c8s
+candidates 2
+    sha256:1111…  [/serve]
+  - sha256:9999…  [get-secret]
+    sha256:8888…  [sh -c sleep 1]
+
+vllm-llama  NEAR MISS
+  foreign  sha256:8888…  [sh -c sleep 1]
+           no container in this entry declares it
+
+nothing is released: no entry describes the candidate set
+```
+
+The sandbox ID is on the pod's certificate; `c8s verify` prints it. `--json`
+emits the report as it arrives.
+
+It reads the same inventory, binding and allowlist the release path reads, and
+measures entries with the same matcher, so it reports the decision rather than a
+reconstruction of it. It answers to the operator key, since it describes a pod
+the caller may not own. The report carries grant paths; a value never appears in
+it.
+
+`GET /secrets-explain/{sandboxID}` is a sibling of `/secrets`, not a path under
+it: a literal segment beats the wildcard in routing, so mounting it below
+`/secrets` would make every secret stored under that prefix unreachable.
+
 ## What CDS checks
 
 1. The client certificate chains to the mesh CA — verified by crypto/tls, not

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -2,6 +2,7 @@ package allowlist
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -18,11 +19,16 @@ func newLintCmd(o *options) *cobra.Command {
 		Use:   "lint <file|->",
 		Short: "Validate an allowlist file and report semantic warnings",
 		Long: `Parse and validate an allowlist file (or stdin with '-') and report semantic
-warnings: entries with no containers, a container that can never start, digests
+findings: entries with no containers, a container that can never start, digests
 whose effective policy is unconstrained, a digest that is floor-listed while also
 carrying a workload policy (the floor short-circuits it), tag-form image labels
 (TOCTOU), and root-subtree path grants. --online additionally checks each digest
-exists in its registry via crane. --strict makes any warning exit non-zero.`,
+exists in its registry via crane.
+
+Two entries declaring the same containers with the same argv policy are an
+error: release requires exactly one entry to match, so both are refused
+forever. Errors exit non-zero on their own; --strict makes warnings do the
+same.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, err := readFileOrStdin(cmd, args[0])
@@ -33,22 +39,26 @@ exists in its registry via crane. --strict makes any warning exit non-zero.`,
 			if err != nil {
 				return err
 			}
-			warnings := lintOffline(al)
+			findings := lintOffline(al)
 			if online {
 				if err := requireCrane(); err != nil {
 					return err
 				}
-				warnings = append(warnings, lintOnline(ctx(cmd), al)...)
+				findings = append(findings, lintOnline(ctx(cmd), al)...)
 			}
-			for _, w := range warnings {
-				fmt.Fprintf(cmd.OutOrStdout(), "warning: %s\n", w)
+			for _, f := range findings {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\n", f)
 			}
-			if len(warnings) == 0 {
-				fmt.Fprintln(cmd.OutOrStdout(), "ok: no warnings")
+			if len(findings) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "ok: no findings")
 			}
-			if strict && len(warnings) > 0 {
+			if errs := countErrors(findings); errs > 0 {
 				cmd.SilenceErrors = true
-				return fmt.Errorf("%d lint warning(s) with --strict", len(warnings))
+				return fmt.Errorf("%d lint error(s)", errs)
+			}
+			if strict && len(findings) > 0 {
+				cmd.SilenceErrors = true
+				return fmt.Errorf("%d lint warning(s) with --strict", len(findings))
 			}
 			return nil
 		},
@@ -97,10 +107,45 @@ policy. This reads the registry only; it never contacts CDS.`,
 	}
 }
 
-// lintOffline reports semantic warnings for an allowlist without any registry or
+// finding is one lint result.
+//
+// An error is a document that cannot work rather than a judgement an operator
+// may accept, so it fails a lint whatever --strict says and blocks a write.
+type finding struct {
+	err bool
+	msg string
+}
+
+func (f finding) String() string {
+	if f.err {
+		return "error: " + f.msg
+	}
+	return "warning: " + f.msg
+}
+
+func warnf(format string, args ...any) finding {
+	return finding{msg: fmt.Sprintf(format, args...)}
+}
+
+func errorf(format string, args ...any) finding {
+	return finding{err: true, msg: fmt.Sprintf(format, args...)}
+}
+
+// countErrors reports how many findings are errors.
+func countErrors(findings []finding) int {
+	n := 0
+	for _, f := range findings {
+		if f.err {
+			n++
+		}
+	}
+	return n
+}
+
+// lintOffline reports semantic findings for an allowlist without any registry or
 // CDS access. The document is assumed already parsed/validated by ParseJSON.
-func lintOffline(al *pkgallowlist.Allowlist) []string {
-	var warnings []string
+func lintOffline(al *pkgallowlist.Allowlist) []finding {
+	var warnings []finding
 	anyCount := 0
 
 	// digest -> set of distinct entry names; and whether some occurrence is
@@ -111,10 +156,10 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 	for _, name := range sortedWorkloadNames(al.Workloads) {
 		w := al.Workloads[name]
 		if len(w.InitContainers) == 0 && len(w.Containers) == 0 {
-			warnings = append(warnings, fmt.Sprintf("workload %q has no init or main containers", name))
+			warnings = append(warnings, warnf("workload %q has no init or main containers", name))
 		}
 		if w.Label != "" && isTagForm(w.Label) {
-			warnings = append(warnings, fmt.Sprintf("workload %q label %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, w.Label))
+			warnings = append(warnings, warnf("workload %q label %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, w.Label))
 		}
 		for _, c := range allContainers(w) {
 			d := c.Digest.String()
@@ -126,7 +171,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 				fullyAny[d] = true
 			}
 			if argvPolicyName(c.Command) == pkgallowlist.PolicyDeny {
-				warnings = append(warnings, fmt.Sprintf("workload %q container %s command is deny; the effective argv must be empty, so the container can never start", name, d))
+				warnings = append(warnings, warnf("workload %q container %s command is deny; the effective argv must be empty, so the container can never start", name, d))
 			}
 			if c.Command.Policy == pkgallowlist.PolicyAny {
 				anyCount++
@@ -135,13 +180,13 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 				anyCount++
 			}
 			if c.Image != "" && isTagForm(c.Image) {
-				warnings = append(warnings, fmt.Sprintf("workload %q container %s image %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, d, c.Image))
+				warnings = append(warnings, warnf("workload %q container %s image %q is a tag, not a digest (informational, but tags are mutable — TOCTOU)", name, d, c.Image))
 			}
 		}
 		if w.Secrets != nil {
 			for _, g := range append(append([]string{}, w.Secrets.Read...), w.Secrets.Write...) {
 				if g == "/**" {
-					warnings = append(warnings, fmt.Sprintf("workload %q grants the root secret subtree %q (every secret in the store)", name, g))
+					warnings = append(warnings, warnf("workload %q grants the root secret subtree %q (every secret in the store)", name, g))
 				}
 			}
 		}
@@ -149,7 +194,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 
 	for _, d := range sortedKeysBool(fullyAny) {
 		if len(entriesByDigest[d]) > 1 {
-			warnings = append(warnings, fmt.Sprintf("digest %s appears in %d entries and one grants 'any'; the effective admission for that digest is 'any' (union across entries)", d, len(entriesByDigest[d])))
+			warnings = append(warnings, warnf("digest %s appears in %d entries and one grants 'any'; the effective admission for that digest is 'any' (union across entries)", d, len(entriesByDigest[d])))
 		}
 	}
 
@@ -159,31 +204,125 @@ func lintOffline(al *pkgallowlist.Allowlist) []string {
 	// digest is dropped from the candidate set.
 	for _, d := range sortedKeys(al.Digests) {
 		if names := entriesByDigest[d]; len(names) > 0 {
-			warnings = append(warnings, fmt.Sprintf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
+			warnings = append(warnings, warnf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
 		}
 	}
 
+	warnings = append(warnings, indistinguishableEntries(al)...)
+
 	if anyCount > 0 {
-		warnings = append(warnings, fmt.Sprintf("%d 'any' (unconstrained) policy value(s) across all entries", anyCount))
+		warnings = append(warnings, warnf("%d 'any' (unconstrained) policy value(s) across all entries", anyCount))
 	}
 	return warnings
 }
 
+// indistinguishableEntries reports entries that no running set can tell apart.
+//
+// Release requires exactly one entry to describe the containers a sandbox runs,
+// so entries with the same shape both match or neither does — the match is
+// ambiguous forever and every pod resolving to them is refused, whichever grant
+// an operator meant. Nothing a workload can do fixes it, so this is an error.
+func indistinguishableEntries(al *pkgallowlist.Allowlist) []finding {
+	groups, err := indistinguishableGroups(al)
+	if err != nil {
+		return []finding{errorf("workload entries could not be compared: %v", err)}
+	}
+	out := make([]finding, 0, len(groups))
+	for _, names := range groups {
+		out = append(out, ambiguousGroupFinding(names))
+	}
+	return out
+}
+
+// indistinguishableGroups returns each set of two or more entry names sharing a
+// shape, in a stable order.
+func indistinguishableGroups(al *pkgallowlist.Allowlist) ([][]string, error) {
+	byShape := map[string][]string{}
+	for _, name := range sortedWorkloadNames(al.Workloads) {
+		shape, err := entryShape(al.Workloads[name])
+		if err != nil {
+			// A shape that will not marshal cannot be compared; say so rather
+			// than silently treating the entry as unique.
+			return nil, fmt.Errorf("workload %q: %w", name, err)
+		}
+		byShape[shape] = append(byShape[shape], name)
+	}
+	var out [][]string
+	for _, shape := range sortedKeysStrings(byShape) {
+		if names := byShape[shape]; len(names) > 1 {
+			out = append(out, names)
+		}
+	}
+	return out, nil
+}
+
+func ambiguousGroupFinding(names []string) finding {
+	return errorf(
+		"workloads [%s] declare the same containers with the same argv policy; release requires exactly one entry to match, so all of them are refused (merge them, or narrow the argv policy so a running pod resolves to one)",
+		strings.Join(names, ", "))
+}
+
+// entryShape is the part of an entry a release decision reads: the digests and
+// argv policies of each container list. Image labels and the secret grant are
+// excluded — two entries differing only in those are exactly the dangerous
+// case, since the grant an operator intended is the thing that never resolves.
+func entryShape(w pkgallowlist.Workload) (string, error) {
+	type containerShape struct {
+		Digest  string                  `json:"digest"`
+		Command pkgallowlist.ArgvPolicy `json:"command"`
+		Args    pkgallowlist.ArgvPolicy `json:"args"`
+	}
+	shape := func(cs []pkgallowlist.Container) ([]string, error) {
+		out := make([]string, 0, len(cs))
+		for _, c := range cs {
+			b, err := json.Marshal(containerShape{Digest: c.Digest.String(), Command: c.Command, Args: c.Args})
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, string(b))
+		}
+		// Sorted so declaration order is not mistaken for a difference.
+		sort.Strings(out)
+		return out, nil
+	}
+	mains, err := shape(w.Containers)
+	if err != nil {
+		return "", err
+	}
+	inits, err := shape(w.InitContainers)
+	if err != nil {
+		return "", err
+	}
+	// The two lists stay distinct: a main is required to be present and an init
+	// is not, so moving a container between them changes what matches.
+	b, err := json.Marshal([][]string{mains, inits})
+	return string(b), err
+}
+
+func sortedKeysStrings(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 // lintOnline checks each workload container digest is resolvable in its
 // registry via crane. It needs the container image label to know the repo.
-func lintOnline(ctx context.Context, al *pkgallowlist.Allowlist) []string {
-	var warnings []string
+func lintOnline(ctx context.Context, al *pkgallowlist.Allowlist) []finding {
+	var warnings []finding
 	checked := map[string]bool{}
 	for _, name := range sortedWorkloadNames(al.Workloads) {
 		w := al.Workloads[name]
 		for _, c := range allContainers(w) {
 			if c.Image == "" {
-				warnings = append(warnings, fmt.Sprintf("workload %q container %s has no image label; cannot check the digest online", name, c.Digest))
+				warnings = append(warnings, warnf("workload %q container %s has no image label; cannot check the digest online", name, c.Digest))
 				continue
 			}
 			named, err := reference.ParseDockerRef(c.Image)
 			if err != nil {
-				warnings = append(warnings, fmt.Sprintf("workload %q container %s image %q: %v", name, c.Digest, c.Image, err))
+				warnings = append(warnings, warnf("workload %q container %s image %q: %v", name, c.Digest, c.Image, err))
 				continue
 			}
 			ref := reference.TrimNamed(named).String() + "@" + c.Digest.String()
@@ -192,7 +331,7 @@ func lintOnline(ctx context.Context, al *pkgallowlist.Allowlist) []string {
 			}
 			checked[ref] = true
 			if err := craneManifestExists(ctx, ref); err != nil {
-				warnings = append(warnings, fmt.Sprintf("workload %q container digest not found in registry: %s (%v)", name, ref, err))
+				warnings = append(warnings, warnf("workload %q container digest not found in registry: %s (%v)", name, ref, err))
 			}
 		}
 	}

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -23,8 +23,8 @@ func TestLintFloorWorkloadOverlap(t *testing.T) {
 
 	var overlap []string
 	for _, w := range lintOffline(al) {
-		if strings.Contains(w, "floor-listed") {
-			overlap = append(overlap, w)
+		if strings.Contains(w.msg, "floor-listed") {
+			overlap = append(overlap, w.msg)
 		}
 	}
 	joined := strings.Join(overlap, "\n")
@@ -46,8 +46,8 @@ func TestLintCleanAllowlistReportsOK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lint: %v", err)
 	}
-	if out != "ok: no warnings\n" {
-		t.Fatalf("lint output = %q, want %q", out, "ok: no warnings\n")
+	if out != "ok: no findings\n" {
+		t.Fatalf("lint output = %q, want %q", out, "ok: no findings\n")
 	}
 
 	if _, _, err := runCmd("lint", "--strict", f); err != nil {
@@ -174,8 +174,172 @@ func TestLintNoFloorOverlap(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, w := range lintOffline(al) {
-		if strings.Contains(w, "floor-listed") {
+		if strings.Contains(w.msg, "floor-listed") {
 			t.Fatalf("disjoint floor and workloads must not warn, got: %s", w)
 		}
+	}
+}
+
+// --- indistinguishable entries ---
+
+// entryPair builds a document with two entries whose container lists are given
+// as raw JSON, so a test can vary one field at a time.
+func entryPair(t *testing.T, a, b string) *pkgallowlist.Allowlist {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"alpha":{"containers":` + a + `},
+		"beta":{"containers":` + b + `}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return al
+}
+
+func ambiguityErrors(findings []finding) []string {
+	var out []string
+	for _, f := range findings {
+		if f.err && strings.Contains(f.msg, "same containers with the same argv policy") {
+			out = append(out, f.msg)
+		}
+	}
+	return out
+}
+
+// Two entries no running set can tell apart are refused forever, so this is an
+// error rather than something an operator can weigh up.
+func TestLintIndistinguishableEntriesIsAnError(t *testing.T) {
+	same := `[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`
+	al := entryPair(t, same, same)
+
+	errs := ambiguityErrors(lintOffline(al))
+	if len(errs) != 1 {
+		t.Fatalf("expected one ambiguity error, got %v", errs)
+	}
+	if !strings.Contains(errs[0], "alpha") || !strings.Contains(errs[0], "beta") {
+		t.Fatalf("the error must name both entries, got %q", errs[0])
+	}
+	if countErrors(lintOffline(al)) == 0 {
+		t.Fatal("the finding is not flagged as an error")
+	}
+}
+
+// Argv is carried at release time and matched against each entry's own policy,
+// so entries differing only in argv are distinguishable and must not be flagged.
+func TestLintDistinctArgvIsNotAmbiguous(t *testing.T) {
+	al := entryPair(t,
+		`[{"digest":"`+digA+`","command":{"policy":"exact","argv":["/serve"]},"args":{"policy":"deny"}}]`,
+		`[{"digest":"`+digA+`","command":{"policy":"exact","argv":["/train"]},"args":{"policy":"deny"}}]`)
+
+	if errs := ambiguityErrors(lintOffline(al)); len(errs) != 0 {
+		t.Fatalf("entries differing in argv are distinguishable, got %v", errs)
+	}
+}
+
+// A main is required to be present and an init is not, so the same digest in
+// different lists produces entries a running set can tell apart.
+func TestLintMainVersusInitIsNotAmbiguous(t *testing.T) {
+	body := `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}`
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"alpha":{"containers":[` + body + `]},
+		"beta":{"initContainers":[` + body + `],"containers":[
+			{"digest":"` + digC + `","command":{"policy":"exact","argv":["/x"]},"args":{"policy":"deny"}}]}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := ambiguityErrors(lintOffline(al)); len(errs) != 0 {
+		t.Fatalf("a container in different lists is distinguishable, got %v", errs)
+	}
+}
+
+// Declaration order is not a difference: the shape is compared as a set.
+func TestLintAmbiguityIgnoresDeclarationOrder(t *testing.T) {
+	one := `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"}}`
+	two := `{"digest":"` + digC + `","command":{"policy":"exact","argv":["/c"]},"args":{"policy":"deny"}}`
+	al := entryPair(t, `[`+one+`,`+two+`]`, `[`+two+`,`+one+`]`)
+
+	if errs := ambiguityErrors(lintOffline(al)); len(errs) != 1 {
+		t.Fatalf("reordered declarations are the same shape, got %v", errs)
+	}
+}
+
+// The grant is deliberately outside the shape: two entries alike but for their
+// secrets are the dangerous case, since the grant an operator wrote is the
+// thing that never resolves.
+func TestLintAmbiguityIgnoresTheGrant(t *testing.T) {
+	body := `[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"alpha":{"containers":` + body + `,"secrets":{"policy":"allow","read":["/a/**"]}},
+		"beta":{"containers":` + body + `,"secrets":{"policy":"allow","read":["/b/**"]}}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if errs := ambiguityErrors(lintOffline(al)); len(errs) != 1 {
+		t.Fatalf("differing grants do not make entries distinguishable, got %v", errs)
+	}
+}
+
+// A single entry, and entries that genuinely differ, stay clean.
+func TestLintNoFalseAmbiguity(t *testing.T) {
+	al := entryPair(t,
+		`[{"digest":"`+digA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`,
+		`[{"digest":"`+digC+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`)
+	if errs := ambiguityErrors(lintOffline(al)); len(errs) != 0 {
+		t.Fatalf("distinct digests are distinguishable, got %v", errs)
+	}
+}
+
+// An entry that collides with one already served is the realistic case: an
+// operator applies one entry at a time, so the file alone never shows it.
+func TestWorkloadApplyRefusesCollisionWithLive(t *testing.T) {
+	body := `[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`
+	live, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"served":{"containers":` + body + `}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	incoming, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"incoming":{"containers":` + body + `}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	findings := collisionsWithLive(incoming.Workloads, live)
+	if countErrors(findings) != 1 {
+		t.Fatalf("expected one collision error, got %v", findings)
+	}
+	if !strings.Contains(findings[0].msg, "served") || !strings.Contains(findings[0].msg, "incoming") {
+		t.Fatalf("the error must name both sides, got %q", findings[0].msg)
+	}
+}
+
+// Replacing an entry with itself is an ordinary re-apply, not a collision.
+func TestWorkloadApplyReplacingItselfIsNotACollision(t *testing.T) {
+	body := `[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`
+	doc, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"same":{"containers":` + body + `}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findings := collisionsWithLive(doc.Workloads, doc); len(findings) != 0 {
+		t.Fatalf("re-applying an entry over itself must be clean, got %v", findings)
+	}
+}
+
+// A collision wholly inside the applied file is reported by the file lint, so
+// the live check does not repeat it.
+func TestWorkloadApplyDoesNotDoubleReportInFileCollision(t *testing.T) {
+	body := `[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]`
+	incoming, err := pkgallowlist.ParseJSON([]byte(`{"schema":"` + pkgallowlist.Schema + `","workloads":{
+		"alpha":{"containers":` + body + `},
+		"beta":{"containers":` + body + `}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	empty := &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema}
+	if findings := collisionsWithLive(incoming.Workloads, empty); len(findings) != 0 {
+		t.Fatalf("an in-file collision belongs to the file lint, got %v", findings)
+	}
+	if len(ambiguityErrors(lintOffline(incoming))) != 1 {
+		t.Fatal("the file lint should have reported it")
 	}
 }

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -103,9 +103,7 @@ digests in the file are ignored; use 'upload' or 'add'.`,
 				fmt.Fprintf(cmd.ErrOrStderr(), "note: %d floor digest(s) in the file are ignored by 'workload apply'; use 'upload' or 'add'\n", ignoredFloor)
 			}
 
-			for _, wmsg := range lintOffline(&pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: entries}) {
-				fmt.Fprintf(cmd.ErrOrStderr(), "lint: %s\n", wmsg)
-			}
+			findings := lintOffline(&pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: entries})
 
 			c, err := o.client(ctx(cmd))
 			if err != nil {
@@ -114,6 +112,18 @@ digests in the file are ignored; use 'upload' or 'add'.`,
 			live, _, err := c.List(ctx(cmd))
 			if err != nil {
 				return err
+			}
+
+			// The ambiguity check is the one finding that cannot be made from
+			// the file alone: the entry it collides with is usually one already
+			// served. Only pairs that span both are added here, since a
+			// collision inside the file is already reported above.
+			findings = append(findings, collisionsWithLive(entries, live)...)
+			for _, f := range findings {
+				fmt.Fprintf(cmd.ErrOrStderr(), "lint: %s\n", f)
+			}
+			if errs := countErrors(findings); errs > 0 {
+				return fmt.Errorf("refusing to apply: %d lint error(s)", errs)
 			}
 
 			names := sortedWorkloadNames(entries)
@@ -233,6 +243,39 @@ func newWorkloadDeleteCmd(o *options) *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// collisionsWithLive reports entries being applied that no running set could
+// tell apart from an entry already served, which would refuse both. Groups
+// entirely inside the applied set are left out: lintOffline over the file has
+// already named those.
+func collisionsWithLive(entries map[string]pkgallowlist.Workload, live *pkgallowlist.Allowlist) []finding {
+	merged := make(map[string]pkgallowlist.Workload, len(live.Workloads)+len(entries))
+	for name, w := range live.Workloads {
+		merged[name] = w
+	}
+	for name, w := range entries {
+		merged[name] = w
+	}
+	groups, err := indistinguishableGroups(&pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: merged})
+	if err != nil {
+		return []finding{errorf("workload entries could not be compared with the served allowlist: %v", err)}
+	}
+	var out []finding
+	for _, names := range groups {
+		applied, served := 0, 0
+		for _, n := range names {
+			if _, ok := entries[n]; ok {
+				applied++
+			} else {
+				served++
+			}
+		}
+		if applied > 0 && served > 0 {
+			out = append(out, ambiguousGroupFinding(names))
+		}
+	}
+	return out
 }
 
 // --- shared helpers ---

--- a/internal/cmds/allowlist/write.go
+++ b/internal/cmds/allowlist/write.go
@@ -148,12 +148,17 @@ before upload; --strict makes lint warnings fatal.`,
 				return err
 			}
 
-			warnings := lintOffline(desired)
-			for _, wmsg := range warnings {
-				fmt.Fprintf(cmd.ErrOrStderr(), "lint: %s\n", wmsg)
+			findings := lintOffline(desired)
+			for _, f := range findings {
+				fmt.Fprintf(cmd.ErrOrStderr(), "lint: %s\n", f)
 			}
-			if strict && len(warnings) > 0 {
-				return fmt.Errorf("refusing to upload: %d lint warning(s) with --strict", len(warnings))
+			// An error means the document cannot do what it says, so --force
+			// does not reach it: that flag is about missing components.
+			if errs := countErrors(findings); errs > 0 {
+				return fmt.Errorf("refusing to upload: %d lint error(s)", errs)
+			}
+			if strict && len(findings) > 0 {
+				return fmt.Errorf("refusing to upload: %d lint warning(s) with --strict", len(findings))
 			}
 
 			reqComponents := defaultRequiredComponents

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -31,6 +31,7 @@ type dependencies struct {
 	SecretsHandler    *secrets.Handler      // nil leaves /secrets unrouted (--secrets off)
 	SecretsChallenges *attestation.ChallengeStore
 	SecretsOperator   *secrets.OperatorHandler // operator-supplied values; routed with SecretsHandler
+	SecretsExplain    *secrets.ExplainHandler  // release diagnostic; routed with SecretsHandler
 }
 
 func newRouter(deps dependencies) http.Handler {
@@ -75,13 +76,14 @@ func newRouter(deps dependencies) http.Handler {
 	// token. PUT is the operator's, on allowlistWrite so it carries the same
 	// body-bound operator token an allowlist mutation does.
 	if deps.SecretsHandler != nil {
-		if deps.SecretsOperator == nil {
-			panic("cds: dependencies.SecretsOperator must be set alongside SecretsHandler")
+		if deps.SecretsOperator == nil || deps.SecretsExplain == nil {
+			panic("cds: dependencies.SecretsOperator and SecretsExplain must be set alongside SecretsHandler")
 		}
 		r.Method(http.MethodPost, secrets.ChallengeRoute, deps.protected(attestation.HandleAuthenticate(deps.SecretsChallenges)))
 		r.Method(http.MethodGet, secrets.Route, deps.protected(deps.SecretsHandler))
 		r.Method(http.MethodPost, secrets.Route, deps.protected(deps.SecretsHandler))
 		r.Method(http.MethodPut, secrets.Route, deps.allowlistWrite(deps.SecretsOperator))
+		r.Method(http.MethodGet, secrets.ExplainRoute, deps.allowlistWrite(deps.SecretsExplain))
 	}
 
 	r.Get("/ca", handleCA(deps.CACertPEM))

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -35,6 +35,7 @@ func secretsRouter(t *testing.T, enabled bool) http.Handler {
 		deps.SecretsHandler = &secrets.Handler{}
 		deps.SecretsChallenges = &secretsCS
 		deps.SecretsOperator = &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)}
+		deps.SecretsExplain = &secrets.ExplainHandler{}
 	}
 	return newRouter(deps)
 }
@@ -73,6 +74,7 @@ func TestRouter_SecretsUnroutedWhenDisabled(t *testing.T) {
 		{http.MethodGet, "/secrets/api/db"},
 		{http.MethodPost, "/secrets/api/db"},
 		{http.MethodPut, "/secrets/api/db"},
+		{http.MethodGet, "/secrets-explain/" + strings.Repeat("a", 64)},
 	} {
 		if code := get(t, r, tc.method, tc.path); code != http.StatusNotFound {
 			t.Fatalf("%s %s = %d with secrets disabled, want 404", tc.method, tc.path, code)
@@ -97,6 +99,7 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
 		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)},
+		SecretsExplain:    &secrets.ExplainHandler{},
 	}
 	_ = newRouter(deps)
 
@@ -137,6 +140,7 @@ func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
 		MaxRequestSize:    8,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
+		SecretsExplain:    &secrets.ExplainHandler{},
 		SecretsOperator: &secrets.OperatorHandler{
 			Store:        secrets.NewMemoryStore(8, 4096),
 			MaxBodyBytes: allowlistWriteBodyCap,
@@ -154,5 +158,25 @@ func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
 	}
 	if seen != len(body) {
 		t.Fatalf("authorizer saw %d bytes, want the whole %d-byte body", seen, len(body))
+	}
+}
+
+// The diagnostic is a sibling of /secrets, not a path beneath it. chi prefers a
+// literal segment over a wildcard, so had it been mounted at
+// /secrets/explain/... every secret stored under /explain/ would have become
+// unreachable — a store path silently shadowed by a route.
+func TestRouter_ExplainDoesNotShadowSecretPaths(t *testing.T) {
+	r := secretsRouter(t, true)
+
+	sandbox := strings.Repeat("a", 64)
+	if code := get(t, r, http.MethodGet, "/secrets-explain/"+sandbox); code != http.StatusUnauthorized {
+		t.Fatalf("GET /secrets-explain = %d, want 401 (operator-authorized)", code)
+	}
+	// A secret literally under /explain still reaches the release handler,
+	// which refuses it for want of a client certificate rather than 404ing.
+	for _, p := range []string{"/secrets/explain", "/secrets/explain/" + sandbox, "/secrets/explain/db"} {
+		if code := get(t, r, http.MethodGet, p); code == http.StatusNotFound {
+			t.Fatalf("GET %s = 404: the explain route shadowed a store path", p)
+		}
 	}
 }

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -264,17 +264,19 @@ func run(cfg config) error {
 	var (
 		secretsHandler  *secrets.Handler
 		secretsOperator *secrets.OperatorHandler
+		secretsExplain  *secrets.ExplainHandler
 	)
 	if enabled, why := secretsEnabled(cfg, sandboxDigests, inventoryHosts); enabled {
 		// One store behind both handlers: an operator write and a workload read
 		// are two doors onto the same paths.
 		store := secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxValueBytes)
+		policy := secrets.NewCachedPolicy(&allowlistStore)
 		secretsHandler = &secrets.Handler{
 			Store:          store,
 			Challenges:     &secretsChallenges,
 			Inventory:      sandboxDigests,
 			Bindings:       sandboxBindings,
-			Policy:         secrets.NewCachedPolicy(&allowlistStore),
+			Policy:         policy,
 			InventoryHosts: inventoryHosts,
 			Logger:         slog.Default(),
 		}
@@ -283,6 +285,16 @@ func run(cfg config) error {
 			Authorize:    writeAuthorizer,
 			MaxBodyBytes: allowlistWriteBodyCap,
 			Logger:       slog.Default(),
+		}
+		// The same inventory, binding and policy the release path reads, so the
+		// diagnostic answers about the decision rather than about a copy of it.
+		secretsExplain = &secrets.ExplainHandler{
+			Inventory:      sandboxDigests,
+			Bindings:       sandboxBindings,
+			Policy:         policy,
+			InventoryHosts: inventoryHosts,
+			Authorize:      writeAuthorizer,
+			Logger:         slog.Default(),
 		}
 		slog.Info("serving /secrets; release is gated on an allowlist entry carrying a secrets grant")
 	} else {
@@ -333,6 +345,7 @@ func run(cfg config) error {
 		SecretsHandler:    secretsHandler,
 		SecretsChallenges: &secretsChallenges,
 		SecretsOperator:   secretsOperator,
+		SecretsExplain:    secretsExplain,
 	}
 	if cfg.rotationInterval > 0 {
 		go rotator.Run(ctx)

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -92,6 +92,39 @@ func (c client) put(ctx context.Context, path string, value []byte, overwrite bo
 	}
 }
 
-// maxResponseBytes bounds a CDS reply. The body is a three-field status
-// object; anything approaching this is a wrong endpoint.
-const maxResponseBytes = 64 * 1024
+// explain asks CDS what a sandbox resolves to and why.
+func (c client) explain(ctx context.Context, sandboxID string, auth authorizer) (intsecrets.ExplainResponse, error) {
+	var out intsecrets.ExplainResponse
+	url := c.baseURL + "/secrets-explain/" + sandboxID
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return out, err
+	}
+	authz, err := auth.Authorization(http.MethodGet, req.URL.Path, nil)
+	if err != nil {
+		return out, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Authorization", authz)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return out, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return out, fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return out, fmt.Errorf("cds returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return out, fmt.Errorf("decode response: %w", err)
+	}
+	return out, nil
+}
+
+// maxResponseBytes bounds a CDS reply. The largest is an explain report over
+// every workload entry; anything approaching this is a wrong endpoint.
+const maxResponseBytes = 1 << 20

--- a/internal/cmds/secrets/cmd.go
+++ b/internal/cmds/secrets/cmd.go
@@ -51,7 +51,7 @@ docs/secrets.md).`,
 	}
 
 	cdsconn.BindFlags(cmd.PersistentFlags(), &o.Options)
-	cmd.AddCommand(newPutCmd(o))
+	cmd.AddCommand(newPutCmd(o), newExplainCmd(o))
 	return cmd
 }
 

--- a/internal/cmds/secrets/explain.go
+++ b/internal/cmds/secrets/explain.go
@@ -1,0 +1,140 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+func newExplainCmd(o *options) *cobra.Command {
+	var (
+		sandboxID string
+		asJSON    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "explain",
+		Short: "Show why a sandbox does or does not receive its secrets",
+		Long: `Report the release decision for one sandbox: what its node's inventory says it
+is running, which of those containers c8s injected and drops, what is left to
+match, how each workload entry measures against that, and the grant that
+resolves.
+
+A refused release tells the pod only that it was refused, and the input that
+decides it — the container set — is visible only to CDS, so this is where a
+wedged pod is diagnosed.
+
+The sandbox ID is on the pod's certificate; 'c8s verify' prints it.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			if err := ratls.ValidateSandboxID(sandboxID); err != nil {
+				return fmt.Errorf("--sandbox: %w", err)
+			}
+			signer, err := o.Signer()
+			if err != nil {
+				return err
+			}
+			c, err := o.client(cmdCtx(cmd))
+			if err != nil {
+				return err
+			}
+			resp, err := c.explain(cmdCtx(cmd), sandboxID, signer)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(resp)
+			}
+			printExplain(cmd.OutOrStdout(), resp)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&sandboxID, "sandbox", "", "sandbox ID to explain (required)")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print the raw report")
+	_ = cmd.MarkFlagRequired("sandbox")
+	return cmd
+}
+
+// printExplain lays the report out in the order CDS decides, so the first thing
+// that goes wrong is the first thing read.
+func printExplain(w io.Writer, r intsecrets.ExplainResponse) {
+	fmt.Fprintf(w, "sandbox    %s\n", r.SandboxID)
+	if r.InventoryHost != "" {
+		fmt.Fprintf(w, "inventory  %s\n", r.InventoryHost)
+	}
+
+	if len(r.Reported) > 0 {
+		injected := 0
+		for _, c := range r.Reported {
+			if c.Injected {
+				injected++
+			}
+		}
+		fmt.Fprintf(w, "reported   %d container(s)\n", len(r.Reported))
+		fmt.Fprintf(w, "dropped    %d injected by c8s\n", injected)
+		fmt.Fprintf(w, "candidates %d\n", len(r.Candidates))
+		for _, c := range r.Reported {
+			mark := " "
+			if c.Injected {
+				mark = "-"
+			}
+			fmt.Fprintf(w, "  %s %s  %s\n", mark, c.Digest, shellArgv(c.Argv))
+		}
+	}
+
+	for _, e := range r.Entries {
+		fmt.Fprintln(w)
+		switch {
+		case e.Matches && e.HasGrant:
+			fmt.Fprintf(w, "%s  MATCH\n", e.Name)
+		case e.Matches:
+			fmt.Fprintf(w, "%s  MATCH (no secret grant)\n", e.Name)
+		default:
+			fmt.Fprintf(w, "%s  NEAR MISS\n", e.Name)
+		}
+		for _, f := range e.Foreign {
+			fmt.Fprintf(w, "  foreign  %s  %s\n", f.Digest, shellArgv(f.Argv))
+			fmt.Fprintf(w, "           no container in this entry declares it\n")
+		}
+		for _, m := range e.MissingMains {
+			label := m.Digest
+			if m.Image != "" {
+				label = fmt.Sprintf("%s (%s)", m.Digest, m.Image)
+			}
+			fmt.Fprintf(w, "  missing  %s\n", label)
+			fmt.Fprintf(w, "           declared as a main container, nothing running satisfies it\n")
+		}
+	}
+
+	fmt.Fprintln(w)
+	if r.Grant != nil {
+		fmt.Fprintf(w, "released via %q\n", r.Match)
+		if len(r.Grant.Read) > 0 {
+			fmt.Fprintf(w, "  read   %s\n", strings.Join(r.Grant.Read, " "))
+		}
+		if len(r.Grant.Write) > 0 {
+			fmt.Fprintf(w, "  write  %s\n", strings.Join(r.Grant.Write, " "))
+		}
+		return
+	}
+	fmt.Fprintf(w, "nothing is released: %s\n", r.Refusal)
+}
+
+// shellArgv renders an argv for reading. Empty is explicit, since a container
+// with no reported argv is never dropped as injected and that is worth seeing.
+func shellArgv(argv []string) string {
+	if len(argv) == 0 {
+		return "(no argv reported)"
+	}
+	return "[" + strings.Join(argv, " ") + "]"
+}

--- a/internal/cmds/secrets/put_test.go
+++ b/internal/cmds/secrets/put_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 	"github.com/confidential-dot-ai/c8s/internal/localverify"
 	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
 
 // fakeCDS serves PUT /secrets/* with the create-safe semantics the real handler
@@ -315,6 +316,148 @@ func TestPutSurfacesServerErrors(t *testing.T) {
 	key := writeOperatorKey(t)
 	_, _, err := run(t, "v", "put", "/a", "--url", url, "--insecure", "--operator-key", key)
 	if err == nil || !strings.Contains(err.Error(), "cds returned 500") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// --- explain ---
+
+// explainServer answers the diagnostic route with a canned report, recording
+// what the CLI asked for.
+func explainServer(t *testing.T, resp intsecrets.ExplainResponse) (*string, *string, string) {
+	t.Helper()
+	var gotPath, gotAuthz string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuthz = r.URL.Path, r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	t.Cleanup(srv.Close)
+	return &gotPath, &gotAuthz, srv.URL
+}
+
+const testSandboxID = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestExplainPrintsAResolvedGrant(t *testing.T) {
+	path, authz, url := explainServer(t, intsecrets.ExplainResponse{
+		SandboxID:     testSandboxID,
+		InventoryHost: "10.0.0.7",
+		Reported: []intsecrets.ReportedContainer{
+			{Digest: "sha256:app", Argv: []string{"/serve"}},
+			{Digest: "sha256:c8s", Argv: []string{"get-secret"}, Injected: true},
+		},
+		Candidates: []intsecrets.ReportedContainer{{Digest: "sha256:app", Argv: []string{"/serve"}}},
+		Entries:    []intsecrets.EntryVerdict{{Name: "api", Matches: true, HasGrant: true}},
+		Match:      "api",
+		Grant:      &pkgallowlist.SecretsPolicy{Policy: "allow", Read: []string{"/api/**"}},
+	})
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "", "explain", "--sandbox", testSandboxID, "--url", url, "--insecure", "--operator-key", key)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	for _, want := range []string{"reported   2", "dropped    1 injected", "candidates 1", "api  MATCH", "released via", "/api/**"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+	if *path != "/secrets-explain/"+testSandboxID {
+		t.Fatalf("path = %q", *path)
+	}
+	if !strings.HasPrefix(*authz, "Bearer ") {
+		t.Fatalf("Authorization = %q, want an operator bearer token", *authz)
+	}
+}
+
+// The near miss is the reason the command exists, so the foreign container and
+// the refusal both have to be legible.
+func TestExplainPrintsANearMiss(t *testing.T) {
+	_, _, url := explainServer(t, intsecrets.ExplainResponse{
+		SandboxID: testSandboxID,
+		Entries: []intsecrets.EntryVerdict{{
+			Name:         "api",
+			Foreign:      []intsecrets.ReportedContainer{{Digest: "sha256:busybox", Argv: []string{"sh", "-c", "sleep"}}},
+			MissingMains: []intsecrets.MissingContainer{{Digest: "sha256:app", Image: "ghcr.io/x/app"}},
+		}},
+		Refusal: "no entry describes the candidate set",
+	})
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "", "explain", "--sandbox", testSandboxID, "--url", url, "--insecure", "--operator-key", key)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	for _, want := range []string{
+		"api  NEAR MISS",
+		"foreign  sha256:busybox",
+		"no container in this entry declares it",
+		"missing  sha256:app (ghcr.io/x/app)",
+		"nothing is released: no entry describes the candidate set",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// A container with no reported argv is never dropped as injected, so its
+// absence has to be visible rather than rendered as an empty gap.
+func TestExplainRendersAnEmptyArgv(t *testing.T) {
+	_, _, url := explainServer(t, intsecrets.ExplainResponse{
+		SandboxID: testSandboxID,
+		Reported:  []intsecrets.ReportedContainer{{Digest: "sha256:app"}},
+		Refusal:   "no entry describes the candidate set",
+	})
+	key := writeOperatorKey(t)
+	out, _, err := run(t, "", "explain", "--sandbox", testSandboxID, "--url", url, "--insecure", "--operator-key", key)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	if !strings.Contains(out, "(no argv reported)") {
+		t.Fatalf("output = %s", out)
+	}
+}
+
+func TestExplainJSONPassesTheReportThrough(t *testing.T) {
+	_, _, url := explainServer(t, intsecrets.ExplainResponse{SandboxID: testSandboxID, Refusal: "no inventory is bound"})
+	key := writeOperatorKey(t)
+
+	out, _, err := run(t, "", "explain", "--sandbox", testSandboxID, "--url", url, "--insecure", "--operator-key", key, "--json")
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	var got intsecrets.ExplainResponse
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("--json did not emit JSON: %v\n%s", err, out)
+	}
+	if got.Refusal != "no inventory is bound" {
+		t.Fatalf("got = %+v", got)
+	}
+}
+
+func TestExplainValidatesItsArguments(t *testing.T) {
+	_, _, url := explainServer(t, intsecrets.ExplainResponse{})
+	key := writeOperatorKey(t)
+
+	if _, _, err := run(t, "", "explain", "--sandbox", "bad!id", "--url", url, "--insecure", "--operator-key", key); err == nil ||
+		!strings.Contains(err.Error(), "--sandbox") {
+		t.Fatalf("err = %v, want a --sandbox error", err)
+	}
+	if _, _, err := run(t, "", "explain", "--url", url, "--insecure", "--operator-key", key); err == nil {
+		t.Fatal("--sandbox is required")
+	}
+}
+
+func TestExplainSurfacesServerErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	key := writeOperatorKey(t)
+
+	_, _, err := run(t, "", "explain", "--sandbox", testSandboxID, "--url", srv.URL, "--insecure", "--operator-key", key)
+	if err == nil || !strings.Contains(err.Error(), "cds returned 401") {
 		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/secrets/explain.go
+++ b/internal/secrets/explain.go
@@ -1,0 +1,218 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/go-chi/chi/v5"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// ExplainRoute answers what a sandbox would be released and why. It is a
+// sibling of Route rather than a path under it: chi prefers a literal segment
+// over a wildcard, so "/secrets/explain/..." would make a secret stored at
+// /explain/... unreachable.
+const ExplainRoute = "/secrets-explain/{sandboxID}"
+
+// ReportedContainer is one container the inventory named, and whether the
+// release path drops it as a platform-injected one.
+type ReportedContainer struct {
+	Digest   string   `json:"digest"`
+	Argv     []string `json:"argv"`
+	Injected bool     `json:"injected"`
+}
+
+// EntryVerdict is one workload entry measured against the candidate set.
+type EntryVerdict struct {
+	Name string `json:"name"`
+	// Foreign is what the sandbox runs that this entry does not declare.
+	Foreign []ReportedContainer `json:"foreign,omitempty"`
+	// MissingMains is the main containers this entry declares that nothing
+	// running satisfies.
+	MissingMains []MissingContainer `json:"missingMains,omitempty"`
+	Matches      bool               `json:"matches"`
+	// HasGrant reports whether a matching entry would release anything.
+	HasGrant bool `json:"hasGrant"`
+}
+
+// MissingContainer names a declared main the sandbox is not running.
+type MissingContainer struct {
+	Digest string `json:"digest"`
+	Image  string `json:"image,omitempty"`
+}
+
+// ExplainResponse is the whole decision, in the order it is made.
+type ExplainResponse struct {
+	SandboxID     string              `json:"sandboxID"`
+	InventoryHost string              `json:"inventoryHost,omitempty"`
+	Reported      []ReportedContainer `json:"reported,omitempty"`
+	Candidates    []ReportedContainer `json:"candidates,omitempty"`
+	Entries       []EntryVerdict      `json:"entries,omitempty"`
+	// Match names the single entry that describes the candidate set.
+	Match string `json:"match,omitempty"`
+	// Grant is that entry's secret grant. Paths only; a value never appears
+	// here.
+	Grant *pkgallowlist.SecretsPolicy `json:"grant,omitempty"`
+	// Refusal states why nothing is released, in the terms the release path
+	// uses. Empty when a grant resolved.
+	Refusal string `json:"refusal,omitempty"`
+}
+
+// ExplainHandler serves ExplainRoute.
+//
+// Release denials are opaque to the workload by design and the input that
+// decides them — what the sandbox is running — is visible only to CDS, so
+// without this a wedged pod is diagnosable only from CDS logs.
+//
+// It answers to the operator key, not to a sandbox token: the caller is asking
+// about someone else's pod, which no workload may do.
+type ExplainHandler struct {
+	Inventory      inventorySource
+	Bindings       bindingSource
+	Policy         policySource
+	InventoryHosts workloadclaims.InventoryHosts
+
+	// Authorize is operatorauth.Verifier.Authorize. Nil rejects every request.
+	Authorize func(r *http.Request, body []byte) error
+
+	Logger *slog.Logger
+}
+
+func (h ExplainHandler) logger() *slog.Logger {
+	if h.Logger != nil {
+		return h.Logger
+	}
+	return slog.Default()
+}
+
+func (h ExplainHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.Authorize == nil {
+		http.Error(w, "operator writes are not configured", http.StatusUnauthorized)
+		return
+	}
+	// The read has no body; the token still binds the method and the sandbox ID
+	// in the path.
+	if err := h.Authorize(r, nil); err != nil {
+		h.logger().Warn("secret explain rejected", "remote", r.RemoteAddr, "reason", err)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	sandboxID := chi.URLParam(r, "sandboxID")
+	if err := ratls.ValidateSandboxID(sandboxID); err != nil {
+		http.Error(w, "invalid sandbox ID", http.StatusBadRequest)
+		return
+	}
+
+	resp := h.explain(r.Context(), sandboxID)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// explain walks the release decision in order and stops at the first thing that
+// would refuse, so the answer names the earliest cause rather than a downstream
+// symptom of it.
+func (h ExplainHandler) explain(ctx context.Context, sandboxID string) ExplainResponse {
+	resp := ExplainResponse{SandboxID: sandboxID}
+
+	if h.Bindings == nil || h.Inventory == nil {
+		resp.Refusal = "secrets are not configured to reach an inventory"
+		return resp
+	}
+	host, ok := h.Bindings.Lookup(sandboxID)
+	if !ok {
+		resp.Refusal = "no inventory is bound to this sandbox: it has not attested since CDS started, or a second inventory claimed the ID"
+		return resp
+	}
+	if !h.InventoryHosts.Contains(host) {
+		resp.InventoryHost = host
+		resp.Refusal = "the bound inventory is outside the configured --sandbox-inventory-cidr range"
+		return resp
+	}
+	resp.InventoryHost = host
+
+	al, err := h.Policy.Allowlist()
+	if err != nil {
+		resp.Refusal = "the allowlist could not be loaded"
+		return resp
+	}
+	sandbox, err := h.Inventory.FetchSandbox(ctx, host, sandboxID)
+	if err != nil {
+		resp.Refusal = "the bound inventory did not answer for this sandbox"
+		return resp
+	}
+	reported, err := sandbox.RequireContainers()
+	if err != nil {
+		resp.Refusal = "the inventory reports no per-container detail: it predates argv reporting and cannot be used for release"
+		return resp
+	}
+
+	var candidates []pkgallowlist.RunningContainer
+	for _, c := range reported {
+		injected := isInjected(al, c)
+		entry := ReportedContainer{Digest: c.Digest, Argv: c.Argv, Injected: injected}
+		resp.Reported = append(resp.Reported, entry)
+		if injected {
+			continue
+		}
+		resp.Candidates = append(resp.Candidates, entry)
+		candidates = append(candidates, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+	}
+	if len(candidates) == 0 {
+		resp.Refusal = "every container the sandbox reports is a platform-injected one, so there is nothing to match"
+		return resp
+	}
+
+	var matched []string
+	for _, name := range sortedNames(al.Workloads) {
+		d := al.Workloads[name].Diff(candidates)
+		v := EntryVerdict{
+			Name:     name,
+			Matches:  d.Describes(),
+			HasGrant: al.Workloads[name].Secrets != nil,
+		}
+		for _, f := range d.Foreign {
+			v.Foreign = append(v.Foreign, ReportedContainer{Digest: f.Digest, Argv: f.Argv})
+		}
+		for _, m := range d.MissingMains {
+			v.MissingMains = append(v.MissingMains, MissingContainer{Digest: m.Digest.String(), Image: m.Image})
+		}
+		resp.Entries = append(resp.Entries, v)
+		if v.Matches {
+			matched = append(matched, name)
+		}
+	}
+
+	switch {
+	case len(matched) == 0:
+		resp.Refusal = "no entry describes the candidate set"
+	case len(matched) > 1:
+		resp.Refusal = "more than one entry describes the candidate set, so the match is ambiguous"
+	default:
+		resp.Match = matched[0]
+		grant := al.Workloads[matched[0]].Secrets
+		if grant == nil {
+			resp.Refusal = "the matching entry carries no secret grant"
+			return resp
+		}
+		resp.Grant = grant
+	}
+	return resp
+}
+
+// sortedNames keeps the verdict list stable across calls.
+func sortedNames(m map[string]pkgallowlist.Workload) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/internal/secrets/explain_test.go
+++ b/internal/secrets/explain_test.go
@@ -1,0 +1,321 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// explainHarness reuses the release harness's allowlist and inventory, so the
+// diagnostic is exercised against the same policy the handler decides on.
+type explainHarness struct {
+	h       ExplainHandler
+	inv     *fakeInventory
+	authErr error
+}
+
+func newExplainHarness(t *testing.T) *explainHarness {
+	t.Helper()
+	rel := newHarness(t)
+	eh := &explainHarness{inv: rel.inv}
+	eh.h = ExplainHandler{
+		Inventory:      rel.h.Inventory,
+		Bindings:       rel.h.Bindings,
+		Policy:         rel.h.Policy,
+		InventoryHosts: rel.h.InventoryHosts,
+		Authorize:      func(*http.Request, []byte) error { return eh.authErr },
+	}
+	return eh
+}
+
+// serve routes through chi so the {sandboxID} parameter is populated the way
+// the real router populates it.
+func (eh *explainHarness) serve(sandboxID string) (*httptest.ResponseRecorder, ExplainResponse) {
+	r := chi.NewRouter()
+	r.Method(http.MethodGet, ExplainRoute, eh.h)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/secrets-explain/"+sandboxID, nil))
+	var resp ExplainResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	return w, resp
+}
+
+func TestExplainResolvesTheGrant(t *testing.T) {
+	eh := newExplainHarness(t)
+	w, resp := eh.serve(testSandbox)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: %s", w.Code, w.Body)
+	}
+	if resp.Match != "api" || resp.Grant == nil {
+		t.Fatalf("resp = %+v, want a resolved grant for api", resp)
+	}
+	if resp.Refusal != "" {
+		t.Fatalf("a resolved grant must carry no refusal, got %q", resp.Refusal)
+	}
+	if resp.InventoryHost != testHost {
+		t.Fatalf("inventory = %q, want the bound host", resp.InventoryHost)
+	}
+}
+
+// The injected sidecar is reported but marked, and does not reach the candidate
+// set — the operator has to be able to see why it is excluded.
+func TestExplainMarksInjectedContainers(t *testing.T) {
+	eh := newExplainHarness(t)
+	_, resp := eh.serve(testSandbox)
+
+	if len(resp.Reported) != 2 || len(resp.Candidates) != 1 {
+		t.Fatalf("reported=%d candidates=%d, want 2 and 1", len(resp.Reported), len(resp.Candidates))
+	}
+	var injected int
+	for _, c := range resp.Reported {
+		if c.Injected {
+			injected++
+			if c.Digest != testInjected {
+				t.Fatalf("the wrong container was dropped: %s", c.Digest)
+			}
+		}
+	}
+	if injected != 1 {
+		t.Fatalf("injected = %d, want 1", injected)
+	}
+	if resp.Candidates[0].Digest != testAppImg {
+		t.Fatalf("candidate = %s, want the app image", resp.Candidates[0].Digest)
+	}
+}
+
+// The near-miss case the command exists for: a pod runs an undeclared image, so
+// the entry fails the subset check and the diagnostic names the culprit.
+func TestExplainNamesTheForeignContainer(t *testing.T) {
+	eh := newExplainHarness(t)
+	eh.inv.containers = append(eh.inv.containers,
+		workloadclaims.SandboxContainer{Digest: testOther, Argv: []string{"sh", "-c", "sleep 1"}})
+
+	_, resp := eh.serve(testSandbox)
+	if resp.Match != "" || resp.Grant != nil {
+		t.Fatalf("an undeclared image must refuse, got %+v", resp)
+	}
+	if !strings.Contains(resp.Refusal, "no entry describes") {
+		t.Fatalf("refusal = %q", resp.Refusal)
+	}
+	var found bool
+	for _, e := range resp.Entries {
+		if e.Name != "api" {
+			continue
+		}
+		if e.Matches {
+			t.Fatal("api must not match once a foreign image is running")
+		}
+		for _, f := range e.Foreign {
+			if f.Digest == testOther {
+				found = true
+				if len(f.Argv) == 0 {
+					t.Fatal("the foreign container's argv is what identifies it")
+				}
+			}
+		}
+	}
+	if !found {
+		t.Fatal("the foreign digest was not named in the entry's diff")
+	}
+}
+
+// A floor image running a shell is not an injected container, so it must land
+// in candidates rather than being silently dropped.
+func TestExplainDoesNotDropAFloorImageRunningAShell(t *testing.T) {
+	eh := newExplainHarness(t)
+	eh.inv.containers = append(eh.inv.containers,
+		workloadclaims.SandboxContainer{Digest: testInjected, Argv: []string{"sh", "-c", "cat /run/c8s/secrets/DB"}})
+
+	_, resp := eh.serve(testSandbox)
+	for _, c := range resp.Reported {
+		if c.Digest == testInjected && len(c.Argv) > 0 && c.Argv[0] == "sh" && c.Injected {
+			t.Fatal("a floor image running a shell was dropped as injected")
+		}
+	}
+	if resp.Match != "" {
+		t.Fatalf("it must break the match, got %q", resp.Match)
+	}
+}
+
+// A declared main that is not running is the other half of the diff.
+func TestExplainNamesAMissingMain(t *testing.T) {
+	eh := newExplainHarness(t)
+	eh.inv.containers = []workloadclaims.SandboxContainer{
+		{Digest: testInjected, Argv: []string{"get-cert", "--san=x"}},
+		{Digest: testOther, Argv: []string{"sh"}},
+	}
+
+	_, resp := eh.serve(testSandbox)
+	for _, e := range resp.Entries {
+		if e.Name != "api" {
+			continue
+		}
+		if len(e.MissingMains) != 1 || e.MissingMains[0].Digest != testAppImg {
+			t.Fatalf("missing mains = %+v, want the app image", e.MissingMains)
+		}
+	}
+}
+
+// Every refusal the release path can reach has to be nameable here, or the
+// command answers the easy cases only.
+func TestExplainReportsEarlyRefusals(t *testing.T) {
+	t.Run("no binding", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		eh.h.Bindings = fakeBindings{}
+		_, resp := eh.serve(testSandbox)
+		if !strings.Contains(resp.Refusal, "no inventory is bound") {
+			t.Fatalf("refusal = %q", resp.Refusal)
+		}
+	})
+	t.Run("host outside the CIDRs", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		eh.h.Bindings = fakeBindings{host: "192.168.1.1"}
+		_, resp := eh.serve(testSandbox)
+		if !strings.Contains(resp.Refusal, "outside the configured") {
+			t.Fatalf("refusal = %q", resp.Refusal)
+		}
+	})
+	t.Run("inventory unreachable", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		eh.inv.err = fmt.Errorf("connection refused")
+		_, resp := eh.serve(testSandbox)
+		if !strings.Contains(resp.Refusal, "did not answer") {
+			t.Fatalf("refusal = %q", resp.Refusal)
+		}
+	})
+	t.Run("only injected containers", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		eh.inv.containers = []workloadclaims.SandboxContainer{
+			{Digest: testInjected, Argv: []string{"get-cert"}},
+		}
+		_, resp := eh.serve(testSandbox)
+		if !strings.Contains(resp.Refusal, "platform-injected") {
+			t.Fatalf("refusal = %q", resp.Refusal)
+		}
+	})
+	t.Run("matching entry has no grant", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		al, _ := eh.h.Policy.Allowlist()
+		entry := al.Workloads["api"]
+		entry.Secrets = nil
+		al.Workloads["api"] = entry
+		_, resp := eh.serve(testSandbox)
+		if resp.Match != "api" || !strings.Contains(resp.Refusal, "no secret grant") {
+			t.Fatalf("match=%q refusal=%q", resp.Match, resp.Refusal)
+		}
+	})
+	t.Run("ambiguous match", func(t *testing.T) {
+		eh := newExplainHarness(t)
+		al, _ := eh.h.Policy.Allowlist()
+		al.Workloads["api-copy"] = al.Workloads["api"]
+		_, resp := eh.serve(testSandbox)
+		if !strings.Contains(resp.Refusal, "ambiguous") {
+			t.Fatalf("refusal = %q", resp.Refusal)
+		}
+	})
+}
+
+// The report describes someone else's pod, so it answers only to the operator
+// key — never to a sandbox token, and never to nothing at all.
+func TestExplainRequiresOperatorAuth(t *testing.T) {
+	eh := newExplainHarness(t)
+	eh.authErr = fmt.Errorf("no token")
+	w, _ := eh.serve(testSandbox)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+
+	unconfigured := ExplainHandler{}
+	r := chi.NewRouter()
+	r.Method(http.MethodGet, ExplainRoute, unconfigured)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/secrets-explain/"+testSandbox, nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d with no authorizer, want 401", rec.Code)
+	}
+}
+
+// The ID is bounded by the same rule CDS applies when it stamps one on a leaf,
+// so the diagnostic accepts exactly the IDs that can exist and refuses the rest
+// before dialling anything.
+func TestExplainRejectsAMalformedSandboxID(t *testing.T) {
+	for _, tc := range []struct{ name, id string }{
+		{"out of character class", "sandbox!id"},
+		{"over the length bound", strings.Repeat("a", 129)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eh := newExplainHarness(t)
+			w, _ := eh.serve(tc.id)
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+// A value must never reach this report; it carries paths only.
+func TestExplainCarriesNoSecretValues(t *testing.T) {
+	eh := newExplainHarness(t)
+	w, resp := eh.serve(testSandbox)
+	if resp.Grant == nil {
+		t.Fatal("expected a grant")
+	}
+	for _, p := range append(append([]string{}, resp.Grant.Read...), resp.Grant.Write...) {
+		if !strings.HasPrefix(p, "/") {
+			t.Fatalf("grant entry %q is not a path", p)
+		}
+	}
+	if strings.Contains(w.Body.String(), "value") {
+		t.Fatalf("the report mentions a value: %s", w.Body)
+	}
+}
+
+// The diagnostic is the release decision, not a second opinion on it: whatever
+// the handler resolves, MatchWorkload must resolve the same way.
+func TestExplainAgreesWithTheMatcher(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		running []workloadclaims.SandboxContainer
+	}{
+		{"match", []workloadclaims.SandboxContainer{
+			{Digest: testAppImg, Argv: []string{"/serve"}},
+			{Digest: testInjected, Argv: []string{"get-cert"}},
+		}},
+		{"foreign image", []workloadclaims.SandboxContainer{
+			{Digest: testAppImg, Argv: []string{"/serve"}},
+			{Digest: testOther, Argv: []string{"sh"}},
+		}},
+		{"wrong argv", []workloadclaims.SandboxContainer{
+			{Digest: testAppImg, Argv: []string{"/bin/sh"}},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eh := newExplainHarness(t)
+			eh.inv.containers = tc.running
+			_, resp := eh.serve(testSandbox)
+
+			al, _ := eh.h.Policy.Allowlist()
+			var candidates []pkgallowlist.RunningContainer
+			for _, c := range tc.running {
+				if !isInjected(al, c) {
+					candidates = append(candidates, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+				}
+			}
+			name, _, err := al.MatchWorkload(candidates)
+			if err != nil {
+				name = ""
+			}
+			if resp.Match != name {
+				t.Fatalf("explain says %q, the matcher says %q", resp.Match, name)
+			}
+		})
+	}
+}

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -65,24 +65,50 @@ func (a *Allowlist) MatchWorkload(running []RunningContainer) (string, Workload,
 	return foundName, found, nil
 }
 
-// describes reports whether the entry admits everything running and has all its
-// main containers present.
-func (w Workload) describes(running []RunningContainer) bool {
+// EntryDiff is the distance between an entry and a running set: what is running
+// that the entry does not name, and what it declares as a main that nothing
+// running satisfies. Both empty means the entry describes the set.
+type EntryDiff struct {
+	// Foreign is running containers no declared container admits — the ⊆ half.
+	Foreign []RunningContainer
+	// MissingMains is declared main containers nothing running satisfies — the
+	// ⊇ half. An init container is absent from this by design: a declared init
+	// may have exited.
+	MissingMains []Container
+}
+
+// Describes reports whether the entry matches.
+func (d EntryDiff) Describes() bool { return len(d.Foreign) == 0 && len(d.MissingMains) == 0 }
+
+// Diff evaluates an entry against a running set without short-circuiting, so a
+// near miss can be reported in full.
+//
+// This is the release decision itself, not a reconstruction of it: describes is
+// Diff().Describes(), so a diagnostic built on this cannot disagree with what
+// CDS actually did.
+func (w Workload) Diff(running []RunningContainer) EntryDiff {
 	declared := make([]Container, 0, len(w.Containers)+len(w.InitContainers))
 	declared = append(declared, w.Containers...)
 	declared = append(declared, w.InitContainers...)
 
+	var d EntryDiff
 	for _, r := range running {
 		if !admittedBy(declared, r) {
-			return false
+			d.Foreign = append(d.Foreign, r)
 		}
 	}
 	for _, c := range w.Containers {
 		if !anyRunning(running, c) {
-			return false
+			d.MissingMains = append(d.MissingMains, c)
 		}
 	}
-	return true
+	return d
+}
+
+// describes reports whether the entry admits everything running and has all its
+// main containers present.
+func (w Workload) describes(running []RunningContainer) bool {
+	return w.Diff(running).Describes()
 }
 
 // admittedBy reports whether some declared container permits this running


### PR DESCRIPTION
…ot be told apart

Two diagnostics for the same failure: a pod that starts, never gets its file, and gives nobody a reason.

`c8s secrets explain --sandbox <id>` reports the decision in the order CDS makes it — the bound inventory, what that inventory says the sandbox has run, which containers are dropped as c8s-injected, what is left to match, how each entry measures against that set, and the grant that resolves. Release denials are opaque to the workload by design and the deciding input is visible only to CDS, so this is the only place the answer exists outside a log.

It is the decision rather than a reconstruction of it. Workload.describes is now Diff().Describes(): one implementation, so the report cannot disagree with what the release path did. Diff does not short-circuit, which is what lets a near miss name the container that broke it. The handler is wired to the same inventory, binding ledger and cached policy the release handler holds.

GET /secrets-explain/{sandboxID} is a sibling of /secrets rather than a path beneath it. chi prefers a literal segment over a wildcard, so /secrets/explain/... would have made every secret stored under /explain/ permanently unreachable — the same shadowing the challenge route was shaped to avoid. It answers to the operator key, since the report describes a pod the caller may not own, and carries grant paths only.

`c8s allowlist lint` gains its first error level. Two entries declaring the same containers with the same argv policy either both match a running set or neither does, so release is ambiguous forever and every pod resolving to them is refused — whichever grant was meant. No workload action fixes it, so it is not a judgement an operator can accept, and it blocks a write on its own rather than needing --strict.

The predicate is the design's, not the shorthand: identical digest sets AND identical argv policies. Since release now matches (digest, argv) against each entry's own policy, entries differing only in argv are distinguishable and flagging them would be a false positive. The compared shape excludes the image label and the secret grant — two entries alike but for their grants are precisely the case worth catching, since the grant is the thing that never resolves. Mains and inits stay separate: a main must be present and an init need not, so moving one between the lists changes what matches.

`workload apply` runs the check against the served allowlist as well as the file. An operator applies one entry at a time, so the entry a new one collides with is almost always one already there, and a file-only check would miss the whole realistic case. Groups falling entirely inside the applied file are left to the file lint rather than reported twice.
