### PR TITLE
ci: drop stale scripts/testdata path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
       - "internal/helmchart/c8s/**"
       - "scripts/coverage-gate.sh"
       - "scripts/mutation-check.sh"
-      - "scripts/testdata/**"
       - ".gremlins.yaml"
       - ".github/workflows/ci.yml"
       # internal/kataspec reads the baked policy and asserts the two admit the


### PR DESCRIPTION
PR #162's mutation-check selftest originally read committed fixtures under `scripts/testdata/` and added a CI path filter for them. The selftest was later reworked to generate its fixtures inline in a temp dir, and the committed files were removed — but the path filter stayed behind. The directory no longer exists and nothing references it, so the filter matches nothing. The selftest remains covered by the `scripts/mutation-check.sh` and workflow-file filters.