### PR TITLE
fix(install): support macOS CLI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Build macOS CLI
+        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/c8s-darwin ./cmd/c8s
+
       - name: Test
         run: make test
 

--- a/cmd/c8s/get_volume.go
+++ b/cmd/c8s/get_volume.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import "github.com/confidential-dot-ai/c8s/internal/cmds/getvolume"

--- a/cmd/c8s/volumed.go
+++ b/cmd/c8s/volumed.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package main
 
 import "github.com/confidential-dot-ai/c8s/internal/cmds/volumed"

--- a/internal/cmds/volume/create.go
+++ b/internal/cmds/volume/create.go
@@ -6,24 +6,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"regexp"
 
 	"github.com/spf13/cobra"
 
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
-
-// maxNameLen bounds the volume name at 12 characters.
-//
-// The node selects the device by its virtio-block serial, and
-// VIRTIO_BLK_ID_BYTES is 20. With the "c8s-vol-" prefix that leaves 12; a
-// thirteenth character is silently dropped, so two volumes would present
-// identically to the node with no way to tell them apart.
-const maxNameLen = 12
-
-const serialPrefix = "c8s-vol-"
-
-var nameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 type createConfig struct {
 	name      string
@@ -139,12 +126,8 @@ func validateCreate(cfg *createConfig) (string, error) {
 	case cfg.escrowOut == "":
 		return "", fmt.Errorf("--escrow-out is required: it is the only copy of the key outside CDS")
 	}
-	if len(cfg.name) > maxNameLen {
-		return "", fmt.Errorf("--name %q is %d characters; the device serial holds %d",
-			cfg.name, len(cfg.name), maxNameLen)
-	}
-	if !nameRE.MatchString(cfg.name) {
-		return "", fmt.Errorf("--name %q must be lowercase alphanumeric, may contain '-', and must start and end alphanumeric", cfg.name)
+	if err := ValidVolumeName(cfg.name); err != nil {
+		return "", fmt.Errorf("--name: %w", err)
 	}
 	path, err := pkgallowlist.CanonicalSecretPath(cfg.path)
 	if err != nil {
@@ -176,7 +159,7 @@ func printResult(w io.Writer, cfg createConfig, path string, v Verity) {
 	fmt.Fprintf(w, "+ key stored at %s\n", path)
 	fmt.Fprintf(w, "+ key escrowed to %s — keep it; a CDS restart needs it\n\n", cfg.escrowOut)
 
-	fmt.Fprintf(w, "Attach %s to the node as a raw block device with serial %s%s.\n\n", cfg.out, serialPrefix, cfg.name)
+	fmt.Fprintf(w, "Attach %s to the node as a raw block device with serial %s%s.\n\n", cfg.out, SerialPrefix, cfg.name)
 
 	fmt.Fprintf(w, "Pod annotations:\n")
 	fmt.Fprintf(w, "  confidential.ai/cw: <workload-id>\n")

--- a/internal/cmds/volume/names.go
+++ b/internal/cmds/volume/names.go
@@ -1,0 +1,33 @@
+package volume
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// SerialPrefix precedes a volume name in its virtio-block serial.
+const SerialPrefix = "c8s-vol-"
+
+// KubeVolumePrefix precedes a volume name in the injected Kubernetes volume.
+const KubeVolumePrefix = "c8s-volume-"
+
+// maxNameLen is what remains of VIRTIO_BLK_ID_BYTES after SerialPrefix.
+const maxNameLen = 20 - len(SerialPrefix)
+
+var nameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+
+// ValidVolumeName reports whether name can be both a Kubernetes volume and a
+// virtio-block serial without truncation.
+func ValidVolumeName(name string) error {
+	if !nameRE.MatchString(name) {
+		return fmt.Errorf("volume name %q is not a dns-1123 label", name)
+	}
+	if len(name) > maxNameLen {
+		return fmt.Errorf("volume name %q is %d characters; the device serial holds %d",
+			name, len(name), maxNameLen)
+	}
+	return nil
+}
+
+// KubeVolumeName is the Kubernetes volume carrying the named volume.
+func KubeVolumeName(name string) string { return KubeVolumePrefix + name }

--- a/internal/cmds/volume/names_test.go
+++ b/internal/cmds/volume/names_test.go
@@ -1,0 +1,23 @@
+package volume
+
+import "testing"
+
+func TestVolumeNamesMatchDeviceAndKubernetesConventions(t *testing.T) {
+	if got := SerialPrefix + "weights"; got != "c8s-vol-weights" {
+		t.Fatalf("device serial = %q", got)
+	}
+	if got := KubeVolumeName("weights"); got != "c8s-volume-weights" {
+		t.Fatalf("Kubernetes volume name = %q", got)
+	}
+}
+
+func TestValidVolumeNameEnforcesTheSerialBound(t *testing.T) {
+	for _, name := range []string{"", "Weights", "-weights", "weights-", "we/ights", "thirteenchars"} {
+		if err := ValidVolumeName(name); err == nil {
+			t.Errorf("name %q: accepted", name)
+		}
+	}
+	if err := ValidVolumeName("twelve-chars"); err != nil {
+		t.Fatalf("12-character name rejected: %v", err)
+	}
+}

--- a/internal/cmds/volumed/devices.go
+++ b/internal/cmds/volumed/devices.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 )
 
 // SerialPrefix precedes the volume name in a device's virtio-block serial.
 // VIRTIO_BLK_ID_BYTES is 20, so this leaves 12 characters for the name — which
 // is why `c8s volume create` caps it there.
-const SerialPrefix = "c8s-vol-"
+const SerialPrefix = volume.SerialPrefix
 
 // SysBlock is the sysfs directory listing block devices.
 const SysBlock = "/sys/block"
@@ -70,21 +72,12 @@ func (d SerialDevices) Device(name string) (string, error) {
 	}
 }
 
-// maxSerialNameLen is what remains of VIRTIO_BLK_ID_BYTES after SerialPrefix.
-// A longer name is silently truncated by the transport, so two volumes would
-// present the same serial with nothing able to tell them apart.
-const maxSerialNameLen = 20 - len(SerialPrefix)
-
 // ValidVolumeName reports whether name can be both a Kubernetes volume and a
 // virtio serial. The webhook, the sidecar and this daemon all apply it, so a
 // name accepted at admission is one the node can resolve to a device.
 func ValidVolumeName(name string) error {
-	if !volumeNameRE.MatchString(name) {
-		return fmt.Errorf("volumed: volume name %q is not a dns-1123 label", name)
-	}
-	if len(name) > maxSerialNameLen {
-		return fmt.Errorf("volumed: volume name %q is %d characters; a device serial holds %d",
-			name, len(name), maxSerialNameLen)
+	if err := volume.ValidVolumeName(name); err != nil {
+		return fmt.Errorf("volumed: %w", err)
 	}
 	return nil
 }

--- a/internal/cmds/volumed/devices_test.go
+++ b/internal/cmds/volumed/devices_test.go
@@ -89,9 +89,6 @@ func TestDeviceRefusesANameTooLongForASerial(t *testing.T) {
 	if _, err := d.Device("thirteenchars"); err == nil {
 		t.Fatal("accepted a name longer than the serial holds")
 	}
-	if maxSerialNameLen != 12 {
-		t.Fatalf("maxSerialNameLen = %d, want 12", maxSerialNameLen)
-	}
 }
 
 func TestDeviceRefusesAMalformedName(t *testing.T) {

--- a/internal/cmds/volumed/target.go
+++ b/internal/cmds/volumed/target.go
@@ -7,6 +7,8 @@ import (
 	"regexp"
 
 	"golang.org/x/sys/unix"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 )
 
 // emptyDirSubdir is where kubelet materializes an emptyDir volume under a pod's
@@ -17,10 +19,10 @@ const emptyDirSubdir = "volumes/kubernetes.io~empty-dir"
 // KubeVolumePrefix precedes a volume's name in the Kubernetes volume the
 // webhook injects, and so in the kubelet directory this mounts into. The
 // webhook reserves the whole prefix; both sides must spell it the same.
-const KubeVolumePrefix = "c8s-volume-"
+const KubeVolumePrefix = volume.KubeVolumePrefix
 
 // KubeVolumeName is the Kubernetes volume carrying the named volume.
-func KubeVolumeName(name string) string { return KubeVolumePrefix + name }
+func KubeVolumeName(name string) string { return volume.KubeVolumeName(name) }
 
 var (
 	podUIDRE     = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/confidential-dot-ai/c8s/internal/cmds/volumed"
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 	corev1 "k8s.io/api/core/v1"
@@ -517,7 +517,7 @@ func (v volumesSpec) validate() error {
 				errInvalidInjectionAnnotation, AnnotationVolumes, spec)
 		}
 		name = strings.TrimSpace(name)
-		if err := volumed.ValidVolumeName(name); err != nil {
+		if err := volume.ValidVolumeName(name); err != nil {
 			return fmt.Errorf("%w: %s: %s", errInvalidInjectionAnnotation, AnnotationVolumes, err)
 		}
 		if seen[name] {
@@ -927,7 +927,7 @@ func mutatePod(pod *corev1.Pod, inj *injection, cfg Config) {
 		for _, name := range volumeNames(effective.Volumes.Specs) {
 			replaceVolume(pod, openedVolume(name))
 			remountAll(pod, corev1.VolumeMount{
-				Name:      volumed.KubeVolumeName(name),
+				Name:      volume.KubeVolumeName(name),
 				MountPath: filepath.Join(effective.Volumes.Dir, name),
 				ReadOnly:  true,
 				// The node agent makes the mount outside this pod; without
@@ -1234,7 +1234,7 @@ func rejectEphemeralReservedMounts(pod *corev1.Pod) error {
 		for _, m := range c.VolumeMounts {
 			// By prefix as well as by set: an opened volume is reserved
 			// whatever the host-written annotation says its name is.
-			if reserved[m.Name] || strings.HasPrefix(m.Name, volumed.KubeVolumePrefix) {
+			if reserved[m.Name] || strings.HasPrefix(m.Name, volume.KubeVolumePrefix) {
 				return fmt.Errorf("%w: ephemeral container %q may not mount %q, which holds c8s-released material",
 					errInvalidInjectionAnnotation, c.Name, m.Name)
 			}
@@ -1317,7 +1317,7 @@ func volumeNames(specs []string) []string {
 // placeholder is unreachable by construction.
 func openedVolume(name string) corev1.Volume {
 	return corev1.Volume{
-		Name: volumed.KubeVolumeName(name),
+		Name: volume.KubeVolumeName(name),
 		VolumeSource: corev1.VolumeSource{
 			EmptyDir: &corev1.EmptyDirVolumeSource{},
 		},
@@ -1362,7 +1362,7 @@ func remountAll(pod *corev1.Pod, mount corev1.VolumeMount) {
 func rejectReservedVolumeVolume(pod *corev1.Pod) error {
 	for i := range pod.Spec.Volumes {
 		v := &pod.Spec.Volumes[i]
-		if !strings.HasPrefix(v.Name, volumed.KubeVolumePrefix) {
+		if !strings.HasPrefix(v.Name, volume.KubeVolumePrefix) {
 			continue
 		}
 		if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumDefault {

--- a/internal/webhook/pod_mutator_volumes_test.go
+++ b/internal/webhook/pod_mutator_volumes_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/confidential-dot-ai/c8s/internal/cmds/volumed"
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +30,7 @@ func TestNoVolumesRequestedInjectsNothing(t *testing.T) {
 		t.Fatal("the fetcher was injected without a volumes annotation")
 	}
 	for _, v := range pod.Spec.Volumes {
-		if strings.HasPrefix(v.Name, volumed.KubeVolumePrefix) {
+		if strings.HasPrefix(v.Name, volume.KubeVolumePrefix) {
 			t.Fatalf("volume %q was injected without a volumes annotation", v.Name)
 		}
 	}
@@ -72,7 +72,7 @@ func TestVolumeMountIsReadOnlyAndPropagated(t *testing.T) {
 	mutateWithVolumes(t, pod, []string{"weights=/tenant-a/volumes/weights"}, "")
 
 	app := workloadContainer(t, pod, "app")
-	m := mountNamed(app, volumed.KubeVolumeName("weights"))
+	m := mountNamed(app, volume.KubeVolumeName("weights"))
 	if m == nil {
 		t.Fatalf("app has no volume mount; mounts = %v", mountNames(app))
 	}
@@ -92,7 +92,7 @@ func TestVolumeDirOverride(t *testing.T) {
 	mutateWithVolumes(t, pod, []string{"weights=/tenant-a/volumes/weights"}, "/models")
 
 	app := workloadContainer(t, pod, "app")
-	if m := mountNamed(app, volumed.KubeVolumeName("weights")); m == nil || m.MountPath != "/models/weights" {
+	if m := mountNamed(app, volume.KubeVolumeName("weights")); m == nil || m.MountPath != "/models/weights" {
 		t.Errorf("mount path = %v, want /models/weights", m)
 	}
 }
@@ -106,7 +106,7 @@ func TestVolumeDirOverride(t *testing.T) {
 func TestInjectedVolumePlaceholderSharesPodFilesystem(t *testing.T) {
 	pod := podWithApp()
 	mutateWithVolumes(t, pod, []string{"weights=/tenant-a/volumes/weights"}, "")
-	name := volumed.KubeVolumeName("weights")
+	name := volume.KubeVolumeName("weights")
 	for _, v := range pod.Spec.Volumes {
 		if v.Name != name {
 			continue
@@ -124,7 +124,7 @@ func TestInjectedVolumePlaceholderSharesPodFilesystem(t *testing.T) {
 
 func TestPreDeclaredVolumeAndMountAreOverwritten(t *testing.T) {
 	pod := podWithApp()
-	name := volumed.KubeVolumeName("weights")
+	name := volume.KubeVolumeName("weights")
 	pod.Spec.Volumes = []corev1.Volume{{
 		Name:         name,
 		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
@@ -170,8 +170,8 @@ func TestPreDeclaredVolumeAndMountAreOverwritten(t *testing.T) {
 // it is meant to protect.
 func TestReservedVolumePrefixMustBeMemoryBacked(t *testing.T) {
 	for _, name := range []string{
-		volumed.KubeVolumeName("weights"),
-		volumed.KubeVolumePrefix + "not-even-requested",
+		volume.KubeVolumeName("weights"),
+		volume.KubeVolumePrefix + "not-even-requested",
 	} {
 		pod := podWithApp()
 		pod.Spec.Volumes = []corev1.Volume{{
@@ -204,7 +204,7 @@ func TestEphemeralContainerMayNotMountAnOpenedVolume(t *testing.T) {
 	pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:         "debug",
-			VolumeMounts: []corev1.VolumeMount{{Name: volumed.KubeVolumeName("weights")}},
+			VolumeMounts: []corev1.VolumeMount{{Name: volume.KubeVolumeName("weights")}},
 		},
 	}}
 	if err := rejectEphemeralReservedMounts(pod); err == nil {


### PR DESCRIPTION
## Review Focus Areas (required)

11 files changed: 4 Critical, 6 Standard, 1 Light. Estimated review time: medium — the diff is small, but the shared volume name and reserved-prefix invariant crosses admission and node mount boundaries.

| File / Area | Focus | Why |
|-------------|-------|-----|
| `internal/cmds/volume/names.go`, `internal/webhook/pod_mutator.go` | Critical | Centralizes validation and the reserved Kubernetes-volume prefix used against host-authored pod input. Review `ValidVolumeName`, `KubeVolumePrefix`, and every webhook substitution together. |
| `internal/cmds/volumed/devices.go`, `internal/cmds/volumed/target.go` | Critical | The daemon must use the exact same device serial and kubelet mount-target names as creation and admission. |
| `internal/cmds/volume/create.go` | Standard | Routes operator-side validation and emitted serials through the shared invariant. |
| `cmd/c8s/get_volume.go`, `cmd/c8s/volumed.go` | Standard | Build constraints decide which runtime commands exist on Linux versus macOS. |
| Volume naming and webhook tests | Standard | Pins the serial-length bound, exact prefixes, and reserved-volume behavior. |
| `.github/workflows/ci.yml` | Light | Adds a compile-only Darwin arm64 regression check. |

The build-tag files are classified Standard rather than Light because they change the command surface by OS. The four Critical files form one coupled naming invariant and should be reviewed together.

## What Changed

Gate the Linux-only `volumed` and `get-volume` command registrations behind Go build constraints. Move shared volume naming and validation into the platform-neutral `volume` package, then consume it from image creation, admission, and the daemon. Add a Darwin arm64 CLI build to CI.

## Why

`make install` on macOS followed the admission webhook's import of `volumed` into Linux-only `mount`, `memfd_create`, `openat2`, and block-ioctl symbols, so the operator CLI could not compile. No linked issue.

## Design Doc

N/A — focused platform build fix with no new architecture or dependency.

## Verification

- [x] `make install`
- [x] `go test -race ./internal/cmds/volume ./internal/webhook ./cmd/c8s`
- [x] `go vet ./internal/cmds/volume ./internal/webhook ./cmd/c8s`
- [x] Darwin arm64 and Linux arm64 `./cmd/c8s` builds
- [x] Linux compile checks for `volumed`, `getvolume`, `webhook`, and `cmd/c8s`
- [x] `git diff --check` and workflow YAML parse

## Checklist

- [x] New dependencies justified (none added)
- [x] Tests verify invariants, not just output format
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: N/A (no TEE code changed)
- [x] For crypto code: N/A (no cryptographic behavior changed)
