### PR TITLE
fix(ci): stop every c8s-image dispatch sharing one concurrency group

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -29,7 +29,19 @@ permissions:
 
 concurrency:
   # Per triggering commit, not per ref (workflow_run's ref is always main).
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha }}
+  #
+  # The inputs are part of the identity, not decoration. A workflow_dispatch has
+  # no workflow_run event, so the commit term falls through to github.sha —
+  # main's head — which is the SAME value for every dispatch between two pushes.
+  # Without the inputs, two c8s_ref rebuilds, or a dev and a non-dev build, share
+  # a group and queue behind each other (cancel-in-progress is false) despite
+  # producing different images. Nothing about them needs serializing: a c8s_ref
+  # rebuild pushes only :<variant>[-cdi]-<ref>, which is distinct per ref, and
+  # dev builds carry their own -dev tags. They are empty on the workflow_run
+  # path, so the auto path groups exactly as before.
+  group: >-
+    ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha
+    }}-${{ github.event.inputs.c8s_ref }}-${{ github.event.inputs.dev }}
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## What

`c8s-image.yml`'s concurrency group keys its commit term on
`github.event.workflow_run.head_sha || github.sha`, and includes neither
dispatch input.

On the `workflow_run` path that is exactly right — each Docker run carries its
own `head_sha`, so builds for different commits group separately, as the
existing comment says.

On `workflow_dispatch` there is no `workflow_run` event, so the term falls
through to `github.sha` — **main's head**, the same value for every dispatch
between two pushes to main. So all manual builds share one group, and with
`cancel-in-progress: false` they queue instead of running in parallel:

- two `c8s_ref` rebuilds serialize, even though they bake different releases;
- a `dev=true` and a `dev=false` build serialize, even though they produce
  different images and different measurements.

## Fix

Add both inputs to the group.

Nothing about these runs needs serializing. A `c8s_ref` rebuild pushes only
`:<variant>[-cdi]-<ref>`, which is distinct per ref; dev builds carry their own
`-dev` tags. The floating-tag race that *would* matter — two main builds both
repointing `:rke2-cdi` / `:rke2` — is untouched, since those already group by
distinct `head_sha`, so this changes nothing about it either way.

`github.event.inputs` is absent on the `workflow_run` path, so both new terms
render empty there and the auto path groups exactly as before.

## Verification

The folded scalar renders to the intended single-line expression (pyyaml):

```
'${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha }}-${{ github.event.inputs.c8s_ref }}-${{ github.event.inputs.dev }}'
```

## Found via

Rebuilding a node image with `c8s_ref=04501e1` to repair a measured-allowlist-floor
mismatch (the image's two-entry floor pinned a different `cds` digest than the
installed release, so CDS was denied at container create and the whole
`c8s-system` namespace stalled in `CreateContainerError`). Wanting a second
rebuild in parallel is what surfaced the shared group.

## Deliberately not changed

`confidential-e2e.yml:34` has the identical expression and also takes a `c8s_ref`
dispatch input, so it collapses the same way. Left alone on purpose: that lane
runs on self-hosted org hardware and leases a finite bare-metal CVM host, so its
accidental serialization may be load-bearing. Worth a separate look by someone
who knows whether the downstream lane's own concurrency already covers it.