### PR TITLE
fix(policy-monitor): let the enforcement SIGKILL actually land

### DIFF
--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -159,6 +159,21 @@ not-found, so the SIGKILL never fires and the denied image runs **unenforced**
 systemd-scope naming — see `internal/cmds/policymonitor/kill.go`
 (`cgroupDirMatchesCID`).
 
+The other way the kill silently misses is the write itself. The unit's
+`ProtectControlGroups=yes` remounted `/sys/fs/cgroup` read-only *inside
+policy-monitor's own mount namespace*, so every `cgroup.kill` write returned
+`EROFS` while the hierarchy looked `rw` to everything else in the guest — a
+non-allowlisted image ran unenforced for its full lifetime. Because that class
+of failure is invisible from outside the unit, policy-monitor now runs a
+**boot-time kill-path self-test** (`cgroupKiller.selfTest`): it creates a
+scratch cgroup under the configured cgroup root, writes its `cgroup.kill`, and
+removes it. On failure the process exits non-zero before installing the inotify
+watch, so `c8s-ready.target` never activates and no workload container is
+admitted. A policy-monitor that cannot kill must not look healthy.
+Correspondingly, a denied container whose kill errors — or which is never
+confirmed dead — is logged at **error**, not warning: it is a total bypass of
+the image policy, not a hiccup.
+
 ## Why the OPA policy is permissive
 
 kata-agent's bootstrap OPA policy in this image is
@@ -358,9 +373,11 @@ SIGKILL it.
 
 **Flow.** policy-monitor reads cgroup.procs and either gets ESRCH
 on the kill (process already gone) or doesn't find a PID at all
-(cgroup empty). The monitor logs the case at info level and moves
+(cgroup empty). The monitor logs the case at **error** level and moves
 on. The container is effectively "killed" — by itself — before any
-useful work.
+useful work. The severity is deliberate even though this case is benign:
+"denied, and not confirmed dead" is indistinguishable from a kill that
+silently missed (the two field bugs above), so an operator has to see it.
 
 **Outcome.** Denied container exits, just as if policy-monitor had
 killed it. No false-positive enforcement; no leakage.

--- a/internal/cmds/policymonitor/coverage_test.go
+++ b/internal/cmds/policymonitor/coverage_test.go
@@ -237,22 +237,48 @@ func TestRunAllowlistRefresh_EmptyMeasurementsFailsClosed(t *testing.T) {
 }
 
 // --- monitor.kill paths ---------------------------------------------------
+// captureLogs lives in refreshstate_test.go.
 
 func TestMonitorKill_KillerError(t *testing.T) {
 	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	killer.err = os.ErrPermission
+	buf := captureLogs(m)
 	m.kill("somecid")
 	if calls := killer.snapshot(); len(calls) != 1 {
 		t.Fatalf("expected one cgroup kill attempt, got %+v", calls)
+	}
+	// A denied container that survives its kill is a total bypass of the image
+	// policy, not a warning-grade hiccup.
+	if !strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Errorf("failed kill logged at %s, want ERROR", buf.String())
 	}
 }
 
 func TestMonitorKill_CgroupNotFound(t *testing.T) {
 	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	killer.ok = false
+	buf := captureLogs(m)
 	m.kill("somecid")
 	if calls := killer.snapshot(); len(calls) != 1 {
 		t.Fatalf("expected one cgroup lookup, got %+v", calls)
+	}
+	// "denied but never confirmed dead" is the same bypass — the cgroup that
+	// never materialised is indistinguishable from one we simply failed to find.
+	if !strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Errorf("unconfirmed kill logged at %s, want ERROR", buf.String())
+	}
+}
+
+func TestMonitorKill_SuccessStaysInfo(t *testing.T) {
+	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	killer.ok = true
+	buf := captureLogs(m)
+	m.kill("somecid")
+	if strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Errorf("confirmed kill logged at ERROR: %s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"level":"INFO"`) {
+		t.Errorf("confirmed kill logged at %s, want INFO", buf.String())
 	}
 }
 
@@ -450,6 +476,38 @@ func TestRunMonitor_MissingAllowlist(t *testing.T) {
 	}
 }
 
+// A monitor whose cgroup hierarchy is not writable can decide but cannot
+// enforce. It must exit non-zero rather than run (and gate c8s-ready.target)
+// while silently enforcing nothing — the ProtectControlGroups=yes field bug.
+func TestRunMonitor_FailsWhenKillPathUnusable(t *testing.T) {
+	dir := t.TempDir()
+	allowlistPath := filepath.Join(dir, "allowlist.json")
+	body, _ := json.Marshal(bootstrapAllowlistFile{Sha256Digests: []string{"sha256:" + strings.Repeat("a", 64)}})
+	if err := os.WriteFile(allowlistPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &Config{
+		LogLevel:      "info",
+		AllowlistPath: allowlistPath,
+		WatchDir:      filepath.Join(dir, "watch"),
+		CgroupRoot:    t.TempDir(), // no cgroup.kill: the kill path cannot work
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := runMonitor(ctx, cfg)
+	if err == nil {
+		t.Fatal("runMonitor started with an unusable kill path")
+	}
+	if !strings.Contains(err.Error(), "kill-path self-test") {
+		t.Errorf("error = %v, want it to name the kill-path self-test", err)
+	}
+	// The self-test must gate startup, not just log: nothing should have been
+	// watched.
+	if _, statErr := os.Stat(cfg.WatchDir); !os.IsNotExist(statErr) {
+		t.Errorf("watch dir created despite a failed self-test: stat err = %v", statErr)
+	}
+}
+
 func TestRunMonitor_RunsAndStopsOnContextCancel(t *testing.T) {
 	dir := t.TempDir()
 	allowlistPath := filepath.Join(dir, "allowlist.json")
@@ -461,7 +519,7 @@ func TestRunMonitor_RunsAndStopsOnContextCancel(t *testing.T) {
 		LogLevel:      "info",
 		AllowlistPath: allowlistPath,
 		WatchDir:      filepath.Join(dir, "watch"), // created by runMonitor
-		CgroupRoot:    t.TempDir(),
+		CgroupRoot:    writableCgroupRoot(t),
 		// CDSURL empty: stays baked-seed-only, never touches the network.
 	}
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -50,6 +50,8 @@ import (
 // never materialised within the configured budget.
 type containerKiller interface {
 	kill(containerID string) (bool, error)
+	// selfTest reports whether the kill mechanism is actually usable.
+	selfTest() error
 }
 
 // cgroupKiller searches the configured cgroup root and terminates the
@@ -59,6 +61,9 @@ type containerKiller interface {
 // successful.
 type cgroupKiller struct {
 	cgroupRoot string
+	// procSelfCgroup names this process's own cgroup, under which selfTest
+	// puts its scratch group. Overridable so tests need not be in one.
+	procSelfCgroup string
 	// waitTimeout caps how long we re-scan for the cgroup directory
 	// before giving up. kata-agent creates the cgroup and forks the
 	// init in quick succession after writing config.json, but
@@ -75,10 +80,63 @@ var _ containerKiller = (*cgroupKiller)(nil)
 
 func newCgroupKiller(root string) *cgroupKiller {
 	return &cgroupKiller{
-		cgroupRoot:   root,
-		waitTimeout:  2 * time.Second,
-		pollInterval: 50 * time.Millisecond,
+		cgroupRoot:     root,
+		procSelfCgroup: defaultProcSelfCgroup,
+		waitTimeout:    2 * time.Second,
+		pollInterval:   50 * time.Millisecond,
 	}
+}
+
+const (
+	// defaultProcSelfCgroup is where the kernel reports our own cgroup.
+	defaultProcSelfCgroup = "/proc/self/cgroup"
+
+	// selfTestCgroup is the scratch cgroup selfTest creates; the name makes a
+	// leftover after a hard kill obviously ours.
+	selfTestCgroup = "c8s-policy-monitor-selftest"
+)
+
+// selfTest exercises the real kill path once, at startup: create a scratch
+// cgroup, write its cgroup.kill (a no-op — a fresh cgroup holds no processes),
+// remove it. A read-only /sys/fs/cgroup fails here instead of silently at the
+// first denied container. Nesting the probe under our OWN cgroup is
+// load-bearing, not tidiness: the hierarchy root is mode 0555, so creating a
+// group there would need CAP_DAC_OVERRIDE, which the unit rightly withholds.
+// ProtectControlGroups=yes remounts /sys/fs/cgroup read-only inside this
+// unit's own mount namespace, so cgroup.kill returns EROFS while the guest
+// looks writable from anywhere else — a class of failure invisible without
+// this probe.
+func (c *cgroupKiller) selfTest() error {
+	own, err := ownCgroupPath(c.procSelfCgroup)
+	if err != nil {
+		return err
+	}
+	probe := filepath.Join(c.cgroupRoot, filepath.FromSlash(own), selfTestCgroup)
+	if err := os.Mkdir(probe, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+		return fmt.Errorf("create probe cgroup %s: %w", probe, err)
+	}
+	defer func() { _ = os.Remove(probe) }()
+	if err := writeCgroupKill(probe); err != nil {
+		return fmt.Errorf("kill probe cgroup %s: %w", probe, err)
+	}
+	return nil
+}
+
+// ownCgroupPath returns this process's cgroup relative to the unified
+// hierarchy root, read from the "0::<path>" line of /proc/self/cgroup.
+func ownCgroupPath(path string) (string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read own cgroup: %w", err)
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		rel, ok := strings.CutPrefix(strings.TrimSpace(line), "0::")
+		if !ok {
+			continue
+		}
+		return strings.TrimPrefix(rel, "/"), nil
+	}
+	return "", fmt.Errorf("%s carries no cgroup v2 (0::) entry", path)
 }
 
 func (c *cgroupKiller) kill(containerID string) (bool, error) {

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -15,10 +15,12 @@ import (
 // mutex makes it safe to share between the inotify dispatch goroutine
 // and the test's polling loop in monitor_test.go.
 type fakeKiller struct {
-	mu    sync.Mutex
-	calls []string
-	ok    bool
-	err   error
+	mu           sync.Mutex
+	calls        []string
+	ok           bool
+	err          error
+	selfTestErr  error
+	selfTestSeen bool
 }
 
 func (k *fakeKiller) kill(containerID string) (bool, error) {
@@ -26,6 +28,13 @@ func (k *fakeKiller) kill(containerID string) (bool, error) {
 	defer k.mu.Unlock()
 	k.calls = append(k.calls, containerID)
 	return k.ok, k.err
+}
+
+func (k *fakeKiller) selfTest() error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	k.selfTestSeen = true
+	return k.selfTestErr
 }
 
 // snapshot returns a copy of the recorded calls so tests can assert
@@ -281,6 +290,187 @@ func TestCgroupKiller_PropagatesMalformedProcs(t *testing.T) {
 	killer := &cgroupKiller{cgroupRoot: root, waitTimeout: time.Second, pollInterval: time.Millisecond}
 	if ok, err := killer.kill(cid); err == nil || ok {
 		t.Fatalf("kill = (%v, %v), want permanent parse error", ok, err)
+	}
+}
+
+// testOwnCgroup is the guest-realistic own-cgroup path the self-test fixtures
+// nest the probe under.
+const testOwnCgroup = "/system.slice/policy-monitor.service"
+
+// fakeProcSelfCgroup writes a /proc/self/cgroup stand-in naming own, so the
+// self-test fixtures don't depend on where the test binary's cgroup happens
+// to be.
+func fakeProcSelfCgroup(t *testing.T, own string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cgroup")
+	if err := os.WriteFile(p, []byte("0::"+own+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// seedOwnCgroup creates the killer's own cgroup dir under root, the writable
+// parent the probe is created in.
+func seedOwnCgroup(t *testing.T, root, own string) string {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(own))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// seedProbeCgroup additionally materialises the probe's cgroup.kill, which on a
+// real cgroup2 mount the kernel creates and on a tempdir nothing does.
+func seedProbeCgroup(t *testing.T, root, own string) string {
+	t.Helper()
+	probe := filepath.Join(seedOwnCgroup(t, root, own), selfTestCgroup)
+	if err := os.MkdirAll(probe, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(probe, "cgroup.kill"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return probe
+}
+
+// writableCgroupRoot returns a cgroup root that a newCgroupKiller self-test
+// accepts — seeded at this process's real own-cgroup path, since runMonitor
+// builds its killer against the real /proc/self/cgroup.
+func writableCgroupRoot(t *testing.T) string {
+	t.Helper()
+	own, err := ownCgroupPath(defaultProcSelfCgroup)
+	if err != nil {
+		t.Skipf("no cgroup v2 own-cgroup path: %v", err)
+	}
+	root := t.TempDir()
+	seedProbeCgroup(t, root, own)
+	return root
+}
+
+// newSelfTestKiller wires a killer at root with a fabricated own-cgroup path.
+func newSelfTestKiller(t *testing.T, root string) *cgroupKiller {
+	t.Helper()
+	k := newCgroupKiller(root)
+	k.procSelfCgroup = fakeProcSelfCgroup(t, testOwnCgroup)
+	return k
+}
+
+func TestCgroupKiller_SelfTest_PassesAndExercisesTheKillPrimitive(t *testing.T) {
+	root := t.TempDir()
+	probe := seedProbeCgroup(t, root, testOwnCgroup)
+	if err := newSelfTestKiller(t, root).selfTest(); err != nil {
+		t.Fatalf("selfTest on a writable hierarchy: %v", err)
+	}
+	// The self-test must go through writeCgroupKill, not merely stat the file:
+	// the field failure (ProtectControlGroups=yes) surfaces on open-for-write.
+	contents, err := os.ReadFile(filepath.Join(probe, "cgroup.kill"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "1" {
+		t.Errorf("probe cgroup.kill = %q, want 1", contents)
+	}
+}
+
+// A hierarchy with no cgroup.kill (pre-5.14 kernel) leaves the monitor no way
+// to enforce, so the self-test must fail rather than pass silently.
+func TestCgroupKiller_SelfTest_FailsWithoutKillInterface(t *testing.T) {
+	root := t.TempDir()
+	own := seedOwnCgroup(t, root, testOwnCgroup)
+	if err := newSelfTestKiller(t, root).selfTest(); err == nil {
+		t.Fatal("selfTest passed on a hierarchy with no cgroup.kill")
+	}
+	// And it must not litter the hierarchy with its probe cgroup.
+	if _, err := os.Stat(filepath.Join(own, selfTestCgroup)); !os.IsNotExist(err) {
+		t.Errorf("probe cgroup left behind: stat err = %v", err)
+	}
+}
+
+// The field bug: /sys/fs/cgroup remounted read-only inside the unit's mount
+// namespace, so nothing under it can be created or written.
+func TestCgroupKiller_SelfTest_FailsOnReadOnlyHierarchy(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses directory mode bits; the read-only case needs a real mount")
+	}
+	root := t.TempDir()
+	own := seedOwnCgroup(t, root, testOwnCgroup)
+	if err := os.Chmod(own, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(own, 0o755) })
+	err := newSelfTestKiller(t, root).selfTest()
+	if err == nil {
+		t.Fatal("selfTest passed on a non-writable hierarchy")
+	}
+	if !strings.Contains(err.Error(), "create probe cgroup") {
+		t.Errorf("error = %v, want it to name the probe-cgroup creation failure", err)
+	}
+}
+
+// A cgroup root that isn't there at all (misconfigured --cgroup-root) is the
+// same class of failure: no enforcement is possible.
+func TestCgroupKiller_SelfTest_FailsOnMissingRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "absent", "deeper")
+	if err := newSelfTestKiller(t, root).selfTest(); err == nil {
+		t.Fatal("selfTest passed on a missing cgroup root")
+	}
+}
+
+func TestCgroupKiller_SelfTest_FailsOnUnreadableOwnCgroup(t *testing.T) {
+	k := newCgroupKiller(t.TempDir())
+	k.procSelfCgroup = filepath.Join(t.TempDir(), "absent")
+	err := k.selfTest()
+	if err == nil {
+		t.Fatal("selfTest passed without knowing its own cgroup")
+	}
+	if !strings.Contains(err.Error(), "read own cgroup") {
+		t.Errorf("error = %v, want it to name the own-cgroup read", err)
+	}
+}
+
+// The probe must land under the daemon's own cgroup, never at the hierarchy
+// root: the root is mode 0555, so a group created there needs CAP_DAC_OVERRIDE
+// — which the unit deliberately withholds, and a self-test that demanded it
+// would fail on every guest.
+func TestCgroupKiller_SelfTest_ProbeNestsUnderOwnCgroup(t *testing.T) {
+	root := t.TempDir()
+	seedProbeCgroup(t, root, testOwnCgroup)
+	if err := newSelfTestKiller(t, root).selfTest(); err != nil {
+		t.Fatalf("selfTest: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, selfTestCgroup)); !os.IsNotExist(err) {
+		t.Errorf("probe created at the hierarchy root: stat err = %v", err)
+	}
+}
+
+func TestOwnCgroupPath(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    string
+		wantErr bool
+	}{
+		{"unified", "0::/system.slice/policy-monitor.service\n", "system.slice/policy-monitor.service", false},
+		{"root", "0::/\n", "", false},
+		// A hybrid guest still reports the v2 hierarchy on the 0:: line.
+		{"hybrid", "3:cpu:/foo\n0::/system.slice/a.service\n", "system.slice/a.service", false},
+		{"v1 only", "3:cpu:/foo\n2:memory:/bar\n", "", true},
+		{"empty", "", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "cgroup")
+			if err := os.WriteFile(path, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			got, err := ownCgroupPath(path)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ownCgroupPath err = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && got != tc.want {
+				t.Errorf("ownCgroupPath = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -97,6 +97,14 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		revalidateInterval: 10 * time.Second,
 	}
 
+	// A monitor that cannot write cgroup.kill enforces nothing, so refuse to
+	// come up rather than look healthy: c8s-ready.target Requires= this unit,
+	// so a failed exit keeps the guest from admitting workload containers.
+	if err := m.killer.selfTest(); err != nil {
+		return fmt.Errorf("kill-path self-test: %w", err)
+	}
+	logger.Info("kill-path self-test passed", "cgroup_root", cfg.CgroupRoot)
+
 	// Admission inventory (docs/ratls.md): the guest's sandbox identity, served
 	// to the in-guest get-cert on loopback. Always on — a guest always holds a
 	// pod that will ask, and gating it on configuration would let the untrusted
@@ -504,17 +512,19 @@ func (m *monitor) frozenAttrs() []any {
 	return []any{"allowlist_frozen", true, "frozen_reason", reason, "allowlist_entries", m.allowlist.Size()}
 }
 
-// kill resolves the container's cgroup and terminates it as a unit.
-// Best-effort: if the container has already exited, or its cgroup never
-// materialises within the budget, we log and move on.
+// kill resolves the container's cgroup and terminates it as a unit. Every
+// caller has already DENIED the container, so anything short of a confirmed
+// termination is a bypass of the image policy and logs at Error — including
+// the "cgroup never materialised" case, which is indistinguishable from a
+// container that exited on its own.
 func (m *monitor) kill(cid string) {
 	ok, err := m.killer.kill(cid)
 	if err != nil {
-		m.logger.Warn("kill cgroup failed", "cid", cid, "error", err)
+		m.logger.Error("kill cgroup failed: denied container was NOT terminated", "cid", cid, "error", err)
 		return
 	}
 	if !ok {
-		m.logger.Warn("container cgroup not found", "cid", cid)
+		m.logger.Error("denied container NOT confirmed terminated: cgroup never found or never populated", "cid", cid)
 		return
 	}
 	m.logger.Info("SIGKILLed container cgroup", "cid", cid)

--- a/kata-guest-base/extra/etc/systemd/system/policy-monitor.service
+++ b/kata-guest-base/extra/etc/systemd/system/policy-monitor.service
@@ -65,14 +65,16 @@ ExecStart=/usr/local/bin/policy-monitor monitor
 CapabilityBoundingSet=CAP_KILL CAP_DAC_READ_SEARCH
 AmbientCapabilities=CAP_KILL CAP_DAC_READ_SEARCH
 
-# Hardening — match the strictness of ratls-mesh's unit minus the
-# bits we don't need.
+# Hardening. ProtectControlGroups MUST stay `no`: enforcement is a write to
+# /sys/fs/cgroup/**/cgroup.kill, and `yes` remounts that hierarchy read-only in
+# this unit's own mount namespace — cgroup.kill returns EROFS while the guest
+# looks writable everywhere else. cgroupKiller.selfTest is the boot-time proof.
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
-ProtectControlGroups=yes
+ProtectControlGroups=no
 # RestrictAddressFamilies keeps AF_UNIX (journald) and adds AF_INET/
 # AF_INET6 for the CDS allowlist refresh — policy-monitor pulls
 # CDS's /allowlist over RA-TLS (see cds_refresh.go). With no CDS URL


### PR DESCRIPTION
Image allowlist enforcement is completely inert under `--cvm-mode=pod`. A
non-allowlisted `alpine:3.21` ran indefinitely inside a SEV-SNP CVM on a live
cluster.

`policy-monitor` denies correctly and resolves the right cgroup, then the kill
fails:

```
{"level":"WARN","msg":"deny container: no image digest annotation found","cid":"362c5ff5…"}
{"level":"WARN","msg":"kill cgroup failed","error":"kill cgroup: open /sys/fs/cgroup/…/cri-containerd-362c5ff5….scope/cgroup.kill: read-only file system"}
```

Root cause: `policy-monitor.service` sets `ProtectControlGroups=yes`, which
remounts `/sys/fs/cgroup` read-only inside the unit's own mount namespace. The
daemon's whole enforcement mechanism is writing `cgroup.kill`.

Proof: the identical write from a root shell outside that namespace killed the
container immediately (`exitCode: 9` = SIGKILL). Discovery, naming and path
resolution were already correct.

Also adds a boot-time self-test so a policy-monitor that cannot kill no longer
looks healthy, and raises the failed-kill log to ERROR.
