### PR TITLE
review: inventory view coherence, cert-body checks in verify, bounded-staleness docs

### DIFF
--- a/internal/cmds/cds/attest_sandboxworkload_test.go
+++ b/internal/cmds/cds/attest_sandboxworkload_test.go
@@ -524,3 +524,46 @@ func TestAttest_SandboxWorkload_EmptyArgvDetailIssuesWithoutStamp(t *testing.T) 
 		t.Fatalf("argv-less container detail must degrade to no stamp, got %+v", matched)
 	}
 }
+
+// An inventory whose per-container detail names a digest its flat set does not
+// is reporting two different sandboxes in one response. Even with every
+// individual digest allowlisted, the divergence refuses issuance — gating on
+// one view and stamping from the other would let the difference slip through
+// whichever check only saw its half.
+func TestAttest_SandboxWorkload_ContainerOutsideDigestSetRefuses(t *testing.T) {
+	mock := newMockAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	h.AllowlistStore = floorStore(wlDigestA, wlDigestB)
+	h.SandboxDigests = fakeDigests{
+		digests:    map[string][]string{testSandboxID: {wlDigestA}},
+		containers: sandboxContainers(workloadclaims.SandboxContainer{Digest: wlDigestA}, workloadclaims.SandboxContainer{Digest: wlDigestB}),
+		key:        signer.PublicKey(),
+	}
+
+	csrPEM, _ := generateCSR(t)
+	challenge := issueChallenge(t, h)
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+	}
+}
+
+// The mirror image: a flat digest with no per-container detail is a container
+// the argv matching would never see. Same refusal.
+func TestAttest_SandboxWorkload_DigestWithoutDetailRefuses(t *testing.T) {
+	mock := newMockAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	h.AllowlistStore = floorStore(wlDigestA, wlDigestB)
+	h.SandboxDigests = fakeDigests{
+		digests:    map[string][]string{testSandboxID: {wlDigestA, wlDigestB}},
+		containers: sandboxContainers(workloadclaims.SandboxContainer{Digest: wlDigestA}),
+		key:        signer.PublicKey(),
+	}
+
+	csrPEM, _ := generateCSR(t)
+	challenge := issueChallenge(t, h)
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/cmds/getcert/cdsidentity.go
+++ b/internal/cmds/getcert/cdsidentity.go
@@ -23,8 +23,12 @@ import (
 // passed RA-TLS verification here (ratls.ClientConfig.OnVerifiedPeer fires only
 // after that succeeds). It is also safe to republish over an untrusted path:
 // the certificate is self-authenticating, carrying hardware evidence over its
-// own public key and claims, so substituting it just makes the client's
-// verification fail.
+// own public key and claims, so a tampered or forged copy fails the client's
+// verification. What republishing does NOT prevent is substituting an OLDER
+// genuine certificate: nothing in the certificate is bound to a client
+// challenge, so a replayed one verifies until its validity window closes.
+// Clients get bounded staleness — the window plus any newest-seen floor they
+// keep — not replay immunity.
 type cdsIdentityRecorder struct {
 	mu         sync.Mutex
 	cert       *x509.Certificate

--- a/internal/cmds/verify/certpolicy_test.go
+++ b/internal/cmds/verify/certpolicy_test.go
@@ -1,0 +1,191 @@
+package verify
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// certWithWindow mints a self-signed certificate carrying the attestation
+// extension (the shape of CDS's identity) with the given validity window.
+func certWithWindow(t *testing.T, notBefore, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att := &ratls.Attestation{TEEType: ratls.TEETypeSEVSNP, Report: make([]byte, ratls.SNPReportSize)}
+	attExt, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:    big.NewInt(11),
+		Subject:         pkix.Name{CommonName: "cds"},
+		NotBefore:       notBefore,
+		NotAfter:        notAfter,
+		ExtraExtensions: []pkix.Extension{attExt},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+func certPolicyOutcome(t *testing.T, cert *x509.Certificate) Outcome {
+	t.Helper()
+	ev, err := evidenceFromCert(cert, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oc := Outcome{Verified: true}
+	applyCertificatePolicy(&oc, ev)
+	return oc
+}
+
+// A currently valid, correctly self-signed certificate sails through.
+func TestCertificatePolicyAcceptsValidWindow(t *testing.T) {
+	oc := certPolicyOutcome(t, certWithWindow(t, time.Now().Add(-time.Hour), time.Now().Add(time.Hour)))
+	if !oc.Verified {
+		t.Fatalf("valid certificate demoted: %s", oc.Error)
+	}
+}
+
+// Expiry is the only bound on replaying an old-but-genuine certificate, so an
+// expired one must demote the verdict even though its hardware evidence and
+// self-signature are internally consistent.
+func TestCertificatePolicyRejectsExpired(t *testing.T) {
+	oc := certPolicyOutcome(t, certWithWindow(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour)))
+	if oc.Verified {
+		t.Fatal("expired certificate verified")
+	}
+	if !strings.Contains(oc.Error, "expired") {
+		t.Fatalf("error = %q, want it to name expiry", oc.Error)
+	}
+}
+
+// Future-dated beyond clock skew is refused; within the skew allowance it is
+// accepted, so an issuer marginally ahead of this clock does not false-fail.
+func TestCertificatePolicyNotBeforeSkew(t *testing.T) {
+	oc := certPolicyOutcome(t, certWithWindow(t, time.Now().Add(time.Hour), time.Now().Add(2*time.Hour)))
+	if oc.Verified {
+		t.Fatal("future-dated certificate verified")
+	}
+	if !strings.Contains(oc.Error, "not yet valid") {
+		t.Fatalf("error = %q, want it to say not yet valid", oc.Error)
+	}
+
+	within := certPolicyOutcome(t, certWithWindow(t, time.Now().Add(notBeforeSkew/2), time.Now().Add(time.Hour)))
+	if !within.Verified {
+		t.Fatalf("certificate within skew allowance demoted: %s", within.Error)
+	}
+}
+
+// The window is only worth reading because the self-signature covers it: a
+// certificate whose body no longer verifies under its own (attested) key is
+// refused before its dates are believed.
+func TestCertificatePolicyRejectsTamperedBody(t *testing.T) {
+	cert := certWithWindow(t, time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	cert.Signature[len(cert.Signature)-1] ^= 0x01
+	oc := certPolicyOutcome(t, cert)
+	if oc.Verified {
+		t.Fatal("certificate with a broken self-signature verified")
+	}
+	if !strings.Contains(oc.Error, "self-signed") {
+		t.Fatalf("error = %q, want it to name the self-signature", oc.Error)
+	}
+}
+
+// A mesh-signed (non-self-signed) leaf skips the self-signature check — its
+// body is authenticated by the chain instead — but its window is still
+// enforced: an expired leaf must not verify.
+func TestCertificatePolicyRejectsExpiredMeshLeaf(t *testing.T) {
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "mesh ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	att := &ratls.Attestation{TEEType: ratls.TEETypeSEVSNP, Report: make([]byte, ratls.SNPReportSize)}
+	attExt, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafTmpl := &x509.Certificate{
+		SerialNumber:    big.NewInt(2),
+		Subject:         pkix.Name{CommonName: "workload"},
+		NotBefore:       time.Now().Add(-2 * time.Hour),
+		NotAfter:        time.Now().Add(-time.Hour),
+		ExtraExtensions: []pkix.Extension{attExt},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oc := certPolicyOutcome(t, leaf)
+	if oc.Verified {
+		t.Fatal("expired mesh-signed leaf verified")
+	}
+	if !strings.Contains(oc.Error, "expired") {
+		t.Fatalf("error = %q, want it to name expiry", oc.Error)
+	}
+}
+
+// The policy only ever demotes: a failed hardware verdict stays failed with
+// its original error, and non-certificate evidence is untouched.
+func TestCertificatePolicyOnlyDemotes(t *testing.T) {
+	cert := certWithWindow(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
+	ev, err := evidenceFromCert(cert, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oc := Outcome{Verified: false, Error: "hardware evidence failed"}
+	applyCertificatePolicy(&oc, ev)
+	if oc.Verified || oc.Error != "hardware evidence failed" {
+		t.Fatalf("policy rewrote a failed verdict: verified=%v error=%q", oc.Verified, oc.Error)
+	}
+
+	noLeaf := Outcome{Verified: true}
+	applyCertificatePolicy(&noLeaf, &evidence{})
+	if !noLeaf.Verified {
+		t.Fatal("policy demoted evidence with no certificate")
+	}
+}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -312,6 +312,7 @@ func verifyEvidence(ctx context.Context, cfg config, policy *ratls.VerifyPolicy,
 	oc := newOutcome(cfg, ev, result, verr, policy)
 	oc.OperatorKeys = opKeys.fingerprints
 	oc.OperatorKeysNote = opKeys.note
+	applyCertificatePolicy(&oc, ev)
 	applyClaimsPolicy(&oc, ev, policy, opKeys)
 	applySandboxPolicy(&oc, cfg, ev)
 	render(cfg, oc, out)
@@ -890,6 +891,55 @@ func applyClaimsPolicy(oc *Outcome, ev *evidence, policy *ratls.VerifyPolicy, op
 	}
 	if ev.configClaims != nil && len(opKeys.digest) > 0 && !bytes.Equal(opKeys.digest, ev.configClaims.OperatorKeysDigest) {
 		fail("served /operator-keys digest %x does not match the attested config-claims digest %x", opKeys.digest, ev.configClaims.OperatorKeysDigest)
+	}
+}
+
+// notBeforeSkew is how far in the future a certificate's NotBefore may lie
+// before the verdict fails: enough for ordinary clock drift between the issuer
+// and this machine, without materially extending what a replayed certificate
+// can claim.
+const notBeforeSkew = time.Minute
+
+// applyCertificatePolicy authenticates the BODY of certificate-sourced
+// evidence and enforces its validity window. REPORTDATA covers the public key
+// and the config-claims bytes and nothing else — the validity window, serial
+// and subject live outside it. For a self-signed certificate (CDS's identity)
+// the self-signature by the attested key is what upgrades those fields from
+// attacker-chosen to TEE-asserted, so it is required before the window is
+// worth reading; skipping it would let anyone holding a genuine certificate
+// rewrite its notAfter and replay the pair forever. The window is then the
+// ONLY bound on replaying an old-but-internally-consistent certificate, so it
+// is enforced for every certificate-sourced verdict. Mirrors the JS
+// verifier's attestCDSIdentity. It only ever demotes Verified.
+func applyCertificatePolicy(oc *Outcome, ev *evidence) {
+	if ev.leaf == nil || !oc.Verified {
+		return
+	}
+	fail := func(format string, args ...any) {
+		oc.Verified = false
+		if oc.Error == "" {
+			oc.Error = fmt.Sprintf(format, args...)
+		}
+	}
+	cert := ev.leaf
+	if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
+		if err := cert.CheckSignature(cert.SignatureAlgorithm, cert.RawTBSCertificate, cert.Signature); err != nil {
+			fail("certificate is not self-signed by the attested key — the hardware evidence vouches for the key and claims, but the certificate body around them (validity window, serial, subject) has been altered: %v", err)
+			return
+		}
+	}
+	// A mesh-signed leaf's body is authenticated by its chain instead
+	// (applySandboxPolicy's --mesh-ca check); its window is still enforced
+	// here so an expired leaf cannot verify.
+	now := time.Now()
+	if now.Add(notBeforeSkew).Before(cert.NotBefore) {
+		fail("certificate is not yet valid: notBefore %s is after the current time %s (beyond clock skew)",
+			cert.NotBefore.Format(time.RFC3339), now.UTC().Format(time.RFC3339))
+		return
+	}
+	if now.After(cert.NotAfter) {
+		fail("certificate expired at %s: the issuer re-issues on policy change and renewal, so an expired certificate is a stale snapshot being replayed, not the state in force",
+			cert.NotAfter.Format(time.RFC3339))
 	}
 }
 

--- a/pkg/types/discovery.go
+++ b/pkg/types/discovery.go
@@ -30,8 +30,12 @@ type DiscoveryDocument struct {
 // so a client can complete the attest-once step without reaching CDS — CDS is
 // typically cluster-internal and not routable from a browser. Republishing is
 // safe because the certificate is self-authenticating: it carries hardware
-// evidence binding its own public key and claims, so a tampered or substituted
-// copy fails verification at the client.
+// evidence binding its own public key and claims, so a tampered or forged
+// copy fails verification at the client. It does NOT prove freshness: the
+// certificate carries no client challenge, so an older genuine one substituted
+// here still verifies until it expires. Clients must enforce the validity
+// window (and refuse notBefore rollback where they cache) to bound that
+// staleness — hardware evidence alone gives no replay immunity.
 type CDSIdentityDiscovery struct {
 	// CertificatePEM is CDS's self-signed RA-TLS certificate.
 	CertificatePEM string `json:"certificate_pem"`
@@ -40,6 +44,9 @@ type CDSIdentityDiscovery struct {
 	// fingerprint is precisely the signal to re-attest.
 	CertificateSHA256 string `json:"certificate_sha256"`
 	// ObservedAt is when the publishing workload verified it (RFC3339).
+	// Informational only — it travels outside the certificate and outside any
+	// signature, so it is trivially forgeable and MUST NOT be a trust input.
+	// Freshness judgements come from the certificate's signed validity window.
 	ObservedAt string `json:"observed_at,omitempty"`
 }
 

--- a/pkg/workloadclaims/coherence_test.go
+++ b/pkg/workloadclaims/coherence_test.go
@@ -1,0 +1,115 @@
+package workloadclaims
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const (
+	cohDigestA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cohDigestB = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+// Equal sets pass regardless of ordering and duplicate entries: Containers is
+// not deduplicated by contract (two containers may share an image), and the
+// flat set's ordering carries no meaning.
+func TestRequireContainersAcceptsEqualSets(t *testing.T) {
+	r := SandboxDigestsResponse{
+		Digests: []string{cohDigestB, cohDigestA},
+		Containers: []SandboxContainer{
+			{Digest: cohDigestA, Argv: []string{"/init"}},
+			{Digest: cohDigestB, Argv: []string{"/main"}},
+			{Digest: cohDigestA, Argv: []string{"/init"}}, // replica of the same image
+		},
+	}
+	containers, err := r.RequireContainers()
+	if err != nil {
+		t.Fatalf("RequireContainers: %v", err)
+	}
+	if len(containers) != 3 {
+		t.Fatalf("RequireContainers returned %d containers, want the 3 reported", len(containers))
+	}
+}
+
+// Case differences in the hex are canonicalized before comparison, so an
+// uppercase flat entry and a lowercase container entry are the same digest.
+func TestRequireContainersCanonicalizesBeforeComparing(t *testing.T) {
+	r := SandboxDigestsResponse{
+		Digests:    []string{"sha256:" + strings.ToUpper(cohDigestA[len("sha256:"):])},
+		Containers: []SandboxContainer{{Digest: cohDigestA}},
+	}
+	if _, err := r.RequireContainers(); err != nil {
+		t.Fatalf("RequireContainers: %v", err)
+	}
+}
+
+// A digest only in the flat set means a container the detail view hides —
+// nothing could hold it to an argv policy. Refused.
+func TestRequireContainersRejectsDigestOnlyInFlatSet(t *testing.T) {
+	r := SandboxDigestsResponse{
+		Digests:    []string{cohDigestA, cohDigestB},
+		Containers: []SandboxContainer{{Digest: cohDigestA}},
+	}
+	if _, err := r.RequireContainers(); err == nil {
+		t.Fatal("RequireContainers accepted a digest with no per-container detail")
+	}
+}
+
+// A container only in the detail view means a digest the flat gate never saw.
+// Refused.
+func TestRequireContainersRejectsContainerOutsideFlatSet(t *testing.T) {
+	r := SandboxDigestsResponse{
+		Digests:    []string{cohDigestA},
+		Containers: []SandboxContainer{{Digest: cohDigestA}, {Digest: cohDigestB}},
+	}
+	if _, err := r.RequireContainers(); err == nil {
+		t.Fatal("RequireContainers accepted a container outside the digest set")
+	}
+}
+
+// An empty flat set with per-container detail is the same divergence, not a
+// special case.
+func TestRequireContainersRejectsDetailWithEmptyFlatSet(t *testing.T) {
+	r := SandboxDigestsResponse{
+		Digests:    []string{},
+		Containers: []SandboxContainer{{Digest: cohDigestA}},
+	}
+	if _, err := r.RequireContainers(); err == nil {
+		t.Fatal("RequireContainers accepted containers the empty digest set never named")
+	}
+}
+
+// Malformed digests on either side fail the whole answer rather than being
+// excluded from the comparison — an entry that cannot be parsed cannot be
+// declared consistent either.
+func TestRequireContainersRejectsMalformedDigests(t *testing.T) {
+	for name, r := range map[string]SandboxDigestsResponse{
+		"flat": {
+			Digests:    []string{"not-a-digest"},
+			Containers: []SandboxContainer{{Digest: cohDigestA}},
+		},
+		"container": {
+			Digests:    []string{cohDigestA},
+			Containers: []SandboxContainer{{Digest: "sha256:short"}},
+		},
+		"empty container digest": {
+			Digests:    []string{cohDigestA},
+			Containers: []SandboxContainer{{Digest: ""}},
+		},
+	} {
+		if _, err := r.RequireContainers(); err == nil {
+			t.Errorf("%s: RequireContainers accepted a malformed digest", name)
+		}
+	}
+}
+
+// The legacy compatibility path is untouched: a digest-only inventory (one
+// older than the Containers field) still reports ErrSandboxContainersUnsupported
+// so callers degrade deliberately instead of failing on coherence.
+func TestRequireContainersLegacyDigestOnlyStillUnsupported(t *testing.T) {
+	r := SandboxDigestsResponse{Digests: []string{cohDigestA}}
+	if _, err := r.RequireContainers(); !errors.Is(err, ErrSandboxContainersUnsupported) {
+		t.Fatalf("RequireContainers = %v, want ErrSandboxContainersUnsupported", err)
+	}
+}

--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // DigestsPort is the port every inventory serves its digests endpoint on, and
@@ -374,7 +375,16 @@ func (c *DigestsClient) FetchSandbox(ctx context.Context, host, sandboxID string
 }
 
 // RequireContainers returns the per-container detail, refusing an answer that
-// cannot support a (digest, argv) decision.
+// cannot support a (digest, argv) decision — and one whose two views of the
+// sandbox disagree.
+//
+// Digests and Containers are rendered from the same admission record, so on an
+// honest inventory their deduplicated digest sets are identical. A response
+// where they diverge is malformed or tampered — one consumer gates on Digests
+// while another stamps from Containers, so a difference would slip past
+// whichever check only saw its half. Both sides are parsed with
+// types.ParseDigest so a malformed entry in either is refused rather than
+// excluded from the comparison.
 func (r SandboxDigestsResponse) RequireContainers() ([]SandboxContainer, error) {
 	if len(r.Containers) == 0 {
 		if len(r.Digests) == 0 {
@@ -382,9 +392,30 @@ func (r SandboxDigestsResponse) RequireContainers() ([]SandboxContainer, error) 
 		}
 		return nil, ErrSandboxContainersUnsupported
 	}
+	flat := make(map[string]bool, len(r.Digests))
+	for _, d := range r.Digests {
+		digest, err := types.ParseDigest(d)
+		if err != nil {
+			return nil, fmt.Errorf("workloadclaims: inventory digest %q: %w", d, err)
+		}
+		flat[digest.String()] = true
+	}
+	detailed := make(map[string]bool, len(r.Containers))
 	for _, c := range r.Containers {
-		if c.Digest == "" {
-			return nil, fmt.Errorf("workloadclaims: inventory reported a container with no digest")
+		digest, err := types.ParseDigest(c.Digest)
+		if err != nil {
+			return nil, fmt.Errorf("workloadclaims: inventory container digest %q: %w", c.Digest, err)
+		}
+		detailed[digest.String()] = true
+	}
+	for d := range detailed {
+		if !flat[d] {
+			return nil, fmt.Errorf("workloadclaims: inventory reports container %s outside its digest set — the response's two views of the sandbox disagree", d)
+		}
+	}
+	for d := range flat {
+		if !detailed[d] {
+			return nil, fmt.Errorf("workloadclaims: inventory digest %s has no per-container detail — the response's two views of the sandbox disagree", d)
 		}
 	}
 	return r.Containers, nil


### PR DESCRIPTION
Targets #177 (`feat/cds-identity-claims`). Implements the load-bearing subset of the freshness/inventory review; deliberately **omits** the configurable max-age policy — the staleness bound is the cert TTL (24h default), and a second knob below it would false-reject mid-lifetime certs unless renewal cadence changes first.

## Inventory view coherence (`pkg/workloadclaims`, one check covering both consumers)

`RequireContainers` now refuses a response whose two views of the sandbox disagree: `Digests` and `Containers` are rendered from the same admission record (both inventories sort/compact from one map), so their canonicalized digest sets must be equal. CDS gates issuance on `Digests` and stamps from `Containers`, and the secrets path matches from `Containers` alone — a divergent response could previously slip its difference past whichever check only saw its half. Malformed digests on **either** side refuse the whole answer (previously only an empty container digest was caught); the digest-only legacy inventory still degrades via `ErrSandboxContainersUnsupported`. Tests: equal-sets-with-dupes/ordering accepted, each divergence direction refused (unit + end-to-end 403 through `/attest`), malformed refused, legacy path preserved.

## Certificate-body checks in `c8s verify` (parity with the JS verifier)

The CLI verified the hardware evidence in cert-sourced modes but never authenticated the certificate **body**: REPORTDATA covers the key + claims only, and nothing checked the self-signature or the validity window — an expired, future-dated, or notAfter-rewritten CDS identity verified. New `applyCertificatePolicy` (runs before claims/sandbox policy, only ever demotes): self-signed certs must verify under their own attested key; the window is then enforced for every cert-sourced verdict (mesh-signed leaves keep chain-based body auth but get the window check too), with a 1-minute notBefore skew allowance. Tests: valid accepted, expired/future-dated refused, within-skew accepted, tampered body refused, expired mesh leaf refused, demote-only semantics.

## Bounded staleness, said honestly

The "substituting it just makes the client's verification fail" comments (`getcert/cdsidentity.go`, `types/discovery.go`) claimed replay immunity the mechanism doesn't deliver: an **older genuine** certificate substituted in discovery verifies until it expires. Reworded to bounded staleness (window + rollback floor), and `ObservedAt` is now explicitly documented as informational only — it travels outside any signature and must never be a trust input (no consumer reads it today; JS/pages display only).

## Verification

`gofmt` clean, `go vet ./...` clean, `golangci-lint run ./...` 0 issues, full `go test -race -count=1 ./...` green.