### PR TITLE
feat(allowlist): derive a workload entry from a live Kubernetes object

### DIFF
--- a/internal/cmds/allowlist/derive.go
+++ b/internal/cmds/allowlist/derive.go
@@ -1,0 +1,151 @@
+package allowlist
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// podTemplate is the slice of a Deployment/StatefulSet/DaemonSet/Pod we need.
+// Decoding into this rather than the k8s API types keeps the CLI free of a
+// client-go dependency for what is a pure text transformation.
+type podTemplate struct {
+	InitContainers []templateContainer `json:"initContainers"`
+	Containers     []templateContainer `json:"containers"`
+}
+
+type templateContainer struct {
+	Name    string   `json:"name"`
+	Image   string   `json:"image"`
+	Command []string `json:"command"`
+	Args    []string `json:"args"`
+}
+
+// podSpecOf finds the pod spec in a Pod or in any workload that carries a pod
+// template, so `kubectl get deploy/x -o json` and `kubectl get pod/x -o json`
+// both work without the caller reaching for jq first.
+func podSpecOf(data []byte) (podTemplate, error) {
+	var probe struct {
+		Kind string `json:"kind"`
+		Spec struct {
+			podTemplate
+			Template struct {
+				Spec podTemplate `json:"spec"`
+			} `json:"template"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return podTemplate{}, fmt.Errorf("parse object: %w", err)
+	}
+	if len(probe.Spec.Template.Spec.Containers) > 0 {
+		return probe.Spec.Template.Spec, nil
+	}
+	if len(probe.Spec.Containers) > 0 {
+		return probe.Spec.podTemplate, nil
+	}
+	kind := probe.Kind
+	if kind == "" {
+		kind = "object"
+	}
+	return podTemplate{}, fmt.Errorf("%s carries no containers: expected a Pod or a workload with a pod template", kind)
+}
+
+// argvPolicy renders one half of a container's argv policy.
+//
+// An empty argv is Deny, never Exact: Exact requires equality against a
+// non-empty argv and the apply is rejected outright, and Any would be looser
+// than what the container actually runs.
+func argvPolicy(argv []string) allowlist.ArgvPolicy {
+	if len(argv) == 0 {
+		return allowlist.ArgvPolicy{Policy: allowlist.PolicyDeny}
+	}
+	return allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: argv}
+}
+
+func deriveContainers(cs []templateContainer) ([]allowlist.Container, error) {
+	out := make([]allowlist.Container, 0, len(cs))
+	for _, c := range cs {
+		_, raw, found := strings.Cut(c.Image, "@")
+		if !found {
+			return nil, fmt.Errorf("container %q is not pinned by digest: %s", c.Name, c.Image)
+		}
+		digest, err := types.ParseDigest(raw)
+		if err != nil {
+			return nil, fmt.Errorf("container %q: %w", c.Name, err)
+		}
+		out = append(out, allowlist.Container{
+			Digest:  digest,
+			Image:   c.Image,
+			Command: argvPolicy(c.Command),
+			Args:    argvPolicy(c.Args),
+		})
+	}
+	return out, nil
+}
+
+func newWorkloadDeriveCmd(_ *options) *cobra.Command {
+	var secrets []string
+	var label string
+	cmd := &cobra.Command{
+		Use:   "derive <name> <file|->",
+		Short: "Build a workload entry from a live Kubernetes object",
+		Long: `Emit a workload entry for <name> from a Pod, Deployment, StatefulSet or
+DaemonSet given as JSON in <file> (or stdin with '-'). Nothing is sent; pipe the
+result to 'workload apply'.
+
+Deriving from the live object keeps the entry from drifting away from what is
+actually running, and handles two things a hand-written entry usually gets
+wrong. Init containers are part of the set CDS matches, so omitting them makes
+every release fail with "no workload entry matches the running containers". And
+a container with a command and no args needs an args policy of "deny", because
+"exact" requires a non-empty argv.
+
+The entry pins argv, so it expires the moment a container command changes:
+re-derive and re-apply whenever the workload is edited.
+
+c8s injects its own sidecars and drops them before matching, so they are
+deliberately absent from the derived entry.`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := readFileOrStdin(cmd, args[1])
+			if err != nil {
+				return err
+			}
+			spec, err := podSpecOf(data)
+			if err != nil {
+				return err
+			}
+			containers, err := deriveContainers(spec.Containers)
+			if err != nil {
+				return err
+			}
+			initContainers, err := deriveContainers(spec.InitContainers)
+			if err != nil {
+				return err
+			}
+			w := allowlist.Workload{
+				Label:          label,
+				InitContainers: initContainers,
+				Containers:     containers,
+			}
+			if len(secrets) > 0 {
+				w.Secrets = &allowlist.SecretsPolicy{
+					Policy: allowlist.PolicyAllow,
+					Read:   secrets,
+				}
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			return enc.Encode(map[string]allowlist.Workload{args[0]: w})
+		},
+	}
+	cmd.Flags().StringArrayVar(&secrets, "secret-read", nil,
+		"grant read on this secret path (repeatable); omit for no secrets block")
+	cmd.Flags().StringVar(&label, "label", "", "optional entry label")
+	return cmd
+}

--- a/internal/cmds/allowlist/derive_test.go
+++ b/internal/cmds/allowlist/derive_test.go
@@ -1,0 +1,147 @@
+package allowlist
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+const testDigest = "sha256:effd250754b8a70517c27eab8f18463b395a7b2a8e868fd919226c3180636939"
+const testImage = "nvcr.io/nvidia/ai-dynamo/vllm-runtime@" + testDigest
+
+// deployJSON is a Deployment carrying an init container, a container with a
+// command and no args, and a container with both. That combination is what a
+// hand-written entry gets wrong in practice.
+func deployJSON() string {
+	return `{
+      "kind": "Deployment",
+      "spec": {"template": {"spec": {
+        "initContainers": [
+          {"name": "seed", "image": "` + testImage + `",
+           "command": ["sh", "-c", "cp -an /a/. /seed/"]}
+        ],
+        "containers": [
+          {"name": "frontend", "image": "` + testImage + `",
+           "command": ["python3", "-m", "dynamo.frontend"]},
+          {"name": "worker", "image": "` + testImage + `",
+           "command": ["sh"], "args": ["-c", "exec python3 -m dynamo.vllm"]}
+        ]}}}}`
+}
+
+func runDerive(t *testing.T, stdin string, args ...string) (map[string]pkgallowlist.Workload, error) {
+	t.Helper()
+	cmd := newWorkloadDeriveCmd(&options{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		return nil, err
+	}
+	var got map[string]pkgallowlist.Workload
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("derived output is not a workload map: %v\n%s", err, out.String())
+	}
+	return got, nil
+}
+
+func TestDeriveCoversInitContainers(t *testing.T) {
+	got, err := runDerive(t, deployJSON(), "dynamo", "-")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	w, ok := got["dynamo"]
+	if !ok {
+		t.Fatalf("entry not keyed by name: %v", got)
+	}
+	// CDS matches the whole candidate set, so an undeclared init container
+	// refuses every release with "no workload entry matches the running
+	// containers".
+	if len(w.InitContainers) != 1 {
+		t.Fatalf("init containers = %d, want 1", len(w.InitContainers))
+	}
+	if len(w.Containers) != 2 {
+		t.Fatalf("containers = %d, want 2", len(w.Containers))
+	}
+}
+
+func TestDeriveArgvPolicies(t *testing.T) {
+	got, _ := runDerive(t, deployJSON(), "dynamo", "-")
+	w := got["dynamo"]
+
+	// A command with no args is Deny. Exact would be rejected on apply
+	// ("exact policy requires a non-empty argv") and Any would be looser than
+	// what the container runs.
+	if p := w.Containers[0].Args.Policy; p != pkgallowlist.PolicyDeny {
+		t.Errorf("frontend args policy = %q, want %q", p, pkgallowlist.PolicyDeny)
+	}
+	if p := w.Containers[1].Args.Policy; p != pkgallowlist.PolicyExact {
+		t.Errorf("worker args policy = %q, want %q", p, pkgallowlist.PolicyExact)
+	}
+	if got, want := w.Containers[1].Args.Argv, []string{"-c", "exec python3 -m dynamo.vllm"}; !equalArgv(got, want) {
+		t.Errorf("worker argv = %v, want %v", got, want)
+	}
+	if p := w.InitContainers[0].Command.Policy; p != pkgallowlist.PolicyExact {
+		t.Errorf("init command policy = %q, want %q", p, pkgallowlist.PolicyExact)
+	}
+}
+
+func TestDeriveSecretsOnlyWhenAsked(t *testing.T) {
+	got, _ := runDerive(t, deployJSON(), "dynamo", "-")
+	if got["dynamo"].Secrets != nil {
+		t.Errorf("secrets block emitted without --secret-read")
+	}
+
+	got, _ = runDerive(t, deployJSON(), "dynamo", "-", "--secret-read", "/dynamo/volumes/w235")
+	s := got["dynamo"].Secrets
+	if s == nil {
+		t.Fatal("no secrets block with --secret-read")
+	}
+	if s.Policy != pkgallowlist.PolicyAllow || len(s.Read) != 1 || s.Read[0] != "/dynamo/volumes/w235" {
+		t.Errorf("secrets = %+v", s)
+	}
+}
+
+func TestDeriveAcceptsABarePod(t *testing.T) {
+	pod := `{"kind":"Pod","spec":{"containers":[{"name":"c","image":"` + testImage + `","command":["sleep","inf"]}]}}`
+	got, err := runDerive(t, pod, "p", "-")
+	if err != nil {
+		t.Fatalf("derive pod: %v", err)
+	}
+	if len(got["p"].Containers) != 1 {
+		t.Fatalf("containers = %d, want 1", len(got["p"].Containers))
+	}
+}
+
+func TestDeriveRejectsUnpinnedImage(t *testing.T) {
+	bad := `{"kind":"Pod","spec":{"containers":[{"name":"c","image":"busybox:latest","command":["sh"]}]}}`
+	if _, err := runDerive(t, bad, "p", "-"); err == nil {
+		t.Fatal("accepted an image with no digest")
+	} else if !strings.Contains(err.Error(), "not pinned by digest") {
+		t.Errorf("error = %v, want a digest complaint", err)
+	}
+}
+
+func TestDeriveRejectsObjectWithoutContainers(t *testing.T) {
+	if _, err := runDerive(t, `{"kind":"ConfigMap","spec":{}}`, "x", "-"); err == nil {
+		t.Fatal("accepted an object with no pod spec")
+	} else if !strings.Contains(err.Error(), "carries no containers") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+func equalArgv(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -30,6 +30,7 @@ by name or image ref.`,
 		newWorkloadListCmd(o),
 		newWorkloadGetCmd(o),
 		newWorkloadApplyCmd(o),
+		newWorkloadDeriveCmd(o),
 		newWorkloadEditCmd(o),
 		newWorkloadDeleteCmd(o),
 	)


### PR DESCRIPTION
Closes #211.

Hand-writing a workload entry is the step most likely to wedge a pod, and it fails as a generic `403 Forbidden: not authorized for this secret` that names no cause. We hit two distinct causes bringing up a Dynamo serving pod against an encrypted weights volume, and both cost a round trip to diagnose.

**Init containers are part of the candidate set.** Omit them and CDS refuses with `no workload entry matches the running containers`, while every container you did declare matches fine. `c8s secrets explain` is what makes this visible, marking the undeclared one `foreign` under a NEAR MISS.

**An empty argv is `deny`, not `exact`.** A container with a `command` and no `args` cannot be `{"policy":"exact","argv":[]}`; the apply is rejected with `exact policy requires a non-empty argv`. `any` would be looser than what the container actually runs.

`workload derive <name> <file|->` takes a Pod, Deployment, StatefulSet or DaemonSet as JSON and emits the entry:

```
kubectl -n dynamo get deploy/dynamo -o json \
  | c8s allowlist workload derive dynamo - --secret-read /dynamo/volumes/w235 \
  | c8s allowlist workload apply - --url ... --measurements ... --operator-key ...
```

Nothing is sent by `derive` itself. The doc string also states the thing that bit us twice: the entry pins argv, so it expires the moment a container command changes, and a chart edit plus a grant re-derivation are one operation.

Decoding into a local struct rather than pulling in client-go, since this is a pure text transformation and the CLI has no k8s client dependency today. Tell me if you would rather it used the API types.

Verified against a live 8-GPU Dynamo deployment serving Qwen3-235B from a c8s encrypted volume: one init container, two containers, argv policies `deny` and `exact`, byte-identical to the entry we had derived by hand for that pod. Six table-driven tests cover init containers, both argv policies, the secrets block, a bare Pod, an unpinned image, and an object with no pod spec.