### PR TITLE
fix(kata): stop CI DNS in the sealed guest rootfs latching sandbox tokens off

### DIFF
--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -168,7 +169,7 @@ func sandboxTokenSigner(cfg *Config, logger *slog.Logger) *workloadclaims.Sandbo
 	if len(measurements) == 0 {
 		logger.Warn("C8S_CDS_MEASUREMENTS not set: the sandbox-digests endpoint answers ANY RA-TLS-attested caller, so any TEE that can reach this guest can read what it runs. UNSAFE outside development.")
 	}
-	host, err := sandboxDigestsHost(cfg)
+	host, err := resolveSandboxDigestsHostWithRetry(cfg, logger)
 	if err != nil {
 		logger.Error("sandbox tokens disabled: no reachable digests host", "error", err)
 		return nil
@@ -190,6 +191,44 @@ func sandboxDigestsHost(cfg *Config) (string, error) {
 		cdsHost = u.Host
 	}
 	return workloadclaims.ResolveAdvertiseHost(cfg.SandboxDigestsAdvertiseHost, cdsHost)
+}
+
+// advertiseHostRetryBudget bounds the wait for the guest network to reach a
+// state where the routing-table lookup for CDS returns a real local IP. Kata
+// brings the pod network up after policy-monitor starts, so the first attempts
+// hit `network is unreachable`; that must not permanently latch tokens off.
+// Overridable in tests.
+var (
+	advertiseHostAttempts = 12
+	advertiseHostBackoff  = 5 * time.Second
+)
+
+// resolveSandboxDigestsHostWithRetry keeps retrying the routing-table lookup
+// while the guest's network is still being configured. It returns the last
+// error only when every attempt in the budget failed — the caller then falls
+// back to the same "sandbox tokens disabled" posture it always had.
+func resolveSandboxDigestsHostWithRetry(cfg *Config, logger *slog.Logger) (string, error) {
+	// Explicit host bypasses inference entirely — no reason to wait.
+	if cfg.SandboxDigestsAdvertiseHost != "" {
+		return sandboxDigestsHost(cfg)
+	}
+	var lastErr error
+	for i := 1; i <= advertiseHostAttempts; i++ {
+		host, err := sandboxDigestsHost(cfg)
+		if err == nil {
+			if i > 1 {
+				logger.Info("advertise-host inference recovered", "attempt", i, "host", host)
+			}
+			return host, nil
+		}
+		lastErr = err
+		if i < advertiseHostAttempts {
+			logger.Warn("advertise-host inference failed; retrying",
+				"attempt", i, "of", advertiseHostAttempts, "retry_in", advertiseHostBackoff, "error", err)
+			time.Sleep(advertiseHostBackoff)
+		}
+	}
+	return "", lastErr
 }
 
 // startAdmissionInventory serves the token route on the guest's loopback

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -3,8 +3,12 @@
 package policymonitor
 
 import (
+	"bytes"
+	"log/slog"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
@@ -111,5 +115,53 @@ func TestSandboxDigestsHost(t *testing.T) {
 		CDSURL:                      "https://cds.invalid:8443",
 	}); err == nil {
 		t.Fatal("loopback accepted as an advertise host")
+	}
+}
+
+// A configured advertise host bypasses retry entirely: the routing-table
+// lookup never happens, so the CDS URL not resolving does not matter.
+func TestResolveSandboxDigestsHostWithRetry_ExplicitHostSkipsRetry(t *testing.T) {
+	prev := advertiseHostAttempts
+	advertiseHostAttempts = 3
+	t.Cleanup(func() { advertiseHostAttempts = prev })
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	got, err := resolveSandboxDigestsHostWithRetry(&Config{
+		SandboxDigestsAdvertiseHost: "10.2.3.4",
+		CDSURL:                      "https://cds.invalid:8443",
+	}, logger)
+	if err != nil || got != "10.2.3.4" {
+		t.Fatalf("host = %q, err = %v; want 10.2.3.4 with no error", got, err)
+	}
+	if strings.Contains(buf.String(), "retrying") {
+		t.Fatalf("explicit host should not retry; log:\n%s", buf.String())
+	}
+}
+
+// A CDS URL that does not resolve exhausts the retry budget rather than
+// latching tokens off on the first failure.
+func TestResolveSandboxDigestsHostWithRetry_ExhaustsBudget(t *testing.T) {
+	prevAttempts := advertiseHostAttempts
+	prevBackoff := advertiseHostBackoff
+	advertiseHostAttempts = 3
+	advertiseHostBackoff = time.Millisecond
+	t.Cleanup(func() {
+		advertiseHostAttempts = prevAttempts
+		advertiseHostBackoff = prevBackoff
+	})
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	_, err := resolveSandboxDigestsHostWithRetry(&Config{
+		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
+	}, logger)
+	if err == nil {
+		t.Fatal("want an error after retry budget exhausted")
+	}
+	// Every attempt but the last logs a retry line — proves we did not latch
+	// off on the first failure the way the old code did.
+	if got := strings.Count(buf.String(), `"msg":"advertise-host inference failed; retrying"`); got != advertiseHostAttempts-1 {
+		t.Fatalf("got %d retry log lines, want %d; log:\n%s", got, advertiseHostAttempts-1, buf.String())
 	}
 }

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -506,14 +506,26 @@ sudo rm -rf "${TARGET_ROOTFS}/pause_bundle"
 sudo cp -a "${WORK_DIR}/pause_bundle" "${TARGET_ROOTFS}/pause_bundle"
 
 # --- Reproducibility normalisation (must be the LAST rootfs mutation) ------
-# 1. umoci writes a *.mtree metadata manifest into the pause bundle whose bytes
-#    embed timestamps — the ONLY file that differs between two builds. It is
-#    unused at runtime (kata reads config.json + rootfs/), so drop it.
-# 2. Stamp every file's mtime to SOURCE_DATE_EPOCH so the sealed ext4's inode
+# 1. Drop the build host's /etc/resolv.conf. Docker seeds it into the rootfs
+#    from the daemon's own resolver — Azure CI hosts leave `nameserver
+#    168.63.129.16` in the sealed image. In-guest policy-monitor reads it at
+#    boot, before kata's CopyFile stamps the pod's real resolv.conf on top,
+#    tries to resolve `c8s-cds.c8s-system.svc` against that unreachable Azure
+#    DNS, fails, and latches sandbox tokens off for the guest's whole life.
+#    An empty file boots to loopback DNS for the ~seconds before kata's
+#    CopyFile lands; a symlink into /run picks up systemd-resolved's stub if
+#    it comes up first. Empty file is the safer default under kata's
+#    guest-pull shape (no /run mount at read time).
+# 2. umoci writes a *.mtree metadata manifest into the pause bundle whose
+#    bytes embed timestamps — the ONLY file that differs between two builds.
+#    It is unused at runtime (kata reads config.json + rootfs/), so drop it.
+# 3. Stamp every file's mtime to SOURCE_DATE_EPOCH so the sealed ext4's inode
 #    timestamps are deterministic (image_builder's `cp -a` preserves them).
 # Together with SOURCE_DATE_EPOCH-driven mke2fs (deterministic UUID/hash-seed/
 # created-time) and the fixed VERITY_SALT in seal_and_assemble, this makes the
 # dm-verity root_hash bit-for-bit reproducible.
+sudo rm -f "${TARGET_ROOTFS}/etc/resolv.conf"
+: | sudo tee "${TARGET_ROOTFS}/etc/resolv.conf" >/dev/null
 sudo find "${TARGET_ROOTFS}/pause_bundle" -name '*.mtree' -delete
 sudo find "${TARGET_ROOTFS}" -exec touch --no-dereference --date="@${SOURCE_DATE_EPOCH}" {} +
 


### PR DESCRIPTION
  Docker seeds /etc/resolv.conf into the osbuilder rootfs from the daemon's own
  resolver. The Github CI hosts leave `nameserver 168.63.129.16` in the sealed image;
  in-guest policy-monitor reads it at boot before kata's CopyFile stamps the
  pod's real resolv.conf on top, fails to resolve c8s-cds.c8s-system.svc against
  that unreachable address, and latches sandbox tokens off for the guest's whole
  life. Every downstream sandbox-bound leaf (secrets, encrypted volumes) then
  fails at issuance with no way to recover short of a rootfs rebuild.

  Two changes, one per side of the boundary:

  1. kata-guest-base/scripts/build.sh: empty /etc/resolv.conf as part of the
     pre-seal reproducibility normalisation, so the launch measurement is stable
     and no Docker build-host artifact reaches the guest.

  2. policy-monitor: bounded retry (12 x 5s) on the routing-table advertise-host
     inference. Kata brings the pod network up after policy-monitor starts, so
     the first attempt legitimately hits `network is unreachable`; the old
     single-shot latched tokens off for good on that transient. Tests cover the
     explicit-host bypass and the budget-exhausted path.