### PR TITLE
fix(operator): add a startupProbe so liveness cannot kill it mid-startup

### DIFF
--- a/internal/helmchart/c8s/templates/operator.yaml
+++ b/internal/helmchart/c8s/templates/operator.yaml
@@ -91,6 +91,13 @@ spec:
               containerPort: 8080
             - name: health
               containerPort: 8081
+          # setupManager (CRD discovery + webhook PKI bootstrap) runs before the
+          # health server serves, with :8081 already bound by NewManager, so
+          # probes hang rather than refuse. 30x10s covers that window.
+          startupProbe:
+            httpGet: { path: /healthz, port: health }
+            periodSeconds: 10
+            failureThreshold: 30
           readinessProbe:
             httpGet: { path: /readyz, port: health }
             initialDelaySeconds: 3


### PR DESCRIPTION
The operator is the only control-plane component with no `startupProbe` and no liveness `initialDelaySeconds`:

```
cds.yaml:255      startupProbe   periodSeconds 10, failureThreshold 30   300s
tls-lb:97         liveness       initialDelaySeconds 10
attestation-api   readiness      initialDelaySeconds 2
operator.yaml:97  liveness       periodSeconds 30, nothing else          ~90s
```

It is also the one least likely to fit in 90s on a cold cluster: `setupManager` does CRD discovery and bootstraps the webhook PKI before it registers the health checks at all. controller-runtime binds `:8081` in `NewManager` and only serves it inside `mgr.Start`, so probes hang during that window and a kill restarts straight back into it. `failurePolicy=Fail` means admission is refused while the webhook is down, so no workload pod gets created at all.

Scope of the claim, stated plainly: everything above is read from the source and the rendered chart. What motivated it is a crash-loop on snp-metal at 2026-07-31 09:20Z, where the operator failed both probes with `context deadline exceeded` while cds, tls-lb and attestation-api came up on the same cluster. **I have not confirmed that slow startup caused that incident.** Its operator logs were never captured, and a later run had the operator healthy, so the trigger is still unknown. It could have been OOM, a panic, or apiserver unavailability.

So take this as closing a gap every sibling already covers, with an unexplained incident as the reason anyone looked. It does not come with proof that it fixes that incident.

What would settle it: the operator's own logs from a failing run. `runner.go:148` logs `"starting manager"` immediately before `mgr.Start`, so its absence puts the block inside `setupManager` and its presence puts it later.

Rendered and checked:

```
98   startupProbe:
99     httpGet: { path: /healthz, port: health }
100    periodSeconds: 10
101    failureThreshold: 30
```

`go test -count=1 ./internal/helmchart/...` passes, same as main. Additive only, so a healthy operator is unaffected.
