### PR TITLE
kata-guest-base: pin all component images by immutable reference

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -291,8 +291,7 @@ jobs:
       - name: Setup ORAS
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
         with:
-          # Explicit pin (= current action default) so an action bump can't
-          # silently change the oras that resolves the allowlist digests.
+          # Explicit pin so an action bump can't silently change the oras that resolves the allowlist digests.
           version: "1.2.3"
 
       # Log in to GHCR for the manifest-fetch step: authenticated reads
@@ -507,11 +506,7 @@ jobs:
           # an in-flight kernel change can still publish a branch-* image before
           # the snapshot is committed.
           CHECK_SNAPSHOT: ${{ (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) && '1' || '0' }}
-          # Re-lay toolchain gate: root_hash depends on the host
-          # e2fsprogs/cryptsetup. Values = the published artifact's
-          # relay_toolchain (what `the-machine` runs); a runner upgrade now
-          # fails preflight instead of silently shifting root_hash — update
-          # the pin with the upgrade, expecting a new measurement.
+          # Re-lay toolchain gate (values = published artifact's relay_toolchain): a runner upgrade fails preflight instead of silently shifting root_hash; re-pin on upgrade, expecting a new measurement.
           REPRO_E2FSPROGS_VERSION: "1.47.0"
           REPRO_CRYPTSETUP_VERSION: "2.7.0"
           # GPU variants are mandatory in CI. build.sh Step 6 grafts the

--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -290,6 +290,10 @@ jobs:
       # silently permissive.
       - name: Setup ORAS
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+        with:
+          # Explicit pin (= current action default) so an action bump can't
+          # silently change the oras that resolves the allowlist digests.
+          version: "1.2.3"
 
       # Log in to GHCR for the manifest-fetch step: authenticated reads
       # dodge GHCR's anonymous rate limits. Same token as the publish
@@ -503,13 +507,13 @@ jobs:
           # an in-flight kernel change can still publish a branch-* image before
           # the snapshot is committed.
           CHECK_SNAPSHOT: ${{ (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) && '1' || '0' }}
-          # Re-lay toolchain gate: root_hash is reproducible only for a
-          # matching host e2fsprogs/cryptsetup (build.sh logs the runner's
-          # versions as "re-lay toolchain:" and records them in
-          # manifest.json). Uncomment with the runner's confirmed versions to
-          # make drift fatal on the publish path.
-          # REPRO_E2FSPROGS_VERSION: "1.47.0"
-          # REPRO_CRYPTSETUP_VERSION: "2.7.0"
+          # Re-lay toolchain gate: root_hash depends on the host
+          # e2fsprogs/cryptsetup. Values = the published artifact's
+          # relay_toolchain (what `the-machine` runs); a runner upgrade now
+          # fails preflight instead of silently shifting root_hash — update
+          # the pin with the upgrade, expecting a new measurement.
+          REPRO_E2FSPROGS_VERSION: "1.47.0"
+          REPRO_CRYPTSETUP_VERSION: "2.7.0"
           # GPU variants are mandatory in CI. build.sh Step 6 grafts the
           # NVIDIA payload from the staged kata-static artifacts
           # (KATA_NVIDIA_CONFIDENTIAL_IMG / KATA_NVIDIA_VMLINUZ, exported by

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -275,11 +275,10 @@ randomness:
   regardless of `SOURCE_DATE_EPOCH` (which only pins timestamps), and
   tune2fs can only reset the UUID, not the hash-seed; both live in the
   superblock that dm-verity hashes, so they are injected at mkfs time.
-- `UBUNTU_REPO_URL` — pins the apt archive; empty means osbuilder's
-  default `archive.ubuntu.com`, which drifts over time. Set it to
-  `https://snapshot.ubuntu.com/ubuntu/<YYYYMMDDTHHMMSSZ>` to time-pin
-  the base (old snapshots also need apt `Check-Valid-Until=false` in
-  osbuilder's mmdebstrap call).
+- `UBUNTU_REPO_URL` — the apt archive, defaulted in `build.sh` to a
+  committed `snapshot.ubuntu.com` timestamp so the guest packages don't
+  drift with build date. (Noble's snapshot Release files carry no
+  `Valid-Until`, so no apt override is needed.)
 
 Additionally, `image_builder.sh` populates the partition by mounting an
 empty ext4 and `cp -a`-ing files in, which leaves block allocation,
@@ -294,10 +293,39 @@ geometry.
 the build host, so the `root_hash` is reproducible only across builds
 using the same e2fsprogs and cryptsetup versions. The build records the
 versions it used in `manifest.json` (`relay_toolchain`) so a verifier
-knows exactly what to install; set `REPRO_E2FSPROGS_VERSION` /
-`REPRO_CRYPTSETUP_VERSION` to make a version mismatch fatal (the CI
-publish path should pin both). Running the re-lay inside a
-version-pinned container is the tracked longer-term fix.
+knows exactly what to install; `REPRO_E2FSPROGS_VERSION` /
+`REPRO_CRYPTSETUP_VERSION` make a version mismatch fatal (the CI
+publish path pins both in `kata-guest-base.yml`). Running the re-lay
+inside a version-pinned container is the tracked longer-term fix.
+
+## Component pins
+
+Every external input is pinned by immutable reference. Moving any pin
+moves `root_hash` and the launch measurement — bump deliberately, in a
+reviewed commit.
+
+| Pin | Where | Covers |
+|---|---|---|
+| `KATA_VERSION` / `KATA_SRC_COMMIT` | `build.sh`, workflow env | osbuilder source (tag pinned to its commit) |
+| `KATA_STATIC_SHA256` | `scripts/ci/stage-kata-conf.sh` | guest-components, NVIDIA graft sources, GPU kernel |
+| `PAUSE_IMAGE_DIGEST` + `PAUSE_PINNED_VERSION` | `build.sh` | `/pause_bundle` |
+| `UBUNTU_BASE_DIGEST` | `build.sh` | osbuilder's rootfs-builder toolchain image |
+| `UBUNTU_REPO_URL` (snapshot timestamp) | `build.sh` | guest apt packages |
+| `CONFOS_REF` | workflow env | guest kernel |
+| `REPRO_E2FSPROGS_VERSION` / `REPRO_CRYPTSETUP_VERSION` | workflow env | re-lay toolchain |
+| cds / get-cert / c8s-operator digests | resolved per build by `fetch.sh` | bootstrap allowlist |
+
+Bump procedure:
+
+- **kata bump** (`KATA_VERSION`): re-resolve `KATA_SRC_COMMIT`,
+  `KATA_STATIC_SHA256`, and the pause pin (`build.sh` dies if
+  `versions.yaml`'s pause version moved without it).
+- **periodic refresh** (security updates): re-resolve
+  `UBUNTU_BASE_DIGEST` and bump the `UBUNTU_REPO_URL` snapshot
+  timestamp.
+- **runner upgrade**: update the `REPRO_*` versions with it.
+
+Re-resolve commands sit next to each pin.
 
 ## Releasing and pinning
 

--- a/kata-guest-base/README.md
+++ b/kata-guest-base/README.md
@@ -108,6 +108,14 @@ shows up. For kernel version bumps see
 [base-images/rke2/README.md](https://github.com/confidential-dot-ai/base-images/blob/master/rke2/README.md)
 "Bumping versions".
 
+Every external input is pinned by immutable reference: kata source by
+commit, kata-static by sha256, the pause image and the rootfs-builder
+ubuntu base by digest, the apt archive by snapshot timestamp. Pins live
+at the top of `scripts/build.sh` with re-resolve commands beside each;
+moving any pin moves the verity root_hash. See
+[`../docs/kata-guest-base.md`](../docs/kata-guest-base.md) "Component
+pins" for the bump procedure.
+
 ## How it's consumed in-cluster
 
 The `c8s-kata-image-puller` DaemonSet (`internal/helmchart/c8s/templates/

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -83,6 +83,21 @@ KATA_VERSION="${KATA_VERSION:-3.30.0}"
 # (The kata-static release asset in stage-kata-conf.sh is separately
 # sha256-pinned, so that download already can't drift.)
 KATA_SRC_COMMIT="${KATA_SRC_COMMIT:-86e5975ad6a20f091ed686e492672c70496d0400}"
+# Component-image digest pins: both are otherwise fetched by mutable tag and
+# feed the measured guest, so a registry-side re-point would silently move
+# root_hash. Bumping a pin moves root_hash — commit deliberately.
+#
+# Pause image baked at /pause_bundle (Step 3b). Repo/tag still come from
+# kata's versions.yaml; PAUSE_PINNED_VERSION is the tag this digest was
+# resolved for — Step 3b dies if versions.yaml moves off it. Re-resolve:
+#   skopeo inspect --format '{{.Digest}}' docker://registry.k8s.io/pause:<ver>
+PAUSE_IMAGE_DIGEST="${PAUSE_IMAGE_DIGEST:-sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a}"
+PAUSE_PINNED_VERSION="3.10"
+# Base of osbuilder's rootfs-builder container (`FROM docker.io/ubuntu:
+# <OS_VERSION>`) — the toolchain that runs mmdebstrap and builds the
+# kata-agent. Pre-pulled by digest + retagged in Step 2. Re-resolve:
+#   skopeo inspect --format '{{.Digest}}' docker://docker.io/ubuntu:noble
+UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST:-sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea}"
 # ext4, not erofs: kata 3.30.0's osbuilder only implements the dm-verity /
 # measured-rootfs path for ext4 (create_rootfs_image). Its erofs path
 # (create_erofs_rootfs_image) loop-attaches the image before creating it
@@ -104,7 +119,10 @@ OS_VERSION="${OS_VERSION:-noble}"
 # why: docs/kata-guest-base.md "Reproducible root_hash".
 export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1704067200}"   # 2024-01-01T00:00:00Z
 VERITY_SALT="${VERITY_SALT:-c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8}"   # public; measured via the cmdline
-UBUNTU_REPO_URL="${UBUNTU_REPO_URL:-}"   # empty -> osbuilder's default archive
+# Time-pinned apt mirror for the guest debootstrap (the bulk of the measured
+# rootfs bytes); empty would mean archive.ubuntu.com, which drifts daily.
+# Bump to any recent snapshot timestamp — moves root_hash.
+UBUNTU_REPO_URL="${UBUNTU_REPO_URL:-https://snapshot.ubuntu.com/ubuntu/20260801T000000Z}"
 FIXED_FS_UUID="${FIXED_FS_UUID:-c8c8c8c8-c8c8-c8c8-c8c8-c8c8c8c8c8c8}"
 FIXED_HASH_SEED="${FIXED_HASH_SEED:-d8d8d8d8-d8d8-d8d8-d8d8-d8d8d8d8d8d8}"
 # The deterministic re-lay (seal_and_assemble) runs mkfs.ext4 + veritysetup on
@@ -422,6 +440,10 @@ if [[ -n "${ROOTFS_CACHE_TAR:-}" && -f "${ROOTFS_CACHE_TAR}" ]]; then
     sudo tar "${ROOTFS_TAR_FLAGS[@]}" -xpf "${ROOTFS_CACHE_TAR}" -C "${TARGET_ROOTFS}"
 else
     log "Step 2/5: building ${DISTRO} rootfs with osbuilder (kata-agent included)"
+    # osbuilder's `docker build` runs without --pull, so the retagged pinned
+    # digest wins over the mutable Hub tag.
+    sudo docker pull "docker.io/library/ubuntu@${UBUNTU_BASE_DIGEST}"
+    sudo docker tag "docker.io/library/ubuntu@${UBUNTU_BASE_DIGEST}" "ubuntu:${OS_VERSION}"
     sudo make -C "${OSBUILDER}" \
         DISTRO="${DISTRO}" \
         OS_VERSION="${OS_VERSION}" \
@@ -492,9 +514,12 @@ PAUSE_REPO="$(yq '.externals.pause.repo' "${KATA_SRC}/versions.yaml")"
 PAUSE_VER="$(yq '.externals.pause.version' "${KATA_SRC}/versions.yaml")"
 [[ -n "${PAUSE_REPO}" && "${PAUSE_REPO}" != "null" ]] || die "could not read externals.pause.repo from ${KATA_SRC}/versions.yaml"
 [[ -n "${PAUSE_VER}" && "${PAUSE_VER}" != "null" ]] || die "could not read externals.pause.version from ${KATA_SRC}/versions.yaml"
-log "Step 3b/5: baking pause bundle (${PAUSE_REPO}:${PAUSE_VER}) into the rootfs"
+# Bytes come from the digest pin; the tag only names the OCI-layout ref. A
+# kata bump that moves externals.pause fails here until the pin is re-resolved.
+[[ "${PAUSE_VER}" == "${PAUSE_PINNED_VERSION}" ]] || die "kata versions.yaml pins pause ${PAUSE_VER} but PAUSE_IMAGE_DIGEST was resolved for ${PAUSE_PINNED_VERSION} — re-resolve the pin (top of this script)."
+log "Step 3b/5: baking pause bundle (${PAUSE_REPO}:${PAUSE_VER} @ ${PAUSE_IMAGE_DIGEST}) into the rootfs"
 rm -rf "${WORK_DIR}/pause-oci" "${WORK_DIR}/pause_bundle"
-skopeo copy "${PAUSE_REPO}:${PAUSE_VER}" "oci:${WORK_DIR}/pause-oci:${PAUSE_VER}"
+skopeo copy "${PAUSE_REPO}@${PAUSE_IMAGE_DIGEST}" "oci:${WORK_DIR}/pause-oci:${PAUSE_VER}"
 umoci unpack --rootless --image "${WORK_DIR}/pause-oci:${PAUSE_VER}" "${WORK_DIR}/pause_bundle"
 [[ -f "${WORK_DIR}/pause_bundle/config.json" ]] || die "umoci did not produce pause_bundle/config.json"
 # Reproducibility: umoci emits the OCI runtime config.json with mount `options`

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -83,20 +83,11 @@ KATA_VERSION="${KATA_VERSION:-3.30.0}"
 # (The kata-static release asset in stage-kata-conf.sh is separately
 # sha256-pinned, so that download already can't drift.)
 KATA_SRC_COMMIT="${KATA_SRC_COMMIT:-86e5975ad6a20f091ed686e492672c70496d0400}"
-# Component-image digest pins: both are otherwise fetched by mutable tag and
-# feed the measured guest, so a registry-side re-point would silently move
-# root_hash. Bumping a pin moves root_hash — commit deliberately.
-#
-# Pause image baked at /pause_bundle (Step 3b). Repo/tag still come from
-# kata's versions.yaml; PAUSE_PINNED_VERSION is the tag this digest was
-# resolved for — Step 3b dies if versions.yaml moves off it. Re-resolve:
-#   skopeo inspect --format '{{.Digest}}' docker://registry.k8s.io/pause:<ver>
+# Pause image baked at /pause_bundle (Step 3b); bumping moves root_hash. Re-resolve: skopeo inspect --format '{{.Digest}}' docker://registry.k8s.io/pause:<ver>
 PAUSE_IMAGE_DIGEST="${PAUSE_IMAGE_DIGEST:-sha256:ee6521f290b2168b6e0935a181d4cff9be1ac3f505666ef0e3c98fae8199917a}"
+# The versions.yaml tag this digest was resolved for; Step 3b dies if the kata pin moves off it.
 PAUSE_PINNED_VERSION="3.10"
-# Base of osbuilder's rootfs-builder container (`FROM docker.io/ubuntu:
-# <OS_VERSION>`) — the toolchain that runs mmdebstrap and builds the
-# kata-agent. Pre-pulled by digest + retagged in Step 2. Re-resolve:
-#   skopeo inspect --format '{{.Digest}}' docker://docker.io/ubuntu:noble
+# Base of osbuilder's rootfs-builder container; bumping moves root_hash. Re-resolve: skopeo inspect --format '{{.Digest}}' docker://docker.io/ubuntu:noble
 UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST:-sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea}"
 # ext4, not erofs: kata 3.30.0's osbuilder only implements the dm-verity /
 # measured-rootfs path for ext4 (create_rootfs_image). Its erofs path
@@ -119,9 +110,7 @@ OS_VERSION="${OS_VERSION:-noble}"
 # why: docs/kata-guest-base.md "Reproducible root_hash".
 export SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-1704067200}"   # 2024-01-01T00:00:00Z
 VERITY_SALT="${VERITY_SALT:-c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8c8}"   # public; measured via the cmdline
-# Time-pinned apt mirror for the guest debootstrap (the bulk of the measured
-# rootfs bytes); empty would mean archive.ubuntu.com, which drifts daily.
-# Bump to any recent snapshot timestamp — moves root_hash.
+# Time-pinned apt mirror for the guest debootstrap; bumping the timestamp moves root_hash.
 UBUNTU_REPO_URL="${UBUNTU_REPO_URL:-https://snapshot.ubuntu.com/ubuntu/20260801T000000Z}"
 FIXED_FS_UUID="${FIXED_FS_UUID:-c8c8c8c8-c8c8-c8c8-c8c8-c8c8c8c8c8c8}"
 FIXED_HASH_SEED="${FIXED_HASH_SEED:-d8d8d8d8-d8d8-d8d8-d8d8-d8d8d8d8d8d8}"
@@ -440,8 +429,7 @@ if [[ -n "${ROOTFS_CACHE_TAR:-}" && -f "${ROOTFS_CACHE_TAR}" ]]; then
     sudo tar "${ROOTFS_TAR_FLAGS[@]}" -xpf "${ROOTFS_CACHE_TAR}" -C "${TARGET_ROOTFS}"
 else
     log "Step 2/5: building ${DISTRO} rootfs with osbuilder (kata-agent included)"
-    # osbuilder's `docker build` runs without --pull, so the retagged pinned
-    # digest wins over the mutable Hub tag.
+    # osbuilder's `docker build` runs without --pull, so the retagged pinned digest wins over the Hub tag.
     sudo docker pull "docker.io/library/ubuntu@${UBUNTU_BASE_DIGEST}"
     sudo docker tag "docker.io/library/ubuntu@${UBUNTU_BASE_DIGEST}" "ubuntu:${OS_VERSION}"
     sudo make -C "${OSBUILDER}" \
@@ -514,8 +502,7 @@ PAUSE_REPO="$(yq '.externals.pause.repo' "${KATA_SRC}/versions.yaml")"
 PAUSE_VER="$(yq '.externals.pause.version' "${KATA_SRC}/versions.yaml")"
 [[ -n "${PAUSE_REPO}" && "${PAUSE_REPO}" != "null" ]] || die "could not read externals.pause.repo from ${KATA_SRC}/versions.yaml"
 [[ -n "${PAUSE_VER}" && "${PAUSE_VER}" != "null" ]] || die "could not read externals.pause.version from ${KATA_SRC}/versions.yaml"
-# Bytes come from the digest pin; the tag only names the OCI-layout ref. A
-# kata bump that moves externals.pause fails here until the pin is re-resolved.
+# Bytes come from the digest pin; a kata bump that moves externals.pause fails here until re-resolved.
 [[ "${PAUSE_VER}" == "${PAUSE_PINNED_VERSION}" ]] || die "kata versions.yaml pins pause ${PAUSE_VER} but PAUSE_IMAGE_DIGEST was resolved for ${PAUSE_PINNED_VERSION} — re-resolve the pin (top of this script)."
 log "Step 3b/5: baking pause bundle (${PAUSE_REPO}:${PAUSE_VER} @ ${PAUSE_IMAGE_DIGEST}) into the rootfs"
 rm -rf "${WORK_DIR}/pause-oci" "${WORK_DIR}/pause_bundle"


### PR DESCRIPTION
kata-guest-base build inputs previously fetched by mutable tag are now pinned: pause image and rootfs-builder ubuntu base by digest (build.sh), guest apt archive time-pinned to snapshot.ubuntu.com/20260801T000000Z, REPRO_E2FSPROGS/CRYPTSETUP re-lay gate enabled on the publish path (values confirmed from the published artifact's relay_toolchain), oras version pinned in setup-oras. Docs gain a "Component pins" table + bump procedure.

Note: first build moves root_hash / the SNP launch measurement once (mainly the snapshot pin); downstream attestation reference values roll once, after which rebuilds are reproducible over time.