### PR TITLE
fix(kata): gate kata-agent on in-guest image enforcement

### DIFF
--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -56,28 +56,41 @@ cloud-init.service ─→ c8s-cloudinit-env.service ─┤
                                                  │    readiness-check)    │   (Requires=+After=
                                                  │                        │    both services)
 local-fs.target ─→ policy-monitor.service ───────┘
-                   (Requires=/Wants= nothing else itself; enforces from
-                    t=0 on the baked seed. c8s-ready.target gates on it.)
-
-                                  (parallel) kata-agent.service
-                                             reads /etc/kata-opa/default-policy.rego
-                                             — a baked file in the dm-verity root.
-                                             After= network-online.target only.
+                   (Type=notify; READY=1 once the inotify watch is
+                    installed and the seed pass has run. Enforces from
+                    t=0 on the baked seed.)
+                          │
+                          ├─→ kata-agent.service
+                          │   (Requires=+After= policy-monitor.service, via
+                          │    kata-agent.service.d/10-c8s-policy-monitor.conf)
+                          │   reads /etc/kata-opa/default-policy.rego —
+                          │   a baked file in the dm-verity root.
 ```
 
 The dependency surface is intentionally minimal. kata-agent's bootstrap
 policy is part of the dm-verity root (covered by the launch
 measurement), not a runtime artifact, so kata-agent doesn't wait for any
 other in-guest service to render anything before it can load and enforce
-it. `policy-monitor` pulls in nothing itself (it `Requires=`/`Wants=` no
-other in-guest service), but it is **not** ungated: `c8s-ready.target`
-`Requires=`+`After=` it, so readiness — and therefore workload-container
-creation — waits for the monitor to be up and to have run its startup
-seed pass. It enforces from t=0 on the baked seed with no network, so
-gating on it adds no CDS bootstrap cycle. It observes what
-kata-agent does (via inotify on `/run/kata-containers/`) and reacts. See
-[`kata-image-policy.md`](kata-image-policy.md) for the enforcement
+it. It does wait for `policy-monitor.service`: `Requires=`+`After=`, so a
+monitor that cannot start keeps the agent from starting at all, and
+because the monitor is `Type=notify` the ordering resolves on READY=1 —
+watch installed, seed pass run — not on a fork. policy-monitor itself
+depends on nothing but the dm-verity root, which is what lets it sit
+ahead of the agent: it enforces from t=0 on the baked seed with no
+network, and the CDS refresh is a polling loop that retries. It observes
+what kata-agent does (via inotify on `/run/kata-containers/`) and reacts.
+See [`kata-image-policy.md`](kata-image-policy.md) for the enforcement
 mechanics.
+
+Enforcement readiness is deliberately **not** `c8s-ready.target`. That
+target also gates on `ratls-mesh.service`, which needs the pod IP that
+arrives over kata-agent's own `UpdateInterface` RPC — an agent ordered
+behind it would wait on itself. The mesh gate and the enforcement gate
+are separate edges for that reason.
+
+A policy-monitor that fails past its restart budget takes the guest down
+(`FailureAction=`/`StartLimitAction=poweroff-force`): a VM whose
+enforcement is dead must not keep running the containers it admitted.
 
 ### Readiness semantics and the CDS bootstrap
 
@@ -86,14 +99,13 @@ are bound and the cert manager has minted *any* leaf — the bootstrap
 self-signed one suffices. The background upgrade to a CDS-issued leaf
 does NOT gate readiness.
 
-This is deliberate. The CDS pod's workload is a single CDS container
-that kata-agent starts *after* `c8s-ready.target` is reached — and
-`c8s-ready.target` won't reach unless `ratls-mesh.service` is active.
-If readiness required a CDS-issued leaf, ratls-mesh would wait for
-CDS, kata-agent would wait for ratls-mesh, and CDS would wait for
-kata-agent to start it. Deadlock. The weak readiness gate breaks the
-cycle: ratls-mesh comes up self-signed so `c8s-ready.target` can be
-reached, kata-agent then starts the CDS container, and CDS — being its
+This is deliberate. The CDS pod's workload is a single CDS container, and
+`c8s-ready.target` `Requires=ratls-mesh.service`. If readiness required a
+CDS-issued leaf, ratls-mesh would wait for a CDS that only starts once
+kata-agent runs the container — and the target would never activate, so
+the pod would never report mesh-ready. The weak readiness gate breaks
+that: ratls-mesh comes up self-signed so `c8s-ready.target` can be
+reached, kata-agent starts the CDS container, and CDS — being its
 own in-process CA — issues its own leaf via the in-process
 attest → verify → mint chain (verifying SNP evidence against the
 in-guest attestation-service at `127.0.0.1:8400`, then signing in the

--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -82,38 +82,37 @@ reasons about are shown below; for the full boot/dependency graph
 in [`kata-guest-base.md`](kata-guest-base.md).
 
 ```
-local-fs.target ─→ policy-monitor.service       (orders only on
-                                                  local-fs.target; observes
-                                                  /run/kata-containers and
-                                                  acts on what it sees.
-                                                  c8s-ready.target
-                                                  Requires=+After= it —
-                                                  see kata-guest-base.md)
-
-(parallel) kata-agent.service
-           loads /etc/kata-opa/default-policy.rego
-           — a baked file on the dm-verity root. After=
-           network-online.target only.
+local-fs.target ─→ policy-monitor.service ─→ kata-agent.service
+                   (orders only on              (Requires=+After= the
+                    local-fs.target;             monitor; loads
+                    Type=notify: READY=1         /etc/kata-opa/default-policy.rego
+                    once the watch is            — a baked file on the
+                    installed and the seed       dm-verity root)
+                    pass has run)
 ```
 
 Key invariants:
 
 - **kata-agent's policy is the baked
   `/etc/kata-opa/default-policy.rego`**, a real file on the verity
-  root that's part of the launch measurement. It carries `default
-  SetPolicyRequest := false` plus upstream allow-all defaults for
-  every other RPC. It does NOT carry image-digest enforcement —
-  that's policy-monitor's job.
-- **policy-monitor gates readiness, but `Requires=` nothing itself.**
-  `c8s-ready.target` `Requires=` (and `After=`) policy-monitor.service,
-  so the guest does not reach readiness — and workload containers, which
-  `Requires=c8s-ready.target`, do not start — until the monitor is up and
-  its startup seed pass has run. That closes the window where containers
-  could run while digest enforcement is offline. The monitor itself
-  `Requires=` nothing (only `After=`/`Wants=` ordering for the optional
-  CDS refresh), so there is no bootstrap cycle: it enforces from t=0 on
-  the dm-verity-baked seed with no network. kata-agent doesn't reference
-  the monitor directly — the gate is pulled from c8s-ready.target's side.
+  root that's part of the launch measurement. It denies
+  `SetPolicyRequest`, denies the RPCs that reach into a running
+  container, and binds a `CreateContainerRequest` to the image it
+  names. It does NOT carry the digest allowlist — regorus has no
+  crypto builtins, so that half is policy-monitor's job.
+- **kata-agent gates on policy-monitor.** The drop-in
+  `kata-agent.service.d/10-c8s-policy-monitor.conf` adds
+  `Requires=`+`After=policy-monitor.service`, so a monitor that cannot
+  start keeps the agent from starting at all — no `CreateContainer`, no
+  bundle, no unenforced image. `Type=notify` makes the ordering resolve
+  on READY=1 (watch installed, seed pass run) rather than on a fork. The
+  monitor depends on nothing but the dm-verity root, which is what lets
+  it sit ahead of the agent without a cycle: it enforces from t=0 on the
+  baked seed with no network.
+- **A dead policy-monitor takes the guest with it.**
+  `FailureAction=`/`StartLimitAction=poweroff-force` fire once the
+  restart budget is spent. Ordering only covers startup; this is what
+  covers a monitor that dies while containers are running.
 - **`kata-agent.service` carries `FailureAction=poweroff`.** If
   kata-agent crashes after start, the VM shuts down rather than
   entering an ambiguous half-running state. kata-runtime sees the
@@ -182,8 +181,9 @@ of failure is invisible from outside the unit, policy-monitor now runs a
 **boot-time kill-path self-test** (`cgroupKiller.selfTest`): it creates a
 scratch cgroup under the configured cgroup root, writes its `cgroup.kill`, and
 removes it. On failure the process exits non-zero before installing the inotify
-watch, so `c8s-ready.target` never activates and no workload container is
-admitted. A policy-monitor that cannot kill must not look healthy.
+watch, so READY=1 is never sent, kata-agent's start job never resolves, and the
+poweroff action ends the guest. A policy-monitor that cannot kill must not look
+healthy.
 Correspondingly, a denied container whose kill errors — or which is never
 confirmed dead — is logged at **error**, not warning: it is a total bypass of
 the image policy, not a hiccup.

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -88,6 +88,7 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		overlay:   &policyOverlay{},
 		refresh:   &refreshState{reason: reasonNotYetStarted},
 		killer:    newCgroupKiller(cfg.CgroupRoot),
+		ready:     notifyReady,
 		// The bundle directory appears when the guest pull STARTS and
 		// config.json is written only once it finishes, so the wait is a
 		// registry fetch. configReadDeadline is just how long to poll
@@ -165,6 +166,8 @@ type monitor struct {
 	refresh               *refreshState  // whether the allowlist still tracks CDS
 	killer                containerKiller
 	inventory             *admissionInventory // sandbox identity + digests (docs/ratls.md); always set
+	ready                 func() error        // systemd READY=1; nil outside the unit
+	readyOnce             sync.Once
 	configReadDeadline    time.Duration
 	configReadInterval    time.Duration
 	configPendingInterval time.Duration
@@ -282,6 +285,11 @@ func (m *monitor) watch(ctx context.Context) (done bool, err error) {
 		m.logger.Warn("seed existing containers failed", "error", err)
 	}
 
+	// The watch is installed and the seed pass has dispatched, so every bundle
+	// kata-agent creates from here gets a decision. kata-agent's start job is
+	// waiting on this (see notify.go).
+	m.signalReady()
+
 	// Backstop for the event path below: if the Remove/Rename for the
 	// watch dir itself is dropped (e.g. inside a queue overflow), a
 	// periodic inode identity check still notices the swap.
@@ -376,6 +384,20 @@ func (m *monitor) watch(ctx context.Context) (done bool, err error) {
 			}
 		}
 	}
+}
+
+// signalReady notifies systemd once, on the first watch generation. A failed
+// notification leaves the unit un-started until TimeoutStartSec elapses, which
+// fails it and powers the guest off.
+func (m *monitor) signalReady() {
+	m.readyOnce.Do(func() {
+		if m.ready == nil {
+			return
+		}
+		if err := m.ready(); err != nil {
+			m.logger.Error("systemd readiness notification failed", "error", err)
+		}
+	})
 }
 
 // seedExisting walks the watch dir at startup and dispatches a

--- a/internal/cmds/policymonitor/notify.go
+++ b/internal/cmds/policymonitor/notify.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package policymonitor
+
+// sd_notify(3) readiness, hand-rolled against $NOTIFY_SOCKET.
+//
+// policy-monitor.service is Type=notify and kata-agent.service Requires= it, so
+// READY=1 is what releases kata-agent's start job. It is sent once the inotify
+// watch is installed and the first seed pass has dispatched — the point from
+// which every bundle kata-agent creates gets a decision.
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// notifySocketEnv is systemd's rendezvous with a Type=notify service.
+const notifySocketEnv = "NOTIFY_SOCKET"
+
+// notifyReady sends READY=1 to systemd. Absent $NOTIFY_SOCKET it does nothing,
+// which is the debug-shell and test case.
+func notifyReady() error {
+	return notifyReadyTo(os.Getenv(notifySocketEnv))
+}
+
+func notifyReadyTo(addr string) error {
+	if addr == "" {
+		return nil
+	}
+	// A leading '@' names an abstract socket, whose sun_path starts with NUL.
+	if strings.HasPrefix(addr, "@") {
+		addr = "\x00" + addr[1:]
+	}
+	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		return fmt.Errorf("dial %s %q: %w", notifySocketEnv, addr, err)
+	}
+	defer conn.Close()
+	if _, err := conn.Write([]byte("READY=1")); err != nil {
+		return fmt.Errorf("write READY=1: %w", err)
+	}
+	return nil
+}

--- a/internal/cmds/policymonitor/notify_test.go
+++ b/internal/cmds/policymonitor/notify_test.go
@@ -1,0 +1,104 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// listenNotify binds a unixgram socket and returns its address plus a channel
+// carrying the first datagram, standing in for systemd's notify socket.
+func listenNotify(t *testing.T, addr string) <-chan string {
+	t.Helper()
+	conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: addr, Net: "unixgram"})
+	if err != nil {
+		t.Fatalf("listen %q: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	got := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 64)
+		n, err := conn.Read(buf)
+		if err != nil {
+			return
+		}
+		got <- string(buf[:n])
+	}()
+	return got
+}
+
+func awaitNotify(t *testing.T, got <-chan string) string {
+	t.Helper()
+	select {
+	case msg := <-got:
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("no datagram on the notify socket")
+		return ""
+	}
+}
+
+func TestNotifyReady_PathSocket(t *testing.T) {
+	addr := filepath.Join(t.TempDir(), "notify")
+	got := listenNotify(t, addr)
+	if err := notifyReadyTo(addr); err != nil {
+		t.Fatalf("notifyReadyTo: %v", err)
+	}
+	if msg := awaitNotify(t, got); msg != "READY=1" {
+		t.Errorf("got %q, want READY=1", msg)
+	}
+}
+
+// systemd hands out an abstract socket ("@/org/freedesktop/systemd1/notify")
+// under some configurations; the leading '@' is a NUL in sun_path.
+func TestNotifyReady_AbstractSocket(t *testing.T) {
+	got := listenNotify(t, "\x00c8s-policy-monitor-notify-test")
+	if err := notifyReadyTo("@c8s-policy-monitor-notify-test"); err != nil {
+		t.Fatalf("notifyReadyTo: %v", err)
+	}
+	if msg := awaitNotify(t, got); msg != "READY=1" {
+		t.Errorf("got %q, want READY=1", msg)
+	}
+}
+
+// Outside the unit there is no socket to write to and readiness is a no-op.
+func TestNotifyReady_NoSocketIsNoOp(t *testing.T) {
+	if err := notifyReadyTo(""); err != nil {
+		t.Errorf("notifyReadyTo(\"\") = %v, want nil", err)
+	}
+}
+
+func TestNotifyReady_UnreachableSocketErrors(t *testing.T) {
+	if err := notifyReadyTo(filepath.Join(t.TempDir(), "absent")); err == nil {
+		t.Error("notifyReadyTo on an unbound socket returned nil, want an error")
+	}
+}
+
+// READY=1 is sent on the first watch generation only; kata-agent's start job is
+// released once and later generations must not re-announce.
+func TestSignalReady_OncePerProcess(t *testing.T) {
+	m, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	calls := 0
+	m.ready = func() error { calls++; return nil }
+
+	m.signalReady()
+	m.signalReady()
+	m.signalReady()
+
+	if calls != 1 {
+		t.Errorf("ready called %d times, want 1", calls)
+	}
+}
+
+// A monitor built outside runMonitor (tests, and the code path before the
+// notify hook is wired) must not panic on a nil hook.
+func TestSignalReady_NilHook(t *testing.T) {
+	m, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m.ready = nil
+	m.signalReady()
+}

--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -647,11 +647,11 @@ type readinessCheckResult struct {
 //
 // This is deliberate. Inside the CDS pod's VM, CDS is the workload
 // container itself: it hasn't been started by kata-agent yet when
-// ratls-mesh boots. If /ready required a CDS-signed leaf, the CDS
-// pod would deadlock (ratls-mesh waits for CDS, kata-agent waits
-// for ratls-mesh.service to be active, CDS waits for kata-agent
-// to start it). The weak gate lets the CDS VM boot: ratls-mesh comes
-// up self-signed, kata-agent starts CDS, the upgrade goroutine
+// ratls-mesh boots. c8s-ready.target Requires=ratls-mesh.service, so a
+// /ready that demanded a CDS-signed leaf would wait on a CDS that only
+// exists once the target's own dependency is satisfied, and the pod
+// would never report mesh-ready. The weak gate lets the CDS VM boot:
+// ratls-mesh comes up self-signed, kata-agent starts CDS, the goroutine
 // (which CDS can satisfy by issuing a cert to itself — it is its own
 // CA) eventually swaps the provider. Workload pods, where CDS already
 // exists in a peer VM, go through the same boot path and converge on a

--- a/kata-guest-base/extra/etc/systemd/system/c8s-ready.target
+++ b/kata-guest-base/extra/etc/systemd/system/c8s-ready.target
@@ -1,26 +1,13 @@
 [Unit]
-# Synthetic target reached when the in-guest c8s mesh is healthy.
+# Synthetic target reached when the in-guest c8s mesh is healthy: the
+# workload's traffic is proxied through RA-TLS once this is active.
 #
-# Workload-side units (kata-agent itself; anything ordered before
-# CreateContainer can complete) declare `Requires=c8s-ready.target
-# After=c8s-ready.target` — without c8s-ready active, the kata-agent's
-# CreateContainer flow blocks and kubelet reports CreateContainerError.
-#
-# The target gates on ratls-mesh.service AND policy-monitor.service.
-# Gating on policy-monitor closes the window where the guest goes ready
-# (and kata-agent starts containers) while digest enforcement is offline
-# — e.g. policy-monitor died on a bad or unreadable baked allowlist.
-# This does NOT reintroduce the CDS bootstrap cycle: policy-monitor
-# enforces from t=0 on the dm-verity-baked seed with no network (the CDS
-# allowlist refresh is a separate runtime loop, not a startup dependency),
-# so unlike the old guest-policy-agent it never dials CDS to come up. See
-# docs/kata-guest-base.md for the full rationale.
-#
-# Note: policy-monitor.service is Type=simple, so this gate guarantees the
-# enforcement process is launched (and its startup seed pass has run)
-# before ready — not a separately-signalled "watch is live". Switching it
-# to Type=notify + sd_notify after the inotify watch is established would
-# tighten that residual window further.
+# It is not the image-enforcement gate. kata-agent is held on
+# policy-monitor.service directly (kata-agent.service.d/10-c8s-policy-monitor.conf)
+# because this target also gates on ratls-mesh, which needs the pod IP that
+# arrives over kata-agent's own UpdateInterface RPC — an agent ordered after
+# this target would wait on itself. policy-monitor still appears below so a
+# guest that reaches "ready" has both halves up. See docs/kata-guest-base.md.
 Description=c8s in-guest readiness
 
 Requires=ratls-mesh.service policy-monitor.service

--- a/kata-guest-base/extra/etc/systemd/system/kata-agent.service.d/10-c8s-policy-monitor.conf
+++ b/kata-guest-base/extra/etc/systemd/system/kata-agent.service.d/10-c8s-policy-monitor.conf
@@ -1,0 +1,11 @@
+# The agent must not accept container workloads until in-guest image-digest
+# enforcement is live. policy-monitor.service is Type=notify, so After= here
+# waits for READY=1 (watch installed, seed pass run) rather than for a fork,
+# and Requires= means a monitor that cannot start keeps the agent from
+# starting at all: no CreateContainer, no bundle, no unenforced image.
+#
+# policy-monitor needs only the dm-verity root, so this adds no dependency on
+# the network or on anything the agent itself brings up.
+[Unit]
+Requires=policy-monitor.service
+After=policy-monitor.service

--- a/kata-guest-base/extra/etc/systemd/system/policy-monitor.service
+++ b/kata-guest-base/extra/etc/systemd/system/policy-monitor.service
@@ -23,30 +23,31 @@
 # docs/kata-image-policy.md for the threat-model discussion and the
 # BPF-LSM upgrade path that would close the post-start kill gap.
 #
-# Gating: c8s-ready.target Requires= and After= this unit, so the guest
-# does not reach readiness (and kata-agent does not start workload
-# containers) until policy-monitor has launched and run its startup seed
-# pass — closing the window where containers could run with enforcement
-# offline. This is safe from the CDS-bootstrap angle because startup needs
-# only the dm-verity-baked seed, never a network/CDS round-trip. The unit
-# stays decoupled from CDS at runtime (the allowlist refresh is best-effort
-# and never blocks boot). `Restart=on-failure` below keeps a crashed
-# monitor retrying; while it is down, c8s-ready stays inactive.
+# Gating: kata-agent.service Requires= and After= this unit
+# (kata-agent.service.d/10-c8s-policy-monitor.conf), so no container is
+# created until Type=notify below reports the watch live. Enforcement
+# readiness is deliberately not c8s-ready.target: that target gates on
+# ratls-mesh, which needs the pod IP kata-agent installs, and putting
+# kata-agent behind it would deadlock. This unit needs only the dm-verity
+# root, so it can be ordered ahead of the agent without a cycle.
 Description=c8s policy-monitor (in-guest container-digest enforcement)
 Documentation=https://github.com/confidential-dot-ai/c8s/tree/main/cmd/policy-monitor
 
 # /etc must be readable so the baked allowlist seed is loadable; the
-# verity-protected /etc layer is mounted by the time local-fs.target
-# is reached. network-online.target + c8s-cloudinit-env.service order
-# the CDS allowlist refresh: the env file (C8S_CDS_URL/measurements) and
-# the network must be up before the refresh loop can reach CDS. These
-# are ordering-only (not Requires) — policy-monitor stays decoupled and
-# falls back to baked-seed-only if the env file is absent.
-After=local-fs.target network-online.target c8s-cloudinit-env.service
-Wants=local-fs.target network-online.target
+# verity-protected /etc layer is mounted by the time local-fs.target is
+# reached. c8s-cloudinit-env.service writes the env file below. Both are
+# ordering-only (not Requires) — an absent env file means baked-seed-only.
+# Nothing here may depend on the network: kata-agent waits on this unit, and
+# the guest's addresses arrive over kata-agent's own UpdateInterface RPC. The
+# CDS refresh polls and retries, so it needs no network at start.
+After=local-fs.target c8s-cloudinit-env.service
+Wants=local-fs.target
+Before=kata-agent.service
 
 [Service]
-Type=simple
+# Type=notify: "started" must mean the inotify watch is installed and the seed
+# pass has run, not merely forked. monitor.signalReady sends READY=1 there.
+Type=notify
 
 # Defaults + the cloud-init env: the binary picks up the baked allowlist
 # and /run/kata-containers from its built-in defaults, and the CDS
@@ -75,7 +76,8 @@ ProtectHome=yes
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=no
-# RestrictAddressFamilies keeps AF_UNIX (journald) and adds AF_INET/
+# RestrictAddressFamilies keeps AF_UNIX (journald, and the Type=notify
+# READY=1 datagram — without it the unit never starts) and adds AF_INET/
 # AF_INET6 for the CDS allowlist refresh — policy-monitor pulls
 # CDS's /allowlist over RA-TLS (see cds_refresh.go). With no CDS URL
 # configured the refresh loop never starts and no socket is opened, but
@@ -86,22 +88,25 @@ LockPersonality=yes
 
 # Restart on transient failures (e.g. inotify watcher reset after the
 # kernel drops events under load). A flapping unit is bounded by the
-# StartLimit budget — past that, systemd stops restarting and the
-# admin can see "policy-monitor in failed state" rather than tail-
-# chasing logs.
+# StartLimit budget.
 Restart=on-failure
 RestartSec=2s
 StartLimitIntervalSec=60s
 StartLimitBurst=5
 
+# A guest whose enforcement is down runs unallowlisted images, so it must not
+# outlive it: past the restart budget the VM goes away. Both knobs are set
+# because systemd routes the two terminal paths separately — exhausting the
+# restart budget raises StartLimitAction, any other failed state FailureAction.
+FailureAction=poweroff-force
+StartLimitAction=poweroff-force
+
+# Bounds the Type=notify handshake: no READY=1 within this window fails the
+# unit, and the action above takes the guest down.
 TimeoutStartSec=30s
 
 [Install]
-# Multi-user.target is the right hook: we want policy-monitor enabled and
-# active on a normal boot, by the time any kata-agent CreateContainer call
-# could plausibly land. The readiness gate is pulled from the other side —
-# c8s-ready.target Requires=+After= this unit (see the [Unit] section above
-# and c8s-ready.target) — so we deliberately do NOT also
-# WantedBy=c8s-ready.target here; that would be a redundant second edge to
-# the same gate.
+# Multi-user.target is the right hook for a normal/debug boot. Under kata the
+# unit is started by the kata-containers.target.wants symlink build.sh creates,
+# and pulled in by kata-agent's Requires= either way.
 WantedBy=multi-user.target

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -445,7 +445,8 @@ fi
 # allow-all), the bootstrap allowlist, tmpfiles, and the cloud-init env
 # helper into the rootfs, then enable our units offline so they come up
 # at boot. We do NOT ship a kata-agent.service in the overlay — osbuilder
-# already installed and enabled the version-matched one.
+# already installed and enabled the version-matched one; the overlay only adds
+# a kata-agent.service.d/ drop-in, which needs no enabling.
 log "Step 3/5: overlaying c8s layer into the rootfs"
 sudo rsync -a "${EXTRA_DIR}/" "${TARGET_ROOTFS}/"
 


### PR DESCRIPTION
Three docs and the c8s-ready.target header asserted that kata-agent waits for c8s-ready.target, and therefore for policy-monitor. Nothing wired it: the overlay ships no kata-agent
  drop-in, and upstream's kata-agent.service carries no ordering at all, so the agent started in parallel with enforcement. Containers created in that window ran undecided until the
  monitor's seed pass caught them, and a monitor that died later was unguarded entirely.

The gate could not be c8s-ready.target as documented. That target Requires=ratls-mesh.service, whose in-guest setup resolves the pod IP by enumerating interfaces -- C8S_POD_IP is not
  in the baked cloudinit.env -- and those addresses arrive over kata-agent's own UpdateInterface RPC. An agent ordered behind it waits on itself.

kata-agent.service.d/10-c8s-policy-monitor.conf holds the agent on policy-monitor.service directly, which depends on nothing but the dm-verity root. policy-monitor drops its
  network-online.target ordering for the same reason (the CDS refresh polls and retries, so it needs no network at start) and becomes Type=notify, sending READY=1 once the inotify watch is
  installed and the seed pass has dispatched -- so Requires= resolves on a live watch rather than on a fork.

Ordering only covers startup. FailureAction=/StartLimitAction=poweroff-force cover the rest: past the restart budget the VM goes away rather than keep running containers it can no
  longer enforce.

c8s-ready.target keeps gating the mesh and still lists policy-monitor, so a guest that reports ready has both halves up.