### PR TITLE
feat(allowlist): per-image mount-destination and environment policy

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -130,6 +130,54 @@ entry widens a shared digest to `any`, because that becomes the effective
 container-level policy for the digest everywhere. The narrower, entry-scoped
 guarantee is recovered at [cert issuance](#where-its-enforced).
 
+## Mount and environment policy (`mounts`, `env`)
+
+An image digest pins the bytes, and process policy pins what runs them, but
+neither says anything about what the host lays *over* those bytes at start-up.
+With `shared_fs="none"` the runtime seeds every configmap, secret and
+serviceaccount token by copying it into the sandbox seeding directory and
+bind-mounting it in — a mechanism a pod cannot work without, and one whose
+source directory the host may write. Staging a file there and binding it over a
+path inside the image runs host code from an allowlisted digest, and every
+digest still reports as admitted.
+
+Client-side verification does not catch this, unlike a pod whose trust
+configuration was repointed: the pod keeps its genuine identity — real CDS, real
+mesh CA, correct launch measurement — and a verifying client passes it and sends
+data to a container running injected code.
+
+`mounts` constrains **bind** mounts only, by destination. The rest of a mount
+table names filesystem types (`proc`, `sysfs`, `tmpfs`, `devpts`, `mqueue`,
+`cgroup`) and carries nothing in, so pinning it would only make an operator
+restate the OCI base set to say nothing. `env` constrains variable **names**;
+values are never matched, because the allowlist is served to every enforcer and
+values carry secrets. `LD_PRELOAD` is the case that motivates it — an injected
+name is code execution inside an otherwise-allowlisted image.
+
+```json
+"mounts": { "policy": "exact", "destinations": ["/etc/hosts", "/config"] },
+"env":    { "policy": "exact", "names": ["PATH", "MODEL_DIR"] }
+```
+
+`exact` requires every observed bind destination (or name) to appear in the
+list. An `exact` destination list is what the pod's `volumeMounts` declare plus
+the handful the kubelet always adds — `/etc/hosts`, `/etc/hostname`,
+`/etc/resolv.conf`, `/dev/termination-log`, `/dev/shm`, the serviceaccount token
+— so it is written against a pod spec, not guessed.
+
+Both default to `any` when absent, unlike argv, which defaults to `deny`. A
+container always carries a mount table and an environment it never declared, so
+a `deny` default would refuse every real pod and adopting the field would mean
+adopting an outage. That makes these opt-in: a digest with no policy is
+constrained exactly as much as it was before.
+
+Two limits worth stating. They bind only digests a `workloads` entry names —
+floor digests are admitted on the digest alone, so `c8s allowlist add` does not
+produce a mount-gated image. And an enforcer that cannot observe a field leaves
+it unset, which is treated as nothing-to-refuse rather than a violation: the
+host-side NRI plugin gates images on a node CVM and never sees a guest's mount
+table.
+
 ## Secret grants (`secrets`)
 
 An entry may grant secret-store paths to the workload it names. The subject is

--- a/internal/cmds/cmdsutil/cmdsutil.go
+++ b/internal/cmds/cmdsutil/cmdsutil.go
@@ -55,3 +55,23 @@ func ShutdownOnDone(ctx context.Context, srv *http.Server, timeout time.Duration
 	defer cancel()
 	srv.Shutdown(shutdownCtx)
 }
+
+// CheckCDSPinned reports whether a sidecar may talk to CDS with the launch
+// measurements it was given.
+//
+// An empty set accepts any RA-TLS-attested CDS, so dropping the flag is enough
+// to point a sidecar at a CDS the host runs — and under kata the host writes
+// the argv. Refuse there. Outside kata "no pinning" is a supported development
+// shape (`c8s install --measurements` documents empty as UNSAFE), so it stays a
+// warning. Shared by get-cert, get-secret and get-volume: three copies of this
+// decision would be three chances to drift.
+func CheckCDSPinned(measurementCount int, insideGuest bool, warn string) error {
+	if measurementCount > 0 {
+		return nil
+	}
+	if insideGuest {
+		return errors.New("--measurements is empty: refusing to reach an unpinned CDS from inside a kata guest, where the host writes this argv")
+	}
+	slog.Warn(warn)
+	return nil
+}

--- a/internal/cmds/cmdsutil/cmdsutil_test.go
+++ b/internal/cmds/cmdsutil/cmdsutil_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -95,4 +96,31 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+func TestCheckCDSPinned(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		count       int
+		insideGuest bool
+		wantErr     bool
+	}{
+		// Dropping --measurements is how the host redirects a sidecar at a CDS
+		// it runs; under kata it writes the argv, so this is the whole point.
+		{"unpinned inside a kata guest", 0, true, true},
+		// "no pinning" stays a supported development shape off the guest.
+		{"unpinned outside a kata guest", 0, false, false},
+		{"pinned inside a kata guest", 1, true, false},
+		{"pinned outside a kata guest", 2, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckCDSPinned(tc.count, tc.insideGuest, "warn")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("CheckCDSPinned(%d, %v) = %v, wantErr %v", tc.count, tc.insideGuest, err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "--measurements is empty") {
+				t.Errorf("error %q does not name the flag the operator has to set", err)
+			}
+		})
+	}
 }

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -182,8 +182,9 @@ func cdsHTTPClient(cfg config) (*http.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("--cds-measurements: %w", err)
 	}
-	if len(measurements) == 0 {
-		slog.Warn("--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement")
+	if err := cmdsutil.CheckCDSPinned(len(measurements), cfg.WorkloadClaimsGuest,
+		"--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement"); err != nil {
+		return nil, err
 	}
 
 	client, err := ratls.NewVerifyingHTTPClient(measurements, cfg.AttestationApiURL)

--- a/internal/cmds/getcert/run_extra_test.go
+++ b/internal/cmds/getcert/run_extra_test.go
@@ -1,0 +1,231 @@
+package getcert
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// testCSRKey returns a throwaway public key standing in for the CSR key a
+// sandbox token would be bound to.
+func testCSRKey(t *testing.T) *ecdsa.PublicKey {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &key.PublicKey
+}
+
+// overrideInventoryEndpoint points the compiled inventory endpoint at a test socket
+// and restores the production value on cleanup.
+func overrideInventoryEndpoint(t *testing.T, endpoint string) {
+	t.Helper()
+	old := inventoryEndpoint
+	inventoryEndpoint = func() string { return endpoint }
+	t.Cleanup(func() { inventoryEndpoint = old })
+}
+
+// fakeResolver answers the inventory's sandbox routes with fixed data.
+type fakeResolver struct {
+	sandboxID string
+	err       error
+}
+
+func (f fakeResolver) SandboxForPeer(workloadclaims.Peer) (string, error) {
+	return f.sandboxID, f.err
+}
+
+func (f fakeResolver) DigestsForSandbox(string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
+	return nil, nil, false, nil
+}
+
+// startFakeInventory serves the inventory token socket and returns its unix://
+// endpoint.
+func startFakeInventory(t *testing.T, resolver workloadclaims.SandboxResolver, signer *workloadclaims.SandboxTokenSigner) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "wc.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix %s: %v", sock, err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = workloadclaims.ServeTokens(ctx, l, resolver, signer)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return "unix://" + sock
+}
+
+func testTokenSigner(t *testing.T) *workloadclaims.SandboxTokenSigner {
+	t.Helper()
+	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}
+
+// get-cert forwards the inventory-signed token verbatim and reports no images
+// of its own — CDS resolves those from the inventory.
+func TestFetchSandboxTokenForwardsSignedToken(t *testing.T) {
+	endpoint := startFakeInventory(t, fakeResolver{sandboxID: "sandbox-1"}, testTokenSigner(t))
+	overrideInventoryEndpoint(t, endpoint)
+
+	raw, err := fetchSandboxToken(context.Background(), config{
+		WorkloadClaims:        true,
+		WorkloadClaimsTimeout: 2 * time.Second,
+	}, testCSRKey(t), []byte("test-nonce"))
+	if err != nil {
+		t.Fatalf("fetchSandboxToken: %v", err)
+	}
+	var token workloadclaims.SignedSandboxToken
+	if err := json.Unmarshal(raw, &token); err != nil {
+		t.Fatalf("token is not a SignedSandboxToken: %v", err)
+	}
+	if len(token.Token) == 0 || len(token.Signature) == 0 {
+		t.Fatalf("incomplete token forwarded: %+v", token)
+	}
+}
+
+// An inventory without the token route is not a failure: get-cert issues
+// without a sandbox ID.
+func TestFetchSandboxTokenRouteAbsentIsTokenFree(t *testing.T) {
+	endpoint := startFakeInventory(t, fakeResolver{sandboxID: "sandbox-1"}, nil)
+	overrideInventoryEndpoint(t, endpoint)
+
+	raw, err := fetchSandboxToken(context.Background(), config{
+		WorkloadClaims:        true,
+		WorkloadClaimsTimeout: 2 * time.Second,
+	}, testCSRKey(t), []byte("test-nonce"))
+	if err != nil {
+		t.Fatalf("fetchSandboxToken: %v", err)
+	}
+	if raw != nil {
+		t.Fatalf("expected no token, got %s", raw)
+	}
+}
+
+// An inventory error is fail-closed: issuance aborts rather than silently dropping
+// the workload binding.
+func TestWorkloadClaimsWithInventoryUnreachableFailsClosed(t *testing.T) {
+	overrideInventoryEndpoint(t, "unix://"+filepath.Join(t.TempDir(), "missing.sock"))
+
+	_, err := fetchSandboxToken(context.Background(), config{
+		WorkloadClaims:        true,
+		WorkloadClaimsTimeout: time.Second,
+	}, testCSRKey(t), []byte("test-nonce"))
+	if err == nil {
+		t.Fatal("fetchSandboxToken succeeded, want fail-closed error for unreachable inventory")
+	}
+	// The sandbox-token fetch runs first and hits the dead socket.
+	if !strings.Contains(err.Error(), "fetch sandbox token") {
+		t.Fatalf("error = %v, want fetch sandbox token", err)
+	}
+}
+
+// Drives the full renewal loop: a failing renewal tick, an unchanged watch
+// tick, a changed watch tick (nginx reload attempted and failed — no master in
+// the fake proc root), and finally SIGTERM-triggered graceful shutdown.
+func TestRunRenewalLoopWatchAndShutdown(t *testing.T) {
+	overrideProcRoot(t, t.TempDir()) // no nginx master: reload attempts fail softly
+
+	watched := filepath.Join(t.TempDir(), "tls.crt")
+	if err := os.WriteFile(watched, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := config{
+		CDSURL:                 "https://127.0.0.1:1",
+		AttestationApiURL:      "http://127.0.0.1:1",
+		SAN:                    "host.example.com",
+		InitialRetryTimeout:    0,
+		ContinueOnInitialError: true,
+		RenewInterval:          40 * time.Millisecond,
+		ReloadNginx:            true,
+		ReloadWatchPaths:       []string{watched},
+		ReloadWatchInterval:    20 * time.Millisecond,
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- run(cfg) }()
+
+	// Let the renewal and watch tickers fire a few times, then change the
+	// watched file so the change branch fires too.
+	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(watched, []byte("v2 renewed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(150 * time.Millisecond)
+
+	// run installs a SIGTERM handler via signal.NotifyContext, so signalling
+	// ourselves triggers graceful shutdown without killing the test binary.
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("run returned %v, want nil on graceful shutdown", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not shut down after SIGTERM")
+	}
+}
+
+// Empty measurements accept any RA-TLS-attested CDS. Under kata the host writes
+// this argv, so dropping the flag is how it points the sidecar at a CDS it runs.
+func TestUnpinnedCDSRefusedInsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:              "https://cds:8443",
+		AttestationApiURL:   "http://attestation-api:8400",
+		SAN:                 "host.example.com",
+		WorkloadClaimsGuest: true,
+	}
+	_, err := cdsHTTPClient(cfg)
+	if err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
+		t.Fatalf("error = %v, want a refusal to use an unpinned CDS", err)
+	}
+}
+
+// Outside kata "no pinning" stays a supported development shape.
+func TestUnpinnedCDSAllowedOutsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:            "https://cds:8443",
+		AttestationApiURL: "http://attestation-api:8400",
+		SAN:               "host.example.com",
+	}
+	if _, err := cdsHTTPClient(cfg); err != nil {
+		t.Fatalf("cdsHTTPClient: %v", err)
+	}
+}
+
+// A pinned measurement is what the flag is for; it must still work under kata.
+func TestPinnedCDSAcceptedInsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:              "https://cds:8443",
+		AttestationApiURL:   "http://attestation-api:8400",
+		SAN:                 "host.example.com",
+		CDSMeasurements:     strings.Repeat("ab", 48),
+		WorkloadClaimsGuest: true,
+	}
+	if _, err := cdsHTTPClient(cfg); err != nil {
+		t.Fatalf("cdsHTTPClient: %v", err)
+	}
+}

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -27,6 +27,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/secrets"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -103,8 +104,9 @@ func run(cfg config) error {
 	if err != nil {
 		return fmt.Errorf("--measurements: %w", err)
 	}
-	if len(measurements) == 0 {
-		slog.Warn("--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development.")
+	if err := cmdsutil.CheckCDSPinned(len(measurements), cfg.WorkloadClaimsGuest,
+		"--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development."); err != nil {
+		return err
 	}
 
 	values, err := fetchWithRetry(ctx, cfg, func(ctx context.Context) (map[string][]byte, error) {

--- a/internal/cmds/getvolume/run.go
+++ b/internal/cmds/getvolume/run.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volumed"
 	"github.com/confidential-dot-ai/c8s/internal/secrets"
@@ -109,8 +110,9 @@ func run(cfg config) error {
 	if err != nil {
 		return fmt.Errorf("--measurements: %w", err)
 	}
-	if len(measurements) == 0 {
-		slog.Warn("--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development.")
+	if err := cmdsutil.CheckCDSPinned(len(measurements), cfg.WorkloadClaimsGuest,
+		"--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development."); err != nil {
+		return err
 	}
 
 	if err := openWithRetry(ctx, cfg, func(ctx context.Context) error {

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -382,8 +382,11 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	}
 
 	// Floor digests admit regardless of argv; workload digests require the
-	// effective argv to satisfy some entry's entrypoint/cmd policy.
-	if !snap.index.AdmitsContainer(digest, argv) {
+	// effective argv to satisfy some entry's entrypoint/cmd policy. Mount and env
+	// policy are left unobserved here: this plugin gates images on a node CVM,
+	// where it sees the CRI container rather than a guest's mount table, and an
+	// unobserved field is not a violation (allowlist.RunningContainer).
+	if !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
 		log.Warn("image not admitted by allowlist", "digest", digest, "argv", argv)
 		p.audit.Log(audit.Event{
 			Action:    "deny",

--- a/internal/cmds/nri-image-policy/refresh_test.go
+++ b/internal/cmds/nri-image-policy/refresh_test.go
@@ -83,7 +83,7 @@ func TestMergeAllowlistsCarriesWorkloads(t *testing.T) {
 	if !idx.AdmitsDigest(pushDigestA) {
 		t.Fatal("floor digest not admitted after merge")
 	}
-	if !idx.AdmitsContainer(pushDigestB, []string{"anything"}) {
+	if !idx.AdmitsContainer(allowlist.RunningContainer{Digest: pushDigestB, Argv: []string{"anything"}}) {
 		t.Fatal("workload digest not admitted after merge")
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -225,14 +225,15 @@ func (o *policyOverlay) apply(al *allowlistpkg.Allowlist, version uint64) bool {
 
 // admits reports whether a container may run. The baked floor (additive digest
 // set) admits by digest alone; otherwise the pulled overlay's Index decides on
-// digest + effective argv. With no overlay (CDS refresh disabled, or no
-// successful pull yet) only the baked floor admits — behavior from t=0.
-func (m *monitor) admits(digest string, argv []string) bool {
-	if m.allowlist.Contains(digest) {
+// the whole observation — digest, argv, bind-mount destinations and env names.
+// With no overlay (CDS refresh disabled, or no successful pull yet) only the
+// baked floor admits — behavior from t=0.
+func (m *monitor) admits(rc allowlistpkg.RunningContainer) bool {
+	if m.allowlist.Contains(rc.Digest) {
 		return true
 	}
 	if idx := m.overlay.index(); idx != nil {
-		return idx.AdmitsContainer(digest, argv)
+		return idx.AdmitsContainer(rc)
 	}
 	return false
 }
@@ -523,13 +524,18 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		return
 	}
 
-	// Effective argv (OCI process.args): the merged entrypoint+cmd the container
-	// runs. Floor digests ignore it; workload digests are gated on it.
-	var argv []string
-	if spec.Process != nil {
-		argv = spec.Process.Args
+	// What the container actually runs, as the allowlist describes it. Floor
+	// digests ignore all of it; workload digests are gated on the whole set.
+	rc := allowlistpkg.RunningContainer{
+		Digest:     digest,
+		BindMounts: bindMountDestinations(spec.Mounts),
 	}
-	if m.admits(digest, argv) {
+	if spec.Process != nil {
+		rc.Argv = spec.Process.Args
+		rc.EnvNames = envNames(spec.Process.Env)
+	}
+	argv := rc.Argv
+	if m.admits(rc) {
 		m.logger.Info("allow container", "cid", cid, "digest", digest)
 		if m.inventory != nil {
 			m.inventory.record(cid, digest, argv)
@@ -701,12 +707,50 @@ func (m *monitor) readConfigJSON(ctx context.Context, dir string) (*ociSpec, err
 type ociSpec struct {
 	Annotations map[string]string `json:"annotations"`
 	Process     *ociProcess       `json:"process"`
+	Mounts      []ociMount        `json:"mounts"`
 }
 
-// ociProcess is the process block's argv: the merged image-config + pod-spec
-// command the container actually runs, evaluated against workload argv policy.
+// ociProcess is the process block the container runs: the merged image-config +
+// pod-spec argv, evaluated against workload argv policy, and the environment it
+// starts with, evaluated by name against workload env policy.
 type ociProcess struct {
 	Args []string `json:"args"`
+	Env  []string `json:"env"`
+}
+
+// ociMount is one entry of the container's mount table. The baked kata-agent
+// policy bounds where a bind's source may be; the destination is a path inside
+// the container and is what workload mount policy gates.
+type ociMount struct {
+	Destination string `json:"destination"`
+	Source      string `json:"source"`
+}
+
+// bindMountDestinations returns the destinations of the mounts that carry guest
+// content in. A source that is not an absolute path names a filesystem type
+// (proc, sysfs, tmpfs, devpts, mqueue, cgroup) and carries nothing, so gating it
+// would only make an operator restate the OCI base set.
+func bindMountDestinations(mounts []ociMount) []string {
+	var out []string
+	for _, m := range mounts {
+		if strings.HasPrefix(m.Source, "/") {
+			out = append(out, m.Destination)
+		}
+	}
+	return out
+}
+
+// envNames returns the NAME halves of the spec's "NAME=value" environment.
+// Values never leave this function: policy matches names, because an allowlist
+// is served to every enforcer and values carry secrets.
+func envNames(env []string) []string {
+	var out []string
+	for _, e := range env {
+		if name, _, ok := strings.Cut(e, "="); ok {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func readOCISpec(path string) (*ociSpec, error) {

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -228,10 +228,10 @@ func TestPolicyOverlayAntiRollback(t *testing.T) {
 		t.Fatalf("version = %d, want 5 (rollback ignored)", o.version)
 	}
 	// The version-5 policy still governs: /bin/app matches, /bin/other does not.
-	if !o.index().AdmitsContainer(wl, []string{"/bin/app"}) {
+	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("version-5 argv policy dropped by rollback attempt")
 	}
-	if o.index().AdmitsContainer(wl, []string{"/bin/other"}) {
+	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("rolled-back argv policy took effect")
 	}
 }
@@ -248,10 +248,10 @@ func TestPolicyOverlayIgnoresEqualVersion(t *testing.T) {
 	if o.apply(exactEntrypointOverlay(t, wl, []string{"/bin/other"}), 5) {
 		t.Fatal("replayed version 5 was applied")
 	}
-	if !o.index().AdmitsContainer(wl, []string{"/bin/app"}) {
+	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("original version-5 policy dropped by equal-version replay")
 	}
-	if o.index().AdmitsContainer(wl, []string{"/bin/other"}) {
+	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("equal-version replay policy took effect")
 	}
 }

--- a/internal/cmds/policymonitor/mountpolicy_test.go
+++ b/internal/cmds/policymonitor/mountpolicy_test.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// writeSpec writes a bundle config.json carrying the fields workload policy is
+// evaluated against.
+func writeSpec(t *testing.T, watchDir, cid string, annotations map[string]string, args, env []string, mounts []ociMount) {
+	t.Helper()
+	dir := filepath.Join(watchDir, cid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(ociSpec{
+		Annotations: annotations,
+		Process:     &ociProcess{Args: args, Env: env},
+		Mounts:      mounts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mountPolicyOverlay(t *testing.T, digest string, destinations []string) *allowlistpkg.Allowlist {
+	t.Helper()
+	return &allowlistpkg.Allowlist{
+		Schema: allowlistpkg.Schema,
+		Workloads: map[string]allowlistpkg.Workload{"w": {Containers: []allowlistpkg.Container{{
+			Digest:  mustParseDigest(t, digest),
+			Command: allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+			Args:    allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+			Mounts:  allowlistpkg.MountPolicy{Policy: allowlistpkg.PolicyExact, Destinations: destinations},
+		}}}},
+	}
+}
+
+// The whole point of the policy: the host stages bytes in the sandbox seeding
+// directory — a legitimate CopyFile destination, and an allowed mount source —
+// then binds them over a path inside an allowlisted image. The digest still
+// matches, so only the mount policy can refuse it.
+func TestWorkloadMountPolicy(t *testing.T) {
+	wl := strings.Repeat("b", 64)
+	ann := map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + wl,
+	}
+	seeded := "/run/kata-containers/shared/containers/pod-abc-cm"
+	floor := []string{"sha256:" + strings.Repeat("a", 64)}
+
+	t.Run("declared destinations admitted", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts", "/config"}), 1)
+		writeSpec(t, watchDir, "ok", ann, []string{"/serve"}, []string{"PATH=/bin"}, []ociMount{
+			{Destination: "/proc", Source: "proc"},
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/config", Source: seeded},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "ok"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("declared mounts were refused: %+v", calls)
+		}
+	})
+
+	t.Run("bind over an image path refused", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts", "/config"}), 1)
+		writeSpec(t, watchDir, "shadowed", ann, []string{"/serve"}, nil, []ociMount{
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/usr/local/bin/serve", Source: seeded},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "shadowed"))
+		if calls := killer.snapshot(); len(calls) != 1 {
+			t.Fatalf("a bind over an image path was admitted: %+v", calls)
+		}
+	})
+
+	// Pseudo-filesystem mounts are not binds and carry nothing in, so gating
+	// them would only make an operator restate the OCI base set.
+	t.Run("pseudo-filesystem mounts are not gated", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts"}), 1)
+		writeSpec(t, watchDir, "pseudo", ann, []string{"/serve"}, nil, []ociMount{
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/sys/fs/cgroup", Source: "cgroup"},
+			{Destination: "/dev/mqueue", Source: "mqueue"},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "pseudo"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("a pseudo-filesystem mount was refused: %+v", calls)
+		}
+	})
+
+	// A floor digest is admitted on the digest alone, by design — the mount
+	// policy only binds digests an entry names.
+	t.Run("floor digests stay unconstrained", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts"}), 1)
+		writeSpec(t, watchDir, "floored", map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name":     "ghcr.io/c8s/get-cert@" + floor[0],
+		}, []string{"/get-cert"}, nil, []ociMount{{Destination: "/anywhere", Source: seeded}})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "floored"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("a floor digest was gated on mounts: %+v", calls)
+		}
+	})
+}
+
+func TestEnvNamesDropValues(t *testing.T) {
+	got := envNames([]string{"PATH=/bin", "TOKEN=s3cret", "NOEQUALS"})
+	if strings.Join(got, ",") != "PATH,TOKEN" {
+		t.Errorf("envNames = %v, want the names of the two NAME=value entries", got)
+	}
+	for _, n := range got {
+		if strings.Contains(n, "s3cret") {
+			t.Fatal("a value leaked into the observation policy matches on")
+		}
+	}
+}
+
+func TestBindMountDestinationsIgnoresPseudoFilesystems(t *testing.T) {
+	got := bindMountDestinations([]ociMount{
+		{Destination: "/proc", Source: "proc"},
+		{Destination: "/data", Source: "/run/kata-containers/sandbox/storage/x"},
+		{Destination: "/dev/shm", Source: "/run/kata-containers/sandbox/shm"},
+	})
+	if strings.Join(got, ",") != "/data,/dev/shm" {
+		t.Errorf("bindMountDestinations = %v, want only the bind destinations", got)
+	}
+}

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -66,6 +66,8 @@ type Container struct {
 	Image   string       `json:"image,omitempty"`
 	Command ArgvPolicy   `json:"command"`
 	Args    ArgvPolicy   `json:"args"`
+	Mounts  MountPolicy  `json:"mounts,omitempty"`
+	Env     EnvPolicy    `json:"env,omitempty"`
 }
 
 // ArgvPolicy governs part of a container's effective argv (the OCI process.args
@@ -76,6 +78,34 @@ type Container struct {
 type ArgvPolicy struct {
 	Policy string   `json:"policy"`
 	Argv   []string `json:"argv,omitempty"`
+}
+
+// MountPolicy governs where the host may bind content into the container.
+//
+// It constrains BIND mounts only — a mount whose source is an absolute guest
+// path. The rest of a container's mount table names filesystem types (proc,
+// sysfs, tmpfs, devpts, mqueue, cgroup) and carries nothing in, so pinning it
+// would make an operator restate the OCI base set to say nothing.
+//
+// Exact requires every bind destination to appear in Destinations, which is the
+// set an operator recognises: it is what the pod spec's volumeMounts declare,
+// plus the handful the kubelet always adds (/etc/hosts, /etc/hostname,
+// /etc/resolv.conf, /dev/termination-log, /dev/shm, the serviceaccount token).
+// Any leaves them unconstrained, and is what an absent policy means — unlike
+// argv, a Deny default would refuse every real pod, since the base set is never
+// empty.
+type MountPolicy struct {
+	Policy       string   `json:"policy"`
+	Destinations []string `json:"destinations,omitempty"`
+}
+
+// EnvPolicy governs the environment variable NAMES a container may run with.
+// Values are not matched: they carry secrets, and an allowlist is served to
+// every enforcer. Exact requires every name to appear in Names; Any, the
+// default, leaves them unconstrained.
+type EnvPolicy struct {
+	Policy string   `json:"policy"`
+	Names  []string `json:"names,omitempty"`
 }
 
 // SecretsPolicy grants secret-store read/write globs to a whole workload entry.
@@ -214,8 +244,84 @@ func normalizeContainers(workload, field string, cs []Container) error {
 		if err := normalizeArgv(&c.Args); err != nil {
 			return fmt.Errorf("workload %q %s %s args: %w", workload, field, c.Digest, err)
 		}
+		if err := normalizeMounts(&c.Mounts); err != nil {
+			return fmt.Errorf("workload %q %s %s mounts: %w", workload, field, c.Digest, err)
+		}
+		if err := normalizeEnv(&c.Env); err != nil {
+			return fmt.Errorf("workload %q %s %s env: %w", workload, field, c.Digest, err)
+		}
 	}
 	return nil
+}
+
+// normalizeMounts validates a mount policy. An absent policy canonicalizes to
+// Any: every container has a mount table it did not ask for (the OCI base set,
+// /etc/hosts, the serviceaccount token), so Deny would refuse every real pod and
+// an operator adopting this field would be opting into an outage.
+func normalizeMounts(p *MountPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "":
+		if len(p.Destinations) != 0 {
+			return fmt.Errorf("any policy takes no destinations")
+		}
+		p.Policy = PolicyAny
+		p.Destinations = nil
+	case PolicyExact:
+		if len(p.Destinations) == 0 {
+			return fmt.Errorf("exact policy requires at least one destination")
+		}
+		for _, d := range p.Destinations {
+			if !path.IsAbs(d) {
+				return fmt.Errorf("destination %q is not an absolute path", d)
+			}
+		}
+		p.Destinations = sortedUnique(p.Destinations)
+	default:
+		return fmt.Errorf("unknown mount policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// normalizeEnv validates an env policy, canonicalizing an absent policy to Any
+// for the same reason as mounts: a container inherits names it did not declare.
+func normalizeEnv(p *EnvPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "":
+		if len(p.Names) != 0 {
+			return fmt.Errorf("any policy takes no names")
+		}
+		p.Policy = PolicyAny
+		p.Names = nil
+	case PolicyExact:
+		if len(p.Names) == 0 {
+			return fmt.Errorf("exact policy requires at least one name")
+		}
+		for _, n := range p.Names {
+			if n == "" || strings.ContainsRune(n, '=') {
+				return fmt.Errorf("environment name %q is empty or contains '='", n)
+			}
+		}
+		p.Names = sortedUnique(p.Names)
+	default:
+		return fmt.Errorf("unknown env policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// sortedUnique makes a list a function of its content, so Canonical does not
+// churn on the order an operator happened to write.
+func sortedUnique(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // normalizeArgv validates an argv policy and canonicalizes an absent policy to

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -7,9 +7,20 @@ import "fmt"
 //
 // A local type rather than the inventory's own keeps this package a pure
 // function of the allowlist — the caller converts.
+// RunningContainer is an observed container, as an enforcer sees it.
+//
+// BindMounts holds the destinations of its BIND mounts only — the mounts whose
+// source is a guest path, and so the ones that can carry host-supplied content
+// in. EnvNames holds its environment variable names, without values.
+//
+// An enforcer that cannot observe a field leaves it nil, which an exact policy
+// treats as "nothing to refuse" rather than as a violation: the host-side NRI
+// plugin gates images on a node CVM and does not see the guest's mount table.
 type RunningContainer struct {
-	Digest string
-	Argv   []string
+	Digest     string
+	Argv       []string
+	BindMounts []string
+	EnvNames   []string
 }
 
 // ErrNoMatch reports that no entry describes the running set; ErrAmbiguous that
@@ -139,5 +150,43 @@ func (c Container) admits(r RunningContainer) bool {
 		return false
 	}
 	rest, ok := c.Command.matchCommand(r.Argv)
-	return ok && c.Args.matchArgs(rest)
+	if !ok || !c.Args.matchArgs(rest) {
+		return false
+	}
+	return c.Mounts.admits(r.BindMounts) && c.Env.admits(r.EnvNames)
+}
+
+// admits reports whether every bind destination is one this policy names.
+func (p MountPolicy) admits(destinations []string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	return everyIn(destinations, p.Destinations)
+}
+
+// admits reports whether every environment name is one this policy names.
+func (p EnvPolicy) admits(names []string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	return everyIn(names, p.Names)
+}
+
+// everyIn reports whether every observed value appears in allowed. An empty
+// observation is vacuously true — see RunningContainer on enforcers that cannot
+// see a field.
+func everyIn(observed, allowed []string) bool {
+	if len(observed) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		set[a] = struct{}{}
+	}
+	for _, o := range observed {
+		if _, ok := set[o]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/allowlist/match_test.go
+++ b/pkg/allowlist/match_test.go
@@ -131,7 +131,7 @@ func TestMatchWorkloadDistinguishesByArgv(t *testing.T) {
 	}
 
 	idx := al.BuildIndex()
-	if !idx.AdmitsContainer(dApp, []string{"/serve", "--model", "a"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: dApp, Argv: []string{"/serve", "--model", "a"}}) {
 		t.Fatal("precondition: Index should admit either argv for the shared digest")
 	}
 }

--- a/pkg/allowlist/mountenv_test.go
+++ b/pkg/allowlist/mountenv_test.go
@@ -1,0 +1,150 @@
+package allowlist
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatalf("ParseDigest(%q): %v", s, err)
+	}
+	return d
+}
+
+func containerWith(t *testing.T, mounts MountPolicy, env EnvPolicy) Container {
+	t.Helper()
+	c := Container{
+		Digest:  mustDigest(t, "sha256:"+strings.Repeat("a", 64)),
+		Command: ArgvPolicy{Policy: PolicyAny},
+		Args:    ArgvPolicy{Policy: PolicyAny},
+		Mounts:  mounts,
+		Env:     env,
+	}
+	// normalizeContainers mutates the slice it is given, so read the result back
+	// out of it rather than off the copy that went in.
+	cs := []Container{c}
+	if err := normalizeContainers("w", "containers", cs); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return cs[0]
+}
+
+func running(digest string, mounts, env []string) RunningContainer {
+	return RunningContainer{Digest: digest, BindMounts: mounts, EnvNames: env}
+}
+
+// The threat this policy exists for: the host stages bytes in the sandbox
+// seeding directory (a legitimate CopyFile destination) and binds them over a
+// path inside an allowlisted image, so the container runs host code while every
+// digest still reports as admitted.
+func TestMountPolicyRefusesAnUndeclaredDestination(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts", "/var/run/secrets/kubernetes.io/serviceaccount"}},
+		EnvPolicy{Policy: PolicyAny})
+
+	if !c.admits(running(digest, []string{"/etc/hosts"}, nil)) {
+		t.Error("a declared destination was refused")
+	}
+	if c.admits(running(digest, []string{"/etc/hosts", "/usr/local/bin/get-cert"}, nil)) {
+		t.Error("a bind over an image path was admitted")
+	}
+}
+
+// An absent policy has to mean "unconstrained": every container carries a mount
+// table it never declared, so a Deny default would refuse every real pod.
+func TestAbsentMountAndEnvPolicyAreUnconstrained(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{}, EnvPolicy{})
+
+	if c.Mounts.Policy != PolicyAny || c.Env.Policy != PolicyAny {
+		t.Fatalf("normalized to %q/%q, want %q", c.Mounts.Policy, c.Env.Policy, PolicyAny)
+	}
+	if !c.admits(running(digest, []string{"/anything", "/at/all"}, []string{"LD_PRELOAD"})) {
+		t.Error("an absent policy refused a container")
+	}
+}
+
+// LD_PRELOAD is the sharp case: an injected name is code execution inside an
+// otherwise-allowlisted image.
+func TestEnvPolicyRefusesAnUndeclaredName(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{Policy: PolicyAny},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"PATH", "HOME"}})
+
+	if !c.admits(running(digest, nil, []string{"PATH", "HOME"})) {
+		t.Error("declared names were refused")
+	}
+	if c.admits(running(digest, nil, []string{"PATH", "LD_PRELOAD"})) {
+		t.Error("an injected environment name was admitted")
+	}
+}
+
+// An enforcer that cannot see a field leaves it nil. That is not a violation —
+// the host-side NRI plugin gates images on a node CVM and never sees a guest's
+// mount table, and refusing there would deny every pod it checks.
+func TestUnobservedFieldsAreNotViolations(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts"}},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"PATH"}})
+
+	if !c.admits(RunningContainer{Digest: digest}) {
+		t.Error("an enforcer that observes neither field was refused")
+	}
+}
+
+func TestMountAndEnvPolicyValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    Container
+	}{
+		{"exact mounts with no destinations", Container{Mounts: MountPolicy{Policy: PolicyExact}}},
+		{"any mounts carrying destinations", Container{Mounts: MountPolicy{Policy: PolicyAny, Destinations: []string{"/x"}}}},
+		{"relative destination", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"etc/hosts"}}}},
+		{"unknown mount policy", Container{Mounts: MountPolicy{Policy: "sometimes"}}},
+		{"exact env with no names", Container{Env: EnvPolicy{Policy: PolicyExact}}},
+		{"any env carrying names", Container{Env: EnvPolicy{Policy: PolicyAny, Names: []string{"PATH"}}}},
+		{"name containing =", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"PATH=/bin"}}}},
+		{"unknown env policy", Container{Env: EnvPolicy{Policy: "sometimes"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c
+			c.Digest = mustDigest(t, "sha256:"+strings.Repeat("a", 64))
+			if err := normalizeContainers("w", "containers", []Container{c}); err == nil {
+				t.Error("normalize accepted an invalid policy")
+			}
+		})
+	}
+}
+
+// Canonical is compared byte-for-byte across pulls, so the lists have to be a
+// function of content rather than of the order an operator wrote them.
+func TestMountAndEnvListsAreOrderIndependent(t *testing.T) {
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/b", "/a", "/b"}},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"B", "A", "B"}})
+
+	if got := strings.Join(c.Mounts.Destinations, ","); got != "/a,/b" {
+		t.Errorf("destinations = %q, want sorted and deduplicated", got)
+	}
+	if got := strings.Join(c.Env.Names, ","); got != "A,B" {
+		t.Errorf("names = %q, want sorted and deduplicated", got)
+	}
+}
+
+// A document from a newer release must not freeze an older consumer's policy.
+func TestServedParseIgnoresUnknownFields(t *testing.T) {
+	doc := `{"schema":"` + Schema + `","digests":{},"workloads":{},"somethingNewer":{"x":1}}`
+	if _, err := ParseServedJSON([]byte(doc)); err != nil {
+		t.Fatalf("ParseServedJSON rejected an unknown field: %v", err)
+	}
+	if _, err := ParseJSON([]byte(doc)); err == nil {
+		t.Error("ParseJSON accepted an unknown field in an operator-authored document")
+	}
+}

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -44,21 +44,21 @@ func (i *Index) AdmitsDigest(digest string) bool {
 	return ok
 }
 
-// AdmitsContainer reports whether a container with the given digest may run the
-// given effective argv (its OCI process.args). Floor digests are admitted
-// regardless of argv. For a workload digest, admission is the union across every
-// entry that lists it: the argv must satisfy some container's command (an exact
-// prefix) and args (the remainder) policy.
-func (i *Index) AdmitsContainer(digest string, argv []string) bool {
-	d, err := types.ParseDigest(digest)
+// AdmitsContainer reports whether an observed container may run. Floor digests
+// are admitted on the digest alone. For a workload digest, admission is the
+// union across every entry that lists it: the observation must satisfy some
+// declared container's argv, mount and env policy together.
+func (i *Index) AdmitsContainer(r RunningContainer) bool {
+	d, err := types.ParseDigest(r.Digest)
 	if err != nil {
 		return false
 	}
 	if i.floor[d.String()] {
 		return true
 	}
+	r.Digest = d.String()
 	for _, c := range i.byDigest[d.String()] {
-		if rest, ok := c.Command.matchCommand(argv); ok && c.Args.matchArgs(rest) {
+		if c.admits(r) {
 			return true
 		}
 	}

--- a/pkg/allowlist/policy_test.go
+++ b/pkg/allowlist/policy_test.go
@@ -7,7 +7,7 @@ func TestIndex_FloorAdmitsAnyArgv(t *testing.T) {
 	if !idx.AdmitsDigest(digestA) {
 		t.Fatal("floor digest not admitted")
 	}
-	if !idx.AdmitsContainer(digestA, []string{"/anything", "--dynamic"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/anything", "--dynamic"}}) {
 		t.Fatal("floor digest must be admitted regardless of argv")
 	}
 }
@@ -18,13 +18,13 @@ func TestIndex_MultiTokenCommandPrefix(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/docker-entrypoint.sh","nginx"]},
 		 "args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}}) {
 		t.Fatal("argv starting with the command prefix should be admitted")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/docker-entrypoint.sh"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/docker-entrypoint.sh"}}) {
 		t.Fatal("argv shorter than the command prefix must be rejected")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh", "nginx", "-g"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh", "nginx", "-g"}}) {
 		t.Fatal("a different prefix must be rejected")
 	}
 }
@@ -33,13 +33,13 @@ func TestIndex_FullExact(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/app"]},
 		 "args":{"policy":"exact","argv":["--serve","--port=8080"]}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/app", "--serve", "--port=8080"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--serve", "--port=8080"}}) {
 		t.Fatal("exact command+args should match the concatenation")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh", "--serve", "--port=8080"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh", "--serve", "--port=8080"}}) {
 		t.Fatal("a swapped command must be rejected")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/app", "--serve"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--serve"}}) {
 		t.Fatal("truncated args must be rejected")
 	}
 }
@@ -47,10 +47,10 @@ func TestIndex_FullExact(t *testing.T) {
 func TestIndex_ArgsDenyMeansNoArgs(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/app"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app"}}) {
 		t.Fatal("args:deny should admit the command with no extra args")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/app", "--exfil"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--exfil"}}) {
 		t.Fatal("args:deny must reject any extra args")
 	}
 }
@@ -58,10 +58,10 @@ func TestIndex_ArgsDenyMeansNoArgs(t *testing.T) {
 func TestIndex_CommandDenyMeansEmptyArgv(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"deny"},"args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, nil) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: nil}) {
 		t.Fatal("command:deny should admit an empty argv")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh"}}) {
 		t.Fatal("command:deny must reject any argv")
 	}
 }
@@ -72,20 +72,20 @@ func TestIndex_SharedDigestUnion(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{
 		"a":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["busybox","sleep"]},"args":{"policy":"exact","argv":["1"]}}]},
 		"b":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["busybox","echo"]},"args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"busybox", "sleep", "1"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "sleep", "1"}}) {
 		t.Fatal("first entry's argv should be admitted")
 	}
-	if !idx.AdmitsContainer(digestA, []string{"busybox", "echo", "hi"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "echo", "hi"}}) {
 		t.Fatal("second entry's argv should be admitted")
 	}
-	if idx.AdmitsContainer(digestA, []string{"busybox", "cat", "/etc/shadow"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "cat", "/etc/shadow"}}) {
 		t.Fatal("an argv no entry permits must be rejected")
 	}
 }
 
 func TestIndex_UnknownDigestDenied(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","digests":{"`+digestA+`":"x"}}`).BuildIndex()
-	if idx.AdmitsDigest(digestB) || idx.AdmitsContainer(digestB, nil) {
+	if idx.AdmitsDigest(digestB) || idx.AdmitsContainer(RunningContainer{Digest: digestB, Argv: nil}) {
 		t.Fatal("unknown digest must be denied")
 	}
 }


### PR DESCRIPTION
A digest pins the bytes and process policy pins what runs them, but nothing constrained what the host lays over those bytes at start-up. With shared_fs="none" the runtime seeds every configmap, secret and serviceaccount token by copying it into /run/kata-containers/shared/containers/ and bind-mounting it in — a mechanism a pod cannot work without, and whose source directory the host may write. Staging a file there and binding it over a path inside the image runs host code from an allowlisted digest, and the inventory, RTMR[3] and the issuance gate all still report the digest that was admitted.

Unlike a pod whose trust configuration was repointed, client-side verification does not catch this. The pod keeps its genuine identity — real CDS, real mesh CA, correct launch measurement — so a verifying client passes it and sends data to a container running injected code. That is what makes it worth a schema change where the argv equivalent was not.

Container gains `mounts` and `env`. Mounts constrain BIND mounts by destination; the rest of a mount table names filesystem types and carries nothing in, so pinning it would only make an operator restate the OCI base set. Env constrains variable NAMES — values are never matched, because the allowlist is served to every enforcer and values carry secrets. LD_PRELOAD is the case that motivates env at all.

Both default to `any`, unlike argv's `deny`. A container always carries a mount table and an environment it never declared, so a deny default would refuse every real pod and adopting the field would mean adopting an outage. Opt-in: a digest with no policy is constrained exactly as much as before.

Index.AdmitsContainer now takes the whole RunningContainer rather than (digest, argv), so an enforcer's observation travels as one value and adding the next field does not re-break every call site. An enforcer that cannot see a field leaves it unset, which is nothing-to-refuse rather than a violation — the host-side NRI plugin gates images on a node CVM and never sees a guest's mount table, and refusing there would deny every pod it checks.

Serving is already safe across a partial upgrade: ParseServedJSON ignores unknown fields by design, so a consumer from an older release reads a document carrying these fields and enforces what it knows.

Also folds in the unpinned-CDS hardening. get-cert, get-secret and get-volume each warned and then accepted any RA-TLS-attested CDS when --measurements was empty, which is exactly how a host redirects a sidecar at a CDS it runs. Now cmdsutil.CheckCDSPinned: refuses inside a kata guest, where the host writes the argv; still warns elsewhere, because `c8s install --measurements` documents empty as a supported UNSAFE development shape. One helper rather than three copies.

Limits, stated in the doc: these bind only digests a workloads entry names, so `c8s allowlist add` still produces an unconstrained floor digest.