### PR TITLE
feat(tls-lb): publish the operator /secrets surface through the frontdoor

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -144,6 +144,12 @@ c8s secrets put /tenant-a/hf-token --url "$CDS" --measurements "$M" \
   --operator-key operator.key < token.txt
 ```
 
+The default chart also publishes this surface through tls-lb
+(`tlsLb.secrets.enabled`), the same attested front door as `/allowlist`, so
+`--url` can be the tls-lb URL. Workload secret reads authenticate with the
+pod's mesh leaf, which never crosses that hop — the public route can only
+carry operator-key-signed writes.
+
 The value is read from stdin or `--from-file`, and the bytes are stored exactly
 as read — a trailing newline is part of the value. The byte count is printed to
 confirm which one was sent.

--- a/internal/cmds/allowlistproxy/cmd.go
+++ b/internal/cmds/allowlistproxy/cmd.go
@@ -161,6 +161,8 @@ func newRouter(proxy http.Handler) http.Handler {
 	})
 	mux.Handle("/allowlist", proxy)
 	mux.Handle("/allowlist/", proxy)
+	mux.Handle("/secrets", proxy)
+	mux.Handle("/secrets/", proxy)
 	return mux
 }
 

--- a/internal/cmds/allowlistproxy/cmd_test.go
+++ b/internal/cmds/allowlistproxy/cmd_test.go
@@ -117,7 +117,7 @@ func TestProxyPreservesAuthorizedRequests(t *testing.T) {
 	}
 }
 
-func TestProxyExposesOnlyAllowlistPaths(t *testing.T) {
+func TestProxyExposesOnlyControlPlanePaths(t *testing.T) {
 	hits := 0
 	router := newRouter(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		hits++
@@ -131,6 +131,9 @@ func TestProxyExposesOnlyAllowlistPaths(t *testing.T) {
 		{path: "/allowlist", want: http.StatusNoContent},
 		{path: "/allowlist/digests", want: http.StatusNoContent},
 		{path: "/allowlisted", want: http.StatusNotFound},
+		{path: "/secrets", want: http.StatusNoContent},
+		{path: "/secrets/tenant-a/db", want: http.StatusNoContent},
+		{path: "/secretstore", want: http.StatusNotFound},
 		{path: "/", want: http.StatusNotFound},
 	} {
 		req := httptest.NewRequest(http.MethodGet, tc.path, nil)
@@ -140,8 +143,8 @@ func TestProxyExposesOnlyAllowlistPaths(t *testing.T) {
 			t.Errorf("%s status = %d, want %d", tc.path, rec.Code, tc.want)
 		}
 	}
-	if hits != 2 {
-		t.Fatalf("proxy hits = %d, want 2", hits)
+	if hits != 4 {
+		t.Fatalf("proxy hits = %d, want 4", hits)
 	}
 }
 

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -88,6 +88,11 @@ func (c client) put(ctx context.Context, path string, value []byte, overwrite bo
 		// CLI report a refusal for a write that landed.
 		return result{}, fmt.Errorf("cds replaced a value for a request that did not ask to: %s", path)
 	default:
+		// A 404/405 with a non-JSON body never reached CDS: it is a front
+		// door (an older tls-lb) without the /secrets route.
+		if (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed) && !json.Valid(raw) {
+			return result{}, fmt.Errorf("%s answered %d without reaching CDS: this front door does not route /secrets. Upgrade tls-lb to a chart that publishes it (tlsLb.secrets.enabled), or use a direct CDS URL via a port-forward (kubectl port-forward svc/c8s-cds 8443:8443, then --url https://localhost:8443)", c.baseURL, resp.StatusCode)
+		}
 		return result{}, fmt.Errorf("cds returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
 	}
 }

--- a/internal/cmds/secrets/put_test.go
+++ b/internal/cmds/secrets/put_test.go
@@ -146,6 +146,32 @@ func TestPutCreates(t *testing.T) {
 	}
 }
 
+// A front door without the /secrets route (an older tls-lb) answers with its
+// own HTML error page; the CLI must name the actual problem and the fixes
+// rather than dump nginx HTML.
+func TestPutNamesFrontDoorWithoutSecretsRoute(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write([]byte("<html><body><center><h1>405 Not Allowed</h1></center></body></html>"))
+	}))
+	defer srv.Close()
+	key := writeOperatorKey(t)
+
+	_, _, err := run(t, "hunter2", "put", "/tenant-a/db", "--url", srv.URL, "--insecure", "--operator-key", key)
+	if err == nil {
+		t.Fatal("put against a front door without /secrets succeeded, want error")
+	}
+	for _, want := range []string{"does not route /secrets", "port-forward svc/c8s-cds"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err.Error(), want)
+		}
+	}
+	if strings.Contains(err.Error(), "<html>") {
+		t.Errorf("error %q leaks the HTML error page", err.Error())
+	}
+}
+
 // The refusal names what is there and leaves it alone, which is the whole point
 // of asking to create before asking to replace.
 func TestPutRefusesOccupiedPathWithoutOverwrite(t *testing.T) {

--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -7,6 +7,8 @@
 {{- $upstreamTrustedCAPath := default $defaultMeshCAPath .Values.tlsLb.upstream.tls.trustedCAPath -}}
 {{- $upstreamAddress := .Values.tlsLb.upstream.address | trim -}}
 {{- $renderAllowlistRoute := eq (include "tls-lb.renderAllowlistRoute" .) "true" -}}
+{{- $renderSecretsRoute := eq (include "tls-lb.renderSecretsRoute" .) "true" -}}
+{{- $renderCDSProxy := eq (include "tls-lb.renderCDSProxy" .) "true" -}}
 {{- $allowlistProxyPort := 0 -}}
 {{- $allowlistWriteRate := 0 -}}
 {{- $allowlistWriteBurst := 0 -}}
@@ -14,7 +16,7 @@
 {{- $allowlistWriteTotalBurst := 0 -}}
 {{- $allowlistReadRate := 0 -}}
 {{- $allowlistReadBurst := 0 -}}
-{{- if $renderAllowlistRoute -}}
+{{- if $renderCDSProxy -}}
 {{- $allowlistProxyPort = include "c8s.int" .Values.tlsLb.allowlist.proxyPort | int -}}
 {{- if or (lt $allowlistProxyPort 1) (gt $allowlistProxyPort 65535) -}}
 {{- fail (printf "tlsLb.allowlist.proxyPort must be between 1 and 65535, got: %d" $allowlistProxyPort) -}}
@@ -83,14 +85,16 @@ data:
 {{- if default false .Values.tlsLb.cors.enabled }}
         {{- include "tls-lb.corsMap" . | nindent 8 }}
 {{- end }}
-{{- if $renderAllowlistRoute }}
+{{- if $renderCDSProxy }}
 
-        # Rate-limit /allowlist while nginx still has the public client IP;
-        # empty map keys are not accounted by limit_req. Mutations count per
-        # client and in aggregate (the constant-key zone guards the shared
-        # per-pod-IP CDS bucket; see docs/operator.md), reads per client;
-        # OPTIONS (CORS preflight) is exempt. The total key chains off the
-        # write key so the exempt-method list exists once.
+        # Rate-limit the control-plane routes (/allowlist, /secrets) while
+        # nginx still has the public client IP; empty map keys are not
+        # accounted by limit_req. Mutations count per client and in aggregate
+        # (the constant-key zone guards the shared per-pod-IP CDS bucket; see
+        # docs/operator.md), reads per client; OPTIONS (CORS preflight) is
+        # exempt. The total key chains off the write key so the exempt-method
+        # list exists once. Both routes share one budget: they collapse onto
+        # the same loopback proxy source and the same CDS bucket.
         map $request_method $allowlist_write_rate_key {
             default $binary_remote_addr;
             GET "";
@@ -148,12 +152,21 @@ data:
             proxy_buffer_size 16k;
             proxy_buffers 4 16k;
 
+            {{- if $renderCDSProxy }}
+            # Built-in control-plane routes. Each exact + slash-prefix pair
+            # exposes only the API subtree, not lookalike paths.
+            {{- $cdsProxyLocationArgs := dict "root" $ "proxyPort" $allowlistProxyPort "writeBurst" $allowlistWriteBurst "writeTotalBurst" $allowlistWriteTotalBurst "readBurst" $allowlistReadBurst }}
             {{- if $renderAllowlistRoute }}
-            # Built-in control-plane route. The exact + slash-prefix pair
-            # exposes only /allowlist and its API subtree, not lookalike paths.
-            {{- $allowlistLocationArgs := dict "root" $ "proxyPort" $allowlistProxyPort "writeBurst" $allowlistWriteBurst "writeTotalBurst" $allowlistWriteTotalBurst "readBurst" $allowlistReadBurst }}
-            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" true "path" "/allowlist") $allowlistLocationArgs) | nindent 12 }}
-            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" false "path" "/allowlist/") $allowlistLocationArgs) | nindent 12 }}
+            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" true "path" "/allowlist") $cdsProxyLocationArgs) | nindent 12 }}
+            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" false "path" "/allowlist/") $cdsProxyLocationArgs) | nindent 12 }}
+            {{- end }}
+            {{- if $renderSecretsRoute }}
+            # Operator `c8s secrets put` surface. Workload secret reads
+            # authenticate with the pod's mesh leaf, which never crosses this
+            # hop, so only operator-key-signed writes can succeed here.
+            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" true "path" "/secrets") $cdsProxyLocationArgs) | nindent 12 }}
+            {{- include "tls-lb.allowlistLocation" (merge (dict "exact" false "path" "/secrets/") $cdsProxyLocationArgs) | nindent 12 }}
+            {{- end }}
 
             {{- end }}
             {{- range $i, $route := .Values.tlsLb.routes }}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -9,7 +9,7 @@ Recreate, silently defeating the operator's opt-out. */ -}}
 {{- $attestUsesHTTPSUpstream := and .Values.tlsLb.attest.enabled (eq .Values.tlsLb.upstream.protocol "https") -}}
 {{- $upstreamAddress := .Values.tlsLb.upstream.address -}}
 {{- $attestUpstreamServerName := default (include "tls-lb.serverNameFromAddress" $upstreamAddress) .Values.tlsLb.upstream.tls.serverName -}}
-{{- $renderAllowlistProxy := eq (include "tls-lb.renderAllowlistRoute" .) "true" -}}
+{{- $renderAllowlistProxy := eq (include "tls-lb.renderCDSProxy" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -214,8 +214,9 @@ spec:
         {{- end }}
         {{- if $renderAllowlistProxy }}
         # nginx terminates the public, tls-lb-attested connection and forwards
-        # /allowlist over pod loopback. This sidecar establishes the second
-        # trust hop: it verifies CDS's RA-TLS evidence before proxying.
+        # the /allowlist and /secrets control-plane routes over pod loopback.
+        # This sidecar establishes the second trust hop: it verifies CDS's
+        # RA-TLS evidence before proxying.
         - name: allowlist-proxy
           image: {{ include "c8s.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -177,6 +177,33 @@ both the built-in nginx locations and their loopback proxy sidecar.
 {{- end -}}
 
 {{/*
+Render the built-in /secrets route: the `c8s secrets put` operator surface,
+published through the same attested loopback proxy as /allowlist. A typed
+tlsLb.routes entry owning /secrets suppresses it, like the allowlist route.
+*/}}
+{{- define "tls-lb.renderSecretsRoute" -}}
+{{- if not (kindIs "bool" .Values.tlsLb.secrets.enabled) -}}
+{{- fail (printf "tlsLb.secrets.enabled must be a boolean; do not set it via --set-string, got: %v" .Values.tlsLb.secrets.enabled) -}}
+{{- end -}}
+{{- $found := false -}}
+{{- range $route := .Values.tlsLb.routes -}}
+{{- $path := toString (default "" $route.path) -}}
+{{- if or (eq $path "/secrets") (eq $path "/secrets/") -}}
+{{- $found = true -}}
+{{- end -}}
+{{- end -}}
+{{- and .Values.tlsLb.secrets.enabled (not $found) -}}
+{{- end -}}
+
+{{/*
+True when either built-in CDS control-plane route renders — the condition for
+the loopback proxy sidecar, its rate zones, and Local traffic policy.
+*/}}
+{{- define "tls-lb.renderCDSProxy" -}}
+{{- or (eq (include "tls-lb.renderAllowlistRoute" .) "true") (eq (include "tls-lb.renderSecretsRoute" .) "true") -}}
+{{- end -}}
+
+{{/*
 Render one half of the built-in CDS allowlist route. The caller emits an exact
 /allowlist location and a /allowlist/ prefix location so unrelated paths such
 as /allowlisted never reach the loopback proxy. proxy_pass includes $request_uri

--- a/internal/helmchart/c8s/templates/tls-lb-service.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-service.yaml
@@ -13,12 +13,12 @@ metadata:
 spec:
   type: {{ $svc.type }}
   {{- if or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort") }}
-  {{- $renderAllowlistRoute := eq (include "tls-lb.renderAllowlistRoute" .) "true" }}
-  {{- $policy := default (ternary "Local" "Cluster" $renderAllowlistRoute) $svc.externalTrafficPolicy }}
+  {{- $renderCDSProxy := eq (include "tls-lb.renderCDSProxy" .) "true" }}
+  {{- $policy := default (ternary "Local" "Cluster" $renderCDSProxy) $svc.externalTrafficPolicy }}
   {{- if not (or (eq $policy "Local") (eq $policy "Cluster")) }}
   {{- fail (printf "tlsLb.service.externalTrafficPolicy must be Local or Cluster, got: %s" $policy) }}
   {{- end }}
-  # Local (the default while the built-in /allowlist route renders) preserves
+  # Local (the default while a built-in control-plane route renders) preserves
   # the public source IP its per-client limiters key on; see values.yaml.
   externalTrafficPolicy: {{ $policy }}
   {{- end }}

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -125,7 +125,7 @@
   parsing lives with the zone rendering in tls-lb-configmap.yaml (same
   c8s.positiveInt, so either template failing first reports the same message).
 */ -}}
-{{- if and $tlsLB.enabled (eq (include "tls-lb.renderAllowlistRoute" .) "true") -}}
+{{- if and $tlsLB.enabled (eq (include "tls-lb.renderCDSProxy" .) "true") -}}
 {{- $writeRate := int (include "c8s.positiveInt" (dict "value" $tlsLB.allowlist.rateLimit.requestsPerSecond "label" "tlsLb.allowlist.rateLimit.requestsPerSecond")) -}}
 {{- $writeBurst := int (include "c8s.positiveInt" (dict "value" $tlsLB.allowlist.rateLimit.burst "label" "tlsLb.allowlist.rateLimit.burst")) -}}
 {{- $writeTotalRate := int (include "c8s.positiveInt" (dict "value" $tlsLB.allowlist.rateLimit.totalRequestsPerSecond "label" "tlsLb.allowlist.rateLimit.totalRequestsPerSecond")) -}}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1101,6 +1101,15 @@ tlsLb:
     # -- Container resources for the allowlist proxy.
     resources: {}
 
+  # -- Publish the operator `c8s secrets put` surface (/secrets) through the
+  # same attested loopback proxy and rate budget as /allowlist. Workload
+  # secret reads authenticate with the pod's mesh leaf, which never crosses
+  # this hop, so the route exposes only operator-key-signed writes. Set
+  # enabled: false to keep secret writes off the public route (a direct CDS
+  # URL still works).
+  secrets:
+    enabled: true
+
   # -- Additional path routes proxied before the default upstream backend.
   # Useful for preserving control-plane endpoints while the catch-all route
   # points at an inference backend.

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1905,10 +1905,12 @@ func TestChartTLSLBServiceType(t *testing.T) {
 		{name: "default is ClusterIP", wantType: corev1.ServiceTypeClusterIP},
 		{name: "explicit LoadBalancer", args: []string{"--set", "tlsLb.service.type=LoadBalancer"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
 		{name: "explicit NodePort", args: []string{"--set", "tlsLb.service.type=NodePort"}, wantType: corev1.ServiceTypeNodePort, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
-		// Without the built-in allowlist route there is no source-IP-keyed
-		// limiter, so the default policy must not regress reachability
-		// through nodes that do not run the tls-lb pod.
-		{name: "LoadBalancer without allowlist route", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
+		// Without either built-in control-plane route there is no
+		// source-IP-keyed limiter, so the default policy must not regress
+		// reachability through nodes that do not run the tls-lb pod.
+		{name: "LoadBalancer without control-plane routes", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false", "--set", "tlsLb.secrets.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
+		// One route alone (secrets here) still keys limiters on source IP.
+		{name: "LoadBalancer with secrets route only", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
 		{name: "explicit policy override wins", args: []string{"--set", "tlsLb.service.type=NodePort", "--set", "tlsLb.service.externalTrafficPolicy=Cluster"}, wantType: corev1.ServiceTypeNodePort, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2430,7 +2432,10 @@ func TestTLSLBAllowlistProxyPinsCDSMeasurements(t *testing.T) {
 }
 
 func TestTLSLBBuiltInAllowlistRouteCanBeDisabled(t *testing.T) {
-	out, err := helmTemplateTLSLB(t, "--set", "allowlist.enabled=false")
+	// Both control-plane routes off: the proxy sidecar and its rate zones
+	// must disappear with them (the secrets route alone keeps them alive —
+	// see TestTLSLBSecretsRouteAloneKeepsProxy).
+	out, err := helmTemplateTLSLB(t, "--set", "allowlist.enabled=false", "--set", "secrets.enabled=false")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
@@ -2453,13 +2458,81 @@ func TestTLSLBBuiltInAllowlistRouteCanBeDisabled(t *testing.T) {
 	}
 }
 
+// The /secrets operator surface rides the same attested proxy and rate budget
+// as /allowlist. Workload secret reads authenticate with the pod's mesh leaf,
+// which never crosses this hop, so the route exposes only operator-key-signed
+// writes.
+func TestTLSLBExposesSecretsRouteByDefault(t *testing.T) {
+	out, err := helmTemplateTLSLB(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	for _, route := range []struct {
+		match string
+		path  string
+	}{
+		{match: "exact", path: "/secrets"},
+		{match: "prefix", path: "/secrets/"},
+	} {
+		location := cfg.location(t, route.match, route.path)
+		location.assertDirective(t, "proxy_pass", "http://127.0.0.1:8801$request_uri")
+		location.assertDirective(t, "proxy_set_header", "Authorization", "$http_authorization")
+		location.assertDirective(t, "limit_req", "zone=allowlist_write_per_client", "burst=5", "nodelay")
+		location.assertDirective(t, "limit_req", "zone=allowlist_write_total", "burst=15", "nodelay")
+		location.assertDirective(t, "limit_req_status", "429")
+	}
+}
+
+func TestTLSLBSecretsRouteCanBeDisabled(t *testing.T) {
+	out, err := helmTemplateTLSLB(t, "--set", "secrets.enabled=false")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	for _, key := range []nginxLocationKey{
+		{match: "exact", path: "/secrets"},
+		{match: "prefix", path: "/secrets/"},
+	} {
+		if _, ok := cfg.locations[key]; ok {
+			t.Fatalf("nginx config contains disabled built-in secrets location %#v", key)
+		}
+	}
+	// The allowlist route still renders, so the proxy and zones stay.
+	cfg.location(t, "exact", "/allowlist")
+	renderedDeploymentContainer(t, out, "c8s-tls-lb", "allowlist-proxy")
+}
+
+func TestTLSLBSecretsRouteAloneKeepsProxy(t *testing.T) {
+	out, err := helmTemplateTLSLB(t, "--set", "allowlist.enabled=false")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	cfg.location(t, "exact", "/secrets")
+	cfg.location(t, "prefix", "/secrets/")
+	for _, key := range []nginxLocationKey{
+		{match: "exact", path: "/allowlist"},
+		{match: "prefix", path: "/allowlist/"},
+	} {
+		if _, ok := cfg.locations[key]; ok {
+			t.Fatalf("nginx config contains disabled built-in allowlist location %#v", key)
+		}
+	}
+	cfg.http.assertDirective(t, "limit_req_zone", "$allowlist_write_rate_key", "zone=allowlist_write_per_client:10m", "rate=1r/s")
+	renderedDeploymentContainer(t, out, "c8s-tls-lb", "allowlist-proxy")
+}
+
 func TestTLSLBExplicitAllowlistRouteOverridesBuiltInRoute(t *testing.T) {
+	// secrets.enabled=false so the proxy/zone assertions below see the
+	// explicit route standing entirely alone.
 	out, err := helmTemplateTLSLB(t,
 		"--set-string", "routes[0].path=/allowlist",
 		"--set-string", "routes[0].match=exact",
 		"--set-string", "routes[0].backend.address=custom-cds.example:8443",
 		"--set-string", "routes[0].backend.protocol=https",
 		"--set", "routes[0].backend.tls.verify=true",
+		"--set", "secrets.enabled=false",
 	)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
@@ -5633,10 +5706,11 @@ func renderExampleTLSLBNginxConf() string {
 		"--set", "cds.image.digest=sha256:0000000000000000000000000000000000000000000000000000000000000001",
 		"--set", "nriImagePolicy.image.digest="+baseNRIDigest,
 		"--set-string", "nriImagePolicy.bootstrapAllowlist.digests."+baseNRIDigest+"=ghcr.io/confidential-dot-ai/nri-image-policy@"+baseNRIDigest,
-		// discovery defaults to enabled; scope this example to route rendering
-		// (discovery's own locations are covered by a dedicated test above).
+		// discovery and the built-in secrets route default to enabled; scope
+		// this example to route rendering (each has its own dedicated test).
 		"--set", "tlsLb.discovery.enabled=false",
 		"--set", "tlsLb.attest.enabled=false",
+		"--set", "tlsLb.secrets.enabled=false",
 		"--set-string", "tlsLb.upstream.address=vllm:8000",
 		"--set", "tlsLb.upstream.protocol=https",
 		"--set", "tlsLb.upstream.tls.verify=true",


### PR DESCRIPTION
Route the /secrets paths through the tls-lb so that we don't need kubectl port-forward to access them with the operator key. 

