### PR TITLE
feat(volumed): open volumes and serve the socket

### DIFF
--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -1,0 +1,263 @@
+package volumed
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+)
+
+// DeviceOps are the privileged steps. Behind an interface so the orchestration
+// and every unwind path are exercised without device-mapper.
+//
+// Each Open has a matching Close, and the orchestration calls Close for every
+// step it completed when a later one fails.
+type DeviceOps interface {
+	CryptOpen(ctx context.Context, device, mapper string, key []byte) error
+	CryptClose(ctx context.Context, mapper string) error
+	VerityOpen(ctx context.Context, dataDev, mapper string, v volume.Verity) error
+	VerityClose(ctx context.Context, mapper string) error
+	// MountRO takes the resolved target as an open handle rather than a path:
+	// the implementation mounts through /proc/self/fd so nothing can be swapped
+	// between resolving the target and using it. Unmount takes a path, because
+	// by teardown that handle is long closed.
+	MountRO(ctx context.Context, source string, target *os.File) error
+	Unmount(ctx context.Context, target string) error
+}
+
+// ErrNotAuthorized is returned both for a caller presenting the wrong key for a
+// volume already open and for one with no claim to it at all. One error for
+// both: distinguishing them would tell an unentitled pod which volumes are
+// mounted on its node.
+var ErrNotAuthorized = errors.New("volumed: not authorized for this volume")
+
+// ErrTooManyMounts reports the per-node cap. Each mount costs two device-mapper
+// devices and a mount, and every cw pod can reach the socket.
+var ErrTooManyMounts = errors.New("volumed: too many open volumes on this node")
+
+// Request is one open, after the caller has been resolved and authorized.
+type Request struct {
+	PodUID string
+	Name   string
+	Device string
+	Blob   volume.Blob
+}
+
+// mount is a live volume. The commitment is what a second caller must reproduce
+// to be handed the same mapping.
+type mount struct {
+	podUID     string
+	name       string
+	commitment [sha256.Size]byte
+	cryptDev   string
+	verityDev  string
+	target     string
+}
+
+// Opener opens volumes and remembers what it has open.
+type Opener struct {
+	Ops DeviceOps
+	// KubeletRoot is where kubelet keeps pod directories.
+	KubeletRoot string
+	// MaxMounts caps live volumes; zero means DefaultMaxMounts.
+	MaxMounts int
+
+	mu     sync.Mutex
+	mounts map[string]*mount
+}
+
+// DefaultMaxMounts bounds live volumes when MaxMounts is unset.
+const DefaultMaxMounts = 64
+
+// Open makes the volume readable at the calling pod's mount target, and is
+// idempotent for a caller repeating an identical request — which a restarted
+// sidecar does, since kubelet restarts it for the pod's life.
+//
+// A request naming a volume already open must present the same key and root
+// hash. Without that check the volume *name* would be the credential, and a
+// name is a label in a host-written annotation: any pod reaching the socket
+// would be handed the plaintext once one entitled pod had opened it.
+func (o *Opener) Open(ctx context.Context, req Request) error {
+	key, err := req.Blob.DecodeKey()
+	if err != nil {
+		return err
+	}
+	defer zero(key)
+	if err := req.Blob.Validate(); err != nil {
+		return err
+	}
+	if !volumeNameRE.MatchString(req.Name) {
+		return fmt.Errorf("volumed: volume name %q is not a dns-1123 label", req.Name)
+	}
+
+	commitment := commitmentFor(key, req.Blob.Verity.RootHash)
+
+	o.mu.Lock()
+	if o.mounts == nil {
+		o.mounts = map[string]*mount{}
+	}
+	if existing, ok := o.mounts[mountKey(req.PodUID, req.Name)]; ok {
+		o.mu.Unlock()
+		if subtle.ConstantTimeCompare(existing.commitment[:], commitment[:]) != 1 {
+			return ErrNotAuthorized
+		}
+		return nil
+	}
+	if len(o.mounts) >= o.maxMounts() {
+		o.mu.Unlock()
+		return ErrTooManyMounts
+	}
+	o.mu.Unlock()
+
+	m, err := o.open(ctx, req, key, commitment)
+	if err != nil {
+		return err
+	}
+
+	// A concurrent identical request may have won the race; keep one mapping
+	// and tear the loser down outside the lock.
+	o.mu.Lock()
+	existing, lost := o.mounts[mountKey(req.PodUID, req.Name)]
+	if !lost {
+		o.mounts[mountKey(req.PodUID, req.Name)] = m
+	}
+	o.mu.Unlock()
+	if !lost {
+		return nil
+	}
+	o.teardown(ctx, m)
+	if subtle.ConstantTimeCompare(existing.commitment[:], commitment[:]) != 1 {
+		return ErrNotAuthorized
+	}
+	return nil
+}
+
+// open runs the privileged steps, undoing everything it completed if a later
+// step fails. A half-open volume leaves a device-mapper target holding the key
+// in kernel memory with nothing owning it.
+func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [sha256.Size]byte) (*mount, error) {
+	target, err := TargetDir(o.KubeletRoot, req.PodUID, req.Name)
+	if err != nil {
+		return nil, err
+	}
+	defer target.Close()
+
+	var undo []func()
+	fail := func(err error) (*mount, error) {
+		for i := len(undo) - 1; i >= 0; i-- {
+			undo[i]()
+		}
+		return nil, err
+	}
+
+	cryptMapper := mapperName("crypt", req.PodUID, req.Name)
+	if err := o.Ops.CryptOpen(ctx, req.Device, cryptMapper, key); err != nil {
+		return fail(fmt.Errorf("volumed: open dm-crypt: %w", err))
+	}
+	undo = append(undo, func() { _ = o.Ops.CryptClose(ctx, cryptMapper) })
+
+	verityMapper := mapperName("verity", req.PodUID, req.Name)
+	if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, req.Blob.Verity); err != nil {
+		return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
+	}
+	undo = append(undo, func() { _ = o.Ops.VerityClose(ctx, verityMapper) })
+
+	if err := o.Ops.MountRO(ctx, devPath(verityMapper), target); err != nil {
+		return fail(fmt.Errorf("volumed: mount: %w", err))
+	}
+
+	return &mount{
+		podUID:     req.PodUID,
+		name:       req.Name,
+		commitment: commitment,
+		cryptDev:   cryptMapper,
+		verityDev:  verityMapper,
+		target:     target.Name(),
+	}, nil
+}
+
+// Close tears down one volume. Idempotent: a volume already gone is not an
+// error, because teardown races kubelet removing the pod directory.
+func (o *Opener) Close(ctx context.Context, podUID, name string) {
+	o.mu.Lock()
+	m, ok := o.mounts[mountKey(podUID, name)]
+	if ok {
+		delete(o.mounts, mountKey(podUID, name))
+	}
+	o.mu.Unlock()
+	if ok {
+		o.teardown(ctx, m)
+	}
+}
+
+// ClosePod tears down every volume a pod holds, for when the pod goes away.
+func (o *Opener) ClosePod(ctx context.Context, podUID string) {
+	o.mu.Lock()
+	var doomed []*mount
+	for k, m := range o.mounts {
+		if m.podUID == podUID {
+			doomed = append(doomed, m)
+			delete(o.mounts, k)
+		}
+	}
+	o.mu.Unlock()
+	for _, m := range doomed {
+		o.teardown(ctx, m)
+	}
+}
+
+// teardown unwinds in reverse and does not stop at the first failure: the
+// device-mapper targets hold the key, so a failed unmount must not leave them
+// behind.
+func (o *Opener) teardown(ctx context.Context, m *mount) {
+	_ = o.Ops.Unmount(ctx, m.target)
+	_ = o.Ops.VerityClose(ctx, m.verityDev)
+	_ = o.Ops.CryptClose(ctx, m.cryptDev)
+}
+
+// Len reports live volumes, for metrics and tests.
+func (o *Opener) Len() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return len(o.mounts)
+}
+
+func (o *Opener) maxMounts() int {
+	if o.MaxMounts > 0 {
+		return o.MaxMounts
+	}
+	return DefaultMaxMounts
+}
+
+// commitmentFor binds a mapping to the exact key and root hash that opened it.
+func commitmentFor(key []byte, rootHash string) [sha256.Size]byte {
+	h := sha256.New()
+	h.Write(key)
+	h.Write([]byte(rootHash))
+	var out [sha256.Size]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+func mountKey(podUID, name string) string { return podUID + "/" + name }
+
+// mapperName is scoped by pod so two pods opening the same volume get their own
+// mappings, and one pod's teardown cannot remove another's.
+func mapperName(kind, podUID, name string) string {
+	return fmt.Sprintf("c8s-%s-%s-%s", kind, podUID, name)
+}
+
+func devPath(mapper string) string { return "/dev/mapper/" + mapper }
+
+// zero best-effort clears a key buffer. The blob arrived as JSON, so copies
+// exist that cannot be reached; this clears the one that was used.
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -1,0 +1,424 @@
+package volumed
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+)
+
+// fakeOps records every privileged call and can be told to fail one step.
+type fakeOps struct {
+	mu     sync.Mutex
+	calls  []string
+	failOn string
+
+	cryptOpen, verityOpen, mounted map[string]bool
+}
+
+func newOps() *fakeOps {
+	return &fakeOps{
+		cryptOpen:  map[string]bool{},
+		verityOpen: map[string]bool{},
+		mounted:    map[string]bool{},
+	}
+}
+
+func (f *fakeOps) record(op string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, op)
+	if f.failOn == op {
+		return errors.New(op + " failed")
+	}
+	return nil
+}
+
+func (f *fakeOps) CryptOpen(_ context.Context, _, mapper string, key []byte) error {
+	if len(key) != volume.KeyBytes {
+		return errors.New("wrong key length")
+	}
+	if err := f.record("CryptOpen"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cryptOpen[mapper] = true
+	return nil
+}
+
+func (f *fakeOps) CryptClose(_ context.Context, mapper string) error {
+	if err := f.record("CryptClose"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.cryptOpen, mapper)
+	return nil
+}
+
+func (f *fakeOps) VerityOpen(_ context.Context, _, mapper string, _ volume.Verity) error {
+	if err := f.record("VerityOpen"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.verityOpen[mapper] = true
+	return nil
+}
+
+func (f *fakeOps) VerityClose(_ context.Context, mapper string) error {
+	if err := f.record("VerityClose"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.verityOpen, mapper)
+	return nil
+}
+
+func (f *fakeOps) MountRO(_ context.Context, _ string, target *os.File) error {
+	if err := f.record("MountRO"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	// The kernel resolves /proc/self/fd/N to the directory it names, so the
+	// mount lands at the real path — which is what teardown unmounts.
+	f.mounted[target.Name()] = true
+	return nil
+}
+
+func (f *fakeOps) Unmount(_ context.Context, target string) error {
+	if err := f.record("Unmount"); err != nil {
+		return err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.mounted, target)
+	return nil
+}
+
+// leaked reports device-mapper targets or mounts left behind. A leaked crypt
+// target holds the key in kernel memory with nothing owning it.
+func (f *fakeOps) leaked() (int, int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.cryptOpen), len(f.verityOpen), len(f.mounted)
+}
+
+func (f *fakeOps) sequence() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return strings.Join(f.calls, ",")
+}
+
+func testOpener(t *testing.T, ops DeviceOps) *Opener {
+	t.Helper()
+	root, base := kubeletTree(t)
+	if err := os.Mkdir(filepath.Join(base, "weights"), 0o755); err != nil {
+		t.Fatalf("mkdir volume dir: %v", err)
+	}
+	return &Opener{Ops: ops, KubeletRoot: root}
+}
+
+func testRequest(t *testing.T) Request {
+	t.Helper()
+	blob, err := volume.NewBlob(volumeKey(), volume.Verity{
+		RootHash:   strings.Repeat("ab", 32),
+		Salt:       strings.Repeat("cd", 16),
+		DataBlocks: 4,
+		HashOffset: 4 * volume.VerityBlockSize,
+	})
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	return Request{PodUID: testPodUID, Name: "weights", Device: "/dev/disk/by-id/virtio-c8s-vol-weights", Blob: blob}
+}
+
+func volumeKey() []byte {
+	k := make([]byte, volume.KeyBytes)
+	for i := range k {
+		k[i] = byte(i)
+	}
+	return k
+}
+
+func TestOpenRunsTheStepsInOrder(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+		t.Fatalf("sequence = %q", got)
+	}
+	if o.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want 1", o.Len())
+	}
+}
+
+// Every step that completed must be undone when a later one fails, or the
+// device-mapper targets are left holding the key with no owner.
+func TestOpenUnwindsEveryCompletedStepOnFailure(t *testing.T) {
+	for _, tc := range []struct{ failOn, wantSeq string }{
+		{"CryptOpen", "CryptOpen"},
+		{"VerityOpen", "CryptOpen,VerityOpen,CryptClose"},
+		{"MountRO", "CryptOpen,VerityOpen,MountRO,VerityClose,CryptClose"},
+	} {
+		ops := newOps()
+		ops.failOn = tc.failOn
+		o := testOpener(t, ops)
+
+		if err := o.Open(t.Context(), testRequest(t)); err == nil {
+			t.Fatalf("%s: open succeeded despite failure", tc.failOn)
+		}
+		if got := ops.sequence(); got != tc.wantSeq {
+			t.Errorf("%s: sequence = %q, want %q", tc.failOn, got, tc.wantSeq)
+		}
+		if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+			t.Errorf("%s: leaked crypt=%d verity=%d mounts=%d", tc.failOn, c, v, m)
+		}
+		if o.Len() != 0 {
+			t.Errorf("%s: a failed open was recorded as a mount", tc.failOn)
+		}
+	}
+}
+
+// kubelet restarts a native sidecar for the pod's life, so it re-sends its
+// request; an identical one must not open a second mapping.
+func TestOpenIsIdempotentForAnIdenticalRequest(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testRequest(t)
+
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("repeat open: %v", err)
+	}
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+		t.Fatalf("repeat re-ran privileged steps: %q", got)
+	}
+	if o.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want 1", o.Len())
+	}
+}
+
+// Without this the volume NAME is the credential — and a name is a label in a
+// host-written annotation, so any pod reaching the socket would be handed the
+// plaintext once one entitled pod had opened it.
+func TestOpenRefusesAWrongKeyForAnOpenVolume(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	other := testRequest(t)
+	wrong := make([]byte, volume.KeyBytes)
+	blob, err := volume.NewBlob(wrong, other.Blob.Verity)
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	other.Blob = blob
+
+	if err := o.Open(t.Context(), other); !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("got %v, want ErrNotAuthorized", err)
+	}
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+		t.Fatalf("a refused caller reached the privileged steps: %q", got)
+	}
+}
+
+// The root hash is half the commitment: same key, different integrity anchor is
+// a different volume.
+func TestOpenRefusesADifferentRootHashForAnOpenVolume(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testRequest(t)
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	other := testRequest(t)
+	v := other.Blob.Verity
+	v.RootHash = strings.Repeat("cd", 32)
+	blob, err := volume.NewBlob(volumeKey(), v)
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	other.Blob = blob
+
+	if err := o.Open(t.Context(), other); !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("got %v, want ErrNotAuthorized", err)
+	}
+}
+
+func TestOpenCapsLiveMounts(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	o.MaxMounts = 1
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	// A different pod, so it is not the idempotent path.
+	other := testRequest(t)
+	other.PodUID = "99999999-8888-7777-6666-555555555555"
+	if err := o.Open(t.Context(), other); !errors.Is(err, ErrTooManyMounts) {
+		t.Fatalf("got %v, want ErrTooManyMounts", err)
+	}
+}
+
+func TestCloseTearsDownInReverse(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testRequest(t)
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	o.Close(t.Context(), req.PodUID, req.Name)
+	if got := ops.sequence(); !strings.HasSuffix(got, "Unmount,VerityClose,CryptClose") {
+		t.Fatalf("teardown order = %q", got)
+	}
+	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("leaked crypt=%d verity=%d mounts=%d", c, v, m)
+	}
+	if o.Len() != 0 {
+		t.Fatal("mount still recorded after close")
+	}
+}
+
+// Teardown races kubelet removing the pod directory, so closing something
+// already gone is not an error.
+func TestCloseIsIdempotent(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testRequest(t)
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	o.Close(t.Context(), req.PodUID, req.Name)
+	before := ops.sequence()
+	o.Close(t.Context(), req.PodUID, req.Name)
+	if ops.sequence() != before {
+		t.Fatal("closing an absent volume issued more privileged calls")
+	}
+}
+
+// A failed unmount must not stop the device-mapper targets being removed: they
+// are what holds the key.
+func TestTeardownContinuesPastAFailedUnmount(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testRequest(t)
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	ops.failOn = "Unmount"
+
+	o.Close(t.Context(), req.PodUID, req.Name)
+	if c, v, _ := ops.leaked(); c != 0 || v != 0 {
+		t.Fatalf("a failed unmount left crypt=%d verity=%d behind", c, v)
+	}
+}
+
+func TestClosePodTearsDownEveryVolumeItHolds(t *testing.T) {
+	ops := newOps()
+	root, base := kubeletTree(t)
+	for _, n := range []string{"weights", "datasets"} {
+		if err := os.Mkdir(filepath.Join(base, n), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", n, err)
+		}
+	}
+	o := &Opener{Ops: ops, KubeletRoot: root}
+
+	for _, n := range []string{"weights", "datasets"} {
+		req := testRequest(t)
+		req.Name = n
+		if err := o.Open(t.Context(), req); err != nil {
+			t.Fatalf("open %s: %v", n, err)
+		}
+	}
+	if o.Len() != 2 {
+		t.Fatalf("opener holds %d mounts, want 2", o.Len())
+	}
+
+	o.ClosePod(t.Context(), testPodUID)
+	if o.Len() != 0 {
+		t.Fatalf("opener holds %d mounts after pod teardown", o.Len())
+	}
+	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("leaked crypt=%d verity=%d mounts=%d", c, v, m)
+	}
+}
+
+func TestOpenRejectsMalformedRequests(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+
+	bad := testRequest(t)
+	bad.Name = "Weights"
+	if err := o.Open(t.Context(), bad); err == nil {
+		t.Error("accepted a name that is not a label")
+	}
+
+	bad = testRequest(t)
+	bad.Blob.Verity.RootHash = "short"
+	if err := o.Open(t.Context(), bad); err == nil {
+		t.Error("accepted a blob that fails validation")
+	}
+
+	bad = testRequest(t)
+	bad.Blob.Key = "not base64"
+	if err := o.Open(t.Context(), bad); err == nil {
+		t.Error("accepted a blob with an unusable key")
+	}
+
+	if ops.sequence() != "" {
+		t.Errorf("a malformed request reached the privileged steps: %q", ops.sequence())
+	}
+}
+
+// Two pods opening the same volume get their own mappings, so one pod's
+// teardown cannot remove the other's.
+func TestMapperNamesAreScopedPerPod(t *testing.T) {
+	a := mapperName("crypt", testPodUID, "weights")
+	b := mapperName("crypt", "99999999-8888-7777-6666-555555555555", "weights")
+	if a == b {
+		t.Fatal("two pods share a mapper name")
+	}
+	if !strings.HasPrefix(a, "c8s-crypt-") {
+		t.Fatalf("mapper name = %q", a)
+	}
+}
+
+func TestCommitmentCoversKeyAndRootHash(t *testing.T) {
+	key := volumeKey()
+	base := commitmentFor(key, "aa")
+	if commitmentFor(key, "bb") == base {
+		t.Error("commitment ignores the root hash")
+	}
+	other := make([]byte, volume.KeyBytes)
+	if commitmentFor(other, "aa") == base {
+		t.Error("commitment ignores the key")
+	}
+}
+
+func TestZeroClearsTheBuffer(t *testing.T) {
+	b := []byte{1, 2, 3}
+	zero(b)
+	for i, v := range b {
+		if v != 0 {
+			t.Fatalf("byte %d = %d", i, v)
+		}
+	}
+}

--- a/internal/cmds/volumed/server.go
+++ b/internal/cmds/volumed/server.go
@@ -1,0 +1,232 @@
+package volumed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// VolumePath is the route the fetcher sidecar posts to.
+const VolumePath = "/volume"
+
+// maxRequestBytes bounds a request body. It carries one key blob.
+const maxRequestBytes = 64 << 10
+
+// maxInFlightPerPod bounds concurrent opens from one pod, so a caller looping on
+// the socket cannot occupy every worker.
+const maxInFlightPerPod = 2
+
+// Timeouts are this server's own, deliberately not the inventory's. Opening a
+// volume reads from a host-backed device, which the host can make arbitrarily
+// slow; a bound short enough for the inventory's token route would cut the
+// response while the privileged work carried on, and the sidecar would retry
+// into a duplicate request.
+const (
+	readTimeout  = 30 * time.Second
+	writeTimeout = 5 * time.Minute
+	idleTimeout  = 2 * time.Minute
+)
+
+// OpenRequest is the wire body. It carries no identity: which pod is asking
+// comes from the kernel, and a field claiming otherwise would be the caller
+// naming itself.
+type OpenRequest struct {
+	// Name selects the volume, and with it the device the agent will open.
+	Name string `json:"name"`
+	// Path is the secret-store path the blob came from, checked against the
+	// caller's grant.
+	Path string      `json:"path"`
+	Blob volume.Blob `json:"blob"`
+}
+
+// Identity resolves a connected process to the pod it belongs to.
+type Identity interface {
+	Resolve(peer workloadclaims.Peer) (podUID, sandboxID string, err error)
+}
+
+// KernelIdentity binds a caller using only what the kernel and the inventory
+// say. ProcRoot is normally "/proc".
+type KernelIdentity struct {
+	ProcRoot  string
+	Sandboxes workloadclaims.SandboxResolver
+}
+
+// Resolve returns the caller's pod UID and sandbox ID.
+//
+// Both come from the same peer credentials, and the shallowest pod UID is
+// taken for the reason PodUIDCandidatesForPID documents. IsAlive is rechecked
+// afterwards so a process that exited between the credential read and the
+// /proc lookup cannot have its PID reused by another pod's container.
+func (k KernelIdentity) Resolve(peer workloadclaims.Peer) (string, string, error) {
+	if k.Sandboxes == nil {
+		return "", "", fmt.Errorf("volumed: no sandbox resolver configured")
+	}
+	sandboxID, err := k.Sandboxes.SandboxForPeer(peer)
+	if err != nil {
+		return "", "", fmt.Errorf("volumed: resolve sandbox: %w", err)
+	}
+	uids, err := PodUIDCandidatesForPID(k.procRoot(), peer.PID())
+	if err != nil {
+		return "", "", err
+	}
+	if !peer.IsAlive() {
+		return "", "", fmt.Errorf("volumed: caller exited during resolution")
+	}
+	return uids[0], sandboxID, nil
+}
+
+func (k KernelIdentity) procRoot() string {
+	if k.ProcRoot != "" {
+		return k.ProcRoot
+	}
+	return "/proc"
+}
+
+// Devices maps a volume name to the block device carrying it.
+type Devices interface {
+	Device(name string) (string, error)
+}
+
+// Server serves VolumePath on a unix socket.
+type Server struct {
+	Identity   Identity
+	Authorizer Authorizer
+	Opener     *Opener
+	Devices    Devices
+	Logger     *slog.Logger
+
+	mu       sync.Mutex
+	inFlight map[string]int
+}
+
+func (s *Server) logger() *slog.Logger {
+	if s.Logger != nil {
+		return s.Logger
+	}
+	return slog.Default()
+}
+
+// Serve runs the server on l until ctx is done.
+//
+// The listener is this server's own. Sharing the inventory's would put a
+// wedged volume open behind the same timeouts and the same accept loop as
+// sandbox-token issuance, which every confidential pod depends on to start.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	mux := http.NewServeMux()
+	mux.Handle("POST "+VolumePath, http.HandlerFunc(s.handleOpen))
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: readTimeout,
+		ReadTimeout:       readTimeout,
+		WriteTimeout:      writeTimeout,
+		IdleTimeout:       idleTimeout,
+		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+			return context.WithValue(ctx, connKey{}, c)
+		},
+	}
+	go func() {
+		<-ctx.Done()
+		shutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdown)
+	}()
+	if err := srv.Serve(l); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+type connKey struct{}
+
+func (s *Server) handleOpen(w http.ResponseWriter, r *http.Request) {
+	conn, _ := r.Context().Value(connKey{}).(net.Conn)
+	peer := workloadclaims.PeerFromConn(conn)
+	defer peer.Close()
+
+	podUID, sandboxID, err := s.Identity.Resolve(peer)
+	if err != nil {
+		s.logger().Warn("volume request rejected", "reason", err)
+		http.Error(w, "caller could not be resolved", http.StatusForbidden)
+		return
+	}
+
+	var req OpenRequest
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	release, ok := s.acquire(podUID)
+	if !ok {
+		http.Error(w, "too many concurrent requests", http.StatusTooManyRequests)
+		return
+	}
+	defer release()
+
+	// The blob already passed CDS's release decision, and this repeats it. The
+	// caller hands over a key, a name and a geometry; without a check of its
+	// own the first open of any name is authorized by nothing.
+	if err := s.Authorizer.Authorize(r.Context(), sandboxID, req.Path); err != nil {
+		s.logger().Warn("volume request denied", "sandbox", sandboxID, "path", req.Path, "reason", err)
+		http.Error(w, "not authorized for this volume", http.StatusForbidden)
+		return
+	}
+
+	device, err := s.Devices.Device(req.Name)
+	if err != nil {
+		s.logger().Warn("volume device unavailable", "name", req.Name, "reason", err)
+		http.Error(w, "volume device is not present on this node", http.StatusNotFound)
+		return
+	}
+
+	err = s.Opener.Open(r.Context(), Request{
+		PodUID: podUID, Name: req.Name, Device: device, Blob: req.Blob,
+	})
+	switch {
+	case err == nil:
+		s.logger().Info("volume opened", "pod", podUID, "name", req.Name, "path", req.Path)
+		w.WriteHeader(http.StatusNoContent)
+	case errors.Is(err, ErrNotAuthorized):
+		// Same answer as a failed grant check: telling a caller that a volume
+		// is open but its key is wrong would enumerate what is mounted here.
+		s.logger().Warn("volume request denied", "pod", podUID, "name", req.Name, "reason", err)
+		http.Error(w, "not authorized for this volume", http.StatusForbidden)
+	case errors.Is(err, ErrTooManyMounts):
+		http.Error(w, "too many open volumes on this node", http.StatusInsufficientStorage)
+	default:
+		s.logger().Error("volume open failed", "pod", podUID, "name", req.Name, "error", err)
+		http.Error(w, "could not open the volume", http.StatusInternalServerError)
+	}
+}
+
+// acquire bounds concurrent opens per pod.
+func (s *Server) acquire(podUID string) (func(), bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.inFlight == nil {
+		s.inFlight = map[string]int{}
+	}
+	if s.inFlight[podUID] >= maxInFlightPerPod {
+		return nil, false
+	}
+	s.inFlight[podUID]++
+	return func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.inFlight[podUID]--; s.inFlight[podUID] <= 0 {
+			delete(s.inFlight, podUID)
+		}
+	}, true
+}

--- a/internal/cmds/volumed/server_test.go
+++ b/internal/cmds/volumed/server_test.go
@@ -1,0 +1,334 @@
+package volumed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+type fakeIdentity struct {
+	podUID, sandboxID string
+	err               error
+}
+
+func (f fakeIdentity) Resolve(workloadclaims.Peer) (string, string, error) {
+	return f.podUID, f.sandboxID, f.err
+}
+
+type fakeDevices struct {
+	err error
+}
+
+func (f fakeDevices) Device(name string) (string, error) {
+	if f.err != nil {
+		return "", f.err
+	}
+	return "/dev/disk/by-id/virtio-c8s-vol-" + name, nil
+}
+
+// serverFixture wires a server over a real unix socket, so the connection and
+// peer-credential plumbing is exercised rather than stubbed.
+type serverFixture struct {
+	client *http.Client
+	ops    *fakeOps
+	opener *Opener
+	srv    *Server
+}
+
+func newServerFixture(t *testing.T, ident Identity, grant *pkgallowlist.SecretsPolicy) *serverFixture {
+	t.Helper()
+	ops := newOps()
+	opener := testOpener(t, ops)
+	srv := &Server{
+		Identity:   ident,
+		Authorizer: authorizerFor(runningApp(), grant),
+		Opener:     opener,
+		Devices:    fakeDevices{},
+	}
+
+	sock := filepath.Join(t.TempDir(), "volumed.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = srv.Serve(ctx, l)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+		},
+	}}
+	return &serverFixture{client: client, ops: ops, opener: opener, srv: srv}
+}
+
+func (f *serverFixture) post(t *testing.T, body any) *http.Response {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	resp, err := f.client.Post("http://volumed"+VolumePath, "application/json", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func openBody(t *testing.T) OpenRequest {
+	t.Helper()
+	req := testRequest(t)
+	return OpenRequest{Name: req.Name, Path: storePath, Blob: req.Blob}
+}
+
+func resolvedIdentity() fakeIdentity {
+	return fakeIdentity{podUID: testPodUID, sandboxID: sandboxID}
+}
+
+func TestServerOpensForAnAuthorizedCaller(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	resp := f.post(t, openBody(t))
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+	if f.opener.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want 1", f.opener.Len())
+	}
+}
+
+// The grant is checked before anything privileged happens, so a caller with no
+// claim never reaches device-mapper.
+func TestServerRefusesUngrantedPathBeforeOpening(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant("/tenant-b/volumes/other"))
+	resp := f.post(t, openBody(t))
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if f.ops.sequence() != "" {
+		t.Fatalf("an unauthorized request reached the privileged steps: %q", f.ops.sequence())
+	}
+	if f.opener.Len() != 0 {
+		t.Fatal("an unauthorized request produced a mount")
+	}
+}
+
+// A caller the kernel cannot place in a pod is refused outright.
+func TestServerRefusesUnresolvableCaller(t *testing.T) {
+	f := newServerFixture(t, fakeIdentity{err: errors.New("no pod cgroup")}, readGrant(storePath))
+	resp := f.post(t, openBody(t))
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	if f.ops.sequence() != "" {
+		t.Fatalf("an unresolved caller reached the privileged steps: %q", f.ops.sequence())
+	}
+}
+
+// A wrong key for an already-open volume answers exactly as a failed grant
+// check does; a distinct status would tell an unentitled pod what is mounted.
+func TestServerGivesOneAnswerForBothRefusals(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("first open: status %d", got)
+	}
+
+	body := openBody(t)
+	blob, err := volume.NewBlob(make([]byte, volume.KeyBytes), body.Blob.Verity)
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	body.Blob = blob
+
+	wrongKey := f.post(t, body).StatusCode
+
+	g := newServerFixture(t, resolvedIdentity(), readGrant("/elsewhere"))
+	ungranted := g.post(t, openBody(t)).StatusCode
+
+	if wrongKey != ungranted {
+		t.Fatalf("wrong key answers %d but an ungranted path answers %d", wrongKey, ungranted)
+	}
+}
+
+// The caller never names its own pod; a body field claiming to is rejected
+// rather than ignored.
+func TestServerRejectsUnknownRequestFields(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	raw := map[string]any{"name": "weights", "path": storePath, "pod_uid": "someone-else"}
+	resp := f.post(t, raw)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestServerReportsAMissingDevice(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	f.srv.Devices = fakeDevices{err: errors.New("no such serial")}
+	resp := f.post(t, openBody(t))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+	if f.ops.sequence() != "" {
+		t.Fatalf("a missing device reached the privileged steps: %q", f.ops.sequence())
+	}
+}
+
+func TestServerReportsAFailedOpen(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	f.ops.failOn = "CryptOpen"
+	resp := f.post(t, openBody(t))
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if c, v, m := f.ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("a failed open leaked crypt=%d verity=%d mounts=%d", c, v, m)
+	}
+}
+
+// A restarted sidecar re-sends its request; the repeat must not open a second
+// mapping or fail.
+func TestServerIsIdempotentForARepeatedRequest(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	for i := 0; i < 3; i++ {
+		if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+			t.Fatalf("attempt %d: status %d", i, got)
+		}
+	}
+	if f.opener.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want 1", f.opener.Len())
+	}
+	if got := f.ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+		t.Fatalf("repeats re-ran privileged steps: %q", got)
+	}
+}
+
+// Only POST is served; the route exists for one verb.
+func TestServerServesOnlyPost(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	resp, err := f.client.Get("http://volumed" + VolumePath)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNoContent {
+		t.Fatal("GET was served")
+	}
+}
+
+func TestServerBoundsTheRequestBody(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity(), readGrant(storePath))
+	body := openBody(t)
+	body.Path = "/" + strings.Repeat("a", maxRequestBytes)
+	if got := f.post(t, body).StatusCode; got != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d for an oversized body", got, http.StatusBadRequest)
+	}
+}
+
+func TestAcquireBoundsConcurrentOpensPerPod(t *testing.T) {
+	s := &Server{}
+	var releases []func()
+	for i := 0; i < maxInFlightPerPod; i++ {
+		release, ok := s.acquire(testPodUID)
+		if !ok {
+			t.Fatalf("slot %d refused below the cap", i)
+		}
+		releases = append(releases, release)
+	}
+	if _, ok := s.acquire(testPodUID); ok {
+		t.Fatal("acquired past the per-pod cap")
+	}
+	// A different pod has its own budget.
+	if _, ok := s.acquire("99999999-8888-7777-6666-555555555555"); !ok {
+		t.Fatal("one pod's load blocked another")
+	}
+	for _, r := range releases {
+		r()
+	}
+	if _, ok := s.acquire(testPodUID); !ok {
+		t.Fatal("slots were not released")
+	}
+}
+
+func TestAcquireIsRaceFree(t *testing.T) {
+	s := &Server{}
+	var wg sync.WaitGroup
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if release, ok := s.acquire(testPodUID); ok {
+				release()
+			}
+		}()
+	}
+	wg.Wait()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.inFlight) != 0 {
+		t.Fatalf("in-flight table leaked %d entries", len(s.inFlight))
+	}
+}
+
+func TestKernelIdentityNeedsASandboxResolver(t *testing.T) {
+	if _, _, err := (KernelIdentity{}).Resolve(workloadclaims.PeerForPID(1)); err == nil {
+		t.Fatal("resolved with no sandbox resolver")
+	}
+}
+
+func TestKernelIdentityTakesTheShallowestPodUID(t *testing.T) {
+	root := procWith(t, 4242, "0::/kubepods.slice/kubepods-burstable.slice/"+
+		"kubepods-burstable-pod3f4a1b2c_5d6e_7f80_9a0b_1c2d3e4f5061.slice/"+
+		"cri-containerd-aaaabbbbccccddddeeeeffff00001111aaaabbbbccccddddeeeeffff00001111.scope/"+
+		"pod99999999-8888-7777-6666-555555555555/nested\n")
+
+	k := KernelIdentity{ProcRoot: root, Sandboxes: fakeSandboxes{id: sandboxID}}
+	podUID, gotSandbox, err := k.Resolve(workloadclaims.PeerForPID(4242))
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if podUID != testPodUID {
+		t.Fatalf("pod uid = %q, want the runtime-assigned %q", podUID, testPodUID)
+	}
+	if gotSandbox != sandboxID {
+		t.Fatalf("sandbox = %q", gotSandbox)
+	}
+}
+
+func TestKernelIdentitySurfacesSandboxFailure(t *testing.T) {
+	k := KernelIdentity{ProcRoot: t.TempDir(), Sandboxes: fakeSandboxes{err: errors.New("unknown")}}
+	if _, _, err := k.Resolve(workloadclaims.PeerForPID(1)); err == nil {
+		t.Fatal("resolved despite an unknown sandbox")
+	}
+}
+
+type fakeSandboxes struct {
+	id  string
+	err error
+}
+
+func (f fakeSandboxes) SandboxForPeer(workloadclaims.Peer) (string, error) {
+	return f.id, f.err
+}
+
+func (f fakeSandboxes) DigestsForSandbox(string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
+	return nil, nil, false, nil
+}

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -203,6 +203,12 @@ func peerFromRequest(r *http.Request) Peer {
 	return peerFrom(conn)
 }
 
+// PeerFromConn captures the peer credentials of a unix connection, for a server
+// outside this package that binds its callers the same way. Exported so that
+// server does not reimplement SO_PEERCRED; the returned Peer's pidfd must be
+// released with Close.
+func PeerFromConn(c net.Conn) Peer { return peerFrom(c) }
+
 // maxSandboxRequestBytes bounds a SandboxPath request body; it carries one
 // PKIX public key.
 const maxSandboxRequestBytes = 64 << 10


### PR DESCRIPTION
  Opener drives dm-crypt, dm-verity and the read-only mount behind an interface,
  undoing every completed step when a later one fails: a half-open volume leaves
  a dm-crypt target holding the key in kernel memory with no owner. Teardown does
  not stop at a failed unmount, for the same reason.
  
  Reusing an open mapping requires reproducing SHA-256(key || root_hash),
  compared in constant time. Without it the volume name is the credential, and a
  name is a label in a host-written annotation. An identical repeat is idempotent,
  since kubelet restarts a native sidecar for the pod's life.
  
  MountRO takes the target as an open handle, not a path: the mount goes through
  /proc/self/fd, while teardown must unmount by path once that handle is closed.
  
  Server takes identity from kernel peer credentials and never from the body;
  DisallowUnknownFields rejects a field claiming otherwise. It runs on its own
  listener, because the inventory's 10s write timeout would cut the response while
  a slow device open continued, and nothing here shares a lock with an NRI path.
  workloadclaims gains PeerFromConn so this is not a second copy of SO_PEERCRED.
  
  A wrong key for an open volume and a path outside the grant answer identically,
  so a refusal does not enumerate what is mounted on the node.
