### PR TITLE
fix(volumed): clean deadlock and detachment

### DIFF
--- a/internal/cmds/volume/attach.go
+++ b/internal/cmds/volume/attach.go
@@ -6,8 +6,10 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -41,10 +43,19 @@ var lioModules = []string{"target_core_mod", "target_core_file", "tcm_loop"}
 // ErrNotAttached is returned by Detach when the volume has no backstore.
 var ErrNotAttached = errors.New("volume: not attached")
 
+// ErrInUse is returned by Detach when something still holds the volume's disk.
+var ErrInUse = errors.New("volume: in use")
+
+// DefaultSysRoot is the sysfs mount the attached disk is found through.
+const DefaultSysRoot = "/sys"
+
 // Attacher presents volume images to the node as SCSI disks.
 type Attacher struct {
 	// Root is the configfs mount; empty means DefaultConfigRoot.
 	Root string
+	// SysRoot is the sysfs mount; empty means DefaultSysRoot. Tests point it at
+	// a tree they build.
+	SysRoot string
 	// Run loads the kernel modules; nil uses execRunner. Tests set it so the
 	// configfs orchestration is exercised without root or a real LIO stack.
 	Run Runner
@@ -144,9 +155,20 @@ func (a Attacher) Attach(ctx context.Context, name, image string) (serial string
 // Detach unwinds what Attach built. It tolerates a partially-present tree so a
 // failed attach can always be cleaned up, and reports ErrNotAttached only when
 // there was no backstore to begin with.
+//
+// A disk something has opened is refused: the kernel unbinds it regardless, and
+// what held it is left mapping a device that no longer exists.
 func (a Attacher) Detach(ctx context.Context, name string) error {
 	if err := ValidVolumeName(name); err != nil {
 		return err
+	}
+	holders, err := a.holders(name)
+	if err != nil {
+		return err
+	}
+	if len(holders) > 0 {
+		return fmt.Errorf("%w: %q is held by %s; remove what is using it first",
+			ErrInUse, name, strings.Join(holders, ", "))
 	}
 	store := a.backstore(name)
 	_, statErr := os.Stat(store)
@@ -175,6 +197,49 @@ func (a Attacher) Detach(ctx context.Context, name string) error {
 	return nil
 }
 
+// holders names the kernel devices stacked on this volume's disk — volumed's
+// dm-crypt target is one.
+//
+// The disk is reached through the SCSI address LIO publishes for the target
+// attach built, rather than by scanning for the serial: the address names this
+// target's disk and no other, and a host is free to give a second disk the same
+// serial. A tree that was never built, or a disk the kernel has already dropped,
+// holds nothing.
+func (a Attacher) holders(name string) ([]string, error) {
+	addr, err := os.ReadFile(filepath.Join(a.tpgt(name), "address"))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("volume: read target address for %q: %w", name, err)
+	}
+
+	// address is the "host:channel:target" of the portal group; attach maps the
+	// image at lun_0, which completes the SCSI device's four-part name.
+	blockDir := filepath.Join(a.sysRoot(), "class", "scsi_device",
+		strings.TrimSpace(string(addr))+":0", "device", "block")
+	disks, err := os.ReadDir(blockDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("volume: list disks for %q: %w", name, err)
+	}
+
+	var held []string
+	for _, disk := range disks {
+		entries, err := os.ReadDir(filepath.Join(blockDir, disk.Name(), "holders"))
+		if err != nil {
+			// A disk with no holders directory holds nothing.
+			continue
+		}
+		for _, e := range entries {
+			held = append(held, e.Name())
+		}
+	}
+	return held, nil
+}
+
 func (a Attacher) rmGroup(path string) error {
 	if a.RemoveGroup != nil {
 		return a.RemoveGroup(path)
@@ -187,6 +252,13 @@ func (a Attacher) root() string {
 		return a.Root
 	}
 	return DefaultConfigRoot
+}
+
+func (a Attacher) sysRoot() string {
+	if a.SysRoot != "" {
+		return a.SysRoot
+	}
+	return DefaultSysRoot
 }
 
 func (a Attacher) targetRoot() string { return filepath.Join(a.root(), "target") }

--- a/internal/cmds/volume/attach_test.go
+++ b/internal/cmds/volume/attach_test.go
@@ -45,7 +45,29 @@ func testAttacher(t *testing.T) Attacher {
 	t.Helper()
 	// RemoveAll stands in for configfs freeing a group's attributes with its
 	// directory, which plain rmdir on a temp dir will not do.
-	return Attacher{Root: fakeConfigfs(t), Run: noopModprobe, RemoveGroup: os.RemoveAll}
+	return Attacher{Root: fakeConfigfs(t), SysRoot: t.TempDir(), Run: noopModprobe, RemoveGroup: os.RemoveAll}
+}
+
+// scsiAddress is the "host:channel:target" LIO publishes for a portal group.
+const scsiAddress = "2:0:1"
+
+// attachedDisk adds what the kernel publishes once a target carries a disk: the
+// portal group's SCSI address, and the disk that address resolves to, held by
+// the named devices.
+func attachedDisk(t *testing.T, a Attacher, name string, holders ...string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(a.tpgt(name), "address"), []byte(scsiAddress+"\n"), 0o644); err != nil {
+		t.Fatalf("write address: %v", err)
+	}
+	dir := filepath.Join(a.SysRoot, "class", "scsi_device", scsiAddress+":0", "device", "block", "sdb", "holders")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir holders: %v", err)
+	}
+	for _, h := range holders {
+		if err := os.Mkdir(filepath.Join(dir, h), 0o755); err != nil {
+			t.Fatalf("mkdir holder %s: %v", h, err)
+		}
+	}
 }
 
 func TestAttachBuildsTheBackstoreAndMapsIt(t *testing.T) {
@@ -222,6 +244,49 @@ func TestDetachRemovesTheBackstoreAndTarget(t *testing.T) {
 	target := filepath.Join(a.Root, "target", "loopback", loopbackWWN("weights"))
 	if _, err := os.Stat(target); !os.IsNotExist(err) {
 		t.Errorf("loopback target survived detach: %v", err)
+	}
+}
+
+// The kernel unbinds a disk that is still open, leaving whatever held it mapping
+// a device that no longer exists — volumed's dm-crypt target, in practice.
+func TestDetachRefusesADiskSomethingHolds(t *testing.T) {
+	a := testAttacher(t)
+	if _, err := a.Attach(context.Background(), "weights", imageFile(t, 1)); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	attachedDisk(t, a, "weights", "dm-1")
+
+	err := a.Detach(context.Background(), "weights")
+	if !errors.Is(err, ErrInUse) {
+		t.Fatalf("detach = %v, want ErrInUse", err)
+	}
+	if !strings.Contains(err.Error(), "dm-1") {
+		t.Errorf("detach = %v, want it to name the holder", err)
+	}
+	// Refusing has to leave the volume usable, not half torn down.
+	store := filepath.Join(a.Root, "target", "core", lioHBA, "weights")
+	if _, err := os.Stat(store); err != nil {
+		t.Errorf("refused detach removed the backstore: %v", err)
+	}
+	if _, err := os.Stat(a.tpgt("weights")); err != nil {
+		t.Errorf("refused detach removed the portal group: %v", err)
+	}
+}
+
+// A disk nothing has opened detaches.
+func TestDetachRemovesADiskNothingHolds(t *testing.T) {
+	a := testAttacher(t)
+	if _, err := a.Attach(context.Background(), "weights", imageFile(t, 1)); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	attachedDisk(t, a, "weights")
+
+	if err := a.Detach(context.Background(), "weights"); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+	store := filepath.Join(a.Root, "target", "core", lioHBA, "weights")
+	if _, err := os.Stat(store); !os.IsNotExist(err) {
+		t.Errorf("backstore survived detach: %v", err)
 	}
 }
 

--- a/internal/cmds/volumed/reaper.go
+++ b/internal/cmds/volumed/reaper.go
@@ -8,11 +8,15 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 // DefaultReapInterval is how often teardown checks which pods are gone.
 const DefaultReapInterval = 15 * time.Second
+
+// DefaultConfirmGone is how many consecutive sweeps must agree a pod is gone.
+const DefaultConfirmGone = 2
 
 // DefaultCgroupRoot is where the unified cgroup hierarchy is mounted.
 const DefaultCgroupRoot = "/sys/fs/cgroup"
@@ -26,18 +30,31 @@ type PodLiveness interface {
 
 // Reaper tears down volumes whose pod has gone away.
 //
-// The signal is the pod's cgroup disappearing, not its kubelet directory.
-// kubelet removes that directory when it tears a pod down — but with a volume
-// still mounted under it that removal fails with EBUSY, so waiting for the
-// directory to vanish waits for something this daemon is itself preventing.
-// kubelet retries volume cleanup with backoff, so unmounting shortly after the
-// cgroup goes costs a few "orphaned pod" log lines rather than a stuck pod.
+// The signal is the pod's cgroup emptying of processes, which the runtime does
+// as it removes the last container. Neither the pod's kubelet directory nor its
+// cgroup itself can serve: kubelet removes the directory only once the pod's
+// volumes are cleaned up, and this daemon's mount is what that cleanup blocks
+// on, so both outlive the pod for exactly as long as the reaper waits for them.
+// kubelet retries volume cleanup with backoff, so unmounting once the processes
+// go costs a few "orphaned pod" log lines rather than a stuck pod.
+//
+// Emptiness must hold for ConfirmGone consecutive sweeps. A volume torn down
+// under a live pod does not come back — the sidecar opens once and then idles
+// for the pod's life — so a pod whose containers are momentarily all restarting
+// must not read as gone.
 type Reaper struct {
 	Opener   *Opener
 	Liveness PodLiveness
 	// Interval between sweeps; zero means DefaultReapInterval.
 	Interval time.Duration
-	Logger   *slog.Logger
+	// ConfirmGone is how many consecutive sweeps must find a pod gone before its
+	// volumes go; zero means DefaultConfirmGone.
+	ConfirmGone int
+	Logger      *slog.Logger
+
+	// gone counts consecutive sweeps that found each pod gone. Confined to
+	// Sweep, which only Run calls, so it carries no lock.
+	gone map[string]int
 }
 
 func (r *Reaper) logger() *slog.Logger {
@@ -52,6 +69,13 @@ func (r *Reaper) interval() time.Duration {
 		return r.Interval
 	}
 	return DefaultReapInterval
+}
+
+func (r *Reaper) confirmGone() int {
+	if r.ConfirmGone > 0 {
+		return r.ConfirmGone
+	}
+	return DefaultConfirmGone
 }
 
 // Run sweeps until ctx is done.
@@ -80,14 +104,24 @@ func (r *Reaper) Sweep(ctx context.Context) int {
 		return 0
 	}
 	var closed int
+	// Rebuilt from this sweep alone, so a pod that came back — or one torn down
+	// here — leaves no count behind.
+	seen := map[string]int{}
 	for _, pod := range r.Opener.Pods() {
 		live, err := r.Liveness.Live(pod)
 		if err != nil {
 			r.logger().Warn("pod liveness unknown; leaving its volumes open",
 				"pod", pod.UID, "error", err)
+			// The question went unanswered, so carry the count rather than
+			// letting an unreadable sweep either confirm or forget.
+			seen[pod.UID] = r.gone[pod.UID]
 			continue
 		}
 		if live {
+			continue
+		}
+		if n := r.gone[pod.UID] + 1; n < r.confirmGone() {
+			seen[pod.UID] = n
 			continue
 		}
 		if n := r.Opener.ClosePod(ctx, pod.UID); n > 0 {
@@ -95,26 +129,28 @@ func (r *Reaper) Sweep(ctx context.Context) int {
 			r.logger().Info("pod gone; volumes torn down", "pod", pod.UID, "volumes", n)
 		}
 	}
+	r.gone = seen
 	return closed
 }
 
 // CgroupLiveness answers from the cgroup tree, where the runtime removes a
-// pod's slice once its last container is gone.
+// container's cgroup as the container goes.
 type CgroupLiveness struct {
 	// Root is the cgroup mount; zero means DefaultCgroupRoot.
 	Root string
 }
 
-// Live treats a missing pod cgroup as gone. Any other stat failure is an error,
-// so Sweep leaves the volume alone rather than acting on a lookup that did not
-// happen.
+// Live treats a missing or unpopulated pod cgroup as gone. Any other failure is
+// an error, so Sweep leaves the volume alone rather than acting on a lookup that
+// did not happen.
 func (l CgroupLiveness) Live(pod PodCgroup) (bool, error) {
 	if pod.Path == "" {
 		return false, fmt.Errorf("volumed: pod %s has no cgroup path", pod.UID)
 	}
-	switch _, err := os.Stat(filepath.Join(l.root(), pod.Path)); {
+	dir := filepath.Join(l.root(), pod.Path)
+	switch _, err := os.Stat(dir); {
 	case err == nil:
-		return true, nil
+		return populated(dir)
 	case errors.Is(err, fs.ErrNotExist):
 		// An unmounted cgroup root reads as every pod having exited, which
 		// would tear down every live volume on the node. Confirm the tree is
@@ -126,6 +162,29 @@ func (l CgroupLiveness) Live(pod PodCgroup) (bool, error) {
 	default:
 		return false, fmt.Errorf("volumed: stat pod cgroup: %w", err)
 	}
+}
+
+// populated reports whether any process remains anywhere beneath a cgroup.
+//
+// cgroup.events carries the kernel's own answer over the whole subtree, which is
+// what a pod slice needs: its processes live in the per-container cgroups below
+// it, never in the slice itself. A hierarchy that does not publish the file —
+// cgroup v1 — offers nothing better than the slice being there.
+func populated(dir string) (bool, error) {
+	events := filepath.Join(dir, "cgroup.events")
+	b, err := os.ReadFile(events)
+	if errors.Is(err, fs.ErrNotExist) {
+		return true, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("volumed: read %s: %w", events, err)
+	}
+	for line := range strings.SplitSeq(string(b), "\n") {
+		if key, value, ok := strings.Cut(strings.TrimSpace(line), " "); ok && key == "populated" {
+			return value != "0", nil
+		}
+	}
+	return false, fmt.Errorf("volumed: %s has no populated field", events)
 }
 
 func (l CgroupLiveness) root() string {

--- a/internal/cmds/volumed/reaper_test.go
+++ b/internal/cmds/volumed/reaper_test.go
@@ -22,6 +22,20 @@ func (l livenessFor) Live(pod PodCgroup) (bool, error) {
 	return l.live[pod.UID], nil
 }
 
+// togglingLiveness answers whatever it is currently set to, so a test can move a
+// pod between sweeps.
+type togglingLiveness struct {
+	live bool
+	err  error
+}
+
+func (l *togglingLiveness) Live(PodCgroup) (bool, error) {
+	if l.err != nil {
+		return false, l.err
+	}
+	return l.live, nil
+}
+
 // openerWithVolumes opens one volume per name for testPodUID.
 func openerWithVolumes(t *testing.T, ops *fakeOps, names ...string) *Opener {
 	t.Helper()
@@ -46,7 +60,7 @@ func TestSweepTearsDownAGonePod(t *testing.T) {
 	ops := newOps()
 	o := openerWithVolumes(t, ops, "weights", "datasets")
 
-	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{}}}
+	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{}}, ConfirmGone: 1}
 	if got := r.Sweep(t.Context()); got != 2 {
 		t.Fatalf("swept %d volumes, want 2", got)
 	}
@@ -110,7 +124,7 @@ func TestSweepIsPerPod(t *testing.T) {
 		}
 	}
 
-	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{other: true}}}
+	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{other: true}}, ConfirmGone: 1}
 	if got := r.Sweep(t.Context()); got != 1 {
 		t.Fatalf("swept %d volumes, want 1", got)
 	}
@@ -122,13 +136,70 @@ func TestSweepIsPerPod(t *testing.T) {
 func TestSweepIsIdempotent(t *testing.T) {
 	ops := newOps()
 	o := openerWithVolumes(t, ops, "weights")
-	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{}}}
+	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{}}, ConfirmGone: 1}
 
 	if got := r.Sweep(t.Context()); got != 1 {
 		t.Fatalf("first sweep closed %d", got)
 	}
 	if got := r.Sweep(t.Context()); got != 0 {
 		t.Fatalf("second sweep closed %d, want 0", got)
+	}
+}
+
+// A volume torn down under a live pod never comes back, so one sweep finding
+// the cgroup empty is not enough to act on.
+func TestSweepConfirmsGoneBeforeTearingDown(t *testing.T) {
+	ops := newOps()
+	o := openerWithVolumes(t, ops, "weights")
+	r := &Reaper{Opener: o, Liveness: livenessFor{live: map[string]bool{}}}
+
+	if got := r.Sweep(t.Context()); got != 0 {
+		t.Fatalf("first sweep closed %d, want 0 pending confirmation", got)
+	}
+	if o.Len() != 1 {
+		t.Fatal("an unconfirmed sweep tore down a volume")
+	}
+	if got := r.Sweep(t.Context()); got != 1 {
+		t.Fatalf("confirming sweep closed %d, want 1", got)
+	}
+}
+
+// A pod that is empty for one sweep and populated the next is mid-restart, not
+// gone, and the count it accrued must not carry.
+func TestSweepForgetsAPodThatComesBack(t *testing.T) {
+	ops := newOps()
+	o := openerWithVolumes(t, ops, "weights")
+	liveness := &togglingLiveness{}
+	r := &Reaper{Opener: o, Liveness: liveness}
+
+	r.Sweep(t.Context()) // gone once
+	liveness.live = true
+	r.Sweep(t.Context()) // back
+	liveness.live = false
+	if got := r.Sweep(t.Context()); got != 0 {
+		t.Fatalf("sweep closed %d after the pod came back; the count was carried", got)
+	}
+	if o.Len() != 1 {
+		t.Fatal("a pod that came back lost its volume")
+	}
+}
+
+// An unanswered lookup neither confirms nor forgets, so the sweep after it still
+// needs its own confirmation.
+func TestSweepCarriesTheCountAcrossAnUnansweredLookup(t *testing.T) {
+	ops := newOps()
+	o := openerWithVolumes(t, ops, "weights")
+	liveness := &togglingLiveness{}
+	r := &Reaper{Opener: o, Liveness: liveness}
+
+	r.Sweep(t.Context()) // gone once
+	liveness.err = errors.New("cgroup root unreadable")
+	if got := r.Sweep(t.Context()); got != 0 {
+		t.Fatalf("sweep closed %d on an unanswered lookup", got)
+	}
+	liveness.err = nil
+	if got := r.Sweep(t.Context()); got != 1 {
+		t.Fatalf("sweep closed %d, want the carried count to confirm", got)
 	}
 }
 
@@ -237,6 +308,56 @@ func TestCgroupLivenessRefusesAnAbsentRoot(t *testing.T) {
 	}
 }
 
+// The slice outlives the pod — kubelet holds it until the volumes this daemon
+// has mounted are cleaned up — so an empty one is the pod being gone.
+func TestCgroupLivenessReadsPopulation(t *testing.T) {
+	root := t.TempDir()
+	pod := testPod(testPodUID)
+	slice := filepath.Join(root, pod.Path)
+	if err := os.MkdirAll(slice, 0o755); err != nil {
+		t.Fatalf("mkdir pod slice: %v", err)
+	}
+	events := filepath.Join(slice, "cgroup.events")
+
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"populated", "populated 1\nfrozen 0\n", true},
+		{"empty", "populated 0\nfrozen 0\n", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(events, []byte(tc.content), 0o644); err != nil {
+				t.Fatalf("write cgroup.events: %v", err)
+			}
+			got, err := (CgroupLiveness{Root: root}).Live(pod)
+			if err != nil {
+				t.Fatalf("live: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("live = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A cgroup.events with no populated field answers nothing, so the volume stays.
+func TestCgroupLivenessRefusesEventsWithoutPopulation(t *testing.T) {
+	root := t.TempDir()
+	pod := testPod(testPodUID)
+	slice := filepath.Join(root, pod.Path)
+	if err := os.MkdirAll(slice, 0o755); err != nil {
+		t.Fatalf("mkdir pod slice: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(slice, "cgroup.events"), []byte("frozen 0\n"), 0o644); err != nil {
+		t.Fatalf("write cgroup.events: %v", err)
+	}
+	if _, err := (CgroupLiveness{Root: root}).Live(pod); err == nil {
+		t.Fatal("a cgroup.events with no populated field judged the pod")
+	}
+}
+
 func TestCgroupLivenessDefaultsItsRoot(t *testing.T) {
 	if got := (CgroupLiveness{}).root(); got != DefaultCgroupRoot {
 		t.Fatalf("root = %q, want %q", got, DefaultCgroupRoot)
@@ -248,6 +369,9 @@ func TestCgroupLivenessDefaultsItsRoot(t *testing.T) {
 func TestZeroValuesFallBackToDefaults(t *testing.T) {
 	if got := (&Reaper{}).interval(); got != DefaultReapInterval {
 		t.Errorf("interval = %v, want %v", got, DefaultReapInterval)
+	}
+	if got := (&Reaper{}).confirmGone(); got != DefaultConfirmGone {
+		t.Errorf("confirmGone = %v, want %v", got, DefaultConfirmGone)
 	}
 	if (&Reaper{}).logger() == nil {
 		t.Error("reaper has no logger")


### PR DESCRIPTION
1. Reaper deadlock (internal/cmds/volumed/reaper.go) Liveness now reads cgroup.events and treats populated 0 as gone. The runtime removes per-container cgroups as containers exit, and that isn't downstream of volumed's mount — whereas the kubelet pod dir and the pod slice both are, which is why watching either was waiting on itself.

Measured on the leaked state before I touched anything — exactly what the old code called live:
slice exists      : YES
cgroup.events     : populated 0 frozen 0
dm devices open   : 2
volume still mounted: 1
Added ConfirmGone (default 2 consecutive sweeps). That's load-bearing, not belt-and-braces: the sidecar opens once then idles for the pod's life (getvolume/run.go:123-127), so
a volume torn down under a live pod never comes back. An unanswered lookup carries the count rather than confirming or resetting.

2. Detach guard (internal/cmds/volume/attach.go) Resolves the disk via the SCSI address LIO publishes for the target attach built (<tpgt>/address → /sys/class/scsi_device/<addr>:0/device/block/<disk>) and refuses when it has holders. Reached that way rather than by scanning serials — the address names this target's disk, while a host can give a second disk the same serial.

Verification — repo-wide go test, go vet, and go test -race pass. On the cluster with the fixed binary:
- Detach with the volume open: volume: in use: "msg" is held by dm-1 (exit 1), disk and pod mount intact; detaches fine once free.
- Reaper end-to-end: stood the chart's volumed down and ran the fixed binary on the same host socket, so the injected sidecar reached it unchanged. 10:36:40 volume opened → 10:37:51 pod gone; volumes torn down. ~50s after deletion vs. leaking indefinitely. kubelet then finished the teardown it had been blocked on — pod object, cgroup slice, and kubelet pod dir all reclaimed, so the cycle is broken from both ends.