### PR TITLE
fix(uninstall): scope the kata-pod guard to non-release workloads

### DIFF
--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -58,6 +58,17 @@ var kataRuntimeClassNames = []string{"kata-qemu", "kata-clh", "kata-qemu-snp", "
 // deletes it); --delete-crds removes it by name.
 const confidentialWorkloadCRD = "confidentialworkloads.confidential.ai"
 
+// chartInstanceLabel is on every pod template the chart renders (c8s.commonLabels
+// and tls-lb.selectorLabels) and on nothing the operator creates. With the
+// release namespace it identifies the release's own kata pods — see
+// docs/kata.md "Uninstalling".
+const chartInstanceLabel = "app.kubernetes.io/instance"
+
+// kataPodJSONPath dumps one "namespace\tname\truntimeClass\tinstance" line per
+// pod; jsonpath needs the dots in a label key escaped.
+var kataPodJSONPath = `{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.runtimeClassName}{"\t"}{.metadata.labels.` +
+	strings.ReplaceAll(chartInstanceLabel, ".", `\.`) + `}{"\n"}{end}`
+
 // kataRuntimeNodeLabel is the label kata-deploy stamps on each node once the
 // runtime is installed (and removes again in its cleanup, when that runs to
 // completion).
@@ -133,7 +144,10 @@ distro detected from the cluster.
 
 The uninstall refuses to proceed while pods with a kata RuntimeClass are
 still running — removing the runtime under a running confidential workload
-kills it without cleanup. Delete those workloads first, or pass --force.
+kills it without cleanup. Delete those workloads first, or pass --force. The
+release's own chart-managed pods (CDS and tls-lb pin a kata RuntimeClass) do
+not count: they are matched by the release namespace plus the chart's
+app.kubernetes.io/instance label and are torn down by this uninstall.
 
 Left in place by default: the ConfidentialWorkload CRD (helm never deletes
 crds/; --delete-crds removes it ALONG WITH EVERY ConfidentialWorkload object)
@@ -183,12 +197,12 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH.`,
 		// regardless of the sweep), so the guard applies whenever kata is
 		// being uninstalled, not only when the sweep runs.
 		if (cfg.Enabled || uninstallHostSweepOnly) && !uninstallForce {
-			pods, err := listKataPods(ctx)
+			pods, chartManaged, err := listKataPods(ctx, uninstallNamespace, uninstallRelease)
 			if err != nil {
 				return err
 			}
 			if len(pods) > 0 {
-				return fmt.Errorf("pods with a kata RuntimeClass are still running and would lose their runtime:\n  %s\ndelete them first, or pass --force to uninstall anyway", strings.Join(pods, "\n  "))
+				return kataPodsRunningError(pods, chartManaged, uninstallNamespace, uninstallRelease)
 			}
 		}
 
@@ -421,32 +435,57 @@ func sweepImageRef(tree map[string]any) (string, error) {
 	return "", fmt.Errorf("kata.containerdPrep.image has neither digest nor tag")
 }
 
-// listKataPods returns "namespace/name (runtimeClass)" for every pod whose
-// runtimeClassName is one of the chart's kata RuntimeClasses. runtimeClassName
-// is not a server-side field selector, so the filter runs client-side over a
-// one-line-per-pod jsonpath dump.
-func listKataPods(ctx context.Context) ([]string, error) {
+// listKataPods returns "namespace/name (runtimeClass)" for every pod the guard
+// protects, plus the count of the release's own pods it skipped.
+// runtimeClassName is not a server-side field selector, so the filter runs
+// client-side over a one-line-per-pod jsonpath dump.
+func listKataPods(ctx context.Context, namespace, release string) ([]string, int, error) {
 	out, err := exec.CommandContext(ctx, "kubectl", "get", "pods", "--all-namespaces",
-		"-o", `jsonpath={range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.runtimeClassName}{"\n"}{end}`).Output()
+		"-o", "jsonpath="+kataPodJSONPath).Output()
 	if err != nil {
-		return nil, fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
+		return nil, 0, fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
 	}
-	return filterKataPods(strings.Split(strings.TrimSpace(string(out)), "\n")), nil
+	pods, chartManaged := filterKataPods(strings.Split(strings.TrimSpace(string(out)), "\n"), namespace, release)
+	return pods, chartManaged, nil
 }
 
-// filterKataPods keeps the "namespace\tname\truntimeClass" lines whose class
-// is a kata RuntimeClass. Pods without a runtimeClassName emit an empty third
-// field and are skipped, as is anything malformed.
-func filterKataPods(lines []string) []string {
+// filterKataPods keeps the "namespace\tname\truntimeClass\tinstanceLabel" lines
+// whose class is a kata RuntimeClass, dropping the release's own chart-managed
+// pods (release namespace AND chartInstanceLabel == release) and counting them
+// separately: the chart pins kata on CDS and tls-lb, so counting them would
+// refuse every clean uninstall. Pods without a runtimeClassName emit an empty
+// third field and are skipped, as is anything malformed.
+func filterKataPods(lines []string, namespace, release string) ([]string, int) {
 	var pods []string
+	chartManaged := 0
 	for _, l := range lines {
 		fields := strings.Split(l, "\t")
-		if len(fields) != 3 || !slices.Contains(kataRuntimeClassNames, fields[2]) {
+		if len(fields) != 4 || !slices.Contains(kataRuntimeClassNames, fields[2]) {
+			continue
+		}
+		if fields[0] == namespace && fields[3] == release {
+			chartManaged++
 			continue
 		}
 		pods = append(pods, fmt.Sprintf("%s/%s (%s)", fields[0], fields[1], fields[2]))
 	}
-	return pods
+	return pods, chartManaged
+}
+
+// kataPodsRunningError is the guard's refusal. It reports the chart-managed
+// pods it skipped so the operator sees the guard is scoped, not blanket, and
+// does not reach for --force reflexively.
+func kataPodsRunningError(pods []string, chartManaged int, namespace, release string) error {
+	skipped := ""
+	if chartManaged > 0 {
+		plural := "s"
+		if chartManaged == 1 {
+			plural = ""
+		}
+		skipped = fmt.Sprintf("\n(skipped %d chart-managed pod%s of release %q in namespace %q)", chartManaged, plural, release, namespace)
+	}
+	return fmt.Errorf("pods with a kata RuntimeClass are still running and would lose their runtime:\n  %s%s\ndelete them first, or pass --force to uninstall anyway",
+		strings.Join(pods, "\n  "), skipped)
 }
 
 // runKataSweep removes the kata host artifacts from every node kata-deploy

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -47,17 +47,17 @@ func TestValidateUninstallFlagsRejectsSweepOnlyWithoutSweep(t *testing.T) {
 // are unaffected by a kata uninstall.
 func TestFilterKataPodsKeepsOnlyKataRuntimeClasses(t *testing.T) {
 	lines := []string{
-		"default\tinference-0\tkata-qemu-snp",
-		"default\tweb-0\t", // no runtimeClassName (runc)
-		"team-a\tbatch-1\tkata-qemu",
-		"team-b\tsandbox-2\tgvisor", // non-kata RuntimeClass
-		"team-c\tclh-0\tkata-clh",
-		"team-d\ttd-0\tkata-qemu-tdx",
-		"team-e\tgpu-0\tkata-qemu-snp-nvidia",
+		"default\tinference-0\tkata-qemu-snp\t",
+		"default\tweb-0\t\t", // no runtimeClassName (runc)
+		"team-a\tbatch-1\tkata-qemu\t",
+		"team-b\tsandbox-2\tgvisor\t", // non-kata RuntimeClass
+		"team-c\tclh-0\tkata-clh\t",
+		"team-d\ttd-0\tkata-qemu-tdx\t",
+		"team-e\tgpu-0\tkata-qemu-snp-nvidia\t",
 		"", // trailing blank line from kubectl
 		"malformed-line-no-tabs",
 	}
-	got := filterKataPods(lines)
+	got, chartManaged := filterKataPods(lines, "c8s-system", "c8s")
 	want := []string{
 		"default/inference-0 (kata-qemu-snp)",
 		"team-a/batch-1 (kata-qemu)",
@@ -67,6 +67,97 @@ func TestFilterKataPodsKeepsOnlyKataRuntimeClasses(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("filterKataPods = %v, want %v", got, want)
+	}
+	if chartManaged != 0 {
+		t.Errorf("chartManaged = %d, want 0", chartManaged)
+	}
+}
+
+// The chart pins a kata RuntimeClass on its own CDS and tls-lb pods, so
+// counting them would refuse every uninstall on a cluster with no tenant
+// workloads and train operators to always pass --force. The exclusion is the
+// release namespace AND the chart's instance label, so neither a kata pod in
+// another namespace nor an unlabelled pod in the release namespace escapes it.
+func TestFilterKataPodsExcludesOnlyChartManagedPods(t *testing.T) {
+	const (
+		cdsPod   = "c8s-system\tc8s-cds-774d45db86-jgpp4\tkata-qemu-snp\tc8s"
+		lbPod    = "c8s-system\tc8s-tls-lb-6b9f7c5d4-xk2mq\tkata-qemu-snp\tc8s"
+		tenant   = "team-a\tinference-0\tkata-qemu-snp\t"
+		squatter = "c8s-system\toperator-scratch-0\tkata-qemu\t"
+		// Same instance label, different namespace: not this release's pod.
+		otherRelease = "other-ns\tc8s-cds-0\tkata-qemu-snp\tc8s"
+	)
+	tests := []struct {
+		name             string
+		lines            []string
+		want             []string
+		wantChartManaged int
+	}{
+		{
+			name:             "chart pods only — clean uninstall proceeds",
+			lines:            []string{cdsPod, lbPod},
+			wantChartManaged: 2,
+		},
+		{
+			name:             "tenant kata pod in another namespace still refuses",
+			lines:            []string{cdsPod, lbPod, tenant},
+			want:             []string{"team-a/inference-0 (kata-qemu-snp)"},
+			wantChartManaged: 2,
+		},
+		{
+			name:             "unrelated kata pod in the release namespace still refuses",
+			lines:            []string{cdsPod, squatter},
+			want:             []string{"c8s-system/operator-scratch-0 (kata-qemu)"},
+			wantChartManaged: 1,
+		},
+		{
+			name:  "mixed",
+			lines: []string{cdsPod, tenant, lbPod, squatter, otherRelease},
+			want: []string{
+				"team-a/inference-0 (kata-qemu-snp)",
+				"c8s-system/operator-scratch-0 (kata-qemu)",
+				"other-ns/c8s-cds-0 (kata-qemu-snp)",
+			},
+			wantChartManaged: 2,
+		},
+		{
+			name:  "a differently-named release in the namespace is not ours",
+			lines: []string{"c8s-system\tstaging-cds-0\tkata-qemu-snp\tstaging"},
+			want:  []string{"c8s-system/staging-cds-0 (kata-qemu-snp)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, chartManaged := filterKataPods(tt.lines, "c8s-system", "c8s")
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("pods = %v, want %v", got, tt.want)
+			}
+			if chartManaged != tt.wantChartManaged {
+				t.Errorf("chartManaged = %d, want %d", chartManaged, tt.wantChartManaged)
+			}
+		})
+	}
+}
+
+// The refusal must name the skipped chart pods, or an operator reading it
+// cannot tell a scoped guard from a blanket one and reaches for --force.
+func TestKataPodsRunningErrorReportsSkippedChartPods(t *testing.T) {
+	msg := kataPodsRunningError([]string{"team-a/inference-0 (kata-qemu-snp)"}, 2, "c8s-system", "c8s").Error()
+	for _, want := range []string{
+		"team-a/inference-0 (kata-qemu-snp)",
+		`skipped 2 chart-managed pods of release "c8s" in namespace "c8s-system"`,
+		"--force",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message %q missing %q", msg, want)
+		}
+	}
+	// Nothing skipped — no parenthetical at all.
+	if msg := kataPodsRunningError([]string{"team-a/inference-0 (kata-qemu-snp)"}, 0, "c8s-system", "c8s").Error(); strings.Contains(msg, "skipped") {
+		t.Errorf("message mentions skipped pods when none were skipped: %q", msg)
+	}
+	if msg := kataPodsRunningError([]string{"team-a/inference-0 (kata-qemu-snp)"}, 1, "c8s-system", "c8s").Error(); !strings.Contains(msg, "skipped 1 chart-managed pod of") {
+		t.Errorf("singular skipped count not rendered: %q", msg)
 	}
 }
 

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -591,9 +591,23 @@ containerd-prep initContainer) on the nodes kata-deploy targeted, removing:
 
 The RuntimeClass objects and the enforcement policy are deleted with the
 release. The uninstall refuses to run while pods with a kata RuntimeClass
-are still running (`--force` overrides). If the release is already gone but
-the hosts are dirty — e.g. a previous bare `helm uninstall` — run
-`c8s uninstall --host-sweep-only`.
+are still running (`--force` overrides).
+
+The release's own pods do not count. CDS and tls-lb pin a kata RuntimeClass
+themselves (see "Chart-managed mesh components pin their own RuntimeClass"),
+so counting them would refuse every uninstall on a cluster with zero tenant
+workloads and leave `--force` as the only route — which trains operators to
+pass it reflexively and defeats the guard the next time it fires for real.
+The exclusion is the release namespace **and** the chart's
+`app.kubernetes.io/instance: <release>` label, both of which the uninstall
+already knows: a tenant workload an operator has deliberately placed in the
+release namespace still trips the guard, as does a kata pod carrying the same
+label in another namespace. When the guard does fire it reports how many
+chart-managed pods it skipped, so the scoping is visible. The label contract
+is pinned by `TestChartKataPinnedPodsCarryInstanceLabel`.
+
+If the release is already gone but the hosts are dirty — e.g. a previous bare
+`helm uninstall` — run `c8s uninstall --host-sweep-only`.
 
 A bare `helm uninstall` (or removing `kata.enabled`) still works: you keep
 the preStop-hook cleanup, but none of the sweep guarantees above.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -207,7 +207,10 @@ Guardrails:
 - Uninstall **refuses to run while pods with a kata RuntimeClass are still
   scheduled** — pulling the runtime out from under a confidential workload kills
   it without cleanup. Delete those workloads first, or pass `--force` (the kata
-  VMs keep running unmanaged but cannot restart).
+  VMs keep running unmanaged but cannot restart). The release's own
+  chart-managed pods (CDS and tls-lb pin a kata RuntimeClass) are excluded by
+  release namespace + `app.kubernetes.io/instance`, and the refusal reports how
+  many it skipped; see [`docs/kata.md`](kata.md#uninstalling).
 - `--host-sweep-only` runs only the kata sweep, for a cluster whose release a
   bare `helm uninstall` already removed but whose nodes still carry artifacts;
   it uses the chart defaults and the distro detected from the cluster.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -489,6 +489,17 @@ the cluster converges fine underneath, and a second `c8s install` run (helm
 upgrade) flips it to `deployed`. Don't start debugging from the helm status —
 check the pods first.
 
+## A tenant pod labelled `app.kubernetes.io/instance: <release>` evades the uninstall guard
+
+`cmd/c8s/uninstall.go` (`filterKataPods`)
+
+The running-kata-pod guard skips pods in the release namespace that carry the
+chart's `app.kubernetes.io/instance: <release>` label, so `c8s uninstall` is not
+blocked by its own CDS and tls-lb pods. Nothing stops an operator from putting
+that label on a real workload in `c8s-system`; such a pod is silently not
+protected and loses its runtime. Keep tenant workloads out of the release
+namespace, or off that label.
+
 ## `c8s uninstall` sweeps the TEE node labels — relabel before reinstalling
 
 `cmd/c8s/uninstall.go`, `cmd/c8s/tee_label.go`

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -3773,6 +3773,42 @@ func helmTemplateKata(t *testing.T, args ...string) (string, error) {
 	}, args...)...)
 }
 
+// Contract with the `c8s uninstall` running-pod guard (cmd/c8s/uninstall.go,
+// filterKataPods): it skips the release's own kata pods by release namespace +
+// app.kubernetes.io/instance, so every kata-pinned pod template must carry that
+// label or a clean uninstall is refused again.
+func TestChartKataPinnedPodsCarryInstanceLabel(t *testing.T) {
+	out, err := helmTemplateKata(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	var pinned []string
+	iterateManifests(t, out, func(doc []byte) bool {
+		var obj struct {
+			docMeta
+			Spec struct {
+				Template corev1.PodTemplateSpec `json:"template"`
+			} `json:"spec"`
+		}
+		if err := sigsyaml.Unmarshal(doc, &obj); err != nil {
+			return false
+		}
+		rc := obj.Spec.Template.Spec.RuntimeClassName
+		if rc == nil || !strings.HasPrefix(*rc, "kata-") {
+			return false
+		}
+		pinned = append(pinned, obj.Metadata.Name)
+		if got := obj.Spec.Template.Labels["app.kubernetes.io/instance"]; got != "c8s" {
+			t.Errorf("%s pod template: app.kubernetes.io/instance = %q, want the release name", obj.Metadata.Name, got)
+		}
+		return false
+	})
+	slices.Sort(pinned)
+	if want := []string{"c8s-cds", "c8s-tls-lb"}; !reflect.DeepEqual(pinned, want) {
+		t.Errorf("kata-pinned workloads = %v, want %v", pinned, want)
+	}
+}
+
 func TestChartKataTLSLBAllowlistProxyUsesGuestAttestationAPI(t *testing.T) {
 	out, err := helmTemplateKata(t)
 	if err != nil {


### PR DESCRIPTION
`c8s uninstall` on a `--cvm-mode=pod` install always refuses, because the
chart's own CDS and tls-lb pods pin `kata-qemu-snp`:

```
pods with a kata RuntimeClass are still running and would lose their runtime:
  c8s-system/c8s-cds-774d45db86-jgpp4 (kata-qemu-snp)
delete them first, or pass --force
```

On a cluster with zero tenant workloads, `--force` is the only route. That
trains operators to pass `--force` reflexively, so the next time the guard
fires — protecting a real tenant workload — it gets overridden without thought.

Scopes the guard to pods the release does not manage. Tenant kata pods, in any
namespace including the release namespace, still trip it. `--force` semantics
are unchanged.
