### PR TITLE
fix(getcert): retry on the acquisition cadence until the first cert lands

### DIFF
--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -213,18 +213,27 @@ func run(cfg config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
+	haveCert := true
 	if err := obtainCertWithRetry(ctx, cfg, client); err != nil {
 		if cfg.RenewInterval <= 0 || !cfg.ContinueOnInitialError {
 			return err
 		}
-		slog.Error("initial certificate request failed, will retry next interval", "error", err)
+		haveCert = false
+		slog.Error("initial certificate request failed, retrying on the acquisition cadence", "error", err)
 	} else if cfg.RenewInterval <= 0 {
 		return nil
 	}
 
+	// A pod that has never held a certificate is acquiring, not renewing.
+	// Ticking at RenewInterval here would leave it down for a full interval.
+	interval := cfg.RenewInterval
+	if !haveCert {
+		interval = acquireInterval(cfg)
+	}
+
 	// Daemon mode: renew certificate periodically with graceful shutdown.
-	slog.Info("entering renewal loop", "interval", cfg.RenewInterval)
-	ticker := time.NewTicker(cfg.RenewInterval)
+	slog.Info("entering renewal loop", "interval", interval)
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	var watchC <-chan time.Time
@@ -252,6 +261,11 @@ func run(cfg config) error {
 				slog.Error("certificate renewal failed, will retry next interval", "error", err)
 				continue
 			}
+			if !haveCert {
+				haveCert = true
+				ticker.Reset(cfg.RenewInterval)
+				slog.Info("first certificate obtained, switching to renewal interval", "interval", cfg.RenewInterval)
+			}
 			if cfg.ReloadNginx {
 				if err := reloadNginx(); err != nil {
 					slog.Warn("certificate renewed but nginx reload failed", "error", err)
@@ -273,6 +287,17 @@ func run(cfg config) error {
 			}
 		}
 	}
+}
+
+// acquireInterval is the retry cadence before the first certificate lands.
+// RenewInterval is a renewal cadence, so using it to reach a first issuance
+// leaves the pod down for a whole interval while the paired probe-file init
+// container times out every few minutes against a file nothing is writing.
+func acquireInterval(cfg config) time.Duration {
+	if cfg.InitialRetryTimeout > 0 {
+		return cfg.InitialRetryTimeout
+	}
+	return cfg.RenewInterval
 }
 
 // obtainCertWithRetry runs the first certificate request, retrying in-process

--- a/internal/cmds/getcert/run_test.go
+++ b/internal/cmds/getcert/run_test.go
@@ -1,6 +1,7 @@
 package getcert
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -9,11 +10,14 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -359,4 +363,81 @@ func TestCABundleFromChain(t *testing.T) {
 			t.Fatal("expected error for a leaf-only chain, got nil")
 		}
 	})
+}
+
+func TestAcquireIntervalPrefersInitialRetryTimeout(t *testing.T) {
+	got := acquireInterval(config{InitialRetryTimeout: 2 * time.Minute, RenewInterval: time.Hour})
+	if got != 2*time.Minute {
+		t.Fatalf("acquireInterval = %v, want the initial-retry budget 2m", got)
+	}
+}
+
+func TestAcquireIntervalFallsBackToRenewInterval(t *testing.T) {
+	got := acquireInterval(config{InitialRetryTimeout: 0, RenewInterval: time.Hour})
+	if got != time.Hour {
+		t.Fatalf("acquireInterval = %v, want RenewInterval when no initial-retry budget", got)
+	}
+}
+
+// A pod whose first issuance failed is acquiring, not renewing: it must enter
+// the loop on the acquisition cadence. Ticking at RenewInterval leaves it down
+// for a whole interval while the paired probe-file init container times out
+// against a file nothing is writing (c8s#200).
+func TestRunEntersLoopOnAcquisitionCadenceBeforeFirstCert(t *testing.T) {
+	overrideProcRoot(t, t.TempDir())
+
+	logs := &lockedBuffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	cfg := config{
+		CDSURL:                 "https://127.0.0.1:1",
+		AttestationApiURL:      "http://127.0.0.1:1",
+		SAN:                    "host.example.com",
+		InitialRetryTimeout:    20 * time.Millisecond,
+		InitialRetryInterval:   5 * time.Millisecond,
+		ContinueOnInitialError: true,
+		RenewInterval:          time.Hour,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- run(cfg) }()
+	time.Sleep(200 * time.Millisecond)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not shut down")
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "entering renewal loop") {
+		t.Fatalf("run never entered the loop; logs:\n%s", out)
+	}
+	if strings.Contains(out, "interval=1h0m0s") {
+		t.Fatalf("entered the loop on RenewInterval without holding a cert; logs:\n%s", out)
+	}
+	if !strings.Contains(out, "interval=20ms") {
+		t.Fatalf("want the acquisition cadence 20ms; logs:\n%s", out)
+	}
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }


### PR DESCRIPTION
Fixes #200.

`renewInterval` was being used to reach a first issuance. After `--initial-retry-timeout` (2m) elapsed, a pod that had never held a certificate waited a full renewal interval before trying again: 1h for tls-lb, 6h for webhook-injected workloads. Meanwhile `c8s-cert-wait` times out every 3m against a file nothing is writing, so the pod sits `Init:Error` and never recovers.

Now the loop ticks on the acquisition cadence until the first certificate lands, then resets to `renewInterval`. Recovery drops from an hour to under the initial-retry budget.

Caught on the Azure TDX e2e, where CDS binds its socket only after RA-TLS provisioning and tls-lb spends its first ~47s on `connection refused`. That run won with 73s to spare; an earlier one on the same commit lost and the cluster sat with 5 of 6 components Ready for 25 minutes with CDS healthy throughout.

`TestRunEntersLoopOnAcquisitionCadenceBeforeFirstCert` fails on main and passes here. The two `TestFetchSandboxToken*` failures in this package are pre-existing and macOS-only (temp paths exceed the 104-char `sockaddr_un` limit).

Not covered: the CDS listen-ordering race itself, which matters much less once retries continue. Overlaps #197 and #177, both of which touch this file; happy to rebase onto whichever lands first.
