### PR TITLE
ci(kata): check and decision-test the baked kata-agent policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ on:
       - "scripts/mutation-check.sh"
       - ".gremlins.yaml"
       - ".github/workflows/ci.yml"
+      # internal/kataspec reads the baked policy and asserts the two admit the
+      # same container ids, so a policy-only change has to run this workflow.
+      - "kata-guest-base/extra/etc/kata-opa/**"
+      - "kata-guest-base/tests/**"
   pull_request:
     branches: [main, "feat/**"]
     paths: *go-paths
@@ -52,6 +56,26 @@ jobs:
           # A full major.minor.patch is resolved in-process; anything less is
           # looked up over the network before the linter runs.
           version: v2.12.2
+
+  policy:
+    name: Kata guest policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # kata-agent aborts the VM on a policy it cannot load, so a broken file
+      # costs a guest image build and an E2E run to discover. The decision
+      # tests additionally pin the rules the image binding rests on.
+      - name: Install opa
+        run: |
+          version=$(make -s print-opa-version)
+          curl -fsSL -o /usr/local/bin/opa \
+            "https://openpolicyagent.org/downloads/${version}/opa_linux_amd64_static"
+          chmod +x /usr/local/bin/opa
+          opa version
+
+      - name: Check and test the baked kata-agent policy
+        run: make policy-test
 
   test:
     name: Build & Test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
        test test-integration test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
-       manifests generate check-crd-chart install-controller-gen require-controller-gen
+       manifests generate check-crd-chart install-controller-gen require-controller-gen \
+       policy-test print-opa-version
+
+OPA                ?= opa
+OPA_VERSION        ?= v1.9.0
+KATA_POLICY        ?= kata-guest-base/extra/etc/kata-opa/default-policy.rego
+KATA_POLICY_TESTS  ?= kata-guest-base/tests/default-policy_test.rego
 
 CONTROLLER_GEN         ?= controller-gen
 CONTROLLER_GEN_VERSION ?= v0.20.1
@@ -147,6 +153,19 @@ test-e2e-mesh-cw-enforcement:
 # Needs kubectl pointed at a node-as-CVM cluster with cds.handoff.enabled=true.
 test-e2e-ca-handoff:
 	./test/e2e/ca-handoff.sh
+
+# Parse + decision tests for the baked kata-agent policy. The guest evaluates
+# it with regorus, which reads Rego v0 plus the future keywords, so the checks
+# run with --v0-compatible. Install with:
+#   curl -fsSL -o opa https://openpolicyagent.org/downloads/$(OPA_VERSION)/opa_linux_amd64_static && chmod +x opa
+# Single source of the pinned version for CI's installer step.
+print-opa-version:
+	@echo $(OPA_VERSION)
+
+policy-test:
+	@command -v $(OPA) >/dev/null 2>&1 || { echo "opa not found; see the policy-test comment in the Makefile"; exit 1; }
+	$(OPA) check --v0-compatible --strict $(KATA_POLICY)
+	$(OPA) test --v0-compatible $(KATA_POLICY) $(KATA_POLICY_TESTS)
 
 # --- Linting ---
 

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -29,9 +29,10 @@ it.
 
 Two of the three binaries baked into the image come from this repo
 (`ratls-mesh` from `cmd/ratls-mesh/`, plus the in-guest `C8S_*` cloud-init
-config — **Status:** today a single fixed default baked into the rootfs
-(`C8S_WORKLOAD_ID=c8s-broker`), not per-pod host-injected; per-pod injection
-was never built). The third — the in-guest attester staged
+config — a single fixed default baked into the rootfs
+(`C8S_WORKLOAD_ID=c8s-broker`); per-pod injection was never built, and
+`C8S_CDS_MEASUREMENTS` arrives over SNP init-data rather than either channel,
+see [`kata-image-policy.md`](kata-image-policy.md)). The third — the in-guest attester staged
 under the `attestation-service` role name — is the `attestation-api`
 binary from the sibling
 [confidential-dot-ai/attestation-rs](https://github.com/confidential-dot-ai/attestation-rs)

--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -271,15 +271,28 @@ image, run a CDS in it serving an attacker-chosen allowlist, and pass
 the attack. With the refresh disabled the guest enforces the measured
 seed alone, which is fail-closed.
 
-**Status:** no shipping path delivers this pin to guests today, so the
-refresh is disabled on every default install — operator additions reach
-the host-side enforcer but not running guests. Baking the pin is
-structurally impossible (under kata, CDS runs from this same guest
-image, so the pin's value would change the launch measurement it pins),
-and per-pod cloud-init injection is host-controlled, so a host-supplied
-pin could point at the host's own fake CDS. The candidate fix is
-operator-signed allowlist entries, verified in-guest against a baked
-operator public key.
+Baking the pin is structurally impossible — under kata, CDS runs from
+this same guest image, so the pin's value would change the launch
+measurement it pins — and a plain cloud-init value would be
+host-controlled, so a host-supplied pin could point at the host's own
+fake CDS.
+
+**Delivery: SEV-SNP init-data.** The host writes an init-data document
+the guest reads at `initdata.GuestDocumentPath`, and the shim commits
+`sha256(document)` into `HOST_DATA` at launch. policy-monitor attests
+itself against the in-guest attestation-service, reads `HOST_DATA` out
+of its own SNP report, and compares. The host still chooses the
+document, but it cannot choose one and commit another — the value is
+sealed into the measurement the operator already verifies, so a
+substituted pin changes an attested field rather than passing silently.
+On a mismatch, or with no document, the guest falls back to the baked
+seed.
+
+**TDX has no equivalent path yet:** the digest goes to `MRCONFIGID`
+rather than `HOST_DATA`, which this code does not read, so a TDX guest
+enforces the baked seed alone. Empty `cds.measurements` (the chart
+default) also leaves the refresh disabled on every platform — operator
+additions then reach the host-side enforcer but not running guests.
 
 ## Scenarios
 

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -470,13 +470,16 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   4. Intel PCS API key in `/etc/sgx_default_qcnl.conf` — DCAP fetches
      TCB collateral from Intel PCS during verify.
   5. The node label `confidential.ai/tdx=true` — the
-     `kata-qemu-tdx` RuntimeClass nodeSelector expects it. `c8s install
-     --hardware-platform=tdx` preflight-checks for this label and refuses
-     to proceed if no node has it.
+     `kata-qemu-tdx` RuntimeClass nodeSelector expects it. On the default
+     `--cvm-mode=pod` path the install applies it for you (see
+     [Installing](#installing)); you own it when a `-f` values file sets
+     `kata.tdxNodeSelector` itself, or under `--cvm-mode=node`. Either
+     way `c8s install --hardware-platform=tdx` preflight-checks it and
+     refuses to proceed if no node carries it.
 
-  A ready-made provisioning path is out of scope for this repo — any
-  Ansible playbook / OS-level configuration tool can install DCAP + qgsd
-  + the bridge unit and apply the label. If you're building one from
+  A ready-made provisioning path for items 1–4 is out of scope for this
+  repo — any Ansible playbook / OS-level configuration tool can install
+  DCAP + qgsd + the bridge unit. If you're building one from
   scratch, the [Intel TDX documentation](https://cdrdv2.intel.com/v1/dl/getContent/726790)
   and the DCAP quickstart are the canonical references. Once the host
   is configured, verify:
@@ -485,6 +488,12 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
   ls /dev/tdx_guest                           # exists
   systemctl is-active qgsd                    # active
   systemctl is-active tdx-qgs-bridge          # active
+  ```
+
+  The platform label is worth checking only when you own it; after a
+  default install it is already there:
+
+  ```
   kubectl get node <node> \
     -o jsonpath='{.metadata.labels.confidential\.ai/tdx}'
   # → true

--- a/kata-guest-base/README.md
+++ b/kata-guest-base/README.md
@@ -172,8 +172,16 @@ a debug image can't silently stand in for a locked one. Select it with
   kata-runtime via vsock + cloud-init, and the locked policy denies the
   host exec/stream RPCs — `kubectl exec`/`logs` work only on the `-debug`
   image variant (above).
-- **Cloud-init's user-data is host-injected** and visible to the host —
-  C8S_* values are URLs and workload IDs, not secrets.
+- **The in-guest `C8S_*` config is a baked default.** There is no per-pod
+  NoCloud datasource, so cloud-init finds nothing and
+  `c8s-cloudinit-env.service` materialises `/etc/c8s/cloudinit.env` from the
+  rootfs — one fixed identity (`C8S_WORKLOAD_ID=c8s-broker`) shared by every
+  guest. Should per-pod user-data injection land it would be host-written and
+  host-visible, which is why these values are URLs and workload IDs rather
+  than secrets. The one value that must not come from the host,
+  `C8S_CDS_MEASUREMENTS`, is delivered over SNP init-data instead and checked
+  against `HOST_DATA` (see
+  [`docs/kata-image-policy.md`](../docs/kata-image-policy.md)).
 - **kata version pin.** `scripts/build.sh` (osbuilder source tag) must
   stay in lockstep with `internal/helmchart/c8s/values.yaml` (kata-deploy
   version) — host/guest agent skew breaks the ttRPC contract.

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -1,0 +1,213 @@
+# Decision tests for the baked kata-agent policy.
+#
+# Run by `make policy-test` and the kata-guest-base workflow. This file is
+# deliberately outside extra/, which build.sh rsyncs into the guest rootfs.
+#
+# The policy is evaluated by regorus in the guest, which reads Rego v0 plus the
+# future keywords; the checks run with --v0-compatible for the same reason.
+
+package agent_policy
+
+import future.keywords.every
+import future.keywords.if
+import future.keywords.in
+
+cid := "6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a6"
+
+rootfs := rootfs_of(cid)
+
+rootfs_of(id) := concat("/", ["/run/kata-containers", id, "rootfs"])
+
+digest_ref := "ghcr.io/confidential-dot-ai/assam@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+# A CreateContainerRequest the policy admits: one guest-pull storage at this
+# container's rootfs, digest-pinned, workload markers agreeing everywhere. The
+# rootfs tracks the id, so an id-shape test isolates the id rule instead of
+# tripping the mount-point rule with a stale path.
+workload_input_for(id) := {
+	"container_id": id,
+	"shared_mounts": [],
+	"storages": [{
+		"driver": "image_guest_pull",
+		"mount_point": rootfs_of(id),
+		"source": digest_ref,
+		"options": [],
+		"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"container\"}"],
+	}],
+	"OCI": {"Annotations": {
+		"io.katacontainers.pkg.oci.container_type": "pod_container",
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name": digest_ref,
+	}},
+}
+
+workload_input := workload_input_for(cid)
+
+test_workload_allowed if {
+	CreateContainerRequest with input as workload_input
+}
+
+# --- container id shape -------------------------------------------------
+
+test_container_id_must_be_64_hex if {
+	every bad in [
+		"init",
+		"ab",
+		"shared",
+		"sandbox",
+		"image",
+		"6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a",
+		"6d7f5f7bd6e6b1f3a2c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d3e4f5a66",
+		"6D7F5F7BD6E6B1F3A2C4D5E6F7A8B9C0D1E2F3A4B5C6D7E8F9A0B1C2D3E4F5A6",
+	] {
+		not CreateContainerRequest with input as workload_input_for(bad)
+	}
+}
+
+# Guards the test above: the fixture must admit a well-formed id, or every
+# rejection below proves nothing.
+test_fixture_admits_a_valid_id if {
+	CreateContainerRequest with input as workload_input_for("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+}
+
+# --- rootfs binding -----------------------------------------------------
+
+test_tag_only_source_denied if {
+	tagged := "ghcr.io/confidential-dot-ai/assam:latest"
+	not CreateContainerRequest with input as object.union(workload_input, {
+		"storages": [object.union(workload_input.storages[0], {"source": tagged})],
+		"OCI": {"Annotations": object.union(
+			workload_input.OCI.Annotations,
+			{"io.kubernetes.cri.image-name": tagged},
+		)},
+	})
+}
+
+# The annotation policy-monitor reads and the source kata pulls are independent
+# fields of the same request; admitting a mismatch decouples the decision from
+# the executed bytes.
+test_source_must_equal_image_name_annotation if {
+	not CreateContainerRequest with input as object.union(workload_input, {"OCI": {"Annotations": object.union(
+		workload_input.OCI.Annotations,
+		{"io.kubernetes.cri.image-name": "ghcr.io/other/image@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+	)}})
+}
+
+test_pull_must_be_the_rootfs if {
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": [object.union(
+		workload_input.storages[0],
+		{"mount_point": "/run/kata-containers/other/rootfs"},
+	)]})
+}
+
+test_second_storage_over_rootfs_denied if {
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": array.concat(
+		workload_input.storages,
+		[{"driver": "local", "mount_point": concat("/", [rootfs, "etc"]), "options": []}],
+	)})
+}
+
+test_two_guest_pulls_denied if {
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": array.concat(
+		workload_input.storages,
+		[object.union(workload_input.storages[0], {"mount_point": "/elsewhere"})],
+	)})
+}
+
+test_layered_rootfs_denied if {
+	every layered in [
+		{"driver": "erofs.multi-layer", "mount_point": "/elsewhere", "options": []},
+		{"driver": "local", "mount_point": "/elsewhere", "options": ["X-kata.multi-layer=1"]},
+		{"driver": "local", "mount_point": "/elsewhere", "options": ["X-kata.overlay-lower=1"]},
+	] {
+		not CreateContainerRequest with input as object.union(
+			workload_input,
+			{"storages": array.concat(workload_input.storages, [layered])},
+		)
+	}
+}
+
+test_shared_mounts_denied if {
+	not CreateContainerRequest with input as object.union(
+		workload_input,
+		{"shared_mounts": [{"name": "whatever"}]},
+	)
+}
+
+# --- sandbox vs workload agreement --------------------------------------
+
+sandbox_input := {
+	"container_id": cid,
+	"shared_mounts": [],
+	"storages": [{
+		"driver": "image_guest_pull",
+		"mount_point": rootfs,
+		"source": "pause",
+		"options": [],
+		"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"sandbox\"}"],
+	}],
+	"OCI": {"Annotations": {
+		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+		"io.kubernetes.cri.container-type": "sandbox",
+	}},
+}
+
+test_sandbox_allowed if {
+	CreateContainerRequest with input as sandbox_input
+}
+
+# kata reads the container type from three places. A container that claims to be
+# a workload while its pull metadata says sandbox runs a host-chosen rootfs.
+test_sandbox_metadata_on_workload_denied if {
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": [object.union(
+		workload_input.storages[0],
+		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"sandbox\"}"]},
+	)]})
+}
+
+test_sandbox_source_must_be_pause if {
+	not CreateContainerRequest with input as object.union(
+		sandbox_input,
+		{"storages": [object.union(sandbox_input.storages[0], {"source": digest_ref})]},
+	)
+}
+
+# --- sandbox and ephemeral storages -------------------------------------
+
+test_sandbox_storage_shaped_like_a_rootfs_denied if {
+	not CreateSandboxRequest with input as {"storages": [{"mount_point": rootfs}]}
+	not UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": rootfs}]}
+}
+
+test_sandbox_storage_elsewhere_allowed if {
+	CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/shared/containers/x"}]}
+	UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/y"}]}
+}
+
+# --- CopyFile -----------------------------------------------------------
+
+test_copyfile_scoped_to_the_seeding_dir if {
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/etc/hosts"}
+	not CopyFileRequest with input as {"path": "/run/kata-containers/foo/rootfs/bin/sh"}
+	not CopyFileRequest with input as {"path": "/etc/passwd"}
+}
+
+test_copyfile_rejects_traversal if {
+	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/../../foo/rootfs/x"}
+	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/.."}
+}
+
+# Projected volumes legitimately carry `..data` and `..<timestamp>` names.
+test_copyfile_allows_projected_volume_names if {
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..data/token"}
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..2026_08_05_12_00_00/token"}
+}
+
+# --- host-as-adversary RPCs ---------------------------------------------
+
+test_host_reach_in_rpcs_denied if {
+	not SetPolicyRequest
+	not ExecProcessRequest
+	not ReadStreamRequest
+	not WriteStreamRequest
+}


### PR DESCRIPTION
Nothing validated default-policy.rego. The Go lockstep test only re-runs its container-id pattern through Go's regexp, and ci.yml's path filter did not list the policy at all, so a
  policy-only PR ran no workflow. kata-agent aborts the VM on a policy it cannot load, so a mistake there cost a guest image build and an E2E run to find.

make policy-test runs opa check --v0-compatible --strict plus decision tests pinning the rules the image binding rests on: container-id shape, the rootfs/digest binding, sandbox
  marker agreement, CopyFile scoping, and the denied host-reach-in RPCs. Each assertion was mutation-checked against a policy edited to break it. The tests live outside extra/, which
  build.sh rsyncs into the guest rootfs.

Docs: the SNP init-data pin delivery shipped in #226 without doc changes, so the refresh section still said no path existed; TDX label ownership contradicted itself between two
  sections of kata.md; and the guest README called the in-guest config host-injected while kata-guest-base.md called it a baked default -- the distinction the C8S_CDS_MEASUREMENTS argument
  rests on.