### PR TITLE
fix(secrets): rate-limit the workload routes per sandbox, not per address

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -113,6 +113,14 @@ A path that is not granted is `404`, indistinguishable from one that does not
 exist — otherwise the API enumerates the store. Denials are opaque to the
 client; the reason goes to the CDS log.
 
+**These routes are rate-limited per sandbox**, keyed on the ID in the verified
+client certificate. Pods reach CDS through a NodePort and the host-network mesh
+proxy, so every pod on a node arrives from the node's address: bounded on that,
+one pod could spend the budget its co-tenants share and hold their fetchers in a
+CrashLoop. A request whose certificate is absent or unverified is bounded by
+address instead — it is refused by the handler regardless, and a caller cannot
+opt out of the limit by withholding an identity.
+
 Paths must arrive already canonical: absolute, clean, no trailing slash, and no
 percent-encoding. They are rejected rather than repaired, so the bytes matched
 against a grant and the bytes used as a store key are the bytes the client

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -79,9 +79,9 @@ func newRouter(deps dependencies) http.Handler {
 		if deps.SecretsOperator == nil || deps.SecretsExplain == nil {
 			panic("cds: dependencies.SecretsOperator and SecretsExplain must be set alongside SecretsHandler")
 		}
-		r.Method(http.MethodPost, secrets.ChallengeRoute, deps.protected(attestation.HandleAuthenticate(deps.SecretsChallenges)))
-		r.Method(http.MethodGet, secrets.Route, deps.protected(deps.SecretsHandler))
-		r.Method(http.MethodPost, secrets.Route, deps.protected(deps.SecretsHandler))
+		r.Method(http.MethodPost, secrets.ChallengeRoute, deps.perSandbox(attestation.HandleAuthenticate(deps.SecretsChallenges)))
+		r.Method(http.MethodGet, secrets.Route, deps.perSandbox(deps.SecretsHandler))
+		r.Method(http.MethodPost, secrets.Route, deps.perSandbox(deps.SecretsHandler))
 		r.Method(http.MethodPut, secrets.Route, deps.allowlistWrite(deps.SecretsOperator))
 		r.Method(http.MethodGet, secrets.ExplainRoute, deps.allowlistWrite(deps.SecretsExplain))
 	}
@@ -104,9 +104,18 @@ func (deps dependencies) protected(next http.Handler) http.Handler {
 	return issuer.RateLimitMiddleware(deps.RateLimiter, capBody(deps.MaxRequestSize, next))
 }
 
-// allowlistWrite is protected with the larger allowlist body cap.
+// allowlistWrite is protected with the larger allowlist body cap. Its callers
+// are operators reaching CDS directly, so the source address is the caller.
 func (deps dependencies) allowlistWrite(next http.Handler) http.Handler {
 	return issuer.RateLimitMiddleware(deps.RateLimiter, capBody(allowlistWriteBodyCap, next))
+}
+
+// perSandbox rate-limits by the caller's attested sandbox instead of its
+// address. The workload secret routes are the ones pods reach through a
+// NodePort and the mesh proxy, where the address is the node's rather than the
+// pod's — see secrets.RateKey.
+func (deps dependencies) perSandbox(next http.Handler) http.Handler {
+	return issuer.RateLimitBy(deps.RateLimiter, secrets.RateKey, capBody(deps.MaxRequestSize, next))
 }
 
 func capBody(max int64, next http.Handler) http.Handler {

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -2,7 +2,14 @@ package cds
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +19,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/attestation"
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
 	"github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"golang.org/x/time/rate"
 )
 
@@ -178,5 +186,86 @@ func TestRouter_ExplainDoesNotShadowSecretPaths(t *testing.T) {
 		if code := get(t, r, http.MethodGet, p); code == http.StatusNotFound {
 			t.Fatalf("GET %s = 404: the explain route shadowed a store path", p)
 		}
+	}
+}
+
+// leafWithSandbox mints a client certificate carrying a sandbox ID, as CDS
+// stamps one, so a request can arrive with an identity the router can key on.
+func leafWithSandbox(t *testing.T, sandboxID string) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ext, err := ratls.MarshalSandboxIDExtension(sandboxID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:    big.NewInt(1),
+		NotBefore:       time.Now().Add(-time.Hour),
+		NotAfter:        time.Now().Add(time.Hour),
+		ExtraExtensions: []pkix.Extension{ext},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+// The workload secret routes must bound one sandbox, not one address. Every pod
+// on a node reaches CDS from the same address through the NodePort and the mesh
+// proxy, so an address bucket lets one pod wedge its co-tenants' fetchers.
+func TestRouter_SecretRoutesRateLimitPerSandbox(t *testing.T) {
+	// Burst of one, so the second request against a given bucket is refused.
+	limiter, err := issuer.NewIPRateLimiter(rate.Limit(1), 1, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs := attestation.NewChallengeStore(time.Minute)
+	secretsCS := attestation.NewChallengeStore(time.Minute)
+	r := newRouter(dependencies{
+		AttestHandler:     AttestHandler{Challenges: &cs},
+		ReadyFn:           func() bool { return true },
+		RateLimiter:       limiter,
+		MaxRequestSize:    65536,
+		SecretsHandler:    &secrets.Handler{},
+		SecretsChallenges: &secretsCS,
+		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)},
+		SecretsExplain:    &secrets.ExplainHandler{},
+	})
+
+	send := func(leaf *x509.Certificate) int {
+		req := httptest.NewRequest(http.MethodGet, "/secrets/api/db", nil)
+		req.RemoteAddr = "10.0.0.7:34567" // the node address every pod shares
+		if leaf != nil {
+			req.TLS = &tls.ConnectionState{
+				PeerCertificates: []*x509.Certificate{leaf},
+				VerifiedChains:   [][]*x509.Certificate{{leaf}},
+			}
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	victim := leafWithSandbox(t, strings.Repeat("a", 64))
+	hostile := leafWithSandbox(t, strings.Repeat("b", 64))
+
+	// The hostile pod spends its own burst and is refused for more.
+	if code := send(hostile); code == http.StatusTooManyRequests {
+		t.Fatal("the first request was rate limited")
+	}
+	if code := send(hostile); code != http.StatusTooManyRequests {
+		t.Fatalf("a sandbox past its burst = %d, want 429", code)
+	}
+	// The co-tenant on the same address still gets through.
+	if code := send(victim); code == http.StatusTooManyRequests {
+		t.Fatal("one pod exhausted a co-tenant's bucket: the limiter is keyed on the address")
 	}
 }

--- a/internal/issuer/ratelimit.go
+++ b/internal/issuer/ratelimit.go
@@ -21,7 +21,7 @@ var (
 
 	rateLimiterEntries = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cds_rate_limiter_entries",
-		Help: "Current number of entries in the per-IP rate limiter.",
+		Help: "Current number of entries in the rate limiter.",
 	})
 )
 
@@ -30,9 +30,10 @@ type ipLimiterEntry struct {
 	lastSeen time.Time
 }
 
-// IPRateLimiter implements per-source-IP rate limiting with bounded memory.
-// Entries beyond MaxEntries are evicted LRU in O(n); idle entries are evicted
-// by EvictionLoop at IdleTimeout.
+// IPRateLimiter implements keyed rate limiting with bounded memory. Entries
+// beyond MaxEntries are evicted LRU in O(n); idle entries are evicted by
+// EvictionLoop at IdleTimeout. RateLimitMiddleware keys on the source address;
+// RateLimitBy keys on whatever identifies the caller.
 type IPRateLimiter struct {
 	mu         sync.Mutex
 	limiters   map[string]*ipLimiterEntry
@@ -111,19 +112,49 @@ func (rl *IPRateLimiter) evict(idleTimeout time.Duration) {
 	rateLimiterEntries.Set(float64(len(rl.limiters)))
 }
 
+// KeyFunc names the bucket a request is charged to. Returning "" charges it to
+// the source address.
+//
+// Keys carry a kind prefix so two namespaces can share one limiter without a
+// value in either being able to name a bucket in the other.
+type KeyFunc func(*http.Request) string
+
 // RateLimitMiddleware wraps next with per-source-IP rate limiting against rl.
 // On reject it returns 429 and increments the rejection counter.
 func RateLimitMiddleware(rl *IPRateLimiter, next http.Handler) http.Handler {
+	return RateLimitBy(rl, nil, next)
+}
+
+// RateLimitBy wraps next, charging each request to the bucket key names.
+//
+// Use it where the source address is not the caller: pods reach CDS through a
+// NodePort and the host-network mesh proxy, so every pod on a node presents the
+// same address and one of them could exhaust the bucket every other one shares.
+// A request with no identity to key on still falls back to the address, so
+// nothing escapes limiting by declining to identify itself.
+func RateLimitBy(rl *IPRateLimiter, key KeyFunc, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ip, _, _ := net.SplitHostPort(r.RemoteAddr)
-		if ip == "" {
-			ip = r.RemoteAddr
+		bucket := ""
+		if key != nil {
+			bucket = key(r)
 		}
-		if !rl.getLimiter(ip).Allow() {
+		if bucket == "" {
+			bucket = SourceAddrKey(r)
+		}
+		if !rl.getLimiter(bucket).Allow() {
 			rateLimitRejectionsTotal.Inc()
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// SourceAddrKey charges a request to the address it arrived from.
+func SourceAddrKey(r *http.Request) string {
+	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
+	if ip == "" {
+		ip = r.RemoteAddr
+	}
+	return "addr:" + ip
 }

--- a/internal/issuer/ratelimit_test.go
+++ b/internal/issuer/ratelimit_test.go
@@ -1,6 +1,8 @@
 package issuer
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -69,5 +71,100 @@ func TestRateLimiterMaxEntries(t *testing.T) {
 	defer rl.mu.Unlock()
 	if len(rl.limiters) != 3 {
 		t.Errorf("expected 3 entries after cap, got %d", len(rl.limiters))
+	}
+}
+
+// --- keyed limiting ---
+
+// The point of the keyed middleware: two callers arriving from one address get
+// one bucket each, so exhausting yours leaves mine untouched.
+func TestRateLimitByGivesOneBucketPerKey(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(1), 1, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var key string
+	h := RateLimitBy(rl, func(*http.Request) string { return key }, http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	send := func() int {
+		r := httptest.NewRequest(http.MethodGet, "/secrets/x", nil)
+		r.RemoteAddr = "10.0.0.7:34567" // one node address for every caller
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+
+	key = "sandbox:aaa"
+	if code := send(); code != http.StatusOK {
+		t.Fatalf("first request for aaa = %d, want 200", code)
+	}
+	if code := send(); code != http.StatusTooManyRequests {
+		t.Fatalf("second request for aaa = %d, want 429 (its own burst is spent)", code)
+	}
+	key = "sandbox:bbb"
+	if code := send(); code != http.StatusOK {
+		t.Fatalf("a different sandbox from the same address = %d, want 200", code)
+	}
+}
+
+// A caller that names no key is charged to its address, so withholding an
+// identity is not a way out of the limit.
+func TestRateLimitByFallsBackToTheAddress(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(1), 1, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := RateLimitBy(rl, func(*http.Request) string { return "" }, http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	send := func(addr string) int {
+		r := httptest.NewRequest(http.MethodGet, "/secrets/x", nil)
+		r.RemoteAddr = addr
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+	if code := send("10.0.0.7:1"); code != http.StatusOK {
+		t.Fatalf("first = %d, want 200", code)
+	}
+	if code := send("10.0.0.7:2"); code != http.StatusTooManyRequests {
+		t.Fatalf("same address, different port = %d, want 429 (one bucket per address)", code)
+	}
+	if code := send("10.0.0.8:1"); code != http.StatusOK {
+		t.Fatalf("a different address = %d, want 200", code)
+	}
+}
+
+// Keys are namespaced, so a sandbox ID shaped like an address cannot name the
+// bucket that address is charged to.
+func TestRateLimitKeyNamespacesDoNotCollide(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(1), 1, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := RateLimitBy(rl, func(r *http.Request) string { return r.Header.Get("X-Key") }, http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }))
+
+	send := func(key string) int {
+		r := httptest.NewRequest(http.MethodGet, "/secrets/x", nil)
+		r.RemoteAddr = "10.0.0.7:1"
+		if key != "" {
+			r.Header.Set("X-Key", key)
+		}
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+	// Spend the address bucket.
+	if code := send(""); code != http.StatusOK {
+		t.Fatalf("address request = %d, want 200", code)
+	}
+	if code := send(""); code != http.StatusTooManyRequests {
+		t.Fatalf("address bucket should be spent, got %d", code)
+	}
+	// A sandbox whose ID is that same address string is a different bucket.
+	if code := send("sandbox:10.0.0.7"); code != http.StatusOK {
+		t.Fatalf("an address-shaped sandbox ID shares the address bucket: %d", code)
 	}
 }

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -46,6 +46,30 @@ const (
 // Handler.InjectedDigests.
 var InjectedEntrypoints = []string{"get-cert", "get-secret", "/c8s"}
 
+// RateKey charges a request to the sandbox its client certificate names, so a
+// rate limit bounds one workload rather than one address.
+//
+// Pods reach CDS through a NodePort and the host-network mesh proxy, so every
+// pod on a node arrives from the same address: keyed on that, one hostile pod
+// exhausts the bucket its co-tenants share and wedges their fetchers into a
+// CrashLoop. The sandbox ID is stamped by CDS into a leaf that crypto/tls has
+// verified against the mesh CA, so a caller can only ever name its own.
+//
+// An unverified or absent certificate returns "", charging the request to the
+// source address. Such a request is refused by the handler regardless, and a
+// caller cannot escape limiting by withholding a certificate.
+func RateKey(r *http.Request) string {
+	leaf, err := verifiedLeaf(r)
+	if err != nil {
+		return ""
+	}
+	id, err := ratls.SandboxIDFromCert(leaf)
+	if err != nil || id == "" {
+		return ""
+	}
+	return "sandbox:" + id
+}
+
 // challengeSource issues and consumes the single-use nonces that make a request
 // fresh. The secrets listener holds its own, so a nonce minted for issuance
 // cannot be redeemed here.

--- a/internal/secrets/handler_errors_test.go
+++ b/internal/secrets/handler_errors_test.go
@@ -2,9 +2,12 @@ package secrets
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
@@ -209,5 +212,63 @@ func TestHandlerWithoutLogger(t *testing.T) {
 	hn.h.Logger = nil
 	if w := do(hn.h, hn.request(t, http.MethodGet, "/other/db")); w.Code != http.StatusNotFound {
 		t.Fatalf("logger-less handler = %d, want 404", w.Code)
+	}
+}
+
+// --- rate-limit keying ---
+
+// The key is the sandbox, not the address: pods share a node's address through
+// the NodePort and the mesh proxy, so an address bucket is a shared one.
+func TestRateKeyUsesTheVerifiedSandbox(t *testing.T) {
+	leaf, _ := leafFor(t, testSandbox)
+	r := httptest.NewRequest(http.MethodGet, "/secrets/api/db", nil)
+	r.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{leaf},
+		VerifiedChains:   [][]*x509.Certificate{{leaf}},
+	}
+	if got := RateKey(r); got != "sandbox:"+testSandbox {
+		t.Fatalf("RateKey = %q, want the sandbox bucket", got)
+	}
+}
+
+// A certificate crypto/tls has not chained to the mesh CA carries a sandbox ID
+// its holder chose. Keying on it would let anyone able to mint a self-signed
+// leaf name a victim's bucket and exhaust it — the denial this keying exists to
+// prevent, handed to an unauthenticated caller.
+func TestRateKeyIgnoresAnUnverifiedCertificate(t *testing.T) {
+	leaf, _ := leafFor(t, testSandbox)
+	r := httptest.NewRequest(http.MethodGet, "/secrets/api/db", nil)
+	r.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}
+	if got := RateKey(r); got != "" {
+		t.Fatalf("RateKey = %q, want the address fallback for an unverified chain", got)
+	}
+}
+
+func TestRateKeyFallsBackWithoutASandbox(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		tls  *tls.ConnectionState
+	}{
+		{"no TLS", nil},
+		{"no certificate", &tls.ConnectionState{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/secrets/api/db", nil)
+			r.TLS = tc.tls
+			if got := RateKey(r); got != "" {
+				t.Fatalf("RateKey = %q, want the address fallback", got)
+			}
+		})
+	}
+
+	// A verified leaf carrying no sandbox extension is the same case.
+	bare, _ := leafFor(t, "")
+	r := httptest.NewRequest(http.MethodGet, "/secrets/api/db", nil)
+	r.TLS = &tls.ConnectionState{
+		PeerCertificates: []*x509.Certificate{bare},
+		VerifiedChains:   [][]*x509.Certificate{{bare}},
+	}
+	if got := RateKey(r); got != "" {
+		t.Fatalf("RateKey = %q, want the address fallback with no sandbox ID", got)
 	}
 }


### PR DESCRIPTION
Pods reach CDS through a NodePort and the host-network mesh proxy, so every pod on a node arrives at the same source address. Keyed on that, the /secrets routes gave a node one shared bucket: a single pod spending it held every co-tenant's fetcher in a CrashLoop, and since the file only appears once the whole container set is up, a wedged fetcher is a workload that never receives its secret.

The sandbox ID is the right key. CDS stamps it into the leaf and crypto/tls verifies that leaf against the mesh CA before the handler runs, so a caller can only ever name its own bucket.

secrets.RateKey reads it through the same verifiedLeaf the release path uses, which is what makes the key trustworthy: a certificate that has not chained to the mesh CA carries whatever sandbox ID its holder chose, and keying on that would hand an unauthenticated caller the exact denial this change removes. Such a request keys on the address instead — it is refused by the handler regardless, and no caller can leave the limit by withholding an identity.

The limiter's map was already keyed by string; only the middleware needed to learn where the key comes from. RateLimitBy takes a KeyFunc and RateLimitMiddleware is now that with the source address, so /attest, /sign-csr and the operator routes are unchanged — for those the address is the caller. Keys carry a kind prefix, so a sandbox ID shaped like an address cannot name the bucket that address is charged to.

TestRouter_SecretRoutesRateLimitPerSandbox fails against the previous wiring, so the routing is pinned rather than merely described.
