### PR TITLE
feat(kata): compute TDX MRTD in `c8s kata measure`

### DIFF
--- a/docs/kata-launch-measurement.md
+++ b/docs/kata-launch-measurement.md
@@ -1,17 +1,28 @@
 # Predicting a kata guest's launch measurement
 
-`c8s kata measure` computes the SEV-SNP launch digest of a `kata-qemu-snp`
-guest offline, from the guest image artifacts plus a pod's vCPU count — no
-pod has to boot first.
+`c8s kata measure` computes a kata confidential guest's launch measurement
+offline, from the guest artifacts — no pod has to boot first. `--platform`
+selects which value:
+
+| `--platform` | computes | inputs | one value per |
+|---|---|---|---|
+| `snp` (default) | SEV-SNP launch digest | firmware + guest artifacts + pod vCPU count | **pod shape** |
+| `tdx` | Intel TDX **MRTD** | TDVF firmware only | **fleet** |
 
 ```console
 $ c8s kata measure --vcpus 1
 e246273c1efee7dab0f623ffc04c33315fd37925cd9300fdb39d0a19f1b8e38edb95844464577ee89453e4b1eb46f0fb
+
+$ c8s kata measure --platform tdx
+c78e2b8b2f66207f3807d8d999f51e04f5eab8f7aa02614a86ddd81b61f4e79c5d7616664fcb190b8eaae2e26d60b12a
 ```
 
 Output is the bare hex digest, one per line, so it pipes straight into
 `c8s verify --measurements-file`. `--json` emits the digest plus every input
 that produced it; `-v` prints the same inputs to stderr.
+
+The rest of this document is the SNP path; [Intel TDX](#intel-tdx-mrtd) is at
+the end.
 
 ## Why this exists
 
@@ -132,11 +143,11 @@ Then diff it against `c8s kata measure --vcpus N --json | jq -r .cmdline`.
 
 ## Verifying against a real cluster
 
-The implementation reproduces both live measurements in the table above from
-the artifacts on the node, and `pkg/snpmeasure`'s unit tests check it against
-`sev-snp-measure`'s own published vectors using that project's 4 KiB OVMF
-fixture — so CI validates the algorithm without a multi-GB guest image. The
-end-to-end check against the real image is manual:
+The SNP implementation reproduces both live measurements in the table above
+from the artifacts on the node, and `pkg/snpmeasure`'s unit tests check it
+against `sev-snp-measure`'s own published vectors using that project's 4 KiB
+OVMF fixture — so CI validates the algorithm without a multi-GB guest image.
+The end-to-end check against the real image is manual:
 
 ```console
 $ c8s kata measure --vcpus 1 -v          # on a node with the puller's artifacts
@@ -144,7 +155,119 @@ $ c8s kata measure --vcpus 1 -v          # on a node with the puller's artifacts
 
 and compare with the digest a pod actually reports.
 
+## Intel TDX: MRTD
+
+On TDX the value c8s pins is **MRTD**, and it needs no pod-shape input at all:
+
+```console
+$ c8s kata measure --platform tdx
+c78e2b8b2f66207f3807d8d999f51e04f5eab8f7aa02614a86ddd81b61f4e79c5d7616664fcb190b8eaae2e26d60b12a
+```
+
+`--vcpus`, `--pod-cpu-limit`, `--cmdline` and `--debug-console` are **rejected**
+on this path rather than ignored, so nobody believes they are pinning a
+per-shape value. `--firmware` defaults to `/opt/kata/share/ovmf/OVMF.inteltdx.fd`
+(the `firmware` key of `configuration-qemu-tdx.toml`).
+
+### Why one value covers the fleet
+
+MRTD is built during TD build: `TDH.MEM.PAGE.ADD` extends a SHA-384 with each
+page's GPA, `TDH.MR.EXTEND` with 256-byte chunks of page *contents*, and
+`TDH.MR.FINALIZE` completes it. The pages added before finalize are exactly the
+ones named by TDVF's metadata section table, and only the BFV carries the
+`MR_EXTEND` attribute. The TD HOB — which is where the vCPU count and guest RAM
+size live — is page-added but never content-extended, so its contents never
+reach MRTD. The guest kernel, initrd and command line are measured by TDVF into
+**RTMR[0..2]**, which `pkg/ratls.VerifyPolicy` does not pin (see the comment on
+`Measurements`, and `attestation-go`'s `ExpectedLaunchDigest` → `MrTd` mapping).
+
+Confirmed on live hardware. Two `kata-qemu-tdx` pods on the same node, booting
+the same TDVF, differing only in vCPU shape:
+
+| register | pod A (no CPU limit, `-smp 1`) | pod B (`limits.cpu: 500m`, `-smp 2`) | |
+|---|---|---|---|
+| **MRTD** | `c78e2b8b…60b12a` | `c78e2b8b…60b12a` | **same** |
+| RTMR[0] | `8c7ccd95…` | `9ce3cd3f…` | differs — TD HOB (vCPUs, RAM) |
+| RTMR[1] | `695c8bf4…` | `695c8bf4…` | same — same `vmlinuz` |
+| RTMR[2] | `bd64df1e…` | `1f94cec2…` | differs — cmdline `nr_cpus=1` vs `2` |
+| RTMR[3] | zero | zero | unused here |
+
+This is why the kata-image-puller pins `default_vcpus = 1` on the **SNP** shims
+only and deliberately leaves the TDX shims unpinned
+(`internal/helmchart/c8s/files/scripts/pull-and-configure.sh`).
+
+Practical consequence: give every TDX node the same TDVF and the whole fleet
+shares one allow-list entry. Changing the kata-static payload (and so `TDVF`)
+is the only thing that moves it.
+
+### Implementation
+
+`pkg/tdxmeasure` is a thin wrapper over
+[`github.com/google/gce-tcb-verifier/tdx`](https://github.com/google/gce-tcb-verifier)
+`MRTD()` rather than a local reimplementation of the Intel TDX Module Base
+Architecture Specification. That library is the only maintained Go
+implementation of the algorithm; `go-tdx-guest`, which `attestation-go` already
+wraps, parses and verifies quotes but does not predict measurements.
+
+Its `LaunchOptions` API is GCE-shaped, and **only the plain default is correct
+for kata/QEMU**:
+
+| options | result on our TDVF |
+|---|---|
+| `LaunchOptionsDefault("")` | matches hardware ✅ |
+| `LaunchOptionsDefaultTDHOBBug("")` | `2815d6db…` — models a Google hypervisor bug ❌ |
+| `DisableUnacceptedMemory = true` | `2815d6db…` — changes the TD HOB ❌ |
+
+`pkg/tdxmeasure.launchOptions()` pins the correct one, and
+`TestOtherLaunchOptionsAreWrong` fails if upstream ever makes the others
+equivalent. **Risk accepted:** a change to the library's default `LaunchOptions`
+would silently move the pinned measurement. `TestMRTDMatchesHardware` is the
+tripwire — it asserts the hardware-captured digest, so a dependency bump that
+moves the value fails the build rather than shipping a wrong pin.
+
+### Re-validating against hardware
+
+The 4 MiB TDVF is not committed, so the hardware check runs only where the
+firmware exists (a TDX node, or `C8S_TDVF=/path/to/OVMF.inteltdx.fd`); it skips
+in CI, and also skips if the TDVF is not the sha256 the expected digest was
+captured from. The CLI wiring is covered in CI with a synthetic TDVF.
+
+To re-capture the expected MRTD after a kata-static bump, read it from a live
+pod's own attestation report. The in-guest attestation-service listens on
+`127.0.0.1:8400` inside the guest (the guest has no `curl`, so use bash's
+`/dev/tcp`), reachable via the agent debug console on a `--debug` install:
+
+```console
+$ SID=$(crictl pods --name <pod> -q)
+$ sudo script -qec "/opt/kata/bin/kata-runtime exec $SID" /dev/null
+# RD=$(head -c48 /dev/zero | base64 -w0)   # 64 zero bytes, any report_data works
+# BODY="{\"report_data\":\"$RD\",\"platform\":\"tdx\"}"
+# exec 3<>/dev/tcp/127.0.0.1/8400
+# printf 'POST /attest HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' ${#BODY} "$BODY" >&3; cat <&3
+```
+
+The response's `evidence.quote` is a base64 TDX quote; its `MRTD` is what
+`c8s kata measure --platform tdx` must reproduce. CDS also logs refused
+measurements verbatim (`measurement not in allowlist`) if the allow-list is
+already pinned.
+
+### TDX limitations
+
+- **RTMRs are not computed.** c8s pins MRTD only, so `measure` does not
+  reconstruct RTMR[0..2] (TD HOB, guest firmware, kernel/cmdline). Pinning them
+  would need per-pod-shape values and a CC event log policy — see the
+  `Measurements` comment in `pkg/ratls/verify.go`.
+- **TDVF metadata must be present.** The tool refuses a firmware image without
+  a TDX metadata GUID block, a TD HOB section, or whose firmware volumes do not
+  tile the image.
+- **`MRCONFIGID` / `MROWNER` / `MROWNERCONFIG` are assumed zero**, which is what
+  kata's QEMU launches with today (the `tdx-guest` object sets none of them).
+  They are not part of MRTD, but a policy that pinned them would need capturing
+  separately.
+
 ## Limitations
+
+These apply to the SNP path.
 
 - **QEMU only.** The VMSA reset state is QEMU's. A different VMM produces a
   different page and a different digest.

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -752,3 +752,39 @@ refuses every pod with nothing to diagnose. `openFirmware` therefore stats the
 file for a positive page-multiple size, rejects an image with zero metadata
 sections, and recovers any panic out of the parser into an error. Keep all three
 guards across a dependency bump; upstream has no tests for malformed input.
+
+## TDX MRTD: only the *default* `LaunchOptions` is correct for kata
+
+`pkg/tdxmeasure/tdxmeasure.go` (`launchOptions`)
+
+`c8s kata measure --platform tdx` computes MRTD via
+`github.com/google/gce-tcb-verifier/tdx`, whose `LaunchOptions` API is shaped for
+GCE. Two of its three presets produce a digest that **no kata pod will ever
+report**: `LaunchOptionsDefaultTDHOBBug` models a Google hypervisor bug that
+measures all TDVF metadata regions, and `DisableUnacceptedMemory` changes the TD
+HOB. Both give `2815d6db…` on the TDVF kata boots, against the real `c78e2b8b…`.
+
+Pinning a wrong MRTD is worse than pinning nothing: CDS refuses every pod a
+certificate and the only symptom is `measurement not in allowlist`. Do not
+"tune" these options to fix an unrelated problem. `TestMRTDMatchesHardware`
+asserts the hardware-captured digest and `TestOtherLaunchOptionsAreWrong` asserts
+the rejected presets still differ — both skip without the real TDVF, so run them
+on a TDX node (or with `C8S_TDVF=`) before trusting a dependency bump.
+
+## kata + `shared_fs="none"`: a disk-backed `emptyDir` breaks on a large host FS
+
+Observed on a TDX node with a 28 TB ext4 root; affects any platform.
+
+With `shared_fs = "none"` the kata shim converts a **disk-backed** `emptyDir`
+(`emptyDir: {}`, i.e. `medium` unset) into a `disk.img` block device, and sizes
+that file from the *filesystem*, not the volume. On a filesystem larger than
+ext4's 16 TiB max file size the shim fails at
+`truncate …/disk.img: file too large` and the pod never starts, with the cause
+only visible in the kata shim log — the kubelet event just says
+`failed to create shim task`. Setting `sizeLimit` on the volume does **not**
+help; the shim ignores it.
+
+`emptyDir: {medium: Memory}` is unaffected (it stays a guest tmpfs), which is why
+the webhook-injected `c8s-certs` volume is fine. The CDS `data` volume
+(`cds.yaml`, when `cds.persistence.enabled` is false) is the one that hits this.
+Workaround on such a node: enable `cds.persistence`.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/gce-tcb-verifier v0.3.1
 	github.com/google/go-sev-guest v0.15.0
 	github.com/lestrrat-go/httprc/v3 v3.0.6
 	github.com/lestrrat-go/jwx/v3 v3.1.1
@@ -140,6 +141,7 @@ require (
 	go.uber.org/zap v1.28.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/google/gce-tcb-verifier v0.3.1 h1:4L9YgkOtqC2U7cj4FofCUufHFCCpdD4Y0yPKI8UhOhI=
+github.com/google/gce-tcb-verifier v0.3.1/go.mod h1:GZCDLQxmEOCqUTL2BMB/zjo+hgXdUrR0Wgwz1OrwRYg=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=
 github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -347,6 +349,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
 golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93 h1:fQsdNF2N+/YewlRZiricy4P1iimyPKZ/xwniHj8Q2a0=
+golang.org/x/exp v0.0.0-20251219203646-944ab1f22d93/go.mod h1:EPRbTFwzwjXj9NpYyyrvenVh9Y+GFeEvMNh7Xuz7xgU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.38.0 h1:MECBjubtXD7yj4HrhIUcywNaGeNVUdfVnxmPajOk4yk=
 golang.org/x/mod v0.38.0/go.mod h1:V6Xz0pq8TQ3dGqVQ1FVHuelZpAL0uNhSkk9ogYP3c40=

--- a/internal/cmds/katameasure/cmd.go
+++ b/internal/cmds/katameasure/cmd.go
@@ -1,11 +1,12 @@
 // Package katameasure implements `c8s kata measure`: the offline predictor for
-// the SEV-SNP launch measurement of a kata-qemu-snp guest.
+// a kata confidential guest's launch measurement, on SEV-SNP and on TDX.
 //
-// Under --cvm-mode=pod every pod is its own CVM, and pods that differ in vCPU
-// count have different launch digests, so there is no single fleet-wide value
-// to pin. This command computes the digest for a given guest artifact and pod
-// shape without booting anything, so per-workload measurement sets can be
-// derived ahead of the install. See docs/kata-launch-measurement.md.
+// On SNP, under --cvm-mode=pod every pod is its own CVM and pods that differ in
+// vCPU count have different launch digests, so there is no single fleet-wide
+// value to pin; this command computes the digest for a given guest artifact and
+// pod shape without booting anything. On TDX the pinned value is MRTD, which
+// covers the TDVF image alone — one value covers the fleet.
+// See docs/kata-launch-measurement.md.
 package katameasure
 
 import (
@@ -15,14 +16,18 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/confidential-dot-ai/c8s/pkg/snpmeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/tdxmeasure"
 )
 
 type config struct {
+	platform        string
+	firmwareSet     bool
 	guestDir        string
 	firmware        string
 	vcpus           int
@@ -40,20 +45,22 @@ type config struct {
 	skipVersion     bool
 }
 
-// Result is the --json document.
+// Result is the --json document. The SNP-only fields are omitted on TDX, whose
+// MRTD is a function of the firmware alone.
 type Result struct {
+	Platform      string `json:"platform"`
 	Measurement   string `json:"measurement"`
-	VCPUs         int    `json:"vcpus"`
-	VCPUType      string `json:"vcpuType"`
-	VCPUSignature string `json:"vcpuSignature"`
-	GuestFeatures uint64 `json:"guestFeatures"`
-	Cmdline       string `json:"cmdline"`
+	VCPUs         int    `json:"vcpus,omitempty"`
+	VCPUType      string `json:"vcpuType,omitempty"`
+	VCPUSignature string `json:"vcpuSignature,omitempty"`
+	GuestFeatures uint64 `json:"guestFeatures,omitempty"`
+	Cmdline       string `json:"cmdline,omitempty"`
 	FirmwarePath  string `json:"firmwarePath"`
 	FirmwareSHA   string `json:"firmwareSha256"`
-	KernelPath    string `json:"kernelPath"`
-	KernelSHA     string `json:"kernelSha256"`
-	KataVersion   string `json:"kataVersion"`
-	BuildVariant  string `json:"buildVariant"`
+	KernelPath    string `json:"kernelPath,omitempty"`
+	KernelSHA     string `json:"kernelSha256,omitempty"`
+	KataVersion   string `json:"kataVersion,omitempty"`
+	BuildVariant  string `json:"buildVariant,omitempty"`
 }
 
 // NewCmd returns the `kata` command group with its `measure` subcommand.
@@ -78,31 +85,41 @@ func newMeasureCmd() *cobra.Command {
 	}
 	cmd := &cobra.Command{
 		Use:   "measure",
-		Short: "Compute the expected SEV-SNP launch measurement of a kata guest",
-		Long: `measure predicts the SEV-SNP launch digest of a kata-qemu-snp guest from
-the guest image artifacts and a pod's vCPU count, without booting the pod.
+		Short: "Compute the expected launch measurement of a kata guest",
+		Long: `measure predicts a kata confidential guest's launch measurement from the
+guest image artifacts, without booting the pod.
 
-Under --cvm-mode=pod each pod is its own CVM. The launch digest covers the
-OVMF image, the kernel/initrd/cmdline hash table QEMU builds for
-kernel-hashes=on, and one VMSA page per vCPU — so pods that differ in vCPU
-count measure differently and need separate values in cds.measurements.
+--platform snp (default) computes the SEV-SNP launch digest of a
+kata-qemu-snp guest. Under --cvm-mode=pod each pod is its own CVM. The
+digest covers the OVMF image, the kernel/initrd/cmdline hash table QEMU
+builds for kernel-hashes=on, and one VMSA page per vCPU — so pods that
+differ in vCPU count measure differently and need separate values in
+cds.measurements. The kernel command line is reassembled the way kata ` + SupportedKataVersion + `
+builds it; pass --cmdline to measure an exact captured line instead.
 
-The kernel command line is reassembled the way kata ` + SupportedKataVersion + ` builds it;
-pass --cmdline to measure an exact captured line instead. Output is the bare
-hex digest, one per line, ready for 'c8s verify --measurements-file'.
+--platform tdx computes the Intel TDX MRTD of a kata-qemu-tdx guest. MRTD
+covers the TDVF image alone: the guest kernel, command line, vCPU count and
+RAM size are measured into RTMR[0..2], which c8s does not pin. One MRTD
+therefore covers every pod shape, and the pod-shape flags are rejected.
+
+Output is the bare hex digest, one per line, ready for
+'c8s verify --measurements-file'.
 
     c8s kata measure --vcpus 1
-    c8s kata measure --guest-dir ./output --pod-cpu-limit 500m --json`,
+    c8s kata measure --guest-dir ./output --pod-cpu-limit 500m --json
+    c8s kata measure --platform tdx`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cfg.debugConsoleSet = cmd.Flags().Changed("debug-console")
+			cfg.firmwareSet = cmd.Flags().Changed("firmware")
 			return run(cfg, cmd.OutOrStdout(), cmd.ErrOrStderr())
 		},
 	}
 	f := cmd.Flags()
+	f.StringVar(&cfg.platform, "platform", platformSNP, "TEE platform to measure: snp (SEV-SNP launch digest) or tdx (MRTD)")
 	f.StringVar(&cfg.guestDir, "guest-dir", cfg.guestDir, "kata-guest-base artifact directory (manifest.json + vmlinuz)")
-	f.StringVar(&cfg.firmware, "firmware", cfg.firmware, "OVMF image kata boots the guest with")
+	f.StringVar(&cfg.firmware, "firmware", cfg.firmware, "firmware image kata boots the guest with (default "+DefaultTDXFirmware+" under --platform tdx)")
 	f.IntVar(&cfg.vcpus, "vcpus", 0, "guest vCPU count; required unless --pod-cpu-limit is given")
 	f.StringVar(&cfg.podCPULimit, "pod-cpu-limit", "", "derive --vcpus from a pod's total CPU limit (e.g. 500m); unset means the pod has no CPU limit")
 	f.Float64Var(&cfg.defaultVCPUs, "default-vcpus", cfg.defaultVCPUs, "hypervisor default_vcpus, the base kata adds --pod-cpu-limit to")
@@ -118,7 +135,88 @@ hex digest, one per line, ready for 'c8s verify --measurements-file'.
 	return cmd
 }
 
+// Platforms `measure` can compute a launch measurement for. These match the
+// pkg/types.Platform spellings the CDS allow-list and RA-TLS policy use.
+const (
+	platformSNP = "snp"
+	platformTDX = "tdx"
+)
+
 func run(cfg config, stdout, stderr io.Writer) error {
+	switch cfg.platform {
+	// "" only reaches here from a directly-built config; the flag defaults to snp.
+	case platformSNP, "":
+		return runSNP(cfg, stdout, stderr)
+	case platformTDX:
+		return runTDX(cfg, stdout, stderr)
+	default:
+		return fmt.Errorf("--platform must be %q or %q, got %q", platformSNP, platformTDX, cfg.platform)
+	}
+}
+
+// runTDX computes MRTD. It deliberately reads no guest artifacts: MRTD covers
+// the TDVF image only. Flags that shape a pod are rejected rather than ignored,
+// so a caller who thinks they are pinning a per-shape value finds out here.
+func runTDX(cfg config, stdout, stderr io.Writer) error {
+	if err := rejectSNPOnlyFlags(cfg); err != nil {
+		return err
+	}
+	path := cfg.firmware
+	if !cfg.firmwareSet {
+		path = DefaultTDXFirmware
+	}
+	firmware, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read firmware: %w", err)
+	}
+	mrtd, err := tdxmeasure.MRTD(firmware)
+	if err != nil {
+		return err
+	}
+	res := Result{
+		Platform:     platformTDX,
+		Measurement:  hex.EncodeToString(mrtd),
+		FirmwarePath: path,
+		FirmwareSHA:  hex.EncodeToString(sha256sum(firmware)),
+	}
+	if cfg.asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(res)
+	}
+	if cfg.verbose {
+		fmt.Fprintf(stderr, "platform: tdx (MRTD)\n")
+		fmt.Fprintf(stderr, "firmware: %s sha256=%s\n", res.FirmwarePath, res.FirmwareSHA)
+		fmt.Fprintf(stderr, "note:     covers TDVF only; kernel/cmdline/vCPUs measure into RTMRs\n")
+	}
+	fmt.Fprintln(stdout, res.Measurement)
+	return nil
+}
+
+// rejectSNPOnlyFlags fails on inputs that only shape an SNP digest.
+func rejectSNPOnlyFlags(cfg config) error {
+	var set []string
+	if cfg.vcpus != 0 {
+		set = append(set, "--vcpus")
+	}
+	if cfg.podCPULimit != "" {
+		set = append(set, "--pod-cpu-limit")
+	}
+	if cfg.cmdline != "" {
+		set = append(set, "--cmdline")
+	}
+	if cfg.debugConsoleSet {
+		set = append(set, "--debug-console")
+	}
+	if len(set) == 0 {
+		return nil
+	}
+	return fmt.Errorf("not valid with --platform tdx: %s. Those shape the SNP launch digest only; "+
+		"TDX MRTD covers the TDVF image alone (vCPUs, kernel and command line measure into RTMRs, "+
+		"which c8s does not pin)", strings.Join(set, ", "))
+}
+
+func runSNP(cfg config, stdout, stderr io.Writer) error {
 	guest, err := LoadGuest(cfg.guestDir)
 	if err != nil {
 		return err
@@ -179,6 +277,7 @@ func run(cfg config, stdout, stderr io.Writer) error {
 	}
 
 	res := Result{
+		Platform:      platformSNP,
 		Measurement:   hex.EncodeToString(ld),
 		VCPUs:         vcpus,
 		VCPUType:      cfg.vcpuType,

--- a/internal/cmds/katameasure/guest.go
+++ b/internal/cmds/katameasure/guest.go
@@ -20,6 +20,10 @@ const DefaultGuestDir = "/var/lib/c8s/kata-images/base"
 // configuration-qemu-snp.toml).
 const DefaultFirmware = "/opt/kata/share/ovmf/AMDSEV.fd"
 
+// DefaultTDXFirmware is the TDVF build kata-qemu-tdx boots (the `firmware` key
+// of configuration-qemu-tdx.toml).
+const DefaultTDXFirmware = "/opt/kata/share/ovmf/OVMF.inteltdx.fd"
+
 // DefaultVCPUType is the QEMU CPU model kata launches SNP guests with.
 const DefaultVCPUType = "EPYC-v4"
 

--- a/internal/cmds/katameasure/katameasure_test.go
+++ b/internal/cmds/katameasure/katameasure_test.go
@@ -3,6 +3,7 @@ package katameasure
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"os"
@@ -434,9 +435,169 @@ func TestNewCmdWiring(t *testing.T) {
 	if err != nil || sub.Use != "measure" {
 		t.Fatalf("measure subcommand not registered: %v", err)
 	}
-	for _, name := range []string{"guest-dir", "firmware", "vcpus", "pod-cpu-limit", "vcpu-type", "cmdline", "json"} {
+	for _, name := range []string{"guest-dir", "firmware", "vcpus", "pod-cpu-limit", "vcpu-type", "cmdline", "json", "platform"} {
 		if sub.Flags().Lookup(name) == nil {
 			t.Errorf("missing flag --%s", name)
 		}
+	}
+	if got := sub.Flags().Lookup("platform").DefValue; got != platformSNP {
+		t.Errorf("--platform default = %q, want %q", got, platformSNP)
+	}
+}
+
+// writeTDVF builds a minimal well-formed TDVF image so the CLI path can be
+// exercised without the 4 MiB real firmware. The digest it produces is pinned
+// in pkg/tdxmeasure; here only the wiring matters.
+func writeTDVF(t *testing.T) string {
+	t.Helper()
+	const (
+		page  = 4096
+		pages = 3
+		size  = pages * page
+		// Trailer: 32 bytes padding, the footer entry, the metadata entry's
+		// header and its 4-byte payload.
+		trailer = 32 + 18 + 18 + 4
+	)
+	img := make([]byte, size)
+	for i := range img {
+		img[i] = byte(i * 5)
+	}
+	// The FVs must tile the whole image, as they do in a real TDVF: CFV first,
+	// BFV covering the rest — including the metadata and footer at the end.
+	// dataOffset, rawSize, gpa, memSize, sectionType, attributes.
+	sections := [][6]uint64{
+		{0, page, 0xffc00000, page, 1 /*CFV*/, 0},
+		{page, 2 * page, 0xffc01000, 2 * page, 0 /*BFV*/, 1 /*MR_EXTEND*/},
+		{0, 0, 0x809000, page, 2 /*TD HOB*/, 0},
+		{0, 0, 0x800000, page, 3 /*TempMem*/, 0},
+	}
+	desc := make([]byte, 16)
+	copy(desc, "TDVF")
+	binary.LittleEndian.PutUint32(desc[4:], uint32(16+32*len(sections)))
+	binary.LittleEndian.PutUint32(desc[8:], 1)
+	binary.LittleEndian.PutUint32(desc[12:], uint32(len(sections)))
+	for _, s := range sections {
+		b := make([]byte, 32)
+		binary.LittleEndian.PutUint32(b[0:], uint32(s[0]))
+		binary.LittleEndian.PutUint32(b[4:], uint32(s[1]))
+		binary.LittleEndian.PutUint64(b[8:], s[2])
+		binary.LittleEndian.PutUint64(b[16:], s[3])
+		binary.LittleEndian.PutUint32(b[24:], uint32(s[4]))
+		binary.LittleEndian.PutUint32(b[28:], uint32(s[5]))
+		desc = append(desc, b...)
+	}
+
+	guid := func(s string) []byte {
+		f := strings.Split(s, "-")
+		b, err := hex.DecodeString(strings.Join(f, ""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		out := make([]byte, 16)
+		copy(out, b)
+		binary.LittleEndian.PutUint32(out[0:4], binary.BigEndian.Uint32(b[0:4]))
+		binary.LittleEndian.PutUint16(out[4:6], binary.BigEndian.Uint16(b[4:6]))
+		binary.LittleEndian.PutUint16(out[6:8], binary.BigEndian.Uint16(b[6:8]))
+		return out
+	}
+	// Metadata and footer live at the end of the image, inside the BFV, the way
+	// a real TDVF lays them out. The descriptor is preceded by the TDX metadata
+	// GUID; the footer entry records the descriptor's offset back from the end.
+	descAt := size - trailer - len(desc)
+	copy(img[descAt-16:], guid("e9eaf9f3-168e-44d5-a8eb-7f4d8738f6ae"))
+	copy(img[descAt:], desc)
+
+	payloadAt := size - trailer
+	binary.LittleEndian.PutUint32(img[payloadAt:], uint32(size-descAt))
+	entryHdr := img[payloadAt+4:]
+	binary.LittleEndian.PutUint16(entryHdr, 22)
+	copy(entryHdr[2:], guid("e47a6535-984a-4798-865e-4685a7bf8ec2"))
+
+	footer := img[payloadAt+22:]
+	binary.LittleEndian.PutUint16(footer, 40)
+	copy(footer[2:], guid("96b582de-1fb2-45f7-baea-a366c55a082d"))
+	clear(img[payloadAt+40:])
+
+	path := filepath.Join(t.TempDir(), "tdvf.fd")
+	if err := os.WriteFile(path, img, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunTDX(t *testing.T) {
+	cfg := config{platform: platformTDX, firmware: writeTDVF(t), firmwareSet: true}
+
+	var out, errOut bytes.Buffer
+	if err := run(cfg, &out, &errOut); err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.TrimSpace(out.String())
+	if len(digest) != 96 {
+		t.Fatalf("MRTD hex length = %d, want 96: %q", len(digest), digest)
+	}
+
+	// No guest artifacts are read: MRTD covers the firmware alone, so a bogus
+	// --guest-dir must not affect the result.
+	withGuest := cfg
+	withGuest.guestDir = filepath.Join(t.TempDir(), "does-not-exist")
+	out.Reset()
+	if err := run(withGuest, &out, &errOut); err != nil {
+		t.Fatalf("TDX path read guest artifacts: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != digest {
+		t.Errorf("digest changed with --guest-dir: %s vs %s", got, digest)
+	}
+
+	jsonCfg := cfg
+	jsonCfg.asJSON = true
+	out.Reset()
+	if err := run(jsonCfg, &out, &errOut); err != nil {
+		t.Fatal(err)
+	}
+	var res Result
+	if err := json.Unmarshal(out.Bytes(), &res); err != nil {
+		t.Fatal(err)
+	}
+	if res.Platform != platformTDX || res.Measurement != digest {
+		t.Errorf("json = %+v, want platform tdx and measurement %s", res, digest)
+	}
+	// SNP-shaped fields must be absent, not zero-valued noise.
+	if res.VCPUs != 0 || res.Cmdline != "" || res.KernelPath != "" {
+		t.Errorf("TDX result carries SNP fields: %+v", res)
+	}
+}
+
+func TestRunTDXRejectsPodShapeFlags(t *testing.T) {
+	base := config{platform: platformTDX, firmware: writeTDVF(t), firmwareSet: true}
+	for _, tc := range []struct {
+		name string
+		mut  func(*config)
+	}{
+		{"vcpus", func(c *config) { c.vcpus = 2 }},
+		{"pod-cpu-limit", func(c *config) { c.podCPULimit = "500m" }},
+		{"cmdline", func(c *config) { c.cmdline = "root=/dev/dm-0" }},
+		{"debug-console", func(c *config) { c.debugConsoleSet = true }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.mut(&cfg)
+			var out, errOut bytes.Buffer
+			err := run(cfg, &out, &errOut)
+			if err == nil {
+				t.Fatalf("--%s accepted on the TDX path", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("error %q does not name --%s", err, tc.name)
+			}
+		})
+	}
+}
+
+func TestRunRejectsUnknownPlatform(t *testing.T) {
+	var out, errOut bytes.Buffer
+	err := run(config{platform: "sev-snp"}, &out, &errOut)
+	if err == nil || !strings.Contains(err.Error(), "--platform") {
+		t.Fatalf("want a --platform error, got %v", err)
 	}
 }

--- a/pkg/tdxmeasure/tdxmeasure.go
+++ b/pkg/tdxmeasure/tdxmeasure.go
@@ -1,0 +1,48 @@
+// Package tdxmeasure computes the Intel TDX build-time measurement (MRTD) of a
+// kata confidential guest offline, from the TDVF firmware image, before the
+// guest is ever started.
+//
+// MRTD is an iterative SHA-384 the TDX module builds while the VMM adds the
+// TD's initial pages: TDH.MEM.PAGE.ADD extends it with a page's GPA,
+// TDH.MR.EXTEND with 256-byte chunks of that page's contents, and
+// TDH.MR.FINALIZE completes it. The pages added pre-finalize are exactly those
+// named by TDVF's metadata section table, so MRTD is a function of the TDVF
+// binary alone.
+//
+// It therefore does NOT cover the guest kernel, initrd, kernel command line,
+// vCPU count or guest RAM size — those reach RTMR[0..2], which c8s does not pin
+// (see pkg/ratls.VerifyPolicy). One MRTD covers every pod shape booting the
+// same TDVF; this was confirmed against two live kata-qemu-tdx pods of
+// different vCPU shapes. See docs/kata-launch-measurement.md.
+//
+// The digest itself comes from github.com/google/gce-tcb-verifier/tdx rather
+// than a local reimplementation of the TDX Module Base Architecture
+// Specification.
+package tdxmeasure
+
+import (
+	"fmt"
+
+	gcetdx "github.com/google/gce-tcb-verifier/tdx"
+)
+
+// DigestLen is the length of an MRTD, in bytes.
+const DigestLen = 48
+
+// launchOptions returns the only option set valid for a kata-qemu-tdx guest.
+//
+// LaunchOptions is a GCE-shaped API and its other presets do NOT describe our
+// VMM: MeasureAllRegions (LaunchOptionsDefaultTDHOBBug) models a Google
+// hypervisor bug, and DisableUnacceptedMemory changes the TD HOB. Both produce
+// a different, wrong digest here — see docs/kata-launch-measurement.md.
+// The machine-type argument is unused by the library.
+func launchOptions() *gcetdx.LaunchOptions { return gcetdx.LaunchOptionsDefault("") }
+
+// MRTD returns the 48-byte TDX build-time measurement of a TDVF image.
+func MRTD(firmware []byte) ([]byte, error) {
+	d, err := gcetdx.MRTD(launchOptions(), firmware)
+	if err != nil {
+		return nil, fmt.Errorf("compute MRTD: %w", err)
+	}
+	return d[:], nil
+}

--- a/pkg/tdxmeasure/tdxmeasure_test.go
+++ b/pkg/tdxmeasure/tdxmeasure_test.go
@@ -1,0 +1,113 @@
+package tdxmeasure
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"testing"
+
+	gcetdx "github.com/google/gce-tcb-verifier/tdx"
+)
+
+// tdvfPath is where kata-qemu-tdx's `firmware` key points on a c8s node.
+const tdvfPath = "/opt/kata/share/ovmf/OVMF.inteltdx.fd"
+
+const (
+	// wantMRTD was captured on 2026-08-03 from two live kata-qemu-tdx pods of
+	// different vCPU shapes (1 and 2 vCPU) on b300-node-2, read from each
+	// pod's own attestation report via the in-guest attestation-service. Both
+	// reported this same value.
+	wantMRTD = "c78e2b8b2f66207f3807d8d999f51e04f5eab8f7aa02614a86ddd81b61f4e79c" +
+		"5d7616664fcb190b8eaae2e26d60b12a"
+	// wantTDVFSHA is the TDVF build that produced wantMRTD.
+	wantTDVFSHA = "2af9e5e974c0dc201163d1fd419f234cc4b6e64e99425ce6619e9a077fb0c0b6"
+)
+
+// loadTDVF returns the validated TDVF build, or skips. The 4 MiB image is not
+// committed, so this runs on a TDX node (or with C8S_TDVF set) and is skipped
+// in CI. See docs/kata-launch-measurement.md to re-capture the expected value.
+func loadTDVF(t *testing.T) []byte {
+	t.Helper()
+	p := tdvfPath
+	if env := os.Getenv("C8S_TDVF"); env != "" {
+		p = env
+	}
+	fw, err := os.ReadFile(p)
+	if err != nil {
+		t.Skipf("TDVF not present (%v); set C8S_TDVF to run this check", err)
+	}
+	if sum := sha256.Sum256(fw); hex.EncodeToString(sum[:]) != wantTDVFSHA {
+		t.Skipf("TDVF at %s is not the validated build (sha256 %x)", p, sum)
+	}
+	return fw
+}
+
+// TestMRTDMatchesHardware is the load-bearing test: the value c8s would pin
+// must equal the one real TDX silicon reported. It is also the tripwire for a
+// change in the upstream library's default LaunchOptions, which would silently
+// move the pinned measurement.
+func TestMRTDMatchesHardware(t *testing.T) {
+	got, err := MRTD(loadTDVF(t))
+	if err != nil {
+		t.Fatalf("MRTD: %v", err)
+	}
+	if len(got) != DigestLen {
+		t.Fatalf("MRTD length = %d, want %d", len(got), DigestLen)
+	}
+	if hex.EncodeToString(got) != wantMRTD {
+		t.Errorf("MRTD = %s\nwant  = %s", hex.EncodeToString(got), wantMRTD)
+	}
+}
+
+// TestOtherLaunchOptionsAreWrong pins WHY launchOptions picks the plain
+// default. Both other presets model a Google hypervisor and produce a digest
+// that no kata pod would ever report; pinning one would refuse every pod. If
+// upstream ever makes them equivalent this test fails and the comment in
+// launchOptions needs revisiting.
+func TestOtherLaunchOptionsAreWrong(t *testing.T) {
+	fw := loadTDVF(t)
+
+	unaccepted := gcetdx.LaunchOptionsDefault("")
+	unaccepted.DisableUnacceptedMemory = true //nolint:staticcheck // deprecated upstream; still the preset this test rules out.
+
+	for name, opts := range map[string]*gcetdx.LaunchOptions{
+		"TDHOBBug":                gcetdx.LaunchOptionsDefaultTDHOBBug(""),
+		"DisableUnacceptedMemory": unaccepted,
+	} {
+		d, err := gcetdx.MRTD(opts, fw)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if hex.EncodeToString(d[:]) == wantMRTD {
+			t.Errorf("%s now matches hardware; launchOptions() rationale is stale", name)
+		}
+	}
+}
+
+// TestMRTDIsFirmwareOnly: the signature takes firmware and nothing else, so a
+// caller cannot accidentally feed a pod shape in. Same bytes, same digest.
+func TestMRTDIsFirmwareOnly(t *testing.T) {
+	fw := loadTDVF(t)
+	a, err := MRTD(fw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := MRTD(fw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hex.EncodeToString(a) != hex.EncodeToString(b) {
+		t.Fatalf("MRTD not deterministic: %x vs %x", a, b)
+	}
+}
+
+func TestMRTDRejectsGarbage(t *testing.T) {
+	for name, fw := range map[string][]byte{
+		"empty":       {},
+		"no metadata": make([]byte, 4096),
+	} {
+		if _, err := MRTD(fw); err == nil {
+			t.Errorf("%s: MRTD accepted a non-TDVF image", name)
+		}
+	}
+}


### PR DESCRIPTION
  `c8s kata measure` predicted SEV-SNP launch digests only. Adds
  `--platform tdx`, which computes the Intel TDX MRTD — the one value c8s pins
  on TDX (`pkg/ratls/verify.go`; `attestation-go` maps `ExpectedLaunchDigest`
  to `MrTd`). RTMRs are not pinned and are not computed.

  **Unlike SNP, one MRTD covers the whole fleet.** MRTD is a function of the
  TDVF image alone: only the BFV section is content-extended, while the TD HOB
  — which carries vCPU count and guest RAM — is page-added but never extended.
  Verified on two live `kata-qemu-tdx` pods differing only in vCPU shape:

      pod A (-smp 1)   pod B (-smp 2, limits.cpu: 500m)
      MRTD     c78e2b8b…60b12a   c78e2b8b…60b12a   same
      RTMR[0]  8c7ccd95…         9ce3cd3f…         differs (TD HOB)
      RTMR[2]  bd64df1e…         1f94cec2…         differs (nr_cpus)

  So the pod-shape flags (`--vcpus`, `--pod-cpu-limit`, `--cmdline`,
  `--debug-console`) are rejected on this path rather than silently ignored.
  This is why the image-puller pins `default_vcpus = 1` on the SNP shims only.

  Computed digest matches the hardware value byte-exactly:

      computed  c78e2b8b2f66207f3807d8d999f51e04f5eab8f7aa02614a86ddd81b61f4e79c…
      expected  c78e2b8b2f66207f3807d8d999f51e04f5eab8f7aa02614a86ddd81b61f4e79c…

  `pkg/tdxmeasure` wraps `github.com/google/gce-tcb-verifier/tdx` (new dep,
  +2 go.mod lines) rather than reimplementing the TDX Module spec;
  `go-tdx-guest` verifies quotes but does not predict measurements.

  Worth reviewing:
  - **Only `LaunchOptionsDefault` is correct for kata.** The library's API is GCE-shaped: `LaunchOptionsDefaultTDHOBBug` and `DisableUnacceptedMemory` both yield `2815d6db…`, which no pod would report. Pinning a wrong MRTD refuses every pod a certificate. `launchOptions()` pins the right preset; `TestOtherLaunchOptionsAreWrong` guards it, and `TestMRTDMatchesHardware` is the tripwire for a default change upstream.
  - Hardware assertions skip without the real 4 MiB TDVF (or `C8S_TDVF=`); CI covers the CLI path with a synthetic TDVF. `pkg/snpmeasure/` is untouched.

  Scope: validated against one TDVF build on one host. The platform gate is not
  yet in tree, so `--platform` defaults to `snp`; once the gate lands it should
  select the platform rather than only refusing.