### PR TITLE
chore: bump CONFOS_REF

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -38,7 +38,7 @@ env:
   # SHA (checkout fetches it as a ref). Pinned, not main: bumping it changes
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main.
-  CONFOS_REF: "9873334011e42281b8e23eef2c33eaa1a85ad53d" # confos main (#74)
+  CONFOS_REF: "92a07633e94506ec0a85dfdae0d01e643c051253"
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Bumps `CONFOS_REF` in [.github/workflows/c8s-image.yml](.github/workflows/c8s-image.yml) from `fae2178` to `92a0763`.

