### PR TITLE
fix(kata): admit only CRI-shaped container ids, keep killing a denied container until it is dead

### DIFF
--- a/internal/cmds/policymonitor/containerid_test.go
+++ b/internal/cmds/policymonitor/containerid_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPathLooksLikeContainer(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	for _, tc := range []struct {
+		path string
+		want bool
+	}{
+		{filepath.Join(watchDir, testCID("child")), true},
+		{filepath.Join(watchDir, "aa_1.b"), false},                            // not a 64-hex id
+		{filepath.Join(watchDir, "init"), false},                              // a systemd unit cgroup name
+		{filepath.Join(watchDir, "shared"), false},                            // kata's own dir, never a container
+		{filepath.Join(watchDir, "deep", "nested", testCID("nested")), false}, // not a direct child
+		{filepath.Join(watchDir, ""), false},                                  // empty
+		{watchDir, false},                                                     // the watch dir itself
+	} {
+		got := m.pathLooksLikeContainer(tc.path)
+		if got != tc.want {
+			t.Errorf("pathLooksLikeContainer(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/cmds/policymonitor/coverage_test.go
+++ b/internal/cmds/policymonitor/coverage_test.go
@@ -236,52 +236,6 @@ func TestRunAllowlistRefresh_EmptyMeasurementsFailsClosed(t *testing.T) {
 	}
 }
 
-// --- monitor.kill paths ---------------------------------------------------
-// captureLogs lives in refreshstate_test.go.
-
-func TestMonitorKill_KillerError(t *testing.T) {
-	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	killer.err = os.ErrPermission
-	buf := captureLogs(m)
-	m.kill("somecid")
-	if calls := killer.snapshot(); len(calls) != 1 {
-		t.Fatalf("expected one cgroup kill attempt, got %+v", calls)
-	}
-	// A denied container that survives its kill is a total bypass of the image
-	// policy, not a warning-grade hiccup.
-	if !strings.Contains(buf.String(), `"level":"ERROR"`) {
-		t.Errorf("failed kill logged at %s, want ERROR", buf.String())
-	}
-}
-
-func TestMonitorKill_CgroupNotFound(t *testing.T) {
-	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	killer.ok = false
-	buf := captureLogs(m)
-	m.kill("somecid")
-	if calls := killer.snapshot(); len(calls) != 1 {
-		t.Fatalf("expected one cgroup lookup, got %+v", calls)
-	}
-	// "denied but never confirmed dead" is the same bypass — the cgroup that
-	// never materialised is indistinguishable from one we simply failed to find.
-	if !strings.Contains(buf.String(), `"level":"ERROR"`) {
-		t.Errorf("unconfirmed kill logged at %s, want ERROR", buf.String())
-	}
-}
-
-func TestMonitorKill_SuccessStaysInfo(t *testing.T) {
-	m, killer, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	killer.ok = true
-	buf := captureLogs(m)
-	m.kill("somecid")
-	if strings.Contains(buf.String(), `"level":"ERROR"`) {
-		t.Errorf("confirmed kill logged at ERROR: %s", buf.String())
-	}
-	if !strings.Contains(buf.String(), `"level":"INFO"`) {
-		t.Errorf("confirmed kill logged at %s, want INFO", buf.String())
-	}
-}
-
 // --- seedExisting ---------------------------------------------------------
 
 func TestSeedExisting_DeniesPreexistingContainer(t *testing.T) {
@@ -290,7 +244,7 @@ func TestSeedExisting_DeniesPreexistingContainer(t *testing.T) {
 
 	// A container directory already present when the monitor starts (e.g.
 	// systemd restarted policy-monitor while a workload was live).
-	writeConfigJSON(t, watchDir, "preexisting", map[string]string{
+	writeConfigJSON(t, watchDir, testCID("preexisting"), map[string]string{
 		"io.kubernetes.cri.image-name": "ghcr.io/evil@sha256:" + denied,
 	})
 	// A sibling artifact that is not a container id should be skipped.
@@ -327,7 +281,7 @@ func TestReadConfigJSON_BundleGoneGivesUp(t *testing.T) {
 	m.configReadDeadline = 20 * time.Millisecond
 	m.configReadInterval = 5 * time.Millisecond
 	m.configPendingInterval = 5 * time.Millisecond
-	_, err := m.readConfigJSON(context.Background(), filepath.Join(watchDir, "nope"))
+	_, err := m.readConfigJSON(context.Background(), filepath.Join(watchDir, testCID("nope")))
 	if err == nil {
 		t.Fatal("expected error when the bundle directory does not exist")
 	}
@@ -341,13 +295,14 @@ func TestReadConfigJSON_WaitsOutASlowPull(t *testing.T) {
 	m.configReadInterval = 5 * time.Millisecond
 	m.configPendingInterval = 5 * time.Millisecond
 
-	dir := filepath.Join(watchDir, "slowpull")
+	slowPullCID := testCID("slowpull")
+	dir := filepath.Join(watchDir, slowPullCID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	go func() {
 		time.Sleep(150 * time.Millisecond)
-		writeConfigJSON(t, watchDir, "slowpull", map[string]string{
+		writeConfigJSON(t, watchDir, slowPullCID, map[string]string{
 			"io.kubernetes.cri.image-name": "ghcr.io/x@sha256:" + strings.Repeat("a", 64),
 		})
 	}()
@@ -365,7 +320,7 @@ func TestReadConfigJSON_ContextCancelled(t *testing.T) {
 	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	m.configReadDeadline = 5 * time.Second
 	m.configReadInterval = 10 * time.Millisecond
-	dir := filepath.Join(watchDir, "pending")
+	dir := filepath.Join(watchDir, testCID("pending"))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +336,7 @@ func TestReadConfigJSON_UnrecoverableIsADir(t *testing.T) {
 	// Point at a directory: os.ReadFile returns a non-ENOENT, non-partial
 	// error, which readConfigJSON must surface immediately rather than
 	// waiting for the bundle to go away.
-	dir := filepath.Join(watchDir, "isadir")
+	dir := filepath.Join(watchDir, testCID("isadir"))
 	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -403,7 +358,7 @@ func TestReadConfigJSON_DanglingSymlinkIsUnrecoverable(t *testing.T) {
 	m.configReadDeadline = 20 * time.Millisecond
 	m.configReadInterval = 5 * time.Millisecond
 	m.configPendingInterval = 5 * time.Millisecond
-	dir := filepath.Join(watchDir, "dangling")
+	dir := filepath.Join(watchDir, testCID("dangling"))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -453,13 +408,14 @@ func TestHandleNewContainer_SlowPullStillDenies(t *testing.T) {
 	m.configReadInterval = 5 * time.Millisecond
 	m.configPendingInterval = 5 * time.Millisecond
 
-	dir := filepath.Join(watchDir, "slowpull")
+	slowPullCID := testCID("slowpull")
+	dir := filepath.Join(watchDir, slowPullCID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	go func() {
 		time.Sleep(120 * time.Millisecond)
-		writeConfigJSON(t, watchDir, "slowpull", map[string]string{
+		writeConfigJSON(t, watchDir, slowPullCID, map[string]string{
 			"io.kubernetes.cri.image-name": "ghcr.io/evil@sha256:" + denied,
 		})
 	}()
@@ -478,7 +434,7 @@ func TestHandleNewContainer_BundleRemovedNoKill(t *testing.T) {
 	m.configReadInterval = 5 * time.Millisecond
 	m.configPendingInterval = 5 * time.Millisecond
 
-	dir := filepath.Join(watchDir, "ghost")
+	dir := filepath.Join(watchDir, testCID("ghost"))
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -497,10 +453,11 @@ func TestHandleNewContainer_BundleRemovedNoKill(t *testing.T) {
 // no digest to check against the allowlist.
 func TestHandleNewContainer_TagFormReferenceDenied(t *testing.T) {
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
-	writeConfigJSON(t, watchDir, "tagged", map[string]string{
+	taggedCID := testCID("tagged")
+	writeConfigJSON(t, watchDir, taggedCID, map[string]string{
 		"io.kubernetes.cri.image-name": "nginx:1.27-alpine",
 	})
-	m.handleNewContainer(context.Background(), filepath.Join(watchDir, "tagged"))
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, taggedCID))
 	if calls := killer.snapshot(); len(calls) != 1 {
 		t.Fatalf("expected a kill for a tag-form image reference, got %+v", calls)
 	}
@@ -511,11 +468,12 @@ func TestHandleNewContainer_TagFormReferenceDenied(t *testing.T) {
 func TestHandleNewContainer_AllowlistedImageIDDoesNotAdmit(t *testing.T) {
 	allowed := strings.Repeat("a", 64)
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
-	writeConfigJSON(t, watchDir, "spoofed", map[string]string{
+	spoofedCID := testCID("spoofed")
+	writeConfigJSON(t, watchDir, spoofedCID, map[string]string{
 		"io.kubernetes.cri.image-name": "attacker.example/evil:latest",
 		"io.kubernetes.cri.image-id":   "sha256:" + allowed,
 	})
-	m.handleNewContainer(context.Background(), filepath.Join(watchDir, "spoofed"))
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, spoofedCID))
 	if calls := killer.snapshot(); len(calls) != 1 {
 		t.Fatalf("expected a kill: the allowlisted digest is not the reference the guest pulls, got %+v", calls)
 	}
@@ -676,7 +634,7 @@ func TestMonitorRun_AllowedContainerNotKilled(t *testing.T) {
 	go func() { done <- m.run(ctx) }()
 	time.Sleep(50 * time.Millisecond)
 
-	writeConfigJSON(t, watchDir, "allowed-live", map[string]string{
+	writeConfigJSON(t, watchDir, testCID("allowed-live"), map[string]string{
 		"io.kubernetes.cri.image-name": "ghcr.io/ok@sha256:" + digest,
 	})
 	time.Sleep(200 * time.Millisecond)

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -21,8 +21,8 @@ const (
 func TestKataInventoryIncludesInjectedSidecars(t *testing.T) {
 	b := newAdmissionInventory()
 	b.recordSandboxID(pmSandboxID)
-	b.record("cid-app", pmDigestApp, nil)
-	b.record("cid-cert", pmDigestSidecar, nil)
+	b.record(testCID("app"), pmDigestApp, nil)
+	b.record(testCID("cert"), pmDigestSidecar, nil)
 
 	digests, _, known, err := b.DigestsForSandbox(pmSandboxID)
 	if err != nil || !known {
@@ -80,10 +80,10 @@ func TestSandboxIDFromAnnotations(t *testing.T) {
 func TestKataInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 	b := newAdmissionInventory()
 	b.recordSandboxID(pmSandboxID)
-	b.record("cid-app", pmDigestApp, nil)
-	b.record("cid-gone", pmDigestSidecar, nil)
+	b.record(testCID("app"), pmDigestApp, nil)
+	b.record(testCID("gone"), pmDigestSidecar, nil)
 
-	b.remove("cid-gone")
+	b.remove(testCID("gone"))
 
 	digests, _, known, err := b.DigestsForSandbox(pmSandboxID)
 	if err != nil || !known {

--- a/internal/cmds/policymonitor/kill.go
+++ b/internal/cmds/policymonitor/kill.go
@@ -28,11 +28,9 @@ package policymonitor
 //                     or crio-<cid>.scope (CRI-O), nested under the pod's
 //                     kubepods*.slice — this is what a systemd-PID-1 kata
 //                     guest actually uses, so it is the common case in the
-//                     field. Matching only the bare <cid> basename here was a
-//                     silent enforcement hole: policy-monitor denied a
-//                     non-allowlisted container but then could not find its
-//                     cgroup, so the SIGKILL never landed and the container
-//                     ran. cgroupDirMatchesCID recognises both shapes.
+//                     field.
+//
+// cgroupDirMatchesCID recognises both shapes.
 
 import (
 	"errors"
@@ -212,18 +210,11 @@ func writeCgroupKill(dir string) error {
 	return closeErr
 }
 
-// findCgroupDir walks root looking for a directory that identifies
-// containerID (see cgroupDirMatchesCID for the naming schemes). Returns
-// the first match (depth-first) or an empty string. We don't bother with
-// finer disambiguation — the kata container id is a 64-hex-char SHA-256
-// (or similar high-entropy string) and collisions in the cgroup tree are
-// not credible.
-//
-// Implementation note: we use filepath.WalkDir rather than recursing
-// manually because the cgroup v2 hierarchy can be arbitrarily deep
-// when nested inside systemd slices (e.g. /sys/fs/cgroup/
-// system.slice/kata-shim-<sandbox>.scope/<cid>/), and WalkDir handles
-// the symlink and permission edge cases consistently.
+// findCgroupDir walks root looking for the directory that identifies
+// containerID (see cgroupDirMatchesCID for the naming schemes) and returns it,
+// or an empty string when there is none. The walk is a full-tree WalkDir: the
+// hierarchy is arbitrarily deep once containers are nested inside systemd
+// slices (/sys/fs/cgroup/system.slice/kata-shim-<sandbox>.scope/<cid>/).
 func findCgroupDir(root, containerID string) (string, error) {
 	if containerID == "" {
 		return "", errors.New("empty container id")
@@ -231,17 +222,9 @@ func findCgroupDir(root, containerID string) (string, error) {
 	var matches []string
 	walkErr := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			// Permission-denied on a sibling slice (an unreadable systemd
-			// slice we don't own) is expected during a full-tree walk and
-			// must not stop the search — skip it and keep going. Worst
-			// case we miss the cgroup and the kill is a no-op, which is
-			// fine for a denied container (kata-agent reaps it when
-			// CreateContainer returns). But do NOT swallow *every* error:
-			// anything else (an I/O error, a broken/zombie cgroup) is a
-			// real signal, so propagate it. cgroupKiller returns it as
-			// "walk cgroup hierarchy: ..." and the monitor logs it at
-			// Warn — rather than silently continuing and reporting a
-			// misleading no-op kill for a container we never searched.
+			// A sibling slice we may not read is expected on a full-tree
+			// walk; anything else (I/O error, broken cgroup) means the
+			// search was incomplete and propagates to the caller.
 			if errors.Is(err, os.ErrPermission) {
 				return nil
 			}
@@ -264,12 +247,8 @@ func findCgroupDir(root, containerID string) (string, error) {
 	case 1:
 		return matches[0], nil
 	default:
-		// Ambiguity: more than one cgroup matches this id. The previous code
-		// returned the first depth-first match, so a container id that also
-		// matched an unrelated cgroup could redirect the SIGKILL onto that
-		// unrelated cgroup (H-02). A running denied container owns exactly one
-		// cgroup, so any collision shows up as a second match here; refuse to
-		// guess rather than terminate the wrong one.
+		// A running container owns exactly one cgroup, so a second match is a
+		// collision; refuse to guess rather than terminate the wrong one.
 		return "", fmt.Errorf("ambiguous container id %q matches %d cgroups: %v", containerID, len(matches), matches)
 	}
 }
@@ -280,11 +259,8 @@ func findCgroupDir(root, containerID string) (string, error) {
 //   - systemd scope:            cri-containerd-<cid>.scope, crio-<cid>.scope,
 //     or <cid>.scope
 //
-// Only these exact shapes count. The earlier form accepted any basename ending
-// in "-<cid>", so an unrelated cgroup whose name merely ended that way matched —
-// letting a short or adversarially chosen id redirect the kill onto an
-// unrelated scope (H-02). Enumerate the vendor prefixes kata-agent actually
-// emits instead of accepting an arbitrary one.
+// These exact shapes are the whole set — the vendor prefix is enumerated, not
+// accepted as an arbitrary "<anything>-<cid>".
 func cgroupDirMatchesCID(basename, containerID string) bool {
 	name := strings.TrimSuffix(basename, ".scope")
 	return name == containerID ||

--- a/internal/cmds/policymonitor/kill_test.go
+++ b/internal/cmds/policymonitor/kill_test.go
@@ -49,7 +49,7 @@ func (k *fakeKiller) snapshot() []string {
 
 func TestFindCgroupDir_FoundAtRoot(t *testing.T) {
 	root := t.TempDir()
-	cid := "abc123"
+	cid := testCID("found-at-root")
 	if err := os.MkdirAll(filepath.Join(root, cid), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +67,7 @@ func TestFindCgroupDir_FoundAtRoot(t *testing.T) {
 
 func TestFindCgroupDir_NestedUnderSlice(t *testing.T) {
 	root := t.TempDir()
-	cid := "deadbeef"
+	cid := testCID("nested-under-slice")
 	nested := filepath.Join(root, "system.slice", "kata-shim-foo.scope", cid)
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatal(err)
@@ -153,7 +153,7 @@ func TestFindCgroupDir_AmbiguousMatchRejected(t *testing.T) {
 
 func TestFindCgroupDir_NotFound(t *testing.T) {
 	root := t.TempDir()
-	got, err := findCgroupDir(root, "missing")
+	got, err := findCgroupDir(root, testCID("missing"))
 	if err != nil {
 		t.Fatalf("findCgroupDir: %v", err)
 	}
@@ -164,7 +164,7 @@ func TestFindCgroupDir_NotFound(t *testing.T) {
 
 func TestCgroupKiller_WaitsForCgroupToAppear(t *testing.T) {
 	root := t.TempDir()
-	cid := "feedface"
+	cid := testCID("waits-for-cgroup")
 	killer := &cgroupKiller{
 		cgroupRoot:   root,
 		waitTimeout:  500 * time.Millisecond,
@@ -233,7 +233,7 @@ func TestCgroupKiller_WaitsForProcsToPopulateAndKillsGroup(t *testing.T) {
 // harmless no-op rather than blocking or erroring.
 func TestCgroupKiller_EmptyProcsTimesOut(t *testing.T) {
 	root := t.TempDir()
-	cid := "cafef00d"
+	cid := testCID("empty-procs")
 	scope := filepath.Join(root, "cri-containerd-"+cid+".scope")
 	if err := os.MkdirAll(scope, 0o755); err != nil {
 		t.Fatal(err)
@@ -265,7 +265,7 @@ func TestCgroupKiller_Timeout(t *testing.T) {
 		waitTimeout:  50 * time.Millisecond,
 		pollInterval: 20 * time.Millisecond,
 	}
-	ok, err := killer.kill("never-appears")
+	ok, err := killer.kill(testCID("never-appears"))
 	if err != nil {
 		t.Fatalf("kill: %v", err)
 	}
@@ -276,7 +276,7 @@ func TestCgroupKiller_Timeout(t *testing.T) {
 
 func TestCgroupKiller_PropagatesMalformedProcs(t *testing.T) {
 	root := t.TempDir()
-	cid := "malformed"
+	cid := testCID("malformed-procs")
 	dir := filepath.Join(root, cid)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
@@ -476,7 +476,7 @@ func TestOwnCgroupPath(t *testing.T) {
 
 func TestCgroupKiller_PropagatesMissingKillInterface(t *testing.T) {
 	root := t.TempDir()
-	cid := "missing-kill"
+	cid := testCID("missing-kill-interface")
 	dir := filepath.Join(root, cid)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/cmds/policymonitor/killretry_test.go
+++ b/internal/cmds/policymonitor/killretry_test.go
@@ -1,0 +1,165 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// scriptedKiller answers attempt n from answer(n) and counts the attempts.
+type scriptedKiller struct {
+	mu       sync.Mutex
+	attempts int
+	answer   func(attempt int) (bool, error)
+}
+
+func (k *scriptedKiller) kill(string) (bool, error) {
+	k.mu.Lock()
+	k.attempts++
+	n := k.attempts
+	k.mu.Unlock()
+	return k.answer(n)
+}
+
+func (k *scriptedKiller) selfTest() error { return nil }
+
+func (k *scriptedKiller) count() int {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.attempts
+}
+
+// newRetryMonitor wires a monitor whose killer follows answer, and returns the
+// denied container's bundle directory alongside it.
+func newRetryMonitor(t *testing.T, answer func(attempt int) (bool, error)) (*monitor, *scriptedKiller, string) {
+	t.Helper()
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	killer := &scriptedKiller{answer: answer}
+	m.killer = killer
+	dir := filepath.Join(watchDir, testCID("denied"))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return m, killer, dir
+}
+
+func countLevel(logs, level string) int {
+	return strings.Count(logs, `"level":"`+level+`"`)
+}
+
+// The cgroup can materialise after the killer's own poll window closes — a slow
+// init, or one that forks later. The deny must survive that.
+func TestMonitorKill_LandsOnALaterAttempt(t *testing.T) {
+	m, killer, dir := newRetryMonitor(t, func(attempt int) (bool, error) {
+		return attempt >= 4, nil
+	})
+	buf := captureLogs(m)
+
+	m.kill(context.Background(), dir)
+
+	if got := killer.count(); got != 4 {
+		t.Fatalf("attempts = %d, want 4 (retry until the cgroup appears)", got)
+	}
+	if !strings.Contains(buf.String(), "SIGKILLed container cgroup") {
+		t.Fatalf("no confirmed-kill record: %s", buf.String())
+	}
+	// The first unconfirmed attempt is an Error; the rest are throttled.
+	if n := countLevel(buf.String(), "ERROR"); n != 1 {
+		t.Errorf("ERROR lines = %d, want 1 (one per escalation, not per attempt)", n)
+	}
+}
+
+// kata-agent removing the bundle means there is no container left to kill.
+func TestMonitorKill_StopsWhenBundleRemoved(t *testing.T) {
+	var dir string
+	m, killer, bundle := newRetryMonitor(t, func(attempt int) (bool, error) {
+		if attempt == 3 {
+			if err := os.RemoveAll(dir); err != nil {
+				t.Error(err)
+			}
+		}
+		return false, nil
+	})
+	dir = bundle
+	buf := captureLogs(m)
+
+	m.kill(context.Background(), dir)
+
+	if got := killer.count(); got != 3 {
+		t.Fatalf("attempts = %d, want 3 (stop once the bundle is gone)", got)
+	}
+	if strings.Contains(buf.String(), "SIGKILLed container cgroup") {
+		t.Error("reported a confirmed kill that never landed")
+	}
+	if !strings.Contains(buf.String(), "bundle was removed before a kill was confirmed") {
+		t.Errorf("removal not recorded: %s", buf.String())
+	}
+}
+
+// A cgroup.kill that never accepts the write (EROFS under
+// ProtectControlGroups=yes) keeps the denied container under attack for as long
+// as the monitor runs.
+func TestMonitorKill_RetriesWhileTheWriteKeepsFailing(t *testing.T) {
+	m, killer, dir := newRetryMonitor(t, func(int) (bool, error) {
+		return false, errors.New("kill cgroup: read-only file system")
+	})
+	buf := captureLogs(m)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); m.kill(ctx, dir) }()
+
+	// Past the tight phase, so the back-off escalation is exercised too.
+	start := time.Now()
+	for killer.count() < 10 || time.Since(start) < 2*m.killRetryDeadline {
+		if time.Since(start) > 10*time.Second {
+			t.Fatalf("kill stopped retrying after %d attempts", killer.count())
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("kill did not return after the context was cancelled")
+	}
+
+	attempts := killer.count()
+	if attempts < 10 {
+		t.Fatalf("attempts = %d, want the kill retried until the context ended", attempts)
+	}
+	if !strings.Contains(buf.String(), "gave up killing a denied container") {
+		t.Errorf("context cancellation not recorded: %s", buf.String())
+	}
+	// One line for the first failure, one for the back-off, one for the give-up
+	// — not one per attempt.
+	if n := countLevel(buf.String(), "ERROR"); n != 3 {
+		t.Errorf("ERROR lines = %d across %d attempts, want 3", n, attempts)
+	}
+}
+
+// A kill confirmed on the first attempt is the ordinary path: one Info line and
+// nothing at Error.
+func TestMonitorKill_ConfirmedFirstAttemptStaysInfo(t *testing.T) {
+	m, killer, dir := newRetryMonitor(t, func(int) (bool, error) { return true, nil })
+	buf := captureLogs(m)
+
+	m.kill(context.Background(), dir)
+
+	if got := killer.count(); got != 1 {
+		t.Fatalf("attempts = %d, want 1", got)
+	}
+	if countLevel(buf.String(), "ERROR") != 0 {
+		t.Errorf("confirmed kill logged at ERROR: %s", buf.String())
+	}
+	if countLevel(buf.String(), "INFO") == 0 {
+		t.Errorf("confirmed kill not logged at INFO: %s", buf.String())
+	}
+}

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -96,6 +96,11 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		configReadInterval:    25 * time.Millisecond,
 		configPendingInterval: time.Second,
 		revalidateInterval:    10 * time.Second,
+		// A denied container is re-killed until the kill lands or its bundle
+		// is removed; killRetryDeadline bounds the tight phase.
+		killRetryDeadline:   30 * time.Second,
+		killRetryInterval:   500 * time.Millisecond,
+		killPendingInterval: 10 * time.Second,
 	}
 
 	// A monitor that cannot write cgroup.kill enforces nothing, so refuse to
@@ -164,6 +169,9 @@ type monitor struct {
 	configReadInterval    time.Duration
 	configPendingInterval time.Duration
 	revalidateInterval    time.Duration
+	killRetryDeadline     time.Duration
+	killRetryInterval     time.Duration
+	killPendingInterval   time.Duration
 }
 
 // policyOverlay holds the Index of the latest CDS pull that advanced the epoch.
@@ -430,7 +438,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// itself went away, or we are shutting down — nothing to decide.
 		if _, statErr := os.Lstat(configPath); statErr == nil {
 			m.logger.Warn("deny container: config.json present but unreadable/malformed", "cid", cid, "path", configPath, "error", err)
-			m.kill(cid)
+			m.kill(ctx, dir)
 			return
 		}
 		m.logger.Info("skip: bundle went away before config.json appeared", "cid", cid, "path", configPath, "error", err)
@@ -467,7 +475,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// policy was not in force.
 		m.logger.Warn("deny container: image reference is absent or not digest-pinned",
 			"cid", cid, "reference", spec.Annotations[kataspec.PullReferenceKey])
-		m.kill(cid)
+		m.kill(ctx, dir)
 		return
 	}
 
@@ -486,7 +494,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 	}
 	m.logger.Warn("deny container: digest/argv not allowlisted",
 		append([]any{"cid", cid, "digest", digest, "argv", argv}, m.frozenAttrs()...)...)
-	m.kill(cid)
+	m.kill(ctx, dir)
 }
 
 // frozenAttrs annotates a deny with the fact that the allowlist never left the
@@ -501,22 +509,53 @@ func (m *monitor) frozenAttrs() []any {
 	return []any{"allowlist_frozen", true, "frozen_reason", reason, "allowlist_entries", m.allowlist.Size()}
 }
 
-// kill resolves the container's cgroup and terminates it as a unit. Every
-// caller has already DENIED the container, so anything short of a confirmed
-// termination is a bypass of the image policy and logs at Error — including
-// the "cgroup never materialised" case, which is indistinguishable from a
-// container that exited on its own.
-func (m *monitor) kill(cid string) {
-	ok, err := m.killer.kill(cid)
-	if err != nil {
-		m.logger.Error("kill cgroup failed: denied container was NOT terminated", "cid", cid, "error", err)
-		return
+// kill resolves the denied container's cgroup and terminates it as a unit,
+// re-attempting until the kill is confirmed, the bundle directory goes away
+// (kata-agent removed the container), or ctx ends. Repeat failures are logged
+// once per escalation, not once per attempt.
+func (m *monitor) kill(ctx context.Context, dir string) {
+	cid := filepath.Base(dir)
+	tightUntil := time.Now().Add(m.killRetryDeadline)
+	backedOff := false
+
+	for attempt := 1; ; attempt++ {
+		ok, err := m.killer.kill(cid)
+		switch {
+		case err != nil:
+			if attempt == 1 {
+				m.logger.Error("kill cgroup failed: denied container was NOT terminated; retrying", "cid", cid, "error", err)
+			}
+		case ok:
+			m.logger.Info("SIGKILLed container cgroup", "cid", cid, "attempts", attempt)
+			return
+		default:
+			if attempt == 1 {
+				m.logger.Error("denied container NOT confirmed terminated: cgroup never found or never populated; retrying", "cid", cid)
+			}
+		}
+
+		if _, statErr := os.Stat(dir); statErr != nil {
+			m.logger.Warn("denied container's bundle was removed before a kill was confirmed", "cid", cid, "attempts", attempt)
+			return
+		}
+
+		interval := m.killRetryInterval
+		if time.Now().After(tightUntil) {
+			interval = m.killPendingInterval
+			if !backedOff {
+				backedOff = true
+				m.logger.Error("denied container still NOT terminated; retrying at a slower cadence until its bundle is removed",
+					"cid", cid, "attempts", attempt, "interval", interval)
+			}
+		}
+
+		select {
+		case <-ctx.Done():
+			m.logger.Error("gave up killing a denied container", "cid", cid, "attempts", attempt, "reason", ctx.Err())
+			return
+		case <-time.After(interval):
+		}
 	}
-	if !ok {
-		m.logger.Error("denied container NOT confirmed terminated: cgroup never found or never populated", "cid", cid)
-		return
-	}
-	m.logger.Info("SIGKILLed container cgroup", "cid", cid)
 }
 
 // readConfigJSON waits for kata-agent to write the bundle's config.json and

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -4,6 +4,8 @@ package policymonitor
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -11,11 +13,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/confidential-dot-ai/c8s/internal/kataspec"
 	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
+
+// testCID derives a distinct container id of the shape the CRI generates (32
+// random bytes, hex-encoded) from a descriptive name.
+func testCID(name string) string {
+	sum := sha256.Sum256([]byte(name))
+	return hex.EncodeToString(sum[:])
+}
 
 // mustParseDigest parses a canonical digest or fails the test.
 func mustParseDigest(t *testing.T, s string) types.Digest {
@@ -117,6 +125,9 @@ func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKil
 		configReadDeadline:    200 * time.Millisecond,
 		configReadInterval:    10 * time.Millisecond,
 		configPendingInterval: 10 * time.Millisecond,
+		killRetryDeadline:     50 * time.Millisecond,
+		killRetryInterval:     time.Millisecond,
+		killPendingInterval:   5 * time.Millisecond,
 	}
 	return m, killer, watchDir
 }
@@ -125,7 +136,7 @@ func TestHandleNewContainer_AllowedDigest(t *testing.T) {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
-	cid := "abcdef0123"
+	cid := testCID("allowed-digest")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
@@ -143,7 +154,7 @@ func TestHandleNewContainer_FloorDigestAdmitsAnyArgv(t *testing.T) {
 	digest := strings.Repeat("a", 64)
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
-	cid := "floor-weird-argv"
+	cid := testCID("floor-weird-argv")
 	writeConfigJSONArgs(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
@@ -164,7 +175,7 @@ func TestHandleNewContainer_WorkloadArgvMatchAdmits(t *testing.T) {
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + floor})
 	m.overlay.apply(exactEntrypointOverlay(t, "sha256:"+wl, []string{"/bin/app"}), 1)
 
-	cid := "wl-match"
+	cid := testCID("wl-match")
 	writeConfigJSONArgs(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + wl,
@@ -184,7 +195,7 @@ func TestHandleNewContainer_WorkloadArgvMismatchKills(t *testing.T) {
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + floor})
 	m.overlay.apply(exactEntrypointOverlay(t, "sha256:"+wl, []string{"/bin/app"}), 1)
 
-	cid := "wl-mismatch"
+	cid := testCID("wl-mismatch")
 	writeConfigJSONArgs(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + wl,
@@ -263,7 +274,7 @@ func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
 
-	cid := "deadbeef"
+	cid := testCID("denied-digest")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/evil/badimage@sha256:" + denied,
@@ -282,7 +293,7 @@ func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 
 func TestHandleNewContainer_NoDigestAnnotation_Denies(t *testing.T) {
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "no-anno"
+	cid := testCID("no-anno")
 	writeConfigJSON(t, watchDir, cid, map[string]string{})
 
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
@@ -298,7 +309,7 @@ func TestHandleNewContainer_UnreadableConfigDenies(t *testing.T) {
 	// so the monitor must fail closed (deny+kill) rather than let it run (H-01).
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	m.configReadDeadline = 50 * time.Millisecond
-	cid := "unreadable-config"
+	cid := testCID("unreadable-config")
 	dir := filepath.Join(watchDir, cid)
 	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0o755); err != nil {
 		t.Fatal(err)
@@ -316,7 +327,7 @@ func TestKataOwnDirectoriesAreNotContainers(t *testing.T) {
 	// grow a config.json, so the watcher must not wait on one for a decision.
 	// The baked policy refuses these as container ids, so nothing can hide here.
 	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	for _, name := range kataspec.ReservedBundleNames {
+	for _, name := range []string{"shared", "sandbox", "image"} {
 		if err := os.MkdirAll(filepath.Join(watchDir, name), 0o755); err != nil {
 			t.Fatal(err)
 		}
@@ -329,7 +340,7 @@ func TestKataOwnDirectoriesAreNotContainers(t *testing.T) {
 func TestHandleNewContainer_MalformedConfigDenies(t *testing.T) {
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	m.configReadDeadline = 50 * time.Millisecond
-	cid := "bad-config"
+	cid := testCID("bad-config")
 	dir := filepath.Join(watchDir, cid)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
@@ -351,7 +362,7 @@ func TestHandleNewContainer_SandboxSkipped(t *testing.T) {
 	// policy-monitor must skip it rather than deny — otherwise every pod's
 	// sandbox gets killed and no pod can start.
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "sandbox0"
+	cid := testCID("sandbox0")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "sandbox",
 	})
@@ -373,7 +384,7 @@ func TestHandleNewContainer_SandboxSkippedEvenWithUnallowlistedDigest(t *testing
 	// does (isSandbox), keeping the two in lockstep.
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "sandbox-evil"
+	cid := testCID("sandbox-evil")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "sandbox",
 		"io.kubernetes.cri.image-name":     "ghcr.io/evil/badimage@sha256:" + denied,
@@ -390,7 +401,7 @@ func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 	digest := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
 
-	cid := "late-config"
+	cid := testCID("late-config")
 	// Create only the directory; spawn a goroutine to drop config.json
 	// in after a short delay (mirrors the kata-agent race between mkdir
 	// and write).
@@ -418,7 +429,7 @@ func TestHandleNewContainer_ConfigJSONAppearsLate(t *testing.T) {
 // for an attacker-controlled annotation to appear.
 func TestReadConfigJSON_ValidAnnotationlessSpecReturnsImmediately(t *testing.T) {
 	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	cid := "annotationless"
+	cid := testCID("annotationless")
 	writeConfigJSON(t, watchDir, cid, map[string]string{"unrelated": "x"})
 	m.configReadDeadline = time.Second
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -429,27 +440,6 @@ func TestReadConfigJSON_ValidAnnotationlessSpecReturnsImmediately(t *testing.T) 
 	}
 	if spec == nil || spec.Annotations["unrelated"] != "x" {
 		t.Fatalf("got spec %+v, want complete annotationless spec", spec)
-	}
-}
-
-func TestPathLooksLikeContainer(t *testing.T) {
-	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
-	for _, tc := range []struct {
-		path string
-		want bool
-	}{
-		{filepath.Join(watchDir, "abc123"), true},
-		{filepath.Join(watchDir, "aa_1.b"), true},                    // kata's verify_id charset
-		{filepath.Join(watchDir, "shared"), false},                   // kata's own dir, never a container
-		{filepath.Join(watchDir, "deep", "nested", "abc123"), false}, // not a direct child
-		{filepath.Join(watchDir, "with spaces"), false},              // disallowed character
-		{filepath.Join(watchDir, ""), false},                         // empty
-		{watchDir, false},                                            // the watch dir itself
-	} {
-		got := m.pathLooksLikeContainer(tc.path)
-		if got != tc.want {
-			t.Errorf("pathLooksLikeContainer(%q) = %v, want %v", tc.path, got, tc.want)
-		}
 	}
 }
 
@@ -467,7 +457,7 @@ func TestRun_DetectsCreatedContainer(t *testing.T) {
 	// Give the watcher time to install.
 	time.Sleep(50 * time.Millisecond)
 
-	cid := "live-deny"
+	cid := testCID("live-deny")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.image-name": "ghcr.io/evil/badimage@sha256:" + denied,
 	})
@@ -527,7 +517,7 @@ func TestRun_SurvivesWatchDirReplacement(t *testing.T) {
 	if err := os.MkdirAll(watchDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	writeConfigJSON(t, watchDir, "post-replace-deny", map[string]string{
+	writeConfigJSON(t, watchDir, testCID("post-replace-deny"), map[string]string{
 		"io.kubernetes.cri.image-name": "ghcr.io/evil/badimage@sha256:" + denied,
 	})
 

--- a/internal/cmds/policymonitor/refreshstate_test.go
+++ b/internal/cmds/policymonitor/refreshstate_test.go
@@ -32,7 +32,7 @@ func TestDenyNamesFrozenAllowlist(t *testing.T) {
 	m.refresh = &refreshState{reason: reasonNoMeasurements}
 	buf := captureLogs(m)
 
-	cid := "frozen-deny"
+	cid := testCID("frozen-deny")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + unlisted,
@@ -64,7 +64,7 @@ func TestDenyOmitsFrozenAttrsWhenRefreshLive(t *testing.T) {
 	m.refresh.enable()
 	buf := captureLogs(m)
 
-	cid := "live-deny"
+	cid := testCID("live-deny")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + unlisted,

--- a/internal/kataspec/kataspec.go
+++ b/internal/kataspec/kataspec.go
@@ -55,23 +55,11 @@ func IsSandbox(annotations map[string]string) bool {
 	return false
 }
 
-// containerID is the id set the baked kata-agent policy admits. kata's own
-// verify_id is wider (Unicode alphanumerics, no length bound); the policy
-// narrows CreateContainerRequest to this so that every container the guest
-// creates is one the watchers below resolve.
-var containerID = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]{1,127}$`)
-
-// ReservedBundleNames are kata's own subdirectories of /run/kata-containers.
-// They are not containers and never grow a config.json. The baked policy
-// refuses them as container ids, so skipping them here cannot hide one.
-var ReservedBundleNames = []string{"shared", "sandbox", "image"}
+// containerID is the id set the baked kata-agent policy admits: the 32 random
+// bytes containerd's CRI and CRI-O hex-encode into a container or sandbox id.
+var containerID = regexp.MustCompile(`^[a-f0-9]{64}$`)
 
 // ValidContainerID reports whether id is a container id c8s watches.
 func ValidContainerID(id string) bool {
-	for _, r := range ReservedBundleNames {
-		if id == r {
-			return false
-		}
-	}
 	return containerID.MatchString(id)
 }

--- a/internal/kataspec/kataspec_test.go
+++ b/internal/kataspec/kataspec_test.go
@@ -1,6 +1,9 @@
 package kataspec
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 const (
 	hexA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -115,26 +118,25 @@ func TestValidContainerID(t *testing.T) {
 		want bool
 	}{
 		{"6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6", true},
-		{"aa-1", true},
-		{"aa_1", true},
-		{"aa.1", true},
-		{"ab", true},
-		{"a", false},   // kata's verify_id requires len > 1
-		{"-ab", false}, // must start alphanumeric
-		{".ab", false},
+		{hexA, true},
+		{"init", false}, // a systemd unit cgroup name
+		{"ab", false},
+		{"aa-1", false},
+		{"aa_1", false},
+		{"aa.1", false},
+		{"shared", false}, // kata's own subdirectory of /run/kata-containers
+		{"sandbox", false},
+		{"image", false},
 		{"aa/1", false},
-		{"аа1", false}, // Cyrillic: verify_id accepts it, the policy does not
+		{"аа1", false}, // Cyrillic
 		{"", false},
+		{hexA[:63], false},
+		{hexA + "a", false},
+		{strings.ToUpper(hexA), false},
+		{strings.Repeat("g", 64), false}, // not hex
 	} {
 		if got := ValidContainerID(tc.id); got != tc.want {
 			t.Errorf("ValidContainerID(%q) = %v, want %v", tc.id, got, tc.want)
 		}
-	}
-	long := make([]byte, 129)
-	for i := range long {
-		long[i] = 'a'
-	}
-	if ValidContainerID(string(long)) {
-		t.Errorf("ValidContainerID accepted a 129-char id")
 	}
 }

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -46,20 +46,29 @@ func extractPattern(t *testing.T, policy, subject string) *regexp.Regexp {
 
 func TestContainerIDAgreesWithBakedPolicy(t *testing.T) {
 	policy := extractPattern(t, readPolicy(t), "input.container_id")
+	hex64 := strings.Repeat("a", 64)
 	for _, id := range []string{
-		"6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6",
+		"6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6", hex64,
 		"aa-1", "aa_1", "aa.1", "ab", "a", "-ab", ".ab", "aa/1", "аа1", "",
-		strings.Repeat("a", 128), strings.Repeat("a", 129),
 	} {
 		if policy.MatchString(id) && !ValidContainerID(id) {
 			t.Errorf("policy admits container id %q but ValidContainerID rejects it: nothing would decide on that container", id)
 		}
 	}
-	// The watchers skip kata's own directories by name, which is only safe
-	// because the policy refuses them as container ids.
-	for _, name := range ReservedBundleNames {
-		if !strings.Contains(readPolicy(t), `"`+name+`"`) {
-			t.Errorf("the baked policy does not reserve the bundle name %q", name)
+
+	// Both sides admit only what the CRI generates. A shorter id can name a
+	// systemd unit cgroup, and the kill path resolves a denied container's
+	// cgroup by name; kata's own bundle directories are excluded by the same
+	// pattern rather than by a separate rule.
+	for _, id := range []string{
+		"init", "ab", "shared", "sandbox", "image",
+		hex64[:63], hex64 + "a", strings.ToUpper(hex64),
+	} {
+		if policy.MatchString(id) {
+			t.Errorf("baked policy admits container id %q", id)
+		}
+		if ValidContainerID(id) {
+			t.Errorf("ValidContainerID accepts container id %q", id)
 		}
 	}
 }

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -103,11 +103,8 @@ default CreateContainerRequest := false
 CreateContainerRequest if {
 	print("CreateContainerRequest: start")
 
-	# policy-monitor and rtmr3-measurer only watch ids matching this; kata's
-	# own verify_id is wider (dots, underscores, Unicode), and an id outside
-	# their filter is a container neither of them ever decides on.
-	regex.match("^[a-zA-Z0-9][a-zA-Z0-9._-]{1,127}$", input.container_id)
-	not reserved_bundle_name
+	# A container id is the CRI's 32 random bytes, hex-encoded.
+	regex.match("^[a-f0-9]{64}$", input.container_id)
 	print("CreateContainerRequest: container_id ok")
 
 	# The Go runtime never sets this; setup_shared_mounts bind-mounts a
@@ -136,13 +133,6 @@ CreateContainerRequest if {
 }
 
 container_rootfs := concat("/", ["/run/kata-containers", input.container_id, "rootfs"])
-
-# kata's own subdirectories of /run/kata-containers. A container taking one of
-# these names collides with them, and the c8s watchers skip them by name.
-reserved_bundle_name if {
-	some name in ["shared", "sandbox", "image"]
-	input.container_id == name
-}
 
 sole_guest_pull_storage := s if {
 	pulls := [x | some x in input.storages; x.driver == "image_guest_pull"]


### PR DESCRIPTION
  The baked policy and kataspec both accepted `^[a-zA-Z0-9][a-zA-Z0-9._-]{1,127}$`, and policy-monitor resolves a denied container's cgroup by name. A host creating container_id="init" makes that walk match /sys/fs/cgroup/init.scope: with the container's own cgroup also present there are two matches, the ambiguity guard refuses to guess, and the denied container is never killed. Without it there is a sole match and the SIGKILL lands on systemd's PID 1 scope.

Both sides now anchor ^[a-f0-9]{64}$ -- the 32 random bytes containerd's CRI and CRI-O hex-encode into a container or sandbox id. A 64-hex name cannot collide with a systemd unit cgroup. reserved_bundle_name and ReservedBundleNames go away with it: the pattern already excludes shared/sandbox/image.

Any container id that is not 64 lowercase hex is now PERMISSION_DENIED at CreateContainerRequest. The policy lives on the dm-verity root, so this changes the guest launch measurement -- the guest image needs a rebuild and reference values need re-pinning.

 cgroupKiller.kill polls at most 2s for the container's cgroup to appear and become populated. On a miss it returned (false, nil), monitor.kill logged an error and returned, and a cgroup that materialised late -- or an init that forked after the poll window -- left a denied image running for its full lifetime. A failed cgroup.kill write behaved the same way.

monitor.kill now re-attempts until the kill is confirmed, the bundle directory is removed (kata-agent dropped the container), or the context ends: a tight phase at killRetryInterval up to killRetryDeadline, then killPendingInterval, mirroring readConfigJSON's shape. Failures log once per escalation rather than once per attempt.