### PR TITLE
feat(initdata): deliver CDS measurements into the guest

### DIFF
--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -1,0 +1,115 @@
+package policymonitor
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/go-sev-guest/abi"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+)
+
+// Distinct from a document that fails verification: this is an older control
+// plane, that is a host that tampered.
+var errNoInitData = errors.New("policy-monitor: no init-data document")
+
+// Bounds the self-attestation; on expiry the caller falls back to the seed.
+const initDataTimeout = 15 * time.Second
+
+// Where kata-agent writes the document. A var only so tests can point at a
+// tempdir; production always uses the baked path.
+var initDataDocumentPath = initdata.GuestDocumentPath
+
+// resolveInitDataMeasurements returns the CDS measurements the host delivered.
+//
+// The document is host-supplied; what makes it usable is that the shim commits
+// sha256(document) into HOST_DATA at launch. A mismatch means the host wrote
+// one document and committed another, and is treated as tampering.
+func resolveInitDataMeasurements(ctx context.Context, cfg *Config) (string, error) {
+	raw, err := os.ReadFile(initDataDocumentPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", errNoInitData
+		}
+		return "", fmt.Errorf("read init-data: %w", err)
+	}
+
+	hostData, err := selfHostData(ctx, cfg)
+	if err != nil {
+		return "", err
+	}
+	want := initdata.Digest(raw)
+	if subtle.ConstantTimeCompare(hostData, want[:]) != 1 {
+		return "", fmt.Errorf("policy-monitor: init-data digest %x is not the launch-committed HOST_DATA %x", want, hostData)
+	}
+
+	doc, err := initdata.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse init-data: %w", err)
+	}
+	return doc.Data[initdata.KeyCDSMeasurements], nil
+}
+
+// applyInitDataMeasurements fills cfg.CDSMeasurements from the launch-committed
+// document. It is the only delivery path: the value cannot be baked (it would
+// be a digest of the image it lives in) and unattested env must not be trusted.
+//
+// An explicit value wins, and every failure leaves cfg untouched, so the
+// fallback is always the baked seed.
+func applyInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Config) {
+	if cfg.CDSMeasurements != "" {
+		return
+	}
+	measurements, err := resolveInitDataMeasurements(ctx, cfg)
+	switch {
+	case errors.Is(err, errNoInitData):
+		logger.Warn("no init-data document; CDS measurements unset, so allowlist refresh will stay disabled",
+			"path", initdata.GuestDocumentPath)
+		return
+	case err != nil:
+		// Host tampering or a broken attester; both leave the guest on the seed.
+		logger.Error("init-data rejected; enforcing the baked seed alone", "error", err)
+		return
+	case measurements == "":
+		logger.Warn("init-data carries no CDS measurements; allowlist refresh will stay disabled",
+			"key", initdata.KeyCDSMeasurements)
+		return
+	}
+	cfg.CDSMeasurements = measurements
+	logger.Info("CDS measurements taken from the launch-committed init-data document",
+		"key", initdata.KeyCDSMeasurements)
+}
+
+// selfHostData reads HOST_DATA from a fresh report for this guest. Report data
+// is unused here, hence the zero value.
+//
+// SEV-SNP only: TDX commits the digest to MRCONFIGID, so a TDX guest fails to
+// parse here and falls back to the baked seed — safe, but not yet wired.
+func selfHostData(ctx context.Context, cfg *Config) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, initDataTimeout)
+	defer cancel()
+
+	resp, err := attestclient.NewClient("").GenerateEvidenceContext(ctx, cfg.AttestationServiceURL, make([]byte, 48))
+	if err != nil {
+		return nil, fmt.Errorf("attest self: %w", err)
+	}
+	report, err := attestclient.ExtractSNPReport(resp)
+	if err != nil {
+		return nil, fmt.Errorf("extract snp report: %w", err)
+	}
+	parsed, err := abi.ReportToProto([]byte(report))
+	if err != nil {
+		return nil, fmt.Errorf("parse snp report: %w", err)
+	}
+	hostData := parsed.GetHostData()
+	if len(hostData) != initdata.DigestSize {
+		return nil, fmt.Errorf("policy-monitor: HOST_DATA is %d bytes, want %d", len(hostData), initdata.DigestSize)
+	}
+	return hostData, nil
+}

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -1,0 +1,266 @@
+package policymonitor
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// snpHostDataOffset is HOST_DATA's byte offset in an SEV-SNP ATTESTATION_REPORT
+// (AMD SEV-SNP ABI table: VERSION..PLATFORM_INFO, REPORT_DATA at 0x50,
+// MEASUREMENT at 0x90, HOST_DATA at 0xC0).
+const snpHostDataOffset = 0xC0
+
+const snpReportLen = 1184
+
+// snpPolicyOffset is POLICY's offset. go-sev-guest rejects a report whose
+// bit 17 is clear, so the field cannot be left zero. 0x30000 is what a kata
+// SNP guest actually reports (bit 16 SMT, bit 17 reserved-must-be-1).
+const (
+	snpPolicyOffset = 0x08
+	snpTestPolicy   = 0x30000
+)
+
+// attesterServing returns the URL of a fake in-guest attester whose report
+// carries hostData in HOST_DATA.
+func attesterServing(t *testing.T, hostData []byte) string {
+	t.Helper()
+	report := make([]byte, snpReportLen)
+	report[0] = 0x02 // VERSION 2
+	binary.LittleEndian.PutUint64(report[snpPolicyOffset:], snpTestPolicy)
+	copy(report[snpHostDataOffset:], hostData)
+
+	evidence, err := json.Marshal(map[string]string{
+		"attestation_report": base64.StdEncoding.EncodeToString(report),
+	})
+	if err != nil {
+		t.Fatalf("marshal evidence: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: "snp", Evidence: evidence})
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// writeInitData points initDataDocumentPath at a tempdir holding raw.
+func writeInitData(t *testing.T, raw []byte) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "initdata.toml")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatalf("write init-data: %v", err)
+	}
+	old := initDataDocumentPath
+	initDataDocumentPath = path
+	t.Cleanup(func() { initDataDocumentPath = old })
+}
+
+func testDocument(t *testing.T, measurements string) []byte {
+	t.Helper()
+	raw, err := initdata.New(map[string]string{
+		initdata.KeyRole:            initdata.RoleWorkload,
+		initdata.KeyCDSMeasurements: measurements,
+	}).Render()
+	if err != nil {
+		t.Fatalf("render document: %v", err)
+	}
+	return raw
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestResolveInitDataMeasurementsHonoursCommittedDocument(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+	got, err := resolveInitDataMeasurements(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("resolveInitDataMeasurements: %v", err)
+	}
+	if got != "aabb,ccdd" {
+		t.Fatalf("measurements = %q, want %q", got, "aabb,ccdd")
+	}
+}
+
+// The whole trust anchor: a host that writes one document and commits another
+// must not have its measurements believed.
+func TestResolveInitDataMeasurementsRejectsUncommittedDocument(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+
+	// HOST_DATA commits some other document.
+	other := initdata.Digest(testDocument(t, "deadbeef"))
+	cfg := &Config{AttestationServiceURL: attesterServing(t, other[:])}
+
+	_, err := resolveInitDataMeasurements(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("accepted a document HOST_DATA does not commit")
+	}
+	if !strings.Contains(err.Error(), "HOST_DATA") {
+		t.Fatalf("error = %v, want it to name HOST_DATA", err)
+	}
+}
+
+// A guest whose HOST_DATA was never set (all-zero) must not pass either.
+func TestResolveInitDataMeasurementsRejectsZeroHostData(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, initdata.DigestSize))}
+
+	if _, err := resolveInitDataMeasurements(context.Background(), cfg); err == nil {
+		t.Fatal("accepted a document against zero HOST_DATA")
+	}
+}
+
+func TestResolveInitDataMeasurementsNoDocument(t *testing.T) {
+	old := initDataDocumentPath
+	initDataDocumentPath = filepath.Join(t.TempDir(), "absent.toml")
+	t.Cleanup(func() { initDataDocumentPath = old })
+
+	_, err := resolveInitDataMeasurements(context.Background(), &Config{})
+	if !errors.Is(err, errNoInitData) {
+		t.Fatalf("err = %v, want errNoInitData", err)
+	}
+}
+
+// Verification precedes parsing, so malformed bytes that HOST_DATA does commit
+// still fail — as a parse error, not silently.
+func TestResolveInitDataMeasurementsMalformedDocument(t *testing.T) {
+	raw := []byte("this is not an init-data document\n")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+	_, err := resolveInitDataMeasurements(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "parse init-data") {
+		t.Fatalf("err = %v, want a parse failure", err)
+	}
+}
+
+func TestResolveInitDataMeasurementsAttesterUnreachable(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+	cfg := &Config{AttestationServiceURL: "http://127.0.0.1:1"}
+
+	if _, err := resolveInitDataMeasurements(context.Background(), cfg); err == nil {
+		t.Fatal("succeeded with no reachable attester")
+	}
+}
+
+func TestApplyInitDataMeasurementsSetsFromDocument(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+	applyInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "aabb,ccdd" {
+		t.Fatalf("CDSMeasurements = %q, want it taken from the document", cfg.CDSMeasurements)
+	}
+}
+
+// An operator pinning measurements out-of-band must not be re-pointed by the
+// host, so the attester is never even consulted.
+func TestApplyInitDataMeasurementsExplicitValueWins(t *testing.T) {
+	raw := testDocument(t, "fromdocument")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+
+	cfg := &Config{
+		CDSMeasurements:       "explicit",
+		AttestationServiceURL: attesterServing(t, digest[:]),
+	}
+	applyInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "explicit" {
+		t.Fatalf("CDSMeasurements = %q, want the explicit value kept", cfg.CDSMeasurements)
+	}
+}
+
+// Every failure path must leave cfg untouched: empty measurements is what makes
+// runAllowlistRefresh fail closed onto the baked seed.
+func TestApplyInitDataMeasurementsFailuresLeaveConfigEmpty(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		setup func(t *testing.T) *Config
+	}{
+		{"no document", func(t *testing.T) *Config {
+			old := initDataDocumentPath
+			initDataDocumentPath = filepath.Join(t.TempDir(), "absent.toml")
+			t.Cleanup(func() { initDataDocumentPath = old })
+			return &Config{}
+		}},
+		{"uncommitted document", func(t *testing.T) *Config {
+			writeInitData(t, testDocument(t, "aabb"))
+			other := initdata.Digest(testDocument(t, "other"))
+			return &Config{AttestationServiceURL: attesterServing(t, other[:])}
+		}},
+		{"document without measurements", func(t *testing.T) *Config {
+			raw, err := initdata.New(map[string]string{initdata.KeyRole: initdata.RoleWorkload}).Render()
+			if err != nil {
+				t.Fatalf("render: %v", err)
+			}
+			writeInitData(t, raw)
+			digest := initdata.Digest(raw)
+			return &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.setup(t)
+			applyInitDataMeasurements(context.Background(), quietLogger(), cfg)
+			if cfg.CDSMeasurements != "" {
+				t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed", cfg.CDSMeasurements)
+			}
+		})
+	}
+}
+
+func TestSelfHostDataReadsHostDataField(t *testing.T) {
+	want := make([]byte, initdata.DigestSize)
+	for i := range want {
+		want[i] = byte(i + 1)
+	}
+	cfg := &Config{AttestationServiceURL: attesterServing(t, want)}
+
+	got, err := selfHostData(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("selfHostData: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("HOST_DATA = %x, want %x", got, want)
+	}
+}
+
+func TestSelfHostDataRejectsUnparseableReport(t *testing.T) {
+	evidence, err := json.Marshal(map[string]string{
+		"attestation_report": base64.StdEncoding.EncodeToString([]byte("too short")),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: "snp", Evidence: evidence})
+	}))
+	defer srv.Close()
+
+	if _, err := selfHostData(context.Background(), &Config{AttestationServiceURL: srv.URL}); err == nil {
+		t.Fatal("accepted a report that does not parse")
+	}
+}

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -126,6 +126,7 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	// *allowlist with m, whose merge is mutex-guarded. No CDS URL →
 	// baked-seed-only and the network is never touched.
 	if cfg.CDSURL != "" {
+		applyInitDataMeasurements(ctx, logger, cfg)
 		go runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
 	} else {
 		// Info, not Error: seed-only is the configured intent here, unlike the

--- a/internal/webhook/initdata.go
+++ b/internal/webhook/initdata.go
@@ -1,0 +1,66 @@
+package webhook
+
+import (
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+)
+
+// Classes whose guest runs the c8s in-guest stack. Plain kata-qemu has no
+// policy-monitor to read the document.
+var confidentialKataClasses = map[string]struct{}{
+	kataSnpRuntimeClass:    {},
+	kataSnpGpuRuntimeClass: {},
+	kataTdxRuntimeClass:    {},
+	kataTdxGpuRuntimeClass: {},
+}
+
+// stampInitData carries the CDS measurements to the guest's policy-monitor.
+// Writing the annotation is not what makes it trustworthy — the shim hashes the
+// document into HOST_DATA and the guest re-derives the digest before trusting
+// it (docs/kata-image-policy.md).
+//
+// An author-supplied value would name the CDS their own guest pins, and the
+// HOST_DATA check cannot tell it from ours, so it is rejected. Comparing
+// against the desired value rather than banning the key is what keeps this
+// reinvocation-safe: initdata rendering is canonical.
+func stampInitData(pod *corev1.Pod, kataClass string, measurements []string) error {
+	want, err := initDataAnnotation(kataClass, measurements)
+	if err != nil {
+		return err
+	}
+	if got, ok := pod.Annotations[initdata.AnnotationKey]; ok && got != want {
+		return fmt.Errorf("%w: %s is set by c8s and must not be supplied by the pod author",
+			errInvalidInjectionAnnotation, initdata.AnnotationKey)
+	}
+	if want == "" {
+		return nil
+	}
+	if pod.Annotations == nil {
+		pod.Annotations = map[string]string{}
+	}
+	pod.Annotations[initdata.AnnotationKey] = want
+	return nil
+}
+
+// initDataAnnotation renders the value, or "" when the shape carries none.
+func initDataAnnotation(kataClass string, measurements []string) (string, error) {
+	if _, ok := confidentialKataClasses[kataClass]; !ok {
+		return "", nil
+	}
+	joined := strings.Join(measurements, ",")
+	if joined == "" {
+		return "", nil
+	}
+	built, err := initdata.New(map[string]string{
+		initdata.KeyRole:            initdata.RoleWorkload,
+		initdata.KeyCDSMeasurements: joined,
+	}).Build()
+	if err != nil {
+		return "", fmt.Errorf("build init-data document: %w", err)
+	}
+	return built.Annotation, nil
+}

--- a/internal/webhook/initdata_test.go
+++ b/internal/webhook/initdata_test.go
@@ -1,0 +1,149 @@
+package webhook
+
+import (
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+)
+
+var testMeasurements = []string{
+	"781b4eb3313fe694dcf72ec78853f132590856c7e267797afe9bf45dd2c9fbe8352c71a20cf3f0e1e9ec03da36d5f25a",
+	"da0854af8bff0e67f87b37f84af11a1aac570739efe55032e511c7d13dee180d1f4e3b4b209197d351646ddbd0e91509",
+}
+
+// decodeStamped reads the document back the way policy-monitor does.
+func decodeStamped(t *testing.T, pod *corev1.Pod) initdata.Document {
+	t.Helper()
+	raw, err := initdata.Decode(pod.Annotations[initdata.AnnotationKey])
+	if err != nil {
+		t.Fatalf("decode annotation: %v", err)
+	}
+	doc, err := initdata.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse document: %v", err)
+	}
+	return doc
+}
+
+func TestStampInitDataCarriesMeasurementsAndRole(t *testing.T) {
+	pod := &corev1.Pod{}
+	if err := stampInitData(pod, kataSnpRuntimeClass, testMeasurements); err != nil {
+		t.Fatalf("stampInitData: %v", err)
+	}
+
+	doc := decodeStamped(t, pod)
+	want := testMeasurements[0] + "," + testMeasurements[1]
+	if got := doc.Data[initdata.KeyCDSMeasurements]; got != want {
+		t.Fatalf("measurements = %q, want %q", got, want)
+	}
+	if got := doc.Data[initdata.KeyRole]; got != initdata.RoleWorkload {
+		t.Fatalf("role = %q, want %q", got, initdata.RoleWorkload)
+	}
+}
+
+// What the webhook encodes must decode to the bytes whose digest the shim
+// commits — that equality is the whole trust anchor.
+func TestStampInitDataDigestMatchesEncodedBytes(t *testing.T) {
+	pod := &corev1.Pod{}
+	if err := stampInitData(pod, kataSnpRuntimeClass, testMeasurements); err != nil {
+		t.Fatalf("stampInitData: %v", err)
+	}
+	raw, err := initdata.Decode(pod.Annotations[initdata.AnnotationKey])
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	built, err := initdata.New(map[string]string{
+		initdata.KeyRole:            initdata.RoleWorkload,
+		initdata.KeyCDSMeasurements: testMeasurements[0] + "," + testMeasurements[1],
+	}).Build()
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if initdata.Digest(raw) != built.Digest {
+		t.Fatal("digest of the decoded annotation differs from the document digest the shim commits")
+	}
+}
+
+// Nothing in a plain kata-qemu guest reads the document.
+func TestStampInitDataSkipsNonConfidentialClass(t *testing.T) {
+	pod := &corev1.Pod{}
+	if err := stampInitData(pod, kataRuntimeClass, testMeasurements); err != nil {
+		t.Fatalf("stampInitData: %v", err)
+	}
+	if _, ok := pod.Annotations[initdata.AnnotationKey]; ok {
+		t.Fatal("kata-qemu pod was given an init-data document")
+	}
+}
+
+func TestStampInitDataSkipsWithoutMeasurements(t *testing.T) {
+	pod := &corev1.Pod{}
+	if err := stampInitData(pod, kataSnpRuntimeClass, nil); err != nil {
+		t.Fatalf("stampInitData: %v", err)
+	}
+	if _, ok := pod.Annotations[initdata.AnnotationKey]; ok {
+		t.Fatal("stamped an empty document with no measurements to carry")
+	}
+}
+
+// An author-chosen document names the CDS their guest trusts.
+func TestStampInitDataRejectsAuthorSuppliedValue(t *testing.T) {
+	pod := &corev1.Pod{}
+	pod.Annotations = map[string]string{initdata.AnnotationKey: "rogue"}
+
+	err := stampInitData(pod, kataSnpRuntimeClass, testMeasurements)
+	if !errors.Is(err, errInvalidInjectionAnnotation) {
+		t.Fatalf("err = %v, want errInvalidInjectionAnnotation", err)
+	}
+}
+
+// Including shapes c8s stamps nothing for, where it would otherwise survive
+// untouched and reach the shim.
+func TestStampInitDataRejectsAuthorValueOnUnstampedShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		class        string
+		measurements []string
+	}{
+		{"non-confidential class", kataRuntimeClass, testMeasurements},
+		{"no measurements configured", kataSnpRuntimeClass, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := &corev1.Pod{}
+			pod.Annotations = map[string]string{initdata.AnnotationKey: "rogue"}
+			if err := stampInitData(pod, tc.class, tc.measurements); !errors.Is(err, errInvalidInjectionAnnotation) {
+				t.Fatalf("err = %v, want errInvalidInjectionAnnotation", err)
+			}
+		})
+	}
+}
+
+// The second pass must accept its own stamp, not read it as author-supplied.
+func TestStampInitDataIsReinvocationSafe(t *testing.T) {
+	pod := &corev1.Pod{}
+	if err := stampInitData(pod, kataSnpRuntimeClass, testMeasurements); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	first := pod.Annotations[initdata.AnnotationKey]
+	if err := stampInitData(pod, kataSnpRuntimeClass, testMeasurements); err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if pod.Annotations[initdata.AnnotationKey] != first {
+		t.Fatal("reinvocation changed the stamped document")
+	}
+}
+
+func TestStampInitDataCoversEveryConfidentialClass(t *testing.T) {
+	for class := range confidentialKataClasses {
+		pod := &corev1.Pod{}
+		if err := stampInitData(pod, class, testMeasurements); err != nil {
+			t.Fatalf("stampInitData(%s): %v", class, err)
+		}
+		if _, ok := pod.Annotations[initdata.AnnotationKey]; !ok {
+			t.Fatalf("confidential class %s got no init-data document", class)
+		}
+	}
+}

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -724,6 +724,12 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		if m.cfg.KataGuestReadyGate {
 			requireGuestReadyNode(pod)
 		}
+		if err := stampInitData(pod, kataClass, m.cfg.CDSMeasurements); err != nil {
+			if errors.Is(err, errInvalidInjectionAnnotation) {
+				return admission.Errored(http.StatusBadRequest, err)
+			}
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
 		// Stamp AnnotationInjected here too — mutatePod only runs when
 		// get-cert is needed, but a kata-only mutation is still a mutation
 		// and the alreadyInjected short-circuit above must see it on


### PR DESCRIPTION
  C8S_CDS_MEASUREMENTS cannot be baked (it is a digest of the image it would
  live in) and must not be host-injected unattested, so policy-monitor fails
  closed and 'c8s allowlist add' never reaches a running guest.

  Stamp the value into the kata init-data document the shim hashes into SNP
  HOST_DATA, and have policy-monitor re-derive that digest and check it against
  its own attestation report before using the contents. SNP only; TDX commits
  to MRCONFIGID and still degrades to the baked seed.