### PR TITLE
feat(cds): external KMS backend for the secret store, Azure Key Vault…

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -246,7 +246,10 @@ CDS verifies EAR JWTs against its own in-process signer; there is no JWKS
 fetch to a separate component. The chart does not render a CA private key into
 a Kubernetes Secret. CDS generates its mesh CA key inside the process, keeps it
 in memory, and persists only the public CA bundle in the configured
-public-bundle PVC.
+public-bundle PVC. The same in-memory rule covers any external KMS
+credential an operator applies with `c8s secrets external` (docs/secrets.md): it
+arrives over the attested channel, lives in CDS memory, and is never rendered
+into a Kubernetes resource.
 
 Minimal allowlist-write values (pin operator public keys):
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -190,7 +190,78 @@ keeps it until it is rolled. Replacing a path a workload created is worth
 pausing over for that reason: the pods that generated the value go on using it.
 
 Revoking a value means restarting CDS, which empties the whole store — see
-"Restarts".
+"Restarts". An externally-backed path is revoked at the KMS (delete or disable the
+secret, or cut the grant's access) and takes effect on the next fetch.
+
+## Externally-backed paths
+
+A store path can be backed by an external KMS instead of the CDS store: CDS
+fetches the value at release time and forwards it. The release gate is
+unchanged — mesh leaf, challenge, sandbox token, exact workload match, grant —
+and the workload side changes not at all. One backend is configured at a time;
+`azure-keyvault` is the supported backend, and the backend name is part of the
+config document so future backends share this interface.
+
+The operator connects the KMS over the same channel `put` uses:
+
+```sh
+c8s secrets external apply --url "$CDS" --measurements "$M" \
+  --operator-key operator.key -f external.json
+```
+
+```json
+{
+  "schema": "c8s.secrets-external/v1",
+  "backend": "azure-keyvault",
+  "credential": {"tenantId": "…", "clientId": "…", "clientSecret": "…"},
+  "mappings": {"/tenant-a/hf-token": {"vault": "https://v.vault.azure.net", "name": "hf-token"}}
+}
+```
+
+`apply` replaces the whole backend atomically; an empty document disconnects
+it. `c8s secrets external status` shows the mappings, whether a credential is
+live, and the last fetch per path — never the credential or a value.
+
+For `azure-keyvault`, the credential is an Entra app-registration client
+secret whose data-plane access should be the narrowest vault-scoped grant that
+covers the mapped secrets (`Key Vault Secrets User`, or an access policy with
+`secrets/get`). It reaches CDS over the attested channel and lives in CDS
+memory only — never in a Kubernetes resource. One app registration per trust
+boundary: the credential's RBAC scope is the blast radius if CDS is
+compromised, and the Entra tokens CDS caches are bearer material on the same
+footing.
+
+Semantics of a mapped path:
+
+- The KMS value's bytes are delivered **verbatim**. Encoding is part of the
+  KMS-side value contract — base64 a binary key in the vault if the workload
+  expects raw bytes. (This differs from `put`, where base64 is the wire
+  envelope CDS strips.)
+- The mapping is versionless: fetches resolve latest, so KMS-side rotation
+  takes effect on the next pod start.
+- Writes refuse: a workload `POST` gets the conflict response (no mint), and an
+  operator `put` is refused naming an external-KMS-backed value.
+- A fetch failure — KMS unreachable, secret missing, RBAC denial — is the
+  same opaque 500 as any store error; the sidecar retries. The reason is in
+  the CDS log and on `status`.
+- A mapping shadows any value the CDS store holds at the path; `status` lists
+  shadowed paths. Unmapping lets the stored value resurface.
+- `/external` itself is reserved for the config endpoint and cannot be a
+  store path.
+
+Restarts: the mapping set is persisted beside the allowlist database, so a
+restarted CDS fails mapped paths closed until the operator re-applies the
+credential — a mapped path never silently mints. That file is host-visible and
+unauthenticated: a host that deletes or rolls it back un-backs the paths (mint
+resumes) until re-apply, so the post-restart verify-and-re-apply runbook is the
+detector, not a prevention. Re-verify CDS
+(`c8s cds verify --operator-keys`) before re-applying: the operator key set is
+plumbed by Helm, not bound into CDS's attestation, and the cross-check is what
+detects a swapped set.
+
+CDS needs outbound 443 to the KMS endpoints — for Azure,
+`login.microsoftonline.com` and the vault host — with ordinary public-CA TLS
+over untrusted DNS. Global cloud only.
 
 ## Diagnosing a refusal
 
@@ -369,8 +440,9 @@ release decision.
 
 ## Restarts
 
-**A CDS restart destroys every secret, and requires rolling every workload that
-holds one.**
+**A CDS restart destroys every secret the CDS store holds, and requires rolling
+every workload that holds one.** Externally-backed paths are not in the store:
+they recover on re-apply — see "Externally-backed paths".
 
 The store is process memory and there is no persistence. Worse than losing it:
 a pod recreated after the restart calls `POST`, finds the path empty, and is

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -30,8 +30,9 @@ type dependencies struct {
 	MaxRequestSize    int64                 // applied to write endpoints; must be > 0
 	SecretsHandler    *secrets.Handler      // nil leaves /secrets unrouted (--secrets off)
 	SecretsChallenges *attestation.ChallengeStore
-	SecretsOperator   *secrets.OperatorHandler // operator-supplied values; routed with SecretsHandler
-	SecretsExplain    *secrets.ExplainHandler  // release diagnostic; routed with SecretsHandler
+	SecretsOperator   *secrets.OperatorHandler       // operator-supplied values; routed with SecretsHandler
+	SecretsExplain    *secrets.ExplainHandler        // release diagnostic; routed with SecretsHandler
+	SecretsExternal   *secrets.ExternalConfigHandler // external-KMS config; routed with SecretsHandler
 }
 
 func newRouter(deps dependencies) http.Handler {
@@ -76,14 +77,19 @@ func newRouter(deps dependencies) http.Handler {
 	// token. PUT is the operator's, on allowlistWrite so it carries the same
 	// body-bound operator token an allowlist mutation does.
 	if deps.SecretsHandler != nil {
-		if deps.SecretsOperator == nil || deps.SecretsExplain == nil {
-			panic("cds: dependencies.SecretsOperator and SecretsExplain must be set alongside SecretsHandler")
+		if deps.SecretsOperator == nil || deps.SecretsExplain == nil || deps.SecretsExternal == nil {
+			panic("cds: dependencies.SecretsOperator, SecretsExplain and SecretsExternal must be set alongside SecretsHandler")
 		}
 		r.Method(http.MethodPost, secrets.ChallengeRoute, deps.perSandbox(attestation.HandleAuthenticate(deps.SecretsChallenges)))
 		r.Method(http.MethodGet, secrets.Route, deps.perSandbox(deps.SecretsHandler))
 		r.Method(http.MethodPost, secrets.Route, deps.perSandbox(deps.SecretsHandler))
 		r.Method(http.MethodPut, secrets.Route, deps.allowlistWrite(deps.SecretsOperator))
 		r.Method(http.MethodGet, secrets.ExplainRoute, deps.allowlistWrite(deps.SecretsExplain))
+		r.Method(http.MethodPut, secrets.ExternalRoute, deps.allowlistWrite(deps.SecretsExternal))
+		r.Method(http.MethodGet, secrets.ExternalRoute, deps.allowlistWrite(deps.SecretsExternal))
+		// POST too, so the wildcard below never sees the reserved path as a
+		// store path; the handler answers 405.
+		r.Method(http.MethodPost, secrets.ExternalRoute, deps.allowlistWrite(deps.SecretsExternal))
 	}
 
 	r.Get("/ca", handleCA(deps.CACertPEM))

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -44,6 +44,10 @@ func secretsRouter(t *testing.T, enabled bool) http.Handler {
 		deps.SecretsChallenges = &secretsCS
 		deps.SecretsOperator = &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)}
 		deps.SecretsExplain = &secrets.ExplainHandler{}
+		deps.SecretsExternal = &secrets.ExternalConfigHandler{
+			Backend: secrets.NewExternalBackend(nil, nil, 64),
+			Mem:     secrets.NewMemoryStore(8, 64),
+		}
 	}
 	return newRouter(deps)
 }
@@ -108,6 +112,7 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 		SecretsChallenges: &secretsCS,
 		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)},
 		SecretsExplain:    &secrets.ExplainHandler{},
+		SecretsExternal:   &secrets.ExternalConfigHandler{Backend: secrets.NewExternalBackend(nil, nil, 64), Mem: secrets.NewMemoryStore(8, 64)},
 	}
 	_ = newRouter(deps)
 
@@ -154,6 +159,7 @@ func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
 			MaxBodyBytes: allowlistWriteBodyCap,
 			Authorize:    func(_ *http.Request, body []byte) error { seen = len(body); return nil },
 		},
+		SecretsExternal: &secrets.ExternalConfigHandler{Backend: secrets.NewExternalBackend(nil, nil, 64), Mem: secrets.NewMemoryStore(8, 64)},
 	}
 	r := newRouter(deps)
 
@@ -238,6 +244,7 @@ func TestRouter_SecretRoutesRateLimitPerSandbox(t *testing.T) {
 		SecretsChallenges: &secretsCS,
 		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 64)},
 		SecretsExplain:    &secrets.ExplainHandler{},
+		SecretsExternal:   &secrets.ExternalConfigHandler{Backend: secrets.NewExternalBackend(nil, nil, 64), Mem: secrets.NewMemoryStore(8, 64)},
 	})
 
 	send := func(leaf *x509.Certificate) int {
@@ -267,5 +274,36 @@ func TestRouter_SecretRoutesRateLimitPerSandbox(t *testing.T) {
 	// The co-tenant on the same address still gets through.
 	if code := send(victim); code == http.StatusTooManyRequests {
 		t.Fatal("one pod exhausted a co-tenant's bucket: the limiter is keyed on the address")
+	}
+}
+
+// The external config route is a static segment under the secrets wildcard:
+// chi routes it ahead of the wildcard, and "/external" is a reserved store path.
+func TestRouter_ExternalConfigRoutedWithSecrets(t *testing.T) {
+	r := secretsRouter(t, true)
+	// Reaches the handler, which refuses: no client certificate and no
+	// operator token.
+	if code := get(t, r, http.MethodPut, "/secrets/external"); code == http.StatusNotFound {
+		t.Fatal("PUT /secrets/external = 404: the route did not reach the external config handler")
+	}
+	if code := get(t, r, http.MethodGet, "/secrets/external"); code != http.StatusUnauthorized {
+		t.Fatalf("GET /secrets/external = %d, want 401 from the external config handler", code)
+	}
+	// POST is routed to the config handler too (405 after auth), so the
+	// reserved path never reaches the workload handler as a store path: that
+	// would answer 400 for want of a challenge.
+	if code := get(t, r, http.MethodPost, "/secrets/external"); code != http.StatusUnauthorized {
+		t.Fatalf("POST /secrets/external = %d, want 401 from the external config handler", code)
+	}
+	// The wildcard still covers paths below /secrets.
+	if code := get(t, r, http.MethodGet, "/secrets/other"); code == http.StatusNotFound {
+		t.Fatal("GET /secrets/other = 404: the wildcard no longer covers it")
+	}
+}
+
+func TestRouter_ExternalConfigUnroutedWhenSecretsDisabled(t *testing.T) {
+	r := secretsRouter(t, false)
+	if code := get(t, r, http.MethodPut, "/secrets/external"); code != http.StatusNotFound {
+		t.Fatalf("PUT /secrets/external = %d, want 404 with --secrets off", code)
 	}
 }

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -266,14 +266,30 @@ func run(cfg config) error {
 		secretsHandler  *secrets.Handler
 		secretsOperator *secrets.OperatorHandler
 		secretsExplain  *secrets.ExplainHandler
+		secretsExternal *secrets.ExternalConfigHandler
 	)
 	if enabled, why := secretsEnabled(cfg, sandboxDigests, inventoryHosts); enabled {
 		// One store behind both handlers: an operator write and a workload read
 		// are two doors onto the same paths.
 		store := secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxValueBytes)
+		// Externally-backed paths route around the memory store. The mapping
+		// set is persisted beside the allowlist DB (same durability class);
+		// the credential is memory-only and arrives over PUT /secrets/external.
+		externalMappings, externalPersist, err := secrets.LoadExternalMappings(cfg.allowlistDB)
+		if err != nil {
+			return err
+		}
+		externalBackend := secrets.NewExternalBackend(externalMappings, externalPersist, cfg.secretsMaxValueBytes)
+		routingStore := &secrets.RoutingStore{Mem: store, External: externalBackend}
+		if len(externalMappings) > 0 {
+			slog.Warn("external KMS mappings loaded without a credential: mapped paths fail closed until c8s secrets external apply re-arms them", "mappings", len(externalMappings))
+		}
+		if externalPersist == nil {
+			slog.Warn("--allowlist-db empty: external KMS mappings are not persisted, so a restart silently un-backs mapped paths until c8s secrets external apply re-runs")
+		}
 		policy := secrets.NewCachedPolicy(&allowlistStore)
 		secretsHandler = &secrets.Handler{
-			Store:          store,
+			Store:          routingStore,
 			Challenges:     &secretsChallenges,
 			Inventory:      sandboxDigests,
 			Bindings:       sandboxBindings,
@@ -282,7 +298,14 @@ func run(cfg config) error {
 			Logger:         slog.Default(),
 		}
 		secretsOperator = &secrets.OperatorHandler{
-			Store:        store,
+			Store:        routingStore,
+			Authorize:    writeAuthorizer,
+			MaxBodyBytes: allowlistWriteBodyCap,
+			Logger:       slog.Default(),
+		}
+		secretsExternal = &secrets.ExternalConfigHandler{
+			Backend:      externalBackend,
+			Mem:          store,
 			Authorize:    writeAuthorizer,
 			MaxBodyBytes: allowlistWriteBodyCap,
 			Logger:       slog.Default(),
@@ -349,6 +372,7 @@ func run(cfg config) error {
 		SecretsChallenges: &secretsChallenges,
 		SecretsOperator:   secretsOperator,
 		SecretsExplain:    secretsExplain,
+		SecretsExternal:   secretsExternal,
 	}
 	if cfg.rotationInterval > 0 {
 		go rotator.Run(ctx)

--- a/internal/cmds/cds/run_test.go
+++ b/internal/cmds/cds/run_test.go
@@ -771,3 +771,22 @@ func TestMeasurementDigests(t *testing.T) {
 		t.Fatalf("empty allowlist: got %v, %v", empty, err)
 	}
 }
+
+// A corrupt external-mappings file fails startup loud rather than silently
+// un-backing mapped paths.
+func TestRun_CorruptExternalMappingsFailsClosed(t *testing.T) {
+	api := newHealthyAttestationApi(t)
+	cfg := validRunConfig(t, api.URL)
+	cfg.ratlsPlatform = "snp"
+	cfg.measurements = []string{"deadbeef"}
+	cfg.inventoryCIDRs = []string{"10.0.0.0/24"}
+	dir := t.TempDir()
+	cfg.allowlistDB = filepath.Join(dir, "allowlist.db")
+	if err := os.WriteFile(filepath.Join(dir, "external-mappings.json"), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := run(cfg)
+	if err == nil || !strings.Contains(err.Error(), "external-mappings.json") {
+		t.Fatalf("run = %v, want an external-mappings parse error", err)
+	}
+}

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -128,3 +128,54 @@ func (c client) explain(ctx context.Context, sandboxID string, auth authorizer) 
 // maxResponseBytes bounds a CDS reply. The largest is an explain report over
 // every workload entry; anything approaching this is a wrong endpoint.
 const maxResponseBytes = 1 << 20
+
+// putExternal replaces the Azure backend config, returning the resulting status.
+func (c client) putExternal(ctx context.Context, doc []byte, auth authorizer) (intsecrets.ExternalStatus, error) {
+	var st intsecrets.ExternalStatus
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+intsecrets.ExternalRoute, bytes.NewReader(doc))
+	if err != nil {
+		return st, err
+	}
+	authz, err := auth.Authorization(http.MethodPut, req.URL.Path, doc)
+	if err != nil {
+		return st, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authz)
+	return st, c.doExternal(req, &st)
+}
+
+// getExternal reads the Azure backend status.
+func (c client) getExternal(ctx context.Context, auth authorizer) (intsecrets.ExternalStatus, error) {
+	var st intsecrets.ExternalStatus
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+intsecrets.ExternalRoute, nil)
+	if err != nil {
+		return st, err
+	}
+	authz, err := auth.Authorization(http.MethodGet, req.URL.Path, nil)
+	if err != nil {
+		return st, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Authorization", authz)
+	return st, c.doExternal(req, &st)
+}
+
+// doExternal runs one config-endpoint request and decodes the status reply.
+func (c client) doExternal(req *http.Request, st *intsecrets.ExternalStatus) error {
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("cds returned %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	if err := json.Unmarshal(raw, st); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}

--- a/internal/cmds/secrets/cmd.go
+++ b/internal/cmds/secrets/cmd.go
@@ -47,12 +47,14 @@ Writes are signed with an operator EC private key you supply via --operator-key
 
 Values live in the CDS process and nowhere else, so a CDS restart clears the
 store and every workload holding a secret has to be rolled (see
-docs/secrets.md).`,
+docs/secrets.md) — except paths backed by an external KMS
+('c8s secrets external'), which are fetched from the vault at release time and recover on
+re-apply.`,
 		SilenceUsage: true,
 	}
 
 	cdsconn.BindFlags(cmd.PersistentFlags(), &o.Options)
-	cmd.AddCommand(newPutCmd(o), newExplainCmd(o))
+	cmd.AddCommand(newPutCmd(o), newExplainCmd(o), newExternalCmd(o))
 	return cmd
 }
 

--- a/internal/cmds/secrets/coverage_test.go
+++ b/internal/cmds/secrets/coverage_test.go
@@ -1,0 +1,146 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// --- readExternalDoc ---
+
+func TestReadExternalDocMissingFile(t *testing.T) {
+	cmd := newExternalApplyCmd(&options{})
+	if _, err := readExternalDoc(cmd, filepath.Join(t.TempDir(), "nope.json")); err == nil {
+		t.Fatal("missing file must fail")
+	}
+}
+
+func TestReadExternalDocEmpty(t *testing.T) {
+	cmd := newExternalApplyCmd(&options{})
+	cmd.SetIn(strings.NewReader("  \n"))
+	if _, err := readExternalDoc(cmd, ""); err == nil {
+		t.Fatal("empty stdin must fail")
+	}
+}
+
+func TestReadExternalDocFromFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "doc.json")
+	if err := os.WriteFile(path, []byte(`{"schema":"x"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newExternalApplyCmd(&options{})
+	got, err := readExternalDoc(cmd, path)
+	if err != nil || !strings.Contains(string(got), "schema") {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+// --- printExternalStatus branches ---
+
+func TestPrintExternalStatusBranches(t *testing.T) {
+	var buf bytes.Buffer
+
+	printExternalStatus(&buf, intsecrets.ExternalStatus{})
+	if !strings.Contains(buf.String(), "backend is off") {
+		t.Fatalf("empty: %q", buf.String())
+	}
+
+	buf.Reset()
+	printExternalStatus(&buf, intsecrets.ExternalStatus{
+		Mappings: map[string]intsecrets.AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s"}},
+	})
+	if !strings.Contains(buf.String(), "NO CREDENTIAL") {
+		t.Fatalf("unconfigured: %q", buf.String())
+	}
+
+	buf.Reset()
+	printExternalStatus(&buf, intsecrets.ExternalStatus{
+		Configured: true,
+		Mappings:   map[string]intsecrets.AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s"}},
+		LastFetch: map[string]intsecrets.FetchRecord{
+			"/a": {Err: "secrets: vault answered 500"},
+			"/b": {},
+		},
+		Shadowed: []string{"/a"},
+	})
+	out := buf.String()
+	for _, want := range []string{"credential applied", "last fetch FAILED", "shadows"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in %q", want, out)
+		}
+	}
+}
+
+// --- doExternal error paths ---
+
+func TestDoExternalServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	keyPath := writeOperatorKey(t)
+	if _, _, err := run(t, "", "external", "status", "--url", srv.URL, "--insecure", "--operator-key", keyPath); err == nil {
+		t.Fatal("a CDS error must surface")
+	}
+}
+
+func TestDoExternalBadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	t.Cleanup(srv.Close)
+	keyPath := writeOperatorKey(t)
+	_, _, err := run(t, "", "external", "status", "--url", srv.URL, "--insecure", "--operator-key", keyPath)
+	if err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("err = %v, want a decode failure", err)
+	}
+}
+
+// --- apply: empty stdin refuses before calling CDS ---
+
+func TestExternalApplyEmptyDoc(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("CDS called with an empty document")
+	}))
+	t.Cleanup(srv.Close)
+	keyPath := writeOperatorKey(t)
+	if _, _, err := run(t, "", "external", "apply", "--url", srv.URL, "--insecure", "--operator-key", keyPath); err == nil {
+		t.Fatal("empty document must fail before any call")
+	}
+}
+
+// --- status --json ---
+
+func TestExternalStatusJSON(t *testing.T) {
+	f, url := newFakeExternalCDS(t)
+	f.status = intsecrets.ExternalStatus{Configured: true, Mappings: map[string]intsecrets.AzureMapping{
+		"/a": {Vault: "https://v.vault.azure.net", Name: "s"},
+	}}
+	keyPath := writeOperatorKey(t)
+	out, _, err := run(t, "", "external", "status", "--json", "--url", url, "--insecure", "--operator-key", keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var st intsecrets.ExternalStatus
+	if err := json.Unmarshal([]byte(out), &st); err != nil {
+		t.Fatalf("--json output does not decode: %v", err)
+	}
+}
+
+// --- describe ---
+
+func TestDescribeOrigins(t *testing.T) {
+	if got := describe(intsecrets.Origin("mystery")); got != "a value" {
+		t.Fatalf("describe(default) = %q", got)
+	}
+	if got := describe(intsecrets.OriginExternal); !strings.Contains(got, "external") {
+		t.Fatalf("describe(external) = %q", got)
+	}
+}

--- a/internal/cmds/secrets/external.go
+++ b/internal/cmds/secrets/external.go
@@ -1,0 +1,173 @@
+package secrets
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+func newExternalCmd(o *options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "external",
+		Short: "Manage the external KMS backend",
+		Long: `Connect the CDS secret store to an external KMS: mapped paths are fetched
+from it at release time instead of held by CDS. One backend is configured at
+a time; azure-keyvault is the supported backend.
+
+'apply' replaces the whole backend atomically with a JSON document read from
+--file or stdin:
+
+  {
+    "schema": "c8s.secrets-external/v1",
+    "backend": "azure-keyvault",
+    "credential": {"tenantId": "…", "clientId": "…", "clientSecret": "…"},
+    "mappings": {"/tenant-a/hf-token": {"vault": "https://v.vault.azure.net", "name": "hf-token"}}
+  }
+
+The credential reaches CDS over the attested channel and lives in CDS memory
+only — never in a Kubernetes resource — so a CDS restart clears it. The mapping
+set is persisted beside the allowlist database, so after a restart mapped paths
+fail closed until the credential is re-applied. Apply an empty document
+("mappings": {} and no credential) to disconnect the vault.
+
+Workload access is unchanged: a mapped path still needs an allowlist grant, and
+the workload receives the vault value's bytes verbatim — base64 a binary key
+vault-side if the workload expects raw bytes.`,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newExternalApplyCmd(o), newExternalStatusCmd(o))
+	return cmd
+}
+
+func newExternalApplyCmd(o *options) *cobra.Command {
+	var fromFile string
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Replace the Azure backend config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			doc, err := readExternalDoc(cmd, fromFile)
+			if err != nil {
+				return err
+			}
+			signer, err := o.Signer()
+			if err != nil {
+				return err
+			}
+			c, err := o.client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			st, err := c.putExternal(cmd.Context(), doc, signer)
+			if err != nil {
+				return err
+			}
+			printExternalStatus(cmd.OutOrStdout(), st)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&fromFile, "file", "f", "", "read the config document from this file instead of stdin")
+	return cmd
+}
+
+func newExternalStatusCmd(o *options) *cobra.Command {
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the Azure backend state",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := o.Validate(); err != nil {
+				return err
+			}
+			signer, err := o.Signer()
+			if err != nil {
+				return err
+			}
+			c, err := o.client(cmd.Context())
+			if err != nil {
+				return err
+			}
+			st, err := c.getExternal(cmd.Context(), signer)
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(st)
+			}
+			printExternalStatus(cmd.OutOrStdout(), st)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&asJSON, "json", false, "print the raw report")
+	return cmd
+}
+
+// readExternalDoc reads the config document from a file or stdin. The bytes pass
+// through unmodified; CDS validates.
+func readExternalDoc(cmd *cobra.Command, fromFile string) ([]byte, error) {
+	var (
+		doc []byte
+		err error
+	)
+	if fromFile != "" {
+		doc, err = os.ReadFile(fromFile)
+		if err != nil {
+			return nil, fmt.Errorf("read --file: %w", err)
+		}
+	} else {
+		doc, err = io.ReadAll(cmd.InOrStdin())
+		if err != nil {
+			return nil, fmt.Errorf("read document from stdin: %w", err)
+		}
+	}
+	if len(strings.TrimSpace(string(doc))) == 0 {
+		return nil, fmt.Errorf("document is empty: supply it on stdin or with --file")
+	}
+	return doc, nil
+}
+
+// printExternalStatus renders the backend state. The credential and fetched
+// values are never in it.
+func printExternalStatus(w io.Writer, st intsecrets.ExternalStatus) {
+	if len(st.Mappings) == 0 {
+		fmt.Fprintln(w, "no azure mappings: the vault backend is off")
+		return
+	}
+	if st.Configured {
+		fmt.Fprintln(w, "credential applied")
+	} else {
+		fmt.Fprintln(w, "NO CREDENTIAL: mapped paths fail closed until 'c8s secrets external apply'")
+	}
+	paths := make([]string, 0, len(st.Mappings))
+	for p := range st.Mappings {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		m := st.Mappings[p]
+		fmt.Fprintf(w, "%s -> %s/secrets/%s\n", p, m.Vault, m.Name)
+		if r, ok := st.LastFetch[p]; ok {
+			if r.Err == "" {
+				fmt.Fprintf(w, "    last fetch ok at %s\n", r.At.Format("2006-01-02 15:04:05Z07:00"))
+			} else {
+				fmt.Fprintf(w, "    last fetch FAILED at %s: %s\n", r.At.Format("2006-01-02 15:04:05Z07:00"), r.Err)
+			}
+		}
+	}
+	for _, p := range st.Shadowed {
+		fmt.Fprintf(w, "warning: %s shadows a value held in the CDS store; unmapping exposes it again\n", p)
+	}
+}

--- a/internal/cmds/secrets/external_test.go
+++ b/internal/cmds/secrets/external_test.go
@@ -1,0 +1,100 @@
+package secrets
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+)
+
+// fakeExternalCDS serves PUT/GET on the azure config route, recording what the
+// CLI sent.
+type fakeExternalCDS struct {
+	mu     sync.Mutex
+	status intsecrets.ExternalStatus
+	seen   []string // raw bodies
+	authz  []string
+}
+
+func newFakeExternalCDS(t *testing.T) (*fakeExternalCDS, string) {
+	t.Helper()
+	f := &fakeExternalCDS{status: intsecrets.ExternalStatus{Mappings: map[string]intsecrets.AzureMapping{}}}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		if r.URL.Path != intsecrets.ExternalRoute {
+			http.NotFound(w, r)
+			return
+		}
+		f.authz = append(f.authz, r.Header.Get("Authorization"))
+		switch r.Method {
+		case http.MethodPut:
+			buf, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			f.seen = append(f.seen, string(buf))
+			var doc struct {
+				Mappings map[string]intsecrets.AzureMapping `json:"mappings"`
+			}
+			if err := json.Unmarshal(buf, &doc); err != nil {
+				http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+				return
+			}
+			f.status = intsecrets.ExternalStatus{Configured: len(doc.Mappings) > 0, Mappings: doc.Mappings}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(f.status)
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(f.status)
+		default:
+			http.Error(w, "method", http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return f, srv.URL
+}
+
+const testAzureDoc = `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"https://v.vault.azure.net","name":"s1"}}}`
+
+func TestExternalApplySendsTheDocument(t *testing.T) {
+	f, url := newFakeExternalCDS(t)
+	keyPath := writeOperatorKey(t)
+	out, _, err := run(t, testAzureDoc, "external", "apply", "--url", url, "--insecure", "--operator-key", keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(f.seen) != 1 || !strings.Contains(f.seen[0], `"clientSecret":"s"`) {
+		t.Fatalf("the document did not reach CDS: %v", f.seen)
+	}
+	if len(f.authz) != 1 || !strings.HasPrefix(f.authz[0], "Bearer ") {
+		t.Fatalf("no operator token on the write: %v", f.authz)
+	}
+	if !strings.Contains(out, "/a -> https://v.vault.azure.net/secrets/s1") {
+		t.Fatalf("status output missing the mapping: %q", out)
+	}
+}
+
+func TestExternalStatusHidesNothingButTheSecret(t *testing.T) {
+	_, url := newFakeExternalCDS(t)
+	keyPath := writeOperatorKey(t)
+	if _, _, err := run(t, testAzureDoc, "external", "apply", "--url", url, "--insecure", "--operator-key", keyPath); err != nil {
+		t.Fatal(err)
+	}
+	out, _, err := run(t, "", "external", "status", "--url", url, "--insecure", "--operator-key", keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "credential applied") {
+		t.Fatalf("status output: %q", out)
+	}
+	if strings.Contains(out, `"s"`) || strings.Contains(out, "clientSecret") {
+		t.Fatalf("status leaked the credential: %q", out)
+	}
+}

--- a/internal/cmds/secrets/put.go
+++ b/internal/cmds/secrets/put.go
@@ -70,6 +70,9 @@ reaches a running pod when that pod next restarts.`,
 				fmt.Fprintf(cmd.OutOrStdout(), "wrote %d bytes to %s\n", len(value), path)
 				return nil
 			}
+			if res.Existing == intsecrets.OriginExternal {
+				return fmt.Errorf("%s is backed by the external KMS; writes do not reach it — change the value there, or unmap the path with 'c8s secrets external apply' first", path)
+			}
 			if !overwrite {
 				return fmt.Errorf("%s already holds %s; re-run with --overwrite to replace it", path, describe(res.Existing))
 			}
@@ -78,6 +81,10 @@ reaches a running pod when that pod next restarts.`,
 			res, err = c.put(cmd.Context(), path, value, true, signer)
 			if err != nil {
 				return err
+			}
+			if res.Refused {
+				// The path became external-mapped between the two calls.
+				return fmt.Errorf("%s is backed by the external KMS; writes do not reach it — unmap the path with 'c8s secrets external apply' first", path)
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "wrote %d bytes to %s\n", len(value), path)
 			if res.Existing == intsecrets.OriginWorkload {
@@ -101,6 +108,8 @@ func describe(o intsecrets.Origin) string {
 		return "a workload-generated value"
 	case intsecrets.OriginOperator:
 		return "an operator-supplied value"
+	case intsecrets.OriginExternal:
+		return "an external-KMS-backed value"
 	default:
 		return "a value"
 	}

--- a/internal/cmds/secrets/put_test.go
+++ b/internal/cmds/secrets/put_test.go
@@ -461,3 +461,33 @@ func TestExplainSurfacesServerErrors(t *testing.T) {
 		t.Fatalf("err = %v", err)
 	}
 }
+
+// A put against an external-mapped path must fail loudly on BOTH the plain
+// and the --overwrite path: CDS refuses with Existing=external, and the CLI
+// must not print a success line for a write that never landed.
+func TestPutExternalPathRefusedLoudly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_ = json.NewEncoder(w).Encode(intsecrets.PutResponse{Path: "/a", Existing: intsecrets.OriginExternal})
+	}))
+	t.Cleanup(srv.Close)
+	keyPath := writeOperatorKey(t)
+
+	for _, args := range [][]string{
+		{"put", "/a"},
+		{"put", "/a", "--overwrite"},
+	} {
+		args = append(args, "--url", srv.URL, "--insecure", "--operator-key", keyPath)
+		out, _, err := run(t, "dmFsdWU=", args...)
+		if err == nil {
+			t.Fatalf("%v: exited 0 for a refused write; stdout: %q", args, out)
+		}
+		if strings.Contains(out, "wrote") {
+			t.Fatalf("%v: printed a success line for a refused write: %q", args, out)
+		}
+		if !strings.Contains(err.Error(), "external KMS") {
+			t.Fatalf("%v: error %q does not name the external KMS", args, err)
+		}
+	}
+}

--- a/internal/secrets/azure.go
+++ b/internal/secrets/azure.go
@@ -1,0 +1,262 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Azure direct brokering: CDS fetches a Key Vault secret at release time and
+// forwards it to the attested workload. The credential arrives over the
+// operator channel (PUT on ExternalRoute) and lives in process memory only; the
+// non-secret mapping set is persisted so a restarted CDS fails closed rather
+// than minting over a path the operator believes vault-backed.
+
+// azureAPIVersion is the pinned Key Vault data-plane version. 7.4 is the
+// legacy scheme's last stable; the surface used here (GET secret, token
+// client-credentials) is identical in every later version.
+const azureAPIVersion = "7.4"
+
+// azureScope is the Entra token audience for Key Vault data plane. Global
+// cloud only: sovereign clouds use a different login host and scope and are
+// rejected at config validation.
+const azureScope = "https://vault.azure.net/.default"
+
+// azureLoginHost is the global-cloud Entra token endpoint host.
+const azureLoginHost = "https://login.microsoftonline.com"
+
+// azureTimeout bounds one Entra or vault round trip.
+const azureTimeout = 10 * time.Second
+
+// azureMaxBodyBytes bounds a response from Entra or the vault before decode.
+// A token is ~2 KiB; a secret bundle is the value plus a small envelope, and
+// the value itself is capped again against the store limit after decode.
+const azureMaxBodyBytes = 1 << 20
+
+// errAzureUnauthorized marks a vault 401 so the fetch can drop its cached
+// token and try once more: the credential may have been rotated at Entra
+// out from under a token that has not yet expired.
+var errAzureUnauthorized = errors.New("secrets: azure rejected the token")
+
+// AzureCredential is the Entra app registration the operator provisioned.
+// ClientSecret is write-only: it is accepted over the operator channel and
+// never served back, logged, or persisted.
+type AzureCredential struct {
+	TenantID     string `json:"tenantId"`
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+// AzureMapping binds one canonical store path to one vault secret. Versionless
+// by design: the fetch resolves latest, so vault-side rotation takes effect on
+// the next pod start.
+type AzureMapping struct {
+	Vault string `json:"vault"`
+	Name  string `json:"name"`
+}
+
+// FetchRecord is the per-path outcome of the last fetch, for status. It never
+// carries a value.
+type FetchRecord struct {
+	At  time.Time `json:"at"`
+	Err string    `json:"err,omitempty"`
+}
+
+// azureConfig is one applied document: credential, mappings, and the token
+// cache that belongs to exactly this credential. It is immutable after
+// construction; a replace builds a new one.
+type azureConfig struct {
+	cred     AzureCredential
+	mappings map[string]AzureMapping
+	tokens   *tokenCache
+	client   *http.Client
+	loginURL string // Entra token endpoint prefix; a field so tests can fake it
+
+	mu   sync.Mutex
+	last map[string]FetchRecord
+}
+
+// newAzureConfig builds a config from a validated document.
+func newAzureConfig(cred AzureCredential, mappings map[string]AzureMapping) *azureConfig {
+	return &azureConfig{
+		cred:     cred,
+		mappings: mappings,
+		tokens:   &tokenCache{},
+		client: &http.Client{
+			Timeout: azureTimeout,
+			// A redirect from Entra or the vault is an error, never a hint:
+			// following it would carry the bearer token to a host the
+			// operator did not name.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		loginURL: azureLoginHost,
+		last:     make(map[string]FetchRecord),
+	}
+}
+
+// fetch returns the vault value for a mapped path.
+func (c *azureConfig) fetch(ctx context.Context, path string) ([]byte, error) {
+	m := c.mappings[path]
+	value, err := c.fetchOnce(ctx, m)
+	if errors.Is(err, errAzureUnauthorized) {
+		c.tokens.invalidate()
+		value, err = c.fetchOnce(ctx, m)
+	}
+	c.mu.Lock()
+	c.last[path] = FetchRecord{At: time.Now(), Err: errString(err)}
+	c.mu.Unlock()
+	return value, err
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// transportErr strips the request URL from a transport error: a *url.Error
+// carries method and full URL — query string included — and these errors reach
+// the CDS log and the operator status, where the contract is status only.
+func transportErr(err error) error {
+	var ue *url.Error
+	if errors.As(err, &ue) {
+		return ue.Err
+	}
+	return err
+}
+
+// fetchOnce performs one token + GET round trip.
+func (c *azureConfig) fetchOnce(ctx context.Context, m AzureMapping) ([]byte, error) {
+	token, err := c.tokens.get(func() (string, time.Time, error) {
+		return fetchToken(ctx, c.client, c.loginURL, c.cred)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	u := m.Vault + "/secrets/" + url.PathEscape(m.Name) + "?api-version=" + azureAPIVersion
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: build vault request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("secrets: vault request failed: %w", transportErr(err))
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, errAzureUnauthorized
+	}
+	if resp.StatusCode != http.StatusOK {
+		// The body is not read: the status alone is reported, and the workload
+		// gets the same opaque failure as every other fetch error.
+		return nil, fmt.Errorf("secrets: vault answered %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, azureMaxBodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("secrets: read vault response: %w", err)
+	}
+	var bundle struct {
+		Value *string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &bundle); err != nil {
+		return nil, fmt.Errorf("secrets: decode vault response: %w", err)
+	}
+	if bundle.Value == nil {
+		return nil, fmt.Errorf("secrets: vault response carries no value")
+	}
+	// The string is delivered verbatim: encoding is part of the vault-side
+	// value contract, unlike `c8s secrets put`, where base64 is the wire
+	// envelope CDS strips.
+	return []byte(*bundle.Value), nil
+}
+
+// tokenCache holds the Entra access token for one credential. The mutex makes
+// a refresh single-flight; it is never held by the config swap path, so a slow
+// Entra call stalls only other fetches, never an apply.
+type tokenCache struct {
+	mu     sync.Mutex
+	token  string
+	expiry time.Time
+}
+
+// get returns a usable token, calling fetch to refresh when the cache is
+// empty or inside the expiry margin. fetch is a callback so the cache holds no
+// Azure knowledge of its own.
+func (c *tokenCache) get(fetch func() (string, time.Time, error)) (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.token != "" && time.Now().Before(c.expiry) {
+		return c.token, nil
+	}
+	token, expiry, err := fetch()
+	if err != nil {
+		return "", err
+	}
+	c.token, c.expiry = token, expiry
+	return token, nil
+}
+
+func (c *tokenCache) invalidate() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.token = ""
+	c.expiry = time.Time{}
+}
+
+// fetchToken runs the client-credentials grant against Entra.
+func fetchToken(ctx context.Context, client *http.Client, loginURL string, cred AzureCredential) (string, time.Time, error) {
+	form := url.Values{
+		"grant_type":    {"client_credentials"},
+		"client_id":     {cred.ClientID},
+		"client_secret": {cred.ClientSecret},
+		"scope":         {azureScope},
+	}
+	u := loginURL + "/" + url.PathEscape(cred.TenantID) + "/oauth2/v2.0/token"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("secrets: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("secrets: token request failed: %w", transportErr(err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("secrets: entra answered %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, azureMaxBodyBytes))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("secrets: read token response: %w", err)
+	}
+	var tok struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.Unmarshal(body, &tok); err != nil {
+		return "", time.Time{}, fmt.Errorf("secrets: decode token response: %w", err)
+	}
+	if tok.AccessToken == "" || tok.ExpiresIn <= 0 {
+		return "", time.Time{}, fmt.Errorf("secrets: token response missing access_token or expires_in")
+	}
+	// Refresh at 80% of the stated lifetime so a fetch never starts with a
+	// token that expires mid-flight.
+	return tok.AccessToken, time.Now().Add(time.Duration(tok.ExpiresIn) * time.Second * 4 / 5), nil
+}

--- a/internal/secrets/azure_integration_test.go
+++ b/internal/secrets/azure_integration_test.go
@@ -1,0 +1,120 @@
+package secrets
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// azureHarness wires the workload handler to a RoutingStore whose Azure
+// backend talks to a fake vault.
+func azureHarness(t *testing.T, f *fakeAzure, withCredential bool) (*harness, *ExternalBackend) {
+	t.Helper()
+	hn := newHarness(t)
+	backend := NewExternalBackend(nil, nil, 64)
+	if withCredential {
+		backend.mu.Lock()
+		backend.mapped = map[string]AzureMapping{"/api/key": {Vault: f.srv.URL, Name: "s1"}}
+		backend.live = f.config(testCred, backend.mapped)
+		backend.mu.Unlock()
+	} else {
+		backend.mu.Lock()
+		backend.mapped = map[string]AzureMapping{"/api/key": {Vault: f.srv.URL, Name: "s1"}}
+		backend.mu.Unlock()
+	}
+	hn.h.Store = &RoutingStore{Mem: hn.store, External: backend}
+	return hn, backend
+}
+
+func TestWorkloadGetMappedPathFetchesFromVault(t *testing.T) {
+	f := newFakeAzure(t)
+	hn, _ := azureHarness(t, f, true)
+	w := do(hn.h, hn.request(t, http.MethodGet, "/api/key"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d: %s", w.Code, w.Body)
+	}
+	if got := decodeValue(t, w); got != base64.StdEncoding.EncodeToString([]byte("vault-value")) {
+		t.Fatalf("value = %q", got)
+	}
+}
+
+func TestWorkloadGetMappedPathFailsClosedWithoutCredential(t *testing.T) {
+	f := newFakeAzure(t)
+	hn, _ := azureHarness(t, f, false)
+	w := do(hn.h, hn.request(t, http.MethodGet, "/api/key"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (fail closed)", w.Code)
+	}
+	if got := f.secretCalls.Load(); got != 0 {
+		t.Fatalf("vault calls = %d, want 0 without a credential", got)
+	}
+}
+
+// A POST on a mapped path must not mint: 409, and the vault value is what a
+// following GET reads.
+func TestWorkloadPostMappedPathDoesNotMint(t *testing.T) {
+	f := newFakeAzure(t)
+	hn, _ := azureHarness(t, f, true)
+	w := do(hn.h, hn.request(t, http.MethodPost, "/api/key"))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("POST status = %d, want 409", w.Code)
+	}
+	if _, err := hn.store.Get(t.Context(), "/api/key"); err != ErrNotFound {
+		t.Fatal("the refused POST minted a value into the memory store")
+	}
+	w = do(hn.h, hn.request(t, http.MethodGet, "/api/key"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET after POST status = %d", w.Code)
+	}
+	if got := decodeValue(t, w); got != base64.StdEncoding.EncodeToString([]byte("vault-value")) {
+		t.Fatalf("value = %q, want the vault value", got)
+	}
+}
+
+// The review's regression test: an operator write to a mapped path is a
+// refusal on BOTH the create and the overwrite path — never a false success.
+func TestOperatorPutMappedPathRefusedOnCreateAndOverwrite(t *testing.T) {
+	backend := NewExternalBackend(map[string]AzureMapping{"/api/key": {Vault: "https://v.vault.azure.net", Name: "s1"}}, nil, 64)
+	mem := NewMemoryStore(16, 64)
+	h := OperatorHandler{
+		Store:     &RoutingStore{Mem: mem, External: backend},
+		Authorize: func(*http.Request, []byte) error { return nil },
+	}
+	for _, overwrite := range []bool{false, true} {
+		body, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("x")), Overwrite: overwrite})
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/secrets/api/key", strings.NewReader(string(body))))
+		if w.Code != http.StatusConflict {
+			t.Fatalf("overwrite=%v: status = %d, want 409 (a refusal, not a silent no-op)", overwrite, w.Code)
+		}
+		var resp PutResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		if resp.Existing != OriginExternal {
+			t.Fatalf("overwrite=%v: existing = %q, want %q", overwrite, resp.Existing, OriginExternal)
+		}
+	}
+	if _, err := mem.Get(t.Context(), "/api/key"); err != ErrNotFound {
+		t.Fatal("a refused write landed in the memory store")
+	}
+}
+
+// Unmapped paths are untouched by the backend.
+func TestOperatorPutUnmappedPathStillWorks(t *testing.T) {
+	backend := NewExternalBackend(nil, nil, 64)
+	mem := NewMemoryStore(16, 64)
+	h := OperatorHandler{
+		Store:     &RoutingStore{Mem: mem, External: backend},
+		Authorize: func(*http.Request, []byte) error { return nil },
+	}
+	body, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("x"))})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, "/secrets/api/db", strings.NewReader(string(body))))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+}

--- a/internal/secrets/azure_test.go
+++ b/internal/secrets/azure_test.go
@@ -1,0 +1,235 @@
+package secrets
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeAzure serves the token endpoint and a vault secrets endpoint from one
+// TLS server, counting calls.
+type fakeAzure struct {
+	srv *httptest.Server
+
+	tokenCalls  atomic.Int32
+	secretCalls atomic.Int32
+
+	tokenStatus  int
+	tokenBody    string
+	secret       string
+	secretStatus int
+	// rawSecretBody, when set, is served verbatim instead of a JSON bundle.
+	rawSecretBody string
+	// authHeader records the last Authorization header the vault saw.
+	authHeader atomic.Value
+}
+
+func newFakeAzure(t *testing.T) *fakeAzure {
+	t.Helper()
+	f := &fakeAzure{
+		tokenStatus:  http.StatusOK,
+		tokenBody:    `{"access_token":"tok-1","expires_in":3600}`,
+		secret:       "vault-value",
+		secretStatus: http.StatusOK,
+	}
+	f.srv = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/oauth2/v2.0/token"):
+			f.tokenCalls.Add(1)
+			if err := r.ParseForm(); err != nil {
+				t.Errorf("token form parse: %v", err)
+			}
+			if got := r.Form.Get("grant_type"); got != "client_credentials" {
+				t.Errorf("grant_type = %q", got)
+			}
+			if got := r.Form.Get("scope"); got != azureScope {
+				t.Errorf("scope = %q", got)
+			}
+			if r.Form.Get("client_secret") == "" {
+				t.Error("client_secret empty")
+			}
+			w.WriteHeader(f.tokenStatus)
+			fmt.Fprint(w, f.tokenBody)
+		case strings.HasPrefix(r.URL.Path, "/secrets/"):
+			f.secretCalls.Add(1)
+			f.authHeader.Store(r.Header.Get("Authorization"))
+			if r.URL.Query().Get("api-version") != azureAPIVersion {
+				t.Errorf("api-version = %q", r.URL.Query().Get("api-version"))
+			}
+			w.WriteHeader(f.secretStatus)
+			switch {
+			case f.rawSecretBody != "":
+				fmt.Fprint(w, f.rawSecretBody)
+			case f.secretStatus == http.StatusOK:
+				fmt.Fprintf(w, `{"value":%q,"id":"x"}`, f.secret)
+			default:
+				fmt.Fprint(w, `{"error":{"code":"x","message":"y"}}`)
+			}
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(f.srv.Close)
+	return f
+}
+
+// config points an azureConfig at the fake with its CA trusted.
+func (f *fakeAzure) config(cred AzureCredential, mappings map[string]AzureMapping) *azureConfig {
+	c := newAzureConfig(cred, mappings)
+	c.loginURL = f.srv.URL
+	c.client = &http.Client{
+		Timeout: azureTimeout,
+		Transport: &http.Transport{TLSClientConfig: &tls.Config{
+			RootCAs:    x509Pool(f.srv),
+			MinVersion: tls.VersionTLS12,
+		}},
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	return c
+}
+
+func x509Pool(s *httptest.Server) *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(s.Certificate())
+	return pool
+}
+
+var testCred = AzureCredential{TenantID: "t", ClientID: "c", ClientSecret: "s"}
+
+func TestAzureFetchDeliversVaultValue(t *testing.T) {
+	f := newFakeAzure(t)
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	got, err := c.fetch(context.Background(), "/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "vault-value" {
+		t.Fatalf("value = %q", got)
+	}
+	if got := f.authHeader.Load().(string); got != "Bearer tok-1" {
+		t.Fatalf("authorization = %q", got)
+	}
+	if c.last["/a"].Err != "" {
+		t.Fatalf("last fetch recorded error: %q", c.last["/a"].Err)
+	}
+}
+
+func TestAzureTokenCached(t *testing.T) {
+	f := newFakeAzure(t)
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	for range 3 {
+		if _, err := c.fetch(context.Background(), "/a"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := f.tokenCalls.Load(); got != 1 {
+		t.Fatalf("token calls = %d, want 1 (cached)", got)
+	}
+}
+
+func TestAzureTokenRefreshedWhenExpired(t *testing.T) {
+	f := newFakeAzure(t)
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err != nil {
+		t.Fatal(err)
+	}
+	c.tokens.mu.Lock()
+	c.tokens.expiry = time.Now().Add(-time.Minute)
+	c.tokens.mu.Unlock()
+	if _, err := c.fetch(context.Background(), "/a"); err != nil {
+		t.Fatal(err)
+	}
+	if got := f.tokenCalls.Load(); got != 2 {
+		t.Fatalf("token calls = %d, want 2 (refresh after expiry)", got)
+	}
+}
+
+func TestAzure401DropsTokenAndRetriesOnce(t *testing.T) {
+	f := newFakeAzure(t)
+	f.secretStatus = http.StatusUnauthorized
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil {
+		t.Fatal("expected an error")
+	}
+	// One retry within the request: two vault calls, two token calls (the
+	// second after invalidation).
+	if got := f.secretCalls.Load(); got != 2 {
+		t.Fatalf("secret calls = %d, want 2", got)
+	}
+	if got := f.tokenCalls.Load(); got != 2 {
+		t.Fatalf("token calls = %d, want 2 (invalidate then refetch)", got)
+	}
+}
+
+func TestAzureVault404IsOpaqueErrorNotNotFound(t *testing.T) {
+	f := newFakeAzure(t)
+	f.secretStatus = http.StatusNotFound
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	_, err := c.fetch(context.Background(), "/a")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if err == ErrNotFound {
+		t.Fatal("a vault 404 must not masquerade as an absent path: that triggers the mint dance")
+	}
+	if c.last["/a"].Err == "" {
+		t.Fatal("failure not recorded for status")
+	}
+}
+
+func TestAzureRedirectIsRefused(t *testing.T) {
+	f := newFakeAzure(t)
+	f.secretStatus = http.StatusFound
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil {
+		t.Fatal("a redirect must be an error, not a followed request")
+	}
+	if got := f.secretCalls.Load(); got != 1 {
+		t.Fatalf("secret calls = %d, want 1 (no follow)", got)
+	}
+}
+
+func TestAzureTokenFailure(t *testing.T) {
+	f := newFakeAzure(t)
+	f.tokenStatus = http.StatusBadRequest
+	f.tokenBody = `{"error":"invalid_client"}`
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil {
+		t.Fatal("expected a token failure")
+	}
+	if got := f.secretCalls.Load(); got != 0 {
+		t.Fatalf("secret calls = %d, want 0 (no token, no vault call)", got)
+	}
+}
+
+func TestAzureFetchRejectsOversizedValue(t *testing.T) {
+	f := newFakeAzure(t)
+	f.secret = strings.Repeat("x", 100)
+	backend := NewExternalBackend(nil, nil, 8)
+	backend.mu.Lock()
+	backend.live = f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	backend.mapped = map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}}
+	backend.mu.Unlock()
+	if _, err := backend.Fetch(context.Background(), "/a"); err == nil || !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("expected the size cap to refuse, got %v", err)
+	}
+}
+
+func TestBackendFailsClosedWithoutCredential(t *testing.T) {
+	b := NewExternalBackend(map[string]AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s"}}, nil, 64)
+	if !b.Mapped("/a") {
+		t.Fatal("persisted mapping not loaded")
+	}
+	_, err := b.Fetch(context.Background(), "/a")
+	if err != errNotConfigured {
+		t.Fatalf("Fetch = %v, want errNotConfigured", err)
+	}
+}

--- a/internal/secrets/coverage_test.go
+++ b/internal/secrets/coverage_test.go
@@ -1,0 +1,162 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- newAzureConfig ---
+
+func TestNewAzureConfigRefusesRedirects(t *testing.T) {
+	c := newAzureConfig(testCred, nil)
+	req, _ := http.NewRequest(http.MethodGet, "https://elsewhere.example", nil)
+	if err := c.client.CheckRedirect(req, nil); err != http.ErrUseLastResponse {
+		t.Fatalf("CheckRedirect = %v, want ErrUseLastResponse", err)
+	}
+}
+
+// --- parseMappings malformed shapes ---
+
+func TestParseMappingsMalformed(t *testing.T) {
+	for _, raw := range []string{
+		`[]`,                              // not an object
+		`{`,                               // truncated
+		`{"/a": 5}`,                       // value not an object
+		`{"/a": {"vault": "v"}`,           // truncated object
+		`{"/a": {"vault": 1, "name": 2}}`, // wrong field types
+		`{"a"}`,                           // bare key
+	} {
+		if _, err := parseMappings(json.RawMessage(raw)); err == nil {
+			t.Fatalf("%s: accepted", raw)
+		}
+	}
+	if m, err := parseMappings(json.RawMessage(`{}`)); err != nil || len(m) != 0 {
+		t.Fatalf("empty object: %v %v", m, err)
+	}
+}
+
+// --- handler failure paths ---
+
+func TestExternalConfigMethodNotAllowed(t *testing.T) {
+	h := externalHandler(NewExternalBackend(nil, nil, 64), NewMemoryStore(8, 64))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPost, ExternalRoute, nil))
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405", w.Code)
+	}
+}
+
+func TestExternalConfigClearFailure(t *testing.T) {
+	fail := func(map[string]AzureMapping) error { return os.ErrPermission }
+	h := externalHandler(NewExternalBackend(nil, fail, 64), NewMemoryStore(8, 64))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute,
+		strings.NewReader(`{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{},"mappings":{}}`)))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestExternalConfigApplyFailure(t *testing.T) {
+	fail := func(map[string]AzureMapping) error { return os.ErrPermission }
+	h := externalHandler(NewExternalBackend(nil, fail, 64), NewMemoryStore(8, 64))
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"https://v.vault.azure.net","name":"s"}}}`
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(doc)))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", w.Code)
+	}
+}
+
+func TestExternalConfigNilLogger(t *testing.T) {
+	h := ExternalConfigHandler{Backend: NewExternalBackend(nil, nil, 64), Mem: NewMemoryStore(8, 64)}
+	if h.logger() == nil {
+		t.Fatal("nil logger")
+	}
+}
+
+// --- LoadExternalMappings error paths ---
+
+func TestLoadExternalMappingsPersistFails(t *testing.T) {
+	_, persist, err := LoadExternalMappings(filepath.Join(t.TempDir(), "no-such-dir", "allowlist.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persist == nil {
+		t.Fatal("persist hook nil for a real path")
+	}
+	if err := persist(map[string]AzureMapping{}); err == nil {
+		t.Fatal("persist into a nonexistent directory must fail")
+	}
+}
+
+func TestLoadExternalMappingsUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	// A directory where the file should be: ReadFile fails, not NotExist.
+	if err := os.Mkdir(filepath.Join(dir, externalMappingsFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadExternalMappings(filepath.Join(dir, "allowlist.db")); err == nil {
+		t.Fatal("a mappings path that is a directory must fail loud")
+	}
+}
+
+// --- Fetch on an unmapped path is a programming error, not a fetch ---
+
+func TestExternalBackendFetchUnmapped(t *testing.T) {
+	b := NewExternalBackend(nil, nil, 64)
+	if _, err := b.Fetch(context.Background(), "/nope"); err == nil {
+		t.Fatal("Fetch on an unmapped path must fail")
+	}
+}
+
+// --- azure client error shapes ---
+
+func TestAzureFetchMalformedBundle(t *testing.T) {
+	f := newFakeAzure(t)
+	f.rawSecretBody = `not json`
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("err = %v, want a decode failure", err)
+	}
+}
+
+func TestAzureFetchMissingValueField(t *testing.T) {
+	f := newFakeAzure(t)
+	f.rawSecretBody = `{"id":"x"}`
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil || !strings.Contains(err.Error(), "no value") {
+		t.Fatalf("err = %v, want a missing-value failure", err)
+	}
+}
+
+func TestAzureTokenMalformedJSON(t *testing.T) {
+	f := newFakeAzure(t)
+	f.tokenBody = `not json`
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil || !strings.Contains(err.Error(), "decode") {
+		t.Fatalf("err = %v, want a token decode failure", err)
+	}
+}
+
+func TestAzureTokenMissingFields(t *testing.T) {
+	f := newFakeAzure(t)
+	f.tokenBody = `{"access_token":"","expires_in":0}`
+	c := f.config(testCred, map[string]AzureMapping{"/a": {Vault: f.srv.URL, Name: "s1"}})
+	if _, err := c.fetch(context.Background(), "/a"); err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("err = %v, want a missing-fields failure", err)
+	}
+}
+
+// transportErr passes non-URL errors through.
+func TestTransportErrPassthrough(t *testing.T) {
+	if got := transportErr(os.ErrNotExist); got != os.ErrNotExist {
+		t.Fatalf("transportErr = %v", got)
+	}
+}

--- a/internal/secrets/external.go
+++ b/internal/secrets/external.go
@@ -1,0 +1,293 @@
+package secrets
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// ExternalRoute is the operator endpoint for the external-KMS config. Chi
+// routes the static segment ahead of the "/secrets/*" wildcard, so the exact
+// store path "/external" is reserved; validation refuses it as a mapping key.
+const ExternalRoute = "/secrets/external"
+
+// externalSchema versions the document, following the allowlist's
+// c8s.allowlist/v1 convention.
+const externalSchema = "c8s.secrets-external/v1"
+
+// BackendAzureKeyVault is the only external backend. One backend is
+// configured at a time; the document names it so future backends share this
+// route and document shape.
+const BackendAzureKeyVault = "azure-keyvault"
+
+// ExternalDocument is the PUT body: the backend, its credential, and the full
+// mapping set, applied atomically. An empty document (no credential, no
+// mappings) disconnects the backend.
+type ExternalDocument struct {
+	Schema     string                  `json:"schema"`
+	Backend    string                  `json:"backend"`
+	Credential AzureCredential         `json:"credential"`
+	Mappings   map[string]AzureMapping `json:"mappings"`
+}
+
+// externalDocumentRaw decodes with Mappings deferred: duplicate keys in a JSON
+// object decode last-wins, silently applying whichever binding appeared last,
+// so the mapping set is parsed as an ordered stream that rejects them.
+type externalDocumentRaw struct {
+	Schema     string          `json:"schema"`
+	Backend    string          `json:"backend"`
+	Credential AzureCredential `json:"credential"`
+	Mappings   json.RawMessage `json:"mappings"`
+}
+
+// parseExternalDocument decodes and validates a document. Trailing data after
+// the top-level value is rejected: a whole-backend config document should be
+// exactly one JSON value.
+func parseExternalDocument(body []byte) (*ExternalDocument, error) {
+	var raw externalDocumentRaw
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected data after the document")
+	}
+	mappings, err := parseMappings(raw.Mappings)
+	if err != nil {
+		return nil, err
+	}
+	doc := &ExternalDocument{Schema: raw.Schema, Backend: raw.Backend, Credential: raw.Credential, Mappings: mappings}
+	if err := validateExternalDocument(doc); err != nil {
+		return nil, err
+	}
+	normalizeExternalDocument(doc)
+	return doc, nil
+}
+
+// parseMappings decodes the mappings object, rejecting a duplicate key rather
+// than letting it last-win.
+func parseMappings(raw json.RawMessage) (map[string]AzureMapping, error) {
+	out := map[string]AzureMapping{}
+	if len(raw) == 0 {
+		return out, nil
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != '{' {
+		return nil, fmt.Errorf("mappings must be an object")
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key := keyTok.(string)
+		if _, dup := out[key]; dup {
+			return nil, fmt.Errorf("duplicate mapping %q", key)
+		}
+		var m AzureMapping
+		if err := dec.Decode(&m); err != nil {
+			return nil, fmt.Errorf("mapping %q: %w", key, err)
+		}
+		out[key] = m
+	}
+	if _, err := dec.Token(); err != nil { // closing brace
+		return nil, err
+	}
+	if dec.More() {
+		return nil, fmt.Errorf("unexpected data after the mappings object")
+	}
+	return out, nil
+}
+
+// azureNameRe is the Key Vault secret-name charset.
+var azureNameRe = regexp.MustCompile(`^[0-9a-zA-Z-]+$`)
+
+// validateExternalDocument checks a decoded document. Every mapping key must
+// be canonical — the request side rejects non-canonical paths, so a key that
+// cannot match a request is a path the operator believes vault-backed that
+// actually mints. The vault URL is validated because CDS sends a bearer token
+// to it.
+func validateExternalDocument(doc *ExternalDocument) error {
+	if doc.Schema != externalSchema {
+		return fmt.Errorf("unknown schema %q (expected %q)", doc.Schema, externalSchema)
+	}
+	if doc.Backend != BackendAzureKeyVault {
+		return fmt.Errorf("unknown backend %q (expected %q)", doc.Backend, BackendAzureKeyVault)
+	}
+	if len(doc.Mappings) == 0 {
+		if doc.Credential != (AzureCredential{}) {
+			return fmt.Errorf("credential without mappings: apply a non-empty mapping set or an empty document")
+		}
+		return nil
+	}
+	if doc.Credential.TenantID == "" || doc.Credential.ClientID == "" || doc.Credential.ClientSecret == "" {
+		return fmt.Errorf("credential requires tenantId, clientId and clientSecret")
+	}
+	if strings.ContainsAny(doc.Credential.TenantID, "/?#") {
+		return fmt.Errorf("tenantId must not contain URL separators")
+	}
+	for p, m := range doc.Mappings {
+		if _, err := pkgallowlist.CanonicalSecretPath(p); err != nil {
+			return fmt.Errorf("mapping %q: %w", p, err)
+		}
+		if p == "/external" {
+			return fmt.Errorf("mapping %q: the path is reserved for the external-KMS config endpoint", p)
+		}
+		if !azureNameRe.MatchString(m.Name) {
+			return fmt.Errorf("mapping %q: vault secret name must match %s", p, azureNameRe)
+		}
+		if strings.ContainsAny(m.Vault, "?#") {
+			return fmt.Errorf("mapping %q: vault must be a bare https URL", p)
+		}
+		u, err := url.Parse(m.Vault)
+		if err != nil || u.Scheme != "https" || u.User != nil || u.Path != "" && u.Path != "/" || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+			return fmt.Errorf("mapping %q: vault must be a bare https URL", p)
+		}
+		// CDS sends a bearer token to this host, so it must be exactly one
+		// vault-name label on the global-cloud suffix — no port, no extra
+		// labels, no lookalikes.
+		label, ok := strings.CutSuffix(u.Host, ".vault.azure.net")
+		if !ok || !azureNameRe.MatchString(label) {
+			return fmt.Errorf("mapping %q: vault host must be <name>.vault.azure.net (global cloud only)", p)
+		}
+	}
+	return nil
+}
+
+// normalizeExternalDocument canonicalizes a validated document in place:
+// vault URLs drop a trailing slash so fetch URL construction cannot produce
+// "//secrets/".
+func normalizeExternalDocument(doc *ExternalDocument) {
+	for p, m := range doc.Mappings {
+		m.Vault = strings.TrimSuffix(m.Vault, "/")
+		doc.Mappings[p] = m
+	}
+}
+
+// ExternalConfigHandler serves PUT and GET on ExternalRoute. PUT replaces the
+// whole backend state; GET reports it. Authorization is the operator key, via
+// the same verifier the allowlist writes use.
+type ExternalConfigHandler struct {
+	Backend *ExternalBackend
+	Mem     *MemoryStore
+	// Authorize is operatorauth.Verifier.Authorize. Nil rejects every request.
+	Authorize func(r *http.Request, body []byte) error
+	// MaxBodyBytes caps the request body; zero means DefaultMaxOperatorBodyBytes.
+	MaxBodyBytes int64
+
+	Logger *slog.Logger
+}
+
+func (h ExternalConfigHandler) logger() *slog.Logger {
+	if h.Logger != nil {
+		return h.Logger
+	}
+	return slog.Default()
+}
+
+func (h ExternalConfigHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, ok := h.authorize(w, r)
+	if !ok {
+		return
+	}
+	switch r.Method {
+	case http.MethodPut:
+		h.put(w, r, body)
+	case http.MethodGet:
+		h.get(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (h ExternalConfigHandler) put(w http.ResponseWriter, r *http.Request, body []byte) {
+	doc, err := parseExternalDocument(body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	if len(doc.Mappings) == 0 {
+		if err := h.Backend.Clear(); err != nil {
+			h.logger().Error("external KMS config clear failed", "error", err)
+			http.Error(w, "config clear failed", http.StatusInternalServerError)
+			return
+		}
+		h.logger().Info("external KMS config cleared")
+		writeExternalStatus(w, h.Backend.Status(h.Mem))
+		return
+	}
+	if err := h.Backend.Apply(doc.Credential, doc.Mappings); err != nil {
+		h.logger().Error("external KMS config apply failed", "error", err)
+		http.Error(w, "config apply failed", http.StatusInternalServerError)
+		return
+	}
+	h.logger().Info("external KMS config applied", "backend", doc.Backend, "mappings", len(doc.Mappings))
+	writeExternalStatus(w, h.Backend.Status(h.Mem))
+}
+
+func (h ExternalConfigHandler) get(w http.ResponseWriter, _ *http.Request) {
+	writeExternalStatus(w, h.Backend.Status(h.Mem))
+}
+
+func writeExternalStatus(w http.ResponseWriter, st ExternalStatus) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(st)
+}
+
+func (h ExternalConfigHandler) authorize(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	return authorizeOperator(w, r, h.Authorize, h.MaxBodyBytes, h.logger(), "external KMS config request")
+}
+
+// externalMappingsFile is the persisted mapping set's filename, placed beside
+// the allowlist database so it inherits the same durability class.
+const externalMappingsFile = "external-mappings.json"
+
+// LoadExternalMappings reads the mapping set an earlier run persisted beside
+// the allowlist DB and returns it with the backend's persist hook. The file
+// holds paths, vaults and secret names only — never the credential. An empty
+// allowlist DB path disables persistence rather than writing beside the
+// process's working directory.
+func LoadExternalMappings(allowlistDBPath string) (map[string]AzureMapping, func(map[string]AzureMapping) error, error) {
+	if allowlistDBPath == "" {
+		return nil, nil, nil
+	}
+	path := filepath.Join(filepath.Dir(allowlistDBPath), externalMappingsFile)
+	persist := func(m map[string]AzureMapping) error {
+		data, err := json.Marshal(m)
+		if err != nil {
+			return err
+		}
+		return fileutil.WriteAtomic(path, data, 0o600)
+	}
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, persist, nil
+	}
+	if err != nil {
+		return nil, nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var m map[string]AzureMapping
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return m, persist, nil
+}

--- a/internal/secrets/external_e2e_test.go
+++ b/internal/secrets/external_e2e_test.go
@@ -1,0 +1,199 @@
+package secrets
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// End-to-end: operator applies an external-KMS config over the authorized
+// endpoint, an attested workload reads a mapped path through the release gate,
+// and a simulated restart fails closed until the credential is re-applied.
+// The Azure side is a stubbed Entra+vault TLS server.
+func TestExternalKMSEndToEnd(t *testing.T) {
+	fake := newFakeAzure(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "allowlist.db")
+
+	// The operator keypair: the private half signs CLI requests, the public
+	// half is what CDS pins.
+	opKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	opKeyDER, err := x509.MarshalPKCS8PrivateKey(opKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: opKeyDER}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&opKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+	keys, err := operatorauth.ParsePublicKeysPEM(pubPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := operatorauth.Verifier{Keys: keys}
+
+	// CDS side: one routing store behind the workload, operator, and config
+	// handlers, with real persistence.
+	persisted, persist, err := LoadExternalMappings(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend := NewExternalBackend(persisted, persist, 64)
+	backend.newConfig = func(cred AzureCredential, mappings map[string]AzureMapping) *azureConfig {
+		remapped := map[string]AzureMapping{}
+		for p := range mappings {
+			remapped[p] = AzureMapping{Vault: fake.srv.URL, Name: mappings[p].Name}
+		}
+		return fake.config(cred, remapped)
+	}
+	mem := NewMemoryStore(16, 64)
+	store := &RoutingStore{Mem: mem, External: backend}
+
+	hn := newHarness(t)
+	hn.h.Store = store
+	configH := ExternalConfigHandler{Backend: backend, Mem: mem, Authorize: verifier.Authorize}
+	operatorH := OperatorHandler{Store: store, Authorize: verifier.Authorize}
+
+	// signedCall runs one operator request through the real JWT machinery.
+	signedCall := func(method, path string, body []byte) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(method, path, strings.NewReader(string(body)))
+		authz, err := signer.Authorization(method, req.URL.Path, body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", authz)
+		w := httptest.NewRecorder()
+		configH.ServeHTTP(w, req)
+		return w
+	}
+
+	// 1. An unsigned config write is refused before anything is read.
+	w := httptest.NewRecorder()
+	configH.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(`{"x":1}`)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unsigned config write = %d, want 401", w.Code)
+	}
+
+	// 2. The operator applies the config.
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault",` +
+		`"credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},` +
+		`"mappings":{"/api/key":{"vault":"https://v.vault.azure.net","name":"s1"}}}`
+	if w := signedCall(http.MethodPut, ExternalRoute, []byte(doc)); w.Code != http.StatusOK {
+		t.Fatalf("apply = %d: %s", w.Code, w.Body)
+	}
+
+	// 3. An attested, grant-holding workload reads the vault value.
+	w = do(hn.h, hn.request(t, http.MethodGet, "/api/key"))
+	if w.Code != http.StatusOK {
+		t.Fatalf("workload GET = %d: %s", w.Code, w.Body)
+	}
+	if got := decodeValue(t, w); got != base64.StdEncoding.EncodeToString([]byte("vault-value")) {
+		t.Fatalf("value = %q, want the vault value", got)
+	}
+
+	// 4. A mapped path cannot be minted by a workload...
+	w = do(hn.h, hn.request(t, http.MethodPost, "/api/key"))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("workload POST = %d, want 409", w.Code)
+	}
+	// ...nor written by the operator.
+	putBody, _ := json.Marshal(PutRequest{Value: base64.StdEncoding.EncodeToString([]byte("x"))})
+	req := httptest.NewRequest(http.MethodPut, "/secrets/api/key", strings.NewReader(string(putBody)))
+	authz, err := signer.Authorization(http.MethodPut, req.URL.Path, putBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", authz)
+	w = httptest.NewRecorder()
+	operatorH.ServeHTTP(w, req)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("operator PUT = %d, want 409", w.Code)
+	}
+
+	// 5. The grant gate still runs first: the same workload holds no grant for
+	// /other/key, so mapping or not, it is refused before any store lookup.
+	w = do(hn.h, hn.request(t, http.MethodGet, "/other/key"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("ungranted GET = %d, want 404", w.Code)
+	}
+
+	// 6. Status reports the mapping and the successful fetch, never the
+	// credential or the value.
+	w = signedCall(http.MethodGet, ExternalRoute, nil)
+	var st ExternalStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if !st.Configured || st.Mappings["/api/key"].Name != "s1" || st.LastFetch["/api/key"].Err != "" {
+		t.Fatalf("status = %+v", st)
+	}
+	if strings.Contains(w.Body.String(), "vault-value") || strings.Contains(w.Body.String(), `"s"`) {
+		t.Fatal("status leaked a secret")
+	}
+
+	// 7. Simulate a CDS restart: a new backend over the same persisted file,
+	// no credential. Mapped paths fail closed — no fetch, no mint.
+	restarted := NewExternalBackend(mustLoad(t, dbPath), nil, 64)
+	restarted.newConfig = backend.newConfig
+	hn.h.Store = &RoutingStore{Mem: mem, External: restarted}
+	w = do(hn.h, hn.requestWith(t, http.MethodGet, "/api/key", hn.leaf, testSandbox, []byte("nonce-restart-get")))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("GET after restart = %d, want 500 (fail closed)", w.Code)
+	}
+	w = do(hn.h, hn.requestWith(t, http.MethodPost, "/api/key", hn.leaf, testSandbox, []byte("nonce-restart-post")))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("POST after restart = %d, want 409 (no mint)", w.Code)
+	}
+	if _, err := mem.Get(t.Context(), "/api/key"); err != ErrNotFound {
+		t.Fatal("a value was minted behind the mapping")
+	}
+
+	// 8. Re-applying the credential re-arms the mappings.
+	restartedCfg := ExternalConfigHandler{Backend: restarted, Mem: mem, Authorize: verifier.Authorize}
+	req = httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(doc))
+	authz, err = signer.Authorization(http.MethodPut, req.URL.Path, []byte(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", authz)
+	w = httptest.NewRecorder()
+	restartedCfg.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("re-apply = %d: %s", w.Code, w.Body)
+	}
+	w = do(hn.h, hn.requestWith(t, http.MethodGet, "/api/key", hn.leaf, testSandbox, []byte("nonce-reapply-get")))
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET after re-apply = %d: %s", w.Code, w.Body)
+	}
+}
+
+func mustLoad(t *testing.T, dbPath string) map[string]AzureMapping {
+	t.Helper()
+	m, _, err := LoadExternalMappings(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) == 0 {
+		t.Fatal("no persisted mappings after apply")
+	}
+	return m
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -211,6 +211,12 @@ func (h Handler) servePost(ctx context.Context, w http.ResponseWriter, grant *pk
 	}
 	_, held, err := h.Store.PutIfAbsent(ctx, path, candidate, OriginWorkload)
 	if err != nil {
+		if errors.Is(err, ErrExternal) {
+			// A vault-backed path exists by definition; withhold the value
+			// exactly like a lost create race, so the caller re-reads with GET.
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
 		h.logger().Error("secret create failed", "path", path, "error", err)
 		http.Error(w, "secret unavailable", http.StatusInternalServerError)
 		return

--- a/internal/secrets/operator.go
+++ b/internal/secrets/operator.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 
@@ -101,6 +102,10 @@ func (h OperatorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h OperatorHandler) create(w http.ResponseWriter, r *http.Request, path string, value []byte) {
 	_, held, err := h.Store.PutIfAbsent(r.Context(), path, value, OriginOperator)
 	if err != nil {
+		if errors.Is(err, ErrExternal) {
+			writeResult(w, http.StatusConflict, PutResponse{Path: path, Existing: OriginExternal})
+			return
+		}
 		h.logger().Error("operator secret write failed", "path", path, "error", err)
 		http.Error(w, "secret write failed", http.StatusInternalServerError)
 		return
@@ -116,6 +121,10 @@ func (h OperatorHandler) create(w http.ResponseWriter, r *http.Request, path str
 func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path string, value []byte) {
 	held, err := h.Store.Put(r.Context(), path, value, OriginOperator)
 	if err != nil {
+		if errors.Is(err, ErrExternal) {
+			writeResult(w, http.StatusConflict, PutResponse{Path: path, Existing: OriginExternal})
+			return
+		}
 		h.logger().Error("operator secret write failed", "path", path, "error", err)
 		http.Error(w, "secret write failed", http.StatusInternalServerError)
 		return
@@ -133,11 +142,18 @@ func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path st
 // those exact bytes, so the token's body binding is checked against what the
 // handler goes on to decode.
 func (h OperatorHandler) authorize(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
-	if h.Authorize == nil {
+	return authorizeOperator(w, r, h.Authorize, h.MaxBodyBytes, h.logger(), "operator secret write")
+}
+
+// authorizeOperator is the shared authorization step for operator-facing
+// handlers: body under the cap first, then the token check against those
+// bytes. action names the operation in the rejection log line.
+func authorizeOperator(w http.ResponseWriter, r *http.Request, authorize func(*http.Request, []byte) error, maxBody int64, logger *slog.Logger, action string) ([]byte, bool) {
+	if authorize == nil {
 		http.Error(w, "operator writes are not configured", http.StatusUnauthorized)
 		return nil, false
 	}
-	cap := h.MaxBodyBytes
+	cap := maxBody
 	if cap <= 0 {
 		cap = DefaultMaxOperatorBodyBytes
 	}
@@ -145,8 +161,8 @@ func (h OperatorHandler) authorize(w http.ResponseWriter, r *http.Request) ([]by
 	if !ok {
 		return nil, false
 	}
-	if err := h.Authorize(r, body); err != nil {
-		h.logger().Warn("operator secret write rejected", "remote", r.RemoteAddr, "reason", err)
+	if err := authorize(r, body); err != nil {
+		logger.Warn(action+" rejected", "remote", r.RemoteAddr, "reason", err)
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return nil, false
 	}

--- a/internal/secrets/routing.go
+++ b/internal/secrets/routing.go
@@ -1,0 +1,184 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sync"
+)
+
+// ErrExternal refuses a write to a path backed by the external KMS. Writes do
+// not reach the vault, so the value lives where the operator put it; the
+// handlers map this to a 409 naming OriginExternal, never to a fetch.
+var ErrExternal = errors.New("secrets: path is backed by the external KMS")
+
+// errNotConfigured fails closed a mapped path whose credential has not been
+// re-applied since a restart. The mappings are persisted; the credential is
+// not, and a mapped path must never fall through to minting.
+var errNotConfigured = errors.New("secrets: external KMS credential not applied since restart")
+
+// OriginExternal marks a path whose value lives in the external KMS. It never
+// appears as Held.Origin from a successful write: writes to such paths are
+// refused with ErrExternal instead.
+const OriginExternal Origin = "external"
+
+// RoutingStore dispatches between the external KMS backend (mapped paths) and
+// the memory store (everything else). A mapping shadows any memory value at
+// the same path; removing the mapping lets it resurface. It uses the network
+// backend conventions on Store.
+type RoutingStore struct {
+	Mem      *MemoryStore
+	External *ExternalBackend
+}
+
+func (s *RoutingStore) Get(ctx context.Context, path string) ([]byte, error) {
+	if s.External.Mapped(path) {
+		return s.External.Fetch(ctx, path)
+	}
+	return s.Mem.Get(ctx, path)
+}
+
+func (s *RoutingStore) PutIfAbsent(ctx context.Context, path string, value []byte, by Origin) ([]byte, Held, error) {
+	if s.External.Mapped(path) {
+		return nil, Held{}, ErrExternal
+	}
+	return s.Mem.PutIfAbsent(ctx, path, value, by)
+}
+
+func (s *RoutingStore) Put(ctx context.Context, path string, value []byte, by Origin) (Held, error) {
+	if s.External.Mapped(path) {
+		return Held{}, ErrExternal
+	}
+	return s.Mem.Put(ctx, path, value, by)
+}
+
+// ExternalStatus is what GET on the config route reports: the mapping set,
+// whether a credential is live, the last fetch per path, and any mapped path
+// currently shadowing a memory value. It never carries the credential or a
+// fetched value.
+type ExternalStatus struct {
+	Configured bool                    `json:"configured"`
+	Mappings   map[string]AzureMapping `json:"mappings"`
+	LastFetch  map[string]FetchRecord  `json:"lastFetch,omitempty"`
+	Shadowed   []string                `json:"shadowed,omitempty"`
+}
+
+// ExternalBackend holds the mapping set and the live credential config. The
+// two are updated together under mu; fetches look up under a read lock and
+// then release it before any network I/O, so an apply never waits on the KMS
+// and a fetch never blocks an apply.
+type ExternalBackend struct {
+	mu       sync.RWMutex
+	mapped   map[string]AzureMapping // persisted set; == live.mappings when live != nil
+	live     *azureConfig
+	persist  func(map[string]AzureMapping) error // nil disables persistence (tests)
+	maxValue int
+	// newConfig builds the live config on Apply; nil means newAzureConfig.
+	// Tests point it at a stubbed KMS.
+	newConfig func(AzureCredential, map[string]AzureMapping) *azureConfig
+}
+
+// NewExternalBackend loads the persisted mapping set (nil mappings means none)
+// and returns a backend with no live credential.
+func NewExternalBackend(persisted map[string]AzureMapping, persist func(map[string]AzureMapping) error, maxValue int) *ExternalBackend {
+	if persisted == nil {
+		persisted = map[string]AzureMapping{}
+	}
+	return &ExternalBackend{mapped: persisted, persist: persist, maxValue: maxValue}
+}
+
+// Mapped reports whether path is backed by the vault, regardless of whether a
+// credential is live.
+func (b *ExternalBackend) Mapped(path string) bool {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	_, ok := b.mapped[path]
+	return ok
+}
+
+// Fetch returns the vault value for a mapped path, failing closed when no
+// credential has been applied since startup. The mapping lookup and the live
+// read share one critical section, so Fetch is safe regardless of what the
+// caller checked first.
+func (b *ExternalBackend) Fetch(ctx context.Context, path string) ([]byte, error) {
+	b.mu.RLock()
+	live := b.live
+	_, mapped := b.mapped[path]
+	b.mu.RUnlock()
+	if !mapped {
+		return nil, fmt.Errorf("secrets: %s is not azure-backed", path)
+	}
+	if live == nil {
+		return nil, errNotConfigured
+	}
+	value, err := live.fetch(ctx, path)
+	if err == nil && b.maxValue > 0 && len(value) > b.maxValue {
+		return nil, fmt.Errorf("secrets: vault value is %d bytes, limit is %d", len(value), b.maxValue)
+	}
+	return value, err
+}
+
+// Apply replaces the whole backend state: validate (done by the caller),
+// persist, then swap. The lock spans persist and swap so two concurrent
+// applies cannot interleave into a live set that diverges from what a restart
+// would reload; a persist failure refuses the apply outright.
+func (b *ExternalBackend) Apply(cred AzureCredential, mappings map[string]AzureMapping) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.persist != nil {
+		if err := b.persist(mappings); err != nil {
+			return fmt.Errorf("secrets: persist azure mappings: %w", err)
+		}
+	}
+	newConfig := b.newConfig
+	if newConfig == nil {
+		newConfig = newAzureConfig
+	}
+	b.mapped = mappings
+	b.live = newConfig(cred, mappings)
+	return nil
+}
+
+// Clear removes all mappings and the credential.
+func (b *ExternalBackend) Clear() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.persist != nil {
+		if err := b.persist(map[string]AzureMapping{}); err != nil {
+			return fmt.Errorf("secrets: persist azure mappings: %w", err)
+		}
+	}
+	b.mapped = map[string]AzureMapping{}
+	b.live = nil
+	return nil
+}
+
+// Status snapshots the backend for the operator. shadowed lists mapped paths
+// that currently cover a memory value, so unmapping is never a surprise.
+func (b *ExternalBackend) Status(mem *MemoryStore) ExternalStatus {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	st := ExternalStatus{
+		Configured: b.live != nil,
+		Mappings:   make(map[string]AzureMapping, len(b.mapped)),
+	}
+	for p, m := range b.mapped {
+		st.Mappings[p] = m
+	}
+	if b.live != nil {
+		b.live.mu.Lock()
+		st.LastFetch = make(map[string]FetchRecord, len(b.live.last))
+		for p, r := range b.live.last {
+			st.LastFetch[p] = r
+		}
+		b.live.mu.Unlock()
+	}
+	for p := range b.mapped {
+		if _, err := mem.Get(context.Background(), p); err == nil {
+			st.Shadowed = append(st.Shadowed, p)
+		}
+	}
+	slices.Sort(st.Shadowed)
+	return st
+}

--- a/internal/secrets/routing_test.go
+++ b/internal/secrets/routing_test.go
@@ -1,0 +1,371 @@
+package secrets
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- RoutingStore dispatch ---
+
+func TestRoutingStoreUnmappedPathsUseMemory(t *testing.T) {
+	mem := NewMemoryStore(8, 64)
+	s := &RoutingStore{Mem: mem, External: NewExternalBackend(nil, nil, 64)}
+	if _, _, err := s.PutIfAbsent(context.Background(), "/p", []byte("v"), OriginOperator); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(context.Background(), "/p")
+	if err != nil || string(got) != "v" {
+		t.Fatalf("Get = %q, %v", got, err)
+	}
+}
+
+func TestRoutingStoreMappedWritesRefused(t *testing.T) {
+	mem := NewMemoryStore(8, 64)
+	backend := NewExternalBackend(map[string]AzureMapping{"/m": {Vault: "https://v.vault.azure.net", Name: "s"}}, nil, 64)
+	s := &RoutingStore{Mem: mem, External: backend}
+
+	if _, _, err := s.PutIfAbsent(context.Background(), "/m", []byte("v"), OriginWorkload); !errors.Is(err, ErrExternal) {
+		t.Fatalf("PutIfAbsent = %v, want ErrExternal", err)
+	}
+	if _, err := s.Put(context.Background(), "/m", []byte("v"), OriginOperator); !errors.Is(err, ErrExternal) {
+		t.Fatalf("Put = %v, want ErrExternal", err)
+	}
+	// The refusal must not fetch: Held carries no value.
+	if _, err := s.Get(context.Background(), "/m"); err != errNotConfigured {
+		t.Fatalf("Get = %v, want errNotConfigured (fail closed, no credential)", err)
+	}
+}
+
+func TestRoutingStoreMappingShadowsMemoryValue(t *testing.T) {
+	mem := NewMemoryStore(8, 64)
+	if _, _, err := mem.PutIfAbsent(context.Background(), "/m", []byte("stale"), OriginWorkload); err != nil {
+		t.Fatal(err)
+	}
+	backend := NewExternalBackend(map[string]AzureMapping{"/m": {Vault: "https://v.vault.azure.net", Name: "s"}}, nil, 64)
+	s := &RoutingStore{Mem: mem, External: backend}
+
+	st := backend.Status(mem)
+	if len(st.Shadowed) != 1 || st.Shadowed[0] != "/m" {
+		t.Fatalf("shadowed = %v, want [/m]", st.Shadowed)
+	}
+	if st.Configured {
+		t.Fatal("configured = true with no credential")
+	}
+	// Unmap: the memory value resurfaces.
+	if err := backend.Clear(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.Get(context.Background(), "/m")
+	if err != nil || string(got) != "stale" {
+		t.Fatalf("after unmap Get = %q, %v", got, err)
+	}
+}
+
+// --- document validation ---
+
+func validDoc() *ExternalDocument {
+	return &ExternalDocument{
+		Schema:     externalSchema,
+		Backend:    BackendAzureKeyVault,
+		Credential: AzureCredential{TenantID: "t", ClientID: "c", ClientSecret: "s"},
+		Mappings:   map[string]AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s1"}},
+	}
+}
+
+func TestValidateExternalDocument(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*ExternalDocument)
+		want string
+	}{
+		{"ok", func(d *ExternalDocument) {}, ""},
+		{"unknown backend", func(d *ExternalDocument) { d.Backend = "vault" }, "unknown backend"},
+		{"schema", func(d *ExternalDocument) { d.Schema = "v2" }, "unknown schema"},
+		{"non-canonical path", func(d *ExternalDocument) {
+			d.Mappings = map[string]AzureMapping{"a/rel": {Vault: "https://v.vault.azure.net", Name: "s"}}
+		}, "absolute"},
+		{"trailing slash path", func(d *ExternalDocument) {
+			d.Mappings = map[string]AzureMapping{"/a/": {Vault: "https://v.vault.azure.net", Name: "s"}}
+		}, "trailing slash"},
+		{"percent path", func(d *ExternalDocument) {
+			d.Mappings = map[string]AzureMapping{"/a%2Fb": {Vault: "https://v.vault.azure.net", Name: "s"}}
+		}, "percent"},
+		{"http vault", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "http://v.vault.azure.net", Name: "s"}
+		}, "bare https"},
+		{"non-vault host", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://evil.example.com", Name: "s"}
+		}, ".vault.azure.net"},
+		{"lookalike host", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://vault.azure.net.evil.example", Name: "s"}
+		}, ".vault.azure.net"},
+		{"explicit port refused", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://v.vault.azure.net:443", Name: "s"}
+		}, ".vault.azure.net"},
+		{"empty label", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://.vault.azure.net", Name: "s"}
+		}, ".vault.azure.net"},
+		{"trailing question mark", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://v.vault.azure.net?", Name: "s"}
+		}, "bare https"},
+		{"trailing fragment", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://v.vault.azure.net#", Name: "s"}
+		}, "bare https"},
+		{"multi-label host", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://a.b.vault.azure.net", Name: "s"}
+		}, ".vault.azure.net"},
+		{"vault with userinfo", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://u:p@v.vault.azure.net", Name: "s"}
+		}, "bare https"},
+		{"vault with path", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://v.vault.azure.net/x", Name: "s"}
+		}, "bare https"},
+		{"bad secret name", func(d *ExternalDocument) {
+			d.Mappings["/a"] = AzureMapping{Vault: "https://v.vault.azure.net", Name: "has space"}
+		}, "must match"},
+		{"tenant with slash", func(d *ExternalDocument) { d.Credential.TenantID = "a/b" }, "tenantId"},
+		{"mappings without credential", func(d *ExternalDocument) { d.Credential = AzureCredential{} }, "credential requires"},
+		{"credential without mappings", func(d *ExternalDocument) { d.Mappings = nil }, "credential without mappings"},
+		{"empty document", func(d *ExternalDocument) {
+			d.Credential = AzureCredential{}
+			d.Mappings = nil
+		}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := validDoc()
+			tc.mut(doc)
+			err := validateExternalDocument(doc)
+			if tc.want == "" && err != nil {
+				t.Fatalf("rejected: %v", err)
+			}
+			if tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)) {
+				t.Fatalf("err = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// --- config handler ---
+
+func externalHandler(backend *ExternalBackend, mem *MemoryStore) ExternalConfigHandler {
+	return ExternalConfigHandler{
+		Backend:   backend,
+		Mem:       mem,
+		Authorize: func(*http.Request, []byte) error { return nil },
+	}
+}
+
+func TestExternalConfigHandlerRequiresAuthorization(t *testing.T) {
+	h := ExternalConfigHandler{Backend: NewExternalBackend(nil, nil, 64), Mem: NewMemoryStore(8, 64)}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(`{}`)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestExternalConfigApplyStatusClearRoundTrip(t *testing.T) {
+	backend := NewExternalBackend(nil, nil, 64)
+	h := externalHandler(backend, NewMemoryStore(8, 64))
+
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"https://v.vault.azure.net","name":"s1"}}}`
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(doc)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("apply status = %d: %s", w.Code, w.Body)
+	}
+	if !backend.Mapped("/a") {
+		t.Fatal("mapping not live after apply")
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, ExternalRoute, nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var st ExternalStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatal(err)
+	}
+	if !st.Configured || st.Mappings["/a"].Name != "s1" {
+		t.Fatalf("status = %+v", st)
+	}
+	if strings.Contains(w.Body.String(), "clientSecret") {
+		t.Fatal("status leaked the credential field")
+	}
+
+	// Empty document clears.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(`{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{},"mappings":{}}`)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear status = %d: %s", w.Code, w.Body)
+	}
+	if backend.Mapped("/a") {
+		t.Fatal("mapping survived clear")
+	}
+}
+
+func TestExternalConfigRejectsInvalidDocument(t *testing.T) {
+	backend := NewExternalBackend(nil, nil, 64)
+	h := externalHandler(backend, NewMemoryStore(8, 64))
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"http://insecure.vault.azure.net","name":"s1"}}}`
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(doc)))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
+	}
+	if backend.Mapped("/a") {
+		t.Fatal("invalid document changed the backend")
+	}
+}
+
+// --- persistence ---
+
+func TestExternalMappingsPersistenceRoundTrip(t *testing.T) {
+	db := filepath.Join(t.TempDir(), "allowlist.db")
+	loaded, persist, err := LoadExternalMappings(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded != nil {
+		t.Fatalf("loaded = %v, want nil for a fresh store", loaded)
+	}
+	m := map[string]AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s1"}}
+	if err := persist(m); err != nil {
+		t.Fatal(err)
+	}
+	loaded, _, err = LoadExternalMappings(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded["/a"].Name != "s1" {
+		t.Fatalf("loaded = %v", loaded)
+	}
+}
+
+func TestExternalMappingsCorruptFileFailsLoud(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "allowlist.db")
+	if err := os.WriteFile(filepath.Join(dir, externalMappingsFile), []byte("not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadExternalMappings(db); err == nil {
+		t.Fatal("corrupt mappings file must fail startup, not silently un-back paths")
+	}
+}
+
+// Duplicate mapping keys must be rejected, not last-wins.
+func TestExternalConfigRejectsDuplicateMappingKeys(t *testing.T) {
+	backend := NewExternalBackend(nil, nil, 64)
+	h := externalHandler(backend, NewMemoryStore(8, 64))
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"https://v.vault.azure.net","name":"s1"},"/a":{"vault":"https://w.vault.azure.net","name":"s2"}}}`
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(doc)))
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", w.Code)
+	}
+	if backend.Mapped("/a") {
+		t.Fatal("a duplicate-keyed document changed the backend")
+	}
+}
+
+// Authorization runs before the body is parsed: a malformed document with no
+// token is a 401, never a 422.
+func TestExternalConfigAuthPrecedesParse(t *testing.T) {
+	h := ExternalConfigHandler{Backend: NewExternalBackend(nil, nil, 64), Mem: NewMemoryStore(8, 64)}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader("not json")))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", w.Code)
+	}
+}
+
+// The body cap applies to the azure route.
+func TestExternalConfigBodyCap(t *testing.T) {
+	h := ExternalConfigHandler{
+		Backend: NewExternalBackend(nil, nil, 64), Mem: NewMemoryStore(8, 64),
+		Authorize: func(*http.Request, []byte) error { return nil }, MaxBodyBytes: 8,
+	}
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodPut, ExternalRoute, strings.NewReader(strings.Repeat("x", 64))))
+	if w.Code == http.StatusOK || w.Code == http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want a body-cap refusal", w.Code)
+	}
+}
+
+// A persist failure refuses the apply and leaves the backend untouched.
+func TestExternalBackendApplyRefusedWhenPersistFails(t *testing.T) {
+	fail := func(map[string]AzureMapping) error { return errors.New("disk full") }
+	backend := NewExternalBackend(nil, fail, 64)
+	err := backend.Apply(testCred, map[string]AzureMapping{"/a": {Vault: "https://v.vault.azure.net", Name: "s"}})
+	if err == nil {
+		t.Fatal("apply must fail when persist fails")
+	}
+	if backend.Mapped("/a") {
+		t.Fatal("a refused apply changed the mapping set")
+	}
+	if err := backend.Clear(); err == nil {
+		t.Fatal("clear must fail when persist fails")
+	}
+}
+
+// A transport error must not carry the request URL — query string included —
+// into logs or status.
+func TestAzureTransportErrorStripsURL(t *testing.T) {
+	c := newAzureConfig(testCred, map[string]AzureMapping{"/a": {Vault: "https://unreachable.vault.azure.net", Name: "topsecret-name"}})
+	c.loginURL = "https://unreachable.login.example"
+	c.client = &http.Client{Timeout: time.Second}
+	_, err := c.fetch(context.Background(), "/a")
+	if err == nil {
+		t.Fatal("expected a transport error")
+	}
+	if strings.Contains(err.Error(), "topsecret-name") || strings.Contains(err.Error(), "api-version") {
+		t.Fatalf("error leaks the request URL: %v", err)
+	}
+}
+
+// The validate-then-construct pipeline produces exactly the Azure URL shape.
+func TestAzureFetchURLShape(t *testing.T) {
+	doc, err := parseExternalDocument([]byte(`{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t-id","clientId":"c","clientSecret":"s"},"mappings":{"/a":{"vault":"https://v.vault.azure.net/","name":"my-key"}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := doc.Mappings["/a"]
+	if m.Vault != "https://v.vault.azure.net" {
+		t.Fatalf("vault not normalized: %q", m.Vault)
+	}
+	want := "https://v.vault.azure.net/secrets/my-key?api-version=" + azureAPIVersion
+	got := m.Vault + "/secrets/" + m.Name + "?api-version=" + azureAPIVersion
+	if got != want {
+		t.Fatalf("fetch URL = %q, want %q", got, want)
+	}
+}
+
+// Trailing data after the document is rejected.
+func TestParseExternalDocumentRejectsTrailingData(t *testing.T) {
+	doc := `{"schema":"c8s.secrets-external/v1","backend":"azure-keyvault","credential":{"tenantId":"t","clientId":"c","clientSecret":"s"},"mappings":{}} trailing`
+	if _, err := parseExternalDocument([]byte(doc)); err == nil {
+		t.Fatal("trailing data accepted")
+	}
+}
+
+// An empty allowlist DB path disables persistence instead of writing to the
+// process working directory.
+func TestLoadExternalMappingsEmptyPathDisablesPersistence(t *testing.T) {
+	m, persist, err := LoadExternalMappings("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m != nil || persist != nil {
+		t.Fatal("an empty DB path must disable persistence")
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -39,6 +39,10 @@ type Held struct {
 // chose values would force every backend to reimplement or contradict this
 // one's policy. PutIfAbsent is a compare-and-set, which every real key-value
 // store offers.
+//
+// Two conventions extend the contract for network backends: a write refusal
+// carries no current value (a write must not become a read), and Get may
+// perform blocking network I/O under the caller's context.
 type Store interface {
 	Get(ctx context.Context, path string) ([]byte, error)
 	// PutIfAbsent stores value at path if nothing is there, returning what the


### PR DESCRIPTION
… first

A store path can now be backed by an external KMS: CDS fetches the value at release time and forwards it to the attested workload, instead of holding it in process memory. This is the direct-brokering shape of whitepaper §5.6.4, with one deliberate substitution — Key Vault cannot verify CDS's attestation (SKR is locked to MAA, which attests Azure-hosted TEEs only), so CDS authenticates with an operator-provisioned Entra credential.

The release gate is untouched: mesh leaf, challenge, sandbox token, exact workload match, grant. Only the store lookup changes. The Store interface was written for this ("a KMS wraps a key, a vault mints its own"); RoutingStore dispatches mapped paths to the KMS and everything else to the memory store. The webhook, get-secret sidecar, and grant model carry no new code. Brokering rather than `secrets put` because the vault stays the custody and audit point, vault-side rotation takes effect on pod restart with no operator action, and plaintext keys never transit the operator workstation.

The operator connects the KMS with `c8s secrets external apply` over the existing attested channel (RA-TLS pinned to the CDS measurement, operator JWT bound to method/path/body). The credential lives in CDS memory only — never a Kubernetes resource. The mapping set (paths, vaults, secret names; no credential) persists beside the allowlist DB, so a restarted CDS fails mapped paths closed instead of minting a divergent value; re-applying re-arms them. That file is host-visible, so the post-restart runbook — `c8s cds verify --operator-keys`, then re-apply — is the detector for a swapped key set or a rolled-back mappings file, not a prevention.

One backend at a time; the document's `backend` field names it so future backends share PUT/GET /secrets/external. `/external` is a reserved store path. Mapped paths are read-only from c8s: workload POST 409s without minting, operator PUT 409s naming the external backing. Fetches are versionless (latest at request time), values are delivered verbatim, fetch failures are the same opaque 500 as any store error, and the get-secret sidecar's retry loop is the only retry.

Stated residuals: the Entra credential is bearer material — a CDS compromise exposes it and in-flight values (the accepted direct-brokering trade-off; RBAC scope is the blast-radius bound, and the cached Entra tokens are bearer too). A control plane booting a same-measurement clone could harvest it from a steered apply; that inherits the known clone gap in docs/operator.md. SKR remains the upgrade that lets the KMS itself check CDS's attestation, viable once CDS-on-Azure is a supported shape; gaps.md's close criterion stays open until then.

Verified by unit and handler tests plus an in-process end-to-end test against a stubbed Entra+vault TLS server: real operator-JWT apply, attested workload fetch through the full gate, no-mint and operator-write refusals, grant-first denial, restart fail-closed, and re-apply recovery. `go test -race` clean on the touched packages. Not run against a live Azure tenant or on hardware.