### PR TITLE
fix(kata): gate confidential pods on the node's guest image being reconciled

### DIFF
--- a/cmd/c8s/operator.go
+++ b/cmd/c8s/operator.go
@@ -53,6 +53,7 @@ by this command.`,
 			GetCertRunAsGroup:       getCertRunAsGroup,
 			GetCertRunAsNonRoot:     getCertRunAsNonRoot,
 			KataEnforce:             kataEnforce,
+			KataGuestReadyGate:      kataGuestReadyGate,
 			HardwarePlatform:        operatorHardwarePlatform,
 			WorkloadClaimsHostDir:   workloadClaimsHostDir,
 			WorkloadClaimsGuest:     workloadClaimsGuest,
@@ -82,6 +83,7 @@ var (
 	getCertRunAsNonRoot     bool
 
 	kataEnforce              bool
+	kataGuestReadyGate       bool
 	operatorHardwarePlatform string
 	workloadClaimsHostDir    string
 	workloadClaimsGuest      bool
@@ -107,6 +109,7 @@ func init() {
 	operatorCmd.Flags().Int64Var(&getCertRunAsUser, "get-cert-run-as-user", 65532, "runAsUser for injected get-cert containers")
 	operatorCmd.Flags().Int64Var(&getCertRunAsGroup, "get-cert-run-as-group", 65532, "runAsGroup for injected get-cert containers")
 	operatorCmd.Flags().BoolVar(&getCertRunAsNonRoot, "get-cert-run-as-non-root", true, "set runAsNonRoot for injected get-cert containers")
+	operatorCmd.Flags().BoolVar(&kataGuestReadyGate, "kata-guest-ready-gate", false, "maintain the "+webhook.GuestReadyNodeLabel+" node label from kata-image-puller readiness and require it on confidential pods (set by the chart when the puller is deployed)")
 	operatorCmd.Flags().BoolVar(&kataEnforce, "kata-enforce", false, "inject a kata runtimeClassName into workload pods that don't request one and enforce kata RuntimeClasses (set by the chart under kata.enabled)")
 	operatorCmd.Flags().StringVar(&operatorHardwarePlatform, "hardware-platform", webhook.HardwarePlatformSNP, "CPU TEE the injected confidential kata classes target: sev-snp or tdx (set by the chart to match the RuntimeClasses it renders)")
 	operatorCmd.Flags().StringVar(&workloadClaimsHostDir, "workload-claims-host-dir", "", "host directory holding the nri-image-policy inventory socket (node-CVM); when set, the webhook mounts it into c8s-cert and injects --workload-claims so get-cert redeems a sandbox token (docs/ratls.md)")

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/confidential-dot-ai/c8s/internal/helmchart"
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
 // kataSweepScript reverses the kata host install on a single node. Kept as a
@@ -567,7 +568,9 @@ func runKataSweep(ctx context.Context, namespace, release string, cfg kataUninst
 	// cosmetic and must not abort the nuke mid-flight. The pre-check avoids
 	// handing `kubectl label` an empty node set, whose exit status varies
 	// across kubectl versions.
-	for _, label := range []string{kataRuntimeNodeLabel, snpCapabilityNodeLabel, tdxHostLabelKey} {
+	// GuestReadyNodeLabel joins them: its controller goes with the release, so
+	// the node would keep asserting a readiness nothing maintains.
+	for _, label := range []string{kataRuntimeNodeLabel, snpCapabilityNodeLabel, tdxHostLabelKey, webhook.GuestReadyNodeLabel} {
 		labelled, err := exec.CommandContext(ctx, "kubectl", "get", "nodes",
 			"-l", label, "-o", "name").Output()
 		if err != nil {

--- a/docs/pitfalls.md
+++ b/docs/pitfalls.md
@@ -788,3 +788,28 @@ help; the shim ignores it.
 the webhook-injected `c8s-certs` volume is fine. The CDS `data` volume
 (`cds.yaml`, when `cds.persistence.enabled` is false) is the one that hits this.
 Workaround on such a node: enable `cds.persistence`.
+
+## A kata pod placed before the guest drop-in exists is stuck on the stock guest
+
+`kata-runtime` resolves the c8s guest through a `config.d/50-c8s.toml` drop-in
+that the kata-image-puller writes per node. Until it lands, the same
+`kata-qemu-snp` RuntimeClass resolves the **stock** kata guest, which carries
+none of the c8s in-guest stack — no attestation-service on `127.0.0.1:8400`, no
+policy-monitor, no mesh.
+
+Nothing about the pod says so. `kubectl get pod` shows the confidential
+RuntimeClass either way; the only tell is the QEMU cmdline
+(`/proc/<pid>/cmdline`: `kata-ubuntu-noble-confidential.image` and the base
+config's verity root hash, instead of `/var/lib/c8s/kata-images/base/…`).
+
+**A kata sandbox is created once and reused across container restarts**, so a
+pod that lands in that window cannot recover: CrashLoopBackOff retries forever
+against a VM that will never gain the missing services. Deleting the *pod* is
+the only fix — deleting the container is not.
+
+`confidential.ai/kata-guest-ready` (webhook.GuestReadyNodeLabel) is the gate
+that prevents this: the operator's kata-guest-ready controller mirrors the
+puller's readiness onto the node, and both the webhook and the chart-pinned
+pods (cds, tls-lb) require it. If confidential pods sit `Pending` with
+`didn't match Pod's node affinity/selector`, check the puller on that node
+before touching the affinity — the gate is reporting a real condition.

--- a/internal/controller/kataguestready_controller.go
+++ b/internal/controller/kataguestready_controller.go
@@ -1,0 +1,125 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
+)
+
+const kataImagePullerComponent = "kata-image-puller"
+
+const componentLabel = "app.kubernetes.io/component"
+
+// KataGuestReadyReconciler maintains webhook.GuestReadyNodeLabel from the
+// node's kata-image-puller readiness, which already re-validates the drop-in
+// fingerprint and the pulled artifacts. Mirroring it keeps one source of truth.
+//
+// Keyed on Node, not Pod, so a deleted puller pod still clears the label.
+type KataGuestReadyReconciler struct {
+	client.Client
+
+	// Namespace is the release namespace holding the puller DaemonSet.
+	Namespace string
+}
+
+func (r *KataGuestReadyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	l := log.FromContext(ctx)
+
+	var node corev1.Node
+	if err := r.Get(ctx, req.NamespacedName, &node); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get node %s: %w", req.Name, err)
+	}
+
+	ready, err := r.pullerReadyOn(ctx, node.Name)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	_, labelled := node.Labels[webhook.GuestReadyNodeLabel]
+	want := "true"
+	if ready && node.Labels[webhook.GuestReadyNodeLabel] == want {
+		return ctrl.Result{}, nil
+	}
+	if !ready && !labelled {
+		return ctrl.Result{}, nil
+	}
+
+	patch := client.MergeFrom(node.DeepCopy())
+	if ready {
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels[webhook.GuestReadyNodeLabel] = want
+	} else {
+		delete(node.Labels, webhook.GuestReadyNodeLabel)
+	}
+	if err := r.Patch(ctx, &node, patch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("patch node %s: %w", node.Name, err)
+	}
+	l.Info("kata guest readiness changed", "node", node.Name, "ready", ready)
+	return ctrl.Result{}, nil
+}
+
+// pullerReadyOn reports whether a Ready puller pod is running on node. Absent,
+// pending and terminating all read as not ready.
+func (r *KataGuestReadyReconciler) pullerReadyOn(ctx context.Context, node string) (bool, error) {
+	var pods corev1.PodList
+	if err := r.List(ctx, &pods,
+		client.InNamespace(r.Namespace),
+		client.MatchingLabels{componentLabel: kataImagePullerComponent},
+	); err != nil {
+		return false, fmt.Errorf("list kata-image-puller pods: %w", err)
+	}
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Spec.NodeName != node || pod.DeletionTimestamp != nil {
+			continue
+		}
+		if isPodReady(pod) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (r *KataGuestReadyReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(pullerPodToNode),
+			builder.WithPredicates(pullerPodPredicate(r.Namespace)),
+		).
+		Named("kata-guest-ready").
+		Complete(r)
+}
+
+// pullerPodToNode maps a puller pod event onto its node.
+func pullerPodToNode(_ context.Context, obj client.Object) []ctrl.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: pod.Spec.NodeName}}}
+}
+
+// pullerPodPredicate keeps the shared Pod informer from waking this controller
+// for every pod in the cluster.
+func pullerPodPredicate(namespace string) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetNamespace() == namespace &&
+			obj.GetLabels()[componentLabel] == kataImagePullerComponent
+	})
+}

--- a/internal/controller/kataguestready_controller_test.go
+++ b/internal/controller/kataguestready_controller_test.go
@@ -1,0 +1,163 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
+)
+
+const testReleaseNS = "c8s-system"
+
+func guestReadyNode(name string, labelled bool) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{}}}
+	if labelled {
+		n.Labels[webhook.GuestReadyNodeLabel] = "true"
+	}
+	return n
+}
+
+func pullerPod(name, node string, ready bool) *corev1.Pod {
+	cond := corev1.ConditionFalse
+	if ready {
+		cond = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testReleaseNS,
+			Labels:    map[string]string{componentLabel: kataImagePullerComponent},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: cond}},
+		},
+	}
+}
+
+func reconcileNode(t *testing.T, objs []client.Object, node string) *corev1.Node {
+	t.Helper()
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	r := &KataGuestReadyReconciler{Client: c, Namespace: testReleaseNS}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: node},
+	}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	var got corev1.Node
+	if err := c.Get(context.Background(), client.ObjectKey{Name: node}, &got); err != nil {
+		t.Fatalf("get node: %v", err)
+	}
+	return &got
+}
+
+func TestGuestReadyLabelAppliedWhenPullerReady(t *testing.T) {
+	got := reconcileNode(t, []client.Object{
+		guestReadyNode("n1", false),
+		pullerPod("puller-n1", "n1", true),
+	}, "n1")
+
+	if got.Labels[webhook.GuestReadyNodeLabel] != "true" {
+		t.Fatalf("label = %q, want true — a ready puller means the node resolves the c8s guest",
+			got.Labels[webhook.GuestReadyNodeLabel])
+	}
+}
+
+// A regressed puller (values changed, drop-in stale) must clear the label.
+func TestGuestReadyLabelRemovedWhenPullerNotReady(t *testing.T) {
+	got := reconcileNode(t, []client.Object{
+		guestReadyNode("n1", true),
+		pullerPod("puller-n1", "n1", false),
+	}, "n1")
+
+	if _, ok := got.Labels[webhook.GuestReadyNodeLabel]; ok {
+		t.Fatal("label still present after the puller went unready")
+	}
+}
+
+func TestGuestReadyLabelRemovedWhenPullerAbsent(t *testing.T) {
+	got := reconcileNode(t, []client.Object{guestReadyNode("n1", true)}, "n1")
+
+	if _, ok := got.Labels[webhook.GuestReadyNodeLabel]; ok {
+		t.Fatal("label still present with no puller pod on the node")
+	}
+}
+
+// A ready puller on a different node says nothing about this one.
+func TestGuestReadyLabelIsPerNode(t *testing.T) {
+	got := reconcileNode(t, []client.Object{
+		guestReadyNode("n1", false),
+		guestReadyNode("n2", false),
+		pullerPod("puller-n2", "n2", true),
+	}, "n1")
+
+	if _, ok := got.Labels[webhook.GuestReadyNodeLabel]; ok {
+		t.Fatal("n1 labelled from a puller running on n2")
+	}
+}
+
+// A terminating pod reports Ready until it is gone, which would hold the gate
+// open across the rollout replacing it.
+func TestGuestReadyLabelIgnoresTerminatingPuller(t *testing.T) {
+	pod := pullerPod("puller-n1", "n1", true)
+	now := metav1.Now()
+	pod.DeletionTimestamp = &now
+	pod.Finalizers = []string{"c8s.test/hold"}
+
+	got := reconcileNode(t, []client.Object{guestReadyNode("n1", true), pod}, "n1")
+
+	if _, ok := got.Labels[webhook.GuestReadyNodeLabel]; ok {
+		t.Fatal("label held open by a terminating puller pod")
+	}
+}
+
+// The component label is not namespaced; the release namespace is the guard.
+func TestGuestReadyLabelIgnoresForeignNamespace(t *testing.T) {
+	pod := pullerPod("puller-n1", "n1", true)
+	pod.Namespace = "attacker"
+
+	got := reconcileNode(t, []client.Object{guestReadyNode("n1", false), pod}, "n1")
+
+	if _, ok := got.Labels[webhook.GuestReadyNodeLabel]; ok {
+		t.Fatal("node labelled from a puller-labelled pod outside the release namespace")
+	}
+}
+
+func TestGuestReadyReconcileMissingNodeIsNoop(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &KataGuestReadyReconciler{Client: c, Namespace: testReleaseNS}
+	if _, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKey{Name: "gone"},
+	}); err != nil {
+		t.Fatalf("Reconcile on a deleted node: %v", err)
+	}
+}
+
+func TestPullerPodToNode(t *testing.T) {
+	reqs := pullerPodToNode(context.Background(), pullerPod("p", "n1", true))
+	if len(reqs) != 1 || reqs[0].Name != "n1" {
+		t.Fatalf("pullerPodToNode = %+v, want one request for n1", reqs)
+	}
+	if got := pullerPodToNode(context.Background(), pullerPod("p", "", true)); len(got) != 0 {
+		t.Fatalf("unscheduled pod produced %d requests, want 0", len(got))
+	}
+}
+
+func TestPullerPodPredicate(t *testing.T) {
+	p := pullerPodPredicate(testReleaseNS)
+	if !p.Create(event.CreateEvent{Object: pullerPod("p", "n1", true)}) {
+		t.Fatal("predicate rejected a puller pod in the release namespace")
+	}
+	other := pullerPod("p", "n1", true)
+	other.Labels[componentLabel] = "cds"
+	if p.Create(event.CreateEvent{Object: other}) {
+		t.Fatal("predicate accepted a non-puller pod")
+	}
+}

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -90,6 +90,11 @@ type Options struct {
 	// (webhook.HardwarePlatformSNP or ...TDX; the operator command validates).
 	HardwarePlatform string
 
+	// KataGuestReadyGate runs the kata-guest-ready node-label controller and
+	// makes the webhook require that label. Only valid where the
+	// kata-image-puller is deployed — see webhook.Config.
+	KataGuestReadyGate bool
+
 	// WorkloadClaimsHostDir, when set (node-CVM), is the nri-image-policy inventory
 	// socket directory: the webhook mounts it into c8s-cert and injects the
 	// get-cert workload-digest claim (docs/ratls.md). See webhook.Config.
@@ -227,6 +232,18 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 		}
 	}
 
+	// Must run wherever the webhook injects the matching nodeAffinity, or
+	// nothing ever sets the label and confidential pods never schedule.
+	if opts.KataGuestReadyGate {
+		if err := (&KataGuestReadyReconciler{
+			Client:    mgr.GetClient(),
+			Namespace: opts.LeaderElectionNS,
+		}).SetupWithManager(mgr); err != nil {
+			return fmt.Errorf("setup kata-guest-ready reconciler: %w", err)
+		}
+		logger.Info("kata guest-readiness scheduling gate enabled", "label", webhook.GuestReadyNodeLabel)
+	}
+
 	// Admission webhook — injects get-cert containers into annotated pods, and
 	// (when kata enforcement is on) a kata runtimeClassName into workload
 	// pods. Registers when either job is wanted.
@@ -247,6 +264,7 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 			GetCertRunAsNonRoot:   boolPtr(opts.GetCertRunAsNonRoot),
 			KataEnforce:           opts.KataEnforce,
 			HardwarePlatform:      opts.HardwarePlatform,
+			KataGuestReadyGate:    opts.KataGuestReadyGate,
 			WorkloadClaimsHostDir: opts.WorkloadClaimsHostDir,
 			WorkloadClaimsGuest:   opts.WorkloadClaimsGuest,
 		}); err != nil {

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -745,3 +745,31 @@ imagePullSecrets:
     - {{ . }}
     {{- end }}
 {{- end }}
+
+{{/*
+c8s.kataGuestReadyGate — "true" when the kata-image-puller whose readiness the
+label mirrors is deployed. Gating without it leaves every confidential pod
+Pending forever.
+*/}}
+{{- define "c8s.kataGuestReadyGate" -}}
+{{- if and .Values.kata.enabled .Values.kata.guestImage.enabled -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+c8s.kataGuestReadyAffinity — the gate for chart-managed pods that pin a kata
+RuntimeClass themselves and so bypass the injecting webhook.
+*/}}
+{{- define "c8s.kataGuestReadyAffinity" -}}
+{{- if include "c8s.kataGuestReadyGate" . }}
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: confidential.ai/kata-guest-ready
+              operator: In
+              values: ["true"]
+{{- end }}
+{{- end -}}

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -161,6 +161,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- /* Pinned above, not injected, so the gate is spelled out here too. */}}
+      {{- include "c8s.kataGuestReadyAffinity" . | nindent 6 }}
       securityContext:
       {{- if .Values.kata.enabled }}
         # In a kata-qemu-snp guest with shared_fs="none", the kubelet fsGroup

--- a/internal/helmchart/c8s/templates/operator.yaml
+++ b/internal/helmchart/c8s/templates/operator.yaml
@@ -70,6 +70,9 @@ spec:
             - --kata-enforce=true
             - --hardware-platform={{ include "c8s.hardwarePlatform" . }}
             {{- end }}
+            {{- if include "c8s.kataGuestReadyGate" . }}
+            - --kata-guest-ready-gate=true
+            {{- end }}
             {{- /* Workload-digest claims (docs/ratls.md): get-cert
                    redeems a sandbox token from the node's inventory over a
                    compiled endpoint: the nri-image-policy socket mounted into

--- a/internal/helmchart/c8s/templates/rbac.yaml
+++ b/internal/helmchart/c8s/templates/rbac.yaml
@@ -25,6 +25,14 @@ rules:
     # delete: the startup reinject sweep deletes un-injected cw pods so their
     # controllers recreate them through the webhook.
     verbs: [get, list, watch, delete]
+  {{- if include "c8s.kataGuestReadyGate" . }}
+  - apiGroups: [""]
+    resources: [nodes]
+    # For the kata-guest-ready controller's one label. RBAC cannot scope a
+    # patch to a label key, so taints and unschedulable come with it — hence
+    # kata-only.
+    verbs: [get, list, watch, patch]
+  {{- end }}
   - apiGroups: [apps]
     resources: [deployments, statefulsets, daemonsets]
     # The workload-service reconciler watches these for the confidential.ai/cw

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -53,6 +53,8 @@ spec:
       # must stay inside the TEE boundary.
       runtimeClassName: {{ include "c8s.controlPlaneKataRuntimeClass" . }}
       {{- end }}
+      {{- /* Pinned above, not injected, so the gate is spelled out here too. */}}
+      {{- include "c8s.kataGuestReadyAffinity" . | nindent 6 }}
       {{- include "c8s.imagePullSecrets" (dict "root" $ "local" .Values.tlsLb.imagePullSecrets) | nindent 6 }}
       shareProcessNamespace: true
       initContainers:

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"gopkg.in/yaml.v3"
@@ -6509,5 +6510,83 @@ func TestChartVolumedAndWebhookAgreeOnTheSocketDir(t *testing.T) {
 	}
 	if hostDir != socketDir {
 		t.Errorf("the operator mounts %q into cw pods but volumed serves in %q", hostDir, socketDir)
+	}
+}
+
+// The one install shape granting the operator node RBAC. Asserted exactly
+// here: TestChartOperatorRBACIsScoped's ban never renders this branch.
+func TestChartOperatorNodeRBACOnlyUnderKataGuestReadyGate(t *testing.T) {
+	out, err := helmTemplateKata(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	var role rbacv1.ClusterRole
+	if !findDoc(t, out, "ClusterRole", "c8s-operator", &role) {
+		t.Fatalf("render missing ClusterRole c8s-operator\n%s", out)
+	}
+	got := operatorVerbsFor(role, "", "nodes")
+	want := []string{"get", "list", "watch", "patch"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("operator nodes verbs under kata = %v, want %v", got, want)
+	}
+
+	// No puller, no controller: the grant and the gate must both go with it.
+	out, err = helmTemplateKata(t, "--set", "kata.guestImage.enabled=false")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	if !findDoc(t, out, "ClusterRole", "c8s-operator", &role) {
+		t.Fatalf("render missing ClusterRole c8s-operator\n%s", out)
+	}
+	if got := operatorVerbsFor(role, "", "nodes"); got != nil {
+		t.Fatalf("operator keeps nodes verbs %v with the puller disabled", got)
+	}
+	if strings.Contains(out, "kata-guest-ready-gate=true") {
+		t.Fatal("operator still told to enforce the guest-ready gate with no puller to set the label")
+	}
+}
+
+// Pods pinning a kata RuntimeClass bypass the injecting webhook.
+func TestChartKataPinnedPodsCarryGuestReadyAffinity(t *testing.T) {
+	out, err := helmTemplateKata(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	seen := map[string]bool{}
+	iterateManifests(t, out, func(doc []byte) bool {
+		var obj struct {
+			docMeta
+			Spec struct {
+				Template corev1.PodTemplateSpec `json:"template"`
+			} `json:"spec"`
+		}
+		if err := sigsyaml.Unmarshal(doc, &obj); err != nil {
+			return false
+		}
+		spec := obj.Spec.Template.Spec
+		if spec.RuntimeClassName == nil || !strings.HasPrefix(*spec.RuntimeClassName, "kata-") {
+			return false
+		}
+		if spec.Affinity == nil || spec.Affinity.NodeAffinity == nil ||
+			spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+			t.Errorf("%s %s pins %s but has no required node affinity", obj.Kind, obj.Metadata.Name, *spec.RuntimeClassName)
+			return false
+		}
+		for _, term := range spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+			for _, e := range term.MatchExpressions {
+				if e.Key == webhook.GuestReadyNodeLabel {
+					seen[obj.Metadata.Name] = true
+				}
+			}
+		}
+		if !seen[obj.Metadata.Name] {
+			t.Errorf("%s %s pins %s without the guest-ready gate", obj.Kind, obj.Metadata.Name, *spec.RuntimeClassName)
+		}
+		return false
+	})
+	for _, name := range []string{"c8s-cds", "c8s-tls-lb"} {
+		if !seen[name] {
+			t.Errorf("%s missing the guest-ready node affinity", name)
+		}
 	}
 }

--- a/internal/webhook/guest_ready_affinity_test.go
+++ b/internal/webhook/guest_ready_affinity_test.go
@@ -1,0 +1,107 @@
+package webhook
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// guestReadyExprs returns the guest-ready requirement from every term it
+// appears in.
+func guestReadyExprs(pod *corev1.Pod) []corev1.NodeSelectorRequirement {
+	var out []corev1.NodeSelectorRequirement
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.NodeAffinity == nil {
+		return out
+	}
+	req := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+	if req == nil {
+		return out
+	}
+	for _, term := range req.NodeSelectorTerms {
+		for _, e := range term.MatchExpressions {
+			if e.Key == GuestReadyNodeLabel {
+				out = append(out, e)
+			}
+		}
+	}
+	return out
+}
+
+func TestRequireGuestReadyNodeOnBarePod(t *testing.T) {
+	pod := &corev1.Pod{}
+	requireGuestReadyNode(pod)
+
+	got := guestReadyExprs(pod)
+	if len(got) != 1 {
+		t.Fatalf("guest-ready requirements = %d, want 1", len(got))
+	}
+	if got[0].Operator != corev1.NodeSelectorOpIn || len(got[0].Values) != 1 || got[0].Values[0] != "true" {
+		t.Fatalf("requirement = %+v, want In [true]", got[0])
+	}
+}
+
+// Terms are OR-ed, so the gate must land in every one of them.
+func TestRequireGuestReadyNodeAndsWithEveryExistingTerm(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"a"},
+					}}},
+					{MatchExpressions: []corev1.NodeSelectorRequirement{{
+						Key: "zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"b"},
+					}}},
+				},
+			},
+		},
+	}}}
+	requireGuestReadyNode(pod)
+
+	terms := pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) != 2 {
+		t.Fatalf("nodeSelectorTerms = %d, want the original 2 (a new term would OR away the gate)", len(terms))
+	}
+	for i, term := range terms {
+		var found bool
+		for _, e := range term.MatchExpressions {
+			if e.Key == GuestReadyNodeLabel {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("term %d has no guest-ready requirement; the gate is satisfiable without it", i)
+		}
+	}
+}
+
+// reinvocationPolicy: IfNeeded — a second pass must not stack the expression.
+func TestRequireGuestReadyNodeIsIdempotent(t *testing.T) {
+	pod := &corev1.Pod{}
+	requireGuestReadyNode(pod)
+	requireGuestReadyNode(pod)
+
+	if got := guestReadyExprs(pod); len(got) != 1 {
+		t.Fatalf("guest-ready requirements after two passes = %d, want 1", len(got))
+	}
+}
+
+func TestRequireGuestReadyNodePreservesUnrelatedAffinity(t *testing.T) {
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Affinity: &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{},
+		NodeAffinity: &corev1.NodeAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{{Weight: 1}},
+		},
+	}}}
+	requireGuestReadyNode(pod)
+
+	if pod.Spec.Affinity.PodAntiAffinity == nil {
+		t.Fatal("podAntiAffinity was dropped")
+	}
+	if len(pod.Spec.Affinity.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 1 {
+		t.Fatal("preferred node affinity was dropped")
+	}
+	if len(guestReadyExprs(pod)) != 1 {
+		t.Fatal("guest-ready requirement missing")
+	}
+}

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -173,6 +174,11 @@ const (
 // webhook matches the prefix rather than a fixed resource name.
 const nvidiaGpuResourcePrefix = "nvidia.com/"
 
+// GuestReadyNodeLabel marks a node whose kata-image-puller has reconciled the
+// c8s guest. Without it kata-runtime still resolves the stock guest — see
+// docs/pitfalls.md, "A kata pod placed before the guest drop-in exists".
+const GuestReadyNodeLabel = "confidential.ai/kata-guest-ready"
+
 // Config tunes the injector.
 type Config struct {
 	// GetCertImage is the c8s multi-mode binary image used for the
@@ -231,6 +237,11 @@ type Config struct {
 	// --workload-claims so get-cert redeems a sandbox token over that socket
 	// (docs/ratls.md).
 	WorkloadClaimsHostDir string
+
+	// KataGuestReadyGate makes kata runtimeClass injection also require
+	// GuestReadyNodeLabel. Only valid where the image-puller is deployed:
+	// nothing else sets the label, so pods would stay Pending forever.
+	KataGuestReadyGate bool
 
 	// WorkloadClaimsGuest selects the kata shape: the inventory is
 	// policy-monitor inside the guest, reached on the guest's loopback address
@@ -710,6 +721,9 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	if kataClass != "" {
 		l.Info("injecting kata runtimeClassName", "runtimeClass", kataClass)
 		pod.Spec.RuntimeClassName = &kataClass
+		if m.cfg.KataGuestReadyGate {
+			requireGuestReadyNode(pod)
+		}
 		// Stamp AnnotationInjected here too — mutatePod only runs when
 		// get-cert is needed, but a kata-only mutation is still a mutation
 		// and the alreadyInjected short-circuit above must see it on
@@ -843,6 +857,41 @@ func kataRuntimeClassFor(pod *corev1.Pod, cfg Config) string {
 		return kataSnpRuntimeClass
 	}
 	return kataRuntimeClass
+}
+
+// requireGuestReadyNode pins a confidential pod to a node carrying
+// GuestReadyNodeLabel.
+//
+// INVARIANT: the requirement lands in every nodeSelectorTerm. Terms are OR-ed,
+// so a term of its own would leave the affinity satisfiable without it.
+func requireGuestReadyNode(pod *corev1.Pod) {
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	na := pod.Spec.Affinity.NodeAffinity
+	if na.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		na.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+	terms := na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(terms) == 0 {
+		terms = []corev1.NodeSelectorTerm{{}}
+	}
+	for i := range terms {
+		if slices.ContainsFunc(terms[i].MatchExpressions, func(e corev1.NodeSelectorRequirement) bool {
+			return e.Key == GuestReadyNodeLabel
+		}) {
+			continue
+		}
+		terms[i].MatchExpressions = append(terms[i].MatchExpressions, corev1.NodeSelectorRequirement{
+			Key:      GuestReadyNodeLabel,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{"true"},
+		})
+	}
+	na.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = terms
 }
 
 // podRequestsNvidiaGpu reports whether any container (regular or init) asks


### PR DESCRIPTION
A kata pod created before the image-puller writes its config.d drop-in boots
the STOCK kata guest: no attestation-service, no policy-monitor, no mesh,
while still reporting a confidential runtimeClassName. A kata sandbox is
created once and reused across container restarts, so the pod cannot recover
and the install hangs until an operator deletes it by hand.

Mirror the puller's readiness onto confidential.ai/kata-guest-ready and
require it wherever a kata RuntimeClass is assigned. Gating placement, not
install order, also covers nodes that join later.

Grants the operator node get/list/watch/patch, but only under the kata shape.