### PR TITLE
fix(kata): fetch gperf from a mirror that is actually up

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -373,7 +373,8 @@ jobs:
       #
       # Key: KATA_VERSION (osbuilder + agent + toolchain pins all derive from
       # it) + build.sh itself, whose Step 2 block holds the remaining inputs
-      # (DISTRO/OS_VERSION/AGENT_*/EXTRA_PKGS). Hashing the whole script
+      # (DISTRO/OS_VERSION/AGENT_*/EXTRA_PKGS) + patches/, which osbuilder
+      # compiles into the cached kata-agent. Hashing the whole script
       # over-invalidates — any build.sh edit re-pays the ~4 min — which is the
       # safe direction; a stale hit is impossible by construction. No
       # restore-keys: a partial-input match could resurrect a rootfs built
@@ -383,7 +384,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ runner.temp }}/kata-base-rootfs.tar.zst
-          key: kata-base-rootfs-${{ env.KATA_VERSION }}-${{ hashFiles('c8s/kata-guest-base/scripts/build.sh') }}
+          key: kata-base-rootfs-${{ env.KATA_VERSION }}-${{ hashFiles('c8s/kata-guest-base/scripts/build.sh', 'c8s/kata-guest-base/patches/*.patch') }}
 
       # Cache the guest kernel build output (confidential-os-builder/output/kernel) — the most
       # expensive INVARIANT in this job. build.sh Step 1/5 runs `confos kernel`,

--- a/kata-guest-base/patches/0003-versions-fetch-gperf-from-the-canonical-gnu-mirror.patch
+++ b/kata-guest-base/patches/0003-versions-fetch-gperf-from-the-canonical-gnu-mirror.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] versions: fetch gperf from the canonical GNU mirror
+
+osbuilder builds libseccomp inside the rootfs-builder container, and that needs
+gperf from `externals.gperf.url`. The pinned URL is a UK GNU mirror that no
+longer answers on 443, so every cold rootfs build burns the curl timeout and
+then dies:
+
+    INFO: Downloading from upstream: https://ftp.gnu.org.uk/gnu/gperf//gperf-3.3.tar.gz
+    curl: (28) Failed to connect to ftp.gnu.org.uk port 443 after 133741 ms
+    ERROR: Could not download from https://ftp.gnu.org.uk/gnu/gperf//gperf-3.3.tar.gz
+
+ftp.gnu.org is GNU's own host and serves the .sig alongside the tarball, so the
+helper's signature check is unchanged, and the gperf-3.3.tar.gz it returns is
+byte-identical to the one in kata's cached-tarballs artefact. ftpmirror.gnu.org
+is the usual redirector, but it resolves to whichever mirror is nearest and was
+itself returning 502 when this was written.
+
+--- a/versions.yaml
++++ b/versions.yaml
+@@ -336,7 +336,7 @@
+
+   gperf:
+     description: "GNU gperf is a perfect hash function generator"
+-    url: "https://ftp.gnu.org.uk/gnu/gperf/"
++    url: "https://ftp.gnu.org/gnu/gperf/"
+     version: "3.3"
+
+   hadolint:

--- a/kata-guest-base/patches/0004-oras-install-without-sudo-when-already-root.patch
+++ b/kata-guest-base/patches/0004-oras-install-without-sudo-when-already-root.patch
@@ -1,0 +1,51 @@
+Subject: [PATCH] oras: install without sudo when already root
+
+install_libseccomp.sh prefers the ORAS cache
+(ghcr.io/kata-containers/cached-tarballs/gperf:3.3) over a source download, and
+that artefact carries the tarball, its .sig and the signing key, so the cache
+path verifies the signature offline. Reaching it means installing ORAS, and
+install_oras.sh reaches for sudo — which the rootfs-builder container does not
+have:
+
+    INFO: Installing ORAS using existing script
+    install_oras.sh: line 43: sudo: command not found
+    WARN: ORAS installation script failed
+    INFO: ORAS not available, downloading directly from upstream
+
+The container is already root, so the elevation is only needed when a developer
+runs this on their own host. Falling back to the GNU mirror still works, but it
+then depends on a keyserver round-trip to import the gperf signing key, which is
+the flakier of the two paths.
+
+--- a/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
++++ b/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
+@@ -11,6 +11,10 @@
+
+ install_dest="/usr/local/bin"
+
++# osbuilder's rootfs-builder container runs as root and ships no sudo binary.
++sudo_cmd=""
++[[ "$(id -u)" -eq 0 ]] || sudo_cmd="sudo"
++
+ function get_installed_oras_version() {
+ 	oras version | grep Version | sed -e s/Version:// | tr -d '[:blank:]'
+ }
+@@ -24,7 +28,7 @@
+
+ 	echo "Proceeding to cleanup the previous installed version of ORAS, and install the version specified in the versions.yaml file"
+ 	oras_system_path=$(which oras)
+-	sudo rm -f "${oras_system_path}"
++	${sudo_cmd} rm -f "${oras_system_path}"
+ fi
+
+ arch=$(uname -m)
+@@ -40,6 +44,6 @@
+ curl -OL "https://github.com/oras-project/oras/releases/download/${oras_required_version}/${oras_tarball}"
+
+ echo "Installing ORAS to ${install_dest}"
+-sudo mkdir -p "${install_dest}"
+-sudo tar -C "${install_dest}" -xzf "${oras_tarball}"
+-sudo rm -f "${oras_tarball}"
++${sudo_cmd} mkdir -p "${install_dest}"
++${sudo_cmd} tar -C "${install_dest}" -xzf "${oras_tarball}"
++${sudo_cmd} rm -f "${oras_tarball}"


### PR DESCRIPTION
The cold rootfs build has been dead since the base-rootfs cache key last turned over: osbuilder builds libseccomp inside the rootfs-builder container, that needs gperf, and kata pins its URL to a UK GNU mirror that no longer answers on
443. Both failures on main are the same 133s curl timeout and make Error 1.

The cache path that exists precisely to avoid the mirror could not run either: the download helper installs ORAS via install_oras.sh, which reaches for sudo, and the container is root without a sudo binary.

Two patches against the pinned kata tree: point externals.gperf.url at ftp.gnu.org, and elevate in install_oras.sh only when not already root. The cache becomes the primary path (tarball + .sig + signing key, verified offline), with the GNU mirror as a fallback that now resolves. Both verified against the pinned commit: each lands a byte-identical gperf-3.3.tar.gz with a good signature.

Also add patches/ to the base-rootfs cache key. osbuilder compiles kata-agent from the patched tree during the cached step, so editing a patch without touching build.sh would have restored a rootfs built from the old agent.