### PR TITLE
fix(policy-monitor): stop denying a container whose config.json lands…

### DIFF
--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -620,10 +620,13 @@ func (m *monitor) readConfigJSON(ctx context.Context, dir string) (*ociSpec, err
 				return nil, err
 			}
 		default:
-			// Absent. A name that exists but does not resolve is something the
-			// host planted, not a file kata has yet to write.
-			if _, lerr := os.Lstat(path); lerr == nil {
-				return nil, fmt.Errorf("config.json exists but does not resolve to a readable file")
+			// Absent. A symlink here resolved to nothing, which is a name the
+			// host planted rather than a file kata has yet to write — the open
+			// returned ENOENT through the link, so it is dangling. Anything else
+			// Lstat can see is a regular config.json that kata created between
+			// the read above and this call; loop and read it.
+			if fi, lerr := os.Lstat(path); lerr == nil && fi.Mode()&os.ModeSymlink != 0 {
+				return nil, fmt.Errorf("config.json is a symlink that does not resolve")
 			}
 			if _, derr := os.Stat(dir); derr != nil {
 				return nil, fmt.Errorf("bundle %s went away before config.json appeared: %w", dir, derr)

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -536,3 +536,39 @@ func TestRun_SurvivesWatchDirReplacement(t *testing.T) {
 		t.Fatalf("run returned err: %v", err)
 	}
 }
+
+// kata-agent creating config.json between readConfigJSON's open and its
+// follow-up Lstat must not read as a host-planted name. The loop below spins
+// the poll hot across the write so the window is hit repeatedly: treating any
+// Lstat-visible name as unresolvable denied a legitimate container here.
+func TestHandleNewContainer_ConfigAppearingDuringPollIsNotDenied(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	for i := 0; i < 20; i++ {
+		m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+		m.configReadInterval = 50 * time.Microsecond
+
+		cid := testCID("poll-race")
+		dir := filepath.Join(watchDir, cid)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body, err := json.Marshal(ociSpec{
+			Annotations: map[string]string{
+				"io.kubernetes.cri.container-type": "container",
+				"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			_ = os.WriteFile(filepath.Join(dir, "config.json"), body, 0o644)
+		}()
+		m.handleNewContainer(context.Background(), dir)
+
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("iteration %d: denied a container whose config.json appeared mid-poll, got %+v", i, calls)
+		}
+	}
+}


### PR DESCRIPTION
… mid-poll

readConfigJSON treated any name Lstat could see after an ENOENT read as host-planted. kata-agent creating config.json between those two calls hits that, so an allowlisted container
  was denied and killed on a race whose odds grow with the guest pull. The bundle is on guest tmpfs and the write is not atomic, so the window is real rather than theoretical.

Only a symlink can be visible to Lstat and still fail to open with ENOENT, so the dangling-symlink case the check was written for is now identified directly and everything else loops
  back to read the file kata just wrote.