### PR TITLE
fix(volumed): read the disk serial from SCSI VPD as well as virtio

### DIFF
--- a/internal/cmds/volumed/devices.go
+++ b/internal/cmds/volumed/devices.go
@@ -15,11 +15,17 @@ const SerialPrefix = "c8s-vol-"
 // SysBlock is the sysfs directory listing block devices.
 const SysBlock = "/sys/block"
 
-// SerialDevices finds a volume's device by its virtio-block serial.
+// SerialDevices finds a volume's device by its disk serial.
 //
 // The serial is read from sysfs rather than resolved through
 // /dev/disk/by-id, which only exists where udev has run. This is the same
 // signal the confos initrd matches on to find its scratch disk.
+//
+// Two sysfs spellings, because the transport decides which one exists.
+// virtio-blk publishes the serial at <dev>/serial. SCSI does not, and
+// publishes it as VPD page 0x80 at <dev>/device/vpd_pg80 instead — which is
+// the only spelling available for a KubeVirt hotplugged disk, since its
+// validating webhook admits hotplugs on a scsi bus alone.
 //
 // The serial is a **selector, not a trust input**: the host chooses it, and
 // answers the query per read. Naming the wrong device fails closed later — the
@@ -50,12 +56,12 @@ func (d SerialDevices) Device(name string) (string, error) {
 	}
 	var found []string
 	for _, e := range entries {
-		serial, err := os.ReadFile(filepath.Join(d.sysBlock(), e.Name(), "serial"))
-		if err != nil {
+		serial, ok := d.serialOf(e.Name())
+		if !ok {
 			// A device without a serial is simply not a candidate.
 			continue
 		}
-		if strings.TrimSpace(string(serial)) == want {
+		if serial == want {
 			found = append(found, e.Name())
 		}
 	}
@@ -87,6 +93,48 @@ func ValidVolumeName(name string) error {
 			name, len(name), maxSerialNameLen)
 	}
 	return nil
+}
+
+// serialOf returns a device's serial, from whichever sysfs spelling its
+// transport provides. Reports false when the device has no serial at all,
+// which makes it simply not a candidate.
+func (d SerialDevices) serialOf(dev string) (string, bool) {
+	if b, err := os.ReadFile(filepath.Join(d.sysBlock(), dev, "serial")); err == nil {
+		return strings.TrimSpace(string(b)), true
+	}
+	b, err := os.ReadFile(filepath.Join(d.sysBlock(), dev, "device", "vpd_pg80"))
+	if err != nil {
+		return "", false
+	}
+	return parseVPD80(b)
+}
+
+// vpd80HeaderLen is the SPC peripheral-device header preceding the serial:
+// device type, page code 0x80, then the length as a big-endian uint16.
+const vpd80HeaderLen = 4
+
+// parseVPD80 pulls the unit serial out of SCSI VPD page 0x80.
+//
+// The declared length is trusted only as far as the buffer allows — a short
+// read yields a short serial rather than a panic, and a device whose serial
+// does not match is a non-candidate either way. Trailing NULs and spaces are
+// stripped: the field is fixed-width and padded, so a serial written by
+// QEMU arrives padded to the device's width.
+func parseVPD80(b []byte) (string, bool) {
+	if len(b) < vpd80HeaderLen {
+		return "", false
+	}
+	n := int(b[2])<<8 | int(b[3])
+	if end := vpd80HeaderLen + n; n > 0 && end <= len(b) {
+		b = b[vpd80HeaderLen:end]
+	} else {
+		b = b[vpd80HeaderLen:]
+	}
+	s := strings.Trim(string(b), "\x00 \t\r\n")
+	if s == "" {
+		return "", false
+	}
+	return s, true
 }
 
 func (d SerialDevices) sysBlock() string {

--- a/internal/cmds/volumed/devices_test.go
+++ b/internal/cmds/volumed/devices_test.go
@@ -131,3 +131,154 @@ func TestSerialDevicesDefaultTheirPaths(t *testing.T) {
 		t.Errorf("devDir = %q, want /dev", got)
 	}
 }
+
+// vpd80 builds a SCSI VPD page 0x80 payload the way the kernel exposes it:
+// device type, page code, big-endian length, then the padded serial.
+func vpd80(serial string, width int) []byte {
+	body := make([]byte, width)
+	copy(body, serial)
+	out := []byte{0x00, 0x80, byte(len(body) >> 8), byte(len(body))}
+	return append(out, body...)
+}
+
+// sysBlockSCSI builds a fake /sys/block where devices carry their serial as
+// VPD page 0x80 under device/, which is how a SCSI disk presents it — there is
+// no <dev>/serial at all. This is the shape a KubeVirt hotplugged disk takes,
+// since its webhook admits hotplugs on a scsi bus alone.
+func sysBlockSCSI(t *testing.T, devices map[string]string) SerialDevices {
+	t.Helper()
+	root := t.TempDir()
+	for dev, serial := range devices {
+		dir := filepath.Join(root, dev, "device")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dev, err)
+		}
+		if serial == "" {
+			continue
+		}
+		if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), vpd80(serial, 20), 0o444); err != nil {
+			t.Fatalf("write vpd_pg80: %v", err)
+		}
+	}
+	return SerialDevices{SysBlock: root, DevDir: "/dev"}
+}
+
+func TestDeviceFindsASCSISerialFromVPD80(t *testing.T) {
+	d := sysBlockSCSI(t, map[string]string{
+		"sda": "confai-containerd",
+		"sdb": "confai-models",
+		"sdc": "c8s-vol-weights",
+	})
+	got, err := d.Device("weights")
+	if err != nil {
+		t.Fatalf("device: %v", err)
+	}
+	if got != "/dev/sdc" {
+		t.Fatalf("device = %q, want /dev/sdc", got)
+	}
+}
+
+// A mixed node: the root disk is virtio and the hotplugged ciphertext is SCSI.
+// Both spellings have to resolve in one sweep.
+func TestDeviceResolvesVirtioAndSCSITogether(t *testing.T) {
+	root := t.TempDir()
+	mkVirtio := func(dev, serial string) {
+		dir := filepath.Join(root, dev)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "serial"), []byte(serial+"\n"), 0o444); err != nil {
+			t.Fatalf("write serial: %v", err)
+		}
+	}
+	mkSCSI := func(dev, serial string) {
+		dir := filepath.Join(root, dev, "device")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), vpd80(serial, 20), 0o444); err != nil {
+			t.Fatalf("write vpd_pg80: %v", err)
+		}
+	}
+	mkVirtio("vda", "confai-scratch")
+	mkSCSI("sdc", "c8s-vol-weights")
+	d := SerialDevices{SysBlock: root, DevDir: "/dev"}
+
+	got, err := d.Device("weights")
+	if err != nil {
+		t.Fatalf("device: %v", err)
+	}
+	if got != "/dev/sdc" {
+		t.Fatalf("device = %q, want /dev/sdc", got)
+	}
+}
+
+// The same serial on a virtio and a SCSI disk is still ambiguous; reading two
+// spellings must not turn a refusal into a scan-order-dependent pick.
+func TestDeviceRefusesADuplicateAcrossTransports(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "vdb"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vdb", "serial"), []byte("c8s-vol-weights\n"), 0o444); err != nil {
+		t.Fatalf("write serial: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "sdc", "device"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sdc", "device", "vpd_pg80"), vpd80("c8s-vol-weights", 20), 0o444); err != nil {
+		t.Fatalf("write vpd_pg80: %v", err)
+	}
+	d := SerialDevices{SysBlock: root, DevDir: "/dev"}
+
+	if _, err := d.Device("weights"); err == nil {
+		t.Fatal("resolved an ambiguous serial across transports")
+	}
+}
+
+// virtio wins when a device somehow carries both, so behaviour on existing
+// nodes is exactly what it was before VPD was consulted.
+func TestDevicePrefersTheVirtioSpelling(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "vdc", "device")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "vdc", "serial"), []byte("c8s-vol-weights\n"), 0o444); err != nil {
+		t.Fatalf("write serial: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "vpd_pg80"), vpd80("c8s-vol-other", 20), 0o444); err != nil {
+		t.Fatalf("write vpd_pg80: %v", err)
+	}
+	d := SerialDevices{SysBlock: root, DevDir: "/dev"}
+
+	got, err := d.Device("weights")
+	if err != nil {
+		t.Fatalf("device: %v", err)
+	}
+	if got != "/dev/vdc" {
+		t.Fatalf("device = %q, want /dev/vdc", got)
+	}
+}
+
+func TestParseVPD80(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []byte
+		want string
+		ok   bool
+	}{
+		{"padded", vpd80("c8s-vol-weights", 20), "c8s-vol-weights", true},
+		{"exact", vpd80("c8s-vol-weights", 15), "c8s-vol-weights", true},
+		{"empty page", vpd80("", 20), "", false},
+		{"truncated header", []byte{0x00, 0x80}, "", false},
+		{"length overruns buffer", []byte{0x00, 0x80, 0x00, 0xff, 'a', 'b'}, "ab", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseVPD80(tc.in)
+			if ok != tc.ok || got != tc.want {
+				t.Fatalf("parseVPD80 = %q,%v; want %q,%v", got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Review: normal** · device selection for encrypted volumes; not a trust input

## What
`volumed` resolves a volume's device by matching `c8s-vol-<name>` against `/sys/block/<dev>/serial`. Only virtio-blk publishes that file, so SCSI disks were invisible. Fall back to VPD page 0x80 at `<dev>/device/vpd_pg80`, which is where SCSI carries the same serial.

## Why it matters
Any SCSI-attached ciphertext fails with `no block device carries serial c8s-vol-<name>`, surfaced to the sidecar as a 404, even though the serial is present and correct. That rules out KubeVirt hotplug entirely, since its validating webhook admits hotplugged disks on a scsi bus alone — leaving launch-time attachment as the only option, which forces the PVC to exist before the CVM and the image to be written into the claim's backing file afterwards.

## How to test
- `go test -race -count=1 ./internal/cmds/volumed/`
- The new cases cover a SCSI-only node, a mixed virtio+SCSI node, and the VPD header parse. Reverting the fallback in `serialOf` fails three of them, so they hold the behaviour rather than merely exercising it.

## Review focus areas
- `parseVPD80` — the declared length is trusted only as far as the buffer allows, so a short or malformed read yields a short serial rather than a panic.
- Duplicate handling in `Device`: reading a second spelling must not turn an ambiguous serial into a scan-order-dependent pick. `TestDeviceRefusesADuplicateAcrossTransports` pins that.
- virtio keeps precedence, so nodes that resolve today resolve the same device.

## Caveats
`/dev/disk/by-id` is still not used, for the reason already in that file: it exists only where udev has run. VPD keeps the lookup in sysfs.