### PR TITLE
feat(volume): c8s volume create

### DIFF
--- a/cmd/c8s/volume.go
+++ b/cmd/c8s/volume.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+
+func init() {
+	rootCmd.AddCommand(volume.NewCmd())
+}

--- a/internal/cmds/volume/cmd.go
+++ b/internal/cmds/volume/cmd.go
@@ -1,0 +1,110 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// options holds the flags every subcommand shares.
+type options struct {
+	cdsconn.Options
+}
+
+// NewCmd returns the `c8s volume` command tree.
+func NewCmd() *cobra.Command {
+	return newCmd(localverify.Verify)
+}
+
+func newCmd(verify localverify.VerifyFunc) *cobra.Command {
+	o := &options{Options: cdsconn.Options{Verify: verify}}
+	cmd := &cobra.Command{
+		Use:   "volume",
+		Short: "Build encrypted volumes and store their keys in CDS",
+		Long: `Build a volume that only an attested workload can read.
+
+'create' packages a directory into an encrypted, integrity-protected image and
+puts its key into the CDS secret store. The image is ciphertext: copy it to the
+node by any means, including through the untrusted host.
+
+The key is released to a pod when the images running in that pod's sandbox match
+an allowlist entry whose 'secrets' grant covers the key's path. 'create' prints
+the grant and the pod annotations to apply; it does not modify any workload.
+
+Writes are signed with an operator EC private key you supply via --operator-key
+(or C8S_OPERATOR_KEY), whose public half CDS pins via 'c8s install
+--operator-keys'.
+
+Keys live in the CDS process and nowhere else, so a CDS restart makes every
+volume in the cluster unopenable until its key is written again. Keep the escrow
+file 'create' writes.`,
+		SilenceUsage: true,
+	}
+	cdsconn.BindFlags(cmd.PersistentFlags(), &o.Options)
+	cmd.AddCommand(newCreateCmd(o))
+	return cmd
+}
+
+// putBlob stores the key blob, and refuses a path that already holds anything.
+//
+// Create-only, deliberately: a volume's key and its ciphertext are one unit, so
+// replacing the key of a path some volume is already using does not rotate
+// anything — it strands that volume with no way back. `c8s secrets put
+// --overwrite` is the deliberate way to replace a value, and this is not it.
+func putBlob(ctx context.Context, hc *http.Client, baseURL, path string, blob Blob, auth authorizer) error {
+	value, err := blob.Marshal()
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(intsecrets.PutRequest{
+		Value:     base64Std(value),
+		Overwrite: false,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, baseURL+"/secrets"+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	authz, err := auth.Authorization(http.MethodPut, req.URL.Path, body)
+	if err != nil {
+		return fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authz)
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+
+	switch resp.StatusCode {
+	case http.StatusCreated:
+		return nil
+	case http.StatusConflict:
+		return fmt.Errorf("%s already holds a value; a volume key is not replaceable — "+
+			"choose another path, or remove the volume that uses this one", path)
+	default:
+		return fmt.Errorf("cds returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+}
+
+// authorizer mints the operator Authorization header for one write, bound to
+// its method, path, and body. Implemented by operatorauth.Signer.
+type authorizer interface {
+	Authorization(method, path string, body []byte) (string, error)
+}

--- a/internal/cmds/volume/cmd_test.go
+++ b/internal/cmds/volume/cmd_test.go
@@ -1,0 +1,127 @@
+package volume
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+type fakeSigner struct {
+	method, path string
+	body         []byte
+}
+
+func (f *fakeSigner) Authorization(method, path string, body []byte) (string, error) {
+	f.method, f.path, f.body = method, path, body
+	return "Bearer test-token", nil
+}
+
+// putServer records the one request it receives and answers with status.
+type putServer struct {
+	status int
+	gotReq intsecrets.PutRequest
+	gotAuth,
+	gotPath string
+}
+
+func (p *putServer) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p.gotAuth = r.Header.Get("Authorization")
+		p.gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &p.gotReq)
+		w.WriteHeader(p.status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func testBlob(t *testing.T) Blob {
+	t.Helper()
+	b, err := NewBlob(testKey(), validVerity())
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	return b
+}
+
+func TestPutBlobSendsTheBlobUnderTheOperatorToken(t *testing.T) {
+	p := &putServer{status: http.StatusCreated}
+	srv := p.start(t)
+	signer := &fakeSigner{}
+
+	if err := putBlob(t.Context(), srv.Client(), srv.URL, "/tenant-a/volumes/weights", testBlob(t), signer); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+
+	if p.gotPath != "/secrets/tenant-a/volumes/weights" {
+		t.Errorf("path = %q", p.gotPath)
+	}
+	if p.gotAuth != "Bearer test-token" {
+		t.Errorf("authorization = %q", p.gotAuth)
+	}
+	// The token must be bound to the same path and bytes the server received,
+	// or the binding proves nothing about this request.
+	if signer.path != p.gotPath {
+		t.Errorf("token bound to %q, request went to %q", signer.path, p.gotPath)
+	}
+	if signer.method != http.MethodPut {
+		t.Errorf("token bound to method %q", signer.method)
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(p.gotReq.Value)
+	if err != nil {
+		t.Fatalf("value is not base64: %v", err)
+	}
+	got, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("server received something that is not a key blob: %v", err)
+	}
+	if got.Key != testBlob(t).Key || got.Verity != validVerity() {
+		t.Error("server received a different blob than was built")
+	}
+}
+
+// A volume key and its ciphertext are one unit, so create never carries
+// overwrite intent: replacing the key of a path some volume already uses
+// strands that volume with no way back.
+func TestPutBlobNeverAsksToOverwrite(t *testing.T) {
+	p := &putServer{status: http.StatusCreated}
+	srv := p.start(t)
+	if err := putBlob(t.Context(), srv.Client(), srv.URL, "/a/b", testBlob(t), &fakeSigner{}); err != nil {
+		t.Fatalf("put: %v", err)
+	}
+	if p.gotReq.Overwrite {
+		t.Fatal("create asked CDS to overwrite")
+	}
+}
+
+func TestPutBlobRefusesAnOccupiedPath(t *testing.T) {
+	p := &putServer{status: http.StatusConflict}
+	srv := p.start(t)
+	err := putBlob(t.Context(), srv.Client(), srv.URL, "/a/b", testBlob(t), &fakeSigner{})
+	if err == nil {
+		t.Fatal("accepted a conflict")
+	}
+	if !strings.Contains(err.Error(), "not replaceable") {
+		t.Errorf("error should say a volume key cannot be replaced: %v", err)
+	}
+}
+
+func TestPutBlobSurfacesOtherStatuses(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusInternalServerError} {
+		p := &putServer{status: status}
+		srv := p.start(t)
+		err := putBlob(t.Context(), srv.Client(), srv.URL, "/a/b", testBlob(t), &fakeSigner{})
+		if err == nil {
+			t.Errorf("status %d: accepted", status)
+		}
+	}
+}

--- a/internal/cmds/volume/create.go
+++ b/internal/cmds/volume/create.go
@@ -1,0 +1,208 @@
+package volume
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+
+	"github.com/spf13/cobra"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// maxNameLen bounds the volume name at 12 characters.
+//
+// The node selects the device by its virtio-block serial, and
+// VIRTIO_BLK_ID_BYTES is 20. With the "c8s-vol-" prefix that leaves 12; a
+// thirteenth character is silently dropped, so two volumes would present
+// identically to the node with no way to tell them apart.
+const maxNameLen = 12
+
+const serialPrefix = "c8s-vol-"
+
+var nameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+type createConfig struct {
+	name      string
+	source    string
+	out       string
+	path      string
+	escrowOut string
+	node      string
+	workDir   string
+	dryRun    bool
+
+	// run executes the build tools. Not a flag: tests set it so the whole
+	// create flow is exercised without erofs-utils and cryptsetup installed.
+	run Runner
+}
+
+func newCreateCmd(o *options) *cobra.Command {
+	var cfg createConfig
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Build an encrypted volume and store its key",
+		Long: `Package --source into an encrypted image at --out and store its key at --path
+in the CDS secret store.
+
+The image is written as ciphertext and can travel by any means, including
+through the untrusted host. Attach it to the node as a raw block device whose
+virtio serial is c8s-vol-<name>.
+
+The key is generated here and exists in exactly two places: the CDS process, and
+the escrow file. A CDS restart empties the store, and without the escrow file
+the volume is unopenable — keep it somewhere durable and access-controlled.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(cmd, o, cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cfg.name, "name", "", "volume name; forms the device serial c8s-vol-<name> (required, max 12 chars)")
+	f.StringVar(&cfg.source, "source", "", "directory whose contents become the volume (required)")
+	f.StringVar(&cfg.out, "out", "", "where to write the encrypted image; must not exist (required)")
+	f.StringVar(&cfg.path, "path", "", "secret-store path for the key, e.g. /tenant-a/volumes/weights (required)")
+	f.StringVar(&cfg.escrowOut, "escrow-out", "", "where to write the key blob you must keep (required)")
+	f.StringVar(&cfg.node, "node", "", "node holding the device; emitted as a nodeSelector on the printed annotations")
+	f.StringVar(&cfg.workDir, "work-dir", "", "directory for build intermediates (default: a temp dir); they are removed either way")
+	f.BoolVar(&cfg.dryRun, "dry-run", false, "build the image and write escrow, but do not call CDS")
+	return cmd
+}
+
+func runCreate(cmd *cobra.Command, o *options, cfg createConfig) error {
+	path, err := validateCreate(&cfg)
+	if err != nil {
+		return err
+	}
+	if !cfg.dryRun {
+		if err := o.Validate(); err != nil {
+			return err
+		}
+	}
+
+	key, err := GenerateKey()
+	if err != nil {
+		return err
+	}
+	verity, err := Build(cmdCtx(cmd), BuildConfig{
+		Source: cfg.source, Out: cfg.out, Key: key, WorkDir: cfg.workDir, Run: cfg.run,
+	})
+	if err != nil {
+		return err
+	}
+	blob, err := NewBlob(key, verity)
+	if err != nil {
+		return err
+	}
+
+	// Escrow before CDS. The image already exists at this point, so a key that
+	// reached neither the operator's disk nor the store would leave ciphertext
+	// nothing can ever open.
+	if err := writeEscrow(cfg.escrowOut, blob); err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	if cfg.dryRun {
+		fmt.Fprintf(out, "built %s (%d data blocks); key escrowed to %s; CDS not called\n",
+			cfg.out, verity.DataBlocks, cfg.escrowOut)
+		return nil
+	}
+
+	signer, err := o.Signer()
+	if err != nil {
+		return err
+	}
+	hc, err := o.HTTPClient(cmdCtx(cmd))
+	if err != nil {
+		return err
+	}
+	if err := putBlob(cmdCtx(cmd), hc, trimSlash(o.URL), path, blob, signer); err != nil {
+		return err
+	}
+
+	printResult(out, cfg, path, verity)
+	return nil
+}
+
+func validateCreate(cfg *createConfig) (string, error) {
+	switch {
+	case cfg.name == "":
+		return "", fmt.Errorf("--name is required")
+	case cfg.source == "":
+		return "", fmt.Errorf("--source is required")
+	case cfg.out == "":
+		return "", fmt.Errorf("--out is required")
+	case cfg.escrowOut == "":
+		return "", fmt.Errorf("--escrow-out is required: it is the only copy of the key outside CDS")
+	}
+	if len(cfg.name) > maxNameLen {
+		return "", fmt.Errorf("--name %q is %d characters; the device serial holds %d",
+			cfg.name, len(cfg.name), maxNameLen)
+	}
+	if !nameRE.MatchString(cfg.name) {
+		return "", fmt.Errorf("--name %q must be lowercase alphanumeric, may contain '-', and must start and end alphanumeric", cfg.name)
+	}
+	path, err := pkgallowlist.CanonicalSecretPath(cfg.path)
+	if err != nil {
+		return "", fmt.Errorf("--path: %w", err)
+	}
+	return path, nil
+}
+
+// writeEscrow saves the blob, O_EXCL and 0600. It is the whole key: an operator
+// who loses it and restarts CDS has ciphertext and nothing that opens it.
+func writeEscrow(dest string, blob Blob) error {
+	raw, err := blob.Marshal()
+	if err != nil {
+		return err
+	}
+	f, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("--escrow-out: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(raw); err != nil {
+		return fmt.Errorf("write escrow: %w", err)
+	}
+	return nil
+}
+
+func printResult(w io.Writer, cfg createConfig, path string, v Verity) {
+	fmt.Fprintf(w, "+ %s (%d data blocks)\n", cfg.out, v.DataBlocks)
+	fmt.Fprintf(w, "+ key stored at %s\n", path)
+	fmt.Fprintf(w, "+ key escrowed to %s — keep it; a CDS restart needs it\n\n", cfg.escrowOut)
+
+	fmt.Fprintf(w, "Attach %s to the node as a raw block device with serial %s%s.\n\n", cfg.out, serialPrefix, cfg.name)
+
+	fmt.Fprintf(w, "Pod annotations:\n")
+	fmt.Fprintf(w, "  confidential.ai/cw: <workload-id>\n")
+	fmt.Fprintf(w, "  confidential.ai/c8s-volumes: %q\n", cfg.name+"="+path)
+	if cfg.node != "" {
+		fmt.Fprintf(w, "\nPod nodeSelector (the device is on one node):\n")
+		fmt.Fprintf(w, "  kubernetes.io/hostname: %s\n", cfg.node)
+	}
+
+	fmt.Fprintf(w, "\nAllowlist grant for the workload entry (read-only, exact path):\n")
+	fmt.Fprintf(w, "  \"secrets\": {\"policy\": \"allow\", \"read\": [%q]}\n", path)
+	fmt.Fprintf(w, "\nA subtree grant would cover every volume beneath it, so this names one path.\n")
+}
+
+func base64Std(b []byte) string { return base64.StdEncoding.EncodeToString(b) }
+
+func trimSlash(u string) string {
+	for len(u) > 0 && u[len(u)-1] == '/' {
+		u = u[:len(u)-1]
+	}
+	return u
+}
+
+func cmdCtx(cmd *cobra.Command) context.Context {
+	if c := cmd.Context(); c != nil {
+		return c
+	}
+	return context.Background()
+}

--- a/internal/cmds/volume/create_flow_test.go
+++ b/internal/cmds/volume/create_flow_test.go
@@ -1,0 +1,260 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// flowFixture is a source directory, an output path, and an escrow path.
+type flowFixture struct {
+	dir, src, out, escrow string
+}
+
+func newFlowFixture(t *testing.T) flowFixture {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	return flowFixture{dir: dir, src: src, out: filepath.Join(dir, "vol.img"), escrow: filepath.Join(dir, "escrow.json")}
+}
+
+func (f flowFixture) config(fake *fakeTools) createConfig {
+	return createConfig{
+		name:      "weights",
+		source:    f.src,
+		out:       f.out,
+		path:      "/tenant-a/volumes/weights",
+		escrowOut: f.escrow,
+		run:       fake.run,
+	}
+}
+
+func captureCmd() (*cobra.Command, *bytes.Buffer) {
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetContext(context.Background())
+	return cmd, &out
+}
+
+// operatorKeyFile writes a fresh operator private key and returns its path.
+func operatorKeyFile(t *testing.T, dir string) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	path := filepath.Join(dir, "operator.key")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path
+}
+
+// A dry run builds the image and writes escrow but never reaches CDS, so an
+// operator can produce an artifact offline.
+func TestRunCreateDryRunBuildsAndEscrowsWithoutCDS(t *testing.T) {
+	f := newFlowFixture(t)
+	fake := newFake()
+	cfg := f.config(fake)
+	cfg.dryRun = true
+
+	cmd, out := captureCmd()
+	if err := runCreate(cmd, &options{}, cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	img, err := os.ReadFile(f.out)
+	if err != nil {
+		t.Fatalf("image not written: %v", err)
+	}
+	if len(img) != fake.dataBytes+fake.treeBytes {
+		t.Errorf("image is %d bytes, want %d", len(img), fake.dataBytes+fake.treeBytes)
+	}
+	raw, err := os.ReadFile(f.escrow)
+	if err != nil {
+		t.Fatalf("escrow not written: %v", err)
+	}
+	blob, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("escrow is not a key blob: %v", err)
+	}
+
+	// The escrowed key must be the one the image was encrypted with, or the
+	// escrow file recovers nothing.
+	key, err := blob.DecodeKey()
+	if err != nil {
+		t.Fatalf("escrow key: %v", err)
+	}
+	var plain bytes.Buffer
+	if err := Decrypt(&plain, bytes.NewReader(img), key); err != nil {
+		t.Fatalf("decrypt with escrowed key: %v", err)
+	}
+	want := append(bytes.Repeat([]byte{0xA5}, fake.dataBytes), bytes.Repeat([]byte{0x5A}, fake.treeBytes)...)
+	if !bytes.Equal(plain.Bytes(), want) {
+		t.Fatal("escrowed key does not decrypt the image it was written alongside")
+	}
+	if !strings.Contains(out.String(), "CDS not called") {
+		t.Errorf("dry run did not say CDS was skipped: %s", out.String())
+	}
+}
+
+func TestRunCreateStoresBlobAndPrintsGuidance(t *testing.T) {
+	f := newFlowFixture(t)
+	fake := newFake()
+
+	var gotPath string
+	var gotReq intsecrets.PutRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		raw, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(raw, &gotReq)
+		w.WriteHeader(http.StatusCreated)
+	}))
+	defer srv.Close()
+
+	o := &options{Options: cdsconn.Options{
+		URL:         srv.URL,
+		Insecure:    true,
+		OperatorKey: operatorKeyFile(t, f.dir),
+	}}
+	cfg := f.config(fake)
+	cfg.node = "node-1"
+
+	cmd, out := captureCmd()
+	if err := runCreate(cmd, o, cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	if gotPath != "/secrets/tenant-a/volumes/weights" {
+		t.Errorf("cds path = %q", gotPath)
+	}
+	if gotReq.Overwrite {
+		t.Error("create asked to overwrite")
+	}
+	raw, err := base64.StdEncoding.DecodeString(gotReq.Value)
+	if err != nil {
+		t.Fatalf("stored value is not base64: %v", err)
+	}
+	stored, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("stored value is not a key blob: %v", err)
+	}
+
+	// What CDS holds and what escrow holds have to be the same key, or a
+	// restart recovers a volume nobody can open.
+	escrowRaw, err := os.ReadFile(f.escrow)
+	if err != nil {
+		t.Fatalf("escrow: %v", err)
+	}
+	escrowed, err := DecodeBlob(escrowRaw)
+	if err != nil {
+		t.Fatalf("escrow blob: %v", err)
+	}
+	if stored.Key != escrowed.Key || stored.Verity != escrowed.Verity {
+		t.Fatal("the blob stored in CDS differs from the escrowed one")
+	}
+
+	got := out.String()
+	for _, want := range []string{"c8s-vol-weights", "kubernetes.io/hostname: node-1", `"read": ["/tenant-a/volumes/weights"]`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// A CDS refusal must not leave a half-finished volume looking successful.
+func TestRunCreateSurfacesCDSRefusal(t *testing.T) {
+	f := newFlowFixture(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+	}))
+	defer srv.Close()
+
+	o := &options{Options: cdsconn.Options{
+		URL: srv.URL, Insecure: true, OperatorKey: operatorKeyFile(t, f.dir),
+	}}
+	cmd, _ := captureCmd()
+	err := runCreate(cmd, o, f.config(newFake()))
+	if err == nil || !strings.Contains(err.Error(), "not replaceable") {
+		t.Fatalf("got %v, want a refusal naming the occupied path", err)
+	}
+	// Escrow is written before CDS, so the key survives a failed store — the
+	// image on disk is openable once the path question is resolved.
+	if _, statErr := os.Stat(f.escrow); statErr != nil {
+		t.Errorf("escrow missing after a CDS refusal: %v", statErr)
+	}
+}
+
+func TestRunCreateRejectsBadFlagsBeforeBuilding(t *testing.T) {
+	f := newFlowFixture(t)
+	cfg := f.config(newFake())
+	cfg.name = ""
+	cmd, _ := captureCmd()
+	if err := runCreate(cmd, &options{}, cfg); err == nil {
+		t.Fatal("accepted an empty --name")
+	}
+	if _, err := os.Stat(f.out); !os.IsNotExist(err) {
+		t.Error("an image was built despite invalid flags")
+	}
+}
+
+func TestExecRunnerPinsEnvAndWrapsFailure(t *testing.T) {
+	out, err := execRunner(context.Background(), "sh", "-c", "echo $SOURCE_DATE_EPOCH,$TZ")
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "0,UTC" {
+		t.Errorf("env = %q, want SOURCE_DATE_EPOCH and TZ pinned", got)
+	}
+	if _, err := execRunner(context.Background(), "sh", "-c", "echo boom >&2; exit 3"); err == nil {
+		t.Fatal("a failing tool reported success")
+	} else if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error drops the tool's output: %v", err)
+	}
+}
+
+func TestTrimSlash(t *testing.T) {
+	for in, want := range map[string]string{
+		"https://cds":    "https://cds",
+		"https://cds/":   "https://cds",
+		"https://cds///": "https://cds",
+		"":               "",
+	} {
+		if got := trimSlash(in); got != want {
+			t.Errorf("trimSlash(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCmdCtxFallsBackToBackground(t *testing.T) {
+	if cmdCtx(&cobra.Command{}) == nil {
+		t.Fatal("nil context for a command with none set")
+	}
+}

--- a/internal/cmds/volume/create_test.go
+++ b/internal/cmds/volume/create_test.go
@@ -1,0 +1,199 @@
+package volume
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runCreateDryRun drives the command through cobra so flag validation and the
+// build run exactly as they do for an operator, minus the CDS call.
+func runCreateDryRun(t *testing.T, dir string, extra ...string) (string, error) {
+	t.Helper()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+
+	o := &options{}
+	cmd := newCreateCmd(o)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	args := append([]string{
+		"--name=weights",
+		"--source=" + src,
+		"--out=" + filepath.Join(dir, "vol.img"),
+		"--path=/tenant-a/volumes/weights",
+		"--escrow-out=" + filepath.Join(dir, "escrow.json"),
+		"--dry-run",
+	}, extra...)
+	cmd.SetArgs(args)
+
+	// Build shells out to mkfs.erofs and veritysetup; neither is needed to
+	// exercise validation, so a build failure is reported as-is.
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestCreateRejectsOverlongName(t *testing.T) {
+	dir := t.TempDir()
+	_, err := runCreateDryRun(t, dir, "--name=thirteenchars")
+	if err == nil || !strings.Contains(err.Error(), "device serial holds") {
+		t.Fatalf("got %v, want a name-length error naming the serial bound", err)
+	}
+}
+
+func TestCreateRejectsMalformedName(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"Weights", "-weights", "weights-", "we/ights"} {
+		if _, err := runCreateDryRun(t, dir, "--name="+name); err == nil {
+			t.Errorf("name %q: accepted", name)
+		}
+	}
+}
+
+func TestCreateRequiresEscrowOut(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	o := &options{}
+	cmd := newCreateCmd(o)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--name=weights", "--source=" + src,
+		"--out=" + filepath.Join(dir, "vol.img"),
+		"--path=/tenant-a/volumes/weights", "--dry-run",
+	})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "escrow-out") {
+		t.Fatalf("got %v, want an --escrow-out error", err)
+	}
+}
+
+func TestCreateRejectsNonCanonicalPath(t *testing.T) {
+	dir := t.TempDir()
+	for _, p := range []string{"tenant-a/volumes/weights", "/tenant-a/../weights", "/tenant-a/volumes/"} {
+		if _, err := runCreateDryRun(t, dir, "--path="+p); err == nil {
+			t.Errorf("path %q: accepted", p)
+		}
+	}
+}
+
+// Validation must reject before anything is generated or written: a rejected
+// invocation should leave no image and no escrow file behind.
+func TestCreateValidationLeavesNoArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := runCreateDryRun(t, dir, "--name=thirteenchars"); err == nil {
+		t.Fatal("expected rejection")
+	}
+	for _, f := range []string{"vol.img", "escrow.json"} {
+		if _, err := os.Stat(filepath.Join(dir, f)); !os.IsNotExist(err) {
+			t.Errorf("%s exists after a rejected invocation", f)
+		}
+	}
+}
+
+func TestWriteEscrowRefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "escrow.json")
+	if err := os.WriteFile(dest, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	blob, err := NewBlob(testKey(), validVerity())
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	if err := writeEscrow(dest, blob); err == nil {
+		t.Fatal("overwrote an existing escrow file")
+	}
+	got, _ := os.ReadFile(dest)
+	if string(got) != "existing" {
+		t.Fatal("existing escrow file was modified")
+	}
+}
+
+func TestWriteEscrowIsOwnerOnlyAndReloadable(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "escrow.json")
+	blob, err := NewBlob(testKey(), validVerity())
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	if err := writeEscrow(dest, blob); err != nil {
+		t.Fatalf("write escrow: %v", err)
+	}
+	info, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Errorf("escrow mode is %o, want 600", perm)
+	}
+	raw, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// The escrow file is the recovery path, so it has to decode as a blob.
+	if _, err := DecodeBlob(raw); err != nil {
+		t.Fatalf("escrow file does not decode as a key blob: %v", err)
+	}
+}
+
+func TestPrintResultNamesSerialAnnotationAndExactGrant(t *testing.T) {
+	var out bytes.Buffer
+	printResult(&out, createConfig{
+		name: "weights", out: "/tmp/vol.img", escrowOut: "/tmp/escrow.json", node: "node-1",
+	}, "/tenant-a/volumes/weights", Verity{DataBlocks: 4})
+	got := out.String()
+	for _, want := range []string{
+		"c8s-vol-weights",
+		`confidential.ai/c8s-volumes: "weights=/tenant-a/volumes/weights"`,
+		"kubernetes.io/hostname: node-1",
+		`"read": ["/tenant-a/volumes/weights"]`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+	// A subtree grant would hand over every volume beneath the base.
+	if strings.Contains(got, "/**") {
+		t.Errorf("output offers a subtree grant:\n%s", got)
+	}
+}
+
+func TestNewCmdRegistersCreate(t *testing.T) {
+	cmd := newCmd(nil)
+	var names []string
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+	if !containsStr(names, "create") {
+		t.Fatalf("subcommands = %v, want create", names)
+	}
+}
+
+func containsStr(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWriteEscrowReportsAnUnwritableDestination(t *testing.T) {
+	blob, err := NewBlob(testKey(), validVerity())
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	if err := writeEscrow(filepath.Join(t.TempDir(), "missing-dir", "escrow.json"), blob); err == nil {
+		t.Fatal("accepted a path whose directory does not exist")
+	}
+}

--- a/internal/cmds/volume/image.go
+++ b/internal/cmds/volume/image.go
@@ -1,0 +1,232 @@
+package volume
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// saltBytes is the dm-verity salt length. Fixed, and generated per build: the
+// salt is not secret, but a per-image one keeps two volumes built from the same
+// directory from sharing a hash tree.
+const saltBytes = 32
+
+// Runner executes one build tool. It exists so the orchestration is testable
+// without erofs-utils and cryptsetup on the machine running the tests.
+type Runner func(ctx context.Context, name string, args ...string) ([]byte, error)
+
+// execRunner runs a tool for real, with SOURCE_DATE_EPOCH pinned so mkfs.erofs
+// does not stamp the current time into the image.
+func execRunner(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = append(os.Environ(), "SOURCE_DATE_EPOCH=0", "TZ=UTC", "LC_ALL=C")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return out, fmt.Errorf("%s: %w: %s", name, err, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+// BuildConfig describes one image build.
+type BuildConfig struct {
+	// Source is the directory whose contents become the volume.
+	Source string
+	// Out is where the encrypted image is written. It must not already exist.
+	Out string
+	// Key is the XTS key; GenerateKey supplies it.
+	Key []byte
+	// WorkDir holds the intermediate plaintext image and hash tree. Empty uses
+	// a temp dir. Both intermediates are removed on the way out, whatever
+	// happens — they are the plaintext this whole design exists to protect.
+	WorkDir string
+	// Run executes the build tools; nil uses execRunner.
+	Run Runner
+}
+
+// Build packages Source into an erofs image, formats a dm-verity tree over it,
+// concatenates the two, and encrypts the result to Out.
+//
+// The tree goes inside the encryption rather than outside it. A hash tree is a
+// fingerprint of the plaintext, so leaving it in the clear would hand the host
+// a way to identify the contents; and the root hash then commits to the data
+// itself rather than to one encryption of it.
+func Build(ctx context.Context, cfg BuildConfig) (Verity, error) {
+	run := cfg.Run
+	if run == nil {
+		run = execRunner
+	}
+	if err := checkSource(cfg.Source); err != nil {
+		return Verity{}, err
+	}
+	if len(cfg.Key) != KeyBytes {
+		return Verity{}, fmt.Errorf("volume: key is %d bytes, want %d", len(cfg.Key), KeyBytes)
+	}
+	// O_EXCL on the output: a build that silently replaced an existing image
+	// would destroy a volume whose key is already in the store.
+	out, err := os.OpenFile(cfg.Out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return Verity{}, fmt.Errorf("volume: create %s: %w", cfg.Out, err)
+	}
+	defer out.Close()
+
+	work, cleanup, err := workDir(cfg.WorkDir)
+	if err != nil {
+		return Verity{}, err
+	}
+	defer cleanup()
+
+	dataPath := filepath.Join(work, "data.erofs")
+	treePath := filepath.Join(work, "hash.tree")
+	// The erofs image is the plaintext this design exists to protect, so it goes
+	// whether the build succeeds or not, and whether or not WorkDir was the
+	// caller's (in which case removing the directory is not ours to do).
+	defer func() {
+		os.Remove(dataPath)
+		os.Remove(treePath)
+	}()
+
+	if _, err := run(ctx, "mkfs.erofs", erofsArgs(dataPath, cfg.Source)...); err != nil {
+		return Verity{}, err
+	}
+	dataSize, err := fileSize(dataPath)
+	if err != nil {
+		return Verity{}, err
+	}
+	if dataSize == 0 || dataSize%VerityBlockSize != 0 {
+		return Verity{}, fmt.Errorf("volume: erofs image is %d bytes, not a multiple of %d", dataSize, VerityBlockSize)
+	}
+
+	salt := make([]byte, saltBytes)
+	if _, err := rand.Read(salt); err != nil {
+		return Verity{}, fmt.Errorf("volume: generate verity salt: %w", err)
+	}
+	saltHex := hex.EncodeToString(salt)
+
+	stdout, err := run(ctx, "veritysetup", verityArgs(dataPath, treePath, saltHex)...)
+	if err != nil {
+		return Verity{}, err
+	}
+	rootHash, err := parseRootHash(stdout)
+	if err != nil {
+		return Verity{}, err
+	}
+
+	v := Verity{
+		RootHash:   rootHash,
+		Salt:       saltHex,
+		DataBlocks: dataSize / VerityBlockSize,
+		HashOffset: dataSize,
+	}
+	if err := encryptConcat(out, cfg.Key, dataPath, treePath); err != nil {
+		return Verity{}, err
+	}
+	return v, nil
+}
+
+// erofsArgs pins the inputs that would otherwise vary per build, so the same
+// source directory yields the same image and therefore the same root hash.
+//
+// Ownership and mode are deliberately not normalized: they are preserved into
+// the image and therefore covered by the root hash. Forcing them to root would
+// make a 0600 source file unreadable to a non-root workload.
+//
+// Reproducibility across erofs-utils versions is NOT established — pin the tool
+// version alongside this if you depend on it.
+func erofsArgs(dest, source string) []string {
+	return []string{
+		"-U", "00000000-0000-0000-0000-000000000000",
+		"-T", "0",
+		dest, source,
+	}
+}
+
+// verityArgs formats the tree with every parameter explicit and no superblock.
+//
+// --no-superblock is load-bearing: the opener passes it too and takes the
+// geometry from the key blob instead. A superblock would be host-writable
+// metadata read at open time, which is the thing omitting a LUKS header removed.
+func verityArgs(data, tree, saltHex string) []string {
+	return []string{
+		"format", data, tree,
+		"--no-superblock",
+		"--hash", "sha256",
+		"--format", "1",
+		"--data-block-size", fmt.Sprint(VerityBlockSize),
+		"--hash-block-size", fmt.Sprint(VerityBlockSize),
+		"--salt", saltHex,
+	}
+}
+
+var rootHashRE = regexp.MustCompile(`(?im)^Root hash:\s*([0-9a-fA-F]+)\s*$`)
+
+func parseRootHash(veritysetupOutput []byte) (string, error) {
+	m := rootHashRE.FindSubmatch(veritysetupOutput)
+	if m == nil {
+		return "", fmt.Errorf("volume: veritysetup printed no root hash: %s", strings.TrimSpace(string(veritysetupOutput)))
+	}
+	root := strings.ToLower(string(m[1]))
+	if len(root) != verityHashBytes*2 {
+		return "", fmt.Errorf("volume: veritysetup root hash is %d hex chars, want %d", len(root), verityHashBytes*2)
+	}
+	return root, nil
+}
+
+// encryptConcat encrypts data followed by tree as one stream, so sector indices
+// — and therefore the XTS tweaks — run continuously across the join exactly as
+// they will when the device is read.
+func encryptConcat(out io.Writer, key []byte, dataPath, treePath string) error {
+	data, err := os.Open(dataPath)
+	if err != nil {
+		return fmt.Errorf("volume: open erofs image: %w", err)
+	}
+	defer data.Close()
+	tree, err := os.Open(treePath)
+	if err != nil {
+		return fmt.Errorf("volume: open hash tree: %w", err)
+	}
+	defer tree.Close()
+	return Encrypt(out, io.MultiReader(data, tree), key)
+}
+
+func checkSource(source string) error {
+	if source == "" {
+		return fmt.Errorf("volume: --source is required")
+	}
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("volume: --source: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("volume: --source %s is not a directory", source)
+	}
+	return nil
+}
+
+func fileSize(path string) (uint64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, fmt.Errorf("volume: stat %s: %w", path, err)
+	}
+	return uint64(info.Size()), nil
+}
+
+func workDir(configured string) (string, func(), error) {
+	if configured != "" {
+		if err := os.MkdirAll(configured, 0o700); err != nil {
+			return "", nil, fmt.Errorf("volume: --work-dir: %w", err)
+		}
+		return configured, func() {}, nil
+	}
+	dir, err := os.MkdirTemp("", "c8s-volume-")
+	if err != nil {
+		return "", nil, fmt.Errorf("volume: create work dir: %w", err)
+	}
+	return dir, func() { os.RemoveAll(dir) }, nil
+}

--- a/internal/cmds/volume/image_test.go
+++ b/internal/cmds/volume/image_test.go
@@ -1,0 +1,321 @@
+package volume
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeTools stands in for mkfs.erofs and veritysetup so the orchestration is
+// exercised without either installed. It writes the sizes it is told to and
+// records the argv it was called with.
+type fakeTools struct {
+	dataBytes int
+	treeBytes int
+	rootHash  string
+	calls     [][]string
+	failOn    string
+}
+
+func (f *fakeTools) run(_ context.Context, name string, args ...string) ([]byte, error) {
+	f.calls = append(f.calls, append([]string{name}, args...))
+	if f.failOn == name {
+		return nil, errors.New("tool failed")
+	}
+	switch name {
+	case "mkfs.erofs":
+		// argv is [...flags, dest, source]
+		dest := args[len(args)-2]
+		if err := os.WriteFile(dest, bytes.Repeat([]byte{0xA5}, f.dataBytes), 0o600); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	case "veritysetup":
+		tree := args[2]
+		if err := os.WriteFile(tree, bytes.Repeat([]byte{0x5A}, f.treeBytes), 0o600); err != nil {
+			return nil, err
+		}
+		return []byte("VERITY header information\nRoot hash:      " + f.rootHash + "\n"), nil
+	}
+	return nil, errors.New("unexpected tool " + name)
+}
+
+func newFake() *fakeTools {
+	return &fakeTools{
+		dataBytes: 4 * VerityBlockSize,
+		treeBytes: VerityBlockSize,
+		rootHash:  strings.Repeat("ab", 32),
+	}
+}
+
+func buildInto(t *testing.T, f *fakeTools) (Verity, string, []byte) {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	out := filepath.Join(dir, "vol.img")
+	key := testKey()
+
+	v, err := Build(t.Context(), BuildConfig{Source: src, Out: out, Key: key, Run: f.run})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return v, out, key
+}
+
+func TestBuildProducesDecryptableConcatenation(t *testing.T) {
+	f := newFake()
+	v, out, key := buildInto(t, f)
+
+	ct, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read image: %v", err)
+	}
+	if len(ct) != f.dataBytes+f.treeBytes {
+		t.Fatalf("image is %d bytes, want %d", len(ct), f.dataBytes+f.treeBytes)
+	}
+
+	var plain bytes.Buffer
+	if err := Decrypt(&plain, bytes.NewReader(ct), key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	want := append(bytes.Repeat([]byte{0xA5}, f.dataBytes), bytes.Repeat([]byte{0x5A}, f.treeBytes)...)
+	if !bytes.Equal(plain.Bytes(), want) {
+		t.Fatal("decrypted image is not the erofs data followed by the hash tree")
+	}
+
+	// The geometry has to describe the layout that was actually written, or the
+	// opener hashes the wrong bytes.
+	if v.HashOffset != uint64(f.dataBytes) {
+		t.Errorf("hash_offset = %d, want %d", v.HashOffset, f.dataBytes)
+	}
+	if v.DataBlocks != uint64(f.dataBytes)/VerityBlockSize {
+		t.Errorf("data_blocks = %d, want %d", v.DataBlocks, f.dataBytes/VerityBlockSize)
+	}
+	if _, err := NewBlob(key, v); err != nil {
+		t.Errorf("build produced geometry a blob rejects: %v", err)
+	}
+}
+
+// The tree must be encrypted as a continuation of the data, not as its own
+// stream: sector indices are the XTS tweaks, and they run continuously across
+// the join when the device is read.
+func TestBuildEncryptsTreeAsContinuationOfData(t *testing.T) {
+	f := newFake()
+	_, out, key := buildInto(t, f)
+	ct, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read image: %v", err)
+	}
+
+	var whole bytes.Buffer
+	plain := append(bytes.Repeat([]byte{0xA5}, f.dataBytes), bytes.Repeat([]byte{0x5A}, f.treeBytes)...)
+	if err := Encrypt(&whole, bytes.NewReader(plain), key); err != nil {
+		t.Fatalf("encrypt: %v", err)
+	}
+	if !bytes.Equal(ct, whole.Bytes()) {
+		t.Fatal("image differs from encrypting data||tree as one stream")
+	}
+}
+
+func TestBuildPassesNoSuperblockAndExplicitGeometry(t *testing.T) {
+	f := newFake()
+	buildInto(t, f)
+
+	var verity []string
+	for _, c := range f.calls {
+		if c[0] == "veritysetup" {
+			verity = c
+		}
+	}
+	if verity == nil {
+		t.Fatal("veritysetup was never invoked")
+	}
+	joined := strings.Join(verity, " ")
+	for _, want := range []string{"--no-superblock", "--hash sha256", "--data-block-size 4096", "--salt "} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("veritysetup argv missing %q: %s", want, joined)
+		}
+	}
+}
+
+// The plaintext image is what the whole design protects; it must not survive
+// the build, including when the caller supplied the work directory.
+func TestBuildRemovesPlaintextIntermediates(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	work := filepath.Join(dir, "work")
+	f := newFake()
+
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), WorkDir: work, Run: f.run,
+	}); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	entries, err := os.ReadDir(work)
+	if err != nil {
+		t.Fatalf("read work dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("work dir still holds %d file(s); the plaintext image survived the build", len(entries))
+	}
+}
+
+func TestBuildRemovesIntermediatesOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	work := filepath.Join(dir, "work")
+	f := newFake()
+	f.failOn = "veritysetup"
+
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), WorkDir: work, Run: f.run,
+	}); err == nil {
+		t.Fatal("build succeeded despite veritysetup failing")
+	}
+	entries, _ := os.ReadDir(work)
+	if len(entries) != 0 {
+		t.Fatalf("failed build left %d file(s) behind", len(entries))
+	}
+}
+
+// Replacing an existing image would destroy a volume whose key is already in
+// the store, so the output is created O_EXCL.
+func TestBuildRefusesToOverwriteExistingImage(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	out := filepath.Join(dir, "vol.img")
+	if err := os.WriteFile(out, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("seed out: %v", err)
+	}
+	if _, err := Build(t.Context(), BuildConfig{Source: src, Out: out, Key: testKey(), Run: newFake().run}); err == nil {
+		t.Fatal("build overwrote an existing image")
+	}
+}
+
+func TestBuildRejectsUnalignedErofsImage(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	f := newFake()
+	f.dataBytes = VerityBlockSize + 7
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), Run: f.run,
+	}); err == nil {
+		t.Fatal("accepted an erofs image that is not block-aligned")
+	}
+}
+
+func TestBuildRejectsMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: filepath.Join(dir, "nope"), Out: filepath.Join(dir, "v.img"), Key: testKey(), Run: newFake().run,
+	}); err == nil {
+		t.Fatal("accepted a source directory that does not exist")
+	}
+}
+
+func TestParseRootHash(t *testing.T) {
+	good := hex.EncodeToString(mustSum("x"))
+	got, err := parseRootHash([]byte("Root hash:\t" + strings.ToUpper(good) + "\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got != good {
+		t.Fatalf("root hash = %q, want lowercase %q", got, good)
+	}
+	for name, out := range map[string]string{
+		"absent":    "VERITY header information\n",
+		"truncated": "Root hash: abcd\n",
+	} {
+		if _, err := parseRootHash([]byte(out)); err == nil {
+			t.Errorf("%s: accepted", name)
+		}
+	}
+}
+
+func mustSum(s string) []byte {
+	sum := sha256.Sum256([]byte(s))
+	return sum[:]
+}
+
+func TestBuildRejectsFileAsSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "weights.bin")
+	if err := os.WriteFile(src, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "v.img"), Key: testKey(), Run: newFake().run,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not a directory") {
+		t.Fatalf("got %v, want a not-a-directory error", err)
+	}
+}
+
+func TestBuildRejectsWrongKeyLength(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "v.img"), Key: make([]byte, 32), Run: newFake().run,
+	}); err == nil {
+		t.Fatal("accepted a 32-byte key")
+	}
+}
+
+// A work directory that cannot be created is reported before the build starts,
+// rather than surfacing as a confusing failure from mkfs.erofs.
+func TestBuildRejectsUnusableWorkDir(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "v.img"), Key: testKey(),
+		WorkDir: filepath.Join(blocker, "under-a-file"), Run: newFake().run,
+	}); err == nil {
+		t.Fatal("accepted a work dir that cannot be created")
+	}
+}
+
+func TestBuildFailsWhenErofsFails(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	f := newFake()
+	f.failOn = "mkfs.erofs"
+	if _, err := Build(t.Context(), BuildConfig{
+		Source: src, Out: filepath.Join(dir, "v.img"), Key: testKey(), Run: f.run,
+	}); err == nil {
+		t.Fatal("build succeeded despite mkfs.erofs failing")
+	}
+}


### PR DESCRIPTION
Builds an encrypted volume from a directory and stores its key in the CDS secret store. Completes the operator half of encrypted volumes; nothing consumes the image yet.

The image is an erofs filesystem, a dm-verity tree formatted over it, and the two concatenated and encrypted as one stream. Encrypting them together rather than separately is load-bearing: sector indices are the XTS tweaks, and they have to run continuously across the join exactly as they will when the device is read.

The tree goes inside the encryption. A hash tree is a fingerprint of the plaintext, so leaving it in the clear would hand the host a way to identify the contents, and the root hash then commits to the data itself rather than to one encryption of it. veritysetup runs with --no-superblock and explicit hash and block sizes, because the opener will pass --no-superblock too and take the geometry from the key blob: a verity superblock is host-writable metadata read at open time, which is the thing omitting a LUKS header removed.

The PUT is create-only and deliberately does not reuse `c8s secrets put`. That command's create-then---overwrite flow is right for a token and wrong for a volume: a key and its ciphertext are one unit, so replacing the key at a path some volume already uses does not rotate anything, it strands that volume with no way back. A 409 is an error naming that, not an invitation to retry with --overwrite.

Escrow is written before CDS is called. The image exists by that point, so a key that reached neither the operator's disk nor the store would leave ciphertext nothing can ever open. O_EXCL and 0600, and a test that the file decodes back into a usable blob, since it is the entire recovery path.

--name is capped at 12 characters. The node selects the device by its virtio-block serial, VIRTIO_BLK_ID_BYTES is 20, and the c8s-vol- prefix takes eight. A thirteenth character is silently dropped, so two volumes would present identically to the node with nothing able to tell them apart — a silent collision rather than an error.

The plaintext erofs image is removed whether the build succeeds or fails, and whether or not the work directory was the caller's, in which case removing the directory is not ours to do. Ownership and mode are not normalized: forcing them to root for reproducibility would make a 0600 source file unreadable to a non-root workload, so they are preserved and covered by the root hash instead.

The printed grant names one exact path. A trailing /** would cover every volume beneath the base, each mountable at any path by a host-authored annotation.

The build tools run behind an injectable Runner, so the orchestration, the layout, and the failure paths are all exercised without erofs-utils or cryptsetup present. What that cannot cover is the tool invocations themselves: reproducibility of mkfs.erofs across versions is asserted by -U and -T but not established, and needs validating against a pinned erofs-utils.