### PR TITLE
fix(policy-monitor): exit when the kill path stops working

### DIFF
--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -184,9 +184,15 @@ removes it. On failure the process exits non-zero before installing the inotify
 watch, so READY=1 is never sent, kata-agent's start job never resolves, and the
 poweroff action ends the guest. A policy-monitor that cannot kill must not look
 healthy.
-Correspondingly, a denied container whose kill errors — or which is never
-confirmed dead — is logged at **error**, not warning: it is a total bypass of
-the image policy, not a hiccup.
+The same reasoning applies after boot. A denied container is re-killed until
+the kill lands or kata-agent removes its bundle; a kill path that keeps
+**erroring** past `killEscalateAfter` exits the process non-zero, which the
+unit turns into restarts and then poweroff — the running-guest counterpart of
+the self-test, for a hierarchy remounted read-only after boot. A kill that is
+merely never **confirmed** (cgroup absent or unpopulated) keeps retrying and
+logs at error instead: a denied container that exited on its own is
+indistinguishable from one that never got a cgroup, and that must not power off
+a healthy guest.
 
 ## Why the OPA policy is permissive
 

--- a/internal/cmds/policymonitor/killretry_test.go
+++ b/internal/cmds/policymonitor/killretry_test.go
@@ -163,3 +163,99 @@ func TestMonitorKill_ConfirmedFirstAttemptStaysInfo(t *testing.T) {
 		t.Errorf("confirmed kill not logged at INFO: %s", buf.String())
 	}
 }
+
+// A kill path that keeps erroring is enforcement that no longer works. The
+// process must exit so the unit can restart it and, failing that, power the
+// guest off (policy-monitor.service) — retrying quietly forever leaves a denied
+// container running for the life of the VM.
+func TestMonitorKill_PersistentErrorEscalates(t *testing.T) {
+	erofs := errors.New("kill cgroup: write cgroup.kill: read-only file system")
+	m, killer, dir := newRetryMonitor(t, func(int) (bool, error) { return false, erofs })
+	m.killEscalateAfter = 0
+	buf := captureLogs(m)
+
+	m.kill(context.Background(), dir)
+
+	if got := killer.count(); got != 1 {
+		t.Fatalf("attempts = %d, want 1 (escalate rather than keep retrying)", got)
+	}
+	select {
+	case got := <-m.fatal:
+		if !errors.Is(got, erofs) {
+			t.Errorf("fatal = %v, want it to wrap the kill error", got)
+		}
+	default:
+		t.Fatal("no fatal reported; the process would keep running unenforced")
+	}
+	if !strings.Contains(buf.String(), "enforcement is broken") {
+		t.Errorf("escalation not recorded: %s", buf.String())
+	}
+}
+
+// Escalation is bounded by killEscalateAfter, not by the first error: a kill
+// path that recovers within the window must not take the guest down.
+func TestMonitorKill_TransientErrorDoesNotEscalate(t *testing.T) {
+	m, killer, dir := newRetryMonitor(t, func(attempt int) (bool, error) {
+		if attempt < 3 {
+			return false, errors.New("transient")
+		}
+		return true, nil
+	})
+	buf := captureLogs(m)
+
+	m.kill(context.Background(), dir)
+
+	if got := killer.count(); got != 3 {
+		t.Fatalf("attempts = %d, want 3", got)
+	}
+	select {
+	case err := <-m.fatal:
+		t.Fatalf("escalated on a recoverable error: %v", err)
+	default:
+	}
+	if !strings.Contains(buf.String(), "SIGKILLed container cgroup") {
+		t.Errorf("no confirmed-kill record: %s", buf.String())
+	}
+}
+
+// An unconfirmed kill (cgroup absent or unpopulated) is not the same signal as
+// a broken kill path: a denied container that exited on its own looks exactly
+// like this, so it retries rather than powering the guest off.
+func TestMonitorKill_UnconfirmedDoesNotEscalate(t *testing.T) {
+	m, _, dir := newRetryMonitor(t, func(int) (bool, error) { return false, nil })
+	m.killEscalateAfter = 0
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	m.kill(ctx, dir)
+
+	select {
+	case err := <-m.fatal:
+		t.Fatalf("escalated on an unconfirmed kill: %v", err)
+	default:
+	}
+}
+
+// The watch loop turns a fatal into a non-zero exit from runMonitor.
+func TestWatch_ReturnsFatal(t *testing.T) {
+	m, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	boom := errors.New("kill path unusable")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- m.run(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	m.abort(boom)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, boom) {
+			t.Errorf("run() = %v, want the fatal error", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("run() did not return after abort")
+	}
+}

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -102,6 +102,10 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		killRetryDeadline:   30 * time.Second,
 		killRetryInterval:   500 * time.Millisecond,
 		killPendingInterval: 10 * time.Second,
+		// Well past the tight retry phase: a kill path still erroring here is
+		// broken, not busy.
+		killEscalateAfter: time.Minute,
+		fatal:             make(chan error, 1),
 	}
 
 	// A monitor that cannot write cgroup.kill enforces nothing, so refuse to
@@ -168,6 +172,8 @@ type monitor struct {
 	inventory             *admissionInventory // sandbox identity + digests (docs/ratls.md); always set
 	ready                 func() error        // systemd READY=1; nil outside the unit
 	readyOnce             sync.Once
+	fatal                 chan error // an enforcement failure the process must exit on
+	killEscalateAfter     time.Duration
 	configReadDeadline    time.Duration
 	configReadInterval    time.Duration
 	configPendingInterval time.Duration
@@ -312,6 +318,9 @@ func (m *monitor) watch(ctx context.Context) (done bool, err error) {
 			m.logger.Info("policy-monitor stopping", "reason", ctx.Err())
 			return true, nil
 
+		case err := <-m.fatal:
+			return false, err
+
 		case evt, ok := <-watcher.Events:
 			if !ok {
 				return false, errors.New("watcher events channel closed")
@@ -383,6 +392,18 @@ func (m *monitor) watch(ctx context.Context) (done bool, err error) {
 				return watchDirGone("periodic identity check")
 			}
 		}
+	}
+}
+
+// abort reports a condition the process cannot enforce through. The watch loop
+// returns it, runMonitor exits non-zero, and the unit escalates from there.
+// Buffered and non-blocking: the first caller wins and later ones are noise on
+// a process already on its way down.
+func (m *monitor) abort(err error) {
+	m.logger.Error("enforcement is broken; exiting so the unit can take the guest down", "error", err)
+	select {
+	case m.fatal <- err:
+	default:
 	}
 }
 
@@ -535,17 +556,31 @@ func (m *monitor) frozenAttrs() []any {
 // re-attempting until the kill is confirmed, the bundle directory goes away
 // (kata-agent removed the container), or ctx ends. Repeat failures are logged
 // once per escalation, not once per attempt.
+//
+// A kill mechanism that keeps erroring past killEscalateAfter is not a slow
+// container, it is enforcement that no longer works — cgroup.kill returning
+// EROFS under a remounted hierarchy is the case that motivated the boot-time
+// selfTest. Escalate: the process exits non-zero, and the unit turns that into
+// restarts and then poweroff (see policy-monitor.service). selfTest runs again
+// on each restart, so a hierarchy that is still read-only fails there instead.
 func (m *monitor) kill(ctx context.Context, dir string) {
 	cid := filepath.Base(dir)
 	tightUntil := time.Now().Add(m.killRetryDeadline)
+	escalateAt := time.Now().Add(m.killEscalateAfter)
 	backedOff := false
+	var lastErr error
 
 	for attempt := 1; ; attempt++ {
 		ok, err := m.killer.kill(cid)
 		switch {
 		case err != nil:
+			lastErr = err
 			if attempt == 1 {
 				m.logger.Error("kill cgroup failed: denied container was NOT terminated; retrying", "cid", cid, "error", err)
+			}
+			if time.Now().After(escalateAt) {
+				m.abort(fmt.Errorf("kill path unusable: container %s denied but not terminated after %s: %w", cid, m.killEscalateAfter, lastErr))
+				return
 			}
 		case ok:
 			m.logger.Info("SIGKILLed container cgroup", "cid", cid, "attempts", attempt)

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -128,6 +128,10 @@ func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKil
 		killRetryDeadline:     50 * time.Millisecond,
 		killRetryInterval:     time.Millisecond,
 		killPendingInterval:   5 * time.Millisecond,
+		// Far longer than any interval above, so only the tests that shorten it
+		// exercise the escalation path.
+		killEscalateAfter: time.Minute,
+		fatal:             make(chan error, 1),
 	}
 	return m, killer, watchDir
 }


### PR DESCRIPTION
A denied container was re-killed until the kill landed or its bundle went away, so a cgroup.kill that kept failing -- EROFS under a hierarchy remounted read-only after boot -- retried quietly for the life of the VM while the container ran. The boot-time selfTest covers that condition at startup and nothing covered it afterwards.

A kill still erroring past killEscalateAfter now aborts the watch loop and exits non-zero. policy-monitor.service turns that into restarts and then poweroff-force, and selfTest re-runs on each restart, so a still-read-only hierarchy fails there rather than waiting for the next denied container.

An unconfirmed kill -- cgroup absent or unpopulated -- keeps retrying instead. A denied container that exited on its own presents identically, and that must not power off a healthy guest.