### PR TITLE
ci(tdx-metal): vendor the tool-fetch retry from confidential-ci#59

### DIFF
--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -374,10 +374,20 @@ jobs:
         run: |
           set -euo pipefail
           rm -rf /tmp/c8s-src
-          git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src
+          # Same exposure as the tools step: this clone and the module fetches
+          # behind `go install` cross the public internet under `set -e`.
+          for i in 1 2 3; do
+            git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src && break
+            [ "$i" = 3 ] && { echo "::error::git clone failed after 3 attempts"; exit 1; }
+            echo "clone attempt $i failed, retrying in $((i * 5))s" >&2; rm -rf /tmp/c8s-src; sleep $((i * 5))
+          done
           git -C /tmp/c8s-src checkout -q "$c8sRef" || { echo "::error::bad c8s ref '$c8sRef': refusing to silently test main"; exit 1; }
           echo "c8s ref sha: $(git -C /tmp/c8s-src rev-parse HEAD)"
-          ( cd /tmp/c8s-src && go install ./cmd/c8s )
+          for i in 1 2 3; do
+            ( cd /tmp/c8s-src && go install ./cmd/c8s ) && break
+            [ "$i" = 3 ] && { echo "::error::go install failed after 3 attempts"; exit 1; }
+            echo "go install attempt $i failed, retrying in $((i * 5))s" >&2; sleep $((i * 5))
+          done
           # An unstamped build reports "dev", which is exactly why --image-tag
           # is passed explicitly at install rather than trusting build metadata.
           c8s --version || true

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -106,20 +106,25 @@ jobs:
       - name: tools (kubectl, go, crane, helm)
         run: |
           set -euo pipefail
-          # Each fetch below crosses the public internet from an ephemeral ARC
-          # pod; one hiccup killed the lane twice in six days (30529875545,
-          # 30895640537), both before it reached a CVM.
-          retry() {
-            local i
-            for i in 1 2 3; do
-              if eval "$1"; then return 0; fi
-              echo "attempt $i failed, retrying in $((i * 5))s: $1" >&2
-              sleep $((i * 5))
-            done
-            echo "::error::gave up after 3 attempts: $1" >&2
-            return 1
-          }
+          # Every fetch here crosses the public internet from an ephemeral ARC
+          # pod, and one hiccup fails the lane before it reaches a CVM.
           mkdir -p "$PWD/bin"
+          # retry <shell-snippet>: 4 attempts, exponential backoff 2s/4s/8s.
+          # A file, not a function, because each `run:` block is a fresh shell.
+          printf '%s\n' \
+            'retry() {' \
+            '  local i delay=2' \
+            '  for i in 1 2 3 4; do' \
+            '    if eval "$1"; then return 0; fi' \
+            '    [ "$i" -eq 4 ] && break' \
+            '    echo "attempt $i failed, retrying in ${delay}s: $1" >&2' \
+            '    sleep "$delay"' \
+            '    delay=$((delay * 2))' \
+            '  done' \
+            '  echo "::error::gave up after 4 attempts: $1" >&2' \
+            '  return 1' \
+            '}' > bin/retry.sh
+          . bin/retry.sh
           retry 'curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl'
           chmod +x bin/kubectl
           echo "$PWD/bin" >> "$GITHUB_PATH"
@@ -373,21 +378,13 @@ jobs:
       - name: build the c8s CLI at the paired ref
         run: |
           set -euo pipefail
-          rm -rf /tmp/c8s-src
           # Same exposure as the tools step: this clone and the module fetches
           # behind `go install` cross the public internet under `set -e`.
-          for i in 1 2 3; do
-            git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src && break
-            [ "$i" = 3 ] && { echo "::error::git clone failed after 3 attempts"; exit 1; }
-            echo "clone attempt $i failed, retrying in $((i * 5))s" >&2; rm -rf /tmp/c8s-src; sleep $((i * 5))
-          done
+          . "$GITHUB_WORKSPACE/bin/retry.sh"
+          retry 'rm -rf /tmp/c8s-src && git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src'
           git -C /tmp/c8s-src checkout -q "$c8sRef" || { echo "::error::bad c8s ref '$c8sRef': refusing to silently test main"; exit 1; }
           echo "c8s ref sha: $(git -C /tmp/c8s-src rev-parse HEAD)"
-          for i in 1 2 3; do
-            ( cd /tmp/c8s-src && go install ./cmd/c8s ) && break
-            [ "$i" = 3 ] && { echo "::error::go install failed after 3 attempts"; exit 1; }
-            echo "go install attempt $i failed, retrying in $((i * 5))s" >&2; sleep $((i * 5))
-          done
+          retry '( cd /tmp/c8s-src && go install ./cmd/c8s )'
           # An unstamped build reports "dev", which is exactly why --image-tag
           # is passed explicitly at install rather than trusting build metadata.
           c8s --version || true

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -106,14 +106,29 @@ jobs:
       - name: tools (kubectl, go, crane, helm)
         run: |
           set -euo pipefail
+          # Each fetch below crosses the public internet from an ephemeral ARC
+          # pod; one hiccup killed the lane twice in six days (30529875545,
+          # 30895640537), both before it reached a CVM.
+          retry() {
+            local i
+            for i in 1 2 3; do
+              if eval "$1"; then return 0; fi
+              echo "attempt $i failed, retrying in $((i * 5))s: $1" >&2
+              sleep $((i * 5))
+            done
+            echo "::error::gave up after 3 attempts: $1" >&2
+            return 1
+          }
           mkdir -p "$PWD/bin"
-          curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl
+          retry 'curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl'
           chmod +x bin/kubectl
           echo "$PWD/bin" >> "$GITHUB_PATH"
           if ! command -v go >/dev/null; then
-            GOVER="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -1 | sed 's/^go//')"
+            # `|| true`: under `set -e` a failed substitution exits before the
+            # pinned fallback on the next line can be reached.
+            GOVER="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -1 | sed 's/^go//' || true)"
             [ -n "$GOVER" ] || GOVER=1.26.3
-            curl -fsSL "https://go.dev/dl/go${GOVER}.linux-amd64.tar.gz" | sudo tar -C /usr/local -xz
+            retry "curl -fsSL 'https://go.dev/dl/go${GOVER}.linux-amd64.tar.gz' | sudo tar -C /usr/local -xz"
           fi
           # $GITHUB_PATH only affects LATER steps, so `go` is still not on PATH
           # inside THIS one. `go install crane` below needs it here and now.
@@ -123,12 +138,11 @@ jobs:
           # crane: `c8s install --resolve-digests=true` below shells out to it.
           # Pinned rather than fetched through the GitHub releases API, which
           # rate-limits by IP on a shared self-hosted host.
-          command -v crane >/dev/null || go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+          command -v crane >/dev/null || retry 'go install github.com/google/go-containerregistry/cmd/crane@v0.21.6'
           # helm: c8s install shells out to it too. The ephemeral ARC pod has
           # neither binary, unlike the host, so install rather than assume.
           if ! command -v helm >/dev/null; then
-            curl -fsSL https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz \
-              | tar -xz -C "$PWD/bin" --strip-components=1 linux-amd64/helm
+            retry 'curl -fsSL https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz | tar -xz -C "$PWD/bin" --strip-components=1 linux-amd64/helm'
           fi
 
       # reap-before-provision: a killed run leaks a CVM (and its scratch PVC).


### PR DESCRIPTION
confidential-ci#59 added a retry around the tools step's four internet fetches. This is the vendored copy, and its own header requires the two to stay byte-identical:

```
# workflow_call so the vendored copy can be invoked as a job by c8s's
# e2e-c8s.yml. workflow_dispatch so either copy stays runnable by hand.
# Both copies carry both, so the two files remain byte-identical.
```

Taken verbatim from confidential-ci main after that merge. Blob SHA `02f99dc8` on both sides, so they are identical again.

The change: that step fetches kubectl, go, crane and helm over the public internet under `set -e`, so one hiccup fails the lane before it reaches a CVM. Twice in six days on the other copy:

```
30529875545  2026-07-30  proxy.golang.org: HTTP/2 stream error INTERNAL_ERROR
30895640537  2026-08-04  lookup proxy.golang.org on 172.21.0.10:53: server misbehaving
```

Each fetch now gets 3 attempts with 5s/10s backoff. Also fixes dead code: `GOVER="$(curl ... | sed ...)"` under `set -euo pipefail` exits on a failed fetch, so the pinned `1.26.3` fallback was unreachable (verified: exits 6 as written, reaches the fallback with `|| true`).

Nothing enforces the byte-identity invariant in CI, which is why the drift went unnoticed between #59 merging and this PR. Worth a check if the invariant is meant to hold.
