### PR TITLE
feat(volumed): caller identity, mount target, and independent authorization

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -267,8 +267,7 @@ has to enumerate c8s's own sidecars.
 
 A container is dropped when its digest is an allowlist **floor** entry *and* its
 entrypoint is one c8s injects (`get-cert`, `get-secret`, `get-volume`, `/c8s`).
-Both halves
-are load-bearing. Floor membership alone would let a pod add busybox running a
+Both halves are load-bearing. Floor membership alone would let a pod add busybox running a
 shell — also a floor entry — and have it ignored.
 
 The floor is the source. It already carries the injected image, since it could

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -266,7 +266,8 @@ a workload's declared set, so they are removed before matching — an entry neve
 has to enumerate c8s's own sidecars.
 
 A container is dropped when its digest is an allowlist **floor** entry *and* its
-entrypoint is one c8s injects (`get-cert`, `get-secret`, `/c8s`). Both halves
+entrypoint is one c8s injects (`get-cert`, `get-secret`, `get-volume`, `/c8s`).
+Both halves
 are load-bearing. Floor membership alone would let a pod add busybox running a
 shell — also a floor entry — and have it ignored.
 

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -1,0 +1,201 @@
+# Encrypted volumes
+
+Data too large to be a secret, encrypted at rest on host-visible storage, and
+decryptable only inside a TEE by a workload the allowlist names. Model weights
+are the case this is built for.
+
+> **Status.** `c8s volume create` builds a volume and stores its key. **Delivery
+> is not built yet**: nothing mounts a volume into a pod, so the annotations and
+> the daemon described under [Consuming a volume](#consuming-a-volume) do not
+> exist. Volumes are read-only; read-write is out of scope.
+
+This complements [`secrets.md`](secrets.md) — a volume key *is* a secret, stored
+and released by exactly the machinery described there. What is new is the
+artifact the key opens, and the fact that it persists.
+
+## Why a volume is different from a secret
+
+Every other value c8s protects is RAM-resident and dies with the pod. A volume
+does not: its ciphertext sits on storage the host reads and writes freely, and
+the host keeps it.
+
+That makes a leaked volume key **retroactive and permanent**. A leaked session
+key forges future connections; a leaked volume key decrypts a copy the adversary
+already has. Treat volume keys accordingly.
+
+## The artifact
+
+An image built by `c8s volume create`, in three layers:
+
+| | |
+|---|---|
+| filesystem | erofs, read-only by construction |
+| integrity | dm-verity, hash tree appended to the filesystem |
+| confidentiality | plain dm-crypt, `aes-xts-plain64`, 512-bit key, 512-byte sectors |
+
+**There is no LUKS header.** A LUKS2 header is on-disk metadata whose integrity
+is an unkeyed checksum the host can recompute, and it is parsed as root inside
+the TEE on every open. Plain dm-crypt has no on-disk metadata at all, so every
+parameter comes from the key blob, which only ever travels over the attested
+channel. What a header would buy — rotating the key via keyslots — is not real
+against a host that keeps a copy of the old header and can restore it.
+
+**The hash tree is inside the encryption.** A hash tree is a fingerprint of the
+plaintext, so leaving it in the clear would let the host identify what a volume
+holds. Keeping it inside also means the root hash commits to the data rather
+than to one encryption of it.
+
+**Sector size is 512.** For `aes-xts-plain64` the tweak is the sector index, but
+at a larger sector size dm-crypt's numbering depends on `iv_large_sectors` — and
+a writer and an opener that disagree produce a volume that decrypts to noise
+with nothing to say why.
+
+### The key blob
+
+The value stored at the secret path. Everything needed to open the volume, and
+nothing taken from anywhere else:
+
+```json
+{ "type": "c8s.volume/v1",
+  "key": "<base64, 64 bytes>",
+  "verity": { "root_hash": "<hex>", "salt": "<hex>",
+              "data_blocks": 26214400, "hash_offset": 107374182400 } }
+```
+
+The verity root hash rides here rather than in an annotation or the allowlist
+entry because it is the integrity anchor, and an anchor the host can edit
+anchors nothing. It is also a fingerprint naming which model a volume holds, and
+`GET /allowlist` is unauthenticated.
+
+## Creating a volume
+
+```sh
+c8s volume create \
+  --name weights \
+  --source ./llama-3.1-8b \
+  --out ./weights.img \
+  --path /tenant-a/volumes/weights \
+  --escrow-out ./weights.escrow.json \
+  --node node-1 \
+  --url https://cds.example --measurements-file ./m.txt \
+  --operator-key ./operator.key
+```
+
+It packages the directory, formats the hash tree, generates a key, encrypts, and
+`PUT`s the blob. It prints the annotations, the `nodeSelector`, and the
+allowlist grant to apply; it does not modify any workload.
+
+The key is generated per volume and never taken from you. AES-XTS is
+deterministic, so re-encrypting a changed directory under a reused key would
+tell the host exactly which sectors changed between versions.
+
+`--name` is capped at 12 characters. The node selects the device by its virtio
+serial, `VIRTIO_BLK_ID_BYTES` is 20, and `c8s-vol-` takes eight; a thirteenth
+character is silently dropped, so two volumes would be indistinguishable to the
+node.
+
+Creation needs `mkfs.erofs` and `veritysetup` on the machine running it. It does
+**not** need root, a loop device, or `cryptsetup`: the encryption is done in
+process.
+
+### Keep the escrow file
+
+`--escrow-out` is required, written `0600`, and refuses to overwrite. It holds
+the key.
+
+CDS keeps secrets in process memory and nowhere else, so **a CDS restart makes
+every volume in the cluster unopenable until its key is written again**, and the
+escrow file is what you write it back from. Lose it and restart CDS and the
+ciphertext is unrecoverable — there is no other copy.
+
+Keep escrow files somewhere durable and access-controlled. Their compromise is
+equivalent to handing over the plaintext, permanently.
+
+## Placing the image on a node
+
+The image is ciphertext. Copy it to the node by any means, including through the
+untrusted host — that the host holds the bytes is the design premise, not a
+compromise of it.
+
+Attach it as a **raw block device** whose virtio serial is `c8s-vol-<name>`.
+
+A confos node has no persistent writable storage — the root overlay is
+reformatted on every boot — so a volume must be its own device rather than a
+file on the node's filesystem.
+
+The serial is a **selector, not a trust input**. The host chooses it and answers
+the query per read. Pointing a pod at the wrong device fails closed: the wrong
+key produces noise, and verity refuses it.
+
+Because the device is on one node, the pod must be scheduled there; `create`
+emits the matching `nodeSelector`.
+
+## The grant
+
+Release is gated on the workload entry's `secrets` grant, exactly as in
+[`secrets.md`](secrets.md#the-grant):
+
+```json
+"secrets": { "policy": "allow", "read": ["/tenant-a/volumes/weights"] }
+```
+
+**Name the exact path, not a subtree.** `/tenant-a/volumes/**` grants every
+volume beneath it, and the annotation naming which volume to open is
+host-written. `create` prints an exact-path grant for this reason.
+
+`read` only. A volume is mounted read-only, so a write grant says nothing about
+whether a workload may see the plaintext.
+
+## Consuming a volume
+
+> Not built. Described here because the grant and the artifact above are built
+> against it.
+
+A pod will name its volumes in an annotation, and an injected sidecar will fetch
+the key over the attested `/secrets` flow and hand it to a node daemon that opens
+the device and mounts it read-only.
+
+What decides whether a mount happens, in order:
+
+1. CDS releases the blob to the pod's sandbox — verified mesh leaf, single-use
+   challenge, inventory-signed sandbox token, whole-container-set match against
+   one workload entry, grant covers the path.
+2. The daemon **independently** repeats the entry match and the grant check for
+   the sandbox the kernel says is calling. Possession of a blob is not authority
+   on its own.
+3. The device opens only if the key is right and the verity root hash matches.
+
+The volume appears **after the workload starts**, because release is gated on
+the whole container set having been admitted. A consumer must wait for it rather
+than read it at startup.
+
+## What this defends
+
+| Threat | |
+|---|---|
+| Host reads the volume at rest | prevented — AES-XTS, key never leaves the TEE |
+| Host tampers with the ciphertext | detected — dm-verity fails the affected read |
+| Host rolls the volume back | detected — the root hash covers the whole plaintext |
+| Host swaps in a different device | fails closed — wrong key, or wrong root hash |
+| A pod outside the grant reads it | refused — no grant, no key |
+| An allowlisted but different workload reads it | refused — whole-entry match |
+
+Tamper detection is **lazy**: `veritysetup open` checks the top of the tree, and
+a modified data block surfaces as an I/O error when it is read, not at open.
+
+### What it does not
+
+- **Anyone with pod create or exec RBAC in the workload's namespace can read a
+  mounted volume.** Under `--cvm-mode=node` the control plane runs inside the
+  node CVM, so this is not a capability the host has — but it is a Kubernetes
+  RBAC boundary, not an attested one.
+- **Volume integrity is rooted in the operator keys CDS pins**, and CDS's
+  arguments are host-supplied. A host that restarts CDS under its own operator
+  key can write a matching grant and blob. `THREAT_MODEL.md` records this as
+  detection rather than prevention; the detection is
+  `c8s cds verify --operator-keys`, and running it continuously is a
+  precondition for trusting a volume.
+- **Access patterns are visible.** Which sectors are read, and when, leaks
+  structure.
+- **Availability.** The host can withhold or destroy the device.
+- **Whatever the workload does with the plaintext** once it has it.

--- a/internal/cmds/volumed/authorize.go
+++ b/internal/cmds/volumed/authorize.go
@@ -1,0 +1,108 @@
+package volumed
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/confidential-dot-ai/c8s/internal/secrets"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// Inventory reports what a sandbox has run. On node-CVM this is
+// nri-image-policy, the component that admitted those containers.
+type Inventory interface {
+	FetchSandbox(ctx context.Context, sandboxID string) (workloadclaims.SandboxDigestsResponse, error)
+}
+
+// Policy supplies the current allowlist.
+type Policy interface {
+	Allowlist() (*pkgallowlist.Allowlist, error)
+}
+
+// Authorizer decides whether a sandbox may open the volume keyed at a store
+// path.
+//
+// This repeats a decision CDS already made when it released the blob, and that
+// is the point. The caller hands this daemon a key, a device name and a
+// geometry; without its own check the first open of any name would be
+// authorized by nothing but possession of a blob, and the daemon performs
+// privileged device-mapper and mount work on the strength of it.
+type Authorizer struct {
+	Inventory Inventory
+	Policy    Policy
+}
+
+// Authorize refuses unless the sandbox's admitted container set matches exactly
+// one workload entry, and that entry's grant covers path for reading.
+//
+// Read only: a volume key is delivered to a read-only device, so a write grant
+// says nothing about whether this sandbox may see the plaintext.
+func (a Authorizer) Authorize(ctx context.Context, sandboxID, path string) error {
+	if a.Inventory == nil || a.Policy == nil {
+		return fmt.Errorf("volumed: authorizer is not configured")
+	}
+	if sandboxID == "" {
+		return fmt.Errorf("volumed: no sandbox for the calling process")
+	}
+	canonical, err := pkgallowlist.CanonicalSecretPath(path)
+	if err != nil {
+		return fmt.Errorf("volumed: %w", err)
+	}
+
+	al, err := a.Policy.Allowlist()
+	if err != nil {
+		return fmt.Errorf("volumed: load allowlist: %w", err)
+	}
+	containers, err := a.workloadContainers(ctx, al, sandboxID)
+	if err != nil {
+		return err
+	}
+	name, workload, err := al.MatchWorkload(containers)
+	if err != nil {
+		return fmt.Errorf("volumed: sandbox %s: %w", sandboxID, err)
+	}
+	if !workload.Secrets.Allows(canonical, pkgallowlist.OpRead) {
+		return fmt.Errorf("volumed: workload %q holds no read grant for %s", name, canonical)
+	}
+	return nil
+}
+
+// workloadContainers asks the inventory what the sandbox has run and removes
+// c8s's own injected containers, so a workload entry never has to enumerate
+// them. Mirrors the drop set CDS applies at release (docs/secrets.md).
+func (a Authorizer) workloadContainers(ctx context.Context, al *pkgallowlist.Allowlist, sandboxID string) ([]pkgallowlist.RunningContainer, error) {
+	resp, err := a.Inventory.FetchSandbox(ctx, sandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("volumed: resolve sandbox containers: %w", err)
+	}
+	reported, err := resp.RequireContainers()
+	if err != nil {
+		return nil, fmt.Errorf("volumed: %w", err)
+	}
+	out := make([]pkgallowlist.RunningContainer, 0, len(reported))
+	for _, c := range reported {
+		if isInjected(al, c) {
+			continue
+		}
+		out = append(out, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("volumed: sandbox %s reports no workload containers", sandboxID)
+	}
+	return out, nil
+}
+
+// isInjected reports whether a reported container is one c8s injected: an
+// allowlist floor digest AND an entrypoint c8s injects. Floor membership alone
+// would let a pod add busybox — also a floor entry — and have it ignored.
+func isInjected(al *pkgallowlist.Allowlist, c workloadclaims.SandboxContainer) bool {
+	if len(c.Argv) == 0 {
+		return false
+	}
+	if _, floor := al.Digests[c.Digest]; !floor {
+		return false
+	}
+	return slices.Contains(secrets.InjectedEntrypoints, c.Argv[0])
+}

--- a/internal/cmds/volumed/authorize_test.go
+++ b/internal/cmds/volumed/authorize_test.go
@@ -1,0 +1,218 @@
+package volumed
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+const (
+	appDigest  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	certDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	sandboxID  = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	storePath  = "/tenant-a/volumes/weights"
+)
+
+type fakeInventory struct {
+	containers []workloadclaims.SandboxContainer
+	err        error
+}
+
+func (f fakeInventory) FetchSandbox(context.Context, string) (workloadclaims.SandboxDigestsResponse, error) {
+	if f.err != nil {
+		return workloadclaims.SandboxDigestsResponse{}, f.err
+	}
+	return workloadclaims.SandboxDigestsResponse{Containers: f.containers}, nil
+}
+
+type fakePolicy struct {
+	al  *pkgallowlist.Allowlist
+	err error
+}
+
+func (f fakePolicy) Allowlist() (*pkgallowlist.Allowlist, error) { return f.al, f.err }
+
+// allowlistWith builds a document whose single entry declares the app container
+// and, optionally, a read grant on storePath. The cert sidecar's digest is in
+// the floor, so it is dropped before matching.
+func allowlistWith(grant *pkgallowlist.SecretsPolicy) *pkgallowlist.Allowlist {
+	return &pkgallowlist.Allowlist{
+		Schema:  pkgallowlist.Schema,
+		Digests: map[string]string{certDigest: "ghcr.io/confidential-dot-ai/c8s"},
+		Workloads: map[string]pkgallowlist.Workload{
+			"vllm": {
+				Containers: []pkgallowlist.Container{{
+					Digest:  mustDigest(appDigest),
+					Command: pkgallowlist.ArgvPolicy{Policy: "exact", Argv: []string{"serve"}},
+					Args:    pkgallowlist.ArgvPolicy{Policy: "any"},
+				}},
+				Secrets: grant,
+			},
+		},
+	}
+}
+
+func mustDigest(s string) types.Digest {
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func readGrant(paths ...string) *pkgallowlist.SecretsPolicy {
+	return &pkgallowlist.SecretsPolicy{Policy: pkgallowlist.PolicyAllow, Read: paths}
+}
+
+func runningApp() []workloadclaims.SandboxContainer {
+	return []workloadclaims.SandboxContainer{{Digest: appDigest, Argv: []string{"serve", "--port", "8000"}}}
+}
+
+func authorizerFor(containers []workloadclaims.SandboxContainer, grant *pkgallowlist.SecretsPolicy) Authorizer {
+	return Authorizer{
+		Inventory: fakeInventory{containers: containers},
+		Policy:    fakePolicy{al: allowlistWith(grant)},
+	}
+}
+
+func TestAuthorizeAllowsGrantedPath(t *testing.T) {
+	a := authorizerFor(runningApp(), readGrant(storePath))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err != nil {
+		t.Fatalf("refused a granted path: %v", err)
+	}
+}
+
+func TestAuthorizeRefusesUngrantedPath(t *testing.T) {
+	a := authorizerFor(runningApp(), readGrant("/tenant-b/volumes/other"))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("allowed a path the grant does not cover")
+	}
+}
+
+func TestAuthorizeRefusesEntryWithNoGrant(t *testing.T) {
+	a := authorizerFor(runningApp(), nil)
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("allowed a workload holding no grant")
+	}
+}
+
+// A volume is mounted read-only, so a write grant says nothing about whether
+// this sandbox may see the plaintext.
+func TestAuthorizeIgnoresWriteOnlyGrant(t *testing.T) {
+	a := authorizerFor(runningApp(), &pkgallowlist.SecretsPolicy{
+		Policy: pkgallowlist.PolicyAllow,
+		Read:   []string{"/tenant-a/volumes/other"},
+		Write:  []string{storePath},
+	})
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("a write grant authorized a read")
+	}
+}
+
+// A pod running anything its entry does not declare matches no entry at all —
+// which is what stops a workload adding a container to exfiltrate the plaintext.
+func TestAuthorizeRefusesForeignContainer(t *testing.T) {
+	containers := append(runningApp(), workloadclaims.SandboxContainer{
+		Digest: "sha256:3333333333333333333333333333333333333333333333333333333333333333",
+		Argv:   []string{"/bin/sh"},
+	})
+	a := authorizerFor(containers, readGrant(storePath))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("matched an entry despite an undeclared container")
+	}
+}
+
+// c8s's own injected containers are dropped before matching, so an entry never
+// enumerates them.
+func TestAuthorizeDropsInjectedContainers(t *testing.T) {
+	containers := append(runningApp(), workloadclaims.SandboxContainer{
+		Digest: certDigest, Argv: []string{"get-cert", "--cds-url=https://cds"},
+	}, workloadclaims.SandboxContainer{
+		Digest: certDigest, Argv: []string{"get-volume", "--name=weights"},
+	})
+	a := authorizerFor(containers, readGrant(storePath))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err != nil {
+		t.Fatalf("injected containers were not dropped: %v", err)
+	}
+}
+
+// Floor membership alone is not enough to be dropped: a floor image running
+// something c8s does not inject is a workload container.
+func TestAuthorizeDoesNotDropFloorImageRunningSomethingElse(t *testing.T) {
+	containers := append(runningApp(), workloadclaims.SandboxContainer{
+		Digest: certDigest, Argv: []string{"/bin/sh", "-c", "cat /models/*"},
+	})
+	a := authorizerFor(containers, readGrant(storePath))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("dropped a floor image that was not running an injected entrypoint")
+	}
+}
+
+func TestAuthorizeRefusesUnreachableInventory(t *testing.T) {
+	a := Authorizer{
+		Inventory: fakeInventory{err: errors.New("dial refused")},
+		Policy:    fakePolicy{al: allowlistWith(readGrant(storePath))},
+	}
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("allowed a release with no inventory answer")
+	}
+}
+
+func TestAuthorizeRefusesEmptySandboxReport(t *testing.T) {
+	a := authorizerFor(nil, readGrant(storePath))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("allowed a sandbox reporting no containers")
+	}
+}
+
+func TestAuthorizeRefusesUnloadableAllowlist(t *testing.T) {
+	a := Authorizer{
+		Inventory: fakeInventory{containers: runningApp()},
+		Policy:    fakePolicy{err: errors.New("store closed")},
+	}
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("allowed a release with no allowlist")
+	}
+}
+
+func TestAuthorizeRefusesMalformedInput(t *testing.T) {
+	a := authorizerFor(runningApp(), readGrant(storePath))
+	if err := a.Authorize(t.Context(), "", storePath); err == nil {
+		t.Error("accepted an empty sandbox id")
+	}
+	for _, p := range []string{"", "tenant-a/volumes", "/tenant-a/../weights", "/tenant-a/volumes/"} {
+		if err := a.Authorize(t.Context(), sandboxID, p); err == nil {
+			t.Errorf("path %q: accepted", p)
+		}
+	}
+}
+
+func TestAuthorizeRefusesUnconfigured(t *testing.T) {
+	if err := (Authorizer{}).Authorize(t.Context(), sandboxID, storePath); err == nil {
+		t.Fatal("an unconfigured authorizer allowed a release")
+	}
+}
+
+// A subtree grant covers paths beneath its base but not the base itself.
+func TestAuthorizeHonoursSubtreeGrantSemantics(t *testing.T) {
+	a := authorizerFor(runningApp(), readGrant("/tenant-a/volumes/**"))
+	if err := a.Authorize(t.Context(), sandboxID, storePath); err != nil {
+		t.Fatalf("subtree grant refused a path beneath its base: %v", err)
+	}
+	if err := a.Authorize(t.Context(), sandboxID, "/tenant-a/volumes"); err == nil {
+		t.Fatal("subtree grant covered its own base")
+	}
+}
+
+func TestAuthorizeErrorsNameTheSandbox(t *testing.T) {
+	a := authorizerFor(runningApp(), readGrant("/elsewhere"))
+	err := a.Authorize(t.Context(), sandboxID, storePath)
+	if err == nil || !strings.Contains(err.Error(), "no read grant") {
+		t.Fatalf("got %v, want an error naming the missing grant", err)
+	}
+}

--- a/internal/cmds/volumed/cgroup.go
+++ b/internal/cmds/volumed/cgroup.go
@@ -1,0 +1,66 @@
+// Package volumed implements the node agent that opens encrypted volumes for
+// the pods entitled to them. See docs/volumes.md.
+package volumed
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// podUIDPattern matches the pod UID a CRI runtime embeds in a container
+// process's cgroup path, in both driver spellings:
+//
+//	systemd:  …/kubepods-burstable-pod<uid with underscores>.slice/…
+//	cgroupfs: …/kubepods/burstable/pod<uid with dashes>/…
+//
+// The separator class covers both, because the systemd driver rewrites the
+// UUID's dashes to underscores.
+var podUIDPattern = regexp.MustCompile(`pod([0-9a-fA-F]{8}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{4}[-_][0-9a-fA-F]{12})`)
+
+// PodUIDCandidatesForPID returns every pod UID appearing in a process's cgroup
+// file under procRoot (normally "/proc"), shallowest path component first,
+// deduplicated and normalized to the dashed lowercase form Kubernetes uses.
+//
+// The caller MUST take the SHALLOWEST candidate, for the same reason
+// workloadclaims.ContainerIDCandidatesForPID does: a process can only move
+// itself DEEPER into cgroups it creates, so its runtime-assigned pod slice is
+// always an ancestor of anything it nests beneath. A caller that picked the
+// deepest could be handed a victim's UID by a process that created a child
+// cgroup named after it — and here that would mount another pod's decrypted
+// volume into the attacker's own directory.
+func PodUIDCandidatesForPID(procRoot string, pid int) ([]string, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("volumed: no peer PID (caller not on a unix socket?)")
+	}
+	data, err := os.ReadFile(fmt.Sprintf("%s/%d/cgroup", procRoot, pid))
+	if err != nil {
+		return nil, fmt.Errorf("volumed: read peer cgroup: %w", err)
+	}
+	var (
+		candidates []string
+		seen       = map[string]struct{}{}
+	)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		for _, m := range podUIDPattern.FindAllStringSubmatch(line, -1) {
+			uid := normalizePodUID(m[1])
+			if _, dup := seen[uid]; dup {
+				continue
+			}
+			seen[uid] = struct{}{}
+			candidates = append(candidates, uid)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("volumed: peer pid %d has no pod cgroup", pid)
+	}
+	return candidates, nil
+}
+
+// normalizePodUID converts a cgroup-spelled UID to the form Kubernetes uses in
+// the kubelet pod directory: lowercase, dash-separated. The systemd driver
+// writes underscores, and the kubelet directory does not.
+func normalizePodUID(raw string) string {
+	return strings.ToLower(strings.ReplaceAll(raw, "_", "-"))
+}

--- a/internal/cmds/volumed/cgroup_test.go
+++ b/internal/cmds/volumed/cgroup_test.go
@@ -1,0 +1,128 @@
+package volumed
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// procWith writes a fake /proc/<pid>/cgroup and returns the proc root.
+func procWith(t *testing.T, pid int, content string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, itoa(pid))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "cgroup"), []byte(content), 0o644); err != nil {
+		t.Fatalf("write cgroup: %v", err)
+	}
+	return root
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+const wantUID = "3f4a1b2c-5d6e-7f80-9a0b-1c2d3e4f5061"
+
+func TestPodUIDFromSystemdDriver(t *testing.T) {
+	root := procWith(t, 42, "0::/kubepods.slice/kubepods-burstable.slice/"+
+		"kubepods-burstable-pod3f4a1b2c_5d6e_7f80_9a0b_1c2d3e4f5061.slice/"+
+		"cri-containerd-aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111.scope\n")
+
+	got, err := PodUIDCandidatesForPID(root, 42)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The systemd driver spells the UUID with underscores; the kubelet pod
+	// directory uses dashes, and that directory is what the UID is for.
+	if len(got) != 1 || got[0] != wantUID {
+		t.Fatalf("got %v, want [%s]", got, wantUID)
+	}
+}
+
+func TestPodUIDFromCgroupfsDriver(t *testing.T) {
+	root := procWith(t, 7, "11:devices:/kubepods/besteffort/pod"+wantUID+
+		"/aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111\n"+
+		"0::/kubepods/besteffort/pod"+wantUID+"/aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111\n")
+
+	got, err := PodUIDCandidatesForPID(root, 7)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The same UID on every cgroup v1 controller line is one candidate.
+	if len(got) != 1 || got[0] != wantUID {
+		t.Fatalf("got %v, want [%s]", got, wantUID)
+	}
+}
+
+// A process can only move itself deeper into cgroups it creates, so its
+// runtime-assigned pod slice is always the shallowest. If a nested cgroup named
+// after a victim's UID came first, the agent would mount that pod's decrypted
+// volume into the attacker's own directory.
+func TestPodUIDCandidatesAreShallowestFirst(t *testing.T) {
+	const victim = "99999999-8888-7777-6666-555555555555"
+	root := procWith(t, 9, "0::/kubepods.slice/kubepods-burstable.slice/"+
+		"kubepods-burstable-pod3f4a1b2c_5d6e_7f80_9a0b_1c2d3e4f5061.slice/"+
+		"cri-containerd-aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111.scope/"+
+		"pod"+victim+"/nested\n")
+
+	got, err := PodUIDCandidatesForPID(root, 9)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %v, want two candidates", got)
+	}
+	if got[0] != wantUID {
+		t.Fatalf("shallowest candidate is %q, want the runtime-assigned %q", got[0], wantUID)
+	}
+	if got[1] != victim {
+		t.Fatalf("second candidate is %q, want the nested %q", got[1], victim)
+	}
+}
+
+func TestPodUIDRejectsProcessWithNoPodCgroup(t *testing.T) {
+	root := procWith(t, 3, "0::/system.slice/sshd.service\n")
+	if _, err := PodUIDCandidatesForPID(root, 3); err == nil {
+		t.Fatal("accepted a process outside any pod")
+	}
+}
+
+func TestPodUIDRejectsMissingPeer(t *testing.T) {
+	if _, err := PodUIDCandidatesForPID(t.TempDir(), 0); err == nil {
+		t.Fatal("accepted a zero PID (no peer credentials)")
+	}
+	if _, err := PodUIDCandidatesForPID(t.TempDir(), 1234); err == nil {
+		t.Fatal("accepted a PID with no cgroup file")
+	}
+}
+
+// A UID-shaped string that is not a pod slice must not be picked up: the
+// pattern anchors on the "pod" prefix the runtime writes.
+func TestPodUIDIgnoresNonPodComponents(t *testing.T) {
+	root := procWith(t, 11, "0::/kubepods.slice/notapod-"+wantUID+".slice\n")
+	if _, err := PodUIDCandidatesForPID(root, 11); err == nil {
+		t.Fatal("matched a component that is not a pod slice")
+	}
+}
+
+func TestNormalizePodUID(t *testing.T) {
+	for in, want := range map[string]string{
+		"3F4A1B2C_5D6E_7F80_9A0B_1C2D3E4F5061": wantUID,
+		wantUID:                                wantUID,
+	} {
+		if got := normalizePodUID(in); got != want {
+			t.Errorf("normalizePodUID(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/cmds/volumed/target.go
+++ b/internal/cmds/volumed/target.go
@@ -1,0 +1,80 @@
+package volumed
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"golang.org/x/sys/unix"
+)
+
+// emptyDirSubdir is where kubelet materializes an emptyDir volume under a pod's
+// directory. The mount target is built from this shape and the resolved pod
+// UID, never from anything the caller sends.
+const emptyDirSubdir = "volumes/kubernetes.io~empty-dir"
+
+var (
+	podUIDRE     = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	volumeNameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+)
+
+// TargetDir opens the directory a volume must be mounted at, for the pod the
+// kernel says is calling.
+//
+// The returned file is an O_PATH handle; mount through /proc/self/fd/<n> rather
+// than re-resolving the path, so nothing can be swapped between the check and
+// the mount.
+//
+// Two properties this has to hold, because the calling pod owns the contents of
+// its own emptyDir and can write into it:
+//
+//   - resolution stops at the pod's emptyDir directory (RESOLVE_BENEATH), so a
+//     name cannot climb out with "..";
+//   - no component may be a symlink (RESOLVE_NO_SYMLINKS), so a link planted
+//     inside the emptyDir cannot redirect the mount somewhere else — the pod's
+//     own rootfs, or another pod's directory.
+func TargetDir(kubeletRoot, podUID, volumeName string) (*os.File, error) {
+	if !podUIDRE.MatchString(podUID) {
+		return nil, fmt.Errorf("volumed: pod uid %q is not a uuid", podUID)
+	}
+	if !volumeNameRE.MatchString(volumeName) {
+		return nil, fmt.Errorf("volumed: volume name %q is not a dns-1123 label", volumeName)
+	}
+
+	base := filepath.Join(kubeletRoot, "pods", podUID, emptyDirSubdir)
+	baseFD, err := os.OpenFile(base, unix.O_PATH|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("volumed: open pod volume dir: %w", err)
+	}
+	defer baseFD.Close()
+
+	fd, err := unix.Openat2(int(baseFD.Fd()), volumeName, &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_XDEV,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("volumed: resolve mount target %s/%s: %w", base, volumeName, err)
+	}
+	f := os.NewFile(uintptr(fd), filepath.Join(base, volumeName))
+
+	// O_DIRECTORY already refuses a non-directory, but the error it returns is
+	// ENOTDIR with no context; say which path and why.
+	info, err := f.Stat()
+	if err != nil {
+		f.Close()
+		return nil, fmt.Errorf("volumed: stat mount target: %w", err)
+	}
+	if !info.IsDir() {
+		f.Close()
+		return nil, fmt.Errorf("volumed: mount target %s is not a directory", f.Name())
+	}
+	return f, nil
+}
+
+// ProcPath is the stable reference to an open handle. Mounting through this
+// rather than the resolved name is what closes the window between resolving a
+// path and using it.
+func ProcPath(f *os.File) string {
+	return fmt.Sprintf("/proc/self/fd/%d", f.Fd())
+}

--- a/internal/cmds/volumed/target_test.go
+++ b/internal/cmds/volumed/target_test.go
@@ -1,0 +1,108 @@
+package volumed
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testPodUID = "3f4a1b2c-5d6e-7f80-9a0b-1c2d3e4f5061"
+
+// kubeletTree builds <root>/pods/<uid>/volumes/kubernetes.io~empty-dir and
+// returns the root and that directory.
+func kubeletTree(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	base := filepath.Join(root, "pods", testPodUID, emptyDirSubdir)
+	if err := os.MkdirAll(base, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return root, base
+}
+
+func TestTargetDirResolvesPodEmptyDir(t *testing.T) {
+	root, base := kubeletTree(t)
+	if err := os.Mkdir(filepath.Join(base, "c8s-volume-weights"), 0o755); err != nil {
+		t.Fatalf("mkdir volume: %v", err)
+	}
+
+	f, err := TargetDir(root, testPodUID, "c8s-volume-weights")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	defer f.Close()
+	if !strings.HasSuffix(f.Name(), "c8s-volume-weights") {
+		t.Errorf("resolved %q", f.Name())
+	}
+	if ProcPath(f) == "" {
+		t.Error("no proc path for the handle")
+	}
+}
+
+// The calling pod owns the contents of its own emptyDir, so it can plant a
+// symlink there. Following one would mount the decrypted volume wherever the
+// pod pointed — its own rootfs, or another pod's directory.
+func TestTargetDirRefusesSymlinkedVolume(t *testing.T) {
+	root, base := kubeletTree(t)
+	elsewhere := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatalf("mkdir elsewhere: %v", err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(base, "c8s-volume-weights")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := TargetDir(root, testPodUID, "c8s-volume-weights"); err == nil {
+		t.Fatal("followed a symlink out of the pod's emptyDir")
+	}
+}
+
+// RESOLVE_NO_SYMLINKS stops link traversal but not "..", so the name is
+// validated as a label before it is ever resolved.
+func TestTargetDirRefusesTraversalInName(t *testing.T) {
+	root, _ := kubeletTree(t)
+	for _, name := range []string{"..", "../..", "a/b", "/abs", "c8s-volume-weights/../.."} {
+		if _, err := TargetDir(root, testPodUID, name); err == nil {
+			t.Errorf("name %q: accepted", name)
+		}
+	}
+}
+
+func TestTargetDirRefusesMalformedPodUID(t *testing.T) {
+	root, _ := kubeletTree(t)
+	for _, uid := range []string{
+		"", "not-a-uuid", "../../etc",
+		"3F4A1B2C-5D6E-7F80-9A0B-1C2D3E4F5061", // uppercase: kubelet writes lowercase
+		"3f4a1b2c_5d6e_7f80_9a0b_1c2d3e4f5061", // cgroup spelling, not the directory's
+	} {
+		if _, err := TargetDir(root, uid, "c8s-volume-weights"); err == nil {
+			t.Errorf("uid %q: accepted", uid)
+		}
+	}
+}
+
+func TestTargetDirRefusesNonDirectory(t *testing.T) {
+	root, base := kubeletTree(t)
+	if err := os.WriteFile(filepath.Join(base, "c8s-volume-weights"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if _, err := TargetDir(root, testPodUID, "c8s-volume-weights"); err == nil {
+		t.Fatal("accepted a regular file as a mount target")
+	}
+}
+
+func TestTargetDirRefusesUnknownPod(t *testing.T) {
+	root, _ := kubeletTree(t)
+	other := "99999999-8888-7777-6666-555555555555"
+	if _, err := TargetDir(root, other, "c8s-volume-weights"); err == nil {
+		t.Fatal("resolved a target for a pod with no kubelet directory")
+	}
+}
+
+func TestTargetDirRefusesMissingVolumeDir(t *testing.T) {
+	root, _ := kubeletTree(t)
+	if _, err := TargetDir(root, testPodUID, "c8s-volume-absent"); err == nil {
+		t.Fatal("resolved a volume directory that does not exist")
+	}
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -41,10 +41,13 @@ const (
 
 // InjectedEntrypoints are the argv[0] values the admission webhook injects the
 // c8s image with: get-cert for the cert sidecar, /c8s for the probe-file gate,
-// and get-secret for the fetcher. A container must be running one of these, on
-// an injected digest, to be excluded from workload matching — see
-// Handler.InjectedDigests.
-var InjectedEntrypoints = []string{"get-cert", "get-secret", "/c8s"}
+// get-secret for the fetcher, and get-volume for the volume fetcher. A
+// container must be running one of these, on an injected digest, to be excluded
+// from workload matching — see Handler.InjectedDigests.
+//
+// An entrypoint added here widens the assumption in docs/secrets.md that no
+// floor image other than c8s's carries an executable at one of these names.
+var InjectedEntrypoints = []string{"get-cert", "get-secret", "get-volume", "/c8s"}
 
 // RateKey charges a request to the sandbox its client certificate names, so a
 // rate limit bounds one workload rather than one address.


### PR DESCRIPTION
The three decisions the volume daemon makes before it touches a device. No privileged code and no server yet: this is the part that decides, separated from the part that acts.

Caller resolution derives a pod UID from the peer's cgroup path. This is new code, not a reuse of pkg/workloadclaims, which extracts 64-hex container IDs — a pod UID is a dashed UUID that regex cannot match. Both driver spellings are handled, and the systemd form's underscores are normalized to the dashes the kubelet pod directory actually uses. Candidates are shallowest-first for the same reason the container-ID resolver is: a process can only move itself deeper into cgroups it creates, so its runtime-assigned pod slice is always an ancestor. Taking the deepest would let a pod create a child cgroup named after a victim's UID and have that pod's plaintext mounted into its own directory.

The mount target is built from the resolved UID, never from the request, and resolved with openat2 under RESOLVE_BENEATH|RESOLVE_NO_SYMLINKS|RESOLVE_NO_XDEV against a dirfd, returning an O_PATH handle to mount through /proc/self/fd so nothing can be swapped between the check and the mount. Two separate attacks: the calling pod owns its own emptyDir and can plant a symlink there, which RESOLVE_NO_SYMLINKS stops; it cannot stop "..", so the name is validated as a label first.

Authorization repeats the check CDS already made when it released the blob, and that repetition is the point. The daemon is handed a key, a device name and a geometry over a socket; without its own check the first open of any name would be authorized by nothing but possession of a blob, and privileged device-mapper and mount work would follow. It resolves the sandbox's admitted containers, drops c8s's injected ones, requires exactly one matching workload entry, and requires that entry's grant to cover the path for reading — read only, since the volume is mounted read-only and a write grant says nothing about seeing the plaintext.

InjectedEntrypoints gains get-volume. Without it the injected fetcher counts as a workload container, no entry matches, and release fails for every volume-consuming pod — and since the inventory report is a high-water mark, it never recovers for that pod's life. The authorization test caught this.