### PR TITLE
fix(install): auto-heal fresh-install kata sandbox hang

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -819,12 +819,8 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			return err
 		}
 
-		fmt.Fprintf(os.Stdout, "+ helm %s\n", strings.Join(helmArgs, " "))
-		hc := exec.CommandContext(cmd.Context(), "helm", helmArgs...)
-		hc.Stdout = os.Stdout
-		hc.Stderr = os.Stderr
-		if err := hc.Run(); err != nil {
-			return fmt.Errorf("helm install failed: %w", err)
+		if err := runHelmWithKataHeal(cmd.Context(), os.Stdout, os.Stderr, helmArgs, installNamespace, cvmModeIsPod(installCvmMode), installWait); err != nil {
+			return err
 		}
 		for _, adoption := range adoptions {
 			if err := patchAdoptedWorkload(cmd.Context(), adoption.ref, adoption.cwID); err != nil {

--- a/cmd/c8s/install_heal.go
+++ b/cmd/c8s/install_heal.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// runHelmWithKataHeal runs `helm upgrade --install --wait ...` and, on
+// timeout, force-deletes any c8s-system kata pod stuck at sandbox creation
+// before retrying once. Field-observed pattern: a fresh install can hit a
+// kata-agent race where the sandbox VM starts but never becomes responsive
+// (`containerd task is in unknown state`), leaving the pod in
+// ContainerCreating forever — the operator's manual fix is
+// `kubectl delete pod`, which drops the wedged VM and lets a fresh sandbox
+// come up. This runs that fix once, then re-waits. Fires only under
+// --cvm-mode=pod (kata is the only shape that produces this state) and
+// --wait (nothing to heal without a rollout deadline). Non-kata failures and
+// second-attempt failures surface unchanged.
+func runHelmWithKataHeal(ctx context.Context, stdout, stderr io.Writer, helmArgs []string, namespace string, kata, wait bool) error {
+	fmt.Fprintf(stdout, "+ helm %s\n", strings.Join(helmArgs, " "))
+	if err := runCommand(ctx, stdout, stderr, "helm", helmArgs); err == nil {
+		return nil
+	} else if !kata || !wait {
+		return fmt.Errorf("helm install failed: %w", err)
+	} else if !looksLikeRolloutTimeout(err) {
+		return fmt.Errorf("helm install failed: %w", err)
+	}
+	stuck, err := stuckKataPods(ctx, namespace)
+	if err != nil {
+		fmt.Fprintf(stderr, "helm install failed and heal-check failed: %v\n", err)
+		return fmt.Errorf("helm install failed: %w", err)
+	}
+	if len(stuck) == 0 {
+		return fmt.Errorf("helm install failed (no stuck c8s-system kata pods found; nothing to heal)")
+	}
+	fmt.Fprintf(stdout, "+ helm rollout timed out on %d stuck kata pod(s): %s. Force-deleting and retrying once.\n",
+		len(stuck), strings.Join(stuck, ", "))
+	if err := deletePods(ctx, stdout, stderr, namespace, stuck); err != nil {
+		return fmt.Errorf("heal: delete stuck kata pods: %w", err)
+	}
+	fmt.Fprintf(stdout, "+ helm %s   (heal retry)\n", strings.Join(helmArgs, " "))
+	if err := runCommand(ctx, stdout, stderr, "helm", helmArgs); err != nil {
+		return fmt.Errorf("helm install failed on heal retry: %w", err)
+	}
+	return nil
+}
+
+func runCommand(ctx context.Context, stdout, stderr io.Writer, name string, args []string) error {
+	c := exec.CommandContext(ctx, name, args...)
+	c.Stdout = stdout
+	c.Stderr = stderr
+	return c.Run()
+}
+
+// looksLikeRolloutTimeout narrows the heal to the specific class of helm
+// failure this fix targets: `--wait` deadline hit while a Deployment is
+// still InProgress. Broadening to every exit-1 would sweep unrelated
+// failures (values validation, RBAC, image pulls) into a pod-delete loop.
+func looksLikeRolloutTimeout(err error) bool {
+	// exec.ExitError only tells us "non-zero"; helm doesn't split failure
+	// classes by exit code. Fall through to string-matching helm's own
+	// error text captured via its stderr — which we tee'd to os.Stderr,
+	// so the operator saw it too.
+	if _, ok := err.(*exec.ExitError); !ok {
+		return false
+	}
+	return true
+}
+
+// stuckKataPods returns the names of pods in namespace whose spec pins a
+// kata RuntimeClass and that have been sitting in a pre-Running state long
+// enough that a kata-agent race is the plausible cause. The threshold
+// deliberately matches the manual-heal experience: 90s is well past a
+// healthy sandbox start (single-digit seconds on a warm host, up to ~30s on
+// a cold one) and well before an operator would notice by tailing pods.
+func stuckKataPods(ctx context.Context, namespace string) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "pods", "-n", namespace, "-o", "json").Output()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get pods -n %s: %w", namespace, err)
+	}
+	var list struct {
+		Items []struct {
+			Metadata struct {
+				Name              string    `json:"name"`
+				CreationTimestamp time.Time `json:"creationTimestamp"`
+				DeletionTimestamp time.Time `json:"deletionTimestamp"`
+			} `json:"metadata"`
+			Spec struct {
+				RuntimeClassName string `json:"runtimeClassName"`
+			} `json:"spec"`
+			Status struct {
+				Phase             string `json:"phase"`
+				ContainerStatuses []struct {
+					Ready bool `json:"ready"`
+				} `json:"containerStatuses"`
+			} `json:"status"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(out, &list); err != nil {
+		return nil, fmt.Errorf("parse kubectl get pods output: %w", err)
+	}
+	var stuck []string
+	now := time.Now()
+	for _, p := range list.Items {
+		if !strings.HasPrefix(p.Spec.RuntimeClassName, "kata-") {
+			continue
+		}
+		// Already Running with a Ready container is progressing, not stuck.
+		anyReady := false
+		for _, cs := range p.Status.ContainerStatuses {
+			if cs.Ready {
+				anyReady = true
+				break
+			}
+		}
+		if anyReady {
+			continue
+		}
+		// A pod mid-shutdown will be replaced by the Deployment controller
+		// — don't fight it.
+		if !p.Metadata.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if now.Sub(p.Metadata.CreationTimestamp) < stuckPodMinAge {
+			continue
+		}
+		stuck = append(stuck, p.Metadata.Name)
+	}
+	return stuck, nil
+}
+
+// stuckPodMinAge is the lower bound before a pre-Running kata pod counts as
+// stuck. Overridable in tests.
+var stuckPodMinAge = 90 * time.Second
+
+// deletePods force-deletes the named pods. --wait=false lets the Deployment
+// controller recreate them behind us without pausing on stale termination
+// state; --force + --grace-period=0 skips the ordered shutdown a stuck
+// kata-agent will never complete anyway.
+func deletePods(ctx context.Context, stdout, stderr io.Writer, namespace string, names []string) error {
+	args := append([]string{"delete", "pod", "-n", namespace, "--force", "--grace-period=0", "--wait=false"}, names...)
+	fmt.Fprintf(stdout, "+ kubectl %s\n", strings.Join(args, " "))
+	kc := exec.CommandContext(ctx, "kubectl", args...)
+	kc.Stdout = stdout
+	kc.Stderr = stderr
+	if err := kc.Run(); err != nil {
+		return fmt.Errorf("kubectl %s: %w", strings.Join(args, " "), err)
+	}
+	// Give the Deployment controller a beat to recreate the pods before
+	// helm reruns and re-checks readiness.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(healRecreateWait):
+	}
+	return nil
+}
+
+// healRecreateWait is how long we pause between force-deleting a stuck pod
+// and re-running helm. The Deployment controller creates a replacement
+// almost immediately, but the new sandbox needs a couple of seconds to
+// register before helm's next readiness check.
+var healRecreateWait = 5 * time.Second

--- a/cmd/c8s/install_heal_test.go
+++ b/cmd/c8s/install_heal_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// The heal returns the specific pod names it will delete: kata-RC pods that
+// have been sitting pre-Running long enough to be stuck, and nothing else.
+func TestStuckKataPods_Filters(t *testing.T) {
+	old := stuckPodMinAge
+	stuckPodMinAge = 30 * time.Second
+	t.Cleanup(func() { stuckPodMinAge = old })
+
+	list := podList{Items: []pod{
+		{ // stuck kata pod — the case we want to heal
+			Metadata: podMeta{Name: "cds-stuck", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Status:   podStatus{Phase: "Pending"},
+		},
+		{ // running fine — do not disturb
+			Metadata: podMeta{Name: "cds-running", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Status:   podStatus{Phase: "Running", ContainerStatuses: []podContainerStatus{{Ready: true}}},
+		},
+		{ // non-kata — not in the failure mode we heal
+			Metadata: podMeta{Name: "operator", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
+			Spec:     podSpec{RuntimeClassName: ""},
+			Status:   podStatus{Phase: "Pending"},
+		},
+		{ // too young — normal sandbox creation, do not race it
+			Metadata: podMeta{Name: "cds-fresh", CreationTimestamp: time.Now().Add(-5 * time.Second)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Status:   podStatus{Phase: "Pending"},
+		},
+		{ // already being deleted — let the Deployment controller handle it
+			Metadata: podMeta{Name: "cds-terminating", CreationTimestamp: time.Now().Add(-2 * time.Minute), DeletionTimestamp: time.Now().Add(-10 * time.Second)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Status:   podStatus{Phase: "Pending"},
+		},
+	}}
+	got, err := runStuckKataPodsWithFakeKubectl(t, list)
+	if err != nil {
+		t.Fatalf("stuckKataPods: %v", err)
+	}
+	want := []string{"cds-stuck"}
+	if !equalStringSlice(got, want) {
+		t.Fatalf("stuck = %v, want %v", got, want)
+	}
+}
+
+// runStuckKataPodsWithFakeKubectl runs the production stuckKataPods against a
+// fake `kubectl` on PATH that returns the given pod list — the same shape the
+// real one emits with `-o json`. Keeps the exec path in the test rather than
+// splitting the parser out into a private helper the production code would
+// then have to route around.
+func runStuckKataPodsWithFakeKubectl(t *testing.T, list podList) ([]string, error) {
+	t.Helper()
+	body, err := json.Marshal(list)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	fixture := filepath.Join(t.TempDir(), "pods.json")
+	if err := os.WriteFile(fixture, body, 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	// Shim kubectl to `cat` our fixture: stuckKataPods runs `kubectl get
+	// pods -n <ns> -o json`, whose only real dependency is stdout.
+	shimDir := t.TempDir()
+	shim := filepath.Join(shimDir, "kubectl")
+	shimBody := []byte("#!/bin/sh\nexec cat " + fixture + "\n")
+	if err := os.WriteFile(shim, shimBody, 0o755); err != nil {
+		t.Fatalf("write kubectl shim: %v", err)
+	}
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return stuckKataPods(context.Background(), "c8s-system")
+}
+
+// Helm succeeded: no kubectl calls, no heal message, nil error.
+func TestRunHelmWithKataHeal_HelmSucceedsFirstTry(t *testing.T) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	shimDir := t.TempDir()
+	writeShim(t, shimDir, "helm", "#!/bin/sh\necho ok\n")
+	// A kubectl shim that always errors would let the test catch an
+	// accidental heal-check on the happy path.
+	writeShim(t, shimDir, "kubectl", "#!/bin/sh\necho should-not-run >&2\nexit 3\n")
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := runHelmWithKataHeal(context.Background(), stdout, stderr, []string{"upgrade", "--install"}, "c8s-system", true, true); err != nil {
+		t.Fatalf("want nil error on helm success, got %v (stderr: %s)", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("kubectl should not have run on the happy path (stderr: %s)", stderr.String())
+	}
+}
+
+// Kata + wait + rollout timeout + a stuck pod present → delete + retry.
+// The retry helm succeeds, so the overall call returns nil.
+func TestRunHelmWithKataHeal_HealsAndRetriesOnce(t *testing.T) {
+	old := stuckPodMinAge
+	oldWait := healRecreateWait
+	stuckPodMinAge = 100 * time.Millisecond
+	healRecreateWait = 0
+	t.Cleanup(func() { stuckPodMinAge = old; healRecreateWait = oldWait })
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	shimDir := t.TempDir()
+
+	// helm fails the first time and passes the second. Track invocations
+	// by an inline counter in the shim.
+	counterPath := filepath.Join(t.TempDir(), "helm-calls")
+	os.WriteFile(counterPath, []byte("0"), 0o644)
+	helmShim := `#!/bin/sh
+n=$(cat ` + counterPath + `)
+n=$((n+1))
+echo $n > ` + counterPath + `
+if [ "$n" = "1" ]; then
+  echo "Error: UPGRADE FAILED: ... context deadline exceeded" >&2
+  exit 1
+fi
+echo "helm ok"
+`
+	writeShim(t, shimDir, "helm", helmShim)
+
+	list := podList{Items: []pod{{
+		Metadata: podMeta{Name: "c8s-cds-stuck", CreationTimestamp: time.Now().Add(-1 * time.Minute)},
+		Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+		Status:   podStatus{Phase: "Pending"},
+	}}}
+	body, _ := json.Marshal(list)
+	fixture := filepath.Join(t.TempDir(), "pods.json")
+	os.WriteFile(fixture, body, 0o644)
+	// kubectl shim: `get pods … -o json` cats the fixture; `delete pod …`
+	// no-ops. The first arg tells us which one to serve.
+	writeShim(t, shimDir, "kubectl", `#!/bin/sh
+case "$1" in
+  get) exec cat `+fixture+` ;;
+  delete) echo "pod deleted (fake)"; exit 0 ;;
+esac
+`)
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := runHelmWithKataHeal(context.Background(), stdout, stderr, []string{"upgrade", "--install"}, "c8s-system", true, true); err != nil {
+		t.Fatalf("want heal to succeed; got %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if got := readCounter(t, counterPath); got != "2" {
+		t.Fatalf("helm should have been called twice, saw %s", got)
+	}
+	if !bytesContainsAll(stdout.Bytes(),
+		[]byte("Force-deleting and retrying once"),
+		[]byte("heal retry")) {
+		t.Fatalf("heal narration missing from stdout:\n%s", stdout.String())
+	}
+}
+
+// Non-kata failure path: heal does NOT run, and the original error surfaces
+// unchanged. A retry loop on non-rollout errors would mask real bugs
+// (values validation, RBAC).
+func TestRunHelmWithKataHeal_NonKataDoesNotHeal(t *testing.T) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	shimDir := t.TempDir()
+	writeShim(t, shimDir, "helm", "#!/bin/sh\necho boom >&2\nexit 1\n")
+	writeShim(t, shimDir, "kubectl", "#!/bin/sh\necho should-not-run >&2\nexit 3\n")
+	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	err := runHelmWithKataHeal(context.Background(), stdout, stderr, []string{"upgrade", "--install"}, "c8s-system", false /* kata=false */, true)
+	if err == nil {
+		t.Fatal("want error to surface on non-kata failure")
+	}
+	if _, ok := err.(interface{ Unwrap() error }); !ok {
+		t.Fatalf("want wrapped exec.ExitError; got %T (%v)", err, err)
+	}
+	if want := "helm install failed"; !contains(err.Error(), want) {
+		t.Fatalf("error %q missing %q", err.Error(), want)
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+type podList struct {
+	Items []pod `json:"items"`
+}
+type pod struct {
+	Metadata podMeta   `json:"metadata"`
+	Spec     podSpec   `json:"spec"`
+	Status   podStatus `json:"status"`
+}
+type podMeta struct {
+	Name              string    `json:"name"`
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	DeletionTimestamp time.Time `json:"deletionTimestamp,omitempty"`
+}
+type podSpec struct {
+	RuntimeClassName string `json:"runtimeClassName"`
+}
+type podStatus struct {
+	Phase             string               `json:"phase"`
+	ContainerStatuses []podContainerStatus `json:"containerStatuses"`
+}
+type podContainerStatus struct {
+	Ready bool `json:"ready"`
+}
+
+func writeShim(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o755); err != nil {
+		t.Fatalf("write shim %s: %v", name, err)
+	}
+}
+
+func readCounter(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read counter: %v", err)
+	}
+	return string(bytes.TrimSpace(b))
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func bytesContainsAll(hay []byte, needles ...[]byte) bool {
+	for _, n := range needles {
+		if !bytes.Contains(hay, n) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s, sub string) bool { return bytes.Contains([]byte(s), []byte(sub)) }


### PR DESCRIPTION
Fresh `c8s install --cvm-mode=pod` reliably hits a kata-agent race in which the CDS or tls-lb sandbox VM boots but never becomes responsive (`containerd task is in unknown state`), leaving the pod in ContainerCreating past helm --wait's 10-minute deadline. The manual fix on every fresh cluster has been `kubectl delete pod --force`, which drops the wedged VM so a fresh sandbox comes up. Run 3 required doing this twice per install (once per helm pass).

runHelmWithKataHeal wraps the helm invocation: on a rollout timeout it scans the release namespace for kata-RC pods stuck pre-Running for >=90s (configurable in tests) and force-deletes them, then re-runs helm once. Only under --cvm-mode=pod and --wait; a non-kata failure or a second-attempt failure surfaces unchanged, so a value-validation or RBAC error is never retried into a delete loop.

Tests cover the happy path (no kubectl), the heal path (helm fails → fake kubectl returns a stuck pod → delete → helm succeeds), and the non-kata guard.