### PR TITLE
chore(image): bump CONFOS_REF to the admission-inventory and reproducibility fixes

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -38,7 +38,7 @@ env:
   # SHA (checkout fetches it as a ref). Pinned, not main: bumping it changes
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main.
-  CONFOS_REF: "1180707d8c862ba0c1368f48c15ed6d82817ea52" # confos main (#73)
+  CONFOS_REF: "fae2178766a2bb315a6a9c620765437bbae5a256" # confos main (#74)
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## What

Bump the pinned confos build tree from `1180707` (#73) to `fae2178`.

## Why

Two fixes in that tree, both needed for a node-as-CVM install.

**The node image never enabled the admission inventory.** The baked `image-policy.yaml` had no `workload_claims` section and no `platform`, so the inventory socket never existed and every adopted workload's injected `c8s-cert` sidecar sat at `Init:1/2` indefinitely. Pairs with the sandbox-identity typing fix in #194 — that one made the endpoint serve TDX evidence under a TDX identity; this one makes the inventory exist to be served.

**The build was not reproducible.** Two builds of the same commit produced different RTMR[1] and RTMR[2], traced to the latent-entropy GCC plugin seeding from `/dev/urandom` and NVIDIA stamping a hostname and date into `.rodata`. Every verification path compares live RTMR[1] and RTMR[2] against references, and the honest source of those is "rebuild from source and check", so this is what makes the references checkable by anyone other than whoever ran the build.

## Effect

Changes the image's TDX measurement, as any `CONFOS_REF` bump does. MRTD covers TDVF firmware only and will likely be unchanged; RTMR[1] and RTMR[2] move. Launches from the rebuilt image dir carry their own refreshed `manifest.json`.

Merging triggers the usual Docker → c8s-image chain and publishes a new `c8s-base:rke2-cdi`.