### PR TITLE
fix(install): keep TEE node labelling and the scheduling preflight under -f

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -381,30 +381,20 @@ func preflightTDXNodes(ctx context.Context) error {
 // (kata.snpNodeSelector / kata.tdxNodeSelector), and the chart-managed CDS
 // and tls-lb both pin the platform's CPU class — with no labelled
 // node the whole release sits Pending and `helm --wait` blocks for the full
-// timeout before failing opaquely. It runs right after autoLabelTEENodes,
-// which labels every kata-targeted node from --hardware-platform, so "no
-// labelled node" means no node matched the kata node selector at all. (Why a
-// wrong-TEE node cannot run these pods: docs/pitfalls.md "kata-qemu-snp on a
-// non-SNP host is a QEMU crash-loop".)
+// timeout before failing opaquely. (Why a wrong-TEE node cannot run these
+// pods: docs/pitfalls.md "kata-qemu-snp on a non-SNP host is a QEMU
+// crash-loop".)
 //
-// Like preflightCDSNode it reads the chart's default values, so it guards the
-// default path only; an operator who customizes via -f owns node labels (the
-// caller skips this when -f is supplied).
-func preflightTEENodes(ctx context.Context, chartPath, hardwarePlatform string) error {
-	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()
-	if err != nil {
-		return fmt.Errorf("helm show values %q: %w", chartPath, err)
-	}
-	var tree map[string]any
-	if err := yaml.Unmarshal(out, &tree); err != nil {
-		return fmt.Errorf("parse chart values: %w", err)
-	}
-
-	selKey, otherPlatform := "snpNodeSelector", "tdx"
+// Read-only, and it reads the EFFECTIVE selector (chart defaults + -f +
+// computed --set), so it runs on every --cvm-mode=pod install including -f
+// ones: whoever owns the label, an unlabelled cluster is broken the same way.
+// autoLabelled only picks the remedy the error names.
+func preflightTEENodes(ctx context.Context, values map[string]any, hardwarePlatform string, autoLabelled bool) error {
+	selKey, otherPlatform := teeSelectorKey(hardwarePlatform), "tdx"
 	if hardwarePlatform == "tdx" {
-		selKey, otherPlatform = "tdxNodeSelector", "sev-snp"
+		otherPlatform = "sev-snp"
 	}
-	sel, _ := nestedMap(tree, "kata", selKey)
+	sel, _ := nestedMap(values, "kata", selKey)
 	selector, ok := labelSelector(sel)
 	if !ok {
 		// Empty/cleared selector means unrestricted confidential scheduling —
@@ -418,7 +408,11 @@ func preflightTEENodes(ctx context.Context, chartPath, hardwarePlatform string) 
 		return fmt.Errorf("kubectl get nodes -l %s: %w", selector, err)
 	}
 	if strings.TrimSpace(string(labeled)) == "" {
-		return fmt.Errorf("no node is labelled %s: the install labels every kata-targeted node from --hardware-platform=%s, so no node matched the kata node selector — without a labelled node no confidential pod can schedule, including the chart's own CDS and tls-lb. Check the cluster has schedulable Linux nodes; on a %s cluster pass --hardware-platform=%s instead. To label a host yourself: kubectl label node <node> %s", selector, hardwarePlatform, otherPlatform, otherPlatform, strings.ReplaceAll(selector, ",", " "))
+		why := fmt.Sprintf("the install labels every kata-targeted node from --hardware-platform=%s, so no node matched the kata node selector — check the cluster has schedulable Linux nodes, and on a %s cluster pass --hardware-platform=%s instead", hardwarePlatform, otherPlatform, otherPlatform)
+		if !autoLabelled {
+			why = fmt.Sprintf("a -f values file sets kata.%s, so the install left node labelling to you", selKey)
+		}
+		return fmt.Errorf("no node is labelled %s: %s. Without a labelled node no confidential pod can schedule, including the chart's own CDS and tls-lb, and `helm --wait` blocks until it times out. To label a host: kubectl label node <node> %s", selector, why, strings.ReplaceAll(selector, ",", " "))
 	}
 	return nil
 }
@@ -777,33 +771,40 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		}
 
 		// --cvm-mode=pod: label every kata-targeted node for the declared
-		// --hardware-platform (refusing if the other platform's label is
-		// still present — a platform switch must be the operator's explicit
-		// act), then fail fast if the platform's confidential pods still
-		// have nowhere to schedule. Declarative — the flag is trusted, no
-		// hardware probe (see autoLabelTEENodes). Runs after the read-only
-		// preflights above — it mutates the cluster (node labels). Skipped
-		// with -f, whose owner owns node labels; NOT skipped under
-		// --single-node — even a one-node cluster needs its platform label
-		// for confidential pods to schedule.
-		kataDefaultPath := cvmModeIsPod(installCvmMode) && len(installValues) == 0
-		if kataDefaultPath {
-			if err := autoLabelTEENodes(cmd.Context(), chartPath, installHardwarePlatform); err != nil {
+		// --hardware-platform (see autoLabelTEENodes), then fail fast if
+		// confidential pods still have nowhere to schedule. Labelling mutates
+		// the cluster, so it runs after the read-only preflights above, and
+		// stands aside — loudly — only when a -f file sets the platform's own
+		// selector; the preflight runs either way. NOT skipped under
+		// --single-node: a one-node cluster needs the label too. See
+		// docs/pitfalls.md "A `-f` values file no longer disables TEE node
+		// labelling".
+		if cvmModeIsPod(installCvmMode) {
+			values, err := effectiveValues(cmd.Context(), chartPath, setArgs)
+			if err != nil {
 				return err
 			}
-			if err := preflightTEENodes(cmd.Context(), chartPath, installHardwarePlatform); err != nil {
+			selectorInValues, err := valuesFilesSetTEESelector(installValues, installHardwarePlatform)
+			if err != nil {
+				return err
+			}
+			if selectorInValues {
+				reportTEELabelSkip(os.Stdout, values, installHardwarePlatform)
+			} else if err := autoLabelTEENodes(cmd.Context(), values, installHardwarePlatform); err != nil {
+				return err
+			}
+			if err := preflightTEENodes(cmd.Context(), values, installHardwarePlatform, !selectorInValues); err != nil {
 				return err
 			}
 		}
 
 		// Fail fast when --hardware-platform=tdx but no node carries the TDX
-		// label. Under --cvm-mode=pod the TDX RuntimeClasses have a nodeSelector on
-		// it; under --cvm-mode=node the attestationApi DaemonSet needs at
+		// label. Under --cvm-mode=node the attestationApi DaemonSet needs at
 		// least one TDX-capable node. Checks a fact about the cluster, not
-		// the values, so it runs with -f too — but the default pod (kata) path
-		// above already checked the chart's actual tdxNodeSelector (which
+		// the values, so it runs with -f too — but under --cvm-mode=pod the
+		// block above already checked the effective tdxNodeSelector (which
 		// may be customized or cleared), so skip the fixed-key check there.
-		if installHardwarePlatform == "tdx" && installCvmMode != "aks" && !kataDefaultPath {
+		if installHardwarePlatform == "tdx" && installCvmMode != "aks" && !cvmModeIsPod(installCvmMode) {
 			if err := preflightTDXNodes(cmd.Context()); err != nil {
 				return err
 			}
@@ -1766,6 +1767,20 @@ func appendResolvedDigestArgs(ctx context.Context, chartPath string, helmArgs []
 // pinning its digest, and the render then fails with no image ref. The merged
 // tree is built once and shared across the per-component calls.
 func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []string) (func(valuePath string) (bool, error), error) {
+	tree, err := effectiveValues(ctx, chartPath, setArgs)
+	if err != nil {
+		return nil, err
+	}
+	return func(valuePath string) (bool, error) {
+		return boolAtPath(tree, valuePath), nil
+	}, nil
+}
+
+// effectiveValues resolves the values tree the release will actually render
+// with, in helm's precedence order: chart defaults < -f files in order <
+// --set. Callers that decide on a value the operator may have overridden (the
+// digest resolver, the TEE-node preflight) must read this, not the defaults.
+func effectiveValues(ctx context.Context, chartPath string, setArgs []string) (map[string]any, error) {
 	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()
 	if err != nil {
 		return nil, fmt.Errorf("helm show values %q: %w", chartPath, err)
@@ -1774,10 +1789,9 @@ func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []
 	if err := yaml.Unmarshal(out, &tree); err != nil {
 		return nil, fmt.Errorf("parse chart values: %w", err)
 	}
-	// Operator -f files, lowest precedence after the chart defaults. A "-"
-	// (stdin) entry is skipped: stdin is already consumed by the caller and a
-	// component enabled only there stays invisible to the resolver — a narrow
-	// edge next to a real file, which is the documented path.
+	// A "-" (stdin) entry is skipped: stdin is already consumed by the caller,
+	// so a value set only there stays invisible here — a narrow edge next to a
+	// real file, which is the documented path.
 	for _, vf := range installValues {
 		if vf == "-" {
 			continue
@@ -1795,9 +1809,7 @@ func componentEnabledPredicate(ctx context.Context, chartPath string, setArgs []
 	if err := overlaySetArgs(tree, setArgs); err != nil {
 		return nil, err
 	}
-	return func(valuePath string) (bool, error) {
-		return boolAtPath(tree, valuePath), nil
-	}, nil
+	return tree, nil
 }
 
 // mergeValues deep-merges src onto dst the way helm coalesces a -f file: a map

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1477,6 +1477,65 @@ func TestMergeValuesDeepMergesOverlay(t *testing.T) {
 	}
 }
 
+// The TEE-node preflight reads effectiveValues, so a -f file must move the
+// selector it actually sets and nothing else. The RKE2 case: the tls-lb
+// host-port workaround the install itself recommends must leave the chart's
+// snpNodeSelector standing, or the preflight would stop catching the
+// unlabelled cluster it exists to catch.
+func TestEffectiveValuesResolvesTEESelector(t *testing.T) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm not on PATH")
+	}
+	dir, err := extractChart()
+	if err != nil {
+		t.Fatalf("extractChart: %v", err)
+	}
+	defer os.RemoveAll(dir)
+	chartPath := filepath.Join(dir, helmchart.ChartRoot)
+
+	tmp := t.TempDir()
+	tlsLB := filepath.Join(tmp, "tlslb.yaml")
+	if err := os.WriteFile(tlsLB, []byte("tlsLb:\n  hostPort:\n    enabled: false\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nfd := filepath.Join(tmp, "nfd.yaml")
+	if err := os.WriteFile(nfd, []byte("kata:\n  snpNodeSelector:\n    nfd/snp: \"true\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := installValues
+	defer func() { installValues = prev }()
+
+	selectorFor := func(t *testing.T, files []string) string {
+		t.Helper()
+		installValues = files
+		tree, err := effectiveValues(context.Background(), chartPath, nil)
+		if err != nil {
+			t.Fatalf("effectiveValues(%v): %v", files, err)
+		}
+		sel, _ := nestedMap(tree, "kata", "snpNodeSelector")
+		got, ok := labelSelector(sel)
+		if !ok {
+			return ""
+		}
+		return got
+	}
+
+	if got := selectorFor(t, nil); got != "confidential.ai/sev-snp=true" {
+		t.Errorf("chart default selector = %q, want confidential.ai/sev-snp=true", got)
+	}
+	if got := selectorFor(t, []string{tlsLB}); got != "confidential.ai/sev-snp=true" {
+		t.Errorf("with an unrelated -f, selector = %q, want the chart default confidential.ai/sev-snp=true", got)
+	}
+	// helm coalesces nested maps key-by-key, so repointing the selector at NFD
+	// without nulling the default leaves BOTH labels required — the preflight
+	// must demand what the chart will actually render, not what was written.
+	// See docs/pitfalls.md "Repointing kata.snpNodeSelector at NFD".
+	if got := selectorFor(t, []string{nfd}); got != "confidential.ai/sev-snp=true,nfd/snp=true" {
+		t.Errorf("with a -f repointing the selector, selector = %q, want the coalesced pair confidential.ai/sev-snp=true,nfd/snp=true", got)
+	}
+}
+
 func assertArgsEqual(t *testing.T, got, want []string) {
 	t.Helper()
 	if len(got) != len(want) {

--- a/cmd/c8s/tee_label.go
+++ b/cmd/c8s/tee_label.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -33,20 +34,11 @@ import (
 // or stripped by this path.
 //
 // Labelling is idempotent (kubectl --overwrite; a node already carrying the
-// pair is a server-side no-op). Like the preflights, this reads the chart's
-// default values and only runs on the default install path; -f installs own
-// their node labels (caller skips).
-func autoLabelTEENodes(ctx context.Context, chartPath, hardwarePlatform string) error {
-	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()
-	if err != nil {
-		return fmt.Errorf("helm show values %q: %w", chartPath, err)
-	}
-	var tree map[string]any
-	if err := yaml.Unmarshal(out, &tree); err != nil {
-		return fmt.Errorf("parse chart values: %w", err)
-	}
-
-	plan, ok, err := planTEELabels(tree, hardwarePlatform)
+// pair is a server-side no-op). values is the effective tree (chart defaults
+// + -f + computed --set); the caller skips this only when a -f file sets the
+// platform's own selector — see docs/kata.md "Installing".
+func autoLabelTEENodes(ctx context.Context, values map[string]any, hardwarePlatform string) error {
+	plan, ok, err := planTEELabels(values, hardwarePlatform)
 	if err != nil {
 		return err
 	}
@@ -80,6 +72,56 @@ func autoLabelTEENodes(ctx context.Context, chartPath, hardwarePlatform string) 
 		return fmt.Errorf("labelling %s nodes: %w", hardwarePlatform, err)
 	}
 	return nil
+}
+
+// teeSelectorKey names the kata.* values key holding a platform's node
+// selector — the label the confidential RuntimeClasses schedule on.
+func teeSelectorKey(hardwarePlatform string) string {
+	if hardwarePlatform == "tdx" {
+		return "tdxNodeSelector"
+	}
+	return "snpNodeSelector"
+}
+
+// valuesFilesSetTEESelector reports whether any -f values file explicitly sets
+// the platform's kata.*NodeSelector. When one does, that file owns the TEE node
+// label (NFD, provisioning, GitOps) and auto-labelling stands aside; merely
+// supplying some -f does not. Mirrors valuesFilesSetDistro.
+func valuesFilesSetTEESelector(files []string, hardwarePlatform string) (bool, error) {
+	key := teeSelectorKey(hardwarePlatform)
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return false, fmt.Errorf("read values file %q: %w", f, err)
+		}
+		var tree map[string]any
+		if err := yaml.Unmarshal(data, &tree); err != nil {
+			return false, fmt.Errorf("parse values file %q: %w", f, err)
+		}
+		kata, ok := tree["kata"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, set := kata[key]; set {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// reportTEELabelSkip says auto-labelling stood aside and names the label the
+// operator must apply. Silence here is what left confidential pods Pending
+// until `helm --wait` timed out (docs/pitfalls.md).
+func reportTEELabelSkip(w io.Writer, values map[string]any, hardwarePlatform string) {
+	key := teeSelectorKey(hardwarePlatform)
+	sel, _ := nestedMap(values, "kata", key)
+	selector, ok := labelSelector(sel)
+	if !ok {
+		fmt.Fprintf(w, "+ kata.%s is set by -f and selects no label: confidential scheduling is unrestricted, nothing to label\n", key)
+		return
+	}
+	fmt.Fprintf(w, "+ kata.%s is set by -f: skipping automatic %s node labelling — label the nodes yourself:\n", key, hardwarePlatform)
+	fmt.Fprintf(w, "    kubectl label node <node> %s\n", strings.ReplaceAll(selector, ",", " "))
 }
 
 // teeLabelPlan is the label work a given --hardware-platform implies:

--- a/cmd/c8s/tee_label_test.go
+++ b/cmd/c8s/tee_label_test.go
@@ -3,6 +3,10 @@
 package main
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -121,4 +125,98 @@ func TestPlanTEELabels(t *testing.T) {
 			t.Fatal("planTEELabels accepted a non-string kata.nodeSelector value, want error")
 		}
 	})
+}
+
+// valuesFilesSetTEESelector decides whether -f owns the TEE node label. Any -f
+// used to disable auto-labelling wholesale, which broke the flow the tls-lb
+// host-port preflight itself recommends on RKE2 (`-f` setting
+// tlsLb.hostPort.enabled=false): confidential pods then sat Pending with no
+// message naming the missing label. Only the platform's own selector counts.
+func TestValuesFilesSetTEESelector(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	tlsLB := write("tlslb.yaml", "tlsLb:\n  hostPort:\n    enabled: false\n")
+	kataNodes := write("kata-nodes.yaml", "kata:\n  nodeSelector:\n    pool: kata\n")
+	snp := write("snp.yaml", "kata:\n  snpNodeSelector:\n    feature.node.kubernetes.io/cpu-security.sev.snp.enabled: \"true\"\n")
+	snpCleared := write("snp-cleared.yaml", "kata:\n  snpNodeSelector: {}\n")
+	snpNull := write("snp-null.yaml", "kata:\n  snpNodeSelector:\n")
+	tdx := write("tdx.yaml", "kata:\n  tdxNodeSelector:\n    nfd/tdx: \"true\"\n")
+	empty := write("empty.yaml", "")
+
+	tests := []struct {
+		name     string
+		files    []string
+		platform string
+		want     bool
+	}{
+		{name: "no values files", platform: "sev-snp"},
+		{name: "RKE2 tls-lb host-port opt-out does not disown the label", files: []string{tlsLB}, platform: "sev-snp"},
+		{name: "kata.nodeSelector only narrows the labelled set", files: []string{kataNodes}, platform: "sev-snp"},
+		{name: "empty file", files: []string{empty}, platform: "sev-snp"},
+		{name: "custom snpNodeSelector is operator-owned", files: []string{snp}, platform: "sev-snp", want: true},
+		{name: "cleared snpNodeSelector is operator-owned", files: []string{snpCleared}, platform: "sev-snp", want: true},
+		{name: "explicit null snpNodeSelector is operator-owned", files: []string{snpNull}, platform: "sev-snp", want: true},
+		{name: "later file in the list still counts", files: []string{tlsLB, snp}, platform: "sev-snp", want: true},
+		{name: "snpNodeSelector says nothing about tdx", files: []string{snp}, platform: "tdx"},
+		{name: "tdxNodeSelector is operator-owned on tdx", files: []string{tdx}, platform: "tdx", want: true},
+		{name: "tdxNodeSelector says nothing about sev-snp", files: []string{tdx}, platform: "sev-snp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := valuesFilesSetTEESelector(tt.files, tt.platform)
+			if err != nil {
+				t.Fatalf("valuesFilesSetTEESelector: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("valuesFilesSetTEESelector(%v, %q) = %t, want %t", tt.files, tt.platform, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("missing file errors", func(t *testing.T) {
+		if _, err := valuesFilesSetTEESelector([]string{filepath.Join(dir, "nope.yaml")}, "sev-snp"); err == nil {
+			t.Fatal("missing values file accepted, want error")
+		}
+	})
+	t.Run("malformed yaml errors", func(t *testing.T) {
+		bad := write("bad.yaml", "kata: [oops\n")
+		if _, err := valuesFilesSetTEESelector([]string{bad}, "sev-snp"); err == nil {
+			t.Fatal("malformed values file accepted, want error")
+		}
+	})
+}
+
+// Skipping auto-labelling must be LOUD and actionable: the silent skip is what
+// forced an operator to read the source to find the missing label.
+func TestReportTEELabelSkipNamesTheKubectlCommand(t *testing.T) {
+	var buf bytes.Buffer
+	reportTEELabelSkip(&buf, map[string]any{
+		"kata": map[string]any{
+			"snpNodeSelector": map[string]any{"feature.node.kubernetes.io/cpu-security.sev.snp.enabled": "true"},
+		},
+	}, "sev-snp")
+	got := buf.String()
+	for _, want := range []string{
+		"kata.snpNodeSelector is set by -f",
+		"kubectl label node <node> feature.node.kubernetes.io/cpu-security.sev.snp.enabled=true",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("skip notice missing %q:\n%s", want, got)
+		}
+	}
+
+	// A cleared selector has no label to name — say that, don't print a
+	// kubectl command with an empty selector.
+	buf.Reset()
+	reportTEELabelSkip(&buf, map[string]any{"kata": map[string]any{"tdxNodeSelector": map[string]any{}}}, "tdx")
+	if got := buf.String(); !strings.Contains(got, "unrestricted") || strings.Contains(got, "kubectl label node") {
+		t.Fatalf("cleared selector notice = %q, want the unrestricted-scheduling wording and no kubectl command", got)
+	}
 }

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -81,9 +81,18 @@ attestation remains the real boundary). If any node still carries the
 `--hardware-platform` — the install refuses and prints the exact
 `kubectl label nodes ... <key>-` command to clear it: a platform switch must
 be the operator's explicit act, not a side effect of a mistyped flag.
-Installs that bypass the CLI — a GitOps `HelmRelease`, or `c8s install -f` —
-get no auto-labelling and must label out-of-band (provisioning, NFD, or
-`kubectl label node <node> <platform-label>=true` after checking the host).
+
+A `-f` values file does **not** by itself turn labelling off. Only a file that
+sets the platform's own `kata.snpNodeSelector` / `kata.tdxNodeSelector` hands
+labelling back to you (NFD, provisioning, GitOps) — and when it does, the
+install says so and prints the `kubectl label node ...` command rather than
+labelling silently. Installs that bypass the CLI entirely (a GitOps
+`HelmRelease`) get no auto-labelling and must label out-of-band.
+
+Either way the read-only check runs on every `--cvm-mode=pod` install: if the
+**effective** selector (chart defaults + your `-f` + the CLI's computed
+values) matches no node, the install fails immediately naming the label,
+instead of leaving CDS `Pending` until `helm --wait` times out.
 
 `--debug` switches the guest image to the `<tag>-debug` variant published in
 lockstep with every locked tag: the same build except the baked kata-agent

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -494,9 +494,62 @@ check the pods first.
 `cmd/c8s/uninstall.go`, `cmd/c8s/tee_label.go`
 
 The kata sweep removes `confidential.ai/sev-snp` / `confidential.ai/tdx`
-along with the kata artifacts. A subsequent
-`c8s install --cvm-mode=pod -f <values>` can fail fast at the TDX/SNP node check (the
-auto-label path doesn't cover every `-f` shape). Relabel by hand and rerun.
+along with the kata artifacts. A subsequent `c8s install --cvm-mode=pod`
+relabels automatically, but one whose `-f` owns the selector (see the next
+entry) fails fast at the TEE node check instead. Relabel by hand and rerun.
+
+## A `-f` values file no longer disables TEE node labelling — only one that owns the selector does
+
+`cmd/c8s/install.go:782` (the `--cvm-mode=pod` block), `cmd/c8s/tee_label.go:90`
+(`valuesFilesSetTEESelector`)
+
+Any `-f` used to disable **both** the `confidential.ai/sev-snp` /
+`confidential.ai/tdx` auto-labelling **and** the preflight that catches the
+result — silently. That collided with the first thing a stock RKE2 cluster
+forces: `rke2-ingress-nginx` owns host port 443, so the tls-lb preflight
+(`cmd/c8s/install.go:249`) tells you to `install with -f setting
+tlsLb.hostPort.enabled=false` — and taking the tool's own advice dropped the
+labelling. CDS then sat `Pending` with `didn't match Pod's node
+affinity/selector`, `helm --wait` burned its full 10-minute timeout, and the
+surfaced error was an unrelated `Progress deadline exceeded`. Nothing named
+the missing label.
+
+Now:
+
+- Auto-labelling stands aside only when a `-f` file **sets the platform's own
+  `kata.snpNodeSelector` / `kata.tdxNodeSelector`** — the values-driven
+  install that really does own its labels. Everything else (`tlsLb.*`,
+  `kata.nodeSelector`, digests, …) still gets labelled.
+- When it does stand aside it **says so on stdout** and prints the exact
+  `kubectl label node <node> <k>=<v>` command.
+- The read-only preflight (`preflightTEENodes`, `cmd/c8s/install.go:392`) runs
+  on **every** `--cvm-mode=pod` install, against the *effective* selector
+  (`effectiveValues`, `cmd/c8s/install.go:1783`) rather than the chart
+  defaults. An unlabelled cluster fails in seconds naming the label.
+
+If you genuinely manage labels out of band and the nodes are not labelled yet,
+label them before installing — the preflight is a hard failure, not a warning.
+
+## Repointing `kata.snpNodeSelector` at NFD does not remove the c8s default key
+
+`internal/helmchart/c8s/values.yaml:466`, `cmd/c8s/install.go:1818`
+(`mergeValues`)
+
+helm coalesces nested maps **key-by-key**, so a `-f` file with
+
+```yaml
+kata:
+  snpNodeSelector:
+    feature.node.kubernetes.io/cpu-security.sev.snp.enabled: "true"
+```
+
+renders a selector requiring **both** that key and the chart's
+`confidential.ai/sev-snp: "true"`. The values.yaml comment's "set `{}` for
+unrestricted scheduling" is wrong for the same reason: an empty map coalesces
+to the default and the label is still required. Only `snpNodeSelector: null`
+actually clears it. `c8s install`'s preflight reports the coalesced selector,
+which is what the RuntimeClasses will really schedule on — label for every
+pair it prints, or use `null`.
 
 ## `cds.node.selector: null` in a values file does not survive helm's multi-file merge
 

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -463,9 +463,12 @@ kata:
   ## a security boundary — attestation is. `c8s install --cvm-mode=pod` applies it to
   ## every kata-targeted node (declarative, no probe); -f/GitOps installs
   ## label out-of-band. Swept by `c8s uninstall` — keep in lockstep with
-  ## snpCapabilityNodeLabel in cmd/c8s/uninstall.go. Set {} for unrestricted
-  ## scheduling, or point at an existing capability label (e.g. NFD's
-  ## feature.node.kubernetes.io/cpu-security.sev.snp.enabled: "true").
+  ## snpCapabilityNodeLabel in cmd/c8s/uninstall.go.
+  ## Overriding: helm coalesces nested maps, so `{}` keeps the default and an
+  ## added key ANDs with it. Use `null` to drop the selector entirely; to swap
+  ## in a capability label (e.g. NFD's
+  ## feature.node.kubernetes.io/cpu-security.sev.snp.enabled) set `null` and
+  ## re-add. See docs/pitfalls.md — "Repointing `kata.snpNodeSelector` at NFD".
   snpNodeSelector:
     confidential.ai/sev-snp: "true"
   ## TDX twin of snpNodeSelector: rendered as scheduling.nodeSelector on the


### PR DESCRIPTION
Passing any `-f`/`--values` silently disables both automatic
`confidential.ai/sev-snp=true` node labelling and the read-only preflight that
would catch the fallout (`cmd/c8s/install.go`, `kataDefaultPath`).

This collides with the first thing a stock RKE2 cluster forces you to do. RKE2
ships ingress-nginx, which owns host port 443, so the install's own preflight
tells you to fix it with `-f`:

> tls-lb wants host port 443 but it is already bound on every node by:
> kube-system/rke2-ingress-nginx-controller-… install with -f setting
> tlsLb.hostPort.enabled=false

Taking that advice drops the TEE label. Observed: CDS `Pending` with
`didn't match Pod's node affinity/selector`, `helm --wait` blocking for its full
10-minute timeout, and a surfaced error (`Progress deadline exceeded`) that
names nothing relevant. Diagnosing it required reading the source.

The "-f owners own their node labels" intent is kept; the all-or-nothing,
silent-on-presence-of-any-`-f` behaviour is not.

