### PR TITLE
Using our official PEN now that it's registered

### DIFF
--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -89,7 +89,7 @@ can sign a report, and only code inside the TEE ever holds the private key.
    evidence embedded as a custom extension:
 
    ```text
-   OID 1.3.6.1.4.1.59888.1.1  (RA-TLS attestation extension)
+   OID 1.3.6.1.4.1.66378.1.1  (RA-TLS attestation extension)
    TEEAttestation ::= SEQUENCE {
        teeType     INTEGER,      -- 1 = SEV-SNP, 2 = TDX
        report      OCTET STRING, -- evidence, two shapes (below)
@@ -97,7 +97,7 @@ can sign a report, and only code inside the TEE ever holds the private key.
    }
    ```
 
-The full `1.3.6.1.4.1.59888.1` arc a c8s certificate may carry:
+The full `1.3.6.1.4.1.66378.1` arc a c8s certificate may carry:
 
 | OID | Extension | Stamped by |
 |---|---|---|
@@ -136,7 +136,7 @@ instance — never one across the network (see Guarantees).
    ──────────                                ────────────
 1. TCP connect ────────────────────────────▶
 2.             ◀───────────────────────────  TLS 1.3 ServerHello + leaf cert
-                                             [ext 1.3.6.1.4.1.59888.1.1:
+                                             [ext 1.3.6.1.4.1.66378.1.1:
                                               report with REPORTDATA =
                                               SHA-384(B's pubkey)]
 3. parse cert, extract extension
@@ -344,7 +344,7 @@ when the TEE holds more than one. A CDS-issued leaf names the **CRI pod
 sandbox** it was issued to:
 
 ```text
-OID 1.3.6.1.4.1.59888.1.4  (pod sandbox ID extension)
+OID 1.3.6.1.4.1.66378.1.4  (pod sandbox ID extension)
 SandboxID ::= IA5String     -- e.g. containerd's 64-hex sandbox ID
 ```
 
@@ -572,7 +572,7 @@ degrades issuance — CDS refuses the tokens it cannot check.
 ### Cross-implementation note
 
 A non-Go verifier (e.g. `c8s-verify-js`) reading a sandbox ID needs only the DER
-IA5String at OID `1.3.6.1.4.1.59888.1.4` plus a mesh-CA chain check — the ID is
+IA5String at OID `1.3.6.1.4.1.66378.1.4` plus a mesh-CA chain check — the ID is
 not part of any hash preimage, so there are no canonical-serialization traps.
 The token and digests formats above are internal to the inventory↔CDS path and
 are never presented to a relying party.

--- a/internal/cmds/allowlist/discovery_integration_test.go
+++ b/internal/cmds/allowlist/discovery_integration_test.go
@@ -125,7 +125,7 @@ func runCmdWith(verify localverify.VerifyFunc, args ...string) (string, string, 
 
 // TestListThroughTLSLB is the regression test for `c8s allowlist list` against
 // a tls-lb front door: the serving cert has no RA-TLS extension (OID
-// 1.3.6.1.4.1.59888.1.1), so the CLI must verify the LB's discovery document
+// 1.3.6.1.4.1.66378.1.1), so the CLI must verify the LB's discovery document
 // instead of failing the handshake, then read the allowlist over the pinned
 // cert.
 func TestListThroughTLSLB(t *testing.T) {

--- a/pkg/certutil/certutil.go
+++ b/pkg/certutil/certutil.go
@@ -24,7 +24,7 @@ var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 // OIDAttestationDigest marks issued certificates with a SHA-256 of the
 // attestation evidence that authorized issuance — an audit-trail extension
 // shared between the CDS HTTP signer and the in-process issuer.
-var OIDAttestationDigest = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59888, 1, 2}
+var OIDAttestationDigest = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66378, 1, 2}
 
 // GenerateSerial returns a cryptographically random 128-bit serial number
 // suitable for X.509 certificates.

--- a/pkg/ratls/errors.go
+++ b/pkg/ratls/errors.go
@@ -12,7 +12,7 @@ var (
 	ErrKeyBinding = errors.New("ratls: REPORTDATA does not match key")
 
 	// ErrNotAttested indicates that a certificate does not contain
-	// the RA-TLS attestation extension (OID 1.3.6.1.4.1.59888.1.1).
+	// the RA-TLS attestation extension (OID 1.3.6.1.4.1.66378.1.1).
 	ErrNotAttested = errors.New("ratls: certificate missing RA-TLS extension")
 
 	// ErrSignatureInvalid indicates that the hardware attestation report's

--- a/pkg/ratls/extension.go
+++ b/pkg/ratls/extension.go
@@ -41,18 +41,17 @@ const (
 	SNPMeasurementSize = 48
 )
 
-// OID arc: 1.3.6.1.4.1.59888 is a placeholder PEN (Private Enterprise Number).
-// Replace with an IANA-registered PEN when available.
+// OID arc: 1.3.6.1.4.1.66378 is our official PEN (Private Enterprise Number).
 //
-//	1.3.6.1.4.1.59888.1   - Confidential TEE attestation arc
-//	1.3.6.1.4.1.59888.1.1 - RA-TLS attestation extension
-//	1.3.6.1.4.1.59888.1.2 - attestation-evidence audit digest (certutil)
-//	1.3.6.1.4.1.59888.1.4 - pod sandbox ID extension (sandbox.go)
+//	1.3.6.1.4.1.66378.1   - Confidential TEE attestation arc
+//	1.3.6.1.4.1.66378.1.1 - RA-TLS attestation extension
+//	1.3.6.1.4.1.66378.1.2 - attestation-evidence audit digest (certutil)
+//	1.3.6.1.4.1.66378.1.4 - pod sandbox ID extension (sandbox.go)
 //
 // .1.3 was the RA-TLS config-claims extension; it is retired, not reusable.
 var (
-	OIDConfidentialTEE  = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59888, 1}
-	OIDRATLSAttestation = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59888, 1, 1}
+	OIDConfidentialTEE  = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66378, 1}
+	OIDRATLSAttestation = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66378, 1, 1}
 )
 
 // TEEType identifies the confidential computing platform.

--- a/pkg/ratls/sandbox.go
+++ b/pkg/ratls/sandbox.go
@@ -14,10 +14,10 @@ import (
 )
 
 // OIDSandboxID identifies the pod-sandbox-ID extension (see extension.go for
-// the 1.3.6.1.4.1.59888 arc):
+// the 1.3.6.1.4.1.66378 arc):
 //
-//	1.3.6.1.4.1.59888.1.4 - pod sandbox ID extension
-var OIDSandboxID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 59888, 1, 4}
+//	1.3.6.1.4.1.66378.1.4 - pod sandbox ID extension
+var OIDSandboxID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66378, 1, 4}
 
 // sandboxIDPattern bounds a sandbox ID to what CRI runtimes emit (containerd:
 // 64 hex chars), with headroom for other runtimes.


### PR DESCRIPTION
`66378` is our official, registered IANA PEN:
https://www.iana.org/assignments/enterprise-numbers/?q=Inexorable

(This will require corresponding changes to all the certs consumers, mostly c8s-verify-js for now and some TEErminator PRs.)