### PR TITLE
feat(kata): release secrets and open encrypted volumes inside the guest

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -183,6 +183,11 @@ jobs:
         working-directory: c8s
         run: make build-rtmr3-measurer
 
+      # Same: fetch.sh hard-fails without build/volumed.
+      - name: Build volumed binary
+        working-directory: c8s
+        run: make build-volumed
+
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
-       build-nri-image-policy build-policy-monitor build-rtmr3-measurer \
+       build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
        test test-integration test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen
 
@@ -60,6 +60,17 @@ build-policy-monitor:
 		go build -ldflags="-s -w -X $(MODULE)/internal/version.Version=$(VERSION)" \
 		-o $(BUILD_DIR)/policy-monitor ./cmd/policy-monitor
 	@echo "Built $(BUILD_DIR)/policy-monitor"
+
+# --- Volumed (in-kata-guest encrypted-volume opener) ---
+# Standalone binary baked into kata-guest-base, run as `volumed --guest`. The
+# node-side DaemonSet runs `c8s volumed` from the multi-mode binary instead;
+# the guest gets its own so only this command sits on the dm-verity root.
+build-volumed:
+	@mkdir -p $(BUILD_DIR)
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+		go build -ldflags="-s -w -X $(MODULE)/internal/version.Version=$(VERSION)" \
+		-o $(BUILD_DIR)/volumed ./cmd/volumed
+	@echo "Built $(BUILD_DIR)/volumed"
 
 # --- RTMR3-measurer (in-kata-guest per-workload RTMR[3] measurer) ---
 # Standalone daemon baked into kata-guest-base. Scans kata-agent's container

--- a/cmd/volumed/main.go
+++ b/cmd/volumed/main.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+// Command volumed is the thin wrapper around the `c8s volumed` cobra
+// subcommand, for the copy baked into the kata guest rootfs. The node-side
+// DaemonSet runs `c8s volumed` from the multi-mode binary instead (see the
+// Dockerfile beside this file); a guest cannot, because the whole `c8s` binary
+// would have to sit on the dm-verity root and in the launch measurement.
+// Mirrors the shape of cmd/policy-monitor/main.go.
+package main
+
+import (
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volumed"
+)
+
+func main() { cmdsutil.RunMain(volumed.Run) }

--- a/cmd/volumed/main_other.go
+++ b/cmd/volumed/main_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+// Command volumed requires Linux; this stub keeps cross-platform
+// `go build ./cmd/...` working on non-Linux dev machines (otherwise the
+// package has no buildable files and the build errors). It fails closed at
+// runtime — the daemon depends on device-mapper and mount(2), neither of which
+// exists off Linux.
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "volumed requires Linux (device-mapper, mount(2))")
+	os.Exit(1)
+}

--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -617,6 +617,11 @@ not. Under kata the equivalent ordering is the guest image: a guest whose
 `127.0.0.1:8401`, so roll the guest image before the operator starts injecting
 `--workload-claims-guest`.
 
+The same ordering covers the secret and volume fetchers, which redeem at the
+same endpoints: a guest image predating `volumed --guest` answers nothing on
+`127.0.0.1:8402`, and a pod annotated for volumes there stays without its mount
+until the image is current.
+
 ## Audit pointers
 
 | Concern | Where |

--- a/docs/kata-launch-measurement.md
+++ b/docs/kata-launch-measurement.md
@@ -41,9 +41,9 @@ when it is set (see [`secrets.md`](secrets.md), "When it is served"). So pod
 mode needs the *set* of per-shape digests, and until now the only way to learn
 one was to boot a pod, let attestation fail, and read the
 `measurement not in allowlist` warning out of the CDS log. `c8s install
---cvm-mode=pod` still refuses `--measurements` (`cmd/c8s/install.go`), because
-that flag pins the *node* CVM's measurement; the values this tool produces go
-into a values file instead.
+--cvm-mode=pod --measurements` takes the digests this tool produces
+(`cmd/c8s/install.go`); under `--cvm-mode=node/gke/aks` the same flag takes the
+node image's `manifest.json` value instead.
 
 ## What goes into the digest
 

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -205,7 +205,8 @@ kata-guest-base image:
 |---|---|
 | `ratls-mesh` DaemonSet | in-VM ratls routing |
 | `attestation-api` DaemonSet | in-guest attestation-api on loopback `:8400` (`c8s.attestationApiURL`) |
-| `nri-image-policy` (host NRI plugin) | in-guest policy-monitor, fed from CDS's served `/allowlist` |
+| `nri-image-policy` (host NRI plugin) | in-guest policy-monitor, fed from CDS's served `/allowlist`; also serves the sandbox-token route on loopback `:8401` |
+| `volumed` DaemonSet | in-guest `volumed --guest` on loopback `:8402` ([`docs/volumes.md`](volumes.md)) |
 
 `c8s install --cvm-mode=pod` sets `ratlsMesh.enabled=false`,
 `attestationApi.enabled=false`, and `nriImagePolicy.enabled=false` for you;

--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -533,7 +533,9 @@ Both shapes are wired.
 - **kata.** policy-monitor serves the token route on the guest's loopback
   `127.0.0.1:8401` and the digests routes on `:1019` inside the guest. No
   socket, no mount, and no configuration selects it: the port is compiled, so
-  the untrusted host cannot disable the binding by withholding a value.
+  the untrusted host cannot disable the binding by withholding a value. The
+  in-guest `volumed` follows the same pattern on `127.0.0.1:8402`
+  (docs/volumes.md), after the attestation-service on `:8400`.
   `$C8S_SANDBOX_DIGESTS_ADVERTISE_HOST` overrides the advertised guest IP.
 
 get-cert picks the shape with `--workload-claims-guest`, which the webhook

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -25,17 +25,24 @@ Sizing: `--secrets-max-paths`, `--secrets-max-value-bytes`,
 mesh CA, so a workload able to grow either map without limit could OOM it and
 take every certificate in the cluster with it.
 
-**kata is out of scope.** `--cvm-mode=pod` refuses `--measurements`, so the
-measurement requirement above is unmeetable there. Two other reasons stand
-independently: the kata sandbox ID comes from a host-written CRI annotation, and
-argv enforcement in the guest is watch-and-kill rather than synchronous.
+**kata is supported, with two caveats.** The fetcher redeems its sandbox token
+from whichever inventory its shape has: the mounted nri-image-policy socket on
+node-CVM, or `policy-monitor` on the guest's loopback `127.0.0.1:8401` under
+kata, where nothing is mounted. The webhook selects the shape with
+`--workload-claims-guest` and rejects `confidential.ai/c8s-secrets` only when
+the operator has neither — a pod whose fetcher would CrashLoop while the
+workload blocked forever on a file that never lands.
 
-This is enforced, not just documented: the fetcher redeems its sandbox token
-over the mounted nri-image-policy socket and has no guest (loopback) endpoint,
-so an operator without `--workload-claims-host-dir` has nothing to mount. The
-webhook rejects `confidential.ai/c8s-secrets` at admission there rather than
-admitting a pod whose fetcher would CrashLoop while the workload blocked
-forever on a file that never lands.
+The two caveats are weaker guarantees, not broken ones, and both are properties
+of the guest rather than of secret release:
+
+- the kata sandbox ID comes from a host-written CRI annotation, so the sandbox a
+  token names is asserted by the host rather than read from the kernel as it is
+  on node-CVM;
+- argv enforcement in the guest is watch-and-kill rather than synchronous, so a
+  container running a non-admitted argv is killed rather than refused.
+
+A deployment whose threat model cannot accept either should stay on node-CVM.
 
 ## Asking for a secret
 
@@ -106,9 +113,10 @@ A request carries:
 | `X-C8s-Challenge` | base64 of the challenge, consumed before anything else happens |
 | `Authorization: SandboxToken <base64>` | the inventory-signed token, in a header so it is bounded and never logged |
 
-The token is obtained from the node's admission inventory at `POST /sandbox`,
-bound to the leaf's key and that challenge — the same route and the same
-envelope `get-cert` uses at issuance.
+The token is obtained from the admission inventory at `POST /sandbox` — the
+node's on node-CVM, the guest's own under kata — bound to the leaf's key and
+that challenge, the same route and the same envelope `get-cert` uses at
+issuance.
 
 **`POST` never carries a value.** CDS generates it, so no caller chooses what
 another caller will later read. On a path that already exists it answers `409`

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -160,15 +160,33 @@ most 12 characters, because the serial holds no more.
 The webhook injects a `c8s-volume` sidecar and, per volume, an `emptyDir`
 mounted read-only with `mountPropagation: HostToContainer`. The sidecar fetches
 the key over the attested `/secrets` flow and posts `{name, blob}` to
-`c8s volumed` — a privileged daemon on every node — over a unix socket in the
-inventory's socket directory. The daemon opens the device and mounts it
-read-only into that pod's `emptyDir`.
+`c8s volumed`, which opens the device and mounts it read-only into that pod's
+`emptyDir`.
 
-The daemon is a DaemonSet, **off by default**: it runs privileged, with
-`hostPID` and a writable bind of the kubelet directory. Turn it on with
+Where volumed runs, and how the sidecar reaches it, depends on the shape:
+
+| | node-CVM | kata |
+|---|---|---|
+| volumed | a privileged DaemonSet on every node | `volumed --guest`, baked into the guest rootfs |
+| reached over | a unix socket in the inventory's socket directory | the guest's loopback `127.0.0.1:8402` |
+| mounts into | the pod's kubelet directory | kata's ephemeral directory inside the VM |
+| `emptyDir` medium | default — volumed resolves with `RESOLVE_NO_XDEV` | `Memory`, so kata keeps it a guest tmpfs; with `shared_fs="none"` a default-medium one becomes a `disk.img` block device |
+
+The node-CVM DaemonSet is **off by default**: it runs privileged, with `hostPID`
+and a writable bind of the kubelet directory. Turn it on with
 `volumed.enabled=true` where volumes are served. A pod requesting a volume on a
-cluster without it — under kata, or with `nri-image-policy` disabled — is
+cluster with neither shape — `nri-image-policy` disabled and not kata — is
 refused at admission rather than left waiting on a mount that can never land.
+
+Under kata the device must also reach the guest. kata-agent always mounts a
+block storage it is handed and cannot mount ciphertext, so direct-volume
+assignment is not usable; the qemu wrapper
+(`kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh`) attaches this pod's
+volume devices to its VM instead, read-only and with the serial preserved. Which
+volumes it attaches comes from the pod's annotation — a selector, not a trust
+input, on the same reasoning as the serial: attaching another tenant's device
+hands the guest ciphertext the host already holds, and it still cannot be opened
+without the key CDS releases against the grant.
 
 What decides whether a mount happens, in order:
 
@@ -200,19 +218,27 @@ as long as the mount that would be torn down.
 
 The daemon does not repeat CDS's release decision. It resolves who is calling
 only to decide where to mount, and checks nothing about what that caller is
-entitled to — any pod on the node presenting a well-formed blob has that volume
-opened into its own directory.
+entitled to — any pod that reaches it presenting a well-formed blob has that
+volume opened into its own directory.
 
-This rests on **node-as-CVM being single-tenant**: every pod on the node belongs
-to the same tenant, so a blob one of them can obtain is one they are all entitled
-to. Under kata, volumes are refused at admission, so the case does not arise
-there.
+What makes that sound is that the daemon's reach is confined to one tenant:
 
-A node shared between tenants, or a kata path for volumes, needs a daemon-side
-check restored. That needs the caller's *sandbox*, which the daemon cannot
+- **node-CVM** rests on the node being single-tenant. Every pod on it belongs to
+  the same tenant, so a blob one of them can obtain is one they are all entitled
+  to.
+- **kata** rests on the guest holding exactly one pod. The daemon serves only
+  that guest's loopback, so the only caller that can present a blob is the pod
+  the blob was released to — and with no second pod there is nothing to
+  disambiguate, which is why `--guest` needs no peer credentials, the same
+  reasoning as the token route on `:8401`.
+
+A node shared between tenants breaks the first and needs a daemon-side check
+restored. That needs the caller's *sandbox*, which the node daemon cannot
 resolve for itself — the inventory's socket answers only for the process asking
-it — so the sandbox has to arrive as an inventory-signed token, bound to a nonce
-the daemon issued, because such a token is otherwise transferable between pods.
+it — so the sandbox would have to arrive as an inventory-signed token bound to a
+nonce the daemon issued, because such a token is otherwise transferable between
+pods. The kata shape does not need this: moving the daemon inside the guest
+removes the second caller instead of authenticating it.
 
 ## What this defends
 

--- a/internal/cmds/getsecret/cmd.go
+++ b/internal/cmds/getsecret/cmd.go
@@ -53,5 +53,6 @@ does not survive a CDS restart; nothing durable may be keyed on it.`,
 	f.DurationVar(&cfg.RetryInterval, "retry-interval", 5*time.Second, "wait between attempts")
 	f.DurationVar(&cfg.RequestTimeout, "request-timeout", 10*time.Second, "per-request timeout against CDS")
 	f.DurationVar(&cfg.InventoryTimeout, "inventory-timeout", 5*time.Second, "timeout for redeeming a sandbox token from the node's admission inventory")
+	f.BoolVar(&cfg.WorkloadClaimsGuest, "workload-claims-guest", false, "Reach the inventory on the kata guest's loopback address instead of the node-CVM Unix socket. Both endpoints are compiled in; this only selects which shape applies, so a wrong setting fails closed rather than redirecting the request")
 	return cmd
 }

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -34,10 +34,11 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
-// inventoryEndpoint is where the sandbox token is redeemed. A package variable
-// only so tests can point it at a socket they control; production always uses
-// the compiled path, which is what stops a control-plane value redirecting the
-// redemption to a rogue inventory (docs/getcert-workload-binding.md, Corner 5).
+// inventoryEndpoint is the node-CVM endpoint the sandbox token is redeemed at.
+// A package variable only so tests can point it at a socket they control;
+// production always uses one of the two compiled paths, which is what stops a
+// control-plane value redirecting the redemption to a rogue inventory
+// (docs/getcert-workload-binding.md, Corner 5).
 var inventoryEndpoint = workloadclaims.InventoryEndpoint
 
 // config is everything the sidecar needs. The webhook renders all of it.
@@ -48,6 +49,11 @@ type config struct {
 
 	CertPath string
 	KeyPath  string
+
+	// WorkloadClaimsGuest selects the kata shape: the inventory is
+	// policy-monitor inside the guest, reached on guest loopback rather than
+	// the node-CVM socket, which a kata guest cannot mount.
+	WorkloadClaimsGuest bool
 
 	Secrets  []secretRequest
 	OutDir   string
@@ -209,7 +215,7 @@ func do(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicK
 	if err != nil {
 		return nil, 0, err
 	}
-	token, err := workloadclaims.FetchSandboxToken(ctx, inventoryEndpoint(), cfg.InventoryTimeout, pub, challenge)
+	token, err := workloadclaims.FetchSandboxToken(ctx, cfg.endpoint(), cfg.InventoryTimeout, pub, challenge)
 	if err != nil {
 		return nil, 0, fmt.Errorf("redeem sandbox token: %w", err)
 	}
@@ -251,6 +257,15 @@ func do(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicK
 		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		return nil, resp.StatusCode, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(detail)))
 	}
+}
+
+// endpoint is the compiled inventory endpoint for this sidecar's shape. The
+// flag selects between two baked values, never an address.
+func (c config) endpoint() string {
+	if c.WorkloadClaimsGuest {
+		return workloadclaims.GuestInventoryEndpoint()
+	}
+	return inventoryEndpoint()
 }
 
 func fetchChallenge(ctx context.Context, cfg config, client *http.Client) ([]byte, error) {

--- a/internal/cmds/getsecret/run_test.go
+++ b/internal/cmds/getsecret/run_test.go
@@ -1,11 +1,15 @@
 package getsecret
 
 import (
+	"crypto/ed25519"
+	"crypto/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
 func TestParseSecretSpec(t *testing.T) {
@@ -220,3 +224,30 @@ func TestParseFileMode(t *testing.T) {
 }
 
 func ptr(c config) *config { return &c }
+
+// The two endpoints are compiled: --workload-claims-guest picks a shape, never
+// an address, so a wrong setting fails closed against a port nothing serves
+// rather than redirecting redemption to a rogue inventory.
+func TestEndpointSelectsCompiledShape(t *testing.T) {
+	if got, want := (config{}).endpoint(), workloadclaims.InventoryEndpoint(); got != want {
+		t.Errorf("node-CVM endpoint = %q, want the compiled unix socket %q", got, want)
+	}
+	guest := config{WorkloadClaimsGuest: true}.endpoint()
+	if want := workloadclaims.GuestInventoryEndpoint(); guest != want {
+		t.Errorf("kata endpoint = %q, want the compiled guest loopback %q", guest, want)
+	}
+	// workloadclaims refuses anything that is not one of the two compiled
+	// endpoints, so a shape it rejects would fail every redemption. Use a real
+	// key: a nil one fails at marshalling, short of the endpoint check.
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = workloadclaims.FetchSandboxToken(t.Context(), guest, time.Millisecond, pub, []byte("nonce"))
+	if err == nil {
+		t.Fatal("expected the guest endpoint to fail with nothing listening")
+	}
+	if strings.Contains(err.Error(), "endpoint must be") {
+		t.Fatalf("guest endpoint rejected by the compiled-endpoint check: %v", err)
+	}
+}

--- a/internal/cmds/getvolume/cmd.go
+++ b/internal/cmds/getvolume/cmd.go
@@ -50,6 +50,7 @@ Nothing here creates one.`,
 	f.StringVar(&cfg.KeyPath, "key", "/run/c8s/certs/tls.key", "private key for --cert")
 	f.StringSliceVar(&specs, "volume", nil, "NAME=/store/path to open; NAME selects the device by serial (repeatable)")
 	f.StringVar(&cfg.SocketDir, "socket-dir", workloadclaims.SidecarSocketDir, "directory holding the node agent's socket, as this pod sees it")
+	f.BoolVar(&cfg.WorkloadClaimsGuest, "workload-claims-guest", false, "Reach the inventory and the volume daemon on the kata guest's loopback addresses instead of node-CVM Unix sockets. Both shapes are compiled in; this only selects which applies, so a wrong setting fails closed rather than redirecting the request")
 	f.IntVar(&cfg.Attempts, "attempts", 60, "how many times to try before failing; release is refused until every main container is running, so retries are expected")
 	f.DurationVar(&cfg.RetryInterval, "retry-interval", 5*time.Second, "wait between attempts")
 	f.DurationVar(&cfg.RequestTimeout, "request-timeout", 10*time.Second, "per-request timeout against CDS and the node agent")

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -83,7 +84,7 @@ func startDaemon(t *testing.T, dir string) *recordingOps {
 	ops := &recordingOps{}
 	srv := &volumed.Server{
 		Identity: fixedIdentity{pod: volumed.PodCgroup{UID: e2ePodUID, Path: "/kubepods.slice/pod"}},
-		Opener:   &volumed.Opener{Ops: ops, KubeletRoot: kubeletRoot},
+		Opener:   &volumed.Opener{Ops: ops, Targets: volumed.KubeletTargets{Root: kubeletRoot}},
 		Devices:  fixedDevices{},
 	}
 
@@ -112,7 +113,8 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 
 	cfg := flowConfig(t, url)
 	cfg.SocketDir = socketDir
-	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemonClient(socketDir)); err != nil {
+	daemon, daemonBase := daemonClient(cfg)
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
 		t.Fatalf("open: %v", err)
 	}
 
@@ -169,7 +171,8 @@ func TestSidecarRepeatIsIdempotent(t *testing.T) {
 	cfg := flowConfig(t, url)
 	cfg.SocketDir = socketDir
 	for i := 0; i < 2; i++ {
-		if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemonClient(socketDir)); err != nil {
+		daemon, daemonBase := daemonClient(cfg)
+		if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
 			t.Fatalf("attempt %d: %v", i, err)
 		}
 	}
@@ -196,7 +199,8 @@ func TestSidecarReportsADaemonRefusal(t *testing.T) {
 	cfg.SocketDir = socketDir
 	// A volume the pod has no emptyDir for: the daemon has nowhere to mount it.
 	cfg.Volumes = []volumeRequest{{Name: "absent", Path: "/tenant-a/volumes/weights"}}
-	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemonClient(socketDir)); err == nil {
+	daemon, daemonBase := daemonClient(cfg)
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err == nil {
 		t.Fatal("a refused open was reported as success")
 	}
 }
@@ -210,4 +214,89 @@ func containsDir(path, want string) bool {
 		path = filepath.Dir(path)
 	}
 	return false
+}
+
+// startGuestDaemon runs a real volumed in its in-guest shape on the compiled
+// loopback port, over a kata ephemeral directory with the volume's mount point
+// already materialised.
+func startGuestDaemon(t *testing.T) *recordingOps {
+	t.Helper()
+	ephemeral := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(ephemeral, volumed.KubeVolumeName("weights")), 0o755); err != nil {
+		t.Fatalf("mkdir ephemeral volume: %v", err)
+	}
+
+	ops := &recordingOps{}
+	srv := &volumed.Server{
+		Identity: volumed.GuestIdentity{},
+		Opener:   &volumed.Opener{Ops: ops, Targets: volumed.GuestTargets{Root: ephemeral}},
+		Devices:  fixedDevices{},
+	}
+	l, err := net.Listen("tcp", volumed.GuestAddr())
+	if err != nil {
+		t.Skipf("guest volume port %d unavailable here: %v", volumed.GuestPort, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); _ = srv.Serve(ctx, l) }()
+	t.Cleanup(func() { cancel(); <-done })
+	return ops
+}
+
+// startGuestInventory serves the token route on the compiled guest loopback
+// port, which is where the sidecar redeems under kata and is not overridable.
+func startGuestInventory(t *testing.T) {
+	t.Helper()
+	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(workloadclaims.GuestTokenPort)))
+	if err != nil {
+		t.Skipf("guest token port %d unavailable here: %v", workloadclaims.GuestTokenPort, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	t.Cleanup(func() { cancel(); l.Close() })
+}
+
+// The kata path end to end, with nothing mounted: the sidecar redeems its token
+// on guest loopback, reads the blob from CDS, and hands it to an in-guest
+// volumed that mounts into kata's ephemeral directory. This is the whole of
+// what the host unix socket used to carry.
+func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
+	startGuestInventory(t)
+	_, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testBlobJSON(t)}},
+	})
+	ops := startGuestDaemon(t)
+
+	cfg := flowConfig(t, url)
+	cfg.WorkloadClaimsGuest = true
+	cfg.SocketDir = "" // nothing is mounted in a guest
+
+	daemon, daemonBase := daemonClient(cfg)
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ops.mu.Lock()
+	defer ops.mu.Unlock()
+	want := []string{
+		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + volumed.GuestPodUID + "-weights",
+		"VerityOpen c8s-verity-" + volumed.GuestPodUID + "-weights",
+		"MountRO",
+	}
+	for i, w := range want {
+		if i >= len(ops.calls) || ops.calls[i] != w {
+			t.Fatalf("calls = %v, want %v", ops.calls, want)
+		}
+	}
+	stored, err := testBlob(t).DecodeKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(ops.key) != string(stored) {
+		t.Error("the key handed to dm-crypt is not the one CDS released")
+	}
 }

--- a/internal/cmds/getvolume/run.go
+++ b/internal/cmds/getvolume/run.go
@@ -37,10 +37,11 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
-// inventoryEndpoint is where the sandbox token is redeemed. A package variable
-// only so tests can point it at a socket they control; production always uses
-// the compiled path, which is what stops a control-plane value redirecting the
-// redemption to a rogue inventory (docs/getcert-workload-binding.md, Corner 5).
+// inventoryEndpoint is the node-CVM endpoint the sandbox token is redeemed at.
+// A package variable only so tests can point it at a socket they control;
+// production always uses one of the two compiled paths, which is what stops a
+// control-plane value redirecting the redemption to a rogue inventory
+// (docs/getcert-workload-binding.md, Corner 5).
 var inventoryEndpoint = workloadclaims.InventoryEndpoint
 
 // config is everything the sidecar needs. The webhook renders all of it.
@@ -53,8 +54,15 @@ type config struct {
 	KeyPath  string
 
 	Volumes []volumeRequest
-	// SocketDir holds volumed's socket, as this pod sees it.
+	// SocketDir holds volumed's socket, as this pod sees it. Unused under
+	// WorkloadClaimsGuest, where volumed is in the guest and there is no
+	// filesystem shared with it.
 	SocketDir string
+
+	// WorkloadClaimsGuest selects the kata shape: the inventory and volumed are
+	// both inside the guest, reached on guest loopback rather than over sockets
+	// a kata guest cannot mount.
+	WorkloadClaimsGuest bool
 
 	Attempts         int
 	RetryInterval    time.Duration
@@ -161,21 +169,31 @@ func openAll(ctx context.Context, cfg config, measurements [][]byte) error {
 	if err != nil {
 		return err
 	}
-	return openAllWith(ctx, cfg, client, pub, daemonClient(cfg.SocketDir))
+	daemon, base := daemonClient(cfg)
+	return openAllWith(ctx, cfg, client, pub, daemon, base)
 }
 
 // openAllWith is openAll once the clients exist.
-func openAllWith(ctx context.Context, cfg config, cds *http.Client, pub crypto.PublicKey, daemon *http.Client) error {
+func openAllWith(ctx context.Context, cfg config, cds *http.Client, pub crypto.PublicKey, daemon *http.Client, daemonBase string) error {
 	for _, v := range cfg.Volumes {
 		blob, err := fetchBlob(ctx, cfg, cds, pub, v.Path)
 		if err != nil {
 			return fmt.Errorf("volume %s: %w", v.Name, err)
 		}
-		if err := openOne(ctx, cfg, daemon, v.Name, blob); err != nil {
+		if err := openOne(ctx, cfg, daemon, daemonBase, v.Name, blob); err != nil {
 			return fmt.Errorf("volume %s: %w", v.Name, err)
 		}
 	}
 	return nil
+}
+
+// endpoint is the compiled inventory endpoint for this sidecar's shape. The
+// flag selects between two baked values, never an address.
+func (c config) endpoint() string {
+	if c.WorkloadClaimsGuest {
+		return workloadclaims.GuestInventoryEndpoint()
+	}
+	return inventoryEndpoint()
 }
 
 // fetchBlob reads one volume's key blob from the store.
@@ -201,7 +219,7 @@ func do(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicK
 	if err != nil {
 		return nil, 0, err
 	}
-	token, err := workloadclaims.FetchSandboxToken(ctx, inventoryEndpoint(), cfg.InventoryTimeout, pub, challenge)
+	token, err := workloadclaims.FetchSandboxToken(ctx, cfg.endpoint(), cfg.InventoryTimeout, pub, challenge)
 	if err != nil {
 		return nil, 0, fmt.Errorf("redeem sandbox token: %w", err)
 	}
@@ -245,15 +263,14 @@ func do(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicK
 
 // openOne hands the blob to the node daemon, which resolves this pod from the
 // socket's peer credentials and mounts the volume into it.
-func openOne(ctx context.Context, cfg config, daemon *http.Client, name string, blob volume.Blob) error {
+func openOne(ctx context.Context, cfg config, daemon *http.Client, daemonBase, name string, blob volume.Blob) error {
 	body, err := json.Marshal(volumed.OpenRequest{Name: name, Blob: blob})
 	if err != nil {
 		return err
 	}
 	reqCtx, cancel := context.WithTimeout(ctx, cfg.RequestTimeout)
 	defer cancel()
-	// The host is ignored on a unix transport; it only has to be a valid URL.
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, "http://volumed"+volumed.VolumePath, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, daemonBase+volumed.VolumePath, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -271,15 +288,24 @@ func openOne(ctx context.Context, cfg config, daemon *http.Client, name string, 
 	return nil
 }
 
-// daemonClient dials volumed's socket in the inventory socket directory the
-// webhook mounts into this sidecar.
-func daemonClient(socketDir string) *http.Client {
-	sock := filepath.Join(socketDir, volumed.SocketName)
+// daemonClient reaches volumed and returns the base URL to post to: the socket
+// the webhook mounts into this sidecar on node-CVM, or the guest's compiled
+// loopback address under kata, where volumed is in this VM and there is no
+// shared filesystem. Both are compiled; the flag selects a shape, not an
+// address.
+func daemonClient(cfg config) (*http.Client, string) {
+	if cfg.WorkloadClaimsGuest {
+		// Fresh Transport, so Proxy stays nil: no HTTP_PROXY can interpose on
+		// the key blob's trip to the daemon.
+		return &http.Client{Transport: &http.Transport{}}, volumed.GuestEndpoint()
+	}
+	sock := filepath.Join(cfg.SocketDir, volumed.SocketName)
 	return &http.Client{Transport: &http.Transport{
 		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
 			return (&net.Dialer{}).DialContext(ctx, "unix", sock)
 		},
-	}}
+		// The host is ignored on a unix transport; the URL only has to parse.
+	}}, "http://volumed"
 }
 
 func fetchChallenge(ctx context.Context, cfg config, client *http.Client) ([]byte, error) {
@@ -367,7 +393,9 @@ func validate(cfg *config) error {
 		}
 		seen[v.Name] = true
 	}
-	if cfg.SocketDir == "" {
+	// Under kata volumed is in the guest on a compiled loopback address, so
+	// there is no socket directory to require.
+	if cfg.SocketDir == "" && !cfg.WorkloadClaimsGuest {
 		return fmt.Errorf("--socket-dir is required")
 	}
 	if cfg.Attempts <= 0 {

--- a/internal/cmds/getvolume/run_test.go
+++ b/internal/cmds/getvolume/run_test.go
@@ -4,6 +4,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volumed"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
 func TestParseVolumeSpec(t *testing.T) {
@@ -98,5 +101,46 @@ func TestNewCmdHasTheSidecarFlags(t *testing.T) {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("missing --%s", flag)
 		}
+	}
+}
+
+// A kata guest mounts nothing, so requiring --socket-dir there would refuse
+// every volume the in-guest daemon can serve.
+func TestValidateSocketDirOnlyRequiredOnNodeCVM(t *testing.T) {
+	cfg := validConfig()
+	cfg.SocketDir = ""
+	if err := validate(&cfg); err == nil {
+		t.Error("node-CVM accepted a config with no socket dir")
+	}
+
+	guest := validConfig()
+	guest.SocketDir = ""
+	guest.WorkloadClaimsGuest = true
+	if err := validate(&guest); err != nil {
+		t.Errorf("guest shape rejected for want of a socket dir: %v", err)
+	}
+}
+
+// The daemon endpoint is compiled in both shapes: the flag picks which, never
+// an address, so a wrong setting fails closed instead of posting the key blob
+// somewhere the control plane chose.
+func TestDaemonClientSelectsCompiledShape(t *testing.T) {
+	_, base := daemonClient(config{SocketDir: "/run/c8s/workload-claims"})
+	if base != "http://volumed" {
+		t.Errorf("node-CVM base = %q, want the unix-transport placeholder", base)
+	}
+	if _, guestBase := daemonClient(config{WorkloadClaimsGuest: true}); guestBase != volumed.GuestEndpoint() {
+		t.Errorf("guest base = %q, want the compiled %q", guestBase, volumed.GuestEndpoint())
+	}
+}
+
+// The inventory endpoint moves with the same flag: on node-CVM the guest port
+// serves nothing, and in a guest the socket cannot exist.
+func TestInventoryEndpointFollowsTheShape(t *testing.T) {
+	if got, want := (config{}).endpoint(), workloadclaims.InventoryEndpoint(); got != want {
+		t.Errorf("node-CVM endpoint = %q, want %q", got, want)
+	}
+	if got, want := (config{WorkloadClaimsGuest: true}).endpoint(), workloadclaims.GuestInventoryEndpoint(); got != want {
+		t.Errorf("kata endpoint = %q, want %q", got, want)
 	}
 }

--- a/internal/cmds/volumed/cmd.go
+++ b/internal/cmds/volumed/cmd.go
@@ -31,6 +31,21 @@ type config struct {
 	socketGID    int
 	reapInterval time.Duration
 	maxMounts    int
+	// guest runs the in-guest shape: serve on guest loopback, mount into
+	// kata's ephemeral directory, and let the VM's lifetime do the reaping.
+	guest          bool
+	guestEphemeral string
+}
+
+// Run is the cobra-driven entry point invoked from cmd/volumed/main.go, the
+// standalone binary baked into the kata guest rootfs. runDaemon installs its
+// own signal handling, so this only dispatches. Mirrors the shape of
+// internal/cmds/policymonitor.Run.
+func Run(args []string) error {
+	cmd := NewCmd()
+	cmd.SetArgs(args)
+	cmd.SilenceErrors = true
+	return cmd.Execute()
 }
 
 // NewCmd returns the `c8s volumed` command.
@@ -38,17 +53,22 @@ func NewCmd() *cobra.Command {
 	cfg := config{socketGID: workloadclaims.InventorySocketGID}
 	cmd := &cobra.Command{
 		Use:   "volumed",
-		Short: "Node agent that opens encrypted volumes for entitled pods",
-		Long: `volumed opens an encrypted volume for a pod on this node.
+		Short: "Agent that opens encrypted volumes for entitled pods",
+		Long: `volumed opens an encrypted volume for a pod.
 
 An injected sidecar fetches the volume's key from CDS over the attested secrets
-flow and hands it to this daemon, which resolves the calling pod from kernel
-peer credentials, opens dm-crypt and dm-verity, and mounts the result read-only
-into that pod and no other.
+flow and hands it to this daemon, which opens dm-crypt and dm-verity and mounts
+the result read-only into that pod and no other.
 
-It runs privileged on every node: opening a device and mounting into a pod's
-directory needs it. Where a volume is mounted is never driven by what a caller
-says about itself.`,
+It runs in one of two shapes. On node-CVM it is a privileged node daemon: it
+resolves the calling pod from kernel peer credentials and mounts into that pod's
+kubelet directory. With --guest it runs inside a kata guest, which holds exactly
+one pod, so it serves on guest loopback and mounts into kata's ephemeral
+directory instead.
+
+Either way it runs privileged — opening a device and mounting into a pod's
+directory needs it — and where a volume is mounted is never driven by what a
+caller says about itself.`,
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE:         func(cmd *cobra.Command, _ []string) error { return runDaemon(cmd.Context(), cfg) },
@@ -62,6 +82,10 @@ says about itself.`,
 	f.StringVar(&cfg.cgroupRoot, "cgroup-root", DefaultCgroupRoot, "cgroup mount, where a pod's slice going away is what triggers teardown")
 	f.DurationVar(&cfg.reapInterval, "reap-interval", DefaultReapInterval, "how often to tear down volumes whose pod has gone")
 	f.IntVar(&cfg.maxMounts, "max-mounts", DefaultMaxMounts, "maximum volumes open on this node at once")
+	f.BoolVar(&cfg.guest, "guest", false,
+		"run inside a kata guest: serve on guest loopback, mount into kata's ephemeral directory, and resolve every caller to the guest's single pod")
+	f.StringVar(&cfg.guestEphemeral, "guest-ephemeral-dir", DefaultGuestEphemeralRoot,
+		"where kata-agent materializes memory-backed emptyDir volumes inside the guest (--guest only)")
 	return cmd
 }
 
@@ -75,7 +99,14 @@ func runDaemon(ctx context.Context, cfg config) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	opener := &Opener{Ops: SystemOps{}, KubeletRoot: cfg.kubeletRoot, MaxMounts: cfg.maxMounts}
+	if cfg.guest {
+		return runGuest(ctx, cfg)
+	}
+	return runNode(ctx, cfg)
+}
+
+func runNode(ctx context.Context, cfg config) error {
+	opener := &Opener{Ops: SystemOps{}, Targets: KubeletTargets{Root: cfg.kubeletRoot}, MaxMounts: cfg.maxMounts}
 	srv := &Server{
 		Identity: PeerIdentity{},
 		Opener:   opener,
@@ -101,6 +132,26 @@ func runDaemon(ctx context.Context, cfg config) error {
 	return srv.Serve(ctx, l)
 }
 
+// runGuest serves the in-guest shape. No reaper: the volume dies with the VM
+// that holds it, so there is no surviving daemon to reap for.
+func runGuest(ctx context.Context, cfg config) error {
+	srv := &Server{
+		Identity: GuestIdentity{},
+		Opener:   &Opener{Ops: SystemOps{}, Targets: GuestTargets{Root: cfg.guestEphemeral}, MaxMounts: cfg.maxMounts},
+		Devices:  SerialDevices{},
+		Logger:   slog.Default(),
+	}
+
+	l, err := net.Listen("tcp", GuestAddr())
+	if err != nil {
+		return fmt.Errorf("volumed: listen on %s: %w", GuestAddr(), err)
+	}
+	defer l.Close()
+
+	slog.Info("serving volume opens", "addr", GuestAddr(), "ephemeral_dir", cfg.guestEphemeral)
+	return srv.Serve(ctx, l)
+}
+
 // listen creates the socket, replacing a stale one left by a previous run and
 // group-owning it to gid so the non-root fetcher sidecar can connect.
 //
@@ -111,6 +162,17 @@ func listen(dir string, gid int) (net.Listener, error) {
 }
 
 func validate(cfg config) error {
+	if cfg.maxMounts <= 0 {
+		return fmt.Errorf("--max-mounts must be positive")
+	}
+	// The guest shape has no socket, no kubelet and no reaper, so requiring
+	// their flags would mean carrying values nothing reads.
+	if cfg.guest {
+		if cfg.guestEphemeral == "" {
+			return fmt.Errorf("--guest-ephemeral-dir is required with --guest")
+		}
+		return nil
+	}
 	switch {
 	case cfg.socketDir == "":
 		return fmt.Errorf("--socket-dir is required")
@@ -120,8 +182,6 @@ func validate(cfg config) error {
 		return fmt.Errorf("--cgroup-root is required")
 	case cfg.reapInterval <= 0:
 		return fmt.Errorf("--reap-interval must be positive")
-	case cfg.maxMounts <= 0:
-		return fmt.Errorf("--max-mounts must be positive")
 	}
 	return nil
 }

--- a/internal/cmds/volumed/cmd_test.go
+++ b/internal/cmds/volumed/cmd_test.go
@@ -184,3 +184,104 @@ func TestNewCmdHasTheDaemonFlags(t *testing.T) {
 		}
 	}
 }
+
+func goodGuestConfig() config {
+	return config{
+		guest:          true,
+		guestEphemeral: DefaultGuestEphemeralRoot,
+		maxMounts:      64,
+	}
+}
+
+// The guest shape has no socket, no kubelet and no reaper, so requiring those
+// flags there would refuse every config a guest can actually supply.
+func TestValidateGuestNeedsNoNodeDependencies(t *testing.T) {
+	if err := validate(goodGuestConfig()); err != nil {
+		t.Fatalf("rejected a complete guest config: %v", err)
+	}
+	for name, mutate := range map[string]func(*config){
+		"ephemeral dir": func(c *config) { c.guestEphemeral = "" },
+		"max mounts":    func(c *config) { c.maxMounts = 0 },
+	} {
+		cfg := goodGuestConfig()
+		mutate(&cfg)
+		if err := validate(cfg); err == nil {
+			t.Errorf("%s: accepted", name)
+		}
+	}
+}
+
+// The guest daemon serves on the compiled loopback port and unwinds when its
+// context goes — the same full run as the node shape, minus everything that
+// needs a host.
+func TestRunDaemonServesTheGuestShapeUntilItsContextIsDone(t *testing.T) {
+	if l, err := net.Listen("tcp", GuestAddr()); err != nil {
+		t.Skipf("guest volume port %d unavailable here: %v", GuestPort, err)
+	} else {
+		l.Close()
+	}
+	cfg := goodGuestConfig()
+	cfg.guestEphemeral = t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- runDaemon(ctx, cfg) }()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		c, err := net.Dial("tcp", GuestAddr())
+		if err == nil {
+			c.Close()
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("the guest daemon never accepted on its loopback port")
+		case <-time.After(time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runDaemon(--guest): %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runDaemon(--guest) did not return after its context was cancelled")
+	}
+}
+
+// A port already taken must surface as an error rather than a daemon that
+// silently serves nothing.
+func TestRunGuestReportsAnUnusablePort(t *testing.T) {
+	l, err := net.Listen("tcp", GuestAddr())
+	if err != nil {
+		t.Skipf("guest volume port %d unavailable here: %v", GuestPort, err)
+	}
+	defer l.Close()
+
+	if err := runGuest(context.Background(), goodGuestConfig()); err == nil {
+		t.Fatal("ran with the guest port already bound")
+	}
+}
+
+// Run is the standalone binary's entry point; a bad flag must fail rather than
+// fall through to a daemon with a half-parsed config.
+func TestRunRejectsAnUnknownFlag(t *testing.T) {
+	if err := Run([]string{"--not-a-flag"}); err == nil {
+		t.Fatal("accepted an unknown flag")
+	}
+}
+
+// Both target shapes fall back to their compiled default when no root is set,
+// which is what the daemon relies on in production.
+func TestTargetRootsDefault(t *testing.T) {
+	if got := (KubeletTargets{}).root(); got != DefaultKubeletRoot {
+		t.Errorf("kubelet root = %q, want %q", got, DefaultKubeletRoot)
+	}
+	if got := (GuestTargets{}).root(); got != DefaultGuestEphemeralRoot {
+		t.Errorf("guest root = %q, want %q", got, DefaultGuestEphemeralRoot)
+	}
+}

--- a/internal/cmds/volumed/identity.go
+++ b/internal/cmds/volumed/identity.go
@@ -34,3 +34,21 @@ func (p PeerIdentity) procRoot() string {
 	}
 	return "/proc"
 }
+
+// GuestPodUID stands in for the pod UID inside a kata guest. It is a map key
+// and a device-mapper name component, never an identity claim, and it never
+// reaches a filesystem path: GuestTargets ignores it.
+const GuestPodUID = "guest"
+
+// GuestIdentity resolves every caller to the guest's single pod.
+//
+// A kata guest holds exactly one pod, so there is no caller to tell apart and
+// nothing for peer credentials to decide — the guest boundary is the binding,
+// for the same reason the guest's token route needs no peer credentials. The
+// pod UID kubelet would supply does not exist in here and is not needed.
+type GuestIdentity struct{}
+
+// Resolve returns the guest's single pod.
+func (GuestIdentity) Resolve(workloadclaims.Peer) (PodCgroup, error) {
+	return PodCgroup{UID: GuestPodUID}, nil
+}

--- a/internal/cmds/volumed/identity_test.go
+++ b/internal/cmds/volumed/identity_test.go
@@ -57,3 +57,28 @@ func TestPeerIdentityDefaultsItsProcRoot(t *testing.T) {
 		t.Fatalf("procRoot = %q, want /proc", got)
 	}
 }
+
+// One pod per guest means there is no caller to tell apart, so resolution must
+// succeed without peer credentials — a TCP conn yields a zero-PID Peer, which
+// the node-CVM resolver rejects by design.
+func TestGuestIdentityResolvesWithoutPeerCredentials(t *testing.T) {
+	pod, err := GuestIdentity{}.Resolve(workloadclaims.Peer{})
+	if err != nil {
+		t.Fatalf("guest resolve: %v", err)
+	}
+	if pod.UID != GuestPodUID {
+		t.Fatalf("pod UID = %q, want %q", pod.UID, GuestPodUID)
+	}
+}
+
+// The guest daemon shares the guest's loopback with the attestation-service
+// (8400) and the token route (8401); colliding with either would make one of
+// them fail to bind and take confidential pod startup with it.
+func TestGuestPortDoesNotCollide(t *testing.T) {
+	if GuestPort == workloadclaims.GuestTokenPort {
+		t.Fatalf("volumed and the token route both claim %d", GuestPort)
+	}
+	if GuestPort == 8400 {
+		t.Fatalf("volumed collides with the in-guest attestation-service on %d", GuestPort)
+	}
+}

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -62,8 +62,9 @@ type mount struct {
 // Opener opens volumes and remembers what it has open.
 type Opener struct {
 	Ops DeviceOps
-	// KubeletRoot is where kubelet keeps pod directories.
-	KubeletRoot string
+	// Targets resolves where a volume is mounted: kubelet's pod directory on
+	// node-CVM, the guest's ephemeral directory under kata.
+	Targets Targets
 	// MaxMounts caps live volumes; zero means DefaultMaxMounts.
 	MaxMounts int
 
@@ -141,7 +142,7 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 // step fails. A half-open volume leaves a device-mapper target holding the key
 // in kernel memory with nothing owning it.
 func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [sha256.Size]byte) (*mount, error) {
-	target, err := TargetDir(o.KubeletRoot, req.Pod.UID, KubeVolumeName(req.Name))
+	target, err := o.Targets.Dir(req.Pod.UID, KubeVolumeName(req.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -124,7 +124,7 @@ func testOpener(t *testing.T, ops DeviceOps) *Opener {
 	if err := os.Mkdir(filepath.Join(base, KubeVolumeName("weights")), 0o755); err != nil {
 		t.Fatalf("mkdir volume dir: %v", err)
 	}
-	return &Opener{Ops: ops, KubeletRoot: root}
+	return &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
 }
 
 func testRequest(t *testing.T) Request {
@@ -348,7 +348,7 @@ func TestClosePodTearsDownEveryVolumeItHolds(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", n, err)
 		}
 	}
-	o := &Opener{Ops: ops, KubeletRoot: root}
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
 
 	for _, n := range []string{"weights", "datasets"} {
 		req := testRequest(t)

--- a/internal/cmds/volumed/reaper_test.go
+++ b/internal/cmds/volumed/reaper_test.go
@@ -31,7 +31,7 @@ func openerWithVolumes(t *testing.T, ops *fakeOps, names ...string) *Opener {
 			t.Fatalf("mkdir %s: %v", n, err)
 		}
 	}
-	o := &Opener{Ops: ops, KubeletRoot: root}
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
 	for _, n := range names {
 		req := testRequest(t)
 		req.Name = n
@@ -100,7 +100,7 @@ func TestSweepIsPerPod(t *testing.T) {
 			t.Fatalf("mkdir %s: %v", name, err)
 		}
 	}
-	o := &Opener{Ops: ops, KubeletRoot: root}
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
 
 	for name, uid := range map[string]string{"weights": testPodUID, "datasets": other} {
 		req := testRequest(t)

--- a/internal/cmds/volumed/server.go
+++ b/internal/cmds/volumed/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -17,6 +18,20 @@ import (
 
 // VolumePath is the route the fetcher sidecar posts to.
 const VolumePath = "/volume"
+
+// GuestPort is the in-guest loopback port this daemon serves on under kata,
+// after the attestation-service on 8400 and the token route on 8401. A kata
+// guest holds one pod whose containers share its network namespace, so loopback
+// reaches the daemon without the shared filesystem a socket would need. Like
+// those two it is compiled, not configured: the untrusted host cannot redirect
+// the fetcher by withholding or rewriting a value.
+const GuestPort = 8402
+
+// GuestAddr is the address the in-guest daemon serves on.
+func GuestAddr() string { return net.JoinHostPort("127.0.0.1", strconv.Itoa(GuestPort)) }
+
+// GuestEndpoint is the URL the in-guest fetcher posts to.
+func GuestEndpoint() string { return "http://" + GuestAddr() }
 
 // maxRequestBytes bounds a request body. It carries one key blob.
 const maxRequestBytes = 64 << 10

--- a/internal/cmds/volumed/target.go
+++ b/internal/cmds/volumed/target.go
@@ -16,9 +16,16 @@ import (
 // UID, never from anything the caller sends.
 const emptyDirSubdir = "volumes/kubernetes.io~empty-dir"
 
+// DefaultGuestEphemeralRoot is where kata-agent materializes a memory-backed
+// emptyDir inside the guest (kata's `defaultEphemeralPath`). The webhook pins
+// `medium: Memory` under kata so a volume's mount point lands here: with
+// shared_fs="none" the shim turns a default-medium emptyDir into a disk.img
+// block device instead.
+const DefaultGuestEphemeralRoot = "/run/kata-containers/sandbox/ephemeral"
+
 // KubeVolumePrefix precedes a volume's name in the Kubernetes volume the
-// webhook injects, and so in the kubelet directory this mounts into. The
-// webhook reserves the whole prefix; both sides must spell it the same.
+// webhook injects, and so in the directory this mounts into. The webhook
+// reserves the whole prefix; both sides must spell it the same.
 const KubeVolumePrefix = volume.KubeVolumePrefix
 
 // KubeVolumeName is the Kubernetes volume carrying the named volume.
@@ -29,30 +36,93 @@ var (
 	volumeNameRE = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 )
 
-// TargetDir opens the directory a volume must be mounted at, for the pod the
-// kernel says is calling.
+// Targets resolves the directory a volume must be mounted at. Two shapes: the
+// node-CVM one, where kubelet owns the pod's emptyDir, and the kata guest one,
+// where kata-agent materializes it inside the VM and there is no kubelet.
+type Targets interface {
+	Dir(podUID, volumeName string) (*os.File, error)
+}
+
+// KubeletTargets resolves under kubelet's per-pod directory on node-CVM.
+type KubeletTargets struct {
+	// Root is kubelet's root directory; empty means DefaultKubeletRoot.
+	Root string
+}
+
+// DefaultKubeletRoot is kubelet's root directory when Root is unset.
+const DefaultKubeletRoot = "/var/lib/kubelet"
+
+// Dir opens the mount target for the pod the kernel says is calling.
+//
+// The placeholder is a default-medium emptyDir — a plain directory on the pod
+// directory's filesystem — so resolution can additionally refuse to cross a
+// mount point.
+func (k KubeletTargets) Dir(podUID, volumeName string) (*os.File, error) {
+	if !podUIDRE.MatchString(podUID) {
+		return nil, fmt.Errorf("volumed: pod uid %q is not a uuid", podUID)
+	}
+	return resolveBeneath(filepath.Join(k.root(), "pods", podUID, emptyDirSubdir), volumeName, unix.RESOLVE_NO_XDEV)
+}
+
+func (k KubeletTargets) root() string {
+	if k.Root != "" {
+		return k.Root
+	}
+	return DefaultKubeletRoot
+}
+
+// GuestTargets resolves under the kata guest's ephemeral storage directory.
+//
+// The pod UID plays no part: a kata guest holds exactly one pod, so there is no
+// other pod's directory to be confused with — the same reason the guest's token
+// route needs no peer credentials.
+type GuestTargets struct {
+	// Root is the guest ephemeral directory; empty means
+	// DefaultGuestEphemeralRoot.
+	Root string
+}
+
+// Dir opens the mount target for the guest's single pod.
+//
+// Unlike the kubelet shape this cannot pass RESOLVE_NO_XDEV: kata-agent
+// materializes the memory-backed emptyDir as a tmpfs mounted *at* the volume
+// directory, so refusing to cross a mount point would fail every open with
+// EXDEV. What the flag would guard against does not arise here — the workload
+// holds no CAP_SYS_ADMIN in the sandbox mount namespace this resolves in, so it
+// cannot mount over the target. RESOLVE_BENEATH and RESOLVE_NO_SYMLINKS, which
+// are what stop the workload redirecting the mount using the emptyDir contents
+// it does own, still apply.
+func (g GuestTargets) Dir(_, volumeName string) (*os.File, error) {
+	return resolveBeneath(g.root(), volumeName, 0)
+}
+
+func (g GuestTargets) root() string {
+	if g.Root != "" {
+		return g.Root
+	}
+	return DefaultGuestEphemeralRoot
+}
+
+// resolveBeneath opens volumeName directly beneath base, with extraResolve
+// added to the mandatory hardening flags.
 //
 // The returned file is an O_PATH handle; mount through /proc/self/fd/<n> rather
 // than re-resolving the path, so nothing can be swapped between the check and
 // the mount.
 //
-// Two properties this has to hold, because the calling pod owns the contents of
-// its own emptyDir and can write into it:
+// Two properties this has to hold in both shapes, because the calling pod owns
+// the contents of its own emptyDir and can write into it:
 //
 //   - resolution stops at the pod's emptyDir directory (RESOLVE_BENEATH), so a
 //     name cannot climb out with "..";
 //   - no component may be a symlink (RESOLVE_NO_SYMLINKS), so a link planted
 //     inside the emptyDir cannot redirect the mount somewhere else — the pod's
 //     own rootfs, or another pod's directory.
-func TargetDir(kubeletRoot, podUID, volumeName string) (*os.File, error) {
-	if !podUIDRE.MatchString(podUID) {
-		return nil, fmt.Errorf("volumed: pod uid %q is not a uuid", podUID)
-	}
+func resolveBeneath(base, volumeName string, extraResolve uint64) (*os.File, error) {
 	if !volumeNameRE.MatchString(volumeName) {
 		return nil, fmt.Errorf("volumed: volume name %q is not a dns-1123 label", volumeName)
 	}
 
-	base := filepath.Join(kubeletRoot, "pods", podUID, emptyDirSubdir)
 	baseFD, err := os.OpenFile(base, unix.O_PATH|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
 	if err != nil {
 		return nil, fmt.Errorf("volumed: open pod volume dir: %w", err)
@@ -61,7 +131,7 @@ func TargetDir(kubeletRoot, podUID, volumeName string) (*os.File, error) {
 
 	fd, err := unix.Openat2(int(baseFD.Fd()), volumeName, &unix.OpenHow{
 		Flags:   unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC,
-		Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_XDEV,
+		Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS | extraResolve,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("volumed: resolve mount target %s/%s: %w", base, volumeName, err)

--- a/internal/cmds/volumed/target_test.go
+++ b/internal/cmds/volumed/target_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 const testPodUID = "3f4a1b2c-5d6e-7f80-9a0b-1c2d3e4f5061"
@@ -27,7 +29,7 @@ func TestTargetDirResolvesPodEmptyDir(t *testing.T) {
 		t.Fatalf("mkdir volume: %v", err)
 	}
 
-	f, err := TargetDir(root, testPodUID, "c8s-volume-weights")
+	f, err := (KubeletTargets{Root: root}).Dir(testPodUID, "c8s-volume-weights")
 	if err != nil {
 		t.Fatalf("resolve: %v", err)
 	}
@@ -53,7 +55,7 @@ func TestTargetDirRefusesSymlinkedVolume(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	if _, err := TargetDir(root, testPodUID, "c8s-volume-weights"); err == nil {
+	if _, err := (KubeletTargets{Root: root}).Dir(testPodUID, "c8s-volume-weights"); err == nil {
 		t.Fatal("followed a symlink out of the pod's emptyDir")
 	}
 }
@@ -63,7 +65,7 @@ func TestTargetDirRefusesSymlinkedVolume(t *testing.T) {
 func TestTargetDirRefusesTraversalInName(t *testing.T) {
 	root, _ := kubeletTree(t)
 	for _, name := range []string{"..", "../..", "a/b", "/abs", "c8s-volume-weights/../.."} {
-		if _, err := TargetDir(root, testPodUID, name); err == nil {
+		if _, err := (KubeletTargets{Root: root}).Dir(testPodUID, name); err == nil {
 			t.Errorf("name %q: accepted", name)
 		}
 	}
@@ -76,7 +78,7 @@ func TestTargetDirRefusesMalformedPodUID(t *testing.T) {
 		"3F4A1B2C-5D6E-7F80-9A0B-1C2D3E4F5061", // uppercase: kubelet writes lowercase
 		"3f4a1b2c_5d6e_7f80_9a0b_1c2d3e4f5061", // cgroup spelling, not the directory's
 	} {
-		if _, err := TargetDir(root, uid, "c8s-volume-weights"); err == nil {
+		if _, err := (KubeletTargets{Root: root}).Dir(uid, "c8s-volume-weights"); err == nil {
 			t.Errorf("uid %q: accepted", uid)
 		}
 	}
@@ -87,7 +89,7 @@ func TestTargetDirRefusesNonDirectory(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(base, "c8s-volume-weights"), []byte("x"), 0o600); err != nil {
 		t.Fatalf("seed file: %v", err)
 	}
-	if _, err := TargetDir(root, testPodUID, "c8s-volume-weights"); err == nil {
+	if _, err := (KubeletTargets{Root: root}).Dir(testPodUID, "c8s-volume-weights"); err == nil {
 		t.Fatal("accepted a regular file as a mount target")
 	}
 }
@@ -95,14 +97,119 @@ func TestTargetDirRefusesNonDirectory(t *testing.T) {
 func TestTargetDirRefusesUnknownPod(t *testing.T) {
 	root, _ := kubeletTree(t)
 	other := "99999999-8888-7777-6666-555555555555"
-	if _, err := TargetDir(root, other, "c8s-volume-weights"); err == nil {
+	if _, err := (KubeletTargets{Root: root}).Dir(other, "c8s-volume-weights"); err == nil {
 		t.Fatal("resolved a target for a pod with no kubelet directory")
 	}
 }
 
 func TestTargetDirRefusesMissingVolumeDir(t *testing.T) {
 	root, _ := kubeletTree(t)
-	if _, err := TargetDir(root, testPodUID, "c8s-volume-absent"); err == nil {
+	if _, err := (KubeletTargets{Root: root}).Dir(testPodUID, "c8s-volume-absent"); err == nil {
 		t.Fatal("resolved a volume directory that does not exist")
+	}
+}
+
+// guestTree builds a guest ephemeral directory holding one volume.
+func guestTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "c8s-volume-weights"), 0o755); err != nil {
+		t.Fatalf("mkdir volume: %v", err)
+	}
+	return root
+}
+
+func TestGuestTargetsResolveEphemeralDir(t *testing.T) {
+	root := guestTree(t)
+	f, err := (GuestTargets{Root: root}).Dir(GuestPodUID, "c8s-volume-weights")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	defer f.Close()
+	if !strings.HasSuffix(f.Name(), "c8s-volume-weights") {
+		t.Errorf("resolved %q", f.Name())
+	}
+}
+
+// There is no kubelet and no pod UID inside a guest, so the UID must play no
+// part in resolution — including not being required to look like one.
+func TestGuestTargetsIgnorePodUID(t *testing.T) {
+	root := guestTree(t)
+	for _, uid := range []string{"", GuestPodUID, "not-a-uuid", "../../etc"} {
+		f, err := (GuestTargets{Root: root}).Dir(uid, "c8s-volume-weights")
+		if err != nil {
+			t.Fatalf("uid %q: %v", uid, err)
+		}
+		f.Close()
+	}
+}
+
+// The workload owns its own emptyDir in the guest too, so the hardening that
+// stops it redirecting the mount must survive the move inside the VM.
+func TestGuestTargetsRefuseSymlinkAndTraversal(t *testing.T) {
+	root := guestTree(t)
+	elsewhere := filepath.Join(t.TempDir(), "elsewhere")
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatalf("mkdir elsewhere: %v", err)
+	}
+	if err := os.Symlink(elsewhere, filepath.Join(root, "c8s-volume-linked")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := (GuestTargets{Root: root}).Dir(GuestPodUID, "c8s-volume-linked"); err == nil {
+		t.Error("followed a symlink out of the guest emptyDir")
+	}
+	for _, name := range []string{"..", "../..", "a/b", "/abs"} {
+		if _, err := (GuestTargets{Root: root}).Dir(GuestPodUID, name); err == nil {
+			t.Errorf("name %q: accepted", name)
+		}
+	}
+}
+
+// The default must be the path kata-agent actually materializes a memory-backed
+// emptyDir at; a wrong constant fails every open with a missing directory.
+func TestGuestEphemeralRootMatchesKata(t *testing.T) {
+	if want := "/run/kata-containers/sandbox/ephemeral"; DefaultGuestEphemeralRoot != want {
+		t.Fatalf("DefaultGuestEphemeralRoot = %q, want kata's %q", DefaultGuestEphemeralRoot, want)
+	}
+}
+
+// mountTmpfsAt mounts a tmpfs at dir, skipping when the test lacks the
+// privileges. It reproduces what kata-agent does to a memory-backed emptyDir:
+// the volume directory IS a mount point.
+func mountTmpfsAt(t *testing.T, dir string) {
+	t.Helper()
+	if err := unix.Mount("tmpfs", dir, "tmpfs", 0, ""); err != nil {
+		t.Skipf("cannot mount tmpfs here (needs CAP_SYS_ADMIN in a mount namespace): %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Unmount(dir, unix.MNT_DETACH) })
+}
+
+// The guest target must resolve when the volume directory is itself a mount,
+// which is exactly what kata-agent leaves behind. RESOLVE_NO_XDEV would return
+// EXDEV here and fail every in-guest open.
+func TestGuestTargetsResolveThroughAMountedTarget(t *testing.T) {
+	root := guestTree(t)
+	mountTmpfsAt(t, filepath.Join(root, "c8s-volume-weights"))
+
+	f, err := (GuestTargets{Root: root}).Dir(GuestPodUID, "c8s-volume-weights")
+	if err != nil {
+		t.Fatalf("guest resolve across a mounted target: %v", err)
+	}
+	f.Close()
+}
+
+// The node-CVM shape keeps RESOLVE_NO_XDEV, so a mounted placeholder there is
+// refused rather than silently accepted — the invariant openedVolume's
+// default-medium emptyDir exists to satisfy.
+func TestKubeletTargetsRefuseAMountedTarget(t *testing.T) {
+	root, base := kubeletTree(t)
+	dir := filepath.Join(base, "c8s-volume-weights")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatalf("mkdir volume: %v", err)
+	}
+	mountTmpfsAt(t, dir)
+
+	if _, err := (KubeletTargets{Root: root}).Dir(testPodUID, "c8s-volume-weights"); err == nil {
+		t.Fatal("node-CVM accepted a mounted placeholder; RESOLVE_NO_XDEV is not being applied")
 	}
 }

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -36,8 +36,9 @@
   kata.enabled is enforcing: every workload runs as a kata CVM, where these
   host-side components are replaced by their in-guest counterparts baked into
   kata-guest-base: ratls routing runs in-VM, attestation is served by the
-  in-guest agent on loopback :8400 (see c8s.attestationApiURL), and image
-  admission is the in-guest policy-monitor fed from CDS's served allowlist.
+  in-guest agent on loopback :8400 (see c8s.attestationApiURL), image
+  admission is the in-guest policy-monitor fed from CDS's served allowlist, and
+  encrypted volumes are opened by `volumed --guest` on loopback :8402.
   Deploying the host versions alongside is at best dead weight and at worst a
   second, unattested enforcement path — require them off explicitly.
 */ -}}
@@ -46,8 +47,9 @@
 {{- if .Values.ratlsMesh.enabled -}}{{- $hostSide = append $hostSide "ratlsMesh.enabled" -}}{{- end -}}
 {{- if .Values.attestationApi.enabled -}}{{- $hostSide = append $hostSide "attestationApi.enabled" -}}{{- end -}}
 {{- if .Values.nriImagePolicy.enabled -}}{{- $hostSide = append $hostSide "nriImagePolicy.enabled" -}}{{- end -}}
+{{- if .Values.volumed.enabled -}}{{- $hostSide = append $hostSide "volumed.enabled" -}}{{- end -}}
 {{- with $hostSide -}}
-{{- fail (printf "VALIDATION_ERROR kind=enforce_host_components: kata.enabled=true requires %s =false. kata is enforcing — every workload runs as a kata CVM, where these host-side components are replaced by their in-guest counterparts in the kata-guest-base image (in-VM ratls routing, in-guest attestation-api on loopback, in-guest policy-monitor image admission). `c8s install --cvm-mode=pod` sets them for you." (join ", " .)) -}}
+{{- fail (printf "VALIDATION_ERROR kind=enforce_host_components: kata.enabled=true requires %s =false. kata is enforcing — every workload runs as a kata CVM, where these host-side components are replaced by their in-guest counterparts in the kata-guest-base image (in-VM ratls routing, in-guest attestation-api on loopback, in-guest policy-monitor image admission, in-guest volumed). `c8s install --cvm-mode=pod` sets them for you." (join ", " .)) -}}
 {{- end -}}
 {{- end -}}
 {{- /*

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -6590,3 +6590,21 @@ func TestChartKataPinnedPodsCarryGuestReadyAffinity(t *testing.T) {
 		}
 	}
 }
+
+// The host volumed DaemonSet is replaced under kata by `volumed --guest` inside
+// the guest, which is where the fetcher posts. Leaving the host one enabled
+// deploys a privileged DaemonSet nothing calls, so the chart refuses it for the
+// same reason as the other host-side components.
+func TestChartKataRejectsHostVolumed(t *testing.T) {
+	out, err := helmTemplateKata(t, "--set", "volumed.enabled=true")
+	if err == nil {
+		t.Fatalf("helm template succeeded with kata and host volumed enabled, want failure\n%s", out)
+	}
+	msg := helmFailMessage(t, out)
+	if !strings.Contains(msg, "kind=enforce_host_components") {
+		t.Errorf("fail message %q missing the enforce_host_components marker", msg)
+	}
+	if !strings.Contains(msg, "volumed.enabled") {
+		t.Errorf("fail message %q should name volumed.enabled", msg)
+	}
+}

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -640,26 +640,23 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 			"%w: %s pods must not set hostNetwork — a hostNetwork pod shares the node IP and cannot be mesh-intercepted or protected by the cw inbound guard",
 			errInvalidInjectionAnnotation, AnnotationWorkload))
 	}
-	// The fetcher redeems a sandbox token from the node's inventory over the
-	// mounted nri-image-policy socket, and unlike get-cert it has no guest
-	// (kata loopback) endpoint. Without the host dir there is no socket to
-	// mount, so injecting it would produce a Running pod whose fetcher
-	// CrashLoops on a missing socket while the workload blocks forever waiting
-	// for a file that never lands. Refuse at admission instead — kata secrets
-	// are out of scope for further reasons too (see docs/secrets.md).
-	if inj != nil && len(inj.Secrets.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" {
+	// The fetcher redeems a sandbox token from an inventory: the mounted
+	// nri-image-policy socket on node-CVM, or policy-monitor on guest loopback
+	// under kata. An operator with neither has nothing to point it at, so
+	// injecting would produce a Running pod whose fetcher CrashLoops while the
+	// workload blocks forever on a file that never lands. Refuse at admission.
+	if inj != nil && len(inj.Secrets.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
-			"%w: %s needs the node inventory socket, which this operator is not configured with (kata, or nri-image-policy disabled); see docs/secrets.md",
+			"%w: %s needs an admission inventory, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/secrets.md",
 			errInvalidInjectionAnnotation, AnnotationSecrets))
 	}
-	// Same for volumes, and more so: the fetcher hands the key to a node agent
-	// over that same socket directory, and the agent mounts into the pod's
-	// kubelet directory — neither of which exists for a kata guest. Refuse at
-	// admission rather than leave the workload waiting on a mount that can
-	// never land (docs/volumes.md).
-	if inj != nil && len(inj.Volumes.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" {
+	// Same for volumes: the fetcher hands the key to volumed, over the mounted
+	// socket directory on node-CVM or on guest loopback under kata. An operator
+	// with neither shape has no daemon to hand it to, so the workload would wait
+	// on a mount that can never land (docs/volumes.md).
+	if inj != nil && len(inj.Volumes.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
-			"%w: %s needs the node volume agent, which this operator is not configured with (kata, or nri-image-policy disabled); see docs/volumes.md",
+			"%w: %s needs a volume daemon, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/volumes.md",
 			errInvalidInjectionAnnotation, AnnotationVolumes))
 	}
 	if inj != nil && inj.SAN == "" {
@@ -712,7 +709,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		if err := rejectReservedSecretsVolume(pod); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
-		if err := rejectReservedVolumeVolume(pod); err != nil {
+		if err := rejectReservedVolumeVolume(pod, m.cfg.WorkloadClaimsGuest); err != nil {
 			return admission.Errored(http.StatusBadRequest, err)
 		}
 		l.Info("injecting c8s get-cert containers", "workload", inj.WorkloadID)
@@ -979,7 +976,7 @@ func mutatePod(pod *corev1.Pod, inj *injection, cfg Config) {
 		// host-authored spec could pre-declare the volume or the mount and
 		// choose where the decrypted plaintext lands.
 		for _, name := range volumeNames(effective.Volumes.Specs) {
-			replaceVolume(pod, openedVolume(name))
+			replaceVolume(pod, openedVolume(name, cfg.WorkloadClaimsGuest))
 			remountAll(pod, corev1.VolumeMount{
 				Name:      volume.KubeVolumeName(name),
 				MountPath: filepath.Join(effective.Volumes.Dir, name),
@@ -1364,17 +1361,26 @@ func volumeNames(specs []string) []string {
 	return out
 }
 
-// openedVolume is the mount point the node agent mounts a decrypted volume
-// over. It holds nothing itself — the plaintext lives on the opened device
-// mounted over it — and it must share the pod directory's filesystem: volumed
-// resolves the target with RESOLVE_NO_XDEV, so a memory-backed (tmpfs)
-// placeholder is unreachable by construction.
-func openedVolume(name string) corev1.Volume {
+// openedVolume is the mount point volumed mounts a decrypted volume over. It
+// holds nothing itself — the plaintext lives on the opened device mounted over
+// it.
+//
+// The medium differs by shape, and each is load-bearing:
+//
+//   - node-CVM: default. The placeholder must share the pod directory's
+//     filesystem, because volumed resolves the target with RESOLVE_NO_XDEV.
+//   - kata: Memory. A default-medium emptyDir is turned into a disk.img block
+//     device by the shim under shared_fs="none", whereas a memory-backed one
+//     stays a guest tmpfs at kata's ephemeral path, which is what GuestTargets
+//     resolves.
+func openedVolume(name string, guest bool) corev1.Volume {
+	src := &corev1.EmptyDirVolumeSource{}
+	if guest {
+		src.Medium = corev1.StorageMediumMemory
+	}
 	return corev1.Volume{
-		Name: volume.KubeVolumeName(name),
-		VolumeSource: corev1.VolumeSource{
-			EmptyDir: &corev1.EmptyDirVolumeSource{},
-		},
+		Name:         volume.KubeVolumeName(name),
+		VolumeSource: corev1.VolumeSource{EmptyDir: src},
 	}
 }
 
@@ -1413,18 +1419,29 @@ func remountAll(pod *corev1.Pod, mount corev1.VolumeMount) {
 // Reserved by prefix rather than by re-deriving names from the annotation: the
 // annotation is host-written, so a guard that reads it can be steered away from
 // the name it is meant to protect.
-func rejectReservedVolumeVolume(pod *corev1.Pod) error {
+func rejectReservedVolumeVolume(pod *corev1.Pod, guest bool) error {
+	want := corev1.StorageMediumDefault
+	if guest {
+		want = corev1.StorageMediumMemory
+	}
 	for i := range pod.Spec.Volumes {
 		v := &pod.Spec.Volumes[i]
 		if !strings.HasPrefix(v.Name, volume.KubeVolumePrefix) {
 			continue
 		}
-		if v.EmptyDir == nil || v.EmptyDir.Medium != corev1.StorageMediumDefault {
-			return fmt.Errorf("%w: volume %q is reserved for an encrypted volume; it must be a default-medium emptyDir or omitted (see openedVolume)",
-				errInvalidInjectionAnnotation, v.Name)
+		if v.EmptyDir == nil || v.EmptyDir.Medium != want {
+			return fmt.Errorf("%w: volume %q is reserved for an encrypted volume; it must be a %s-medium emptyDir or omitted (see openedVolume)",
+				errInvalidInjectionAnnotation, v.Name, mediumName(want))
 		}
 	}
 	return nil
+}
+
+func mediumName(m corev1.StorageMedium) string {
+	if m == corev1.StorageMediumMemory {
+		return "Memory"
+	}
+	return "default"
 }
 
 // volumeContainer is the workload's volume fetcher.
@@ -1445,6 +1462,11 @@ func volumeContainer(inj *injection, cfg Config) corev1.Container {
 	}
 	for _, m := range cfg.CDSMeasurements {
 		args = append(args, "--measurements="+m)
+	}
+	// Under kata both the inventory and volumed are inside this guest, on
+	// compiled loopback ports, with nothing mounted to reach them by.
+	if cfg.WorkloadClaimsGuest {
+		args = append(args, "--workload-claims-guest")
 	}
 
 	always := corev1.ContainerRestartPolicyAlways
@@ -1483,6 +1505,11 @@ func secretContainer(inj *injection, cfg Config) corev1.Container {
 	}
 	for _, m := range cfg.CDSMeasurements {
 		args = append(args, "--measurements="+m)
+	}
+	// Unlike get-cert the token is not optional here, so only the shape is
+	// selected: the mounted socket on node-CVM, guest loopback under kata.
+	if cfg.WorkloadClaimsGuest {
+		args = append(args, "--workload-claims-guest")
 	}
 
 	always := corev1.ContainerRestartPolicyAlways

--- a/internal/webhook/pod_mutator_reserved_test.go
+++ b/internal/webhook/pod_mutator_reserved_test.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -168,14 +169,13 @@ func handleSecretsPod(t *testing.T, cfg Config) admission.Response {
 	})
 }
 
-// TestHandleRejectsSecretsWithoutInventorySocket covers the kata shape: the
-// fetcher redeems a sandbox token over the mounted inventory socket and has no
-// guest endpoint, so without a host dir there is nothing to mount. Injecting it
-// anyway produces a Running pod whose fetcher CrashLoops while the workload
-// blocks forever on a file that never lands — fail at admission instead.
-func TestHandleRejectsSecretsWithoutInventorySocket(t *testing.T) {
-	cfg := secretsConfig()
-	cfg.WorkloadClaimsGuest = true // kata: guest loopback, nothing mounted
+// TestHandleRejectsSecretsWithoutAnyInventory covers the shape no fetcher can
+// serve: no mounted socket and not the kata guest, so there is no inventory to
+// redeem a sandbox token at. Injecting anyway produces a Running pod whose
+// fetcher CrashLoops while the workload blocks forever on a file that never
+// lands — fail at admission instead.
+func TestHandleRejectsSecretsWithoutAnyInventory(t *testing.T) {
+	cfg := secretsConfig() // neither WorkloadClaimsHostDir nor WorkloadClaimsGuest
 
 	resp := handleSecretsPod(t, cfg)
 	if resp.Allowed {
@@ -194,5 +194,41 @@ func TestHandleAdmitsSecretsWithInventorySocket(t *testing.T) {
 
 	if resp := handleSecretsPod(t, cfg); !resp.Allowed {
 		t.Fatalf("Handle denied a serviceable secrets pod: %v", resp.Result)
+	}
+}
+
+// Under kata the inventory is policy-monitor on guest loopback, so a secrets
+// pod is serviceable with nothing mounted.
+func TestHandleAdmitsSecretsUnderKataGuest(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsGuest = true
+
+	if resp := handleSecretsPod(t, cfg); !resp.Allowed {
+		t.Fatalf("Handle denied a secrets pod the guest inventory can serve: %v", resp.Result)
+	}
+}
+
+// The fetcher must be told to use the guest endpoint, not merely admitted: the
+// node-CVM socket it would otherwise dial cannot exist in a kata guest.
+func TestSecretContainerSelectsGuestInventoryUnderKata(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsGuest = true
+	inj := &injection{Secrets: secretsSpec{Specs: []string{"DB=/api/db"}, Dir: "/run/c8s/secrets"}}
+
+	args := secretContainer(inj, cfg).Args
+	if !slices.Contains(args, "--workload-claims-guest") {
+		t.Fatalf("get-secret args %v omit --workload-claims-guest under kata", args)
+	}
+}
+
+// And must not be told to under node-CVM, where the guest port serves nothing.
+func TestSecretContainerKeepsSocketInventoryOnNodeCVM(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsHostDir = "/run/c8s/nri"
+	inj := &injection{Secrets: secretsSpec{Specs: []string{"DB=/api/db"}, Dir: "/run/c8s/secrets"}}
+
+	args := secretContainer(inj, cfg).Args
+	if slices.Contains(args, "--workload-claims-guest") {
+		t.Fatalf("get-secret args %v select the guest inventory on node-CVM", args)
 	}
 }

--- a/internal/webhook/pod_mutator_volumes_test.go
+++ b/internal/webhook/pod_mutator_volumes_test.go
@@ -180,18 +180,18 @@ func TestReservedVolumePrefixMustBeMemoryBacked(t *testing.T) {
 				HostPath: &corev1.HostPathVolumeSource{Path: "/tmp/exfil"},
 			},
 		}}
-		if err := rejectReservedVolumeVolume(pod); err == nil {
+		if err := rejectReservedVolumeVolume(pod, false); err == nil {
 			t.Errorf("%s: a hostPath under the reserved prefix was accepted", name)
 		}
 	}
 
 	// The shape the webhook itself injects is fine, as is omitting it.
 	pod := podWithApp()
-	pod.Spec.Volumes = []corev1.Volume{openedVolume("weights")}
-	if err := rejectReservedVolumeVolume(pod); err != nil {
+	pod.Spec.Volumes = []corev1.Volume{openedVolume("weights", false)}
+	if err := rejectReservedVolumeVolume(pod, false); err != nil {
 		t.Errorf("the injected shape was rejected: %v", err)
 	}
-	if err := rejectReservedVolumeVolume(podWithApp()); err != nil {
+	if err := rejectReservedVolumeVolume(podWithApp(), false); err != nil {
 		t.Errorf("an absent volume was rejected: %v", err)
 	}
 }
@@ -285,20 +285,61 @@ func TestVolumesAnnotationParsing(t *testing.T) {
 	}
 }
 
-// The kata shape: the fetcher hands the key to a node agent over the inventory
-// socket directory, and the agent mounts into the pod's kubelet directory.
-// Neither exists for a guest, so admission refuses rather than leaving the
-// workload waiting on a mount that can never land.
-func TestHandleRejectsVolumesWithoutTheNodeAgent(t *testing.T) {
-	cfg := secretsConfig()
-	cfg.WorkloadClaimsGuest = true
+// Neither shape configured means there is no daemon to hand the key to, so
+// admission refuses rather than leaving the workload waiting on a mount that
+// can never land.
+func TestHandleRejectsVolumesWithoutAnyDaemon(t *testing.T) {
+	cfg := secretsConfig() // neither WorkloadClaimsHostDir nor WorkloadClaimsGuest
 
 	resp := handleVolumesPod(t, cfg)
 	if resp.Allowed {
-		t.Fatal("admitted a volumes pod the node agent could never serve")
+		t.Fatal("admitted a volumes pod no daemon could serve")
 	}
 	if msg := resp.Result.Message; !strings.Contains(msg, AnnotationVolumes) {
 		t.Fatalf("denial %q does not name the offending annotation", msg)
+	}
+}
+
+// Under kata volumed runs inside the guest on loopback, so a volumes pod is
+// serviceable with nothing mounted.
+func TestHandleAdmitsVolumesUnderKataGuest(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsGuest = true
+
+	if resp := handleVolumesPod(t, cfg); !resp.Allowed {
+		t.Fatalf("Handle denied a volumes pod the in-guest daemon can serve: %v", resp.Result)
+	}
+}
+
+// The placeholder's medium is load-bearing and differs by shape: a default
+// emptyDir becomes a disk.img block device under shared_fs="none", and a
+// memory-backed one is unreachable to volumed's RESOLVE_NO_XDEV on node-CVM.
+func TestOpenedVolumeMediumFollowsTheShape(t *testing.T) {
+	if got := openedVolume("weights", false).EmptyDir.Medium; got != corev1.StorageMediumDefault {
+		t.Errorf("node-CVM medium = %q, want default", got)
+	}
+	if got := openedVolume("weights", true).EmptyDir.Medium; got != corev1.StorageMediumMemory {
+		t.Errorf("kata medium = %q, want Memory", got)
+	}
+	// And the reserved-volume guard must expect the same shape it injects,
+	// or the webhook would reject its own output on re-admission.
+	for _, guest := range []bool{false, true} {
+		pod := podWithApp()
+		pod.Spec.Volumes = []corev1.Volume{openedVolume("weights", guest)}
+		if err := rejectReservedVolumeVolume(pod, guest); err != nil {
+			t.Errorf("guest=%v: the injected shape was rejected: %v", guest, err)
+		}
+	}
+}
+
+// The fetcher must be told to use the guest endpoints, not merely admitted.
+func TestVolumeContainerSelectsGuestEndpointsUnderKata(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsGuest = true
+	inj := &injection{Volumes: volumesSpec{Specs: []string{"weights=/tenant-a/volumes/weights"}, Dir: "/models"}}
+
+	if args := volumeContainer(inj, cfg).Args; !slices.Contains(args, "--workload-claims-guest") {
+		t.Fatalf("get-volume args %v omit --workload-claims-guest under kata", args)
 	}
 }
 

--- a/kata-guest-base/README.md
+++ b/kata-guest-base/README.md
@@ -46,6 +46,7 @@ the kata-agent + its systemd unit + the OPA policy engine
 | `/usr/local/bin/ratls-mesh` | c8s (Go) | In-guest mesh proxy — runs as `ratls-mesh in-guest`. |
 | `/usr/local/bin/policy-monitor` | c8s (Go) | In-VM container-digest enforcement — watches `/run/kata-containers/` via inotify, SIGKILLs containers whose digest isn't on the baked allowlist. |
 | `/usr/local/bin/attestation-service` | attestation-rs `attestation-api` bin (Rust) | Localhost-only attester on `127.0.0.1:8400` (staged under the attestation-service role name). |
+| `/usr/local/bin/volumed` | c8s (Go) | In-guest encrypted-volume opener — runs as `volumed --guest`, serving `127.0.0.1:8402`. Uses the rootfs's `cryptsetup`/`veritysetup` (`cryptsetup-bin`, already in `KATA_EXTRA_PKGS`). |
 | `/etc/c8s/attestation-service.toml` | this dir | Localhost-only mode config — no API key, no TLS. |
 | `/etc/c8s/bootstrap-allowlist.json` | rendered by `scripts/fetch.sh` | Image-digest allowlist `policy-monitor` reads at boot. Digests of the c8s images at `IMAGE_TAG` are substituted in. Part of the dm-verity root → covered by the launch measurement; updates require an image rebuild. |
 | `/etc/kata-opa/default-policy.rego` | this dir | Overlays osbuilder's allow-all with our policy: `SetPolicyRequest` is denied (the host can't swap the policy at runtime), and so are the host-reach-in RPCs `ExecProcessRequest`/`ReadStreamRequest`/`WriteStreamRequest` (no `kubectl exec`/`logs` against a locked guest — see "Debug variant" below). The agent is built with `AGENT_POLICY=yes` so this is enforced. Per-image-digest gating is policy-monitor's job — see `docs/kata-image-policy.md`. |
@@ -53,6 +54,7 @@ the kata-agent + its systemd unit + the OPA policy engine
 | `/etc/systemd/system/c8s-cloudinit-env.service` | this dir | One-shot — turns cloud-init user-data into `/run/c8s/ratls-mesh.env`. |
 | `/etc/systemd/system/ratls-mesh.service` | this dir | Runs the in-guest proxy with `CAP_NET_ADMIN`. |
 | `/etc/systemd/system/policy-monitor.service` | this dir | Runs `policy-monitor monitor`. |
+| `/etc/systemd/system/volumed.service` | this dir | Runs `volumed --guest`. Not a `c8s-ready.target` gate — release needs every main container already running. |
 | `/etc/systemd/system/c8s-ready.target` | this dir | Synthetic target reached when the in-guest mesh is healthy. |
 | `/etc/tmpfiles.d/c8s.conf` | this dir | Creates `/run/c8s/` early in boot. |
 | `/usr/local/lib/c8s/cloudinit-env.sh` | this dir | Invoked by `c8s-cloudinit-env.service`. |
@@ -73,7 +75,7 @@ comes up independently.
 sudo apt-get install -y docker.io && sudo systemctl enable --now docker
 
 # Once per c8s/attestation-rs revision: build the in-guest binaries.
-cd /workspace/c8s            && make build-c8s-node && make build-policy-monitor && make build-rtmr3-measurer
+cd /workspace/c8s            && make build-c8s-node && make build-policy-monitor && make build-rtmr3-measurer && make build-volumed
 cd /workspace/attestation-rs && cargo build --release -p attestation-api --bin attestation-api --target x86_64-unknown-linux-musl
 
 # Stage the binaries + the bootstrap allowlist into extra/. (The attester

--- a/kata-guest-base/extra/etc/systemd/system/volumed.service
+++ b/kata-guest-base/extra/etc/systemd/system/volumed.service
@@ -1,0 +1,33 @@
+[Unit]
+# Opens this pod's encrypted volumes inside the guest (docs/volumes.md). The
+# get-volume sidecar fetches each key from CDS over the attested secrets flow
+# and posts it here on loopback :8402; this opens dm-crypt + dm-verity and
+# mounts the plaintext read-only into kata's ephemeral directory.
+#
+# The node-side daemon resolves its caller from peer credentials because a node
+# holds many pods. A guest holds one, so there is no caller to tell apart and
+# --guest resolves every request to it — the same reason the token route on
+# :8401 needs no peer credentials.
+#
+# Not a gate on c8s-ready.target: a volume is released only once every main
+# container is running, so this cannot be on the path that starts them. A
+# sidecar that posts before this is up retries (--attempts).
+Description=c8s volumed (in-guest encrypted volume opener)
+Documentation=https://github.com/confidential-dot-ai/c8s/blob/main/docs/volumes.md
+After=local-fs.target
+Wants=local-fs.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/volumed --guest
+
+# Privileged by necessity: device-mapper ioctls and mount(2). No hardening
+# sandbox here — ProtectSystem/RestrictNamespaces would block exactly the
+# mounting this exists to do.
+Restart=on-failure
+RestartSec=2s
+StartLimitIntervalSec=60s
+StartLimitBurst=5
+
+[Install]
+WantedBy=multi-user.target

--- a/kata-guest-base/extra/usr/lib/systemd/system-preset/50-c8s.preset
+++ b/kata-guest-base/extra/usr/lib/systemd/system-preset/50-c8s.preset
@@ -43,6 +43,11 @@ enable rtmr3-measurer.service
 # launched with a confai-scratch disk; no-op otherwise).
 enable scratch-setup.service
 
+# volumed opens this pod's encrypted volumes inside the guest, from keys the
+# get-volume sidecar posts on loopback :8402 (docs/volumes.md). Idle unless the
+# pod asks for a volume.
+enable volumed.service
+
 # Make sure cloud-init's units are on — without these, our env
 # materialisation never sees the user-data. Ubuntu's default preset
 # already enables them, but be explicit so a base-image refactor

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -213,7 +213,7 @@ sudo modprobe loop 2>/dev/null || true
 
 # The overlay binaries must be staged before we build the rootfs image,
 # because they end up in the dm-verity root (and thus the measurement).
-for bin in ratls-mesh policy-monitor attestation-service rtmr3-measurer; do
+for bin in ratls-mesh policy-monitor attestation-service rtmr3-measurer volumed; do
     [[ -x "${EXTRA_DIR}/usr/local/bin/${bin}" ]] || die "${EXTRA_DIR}/usr/local/bin/${bin} missing — run scripts/fetch.sh first."
 done
 [[ -f "${EXTRA_DIR}/etc/c8s/bootstrap-allowlist.json" ]] || die "bootstrap-allowlist.json not staged — run scripts/fetch.sh (with IMAGE_TAG or *_DIGEST env vars) first."
@@ -442,6 +442,7 @@ C8S_UNITS=(
     policy-monitor.service
     rtmr3-measurer.service
     scratch-setup.service
+    volumed.service
     c8s-cloudinit-env.service
 )
 # kata boots the guest with `systemd.unit=kata-containers.target` on the kernel

--- a/kata-guest-base/scripts/fetch.sh
+++ b/kata-guest-base/scripts/fetch.sh
@@ -111,6 +111,21 @@ fi
 install -m 0755 "${RTMR3_MEASURER_BIN}" "${BIN_DIR}/rtmr3-measurer"
 echo "==> rtmr3-measurer: ${BIN_DIR}/rtmr3-measurer ($(stat -c '%s' "${BIN_DIR}/rtmr3-measurer") bytes)"
 
+# volumed: in-VM encrypted-volume opener, run as `volumed --guest`. Opens
+# dm-crypt + dm-verity for keys the get-volume sidecar posts on loopback.
+# Source at /workspace/c8s/cmd/volumed. Built by `make build-volumed` ->
+# ${C8S_DIR}/build/volumed. cryptsetup/veritysetup come from the rootfs's
+# cryptsetup-bin (KATA_EXTRA_PKGS in build.sh), not from here.
+VOLUMED_BIN="${VOLUMED_BIN:-${C8S_DIR}/build/volumed}"
+if [[ ! -x "${VOLUMED_BIN}" ]]; then
+    echo "FATAL: ${VOLUMED_BIN} missing" >&2
+    echo "       Build first:" >&2
+    echo "         cd ${C8S_DIR} && make build-volumed" >&2
+    exit 1
+fi
+install -m 0755 "${VOLUMED_BIN}" "${BIN_DIR}/volumed"
+echo "==> volumed: ${BIN_DIR}/volumed ($(stat -c '%s' "${BIN_DIR}/volumed") bytes)"
+
 # In-guest attester: the `attestation-api` bin from attestation-rs, built for
 # the default (glibc) target. Staged under the attestation-service role name
 # (the in-guest unit, the C8S_ATTESTATION_SERVICE_URL contract, and the

--- a/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
+++ b/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
@@ -1,23 +1,47 @@
 #!/bin/bash
-# PROTOTYPE kata qemu wrapper: attach a per-VM ephemeral scratch disk so the
-# in-guest confidential image store (extra/usr/local/lib/c8s/scratch-setup.sh)
-# can unpack large images to encrypted disk instead of RAM.
+# PROTOTYPE kata qemu wrapper. It attaches two kinds of disk to a guest:
 #
-# Kata has no native per-sandbox scratch-disk knob, so we intercept the qemu
+#  1. a per-VM ephemeral scratch disk, so the in-guest confidential image store
+#     (extra/usr/local/lib/c8s/scratch-setup.sh) can unpack large images to
+#     encrypted disk instead of RAM;
+#  2. this pod's encrypted volumes (docs/volumes.md), so the in-guest volumed
+#     can open them. kata-agent always mounts a block storage it is handed, and
+#     these carry ciphertext it cannot mount, so they must reach the guest as
+#     bare devices rather than through kata's direct-volume assignment.
+#
+# Kata has no native per-sandbox disk knob for either, so we intercept the qemu
 # launch: set [hypervisor.qemu] path = <this script> in the kata-qemu-tdx
-# config. It creates a sparse per-sandbox raw disk and attaches it as
-# serial=confai-scratch (the guest finds it via /sys/block/<dev>/serial). The
-# disk carries only ciphertext (dm-crypt in the guest); the host cannot read it.
+# config. Each disk is found in the guest by its virtio serial
+# (/sys/block/<dev>/serial), and carries only ciphertext — the host cannot read
+# either one.
 #
-# PRODUCTION NOTE: still a prototype. The clean version attaches the disk from
+# Which volumes to attach comes from the pod's host-written annotation, which is
+# a selector and not a trust input: naming another tenant's device attaches
+# ciphertext the host already holds, and the guest still cannot open it without
+# the key CDS releases against the allowlist grant (docs/volumes.md, "The serial
+# is a selector, not a trust input"). Volume devices are attached read-only, so
+# a guest cannot write ciphertext back over one.
+#
+# PRODUCTION NOTE: still a prototype. The clean version attaches the disks from
 # the kata runtime (or a CDI device) rather than wrapping qemu. Tunables via env:
-# CONFAI_REAL_QEMU, CONFAI_SCRATCH_DIR, CONFAI_SCRATCH_SIZE, CONFAI_GC_GRACE_SECS.
+# CONFAI_REAL_QEMU, CONFAI_SCRATCH_DIR, CONFAI_SCRATCH_SIZE, CONFAI_GC_GRACE_SECS,
+# CONFAI_BUNDLE_ROOTS, CONFAI_SYS_BLOCK.
 set -euo pipefail
 
 QEMU="${CONFAI_REAL_QEMU:-/opt/kata/bin/qemu-system-x86_64}"
 SDIR="${CONFAI_SCRATCH_DIR:-/var/lib/kata-scratch}"
 SIZE="${CONFAI_SCRATCH_SIZE:-30G}"
 GRACE="${CONFAI_GC_GRACE_SECS:-120}"
+SYSBLOCK="${CONFAI_SYS_BLOCK:-/sys/block}"
+# Where containerd writes the sandbox's OCI bundle. RKE2/k3s keep their own
+# state root, so both are searched unless overridden.
+BUNDLE_ROOTS="${CONFAI_BUNDLE_ROOTS:-/run/containerd/io.containerd.runtime.v2.task/k8s.io /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io}"
+
+# The annotation naming this pod's volumes, and the serial prefix the guest
+# matches on. Both must agree with the Go side: pkg/allowlist (the annotation)
+# and internal/cmds/volume (SerialPrefix).
+VOLUMES_ANNOTATION="confidential.ai/c8s-volumes"
+SERIAL_PREFIX="c8s-vol-"
 
 # The scratch file MUST be keyed on a reliably-unique id: two VMs sharing one
 # raw disk would corrupt each other. Kata passes the sandbox id in the -name
@@ -51,9 +75,83 @@ done
 
 IMG="$SDIR/scratch-$SBID.img"
 truncate -s "$SIZE" "$IMG"
+
+# volume_names prints this pod's volume names, one per line.
+#
+# The bundle's config.json holds the pod annotations. Rather than parse JSON,
+# the fixed key's value is extracted and every candidate name is validated
+# against the same DNS-1123 label rule (and 12-char serial cap) the webhook, the
+# sidecar and volumed all apply — so a value crafted to confuse the extraction
+# yields names that fail validation and are skipped, never a shell word.
+volume_names() {
+    local cfg="" root
+    for root in $BUNDLE_ROOTS; do
+        if [ -f "$root/$SBID/config.json" ]; then
+            cfg="$root/$SBID/config.json"
+            break
+        fi
+    done
+    [ -n "$cfg" ] || return 0
+
+    local raw
+    raw="$(grep -o "\"$VOLUMES_ANNOTATION\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$cfg" |
+        head -1 | sed 's/.*:[[:space:]]*"//; s/"$//' || true)"
+    [ -n "$raw" ] || return 0
+
+    # Trailing newline matters: without it `read` drops the last entry, and the
+    # pod would silently lose its final volume.
+    printf '%s\n' "$raw" | tr ',' '\n' | while IFS= read -r entry; do
+        local name="${entry%%=*}"
+        if printf '%s' "$name" | grep -qE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' &&
+            [ "${#name}" -le 12 ]; then
+            printf '%s\n' "$name"
+        else
+            echo "kata-qemu-scratch-wrapper: ignoring malformed volume entry '$entry'" >&2
+        fi
+    done
+}
+
+# device_for prints the block device carrying serial $SERIAL_PREFIX$1.
+#
+# A serial matching more than one device is refused rather than resolved to
+# whichever was read first: the host can attach two devices claiming the same
+# serial, and picking one would make which volume a pod gets depend on scan
+# order. Mirrors SerialDevices.Device in internal/cmds/volumed.
+device_for() {
+    local want="$SERIAL_PREFIX$1" found=() d serial
+    for d in "$SYSBLOCK"/*; do
+        [ -r "$d/serial" ] || continue
+        serial="$(tr -d '[:space:]' <"$d/serial")"
+        [ "$serial" = "$want" ] && found+=("$(basename "$d")")
+    done
+    if [ "${#found[@]}" -ne 1 ]; then
+        echo "kata-qemu-scratch-wrapper: ${#found[@]} block devices carry serial $want; not attaching" >&2
+        return 1
+    fi
+    printf '/dev/%s\n' "${found[0]}"
+}
+
+# A missing or ambiguous device is logged and skipped rather than failing the
+# launch: refusing here surfaces as an opaque shim error on a pod that never
+# starts, whereas letting it boot leaves the in-guest daemon to answer "volume
+# device is not present", which is where an operator is already looking.
+volume_args=()
+n=0
+while IFS= read -r vol; do
+    [ -n "$vol" ] || continue
+    if dev="$(device_for "$vol")"; then
+        volume_args+=(
+            -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
+            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol,read-only=on"
+        )
+        n=$((n + 1))
+    fi
+done < <(volume_names)
+
 # file.locking left at the qemu default (on): with unique per-sandbox files a
 # lock conflict now means a real bug (two launches, same id) and should fail
 # loudly rather than silently share the disk.
 exec "$QEMU" "$@" \
     -drive "file=$IMG,format=raw,if=none,id=confaiscratch,cache=none" \
-    -device virtio-blk-pci,drive=confaiscratch,serial=confai-scratch
+    -device virtio-blk-pci,drive=confaiscratch,serial=confai-scratch \
+    "${volume_args[@]+"${volume_args[@]}"}"


### PR DESCRIPTION
Secret and volume release fail-closed under kata: both fetchers redeem their sandbox token over the nri-image-policy unix socket, which cannot exist in a guest (shared_fs="none"), so the webhook refused the annotations at admission.

get-secret needed only a client. policy-monitor has served the token route on the guest's loopback :8401 since get-cert gained --workload-claims-guest; the secret fetcher simply had no way to select it. It gets the same flag, the webhook injects it, and the admission guard now keys on "no inventory in either shape" rather than "no host socket".

Volumes needed the daemon moved. volumed mounted into the pod's kubelet directory over a host socket — neither exists in a guest — and its "possession of the blob is the authorization" rule leaned on node-as-CVM being single-tenant. Running it inside the guest as `volumed --guest` restores that premise rather than replacing it: a guest holds exactly one pod, so there is no second caller to authenticate and no nonce-bound token protocol is needed. It serves loopback :8402, resolves every caller to that pod, and mounts into kata's ephemeral directory.

Three constraints shaped the result:

- The guest target cannot use RESOLVE_NO_XDEV. kata-agent materializes a memory-backed emptyDir as a tmpfs mounted AT the volume directory, so openat2 returns EXDEV; the node-CVM shape keeps the flag. RESOLVE_BENEATH and RESOLVE_NO_SYMLINKS — what actually stops a workload redirecting the mount — apply in both, and the workload holds no CAP_SYS_ADMIN in the sandbox mount namespace this resolves in.
- The placeholder's medium differs by shape. Default becomes a disk.img block device under shared_fs="none"; Memory is unreachable to NO_XDEV on node-CVM.
- kata-agent always mounts a block storage it is handed, so direct-volume assignment cannot deliver ciphertext. The qemu wrapper attaches this pod's volume devices read-only with the serial preserved, resolving names from the bundle's annotations under the same DNS-1123 + 12-char validation the rest of the stack applies. Attaching by a host-written annotation is consistent with the existing model: the serial is a selector, and the key remains the gate.

The guest image gains volumed and its unit, so this needs a rootfs rebuild and re-pinned launch measurements. cryptsetup-bin was already in EXTRA_PKGS for scratch-setup. The chart now requires volumed.enabled=false under kata, matching the other host components it replaces.

docs/secrets.md's "kata is out of scope" no longer holds; its --measurements half was already stale after #220. The two real caveats — a host-written sandbox ID and watch-and-kill argv enforcement — are documented as weaker guarantees rather than blockers.