### PR TITLE
fix(kata): wire the qemu wrapper so volume-annotated pods actually get the disk

### DIFF
--- a/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
+++ b/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# PROTOTYPE kata qemu wrapper. It attaches two kinds of disk to a guest:
+#
+#  1. a per-VM ephemeral scratch disk, so the in-guest confidential image store
+#     (extra/usr/local/lib/c8s/scratch-setup.sh) can unpack large images to
+#     encrypted disk instead of RAM;
+#  2. this pod's encrypted volumes (docs/volumes.md), so the in-guest volumed
+#     can open them. kata-agent always mounts a block storage it is handed, and
+#     these carry ciphertext it cannot mount, so they must reach the guest as
+#     bare devices rather than through kata's direct-volume assignment.
+#
+# Kata has no native per-sandbox disk knob for either, so we intercept the qemu
+# launch: set [hypervisor.qemu] path = <this script> in the kata-qemu-tdx
+# config. Each disk is found in the guest by its virtio serial
+# (/sys/block/<dev>/serial), and carries only ciphertext — the host cannot read
+# either one.
+#
+# Which volumes to attach comes from the pod's host-written annotation, which is
+# a selector and not a trust input: naming another tenant's device attaches
+# ciphertext the host already holds, and the guest still cannot open it without
+# the key CDS releases against the allowlist grant (docs/volumes.md, "The serial
+# is a selector, not a trust input"). Volume devices are attached read-only, so
+# a guest cannot write ciphertext back over one.
+#
+# PRODUCTION NOTE: still a prototype. The clean version attaches the disks from
+# the kata runtime (or a CDI device) rather than wrapping qemu. Tunables via env:
+# CONFAI_REAL_QEMU, CONFAI_SCRATCH_DIR, CONFAI_SCRATCH_SIZE, CONFAI_GC_GRACE_SECS,
+# CONFAI_BUNDLE_ROOTS, CONFAI_SYS_BLOCK.
+set -euo pipefail
+
+QEMU="${CONFAI_REAL_QEMU:-/opt/kata/bin/qemu-system-x86_64}"
+SDIR="${CONFAI_SCRATCH_DIR:-/var/lib/kata-scratch}"
+SIZE="${CONFAI_SCRATCH_SIZE:-30G}"
+GRACE="${CONFAI_GC_GRACE_SECS:-120}"
+SYSBLOCK="${CONFAI_SYS_BLOCK:-/sys/block}"
+# Where containerd writes the sandbox's OCI bundle. RKE2/k3s keep their own
+# state root, so both are searched unless overridden.
+BUNDLE_ROOTS="${CONFAI_BUNDLE_ROOTS:-/run/containerd/io.containerd.runtime.v2.task/k8s.io /run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io}"
+
+# The annotation naming this pod's volumes, and the serial prefix the guest
+# matches on. Both must agree with the Go side: pkg/allowlist (the annotation)
+# and internal/cmds/volume (SerialPrefix).
+VOLUMES_ANNOTATION="confidential.ai/c8s-volumes"
+SERIAL_PREFIX="c8s-vol-"
+
+# The scratch file MUST be keyed on a reliably-unique id: two VMs sharing one
+# raw disk would corrupt each other. Kata passes the sandbox id in the -name
+# argument ("-name sandbox-<64hex>,..."); take the id from THAT arg only (not
+# "first 64-hex anywhere in argv", which could match an unrelated value). If we
+# can't find it, FAIL — never fall back to a shared name.
+name=""
+prev=""
+for a in "$@"; do
+    [ "$prev" = "-name" ] && { name="$a"; break; }
+    prev="$a"
+done
+SBID="$(printf '%s' "$name" | grep -oE '[a-f0-9]{64}' | head -1 || true)"
+if [ -z "$SBID" ]; then
+    echo "kata-qemu-scratch-wrapper: no sandbox id in -name ('$name'); refusing to launch with a shared scratch disk" >&2
+    exit 1
+fi
+
+mkdir -p "$SDIR"
+
+# GC scratch files from VMs that are gone: no process holds the file open AND it
+# is older than the grace window. The grace window makes this safe against a
+# concurrently-launching VM whose file already exists but whose qemu has not
+# opened it yet — that file is fresh, so it is skipped.
+for f in "$SDIR"/scratch-*.img; do
+    [ -e "$f" ] || continue
+    if [ -z "$(find "$f" -newermt "-${GRACE} seconds" 2>/dev/null)" ] && ! fuser "$f" >/dev/null 2>&1; then
+        rm -f "$f"
+    fi
+done
+
+IMG="$SDIR/scratch-$SBID.img"
+truncate -s "$SIZE" "$IMG"
+
+# volume_names prints this pod's volume names, one per line.
+#
+# The bundle's config.json holds the pod annotations. Rather than parse JSON,
+# the fixed key's value is extracted and every candidate name is validated
+# against the same DNS-1123 label rule (and 12-char serial cap) the webhook, the
+# sidecar and volumed all apply — so a value crafted to confuse the extraction
+# yields names that fail validation and are skipped, never a shell word.
+volume_names() {
+    local cfg="" root
+    for root in $BUNDLE_ROOTS; do
+        if [ -f "$root/$SBID/config.json" ]; then
+            cfg="$root/$SBID/config.json"
+            break
+        fi
+    done
+    [ -n "$cfg" ] || return 0
+
+    local raw
+    raw="$(grep -o "\"$VOLUMES_ANNOTATION\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$cfg" |
+        head -1 | sed 's/.*:[[:space:]]*"//; s/"$//' || true)"
+    [ -n "$raw" ] || return 0
+
+    # Trailing newline matters: without it `read` drops the last entry, and the
+    # pod would silently lose its final volume.
+    printf '%s\n' "$raw" | tr ',' '\n' | while IFS= read -r entry; do
+        local name="${entry%%=*}"
+        if printf '%s' "$name" | grep -qE '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$' &&
+            [ "${#name}" -le 12 ]; then
+            printf '%s\n' "$name"
+        else
+            echo "kata-qemu-scratch-wrapper: ignoring malformed volume entry '$entry'" >&2
+        fi
+    done
+}
+
+# device_for prints the block device carrying serial $SERIAL_PREFIX$1.
+#
+# A serial matching more than one device is refused rather than resolved to
+# whichever was read first: the host can attach two devices claiming the same
+# serial, and picking one would make which volume a pod gets depend on scan
+# order. Mirrors SerialDevices.Device in internal/cmds/volumed.
+device_for() {
+    local want="$SERIAL_PREFIX$1" found=() d serial
+    for d in "$SYSBLOCK"/*; do
+        [ -r "$d/serial" ] || continue
+        serial="$(tr -d '[:space:]' <"$d/serial")"
+        [ "$serial" = "$want" ] && found+=("$(basename "$d")")
+    done
+    if [ "${#found[@]}" -ne 1 ]; then
+        echo "kata-qemu-scratch-wrapper: ${#found[@]} block devices carry serial $want; not attaching" >&2
+        return 1
+    fi
+    printf '/dev/%s\n' "${found[0]}"
+}
+
+# A missing or ambiguous device is logged and skipped rather than failing the
+# launch: refusing here surfaces as an opaque shim error on a pod that never
+# starts, whereas letting it boot leaves the in-guest daemon to answer "volume
+# device is not present", which is where an operator is already looking.
+volume_args=()
+n=0
+while IFS= read -r vol; do
+    [ -n "$vol" ] || continue
+    if dev="$(device_for "$vol")"; then
+        volume_args+=(
+            -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
+            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol,read-only=on"
+        )
+        n=$((n + 1))
+    fi
+done < <(volume_names)
+
+# file.locking left at the qemu default (on): with unique per-sandbox files a
+# lock conflict now means a real bug (two launches, same id) and should fail
+# loudly rather than silently share the disk.
+exec "$QEMU" "$@" \
+    -drive "file=$IMG,format=raw,if=none,id=confaiscratch,cache=none" \
+    -device virtio-blk-pci,drive=confaiscratch,serial=confai-scratch \
+    "${volume_args[@]+"${volume_args[@]}"}"

--- a/internal/helmchart/c8s/files/scripts/pull-and-configure.sh
+++ b/internal/helmchart/c8s/files/scripts/pull-and-configure.sh
@@ -110,17 +110,23 @@ dropin="${dropin_dir}/50-c8s.toml"
 # the SAME tag is deliberately not detected: running clusters do NOT pick up
 # new kata-guest-base artifacts.
 # gen= versions the generator itself: bump it whenever the emitted TOML
-# changes shape, so nodes with unchanged inputs still rewrite.
-config_fingerprint="gen=2|registry=${REGISTRY}|tag=${TAG}|dir=${HOST_IMG_DIR}|shim=${SHIM_NAME}|debug=${KATA_DEBUG}|pcie=${GPU_PCIE_ROOT_PORT}|mem=${GPU_DEFAULT_MEMORY}|base_params=${base_kernel_params}"
+# changes shape, so nodes with unchanged inputs still rewrite. gen=3 wires the
+# host qemu wrapper via `[hypervisor.qemu] path=`; an older drop-in without it
+# leaves volume-annotated pods hanging at first StartContainer.
+config_fingerprint="gen=3|registry=${REGISTRY}|tag=${TAG}|dir=${HOST_IMG_DIR}|shim=${SHIM_NAME}|debug=${KATA_DEBUG}|pcie=${GPU_PCIE_ROOT_PORT}|mem=${GPU_DEFAULT_MEMORY}|base_params=${base_kernel_params}"
 marker="# c8s-config: ${config_fingerprint}"
 
 out_dir="${HOST_IMG_DIR}/base"
+wrapper_dst="${HOST_KATA_DIR}/bin/kata-qemu-scratch-wrapper.sh"
 up_to_date=false
 if [ -f "${dropin}" ] && grep -qFx "${marker}" "${dropin}"; then
     up_to_date=true
     for required in vmlinuz kata-rootfs.img kernel_verity_params rootfs_type; do
         [ -f "${out_dir}/${required}" ] || up_to_date=false
     done
+    # A wrapper that got swept between reconciles must trigger the full pass so
+    # the drop-in and the on-disk wrapper stay in lockstep.
+    [ -x "${wrapper_dst}" ] || up_to_date=false
 fi
 if [ "${up_to_date}" = "true" ]; then
     echo "==> c8s-kata-image-puller: up to date (shim=${SHIM_NAME}, mode=${MODE})"
@@ -188,6 +194,20 @@ rm -rf "${old_dir}"
 # the host root at /host; kata-runtime running on the host
 # sees the same files without the prefix.
 host_out_dir="${out_dir#/host}"
+
+# Install the host-side qemu wrapper next to kata's real qemu binary. It
+# resolves the pod's encrypted-volume annotation into a `-device virtio-blk`
+# argv addition before exec'ing the real qemu. Copy is via a temp path +
+# rename so a puller restart mid-copy can't leave a partial script in the
+# path kata is about to exec. Executable-bit is load-bearing: kata calls
+# hypervisor.qemu path directly, no shell in between. wrapper_dst was pinned
+# above so the up-to-date check gates on the same file this write produces.
+wrapper_src="/scripts/kata-qemu-scratch-wrapper.sh"
+host_wrapper_dst="${wrapper_dst#/host}"
+mkdir -p "$(dirname "${wrapper_dst}")"
+cp "${wrapper_src}" "${wrapper_dst}.c8s-tmp"
+chmod 0755 "${wrapper_dst}.c8s-tmp"
+mv -f "${wrapper_dst}.c8s-tmp" "${wrapper_dst}"
 
 # c8s writes ONLY a config.d/ drop-in — never the main configuration-<shim>.toml.
 #
@@ -261,6 +281,13 @@ tmp="${dropin}.c8s-tmp"
     echo "${marker}"
     echo ''
     echo '[hypervisor.qemu]'
+    # Wrap qemu so the launcher can attach this pod's encrypted volume devices
+    # (docs/volumes.md): kata's direct-volume path assumes ciphertext-free
+    # storage kata-agent can mount, and the wrapper carries only the volume
+    # attachment logic — the base qemu path is CONFAI_REAL_QEMU. Without the
+    # override the LIO disk `c8s volume attach` writes to the node is never
+    # attached to the guest, and the sandbox times out at first StartContainer.
+    printf 'path = "%s"\n' "${host_wrapper_dst}"
     printf 'kernel = "%s/vmlinuz"\n' "${host_out_dir}"
     printf 'image = "%s/kata-rootfs.img"\n' "${host_out_dir}"
     printf 'rootfs_type = "%s"\n' "${RFT}"

--- a/internal/helmchart/c8s/templates/kata-image-puller.yaml
+++ b/internal/helmchart/c8s/templates/kata-image-puller.yaml
@@ -36,6 +36,14 @@ metadata:
 data:
   pull-and-configure.sh: |
 {{ .Files.Get "files/scripts/pull-and-configure.sh" | indent 4 }}
+  # Host-side qemu wrapper. Attaches this pod's encrypted volume devices to the
+  # kata guest, since kata's own direct-volume path assumes ciphertext-free
+  # storage. Installed onto the host and pointed at from the drop-in's
+  # [hypervisor.qemu] path by pull-and-configure.sh. Byte-identical to
+  # kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh (enforced by
+  # internal/helmchart/chart_test.go).
+  kata-qemu-scratch-wrapper.sh: |
+{{ .Files.Get "files/scripts/kata-qemu-scratch-wrapper.sh" | indent 4 }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -6636,3 +6636,30 @@ func TestChartKataRejectsHostVolumed(t *testing.T) {
 		t.Errorf("fail message %q should name volumed.enabled", msg)
 	}
 }
+
+// The host qemu wrapper needs one source of truth: the puller ConfigMap ships a
+// copy, and kata-guest-base scripts/ holds the canonical file because it lives
+// alongside the guest tooling it is coupled to. A silent drift would be a
+// launch-behaviour drift the launch measurement can't catch (the wrapper runs
+// on the host outside every attested boundary).
+func TestKataQemuWrapperCopiesMatch(t *testing.T) {
+	// Both paths are repo-relative; the chart test package sits under
+	// internal/helmchart, so climb two levels to reach the repo root.
+	const (
+		chart  = "c8s/files/scripts/kata-qemu-scratch-wrapper.sh"
+		source = "../../kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh"
+	)
+	chartBytes, err := os.ReadFile(chart)
+	if err != nil {
+		t.Fatalf("read %s: %v", chart, err)
+	}
+	sourceBytes, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("read %s: %v", source, err)
+	}
+	if !slices.Equal(chartBytes, sourceBytes) {
+		t.Fatalf("wrapper drift: %s and %s must be byte-identical\n"+
+			"the puller ConfigMap uses the chart copy; the guest-base tree is the source of truth\n"+
+			"fix: cp %s %s", chart, source, source, chart)
+	}
+}


### PR DESCRIPTION
c8s volume attach (LIO, #234) puts a real SCSI disk with VPD c8s-vol-<name>
on the node, and the in-guest volumed (#231) waits for exactly that device
inside the sandbox — but nothing was pointing kata at the wrapper that
attaches it, so the disk never entered the guest. A volume-annotated pod
timed out at the first StartContainer (kata-agent DeadlineExceeded) because
the wrapper's -device virtio-blk addition never made it onto qemu's argv.

Puller ConfigMap now ships kata-qemu-scratch-wrapper.sh alongside
pull-and-configure.sh. On reconcile the puller installs it to
/opt/kata/bin/kata-qemu-scratch-wrapper.sh (0755) via a rename-in-place so a
mid-copy restart cannot leave a partial script on kata's exec path, and the
drop-in's [hypervisor.qemu] path points at it. Fingerprint bumped to gen=3 so
existing nodes re-reconcile, and the up-to-date check gates on the wrapper
existing so an out-of-band `rm` triggers a full reinstall.

The wrapper source of truth stays under kata-guest-base/scripts/; the chart
carries a byte-identical copy (helm's .Files.Get can't reach outside the
chart tree, and //go:embed can't span ..). A chart_test.go check makes drift
a test failure.