### PR TITLE
fix(volumes): remove 1Mi limit for encrypted volumes

### DIFF
--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -31,7 +31,6 @@ import (
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -123,22 +122,12 @@ const secretsVolumeName = "c8s-secrets"
 // defaultSecretDir is where the fetcher writes, matching its own default.
 const defaultSecretDir = "/run/c8s/secrets"
 
-// secretsVolumeSizeLimit bounds the tmpfs. It is charged to the pod's memory
-// (the guest's, under kata), so an unbounded one would let a workload's own
-// writes into the shared directory pressure the pod rather than fail.
-const secretsVolumeSizeLimit = "1Mi"
-
 // reservedVolumeContainerName is the injected volume fetcher. Reserved like the
 // cert containers.
 const reservedVolumeContainerName = "c8s-volume"
 
 // defaultVolumeDir is where opened volumes are mounted, one directory each.
 const defaultVolumeDir = "/run/c8s/volumes"
-
-// volumeMountSizeLimit bounds the emptyDir the node agent mounts the decrypted
-// device over. It holds nothing itself; the bound stops a workload filling node
-// memory through a mount that has not landed yet.
-const volumeMountSizeLimit = "1Mi"
 
 // reservedCertContainerName is the injected mesh-cert sidecar's name. It is
 // operator-reserved: a pod may not declare its own container under it. The
@@ -1213,16 +1202,12 @@ func int64Ptr(v int64) *int64 {
 }
 
 // secretsVolume is the memory-backed volume released values are written to.
-// Bounded: it is charged to the pod's memory, so an unbounded tmpfs would let
-// writes into the shared directory pressure the pod instead of failing.
 func secretsVolume() corev1.Volume {
-	limit := resource.MustParse(secretsVolumeSizeLimit)
 	return corev1.Volume{
 		Name: secretsVolumeName,
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{
-				Medium:    corev1.StorageMediumMemory,
-				SizeLimit: &limit,
+				Medium: corev1.StorageMediumMemory,
 			},
 		},
 	}
@@ -1331,13 +1316,10 @@ func volumeNames(specs []string) []string {
 // resolves the target with RESOLVE_NO_XDEV, so a memory-backed (tmpfs)
 // placeholder is unreachable by construction.
 func openedVolume(name string) corev1.Volume {
-	limit := resource.MustParse(volumeMountSizeLimit)
 	return corev1.Volume{
 		Name: volumed.KubeVolumeName(name),
 		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{
-				SizeLimit: &limit,
-			},
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
 	}
 }

--- a/internal/webhook/pod_mutator_secrets_test.go
+++ b/internal/webhook/pod_mutator_secrets_test.go
@@ -177,9 +177,9 @@ func TestReservedSecretsVolumeMustBeMemoryBacked(t *testing.T) {
 	}
 }
 
-// The injected volume is memory-backed and bounded: it is charged to the pod's
-// memory, so an unbounded tmpfs would let writes pressure the pod.
-func TestInjectedSecretsVolumeIsBoundedTmpfs(t *testing.T) {
+// The injected volume is memory-backed: a released value must never reach the
+// node's disk.
+func TestInjectedSecretsVolumeIsTmpfs(t *testing.T) {
 	pod := podWithApp()
 	mutateWithSecrets(t, pod, []string{"DB=/api/db"}, "")
 
@@ -194,9 +194,6 @@ func TestInjectedSecretsVolumeIsBoundedTmpfs(t *testing.T) {
 	}
 	if found.EmptyDir == nil || found.EmptyDir.Medium != corev1.StorageMediumMemory {
 		t.Fatalf("volume = %+v, want a memory-backed emptyDir", found.VolumeSource)
-	}
-	if found.EmptyDir.SizeLimit == nil || found.EmptyDir.SizeLimit.IsZero() {
-		t.Fatal("the tmpfs is unbounded")
 	}
 }
 

--- a/internal/webhook/pod_mutator_volumes_test.go
+++ b/internal/webhook/pod_mutator_volumes_test.go
@@ -152,15 +152,16 @@ func TestPreDeclaredVolumeAndMountAreOverwritten(t *testing.T) {
 		t.Error("a pre-declared unpropagated mount survived")
 	}
 
-	// And the volume itself is the webhook's, bounded.
+	// And the volume itself is the webhook's: a default-medium emptyDir, the
+	// only shape volumed can mount the opened device over.
 	var found *corev1.Volume
 	for i := range pod.Spec.Volumes {
 		if pod.Spec.Volumes[i].Name == name {
 			found = &pod.Spec.Volumes[i]
 		}
 	}
-	if found == nil || found.EmptyDir == nil || found.EmptyDir.SizeLimit == nil {
-		t.Fatalf("volume = %+v, want the webhook's bounded emptyDir", found)
+	if found == nil || found.EmptyDir == nil || found.EmptyDir.Medium != corev1.StorageMediumDefault {
+		t.Fatalf("volume = %+v, want the webhook's default-medium emptyDir", found)
 	}
 }
 


### PR DESCRIPTION
The webhook injects a 1Mi originally to stop DoS, but is out of scope and blocks big volumes for real usage