### PR TITLE
fix(kata): wait for the admission verdict before the container execs

### DIFF
--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -1,7 +1,10 @@
 # Kata image policy
 
 How c8s prevents an arbitrary container image from running inside a
-kata-qemu-snp VM. This document complements
+confidential kata guest. Both confidential shims — `kata-qemu-snp` and
+`kata-qemu-tdx` — run the same guest image and the same enforcement; the
+walkthroughs below say `kata-qemu-snp` and hold for either. This document
+complements
 [`kata-guest-base.md`](kata-guest-base.md) (the guest-image design) and
 [`kata-guest-base/README.md`](../kata-guest-base/README.md) (the recipe)
 by walking through the threat scenarios the policy defends against, and
@@ -9,10 +12,14 @@ the gaps it does not.
 
 > **Measurement model.** Wherever this doc says a file is "baked in" or
 > "part of the launch measurement", that means it sits on the dm-verity
-> root: its bytes are covered by the SNP launch digest and cannot change
-> without changing the digest. The measurement mechanics (osbuilder
-> dm-verity ext4, `kernel-hashes`, the verity root hash in the kata
-> kernel cmdline, no IGVM/UKI) live in
+> root, whose root hash rides the kata kernel cmdline. On SEV-SNP the
+> cmdline reaches the launch digest via `kernel-hashes`, so those bytes
+> cannot change without changing the value operators pin. **On TDX they
+> can** — the pinned value is MRTD, which covers TDVF only, and the kernel
+> and cmdline land in RTMR[1] and RTMR[2], which nothing verifies today.
+> See [G6](#g6--on-tdx-the-baked-bytes-are-measured-but-not-pinned). The
+> measurement mechanics (osbuilder dm-verity ext4, `kernel-hashes`, the
+> verity root hash in the kata kernel cmdline, no IGVM/UKI) live in
 > [`kata-guest-base/README.md`](../kata-guest-base/README.md).
 
 The short version: the decision is split in two, and both halves are on the
@@ -60,13 +67,13 @@ post-start kill window — is documented in
 
 | Component | In TCB? | Notes |
 |---|---|---|
-| `kata-guest-base` guest image (`vmlinuz` + dm-verity rootfs) | yes | Launch digest verified at boot (SEV-SNP, kernel-hashes). |
+| `kata-guest-base` guest image (`vmlinuz` + dm-verity rootfs) | yes | Launch measurement verified at boot: SEV-SNP launch digest via `kernel-hashes`; on TDX only MRTD is pinned (G6). |
 | `kata-agent` inside the guest | yes | Installed into the rootfs by kata's osbuilder (version-matched) at build. |
 | `policy-monitor` inside the guest | yes | Built from this repo, baked into the dm-verity root. |
 | `/etc/c8s/bootstrap-allowlist.json` (verity root) | yes | The allowlist **seed** the monitor loads at boot. Part of the launch measurement. |
 | CDS `/allowlist` additions (pulled over RA-TLS) | yes, via attestation | Runtime additions merged on top of the seed. Trusted because the pull is RA-TLS-pinned to `cds.measurements` (the host can't substitute a fake CDS), not because they're measured into this guest. |
 | `ratls-mesh` + `attestation-service` inside the guest | yes | Same. |
-| Host (containerd, kata-runtime, kata-shim) | **no** | Adversarial. Can call kata-agent RPCs via vsock, cannot read VM memory (SEV-SNP). |
+| Host (containerd, kata-runtime, kata-shim) | **no** | Adversarial. Can call kata-agent RPCs via vsock, cannot read VM memory (SEV-SNP or TDX). |
 | Cloud-init user-data (the `C8S_*` env file) | **partially** | Host controls its contents when per-pod injected; pinned values must be verifiable inside the guest. Today this is a single fixed default baked into the rootfs, not per-pod host-injected. |
 
 ## Bootstrap order (the load-bearing piece)
@@ -120,7 +127,7 @@ Key invariants:
 - **The seed is read-only; the in-memory set only grows.**
   policy-monitor loads `/etc/c8s/bootstrap-allowlist.json` once at boot
   — the file is on the verity root, so neither the guest nor the host
-  can rewrite it, and SEV-SNP memory encryption covers the in-memory
+  can rewrite it, and CVM memory encryption covers the in-memory
   copy. The runtime CDS refresh only ever *adds* digests to the
   in-memory set (see [Allowlist sourcing](#allowlist-sourcing-baked-seed--cds-refresh));
   it cannot remove the seed or shrink the set, so a compromised or
@@ -394,7 +401,7 @@ via the SignalProcessRequest RPC, but only against PIDs of
 systemd as a system service (PID is allocated by systemd at boot,
 unknown to kata-agent), not as a container; its PID is not a valid
 target for SignalProcessRequest. The host can't otherwise reach into
-the VM's process table because SEV-SNP memory encryption hides it.
+the VM's process table because CVM memory encryption hides it.
 
 **Outcome.** policy-monitor cannot be killed from the host.
 
@@ -571,8 +578,8 @@ Sketch:
 
 Practical considerations:
 
-- BTF: the kernel must be CO-RE-friendly. SEV-SNP-eligible kernels
-  (>= 6.x with the SNP guest patches) ship BTF by default.
+- BTF: the kernel must be CO-RE-friendly. The confidential guest
+  kernels (>= 6.x, SNP or TDX) ship BTF by default.
 - LSM stacking: `CONFIG_LSM=...,bpf,...` must place "bpf" before
   any LSM that fails closed if our program is unloaded. The
   kata-static kernel we use already builds with bpf+selinux
@@ -588,94 +595,6 @@ Practical considerations:
 The work is non-trivial but linear; it's captured here so a future
 contributor doesn't rediscover the option from scratch.
 
-## Known gaps
-
-### G1 — Post-start kill window
-
-policy-monitor enforces *after* kata-agent has forked the container
-init, not before — the mechanics and bounds are in
-[Post-start kill window](#post-start-kill-window) above.
-
-**Severity: low** — *provided the kill lands*. The TCB protection
-(SEV-SNP-encrypted memory) holds for the duration of the gap; the denied
-init cannot exfiltrate. But the gap is honest and called out for
-completeness. Note the bound is only "low severity" once the kill path
-matches the guest's systemd-scope cgroup naming (see the reliability caveat
-in [Post-start kill window](#post-start-kill-window) above); a matcher that
-missed it turned this bounded gap into unbounded non-enforcement.
-
-**Mitigation.** The [BPF-LSM upgrade path](#bpf-lsm-upgrade-path)
-hooks `security_bprm_check_security` to make the decision
-pre-execve. Future direction, not committed today.
-
-### G2 — Allowlist additions no longer need a guest-image rebuild
-
-Earlier baked-only versions of this design required a full guest-image
-rebuild + pod roll to add an allowed digest (the allowlist was *only*
-the measured seed). The hybrid refresh resolves that: operator
-additions land in CDS's allowlist and propagate to running guests over
-the RA-TLS pull within one refresh interval — no rebuild. The
-[Allowlist sourcing](#allowlist-sourcing-baked-seed--cds-refresh)
-section covers the mechanism and its grow-only / fail-safe properties.
-
-**What still needs a rebuild:** the *seed* itself — the bootstrap set
-(cds, get-cert) the guest enforces before its first successful CDS
-pull. That's deliberate: the seed must be measured, and a guest that
-trusted an unmeasured boot-time allowlist would defeat the point. So
-the trust pin is unchanged (the seed is in the launch measurement);
-only the day-2 *additions* are now dynamic, and they ride the same
-RA-TLS-authenticated CDS channel the host enforcer uses.
-
-**Residual note.** The refresh is pull-only and grow-only, so there is
-no in-guest *revocation* path: removing a digest from CDS does not
-retract it from a guest that already pulled it (until that guest
-restarts and reloads the seed). Image policy is an allow-list, so a
-stale-but-larger set only ever permits images the operator explicitly
-allowlisted at some point — acceptable, and called out for honesty.
-
-### G3 — Image content is visible to the host during the guest-pull
-
-The guest runs with `experimental_force_guest_pull = true` and
-`shared_fs = "none"`, so the workload's OCI image is
-[guest-pulled](kata-guest-base.md#what-guest-pull-is) inside the VM
-rather than unpacked on the host and bind-mounted in. The host no
-longer sees the unpacked rootfs.
-
-What the host still sees is the *transport*: it brokers the guest's
-outbound network, so for an anonymous pull from a public registry it
-observes which image reference and layers are fetched (a metadata
-leak, not a content-confidentiality break — the bytes are public).
-
-policy-monitor still enforces on CreateContainer (it reads the
-digest from the bundle's `config.json`). Moving the decision earlier
-— an inotify watch on the guest-pull image work dir
-(`/run/kata-containers/image/`, kata-agent's KATA_IMAGE_WORK_DIR,
-`confidential_data_hub/image.rs:22`) to reject on PullImage rather
-than CreateContainer — would shrink the G1 window further and is
-tracked as a future tightening.
-
-### G4 — BPF-LSM upgrade path
-
-The post-start kill gap (G1) is the most consequential gap the
-current design has. The [BPF-LSM upgrade path](#bpf-lsm-upgrade-path)
-above is the linear, non-controversial way to close it (and carries
-the full implementation sketch). Not on today's roadmap.
-
-### G5 — The enforced digest is bound to the pull, not reported by it
-
-policy-monitor reads the digest from a host-written annotation that the
-baked policy binds to the guest-pull source. The in-guest puller knows the
-digest it resolved first-hand, and CDH already returns it
-(`ImagePullResponse.manifest_digest`) — kata's vendored proto copy declares
-the response empty and drops it. Enforcing on that instead would take the
-annotation out of the trust path and let tag-form references work, since
-the guest would check what it actually got.
-
-It reports the *platform* manifest digest, though, where `crane digest` and
-pod `@sha256:` references name the *index* digest, so adopting it moves the
-allowlist to platform digests. That migration is why this is a follow-up and
-not part of the binding work.
-
 ## What this design does and doesn't claim
 
 **It claims:**
@@ -688,11 +607,11 @@ not part of the binding work.
   `kata-guest-base/patches/0001-agent-refuse-an-init-data-supplied-policy.patch`.
 - The host cannot inject an over-permissive allowlist. The seed
   `/etc/c8s/bootstrap-allowlist.json` is on the verity root and part of
-  the launch measurement (S4), and the runtime CDS additions arrive over
-  RA-TLS pinned to `cds.measurements`, so the host can't substitute a
-  fake CDS ("Host can't substitute a fake CDS allowlist"). At worst the
-  host blocks new additions — it can't shrink enforcement below the
-  measured seed.
+  the launch measurement on SEV-SNP (S4; on TDX see G6), and the runtime
+  CDS additions arrive over RA-TLS pinned to `cds.measurements`, so the
+  host can't substitute a fake CDS ("Host can't substitute a fake CDS
+  allowlist"). At worst the host blocks new additions — it can't shrink
+  enforcement below the measured seed.
 - The host cannot kill policy-monitor from outside the VM. (S5.)
 - The kata VM is the trust boundary (CVM memory encryption — SEV-SNP or
   TDX) and policy-monitor + ratls-mesh + attestation-service inside
@@ -711,10 +630,11 @@ not part of the binding work.
 
 **It does not claim:**
 
-- That the denied container's init *never executes any code*.
-  policy-monitor SIGKILLs the init after the kernel has forked it
-  (G1). The init has no network and no user-execve in that window,
-  but the window exists.
+- That a denied container's init is never *forked*. It is, and
+  policy-monitor SIGKILLs it. What the guest does claim is that it never
+  reaches `execve`: the agent waits for the admission verdict before
+  releasing the exec fifo (G1). The forked init runs no image code in that
+  window — it is parked on the fifo.
 - That CDS unreachability blocks the pod from booting or changes what
   policy-monitor enforces. The measured seed enforces regardless; a CDS
   outage only stops *new* additions from merging (grow-only). (Mesh-layer
@@ -724,12 +644,16 @@ not part of the binding work.
   guest-pull transport (G3).
 - That the rootfs still holds the admitted bytes at `execve`. The claim is
   that it *originates* from a digest-pinned in-guest pull. `CopyFileRequest`
-  is scoped to `/run/kata-containers/shared/containers/` so it can no longer
-  reach the container rootfs, but the argv, env and mounts a container runs
-  with are still the host's (THREAT_MODEL §5).
+  is scoped to `/run/kata-containers/shared/containers/` so it cannot reach
+  the container rootfs, and a mount's *source* must be one of the directories
+  the runtime manages — so nothing binds the verity root, `/run/c8s` or
+  another container's rootfs into a container. But a mount *destination* is
+  any path inside the container, and the host still chooses argv and env
+  (THREAT_MODEL §5). Which paths a given image may have shadowed is
+  per-image knowledge; it belongs in the allowlist document next to the argv
+  policy, not in a policy baked before any workload is known.
 
-The G1 gap (post-start kill window) is the most consequential
-honest limitation. The BPF-LSM upgrade path (G4) is the documented
-way to close it; today's design accepts it because the in-VM
-post-fork pre-execve window is short, capability-poor, and inside
-the CVM trust boundary.
+The most consequential honest limitations left are G6 (on TDX the baked
+bytes are measured but not pinned) and the host's control of argv, env and
+mount destinations (THREAT_MODEL §5). G1 is closed; G4 was its planned
+mitigation and is no longer needed for it.

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -481,7 +481,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// itself went away, or we are shutting down — nothing to decide.
 		if _, statErr := os.Lstat(configPath); statErr == nil {
 			m.logger.Warn("deny container: config.json present but unreadable/malformed", "cid", cid, "path", configPath, "error", err)
-			m.kill(ctx, dir)
+			m.deny(ctx, dir)
 			return
 		}
 		m.logger.Info("skip: bundle went away before config.json appeared", "cid", cid, "path", configPath, "error", err)
@@ -505,6 +505,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 
 	if kataspec.IsSandbox(spec.Annotations) {
 		m.logger.Info("allow sandbox (pause) container — measured via rootfs, not allowlisted", "cid", cid)
+		m.recordVerdict(dir, verdictAllow)
 		return
 	}
 
@@ -518,7 +519,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// policy was not in force.
 		m.logger.Warn("deny container: image reference is absent or not digest-pinned",
 			"cid", cid, "reference", spec.Annotations[kataspec.PullReferenceKey])
-		m.kill(ctx, dir)
+		m.deny(ctx, dir)
 		return
 	}
 
@@ -533,10 +534,20 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		if m.inventory != nil {
 			m.inventory.record(cid, digest, argv)
 		}
+		m.recordVerdict(dir, verdictAllow)
 		return
 	}
 	m.logger.Warn("deny container: digest/argv not allowlisted",
 		append([]any{"cid", cid, "digest", digest, "argv", argv}, m.frozenAttrs()...)...)
+	m.deny(ctx, dir)
+}
+
+// deny records the verdict, then kills. Order matters: the verdict is what
+// stops the container reaching execve, and kill retries until the cgroup is
+// confirmed empty — so writing it second would leave the agent free to start
+// the container while the kill is still being attempted.
+func (m *monitor) deny(ctx context.Context, dir string) {
+	m.recordVerdict(dir, verdictDeny)
 	m.kill(ctx, dir)
 }
 

--- a/internal/cmds/policymonitor/verdict.go
+++ b/internal/cmds/policymonitor/verdict.go
@@ -1,0 +1,81 @@
+//go:build linux
+
+package policymonitor
+
+// The admission decision, written where kata-agent reads it.
+//
+// policy-monitor decides after kata-agent has forked the container's init, but
+// that init is parked on the exec fifo until StartContainerRequest. The patched
+// agent (kata-guest-base/patches/0002-*) waits for this file before writing the
+// fifo, so a denied image never reaches execve — the post-start window closes
+// (docs/kata-image-policy.md G1).
+//
+// The file lives in the container's bundle, which only in-guest root can write:
+// the baked policy scopes CopyFileRequest to the sandbox seeding directory, so
+// the host cannot forge a verdict. No file means no decision, and the agent
+// fails closed on its own timeout.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// VerdictFile is the bundle-relative name the agent polls for.
+const VerdictFile = "c8s-verdict"
+
+const (
+	verdictAllow = "allow"
+	verdictDeny  = "deny"
+)
+
+// writeVerdict records the decision for the container whose bundle is dir.
+// Written to a temp file and renamed so the agent never reads a partial value.
+func writeVerdict(dir, verdict string) error {
+	tmp, err := os.CreateTemp(dir, "."+VerdictFile+"-*")
+	if err != nil {
+		return fmt.Errorf("create verdict temp in %s: %w", dir, err)
+	}
+	return commitVerdict(tmp, dir, verdict)
+}
+
+// commitVerdict flushes verdict through tmp and renames it into place. Split
+// out so tests can drive the flush-time error branches (write on a closed
+// file, chmod on a removed name, …) without hijacking os operations. The
+// temp is best-effort removed on every error path; a successful rename
+// leaves it as the final file so the Remove is a no-op.
+func commitVerdict(tmp *os.File, dir, verdict string) (retErr error) {
+	name := tmp.Name()
+	defer func() {
+		if retErr != nil {
+			_ = os.Remove(name)
+		}
+	}()
+
+	if _, err := tmp.WriteString(verdict); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write verdict: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("sync verdict: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close verdict: %w", err)
+	}
+	if err := os.Chmod(name, 0o644); err != nil {
+		return fmt.Errorf("chmod verdict: %w", err)
+	}
+	return os.Rename(name, filepath.Join(dir, VerdictFile))
+}
+
+// record writes the verdict and logs at Error when it cannot: the agent then
+// waits out its timeout and refuses to start the container, so a container the
+// monitor meant to admit does not run. That is the safe direction, but it turns
+// an allow into a pod failure, which an operator has to be able to see.
+func (m *monitor) recordVerdict(dir, verdict string) {
+	if err := writeVerdict(dir, verdict); err != nil {
+		m.logger.Error("cannot record admission verdict; kata-agent will refuse to start this container",
+			"dir", dir, "verdict", verdict, "error", err)
+	}
+}

--- a/internal/cmds/policymonitor/verdict_test.go
+++ b/internal/cmds/policymonitor/verdict_test.go
@@ -1,0 +1,211 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func readVerdict(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, VerdictFile))
+	if err != nil {
+		t.Fatalf("read verdict in %s: %v", dir, err)
+	}
+	return string(b)
+}
+
+func noVerdict(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(dir, VerdictFile)); err == nil {
+		t.Fatalf("expected no verdict in %s, found %q", dir, readVerdict(t, dir))
+	}
+}
+
+// The patched kata-agent refuses to release the exec fifo without an "allow",
+// so every path that admits a container has to leave one behind.
+func TestVerdict_AllowedContainer(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	writeConfigJSON(t, watchDir, "allowed", map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/x/y@sha256:" + digest,
+	})
+	dir := filepath.Join(watchDir, "allowed")
+	m.handleNewContainer(context.Background(), dir)
+
+	if got := readVerdict(t, dir); got != verdictAllow {
+		t.Errorf("verdict = %q, want %q", got, verdictAllow)
+	}
+	if calls := killer.snapshot(); len(calls) != 0 {
+		t.Errorf("unexpected kills: %+v", calls)
+	}
+}
+
+func TestVerdict_SandboxContainer(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	writeConfigJSON(t, watchDir, "sandbox-ctr", map[string]string{
+		"io.kubernetes.cri.container-type": "sandbox",
+	})
+	dir := filepath.Join(watchDir, "sandbox-ctr")
+	m.handleNewContainer(context.Background(), dir)
+	if got := readVerdict(t, dir); got != verdictAllow {
+		t.Errorf("verdict = %q, want %q — the pause would never start", got, verdictAllow)
+	}
+}
+
+func TestVerdict_DeniedPaths(t *testing.T) {
+	allowed := strings.Repeat("a", 64)
+	for _, tc := range []struct {
+		name        string
+		cid         string
+		annotations map[string]string
+	}{
+		{"not allowlisted", "denied", map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name":     "ghcr.io/evil@sha256:" + strings.Repeat("b", 64),
+		}},
+		{"tag-form reference", "tagged", map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name":     "nginx:1.27-alpine",
+		}},
+		{"no reference at all", "bare", map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
+			writeConfigJSON(t, watchDir, tc.cid, tc.annotations)
+			dir := filepath.Join(watchDir, tc.cid)
+			m.handleNewContainer(context.Background(), dir)
+
+			if got := readVerdict(t, dir); got != verdictDeny {
+				t.Errorf("verdict = %q, want %q", got, verdictDeny)
+			}
+			if calls := killer.snapshot(); len(calls) != 1 {
+				t.Errorf("expected the denied container to be killed, got %+v", calls)
+			}
+		})
+	}
+}
+
+// A bundle with an unreadable spec is a container whose image cannot be
+// determined; the agent must not start it.
+func TestVerdict_UnreadableConfigDenies(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	dir := filepath.Join(watchDir, "bad-config")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m.handleNewContainer(context.Background(), dir)
+	if got := readVerdict(t, dir); got != verdictDeny {
+		t.Errorf("verdict = %q, want %q", got, verdictDeny)
+	}
+}
+
+// No decision is not an admission: the agent's own wait expires and refuses.
+// Writing "allow" for a bundle we never resolved would hand it a free pass.
+func TestVerdict_UndecidedContainerGetsNone(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	m.configReadDeadline = 20 * time.Millisecond
+	m.configReadInterval = 5 * time.Millisecond
+	m.configPendingInterval = 5 * time.Millisecond
+
+	dir := filepath.Join(watchDir, "ghost")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		time.Sleep(60 * time.Millisecond)
+		os.RemoveAll(dir)
+	}()
+	m.handleNewContainer(context.Background(), dir)
+	noVerdict(t, dir)
+}
+
+// A bundle dir the agent tore down between kata-agent's do_create_container
+// and our decision is not a coverage hole — writeVerdict has to report the
+// failure so recordVerdict logs it (rather than reporting success and
+// leaving the agent's own wait to be the only signal).
+func TestVerdict_WriteRequiresBundleDir(t *testing.T) {
+	err := writeVerdict(filepath.Join(t.TempDir(), "does-not-exist"), verdictAllow)
+	if err == nil {
+		t.Fatal("writeVerdict on a missing dir returned nil; agent would treat as absent-verdict timeout with no monitor-side signal")
+	}
+	if !strings.Contains(err.Error(), "create verdict temp") {
+		t.Errorf("error %q should name the failing step (CreateTemp)", err)
+	}
+}
+
+// recordVerdict swallows the error so the caller (handleNewContainer) can
+// still kill on a deny path even if writing failed. It has to log at Error
+// so the operator sees it — an allow-that-didn't-record turns into a pod
+// stuck at StartContainer with no monitor-side breadcrumb.
+func TestVerdict_RecordLogsWhenWriteFails(t *testing.T) {
+	m, _, _ := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
+	buf := captureLogs(m)
+	m.recordVerdict(filepath.Join(t.TempDir(), "does-not-exist"), verdictAllow)
+	if !strings.Contains(buf.String(), `"level":"ERROR"`) {
+		t.Fatalf("recordVerdict should log at ERROR when writeVerdict fails; got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "cannot record admission verdict") {
+		t.Errorf("log missing the operator-facing message; got:\n%s", buf.String())
+	}
+}
+
+// A file handle that's already gone (closed under us, or a bundle whose
+// tmpfile was reaped) has to surface as a labelled error so the operator
+// sees which flush step failed. The kata-agent's own absent-verdict timeout
+// still catches it, but a monitor that silently swallowed the failure would
+// leave nothing to diagnose against.
+func TestVerdict_CommitReportsWriteFailure(t *testing.T) {
+	dir := t.TempDir()
+	tmp, err := os.CreateTemp(dir, "."+VerdictFile+"-*")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	tmp.Close() // simulate a handle that lost its file — WriteString → EBADF
+	err = commitVerdict(tmp, dir, verdictAllow)
+	if err == nil {
+		t.Fatal("commitVerdict on a closed file returned nil")
+	}
+	if !strings.Contains(err.Error(), "write verdict") {
+		t.Errorf("error %q should name the failing step (write)", err)
+	}
+	// The temp is cleaned up on the error path; the caller's dir stays
+	// verdict-less, so the agent's own timeout fires.
+	if _, statErr := os.Stat(filepath.Join(dir, VerdictFile)); statErr == nil {
+		t.Errorf("verdict file exists after commit failed — a stale allow would open the exec fifo")
+	}
+}
+
+// The agent reads this file while policy-monitor may still be writing it, so
+// it has to appear whole or not at all.
+func TestVerdict_WriteIsAtomic(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeVerdict(dir, verdictAllow); err != nil {
+		t.Fatalf("writeVerdict: %v", err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != VerdictFile {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("dir contains %v, want just %q — a temp file was left behind", names, VerdictFile)
+	}
+	if got := readVerdict(t, dir); got != verdictAllow {
+		t.Errorf("verdict = %q, want %q", got, verdictAllow)
+	}
+}

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -128,6 +128,11 @@ CreateContainerRequest if {
 	}
 	print("CreateContainerRequest: no storage shadows the rootfs")
 
+	every m in input.OCI.Mounts {
+		mount_source_allowed(m)
+	}
+	print("CreateContainerRequest: no mount reaches outside the sandbox dirs")
+
 	pull_source_bound(pull)
 	print("CreateContainerRequest: allowed")
 }
@@ -165,6 +170,30 @@ layered_rootfs_storage(s) if {
 layered_rootfs_storage(s) if {
 	some o in s.options
 	startswith(o, "X-kata.overlay-")
+}
+
+# A bind mount's source is a guest path, and the runtime rewrites every one it
+# sends to a directory it manages: the CopyFile-seeded share, or the sandbox's
+# ephemeral/local/storage trees. Anything else — the verity root, /run/c8s,
+# another container's rootfs — is guest state the host is asking to hand a
+# container. Non-bind mounts name a filesystem type (proc, sysfs, tmpfs,
+# devpts, mqueue, cgroup) rather than a path, and carry nothing in.
+#
+# This bounds where mount CONTENT comes from, not where it lands: a destination
+# is a path inside the container, and which paths a workload may have shadowed
+# is per-image knowledge that lives in the allowlist document, not here.
+mount_source_allowed(m) if {
+	not startswith(m.source, "/")
+}
+
+mount_source_allowed(m) if {
+	some prefix in ["/run/kata-containers/shared/containers/", "/run/kata-containers/sandbox/"]
+	startswith(m.source, prefix)
+	no_traversal(m.source)
+}
+
+no_traversal(path) if {
+	not regex.match(`(^|/)\.\.(/|$)`, path)
 }
 
 # kata's own switch is io.katacontainers.pkg.oci.container_type; the guest-pull
@@ -250,6 +279,6 @@ default CopyFileRequest := false
 
 CopyFileRequest if {
 	startswith(input.path, "/run/kata-containers/shared/containers/")
-	not regex.match(`(^|/)\.\.(/|$)`, input.path)
+	no_traversal(input.path)
 	print("CopyFileRequest: allowed")
 }

--- a/kata-guest-base/patches/0002-agent-wait-for-the-admission-verdict.patch
+++ b/kata-guest-base/patches/0002-agent-wait-for-the-admission-verdict.patch
@@ -1,0 +1,77 @@
+Subject: [PATCH] agent: wait for the in-guest admission verdict before execve
+
+policy-monitor decides whether a container's image is allowlisted after
+kata-agent has already forked its init, so enforcement is a race it can lose
+(kata-image-policy.md G1). The init is parked on the exec fifo the whole time
+though, and only do_start_container releases it -- so that is the point where
+the decision can be waited on instead of raced.
+
+policy-monitor writes its verdict into the container's bundle. Only in-guest
+root can write there (the baked agent policy scopes CopyFileRequest to the
+sandbox seeding directory), so the host cannot forge one, and an absent or
+unreadable verdict is not an admission: the wait expires and the container is
+refused. The wait is ahead of the sandbox lock so a slow verdict cannot stall
+unrelated agent work; in practice the spec was written during CreateContainer
+and the verdict is already there.
+
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -360,6 +360,13 @@
+ 
+     #[instrument]
+     async fn do_start_container(&self, req: protocols::agent::StartContainerRequest) -> Result<()> {
++        // c8s: the container's init is parked on the exec fifo until ctr.exec()
++        // below, so this is the last point before it can execve. Wait for
++        // policy-monitor's admission verdict here rather than let the image
++        // policy race the container. Ahead of the sandbox lock: a slow verdict
++        // must not stall every other agent operation.
++        c8s_await_admission(&req.container_id).await?;
++
+         let mut s = self.sandbox.lock().await;
+         let sid = s.id.clone();
+         let cid = req.container_id.clone();
+@@ -2133,6 +2140,44 @@
+     Ok(())
+ }
+ 
++// c8s: policy-monitor writes its admission decision into the container's
++// bundle once it has read the OCI spec. Only in-guest root can write there --
++// the baked agent policy scopes CopyFileRequest to the sandbox seeding
++// directory -- so a verdict cannot be forged by the host. An absent or
++// unreadable verdict is not an admission: this waits, then refuses.
++const C8S_VERDICT_FILE: &str = "c8s-verdict";
++const C8S_VERDICT_TIMEOUT: Duration = Duration::from_secs(30);
++const C8S_VERDICT_POLL: Duration = Duration::from_millis(20);
++
++async fn c8s_await_admission(cid: &str) -> Result<()> {
++    kata_sys_util::validate::verify_id(cid).context("invalid container id")?;
++    let path = safe_path::scoped_join(CONTAINER_BASE, cid)?.join(C8S_VERDICT_FILE);
++    let deadline = tokio::time::Instant::now() + C8S_VERDICT_TIMEOUT;
++    loop {
++        if let Ok(verdict) = fs::read_to_string(&path) {
++            match verdict.trim() {
++                "allow" => return Ok(()),
++                "deny" => {
++                    return Err(anyhow!(
++                        "container {} refused by policy-monitor: image not allowlisted",
++                        cid
++                    ))
++                }
++                // Anything else is not an admission; wait for the timeout.
++                _ => {}
++            }
++        }
++        if tokio::time::Instant::now() >= deadline {
++            return Err(anyhow!(
++                "no policy-monitor verdict for container {} after {:?}; refusing to start it",
++                cid,
++                C8S_VERDICT_TIMEOUT
++            ));
++        }
++        tokio::time::sleep(C8S_VERDICT_POLL).await;
++    }
++}
++
+ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
+     let path = PathBuf::from(req.path.as_str());
+ 

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -222,6 +222,8 @@ done
 # Without it the host can replace the baked policy via init-data, so a guest
 # built without it enforces nothing it claims to.
 [[ -f "${PATCH_DIR}/0001-agent-refuse-an-init-data-supplied-policy.patch" ]] || die "the init-data policy patch is missing from ${PATCH_DIR}."
+# Without it policy-monitor's decision races the container's execve.
+[[ -f "${PATCH_DIR}/0002-agent-wait-for-the-admission-verdict.patch" ]] || die "the admission-verdict patch is missing from ${PATCH_DIR}."
 
 # A prior run's images must not survive to publish time: CI pushes the output
 # dirs verbatim (oras push ./*), and on a persistent runner the root-owned

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -34,11 +34,14 @@ workload_input_for(id) := {
 		"options": [],
 		"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"container\"}"],
 	}],
-	"OCI": {"Annotations": {
-		"io.katacontainers.pkg.oci.container_type": "pod_container",
-		"io.kubernetes.cri.container-type": "container",
-		"io.kubernetes.cri.image-name": digest_ref,
-	}},
+	"OCI": {
+		"Annotations": {
+			"io.katacontainers.pkg.oci.container_type": "pod_container",
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name": digest_ref,
+		},
+		"Mounts": [],
+	},
 }
 
 workload_input := workload_input_for(cid)
@@ -146,10 +149,13 @@ sandbox_input := {
 		"options": [],
 		"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"sandbox\"}"],
 	}],
-	"OCI": {"Annotations": {
-		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
-		"io.kubernetes.cri.container-type": "sandbox",
-	}},
+	"OCI": {
+		"Annotations": {
+			"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+			"io.kubernetes.cri.container-type": "sandbox",
+		},
+		"Mounts": [],
+	},
 }
 
 test_sandbox_allowed if {
@@ -182,6 +188,58 @@ test_sandbox_storage_shaped_like_a_rootfs_denied if {
 test_sandbox_storage_elsewhere_allowed if {
 	CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/shared/containers/x"}]}
 	UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/y"}]}
+}
+
+# --- mounts -------------------------------------------------------------
+#
+# The runtime rewrites every bind source it sends into a directory it manages,
+# so a source anywhere else is guest state the host is asking to hand a
+# container. Where a mount LANDS is not gated here — see the rule comment.
+
+honest_mounts := [
+	{"destination": "/proc", "source": "proc", "type_": "proc", "options": []},
+	{"destination": "/sys/fs/cgroup", "source": "cgroup", "type_": "cgroup", "options": []},
+	{"destination": "/dev/shm", "source": "/run/kata-containers/sandbox/shm", "type_": "bind", "options": []},
+	{"destination": "/etc/resolv.conf", "source": "/run/kata-containers/shared/containers/pod-resolv.conf", "type_": "bind", "options": []},
+	{"destination": "/data", "source": "/run/kata-containers/sandbox/storage/aGk", "type_": "bind", "options": []},
+]
+
+with_mounts(ms) := object.union(workload_input, {"OCI": {"Mounts": ms}})
+
+bind_from(source) := {"destination": "/x", "source": source, "type_": "bind", "options": []}
+
+test_honest_mounts_allowed if {
+	CreateContainerRequest with input as with_mounts(honest_mounts)
+}
+
+test_mount_from_outside_the_sandbox_dirs_denied if {
+	every source in [
+		"/",
+		"/etc/c8s/bootstrap-allowlist.json",
+		"/run/c8s/ratls-mesh.env",
+		"/run/kata-containers/image",
+		"/run/kata-containers/other/rootfs",
+	] {
+		not CreateContainerRequest with input as with_mounts(array.concat(
+			honest_mounts,
+			[bind_from(source)],
+		))
+	}
+}
+
+test_mount_source_traversal_denied if {
+	not CreateContainerRequest with input as with_mounts(array.concat(
+		honest_mounts,
+		[bind_from("/run/kata-containers/sandbox/../../c8s/ratls-mesh.env")],
+	))
+}
+
+# Same names CopyFile has to keep working for.
+test_mount_allows_projected_volume_names if {
+	CreateContainerRequest with input as with_mounts(array.concat(
+		honest_mounts,
+		[bind_from("/run/kata-containers/shared/containers/pod-vol/..data")],
+	))
 }
 
 # --- CopyFile -----------------------------------------------------------


### PR DESCRIPTION
policy-monitor decides whether an image is allowlisted after kata-agent has forked the container's init, so enforcement was a race it could lose — the post-start kill window, G1. The fork is not the exec, though: the init parks on the exec fifo and only do_start_container releases it, so that is a point where the decision can be waited on instead of raced.

policy-monitor now records its decision as `c8s-verdict` in the container's bundle, and a patched agent reads it before writing the fifo. Deny, an unreadable file, or no file within 30s all refuse the container, so a policy-monitor that never came up fails everything closed rather than open. The wait sits ahead of the sandbox lock so a slow verdict cannot stall unrelated agent work; in practice the spec was written during CreateContainer and the verdict is already there.

The verdict is trustworthy because of the CopyFile scoping that landed with the digest binding: the bundle is writable only by in-guest root, so the host cannot forge an admission. Without that this would just move the forgeable input.

The kill still runs — it now cleans up an init that never reached execve rather than being the thing that stops it. G4 (BPF-LSM on security_bprm_check_security) was G1's planned mitigation and is no longer needed for it; the sketch stays for whatever next wants a pre-execve hook.

The agent patch is verified as far as it can be here: it applies to the pinned kata source on top of 0001, the result is rustfmt-clean, and the helper compiles and passes behaviour tests (allow, deny, trailing newline, absent-verdict timeout, late verdict, container-id traversal) against real anyhow/tokio/safe-path. It has not been built into a guest or run on hardware.