### PR TITLE
fix(policy-monitor): surface the frozen in-guest allowlist under kata

### DIFF
--- a/internal/cmds/policymonitor/cds_refresh.go
+++ b/internal/cmds/policymonitor/cds_refresh.go
@@ -15,6 +15,9 @@ package policymonitor
 //
 // Gated on a configured CDS URL: with C8S_CDS_URL unset the monitor
 // stays baked-seed-only and never opens the network.
+//
+// It does not run until a CDS measurement is pinned, which --cvm-mode=pod
+// does not yet deliver.
 
 import (
 	"context"
@@ -32,25 +35,26 @@ import (
 // until ctx is cancelled. Construction failures (bad measurements, RA-TLS
 // setup) disable refresh but never crash the monitor — the baked seed
 // still enforces.
-func runAllowlistRefresh(ctx context.Context, logger *slog.Logger, cfg *Config, a *allowlist, overlay *policyOverlay) {
+func runAllowlistRefresh(ctx context.Context, logger *slog.Logger, cfg *Config, a *allowlist, overlay *policyOverlay, state *refreshState) {
 	measurements, err := ratls.ParseHexMeasurementsList(splitCSV(cfg.CDSMeasurements))
 	if err != nil {
-		logger.Error("allowlist refresh disabled: invalid C8S_CDS_MEASUREMENTS", "error", err)
+		disableRefresh(logger, state, reasonBadMeasurements, a, "error", err)
 		return
 	}
 	if len(measurements) == 0 {
 		// Fail closed: with C8S_CDS_URL set but no measurements pinned, the
 		// RA-TLS handshake would accept any CDS measurement. Disable refresh
 		// rather than open that hole — the baked seed keeps enforcing.
-		logger.Error("allowlist refresh disabled: C8S_CDS_URL set but C8S_CDS_MEASUREMENTS empty (refusing to accept any CDS measurement)")
+		disableRefresh(logger, state, reasonNoMeasurements, a)
 		return
 	}
 	httpClient, err := ratls.NewVerifyingHTTPClient(measurements, cfg.AttestationServiceURL)
 	if err != nil {
-		logger.Error("allowlist refresh disabled: build RA-TLS client failed", "error", err)
+		disableRefresh(logger, state, reasonClientFailed, a, "error", err)
 		return
 	}
 	client := allowlistclient.NewClientWithHTTP(cfg.CDSURL, httpClient)
+	state.enable()
 
 	// Per-call deadline so a hung CDS can't wedge this goroutine. Capped at
 	// half the refresh interval (and never above refreshCallTimeoutMax) so
@@ -77,6 +81,15 @@ func runAllowlistRefresh(ctx context.Context, logger *slog.Logger, cfg *Config, 
 // further clamps to half the configured interval so the call can never
 // outlive the next tick.
 const refreshCallTimeoutMax = 15 * time.Second
+
+// disableRefresh records why the refresh will not run and says so at ERROR,
+// naming the frozen entry count so the line states the blast radius rather than
+// only the cause.
+func disableRefresh(logger *slog.Logger, state *refreshState, reason string, a *allowlist, args ...any) {
+	state.disable(reason)
+	logger.Error("allowlist refresh disabled; enforcement frozen at the baked seed",
+		append([]any{"reason", reason, "entries", a.Size()}, args...)...)
+}
 
 // refreshOnce pulls the current CDS allowlist. Two layers update: the baked
 // floor grows additively with the pulled floor digests (never shrinks — a CDS

--- a/internal/cmds/policymonitor/coverage_test.go
+++ b/internal/cmds/policymonitor/coverage_test.go
@@ -204,9 +204,13 @@ func TestRunAllowlistRefresh_InvalidMeasurements(t *testing.T) {
 		RefreshInterval: time.Second,
 	}
 	// Returns promptly (refresh disabled) and never touches the network.
-	runAllowlistRefresh(context.Background(), testLogger(t), cfg, a, &policyOverlay{})
+	state := &refreshState{reason: reasonNotYetStarted}
+	runAllowlistRefresh(context.Background(), testLogger(t), cfg, a, &policyOverlay{}, state)
 	if a.Size() != 1 {
 		t.Fatalf("size = %d, want 1 (seed unchanged)", a.Size())
+	}
+	if got := state.frozenReason(); got != reasonBadMeasurements {
+		t.Fatalf("frozenReason = %q, want %q", got, reasonBadMeasurements)
 	}
 }
 
@@ -218,9 +222,17 @@ func TestRunAllowlistRefresh_EmptyMeasurementsFailsClosed(t *testing.T) {
 		CDSMeasurements: "",
 		RefreshInterval: time.Second,
 	}
-	runAllowlistRefresh(context.Background(), testLogger(t), cfg, a, &policyOverlay{})
+	state := &refreshState{reason: reasonNotYetStarted}
+	runAllowlistRefresh(context.Background(), testLogger(t), cfg, a, &policyOverlay{}, state)
 	if a.Size() != 1 {
 		t.Fatalf("size = %d, want 1", a.Size())
+	}
+	// The fail-closed must also be reportable, not just logged and forgotten.
+	if got := state.frozenReason(); got != reasonNoMeasurements {
+		t.Fatalf("frozenReason = %q, want %q", got, reasonNoMeasurements)
+	}
+	if rep := state.report(a.Size()); rep.Enabled || rep.Entries != 1 {
+		t.Fatalf("report = %+v, want disabled with 1 entry", rep)
 	}
 }
 

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -37,6 +37,9 @@ type admissionInventory struct {
 	containers map[string]string                          // live container id -> image digest
 	admitted   map[string]workloadclaims.SandboxContainer // key -> everything ever admitted
 	sandboxID  string                                     // the guest's single pod sandbox
+	// refresh renders the allowlist-refresh posture. Set by runMonitor; nil
+	// leaves the field off the wire rather than reporting a false "disabled".
+	refresh func() workloadclaims.AllowlistRefresh
 }
 
 func newAdmissionInventory() *admissionInventory {
@@ -118,6 +121,17 @@ func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []wo
 		return strings.Compare(strings.Join(x.Argv, "\x1f"), strings.Join(y.Argv, "\x1f"))
 	})
 	return slices.Compact(digests), containers, true, nil
+}
+
+// AllowlistRefresh satisfies workloadclaims.AllowlistRefreshReporter: it puts
+// "this guest is enforcing a frozen allowlist" on the CDS-facing digests
+// endpoint, the one authenticated channel out of a guest whose journal the
+// operator cannot read. Diagnostic only — CDS makes no issuance decision on it.
+func (b *admissionInventory) AllowlistRefresh() (workloadclaims.AllowlistRefresh, bool) {
+	if b.refresh == nil {
+		return workloadclaims.AllowlistRefresh{}, false
+	}
+	return b.refresh(), true
 }
 
 // sandboxIDFromAnnotations extracts the pod sandbox ID from a container's OCI

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -53,6 +53,7 @@ import (
 
 	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
 // runMonitor is the long-running entry. It's package-private rather
@@ -85,6 +86,7 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		logger:    logger,
 		allowlist: a,
 		overlay:   &policyOverlay{},
+		refresh:   &refreshState{reason: reasonNotYetStarted},
 		killer:    newCgroupKiller(cfg.CgroupRoot),
 		// configReadDeadline is the budget for re-reading config.json
 		// after the initial CREATE event. kata-agent's setup_bundle
@@ -101,6 +103,7 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	// host switch it off.
 	{
 		m.inventory = newAdmissionInventory()
+		m.inventory.refresh = func() workloadclaims.AllowlistRefresh { return m.refresh.report(a.Size()) }
 		signer := sandboxTokenSigner(cfg, logger)
 		if err := startAdmissionInventory(ctx, logger, m.inventory, signer); err != nil {
 			return fmt.Errorf("start admission inventory: %w", err)
@@ -123,8 +126,12 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	// *allowlist with m, whose merge is mutex-guarded. No CDS URL →
 	// baked-seed-only and the network is never touched.
 	if cfg.CDSURL != "" {
-		go runAllowlistRefresh(ctx, logger, cfg, a, m.overlay)
+		go runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
 	} else {
+		// Info, not Error: seed-only is the configured intent here, unlike the
+		// failure paths in runAllowlistRefresh. Still recorded, so denies and
+		// the digests endpoint report the frozen set either way.
+		m.refresh.disable(reasonNoCDSURL)
 		logger.Info("allowlist refresh disabled (no CDS URL); enforcing baked seed only", "entries", a.Size())
 	}
 
@@ -140,6 +147,7 @@ type monitor struct {
 	logger             *slog.Logger
 	allowlist          *allowlist     // baked floor: additive digest set, never shrinks
 	overlay            *policyOverlay // latest CDS pull's workload argv policy
+	refresh            *refreshState  // whether the allowlist still tracks CDS
 	killer             containerKiller
 	inventory          *admissionInventory // sandbox identity + digests (docs/ratls.md); always set
 	configReadDeadline time.Duration
@@ -478,8 +486,21 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		}
 		return
 	}
-	m.logger.Warn("deny container: digest/argv not allowlisted", "cid", cid, "digest", digest, "argv", argv)
+	m.logger.Warn("deny container: digest/argv not allowlisted",
+		append([]any{"cid", cid, "digest", digest, "argv", argv}, m.frozenAttrs()...)...)
 	m.kill(cid)
+}
+
+// frozenAttrs annotates a deny with the fact that the allowlist never left the
+// baked seed, when that is why the deny happened. Without it a frozen guest and
+// a genuinely-unlisted image produce identical lines — and once the kill lands
+// a frozen guest denies everything at once.
+func (m *monitor) frozenAttrs() []any {
+	reason := m.refresh.frozenReason()
+	if reason == "" {
+		return nil
+	}
+	return []any{"allowlist_frozen", true, "frozen_reason", reason, "allowlist_entries", m.allowlist.Size()}
 }
 
 // kill resolves the container's cgroup and terminates it as a unit.

--- a/internal/cmds/policymonitor/refreshstate.go
+++ b/internal/cmds/policymonitor/refreshstate.go
@@ -1,0 +1,86 @@
+//go:build linux
+
+package policymonitor
+
+// Allowlist-refresh posture, tracked as a value rather than a one-shot startup
+// log line.
+//
+// A guest whose refresh never starts enforces its baked seed forever, and
+// `c8s allowlist add` has no effect on it. That state is invisible from
+// outside: the locked guest denies ReadStreamRequest, so its journal is
+// unreachable (docs/pitfalls.md — "kubectl logs on locked-guest pods is empty
+// by design"). This type carries the state to the two places an operator can
+// reach it: every deny decision, and the CDS-facing digests endpoint.
+
+import (
+	"sync"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// Reasons a refresh never starts. Reported verbatim outside the guest, so they
+// name the operator-visible consequence, not just the internal cause.
+const (
+	// reasonNotYetStarted is the pre-resolution value: the refresh goroutine
+	// has not yet reported. Never a steady state.
+	reasonNotYetStarted = "the CDS refresh loop has not reported yet"
+
+	reasonNoCDSURL = "no CDS URL configured; enforcing the baked seed alone, " +
+		"so `c8s allowlist add` does not reach this guest"
+	reasonNoMeasurements = "C8S_CDS_URL set but C8S_CDS_MEASUREMENTS empty, and an unpinned CDS " +
+		"could serve any allowlist; enforcing the baked seed alone, so `c8s allowlist add` " +
+		"does not reach this guest (docs/kata-image-policy.md)"
+	reasonBadMeasurements = "C8S_CDS_MEASUREMENTS is not a valid measurement list; enforcing the " +
+		"baked seed alone, so `c8s allowlist add` does not reach this guest"
+	reasonClientFailed = "the RA-TLS client to CDS could not be built; enforcing the baked seed " +
+		"alone, so `c8s allowlist add` does not reach this guest"
+)
+
+// refreshState is the allowlist-refresh posture. The zero value is "disabled,
+// reason not yet determined" — runMonitor always resolves it before serving.
+type refreshState struct {
+	mu      sync.RWMutex
+	enabled bool
+	reason  string
+}
+
+// disable records why the refresh loop will not run. Terminal: every caller is
+// a construction failure the loop cannot recover from.
+func (s *refreshState) disable(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enabled = false
+	s.reason = reason
+}
+
+// enable marks the refresh loop live. A later pull failure does not flip it
+// back: the loop keeps retrying and the allowlist stays at its current size.
+func (s *refreshState) enable() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.enabled = true
+	s.reason = ""
+}
+
+// frozenReason is the reason enforcement is stuck at the baked seed, or "" when
+// the refresh is live. Attached to deny decisions so a denied workload names its
+// own cause.
+func (s *refreshState) frozenReason() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.enabled {
+		return ""
+	}
+	return s.reason
+}
+
+// report renders the posture for the digests endpoint — the one authenticated
+// channel carrying it out of the guest.
+func (s *refreshState) report(entries int) workloadclaims.AllowlistRefresh {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return workloadclaims.AllowlistRefresh{Enabled: s.enabled, Reason: s.reason, Entries: entries}
+}

--- a/internal/cmds/policymonitor/refreshstate_test.go
+++ b/internal/cmds/policymonitor/refreshstate_test.go
@@ -1,0 +1,124 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// captureLogs swaps m's logger for one writing to the returned buffer.
+func captureLogs(m *monitor) *bytes.Buffer {
+	var buf bytes.Buffer
+	m.logger = slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	return &buf
+}
+
+// A deny on a guest whose allowlist never left the baked seed must say so.
+// Without it, "frozen allowlist" and "genuinely unlisted image" are the same
+// log line — and once the SIGKILL lands, a frozen guest denies every workload
+// at once with no indication why.
+func TestDenyNamesFrozenAllowlist(t *testing.T) {
+	seed := strings.Repeat("a", 64)
+	unlisted := strings.Repeat("b", 64)
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + seed})
+	m.refresh = &refreshState{reason: reasonNoMeasurements}
+	buf := captureLogs(m)
+
+	cid := "frozen-deny"
+	writeConfigJSON(t, watchDir, cid, map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + unlisted,
+	})
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	if len(killer.snapshot()) != 1 {
+		t.Fatalf("want exactly one kill, got %+v", killer.snapshot())
+	}
+	line := findLog(t, buf, "deny container: digest/argv not allowlisted")
+	if frozen, _ := line["allowlist_frozen"].(bool); !frozen {
+		t.Fatalf("deny line does not report the frozen allowlist: %v", line)
+	}
+	if reason, _ := line["frozen_reason"].(string); reason != reasonNoMeasurements {
+		t.Fatalf("frozen_reason = %q, want %q", reason, reasonNoMeasurements)
+	}
+	if entries, _ := line["allowlist_entries"].(float64); entries != 1 {
+		t.Fatalf("allowlist_entries = %v, want 1", line["allowlist_entries"])
+	}
+}
+
+// With the refresh live, a deny is an ordinary policy decision and must not be
+// dressed up as a degraded guest.
+func TestDenyOmitsFrozenAttrsWhenRefreshLive(t *testing.T) {
+	seed := strings.Repeat("a", 64)
+	unlisted := strings.Repeat("b", 64)
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + seed})
+	m.refresh = &refreshState{}
+	m.refresh.enable()
+	buf := captureLogs(m)
+
+	cid := "live-deny"
+	writeConfigJSON(t, watchDir, cid, map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + unlisted,
+	})
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	line := findLog(t, buf, "deny container: digest/argv not allowlisted")
+	if _, present := line["allowlist_frozen"]; present {
+		t.Fatalf("live refresh reported as frozen: %v", line)
+	}
+}
+
+// A nil refreshState (tests, and any construction path that skips it) must not
+// panic the decision path.
+func TestFrozenAttrsNilStateIsSafe(t *testing.T) {
+	m := &monitor{}
+	if attrs := m.frozenAttrs(); attrs != nil {
+		t.Fatalf("frozenAttrs = %v, want nil", attrs)
+	}
+}
+
+// The posture must reach the digests endpoint, which is the only way it leaves
+// a guest whose journal the operator cannot read.
+func TestInventoryReportsRefreshPosture(t *testing.T) {
+	b := newAdmissionInventory()
+	if _, reported := b.AllowlistRefresh(); reported {
+		t.Fatal("unwired inventory reported a posture; absent must not read as disabled")
+	}
+
+	state := &refreshState{reason: reasonNoMeasurements}
+	b.refresh = func() workloadclaims.AllowlistRefresh { return state.report(3) }
+	got, reported := b.AllowlistRefresh()
+	if !reported || got.Enabled || got.Entries != 3 || got.Reason != reasonNoMeasurements {
+		t.Fatalf("AllowlistRefresh = %+v, %v", got, reported)
+	}
+
+	state.enable()
+	if got, _ := b.AllowlistRefresh(); !got.Enabled || got.Reason != "" {
+		t.Fatalf("after enable: %+v", got)
+	}
+}
+
+// findLog returns the first JSON log record whose msg matches.
+func findLog(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
+	t.Helper()
+	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(raw), &rec); err != nil {
+			continue
+		}
+		if m, _ := rec["msg"].(string); m == msg {
+			return rec
+		}
+	}
+	t.Fatalf("no log record with msg %q in:\n%s", msg, buf.String())
+	return nil
+}

--- a/internal/cmds/policymonitor/run.go
+++ b/internal/cmds/policymonitor/run.go
@@ -5,7 +5,8 @@
 // guest-policy-agent (a Rego renderer that fetched a allowlist from CDS
 // over RA-TLS and rendered it informationally without enforcing).
 // policy-monitor instead enforces directly, off a baked seed allowlist it
-// refreshes from CDS at runtime; see docs/kata-image-policy.md.
+// refreshes from CDS at runtime; see docs/kata-image-policy.md. Under
+// --cvm-mode=pod it does not start until a CDS measurement is pinned.
 //
 // # What it does
 //

--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -370,7 +370,33 @@ func (c *DigestsClient) FetchSandbox(ctx context.Context, host, sandboxID string
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxResponseBytes)).Decode(&out); err != nil {
 		return out, fmt.Errorf("workloadclaims: decode inventory response: %w", err)
 	}
+	// Carry the inventory's degraded posture into the caller's log — a kata
+	// guest's own journal is unreadable, so this is where it becomes visible.
+	// Diagnostic: it never changes the answer.
+	if r := out.AllowlistRefresh; r != nil && !r.Enabled {
+		slog.Warn("inventory reports a frozen image allowlist; operator allowlist additions are NOT reaching it",
+			"host", host, "sandbox", sandboxID, "reason", safeReason(r.Reason), "entries", r.Entries)
+	}
 	return out, nil
+}
+
+// maxReasonLen bounds a logged reason. The field crosses a trust boundary from
+// an inventory this client may not pin, so it is truncated and stripped of
+// control characters — an unbounded raw string could forge lines under a
+// non-JSON slog handler.
+const maxReasonLen = 200
+
+func safeReason(s string) string {
+	cleaned := []rune(strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, s))
+	if len(cleaned) > maxReasonLen {
+		return string(cleaned[:maxReasonLen]) + "…"
+	}
+	return string(cleaned)
 }
 
 // RequireContainers returns the per-container detail, refusing an answer that

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -158,6 +158,32 @@ type SandboxTokenRequest struct {
 type SandboxDigestsResponse struct {
 	Digests    []string           `json:"digests"`
 	Containers []SandboxContainer `json:"containers,omitempty"`
+	// AllowlistRefresh is the inventory's enforcement posture. Absent from an
+	// inventory that predates the field, and from one with nothing to report.
+	AllowlistRefresh *AllowlistRefresh `json:"allowlist_refresh,omitempty"`
+}
+
+// AllowlistRefresh reports whether an inventory's image allowlist still tracks
+// CDS, or has fallen back to whatever it started with. It is the one channel
+// carrying that state out of a kata guest, whose journal the operator cannot
+// read (docs/pitfalls.md — "kubectl logs on locked-guest pods is empty").
+//
+// Diagnostic only: no issuance or release decision reads it, so a guest cannot
+// widen its own admission by lying here.
+type AllowlistRefresh struct {
+	Enabled bool `json:"enabled"`
+	// Reason explains a disabled refresh.
+	Reason string `json:"reason,omitempty"`
+	// Entries is the allowlist size actually being enforced.
+	Entries int `json:"entries"`
+}
+
+// AllowlistRefreshReporter is the optional half of SandboxResolver: an
+// inventory that can describe its refresh posture. ok=false means it has
+// nothing to report, which stays off the wire rather than serializing as a
+// disabled refresh.
+type AllowlistRefreshReporter interface {
+	AllowlistRefresh() (AllowlistRefresh, bool)
 }
 
 // SandboxContainer is one admitted container: the bytes, and what they were
@@ -287,8 +313,14 @@ func ServeDigests(ctx context.Context, l net.Listener, resolver SandboxResolver,
 		if digests == nil {
 			digests = []string{}
 		}
+		resp := SandboxDigestsResponse{Digests: digests, Containers: containers}
+		if rr, ok := resolver.(AllowlistRefreshReporter); ok {
+			if refresh, reported := rr.AllowlistRefresh(); reported {
+				resp.AllowlistRefresh = &refresh
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(SandboxDigestsResponse{Digests: digests, Containers: containers})
+		_ = json.NewEncoder(w).Encode(resp)
 	})
 	return serveUntil(ctx, l, mux)
 }

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -16,9 +16,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
+	"unicode/utf8"
 )
 
 const (
@@ -382,6 +384,75 @@ func TestSandboxDigestsRoute(t *testing.T) {
 
 	if status, _ := inventoryGetRaw(t, sock, SandboxDigestsPrefix+"nope"); status != http.StatusNotFound {
 		t.Fatalf("unknown sandbox status = %d, want 404", status)
+	}
+}
+
+// refreshResolver is a fakeResolver that also reports a refresh posture.
+type refreshResolver struct {
+	fakeResolver
+	refresh  AllowlistRefresh
+	reported bool
+}
+
+func (r *refreshResolver) AllowlistRefresh() (AllowlistRefresh, bool) {
+	return r.refresh, r.reported
+}
+
+// A guest enforcing a frozen allowlist must say so on the one channel that
+// leaves it: its journal is unreadable, so without this the state is invisible.
+func TestSandboxDigestsReportsFrozenAllowlist(t *testing.T) {
+	resolver := &refreshResolver{
+		fakeResolver: fakeResolver{digests: map[string][]string{"sandbox-1": {digestA}}},
+		refresh:      AllowlistRefresh{Enabled: false, Reason: "no measurement pinned", Entries: 3},
+		reported:     true,
+	}
+	status, body := inventoryGetRaw(t, serveDigestsOnUnix(t, resolver), SandboxDigestsPrefix+"sandbox-1")
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	var out SandboxDigestsResponse
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.AllowlistRefresh == nil {
+		t.Fatal("allowlist_refresh absent; the frozen state never leaves the guest")
+	}
+	if out.AllowlistRefresh.Enabled || out.AllowlistRefresh.Reason != "no measurement pinned" || out.AllowlistRefresh.Entries != 3 {
+		t.Fatalf("allowlist_refresh = %+v", *out.AllowlistRefresh)
+	}
+}
+
+// An inventory with nothing to report must leave the field off the wire, so
+// "cannot say" never serializes as "refresh disabled".
+func TestSandboxDigestsOmitsUnreportedRefresh(t *testing.T) {
+	for name, resolver := range map[string]SandboxResolver{
+		"no reporter":    &fakeResolver{digests: map[string][]string{"sandbox-1": {digestA}}},
+		"reports absent": &refreshResolver{fakeResolver: fakeResolver{digests: map[string][]string{"sandbox-1": {digestA}}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, body := inventoryGetRaw(t, serveDigestsOnUnix(t, resolver), SandboxDigestsPrefix+"sandbox-1")
+			if strings.Contains(body, "allowlist_refresh") {
+				t.Fatalf("body = %q, want no allowlist_refresh field", body)
+			}
+		})
+	}
+}
+
+// The reason crosses a trust boundary from an inventory the client may not pin,
+// so it must not be able to forge log lines or blow up a record.
+func TestSafeReasonBoundsRemoteString(t *testing.T) {
+	if got := safeReason("clean reason"); got != "clean reason" {
+		t.Fatalf("safeReason mangled a clean string: %q", got)
+	}
+	if got := safeReason("a\nlevel=ERROR msg=forged\rb\x00c"); strings.ContainsAny(got, "\n\r\x00") {
+		t.Fatalf("control characters survived: %q", got)
+	}
+	long := safeReason(strings.Repeat("é", 5000))
+	if n := len([]rune(long)); n != maxReasonLen+1 {
+		t.Fatalf("truncated to %d runes, want %d plus ellipsis", n, maxReasonLen)
+	}
+	if !utf8.ValidString(long) {
+		t.Fatalf("truncation split a rune: %q", long)
 	}
 }
 


### PR DESCRIPTION
in-guest allowlist is already frozen today, this just surfaces some better error messages when it's the case