### PR TITLE
fix(nri): read the image reference from the container's own annotation

### DIFF
--- a/internal/cmds/nri-image-policy/coverage_test.go
+++ b/internal/cmds/nri-image-policy/coverage_test.go
@@ -245,11 +245,12 @@ func TestCreateContainer_DigestInAllowlist_Allows(t *testing.T) {
 	}
 }
 
-func TestCreateContainer_ImageFromPodAnnotation(t *testing.T) {
-	// Container has no image annotation; falls back to the pod annotation.
+// The pod annotation names the sandbox image, not this container's, so a
+// container without its own annotation has no reference to check.
+func TestCreateContainer_PodAnnotationDoesNotSupplyImage(t *testing.T) {
 	p, _ := newCachedPlugin(&config{
 		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
-		Policy:    policyConfig{Mode: ModeFailClosed},
+		Policy:    policyConfig{Mode: ModeFailClosed, DenyMissingAnnotation: true},
 	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
 	p.SetReady()
 
@@ -258,8 +259,8 @@ func TestCreateContainer_ImageFromPodAnnotation(t *testing.T) {
 	ctr := makeCtr(pod.Id, "myctr") // no annotations
 
 	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
-	if err != nil {
-		t.Fatalf("expected pod-annotation fallback to resolve allowlisted digest, got: %v", err)
+	if err == nil {
+		t.Fatal("expected denial: the container carries no image annotation")
 	}
 }
 

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -586,12 +586,7 @@ func (p *plugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *
 
 	// Image allowlist check (only when configured)
 	if cfg.AllowlistEnabled() {
-		annotations := ctr.GetAnnotations()
-		imageRef := annotations[annotationImageName]
-		if imageRef == "" {
-			podAnnotations := pod.GetAnnotations()
-			imageRef = podAnnotations[annotationImageName]
-		}
+		imageRef := ctr.GetAnnotations()[annotationImageName]
 
 		// Effective argv (ctr.Args): NRI folds the OCI process.args here, so the
 		// full merged entrypoint+cmd the container runs is available at this hook.


### PR DESCRIPTION
CreateContainer fell back to the pod sandbox's io.kubernetes.cri.image-name when the container's own annotation was absent, then ran the allowlist check against it. The pod-level annotation names the sandbox image, and both fields are pod-controlled, so a container with its annotation stripped was admitted on a reference describing something else.

checkExisting already reads only the container's annotation. The two paths now agree, and an absent annotation falls through to deny_missing_annotation (default true).