### PR TITLE
feat(ratls): pin TDX RTMR[1] and RTMR[2]

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -158,6 +158,54 @@ entry widens a shared digest to `any`, because that becomes the effective
 container-level policy for the digest everywhere. The narrower, entry-scoped
 guarantee is recovered at [cert issuance](#where-its-enforced).
 
+## Mount and environment policy (`mounts`, `env`)
+
+An image digest pins the bytes, and process policy pins what runs them, but
+neither says anything about what the host lays *over* those bytes at start-up.
+With `shared_fs="none"` the runtime seeds every configmap, secret and
+serviceaccount token by copying it into the sandbox seeding directory and
+bind-mounting it in — a mechanism a pod cannot work without, and one whose
+source directory the host may write. Staging a file there and binding it over a
+path inside the image runs host code from an allowlisted digest, and every
+digest still reports as admitted.
+
+Client-side verification does not catch this, unlike a pod whose trust
+configuration was repointed: the pod keeps its genuine identity — real CDS, real
+mesh CA, correct launch measurement — and a verifying client passes it and sends
+data to a container running injected code.
+
+`mounts` constrains **bind** mounts only, by destination. The rest of a mount
+table names filesystem types (`proc`, `sysfs`, `tmpfs`, `devpts`, `mqueue`,
+`cgroup`) and carries nothing in, so pinning it would only make an operator
+restate the OCI base set to say nothing. `env` constrains variable **names**;
+values are never matched, because the allowlist is served to every enforcer and
+values carry secrets. `LD_PRELOAD` is the case that motivates it — an injected
+name is code execution inside an otherwise-allowlisted image.
+
+```json
+"mounts": { "policy": "exact", "destinations": ["/etc/hosts", "/config"] },
+"env":    { "policy": "exact", "names": ["PATH", "MODEL_DIR"] }
+```
+
+`exact` requires every observed bind destination (or name) to appear in the
+list. An `exact` destination list is what the pod's `volumeMounts` declare plus
+the handful the kubelet always adds — `/etc/hosts`, `/etc/hostname`,
+`/etc/resolv.conf`, `/dev/termination-log`, `/dev/shm`, the serviceaccount token
+— so it is written against a pod spec, not guessed.
+
+Both default to `any` when absent, unlike argv, which defaults to `deny`. A
+container always carries a mount table and an environment it never declared, so
+a `deny` default would refuse every real pod and adopting the field would mean
+adopting an outage. That makes these opt-in: a digest with no policy is
+constrained exactly as much as it was before.
+
+Two limits worth stating. They bind only digests a `workloads` entry names —
+floor digests are admitted on the digest alone, so `c8s allowlist add` does not
+produce a mount-gated image. And an enforcer that cannot observe a field leaves
+it unset, which is treated as nothing-to-refuse rather than a violation: the
+host-side NRI plugin gates images on a node CVM and never sees a guest's mount
+table.
+
 ## Secret grants (`secrets`)
 
 An entry may grant secret-store paths to the workload it names. The subject is

--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -14,11 +14,13 @@ the gaps it does not.
 > "part of the launch measurement", that means it sits on the dm-verity
 > root, whose root hash rides the kata kernel cmdline. On SEV-SNP the
 > cmdline reaches the launch digest via `kernel-hashes`, so those bytes
-> cannot change without changing the value operators pin. **On TDX they
-> can** — the pinned value is MRTD, which covers TDVF only, and the kernel
-> and cmdline land in RTMR[1] and RTMR[2], which nothing verifies today.
-> See [G6](#g6--on-tdx-the-baked-bytes-are-measured-but-not-pinned). The
-> measurement mechanics (osbuilder dm-verity ext4, `kernel-hashes`, the
+> cannot change without changing the value operators pin. On TDX the launch
+> measurement is MRTD, which covers TDVF only — the kernel lands in RTMR[1]
+> and the cmdline in RTMR[2] — so pinning MRTD alone leaves the guest image
+> substitutable. Those two registers are pinnable
+> (`c8s verify --rtmr 1=<hex> --rtmr 2=<hex>`, `ratls.VerifyPolicy.RTMRs`);
+> what is not yet derivable offline is their expected values, so today they
+> have to come from a known-good boot. The measurement mechanics (osbuilder dm-verity ext4, `kernel-hashes`, the
 > verity root hash in the kata kernel cmdline, no IGVM/UKI) live in
 > [`kata-guest-base/README.md`](../kata-guest-base/README.md).
 
@@ -67,7 +69,7 @@ post-start kill window — is documented in
 
 | Component | In TCB? | Notes |
 |---|---|---|
-| `kata-guest-base` guest image (`vmlinuz` + dm-verity rootfs) | yes | Launch measurement verified at boot: SEV-SNP launch digest via `kernel-hashes`; on TDX only MRTD is pinned (G6). |
+| `kata-guest-base` guest image (`vmlinuz` + dm-verity rootfs) | yes | Launch measurement verified at boot: SEV-SNP launch digest via `kernel-hashes`. On TDX MRTD covers TDVF only, so the guest image is attested only when RTMR[1] and RTMR[2] are pinned too. |
 | `kata-agent` inside the guest | yes | Installed into the rootfs by kata's osbuilder (version-matched) at build. |
 | `policy-monitor` inside the guest | yes | Built from this repo, baked into the dm-verity root. |
 | `/etc/c8s/bootstrap-allowlist.json` (verity root) | yes | The allowlist **seed** the monitor loads at boot. Part of the launch measurement. |
@@ -607,7 +609,8 @@ contributor doesn't rediscover the option from scratch.
   `kata-guest-base/patches/0001-agent-refuse-an-init-data-supplied-policy.patch`.
 - The host cannot inject an over-permissive allowlist. The seed
   `/etc/c8s/bootstrap-allowlist.json` is on the verity root and part of
-  the launch measurement on SEV-SNP (S4; on TDX see G6), and the runtime
+  the launch measurement on SEV-SNP — and on TDX when RTMR[1] and RTMR[2]
+  are pinned alongside MRTD (S4) — and the runtime
   CDS additions arrive over RA-TLS pinned to `cds.measurements`, so the
   host can't substitute a fake CDS ("Host can't substitute a fake CDS
   allowlist"). At worst the host blocks new additions — it can't shrink
@@ -653,7 +656,7 @@ contributor doesn't rediscover the option from scratch.
   per-image knowledge; it belongs in the allowlist document next to the argv
   policy, not in a policy baked before any workload is known.
 
-The most consequential honest limitations left are G6 (on TDX the baked
-bytes are measured but not pinned) and the host's control of argv, env and
-mount destinations (THREAT_MODEL §5). G1 is closed; G4 was its planned
-mitigation and is no longer needed for it.
+The most consequential honest limitations left are the host's control of
+argv, env and mount destinations (THREAT_MODEL §5), and — on TDX — that the
+RTMR values which make the guest image attested cannot yet be derived from a
+guest-image build, only read off a boot that is trusted for other reasons.

--- a/internal/cmds/cmdsutil/cmdsutil.go
+++ b/internal/cmds/cmdsutil/cmdsutil.go
@@ -55,3 +55,23 @@ func ShutdownOnDone(ctx context.Context, srv *http.Server, timeout time.Duration
 	defer cancel()
 	srv.Shutdown(shutdownCtx)
 }
+
+// CheckCDSPinned reports whether a sidecar may talk to CDS with the launch
+// measurements it was given.
+//
+// An empty set accepts any RA-TLS-attested CDS, so dropping the flag is enough
+// to point a sidecar at a CDS the host runs — and under kata the host writes
+// the argv. Refuse there. Outside kata "no pinning" is a supported development
+// shape (`c8s install --measurements` documents empty as UNSAFE), so it stays a
+// warning. Shared by get-cert, get-secret and get-volume: three copies of this
+// decision would be three chances to drift.
+func CheckCDSPinned(measurementCount int, insideGuest bool, warn string) error {
+	if measurementCount > 0 {
+		return nil
+	}
+	if insideGuest {
+		return errors.New("--measurements is empty: refusing to reach an unpinned CDS from inside a kata guest, where the host writes this argv")
+	}
+	slog.Warn(warn)
+	return nil
+}

--- a/internal/cmds/cmdsutil/cmdsutil_test.go
+++ b/internal/cmds/cmdsutil/cmdsutil_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -95,4 +96,31 @@ func contains(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+func TestCheckCDSPinned(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		count       int
+		insideGuest bool
+		wantErr     bool
+	}{
+		// Dropping --measurements is how the host redirects a sidecar at a CDS
+		// it runs; under kata it writes the argv, so this is the whole point.
+		{"unpinned inside a kata guest", 0, true, true},
+		// "no pinning" stays a supported development shape off the guest.
+		{"unpinned outside a kata guest", 0, false, false},
+		{"pinned inside a kata guest", 1, true, false},
+		{"pinned outside a kata guest", 2, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := CheckCDSPinned(tc.count, tc.insideGuest, "warn")
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("CheckCDSPinned(%d, %v) = %v, wantErr %v", tc.count, tc.insideGuest, err, tc.wantErr)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), "--measurements is empty") {
+				t.Errorf("error %q does not name the flag the operator has to set", err)
+			}
+		})
+	}
 }

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -186,8 +186,9 @@ func cdsHTTPClient(cfg config) (*http.Client, error) {
 	if err != nil {
 		return nil, fmt.Errorf("--cds-measurements: %w", err)
 	}
-	if len(measurements) == 0 {
-		slog.Warn("--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement")
+	if err := cmdsutil.CheckCDSPinned(len(measurements), cfg.WorkloadClaimsGuest,
+		"--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement"); err != nil {
+		return nil, err
 	}
 
 	client, err := ratls.NewVerifyingHTTPClient(measurements, cfg.AttestationApiURL)

--- a/internal/cmds/getcert/unpinned_cds_test.go
+++ b/internal/cmds/getcert/unpinned_cds_test.go
@@ -1,0 +1,47 @@
+package getcert
+
+import (
+	"strings"
+	"testing"
+)
+
+// Empty measurements accept any RA-TLS-attested CDS. Under kata the host writes
+// this argv, so dropping the flag is how it points the sidecar at a CDS it runs.
+func TestUnpinnedCDSRefusedInsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:              "https://cds:8443",
+		AttestationApiURL:   "http://attestation-api:8400",
+		SAN:                 "host.example.com",
+		WorkloadClaimsGuest: true,
+	}
+	_, err := cdsHTTPClient(cfg)
+	if err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
+		t.Fatalf("error = %v, want a refusal to use an unpinned CDS", err)
+	}
+}
+
+// Outside kata "no pinning" stays a supported development shape.
+func TestUnpinnedCDSAllowedOutsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:            "https://cds:8443",
+		AttestationApiURL: "http://attestation-api:8400",
+		SAN:               "host.example.com",
+	}
+	if _, err := cdsHTTPClient(cfg); err != nil {
+		t.Fatalf("cdsHTTPClient: %v", err)
+	}
+}
+
+// A pinned measurement is what the flag is for; it must still work under kata.
+func TestPinnedCDSAcceptedInsideAKataGuest(t *testing.T) {
+	cfg := config{
+		CDSURL:              "https://cds:8443",
+		AttestationApiURL:   "http://attestation-api:8400",
+		SAN:                 "host.example.com",
+		CDSMeasurements:     strings.Repeat("ab", 48),
+		WorkloadClaimsGuest: true,
+	}
+	if _, err := cdsHTTPClient(cfg); err != nil {
+		t.Fatalf("cdsHTTPClient: %v", err)
+	}
+}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -382,8 +382,11 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	}
 
 	// Floor digests admit regardless of argv; workload digests require the
-	// effective argv to satisfy some entry's entrypoint/cmd policy.
-	if !snap.index.AdmitsContainer(digest, argv) {
+	// effective argv to satisfy some entry's entrypoint/cmd policy. Mount and env
+	// policy are left unobserved here: this plugin gates images on a node CVM,
+	// where it sees the CRI container rather than a guest's mount table, and an
+	// unobserved field is not a violation (allowlist.RunningContainer).
+	if !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
 		log.Warn("image not admitted by allowlist", "digest", digest, "argv", argv)
 		p.audit.Log(audit.Event{
 			Action:    "deny",

--- a/internal/cmds/nri-image-policy/refresh_test.go
+++ b/internal/cmds/nri-image-policy/refresh_test.go
@@ -83,7 +83,7 @@ func TestMergeAllowlistsCarriesWorkloads(t *testing.T) {
 	if !idx.AdmitsDigest(pushDigestA) {
 		t.Fatal("floor digest not admitted after merge")
 	}
-	if !idx.AdmitsContainer(pushDigestB, []string{"anything"}) {
+	if !idx.AdmitsContainer(allowlist.RunningContainer{Digest: pushDigestB, Argv: []string{"anything"}}) {
 		t.Fatal("workload digest not admitted after merge")
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -225,14 +225,15 @@ func (o *policyOverlay) apply(al *allowlistpkg.Allowlist, version uint64) bool {
 
 // admits reports whether a container may run. The baked floor (additive digest
 // set) admits by digest alone; otherwise the pulled overlay's Index decides on
-// digest + effective argv. With no overlay (CDS refresh disabled, or no
-// successful pull yet) only the baked floor admits — behavior from t=0.
-func (m *monitor) admits(digest string, argv []string) bool {
-	if m.allowlist.Contains(digest) {
+// the whole observation — digest, argv, bind-mount destinations and env names.
+// With no overlay (CDS refresh disabled, or no successful pull yet) only the
+// baked floor admits — behavior from t=0.
+func (m *monitor) admits(rc allowlistpkg.RunningContainer) bool {
+	if m.allowlist.Contains(rc.Digest) {
 		return true
 	}
 	if idx := m.overlay.index(); idx != nil {
-		return idx.AdmitsContainer(digest, argv)
+		return idx.AdmitsContainer(rc)
 	}
 	return false
 }
@@ -523,22 +524,32 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		return
 	}
 
-	// Effective argv (OCI process.args): the merged entrypoint+cmd the container
-	// runs. Floor digests ignore it; workload digests are gated on it.
-	var argv []string
-	if spec.Process != nil {
-		argv = spec.Process.Args
+	// What the container actually runs, as the allowlist describes it. Floor
+	// digests ignore all of it; workload digests are gated on the whole set.
+	rc := allowlistpkg.RunningContainer{
+		Digest:     digest,
+		BindMounts: bindMountDestinations(spec.Mounts),
 	}
-	if m.admits(digest, argv) {
+	if spec.Process != nil {
+		rc.Argv = spec.Process.Args
+		rc.EnvNames = envNames(spec.Process.Env)
+	}
+	if m.admits(rc) {
 		m.logger.Info("allow container", "cid", cid, "digest", digest)
 		if m.inventory != nil {
-			m.inventory.record(cid, digest, argv)
+			m.inventory.record(cid, digest, rc.Argv)
 		}
 		m.recordVerdict(dir, verdictAllow)
 		return
 	}
-	m.logger.Warn("deny container: digest/argv not allowlisted",
-		append([]any{"cid", cid, "digest", digest, "argv", argv}, m.frozenAttrs()...)...)
+	// Name every field the decision looked at: a container denied on its mounts
+	// or environment reported as "digest/argv" would send an operator hunting
+	// the wrong thing.
+	m.logger.Warn("deny container: not admitted by digest, argv, mounts or env",
+		append([]any{
+			"cid", cid, "digest", digest, "argv", rc.Argv,
+			"bind_mounts", rc.BindMounts, "env_names", rc.EnvNames,
+		}, m.frozenAttrs()...)...)
 	m.deny(ctx, dir)
 }
 
@@ -701,12 +712,50 @@ func (m *monitor) readConfigJSON(ctx context.Context, dir string) (*ociSpec, err
 type ociSpec struct {
 	Annotations map[string]string `json:"annotations"`
 	Process     *ociProcess       `json:"process"`
+	Mounts      []ociMount        `json:"mounts"`
 }
 
-// ociProcess is the process block's argv: the merged image-config + pod-spec
-// command the container actually runs, evaluated against workload argv policy.
+// ociProcess is the process block the container runs: the merged image-config +
+// pod-spec argv, evaluated against workload argv policy, and the environment it
+// starts with, evaluated by name against workload env policy.
 type ociProcess struct {
 	Args []string `json:"args"`
+	Env  []string `json:"env"`
+}
+
+// ociMount is one entry of the container's mount table. The baked kata-agent
+// policy bounds where a bind's source may be; the destination is a path inside
+// the container and is what workload mount policy gates.
+type ociMount struct {
+	Destination string `json:"destination"`
+	Source      string `json:"source"`
+}
+
+// bindMountDestinations returns the destinations of the mounts that carry guest
+// content in. A source that is not an absolute path names a filesystem type
+// (proc, sysfs, tmpfs, devpts, mqueue, cgroup) and carries nothing, so gating it
+// would only make an operator restate the OCI base set.
+func bindMountDestinations(mounts []ociMount) []string {
+	var out []string
+	for _, m := range mounts {
+		if strings.HasPrefix(m.Source, "/") {
+			out = append(out, m.Destination)
+		}
+	}
+	return out
+}
+
+// envNames returns the NAME halves of the spec's "NAME=value" environment.
+// Values never leave this function: policy matches names, because an allowlist
+// is served to every enforcer and values carry secrets.
+func envNames(env []string) []string {
+	var out []string
+	for _, e := range env {
+		if name, _, ok := strings.Cut(e, "="); ok {
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 func readOCISpec(path string) (*ociSpec, error) {

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -228,10 +228,10 @@ func TestPolicyOverlayAntiRollback(t *testing.T) {
 		t.Fatalf("version = %d, want 5 (rollback ignored)", o.version)
 	}
 	// The version-5 policy still governs: /bin/app matches, /bin/other does not.
-	if !o.index().AdmitsContainer(wl, []string{"/bin/app"}) {
+	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("version-5 argv policy dropped by rollback attempt")
 	}
-	if o.index().AdmitsContainer(wl, []string{"/bin/other"}) {
+	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("rolled-back argv policy took effect")
 	}
 }
@@ -248,10 +248,10 @@ func TestPolicyOverlayIgnoresEqualVersion(t *testing.T) {
 	if o.apply(exactEntrypointOverlay(t, wl, []string{"/bin/other"}), 5) {
 		t.Fatal("replayed version 5 was applied")
 	}
-	if !o.index().AdmitsContainer(wl, []string{"/bin/app"}) {
+	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("original version-5 policy dropped by equal-version replay")
 	}
-	if o.index().AdmitsContainer(wl, []string{"/bin/other"}) {
+	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("equal-version replay policy took effect")
 	}
 }

--- a/internal/cmds/policymonitor/mountpolicy_test.go
+++ b/internal/cmds/policymonitor/mountpolicy_test.go
@@ -1,0 +1,143 @@
+//go:build linux
+
+package policymonitor
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// writeSpec writes a bundle config.json carrying the fields workload policy is
+// evaluated against.
+func writeSpec(t *testing.T, watchDir, cid string, annotations map[string]string, args, env []string, mounts []ociMount) {
+	t.Helper()
+	dir := filepath.Join(watchDir, cid)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(ociSpec{
+		Annotations: annotations,
+		Process:     &ociProcess{Args: args, Env: env},
+		Mounts:      mounts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mountPolicyOverlay(t *testing.T, digest string, destinations []string) *allowlistpkg.Allowlist {
+	t.Helper()
+	return &allowlistpkg.Allowlist{
+		Schema: allowlistpkg.Schema,
+		Workloads: map[string]allowlistpkg.Workload{"w": {Containers: []allowlistpkg.Container{{
+			Digest:  mustParseDigest(t, digest),
+			Command: allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+			Args:    allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+			Mounts:  allowlistpkg.MountPolicy{Policy: allowlistpkg.PolicyExact, Destinations: destinations},
+		}}}},
+	}
+}
+
+// The whole point of the policy: the host stages bytes in the sandbox seeding
+// directory — a legitimate CopyFile destination, and an allowed mount source —
+// then binds them over a path inside an allowlisted image. The digest still
+// matches, so only the mount policy can refuse it.
+func TestWorkloadMountPolicy(t *testing.T) {
+	wl := strings.Repeat("b", 64)
+	ann := map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + wl,
+	}
+	seeded := "/run/kata-containers/shared/containers/pod-abc-cm"
+	floor := []string{"sha256:" + strings.Repeat("a", 64)}
+
+	t.Run("declared destinations admitted", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts", "/config"}), 1)
+		writeSpec(t, watchDir, "ok", ann, []string{"/serve"}, []string{"PATH=/bin"}, []ociMount{
+			{Destination: "/proc", Source: "proc"},
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/config", Source: seeded},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "ok"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("declared mounts were refused: %+v", calls)
+		}
+	})
+
+	t.Run("bind over an image path refused", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts", "/config"}), 1)
+		writeSpec(t, watchDir, "shadowed", ann, []string{"/serve"}, nil, []ociMount{
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/usr/local/bin/serve", Source: seeded},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "shadowed"))
+		if calls := killer.snapshot(); len(calls) != 1 {
+			t.Fatalf("a bind over an image path was admitted: %+v", calls)
+		}
+	})
+
+	// Pseudo-filesystem mounts are not binds and carry nothing in, so gating
+	// them would only make an operator restate the OCI base set.
+	t.Run("pseudo-filesystem mounts are not gated", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts"}), 1)
+		writeSpec(t, watchDir, "pseudo", ann, []string{"/serve"}, nil, []ociMount{
+			{Destination: "/etc/hosts", Source: seeded},
+			{Destination: "/sys/fs/cgroup", Source: "cgroup"},
+			{Destination: "/dev/mqueue", Source: "mqueue"},
+		})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "pseudo"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("a pseudo-filesystem mount was refused: %+v", calls)
+		}
+	})
+
+	// A floor digest is admitted on the digest alone, by design — the mount
+	// policy only binds digests an entry names.
+	t.Run("floor digests stay unconstrained", func(t *testing.T) {
+		m, killer, watchDir := newTestMonitor(t, floor)
+		m.overlay.apply(mountPolicyOverlay(t, "sha256:"+wl, []string{"/etc/hosts"}), 1)
+		writeSpec(t, watchDir, "floored", map[string]string{
+			"io.kubernetes.cri.container-type": "container",
+			"io.kubernetes.cri.image-name":     "ghcr.io/c8s/get-cert@" + floor[0],
+		}, []string{"/get-cert"}, nil, []ociMount{{Destination: "/anywhere", Source: seeded}})
+		m.handleNewContainer(context.Background(), filepath.Join(watchDir, "floored"))
+		if calls := killer.snapshot(); len(calls) != 0 {
+			t.Fatalf("a floor digest was gated on mounts: %+v", calls)
+		}
+	})
+}
+
+func TestEnvNamesDropValues(t *testing.T) {
+	got := envNames([]string{"PATH=/bin", "TOKEN=s3cret", "NOEQUALS"})
+	if strings.Join(got, ",") != "PATH,TOKEN" {
+		t.Errorf("envNames = %v, want the names of the two NAME=value entries", got)
+	}
+	for _, n := range got {
+		if strings.Contains(n, "s3cret") {
+			t.Fatal("a value leaked into the observation policy matches on")
+		}
+	}
+}
+
+func TestBindMountDestinationsIgnoresPseudoFilesystems(t *testing.T) {
+	got := bindMountDestinations([]ociMount{
+		{Destination: "/proc", Source: "proc"},
+		{Destination: "/data", Source: "/run/kata-containers/sandbox/storage/x"},
+		{Destination: "/dev/shm", Source: "/run/kata-containers/sandbox/shm"},
+	})
+	if strings.Join(got, ",") != "/data,/dev/shm" {
+		t.Errorf("bindMountDestinations = %v, want only the bind destinations", got)
+	}
+}

--- a/internal/cmds/policymonitor/refreshstate_test.go
+++ b/internal/cmds/policymonitor/refreshstate_test.go
@@ -42,7 +42,7 @@ func TestDenyNamesFrozenAllowlist(t *testing.T) {
 	if len(killer.snapshot()) != 1 {
 		t.Fatalf("want exactly one kill, got %+v", killer.snapshot())
 	}
-	line := findLog(t, buf, "deny container: digest/argv not allowlisted")
+	line := findLog(t, buf, denyMsg)
 	if frozen, _ := line["allowlist_frozen"].(bool); !frozen {
 		t.Fatalf("deny line does not report the frozen allowlist: %v", line)
 	}
@@ -71,7 +71,7 @@ func TestDenyOmitsFrozenAttrsWhenRefreshLive(t *testing.T) {
 	})
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
 
-	line := findLog(t, buf, "deny container: digest/argv not allowlisted")
+	line := findLog(t, buf, denyMsg)
 	if _, present := line["allowlist_frozen"]; present {
 		t.Fatalf("live refresh reported as frozen: %v", line)
 	}
@@ -108,6 +108,10 @@ func TestInventoryReportsRefreshPosture(t *testing.T) {
 }
 
 // findLog returns the first JSON log record whose msg matches.
+// denyMsg is the deny line these tests read the frozen-allowlist attributes
+// off. Kept next to them so a reworded message moves in one place.
+const denyMsg = "deny container: not admitted by digest, argv, mounts or env"
+
 func findLog(t *testing.T, buf *bytes.Buffer, msg string) map[string]any {
 	t.Helper()
 	for _, raw := range strings.Split(strings.TrimSpace(buf.String()), "\n") {

--- a/internal/cmds/sidecar/measurements_test.go
+++ b/internal/cmds/sidecar/measurements_test.go
@@ -1,0 +1,48 @@
+package sidecar
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func measurementHex() string { return strings.Repeat(hex.EncodeToString([]byte{0xab}), 48) }
+
+// Empty measurements accept any RA-TLS-attested CDS, so dropping the flag is
+// how a host points a sidecar at a CDS it runs. Under kata it writes the argv.
+func TestParseMeasurementsRefusesAnUnpinnedCDSInsideAKataGuest(t *testing.T) {
+	cfg := Config{WorkloadClaimsGuest: true}
+	if _, err := cfg.ParseMeasurements(); err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
+		t.Fatalf("error = %v, want a refusal to use an unpinned CDS", err)
+	}
+}
+
+// Outside kata "no pinning" is a supported development shape.
+func TestParseMeasurementsWarnsOutsideAKataGuest(t *testing.T) {
+	cfg := Config{}
+	got, err := cfg.ParseMeasurements()
+	if err != nil {
+		t.Fatalf("ParseMeasurements: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("parsed %d measurements, want none", len(got))
+	}
+}
+
+func TestParseMeasurementsAcceptsAPinnedCDSInsideAKataGuest(t *testing.T) {
+	cfg := Config{Measurements: []string{measurementHex()}, WorkloadClaimsGuest: true}
+	got, err := cfg.ParseMeasurements()
+	if err != nil {
+		t.Fatalf("ParseMeasurements: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("parsed %d measurements, want 1", len(got))
+	}
+}
+
+func TestParseMeasurementsRejectsMalformedHex(t *testing.T) {
+	cfg := Config{Measurements: []string{"zz"}}
+	if _, err := cfg.ParseMeasurements(); err == nil || !strings.Contains(err.Error(), "--measurements") {
+		t.Fatalf("error = %v, want a parse error naming the flag", err)
+	}
+}

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
@@ -108,14 +109,16 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// ParseMeasurements decodes --measurements, warning when the pin is empty.
+// ParseMeasurements decodes --measurements, refusing an empty pin inside a kata
+// guest and warning outside one.
 func (c *Config) ParseMeasurements() ([][]byte, error) {
 	measurements, err := ratls.ParseHexMeasurementsList(c.Measurements)
 	if err != nil {
 		return nil, fmt.Errorf("--measurements: %w", err)
 	}
-	if len(measurements) == 0 {
-		slog.Warn("--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development.")
+	if err := cmdsutil.CheckCDSPinned(len(measurements), c.WorkloadClaimsGuest,
+		"--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development."); err != nil {
+		return nil, err
 	}
 	return measurements, nil
 }

--- a/internal/cmds/verify/rtmr_test.go
+++ b/internal/cmds/verify/rtmr_test.go
@@ -1,0 +1,64 @@
+package verify
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+func sha384Hex(b byte) string { return strings.Repeat(hex.EncodeToString([]byte{b}), 48) }
+
+func TestParseRTMRPins(t *testing.T) {
+	t.Run("indices 1 and 2 parse", func(t *testing.T) {
+		got, err := parseRTMRPins([]string{"1=" + sha384Hex(0x11), "2=" + sha384Hex(0x22)})
+		if err != nil {
+			t.Fatalf("parseRTMRPins: %v", err)
+		}
+		if len(got) != 2 || hex.EncodeToString(got[1]) != sha384Hex(0x11) || hex.EncodeToString(got[2]) != sha384Hex(0x22) {
+			t.Fatalf("parsed %v, want RTMR[1] and RTMR[2]", got)
+		}
+	})
+
+	t.Run("no pins is nil", func(t *testing.T) {
+		got, err := parseRTMRPins(nil)
+		if err != nil || got != nil {
+			t.Fatalf("parseRTMRPins(nil) = %v, %v; want nil, nil", got, err)
+		}
+	})
+
+	// Rejected rather than ignored: accepting them would look like a guest
+	// identity pin while providing none.
+	for _, tc := range []struct{ name, pin, want string }{
+		{"RTMR[0] tracks pod shape", "0=" + sha384Hex(0), "TD HOB"},
+		{"RTMR[3] is guest-extended", "3=" + sha384Hex(3), "in-guest software"},
+		{"index out of range", "9=" + sha384Hex(9), "must be 1 or 2"},
+		{"missing =", sha384Hex(1), "<index>=<sha384-hex>"},
+		{"index not a number", "x=" + sha384Hex(1), "not a number"},
+		{"value not hex", "1=zzzz", "not hex"},
+		{"wrong length", "1=" + hex.EncodeToString([]byte{1, 2, 3}), "bytes, want 48"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRTMRPins([]string{tc.pin})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want one mentioning %q", err, tc.want)
+			}
+		})
+	}
+
+	t.Run("repeated index rejected", func(t *testing.T) {
+		_, err := parseRTMRPins([]string{"1=" + sha384Hex(1), "1=" + sha384Hex(2)})
+		if err == nil || !strings.Contains(err.Error(), "more than once") {
+			t.Fatalf("error = %v, want a duplicate-index error", err)
+		}
+	})
+}
+
+func TestBuildPolicyCarriesRTMRPins(t *testing.T) {
+	p, err := buildPolicy(config{rtmrs: []string{"2=" + sha384Hex(0x22)}})
+	if err != nil {
+		t.Fatalf("buildPolicy: %v", err)
+	}
+	if len(p.RTMRs) != 1 || hex.EncodeToString(p.RTMRs[2]) != sha384Hex(0x22) {
+		t.Fatalf("policy RTMRs = %v, want RTMR[2] pinned", p.RTMRs)
+	}
+}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
@@ -88,6 +89,7 @@ type config struct {
 
 	measurements     []string
 	measurementsFile string
+	rtmrs            []string
 	operatorKeys     string
 	sandboxID        string
 	workload         string
@@ -171,6 +173,7 @@ unavailable (unreachable / unparseable).`,
 
 	f.StringSliceVar(&cfg.measurements, "measurements", nil, "allowed SHA-384 hex launch measurement(s) (repeatable / comma-separated); empty = no pinning (UNSAFE)")
 	f.StringVar(&cfg.measurementsFile, "measurements-file", "", "file of allowed launch measurements, one hex digest per line")
+	f.StringSliceVar(&cfg.rtmrs, "rtmr", nil, "expected TDX runtime measurement register(s) as <index>=<sha384-hex> (repeatable). On TDX the launch measurement is MRTD, which covers the firmware only: RTMR[1] pins the guest kernel and RTMR[2] the kernel command line, which carries the dm-verity root hash. Ignored on SNP")
 	f.StringVar(&cfg.operatorKeys, "operator-keys", "", "PEM bundle of expected operator public keys; verification fails unless the key set the attested target serves at /operator-keys matches it (kind=cds targets)")
 	f.StringVar(&cfg.sandboxID, "sandbox-id", "", "expected CRI pod sandbox ID on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the ID (docs/ratls.md)")
 	f.StringVar(&cfg.workload, "workload", "", "expected matched-workload name on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the stamp (docs/ratls.md)")
@@ -383,10 +386,61 @@ func buildPolicy(cfg config) (*ratls.VerifyPolicy, error) {
 		return nil, fmt.Errorf("--allowlist requires --mesh-ca: the stamped policy digest is vouched by CDS's signature on the leaf, not by the hardware evidence")
 	}
 
+	rtmrs, err := parseRTMRPins(cfg.rtmrs)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ratls.VerifyPolicy{
 		Measurements: measurements,
+		RTMRs:        rtmrs,
 		AllowDebug:   cfg.allowDebug,
 	}, nil
+}
+
+// parseRTMRPins parses repeated --rtmr <index>=<sha384-hex> flags.
+//
+// Index 0 and 3 are rejected rather than accepted-and-ignored: RTMR[0] carries
+// the TD HOB, so it tracks the pod's vCPU and memory shape and a fleet-wide pin
+// would deny half the fleet, and RTMR[3] is extended by in-guest software, so
+// pinning it would look like guest identity while a substituted guest simply
+// extends it with the expected value.
+func parseRTMRPins(pins []string) (map[int][]byte, error) {
+	if len(pins) == 0 {
+		return nil, nil
+	}
+	out := make(map[int][]byte, len(pins))
+	for _, p := range pins {
+		idxStr, hexStr, ok := strings.Cut(strings.TrimSpace(p), "=")
+		if !ok {
+			return nil, fmt.Errorf("--rtmr %q: want <index>=<sha384-hex>", p)
+		}
+		idx, err := strconv.Atoi(idxStr)
+		if err != nil {
+			return nil, fmt.Errorf("--rtmr %q: index is not a number: %w", p, err)
+		}
+		switch idx {
+		case 1, 2:
+		case 0:
+			return nil, fmt.Errorf("--rtmr 0 is not pinnable: RTMR[0] carries the TD HOB, so it varies with the pod's vCPU and memory shape")
+		case 3:
+			return nil, fmt.Errorf("--rtmr 3 is not pinnable: RTMR[3] is extended by in-guest software, so it cannot vouch for the guest image")
+		default:
+			return nil, fmt.Errorf("--rtmr %q: index must be 1 or 2", p)
+		}
+		if _, dup := out[idx]; dup {
+			return nil, fmt.Errorf("--rtmr %d given more than once", idx)
+		}
+		v, err := hex.DecodeString(strings.TrimSpace(hexStr))
+		if err != nil {
+			return nil, fmt.Errorf("--rtmr %d: value is not hex: %w", idx, err)
+		}
+		if len(v) != sha512.Size384 {
+			return nil, fmt.Errorf("--rtmr %d: value is %d bytes, want %d", idx, len(v), sha512.Size384)
+		}
+		out[idx] = v
+	}
+	return out, nil
 }
 
 // expectedOperatorKeysDigest is the KeySetDigest of the --operator-keys bundle,

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -68,6 +68,8 @@ type Container struct {
 	Image   string       `json:"image,omitempty"`
 	Command ArgvPolicy   `json:"command"`
 	Args    ArgvPolicy   `json:"args"`
+	Mounts  MountPolicy  `json:"mounts,omitempty"`
+	Env     EnvPolicy    `json:"env,omitempty"`
 }
 
 // ArgvPolicy governs part of a container's effective argv (the OCI process.args
@@ -78,6 +80,34 @@ type Container struct {
 type ArgvPolicy struct {
 	Policy string   `json:"policy"`
 	Argv   []string `json:"argv,omitempty"`
+}
+
+// MountPolicy governs where the host may bind content into the container.
+//
+// It constrains BIND mounts only — a mount whose source is an absolute guest
+// path. The rest of a container's mount table names filesystem types (proc,
+// sysfs, tmpfs, devpts, mqueue, cgroup) and carries nothing in, so pinning it
+// would make an operator restate the OCI base set to say nothing.
+//
+// Exact requires every bind destination to appear in Destinations, which is the
+// set an operator recognises: it is what the pod spec's volumeMounts declare,
+// plus the handful the kubelet always adds (/etc/hosts, /etc/hostname,
+// /etc/resolv.conf, /dev/termination-log, /dev/shm, the serviceaccount token).
+// Any leaves them unconstrained, and is what an absent policy means — unlike
+// argv, a Deny default would refuse every real pod, since the base set is never
+// empty.
+type MountPolicy struct {
+	Policy       string   `json:"policy"`
+	Destinations []string `json:"destinations,omitempty"`
+}
+
+// EnvPolicy governs the environment variable NAMES a container may run with.
+// Values are not matched: they carry secrets, and an allowlist is served to
+// every enforcer. Exact requires every name to appear in Names; Any, the
+// default, leaves them unconstrained.
+type EnvPolicy struct {
+	Policy string   `json:"policy"`
+	Names  []string `json:"names,omitempty"`
 }
 
 // SecretsPolicy grants secret-store read/write globs to a whole workload entry.
@@ -249,8 +279,84 @@ func normalizeContainers(workload, field string, cs []Container) error {
 		if err := normalizeArgv(&c.Args); err != nil {
 			return fmt.Errorf("workload %q %s %s args: %w", workload, field, c.Digest, err)
 		}
+		if err := normalizeMounts(&c.Mounts); err != nil {
+			return fmt.Errorf("workload %q %s %s mounts: %w", workload, field, c.Digest, err)
+		}
+		if err := normalizeEnv(&c.Env); err != nil {
+			return fmt.Errorf("workload %q %s %s env: %w", workload, field, c.Digest, err)
+		}
 	}
 	return nil
+}
+
+// normalizeMounts validates a mount policy. An absent policy canonicalizes to
+// Any: every container has a mount table it did not ask for (the OCI base set,
+// /etc/hosts, the serviceaccount token), so Deny would refuse every real pod and
+// an operator adopting this field would be opting into an outage.
+func normalizeMounts(p *MountPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "":
+		if len(p.Destinations) != 0 {
+			return fmt.Errorf("any policy takes no destinations")
+		}
+		p.Policy = PolicyAny
+		p.Destinations = nil
+	case PolicyExact:
+		if len(p.Destinations) == 0 {
+			return fmt.Errorf("exact policy requires at least one destination")
+		}
+		for _, d := range p.Destinations {
+			if !path.IsAbs(d) {
+				return fmt.Errorf("destination %q is not an absolute path", d)
+			}
+		}
+		p.Destinations = sortedUnique(p.Destinations)
+	default:
+		return fmt.Errorf("unknown mount policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// normalizeEnv validates an env policy, canonicalizing an absent policy to Any
+// for the same reason as mounts: a container inherits names it did not declare.
+func normalizeEnv(p *EnvPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "":
+		if len(p.Names) != 0 {
+			return fmt.Errorf("any policy takes no names")
+		}
+		p.Policy = PolicyAny
+		p.Names = nil
+	case PolicyExact:
+		if len(p.Names) == 0 {
+			return fmt.Errorf("exact policy requires at least one name")
+		}
+		for _, n := range p.Names {
+			if n == "" || strings.ContainsRune(n, '=') {
+				return fmt.Errorf("environment name %q is empty or contains '='", n)
+			}
+		}
+		p.Names = sortedUnique(p.Names)
+	default:
+		return fmt.Errorf("unknown env policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// sortedUnique makes a list a function of its content, so Canonical does not
+// churn on the order an operator happened to write.
+func sortedUnique(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // normalizeArgv validates an argv policy and canonicalizes an absent policy to

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -7,9 +7,20 @@ import "fmt"
 //
 // A local type rather than the inventory's own keeps this package a pure
 // function of the allowlist — the caller converts.
+// RunningContainer is an observed container, as an enforcer sees it.
+//
+// BindMounts holds the destinations of its BIND mounts only — the mounts whose
+// source is a guest path, and so the ones that can carry host-supplied content
+// in. EnvNames holds its environment variable names, without values.
+//
+// An enforcer that cannot observe a field leaves it nil, which an exact policy
+// treats as "nothing to refuse" rather than as a violation: the host-side NRI
+// plugin gates images on a node CVM and does not see the guest's mount table.
 type RunningContainer struct {
-	Digest string
-	Argv   []string
+	Digest     string
+	Argv       []string
+	BindMounts []string
+	EnvNames   []string
 }
 
 // ErrNoMatch reports that no entry describes the running set; ErrAmbiguous that
@@ -139,5 +150,43 @@ func (c Container) admits(r RunningContainer) bool {
 		return false
 	}
 	rest, ok := c.Command.matchCommand(r.Argv)
-	return ok && c.Args.matchArgs(rest)
+	if !ok || !c.Args.matchArgs(rest) {
+		return false
+	}
+	return c.Mounts.admits(r.BindMounts) && c.Env.admits(r.EnvNames)
+}
+
+// admits reports whether every bind destination is one this policy names.
+func (p MountPolicy) admits(destinations []string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	return everyIn(destinations, p.Destinations)
+}
+
+// admits reports whether every environment name is one this policy names.
+func (p EnvPolicy) admits(names []string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	return everyIn(names, p.Names)
+}
+
+// everyIn reports whether every observed value appears in allowed. An empty
+// observation is vacuously true — see RunningContainer on enforcers that cannot
+// see a field.
+func everyIn(observed, allowed []string) bool {
+	if len(observed) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		set[a] = struct{}{}
+	}
+	for _, o := range observed {
+		if _, ok := set[o]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/allowlist/match_test.go
+++ b/pkg/allowlist/match_test.go
@@ -131,7 +131,7 @@ func TestMatchWorkloadDistinguishesByArgv(t *testing.T) {
 	}
 
 	idx := al.BuildIndex()
-	if !idx.AdmitsContainer(dApp, []string{"/serve", "--model", "a"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: dApp, Argv: []string{"/serve", "--model", "a"}}) {
 		t.Fatal("precondition: Index should admit either argv for the shared digest")
 	}
 }

--- a/pkg/allowlist/mountenv_test.go
+++ b/pkg/allowlist/mountenv_test.go
@@ -1,0 +1,150 @@
+package allowlist
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatalf("ParseDigest(%q): %v", s, err)
+	}
+	return d
+}
+
+func containerWith(t *testing.T, mounts MountPolicy, env EnvPolicy) Container {
+	t.Helper()
+	c := Container{
+		Digest:  mustDigest(t, "sha256:"+strings.Repeat("a", 64)),
+		Command: ArgvPolicy{Policy: PolicyAny},
+		Args:    ArgvPolicy{Policy: PolicyAny},
+		Mounts:  mounts,
+		Env:     env,
+	}
+	// normalizeContainers mutates the slice it is given, so read the result back
+	// out of it rather than off the copy that went in.
+	cs := []Container{c}
+	if err := normalizeContainers("w", "containers", cs); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return cs[0]
+}
+
+func running(digest string, mounts, env []string) RunningContainer {
+	return RunningContainer{Digest: digest, BindMounts: mounts, EnvNames: env}
+}
+
+// The threat this policy exists for: the host stages bytes in the sandbox
+// seeding directory (a legitimate CopyFile destination) and binds them over a
+// path inside an allowlisted image, so the container runs host code while every
+// digest still reports as admitted.
+func TestMountPolicyRefusesAnUndeclaredDestination(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts", "/var/run/secrets/kubernetes.io/serviceaccount"}},
+		EnvPolicy{Policy: PolicyAny})
+
+	if !c.admits(running(digest, []string{"/etc/hosts"}, nil)) {
+		t.Error("a declared destination was refused")
+	}
+	if c.admits(running(digest, []string{"/etc/hosts", "/usr/local/bin/get-cert"}, nil)) {
+		t.Error("a bind over an image path was admitted")
+	}
+}
+
+// An absent policy has to mean "unconstrained": every container carries a mount
+// table it never declared, so a Deny default would refuse every real pod.
+func TestAbsentMountAndEnvPolicyAreUnconstrained(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{}, EnvPolicy{})
+
+	if c.Mounts.Policy != PolicyAny || c.Env.Policy != PolicyAny {
+		t.Fatalf("normalized to %q/%q, want %q", c.Mounts.Policy, c.Env.Policy, PolicyAny)
+	}
+	if !c.admits(running(digest, []string{"/anything", "/at/all"}, []string{"LD_PRELOAD"})) {
+		t.Error("an absent policy refused a container")
+	}
+}
+
+// LD_PRELOAD is the sharp case: an injected name is code execution inside an
+// otherwise-allowlisted image.
+func TestEnvPolicyRefusesAnUndeclaredName(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{Policy: PolicyAny},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"PATH", "HOME"}})
+
+	if !c.admits(running(digest, nil, []string{"PATH", "HOME"})) {
+		t.Error("declared names were refused")
+	}
+	if c.admits(running(digest, nil, []string{"PATH", "LD_PRELOAD"})) {
+		t.Error("an injected environment name was admitted")
+	}
+}
+
+// An enforcer that cannot see a field leaves it nil. That is not a violation —
+// the host-side NRI plugin gates images on a node CVM and never sees a guest's
+// mount table, and refusing there would deny every pod it checks.
+func TestUnobservedFieldsAreNotViolations(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts"}},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"PATH"}})
+
+	if !c.admits(RunningContainer{Digest: digest}) {
+		t.Error("an enforcer that observes neither field was refused")
+	}
+}
+
+func TestMountAndEnvPolicyValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    Container
+	}{
+		{"exact mounts with no destinations", Container{Mounts: MountPolicy{Policy: PolicyExact}}},
+		{"any mounts carrying destinations", Container{Mounts: MountPolicy{Policy: PolicyAny, Destinations: []string{"/x"}}}},
+		{"relative destination", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"etc/hosts"}}}},
+		{"unknown mount policy", Container{Mounts: MountPolicy{Policy: "sometimes"}}},
+		{"exact env with no names", Container{Env: EnvPolicy{Policy: PolicyExact}}},
+		{"any env carrying names", Container{Env: EnvPolicy{Policy: PolicyAny, Names: []string{"PATH"}}}},
+		{"name containing =", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"PATH=/bin"}}}},
+		{"unknown env policy", Container{Env: EnvPolicy{Policy: "sometimes"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c
+			c.Digest = mustDigest(t, "sha256:"+strings.Repeat("a", 64))
+			if err := normalizeContainers("w", "containers", []Container{c}); err == nil {
+				t.Error("normalize accepted an invalid policy")
+			}
+		})
+	}
+}
+
+// Canonical is compared byte-for-byte across pulls, so the lists have to be a
+// function of content rather than of the order an operator wrote them.
+func TestMountAndEnvListsAreOrderIndependent(t *testing.T) {
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/b", "/a", "/b"}},
+		EnvPolicy{Policy: PolicyExact, Names: []string{"B", "A", "B"}})
+
+	if got := strings.Join(c.Mounts.Destinations, ","); got != "/a,/b" {
+		t.Errorf("destinations = %q, want sorted and deduplicated", got)
+	}
+	if got := strings.Join(c.Env.Names, ","); got != "A,B" {
+		t.Errorf("names = %q, want sorted and deduplicated", got)
+	}
+}
+
+// A document from a newer release must not freeze an older consumer's policy.
+func TestServedParseIgnoresUnknownFields(t *testing.T) {
+	doc := `{"schema":"` + Schema + `","digests":{},"workloads":{},"somethingNewer":{"x":1}}`
+	if _, err := ParseServedJSON([]byte(doc)); err != nil {
+		t.Fatalf("ParseServedJSON rejected an unknown field: %v", err)
+	}
+	if _, err := ParseJSON([]byte(doc)); err == nil {
+		t.Error("ParseJSON accepted an unknown field in an operator-authored document")
+	}
+}

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -44,21 +44,21 @@ func (i *Index) AdmitsDigest(digest string) bool {
 	return ok
 }
 
-// AdmitsContainer reports whether a container with the given digest may run the
-// given effective argv (its OCI process.args). Floor digests are admitted
-// regardless of argv. For a workload digest, admission is the union across every
-// entry that lists it: the argv must satisfy some container's command (an exact
-// prefix) and args (the remainder) policy.
-func (i *Index) AdmitsContainer(digest string, argv []string) bool {
-	d, err := types.ParseDigest(digest)
+// AdmitsContainer reports whether an observed container may run. Floor digests
+// are admitted on the digest alone. For a workload digest, admission is the
+// union across every entry that lists it: the observation must satisfy some
+// declared container's argv, mount and env policy together.
+func (i *Index) AdmitsContainer(r RunningContainer) bool {
+	d, err := types.ParseDigest(r.Digest)
 	if err != nil {
 		return false
 	}
 	if i.floor[d.String()] {
 		return true
 	}
+	r.Digest = d.String()
 	for _, c := range i.byDigest[d.String()] {
-		if rest, ok := c.Command.matchCommand(argv); ok && c.Args.matchArgs(rest) {
+		if c.admits(r) {
 			return true
 		}
 	}

--- a/pkg/allowlist/policy_test.go
+++ b/pkg/allowlist/policy_test.go
@@ -7,7 +7,7 @@ func TestIndex_FloorAdmitsAnyArgv(t *testing.T) {
 	if !idx.AdmitsDigest(digestA) {
 		t.Fatal("floor digest not admitted")
 	}
-	if !idx.AdmitsContainer(digestA, []string{"/anything", "--dynamic"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/anything", "--dynamic"}}) {
 		t.Fatal("floor digest must be admitted regardless of argv")
 	}
 }
@@ -18,13 +18,13 @@ func TestIndex_MultiTokenCommandPrefix(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/docker-entrypoint.sh","nginx"]},
 		 "args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/docker-entrypoint.sh", "nginx", "-g", "daemon off;"}}) {
 		t.Fatal("argv starting with the command prefix should be admitted")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/docker-entrypoint.sh"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/docker-entrypoint.sh"}}) {
 		t.Fatal("argv shorter than the command prefix must be rejected")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh", "nginx", "-g"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh", "nginx", "-g"}}) {
 		t.Fatal("a different prefix must be rejected")
 	}
 }
@@ -33,13 +33,13 @@ func TestIndex_FullExact(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/app"]},
 		 "args":{"policy":"exact","argv":["--serve","--port=8080"]}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/app", "--serve", "--port=8080"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--serve", "--port=8080"}}) {
 		t.Fatal("exact command+args should match the concatenation")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh", "--serve", "--port=8080"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh", "--serve", "--port=8080"}}) {
 		t.Fatal("a swapped command must be rejected")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/app", "--serve"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--serve"}}) {
 		t.Fatal("truncated args must be rejected")
 	}
 }
@@ -47,10 +47,10 @@ func TestIndex_FullExact(t *testing.T) {
 func TestIndex_ArgsDenyMeansNoArgs(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"/app"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app"}}) {
 		t.Fatal("args:deny should admit the command with no extra args")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/app", "--exfil"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "--exfil"}}) {
 		t.Fatal("args:deny must reject any extra args")
 	}
 }
@@ -58,10 +58,10 @@ func TestIndex_ArgsDenyMeansNoArgs(t *testing.T) {
 func TestIndex_CommandDenyMeansEmptyArgv(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[
 		{"digest":"`+digestA+`","command":{"policy":"deny"},"args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, nil) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: nil}) {
 		t.Fatal("command:deny should admit an empty argv")
 	}
-	if idx.AdmitsContainer(digestA, []string{"/bin/sh"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/bin/sh"}}) {
 		t.Fatal("command:deny must reject any argv")
 	}
 }
@@ -72,20 +72,20 @@ func TestIndex_SharedDigestUnion(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{
 		"a":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["busybox","sleep"]},"args":{"policy":"exact","argv":["1"]}}]},
 		"b":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["busybox","echo"]},"args":{"policy":"any"}}]}}}`).BuildIndex()
-	if !idx.AdmitsContainer(digestA, []string{"busybox", "sleep", "1"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "sleep", "1"}}) {
 		t.Fatal("first entry's argv should be admitted")
 	}
-	if !idx.AdmitsContainer(digestA, []string{"busybox", "echo", "hi"}) {
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "echo", "hi"}}) {
 		t.Fatal("second entry's argv should be admitted")
 	}
-	if idx.AdmitsContainer(digestA, []string{"busybox", "cat", "/etc/shadow"}) {
+	if idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"busybox", "cat", "/etc/shadow"}}) {
 		t.Fatal("an argv no entry permits must be rejected")
 	}
 }
 
 func TestIndex_UnknownDigestDenied(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","digests":{"`+digestA+`":"x"}}`).BuildIndex()
-	if idx.AdmitsDigest(digestB) || idx.AdmitsContainer(digestB, nil) {
+	if idx.AdmitsDigest(digestB) || idx.AdmitsContainer(RunningContainer{Digest: digestB, Argv: nil}) {
 		t.Fatal("unknown digest must be denied")
 	}
 }

--- a/pkg/attestationclient/rtmr_test.go
+++ b/pkg/attestationclient/rtmr_test.go
@@ -1,0 +1,120 @@
+package attestationclient
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func rtmrHex(b byte) string {
+	return strings.Repeat(hex.EncodeToString([]byte{b}), launchMeasurementSize)
+}
+
+func rtmrBytes(t *testing.T, b byte) []byte {
+	t.Helper()
+	d, err := hex.DecodeString(rtmrHex(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func respWithRTMRs(t *testing.T, platform map[string]string) types.VerifyResponse {
+	t.Helper()
+	var raw json.RawMessage
+	if platform != nil {
+		b, err := json.Marshal(platform)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = b
+	}
+	return types.VerifyResponse{Result: types.VerificationResult{
+		Claims: types.Claims{PlatformData: raw},
+	}}
+}
+
+func TestEnforceRTMRs(t *testing.T) {
+	good := map[string]string{
+		"rtmr_0": rtmrHex(0x00),
+		"rtmr_1": rtmrHex(0x11),
+		"rtmr_2": rtmrHex(0x22),
+		"rtmr_3": rtmrHex(0x33),
+	}
+
+	t.Run("no pins accepts anything", func(t *testing.T) {
+		if err := enforceRTMRs(respWithRTMRs(t, nil), nil); err != nil {
+			t.Fatalf("enforceRTMRs: %v", err)
+		}
+	})
+
+	t.Run("matching pins accepted", func(t *testing.T) {
+		pinned := map[int][]byte{1: rtmrBytes(t, 0x11), 2: rtmrBytes(t, 0x22)}
+		if err := enforceRTMRs(respWithRTMRs(t, good), pinned); err != nil {
+			t.Fatalf("enforceRTMRs: %v", err)
+		}
+	})
+
+	// The whole point: a host boots a different guest image, so the kernel and
+	// command line differ while MRTD is unchanged.
+	t.Run("substituted guest refused", func(t *testing.T) {
+		swapped := map[string]string{}
+		for k, v := range good {
+			swapped[k] = v
+		}
+		swapped["rtmr_2"] = rtmrHex(0xee)
+		pinned := map[int][]byte{1: rtmrBytes(t, 0x11), 2: rtmrBytes(t, 0x22)}
+		err := enforceRTMRs(respWithRTMRs(t, swapped), pinned)
+		if !errors.Is(err, ErrRTMRNotAllowed) || !strings.Contains(err.Error(), "RTMR[2]") {
+			t.Fatalf("error = %v, want a RTMR[2] mismatch", err)
+		}
+	})
+
+	// An SNP quote carries no RTMRs. Pinning one and getting nothing back is a
+	// refusal — silently passing would make the pin decorative on the platform
+	// it was added for.
+	t.Run("pinned but unreported refused", func(t *testing.T) {
+		err := enforceRTMRs(respWithRTMRs(t, nil), map[int][]byte{1: rtmrBytes(t, 0x11)})
+		if !errors.Is(err, ErrRTMRNotAllowed) || !strings.Contains(err.Error(), "not reported") {
+			t.Fatalf("error = %v, want a not-reported refusal", err)
+		}
+	})
+
+	t.Run("malformed register refused", func(t *testing.T) {
+		for _, tc := range []struct{ name, value string }{
+			{"not hex", "zzzz"},
+			{"wrong length", hex.EncodeToString([]byte{1, 2, 3})},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				err := enforceRTMRs(respWithRTMRs(t, map[string]string{"rtmr_1": tc.value}),
+					map[int][]byte{1: rtmrBytes(t, 0x11)})
+				if !errors.Is(err, ErrRTMRNotAllowed) {
+					t.Fatalf("error = %v, want ErrRTMRNotAllowed", err)
+				}
+			})
+		}
+	})
+
+	t.Run("out of range index refused", func(t *testing.T) {
+		err := enforceRTMRs(respWithRTMRs(t, good), map[int][]byte{4: rtmrBytes(t, 0x11)})
+		if !errors.Is(err, ErrRTMRNotAllowed) {
+			t.Fatalf("error = %v, want ErrRTMRNotAllowed", err)
+		}
+	})
+
+	// Errors name the lowest failing register regardless of map iteration
+	// order, so an operator does not get a different message each run.
+	t.Run("error names the lowest failing register", func(t *testing.T) {
+		pinned := map[int][]byte{1: rtmrBytes(t, 0xaa), 2: rtmrBytes(t, 0xbb), 3: rtmrBytes(t, 0xcc)}
+		for i := 0; i < 20; i++ {
+			err := enforceRTMRs(respWithRTMRs(t, good), pinned)
+			if err == nil || !strings.Contains(err.Error(), "RTMR[1]") {
+				t.Fatalf("error = %v, want RTMR[1] every time", err)
+			}
+		}
+	})
+}

--- a/pkg/attestationclient/verify.go
+++ b/pkg/attestationclient/verify.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/sha512"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -31,6 +33,10 @@ var (
 	// that is not hex or not measurement-sized — a malformed result, distinct
 	// from a policy miss.
 	ErrInvalidLaunchDigest = errors.New("attestationclient: launch digest malformed")
+
+	// ErrRTMRNotAllowed: a pinned TDX runtime measurement register is absent,
+	// malformed, or does not match the value the policy pins.
+	ErrRTMRNotAllowed = errors.New("attestationclient: RTMR not allowed")
 
 	// ErrUnsupportedPlatform: [Client.VerifyEvidence] has no verification
 	// rules for the envelope's platform and fails closed.
@@ -92,9 +98,22 @@ type EvidencePolicy struct {
 	// Measurements is the set of acceptable launch measurements; empty
 	// accepts any (callers are expected to warn). The attestation-api
 	// normalizes both the SNP LAUNCH_DIGEST and the TDX MRTD into
-	// claims.launch_digest. This policy does not pin TDX RTMRs, including the
-	// per-workload RTMR[3].
+	// claims.launch_digest.
 	Measurements [][]byte
+
+	// RTMRs pins TDX runtime measurement registers by index, and is what makes
+	// a TDX guest's own bytes attested rather than just its firmware's. MRTD
+	// covers TDVF alone: TDVF measures the guest kernel into RTMR[1] and the
+	// kernel command line — which carries the dm-verity root hash — into
+	// RTMR[2], so without these a host can boot a different guest image and
+	// still produce the pinned MRTD.
+	//
+	// Ignored on SNP, where the command line reaches the launch digest through
+	// kernel-hashes. Absent indices are unpinned; RTMR[0] should stay that way,
+	// as it carries the TD HOB and so varies with the pod's vCPU and memory
+	// shape. RTMR[3] is extended by in-guest software and cannot speak to guest
+	// identity — a substituted guest extends it with whatever it likes.
+	RTMRs map[int][]byte
 }
 
 // VerifyEvidence verifies an attestation evidence envelope against policy via
@@ -143,10 +162,10 @@ func (c Client) verifyTDXEvidence(ctx context.Context, evidence types.Attestatio
 		reportData = policy.ExpectedReportData[:sha512.Size384]
 	}
 
-	// The attestation-api surfaces MRTD as claims.launch_digest. Enforce it
-	// client-side just like SNP's LAUNCH_DIGEST. RTMR pinning is deliberately
-	// separate and not yet represented by EvidencePolicy. MinTcb is also
-	// omitted because the c8s TDX request has no minimum-TCB policy field.
+	// The attestation-api surfaces MRTD as claims.launch_digest, and the raw
+	// RTMRs as hex in claims.platform_data. Both are enforced client-side, so
+	// the policy stays here rather than being asserted by the verifier. MinTcb
+	// is omitted because the c8s TDX request has no minimum-TCB policy field.
 	resp, err := c.VerifyEnforced(ctx, verifyRequest(evidence, reportData, policy.AllowDebug, nil))
 	if err != nil {
 		return types.VerifyResponse{}, err
@@ -154,7 +173,63 @@ func (c Client) verifyTDXEvidence(ctx context.Context, evidence types.Attestatio
 	if err := enforceLaunchMeasurement(resp, policy.Measurements); err != nil {
 		return types.VerifyResponse{}, err
 	}
+	if err := enforceRTMRs(resp, policy.RTMRs); err != nil {
+		return types.VerifyResponse{}, err
+	}
 	return resp, nil
+}
+
+// enforceRTMRs requires each pinned register to byte-equal the value the
+// verifier reported. A pinned register the evidence does not carry is a
+// refusal, not a pass: that is what an SNP quote (or a verifier that stopped
+// reporting them) looks like, and neither says the guest is the expected one.
+func enforceRTMRs(resp types.VerifyResponse, pinned map[int][]byte) error {
+	if len(pinned) == 0 {
+		return nil
+	}
+	var platform struct {
+		RTMR0 string `json:"rtmr_0"`
+		RTMR1 string `json:"rtmr_1"`
+		RTMR2 string `json:"rtmr_2"`
+		RTMR3 string `json:"rtmr_3"`
+	}
+	if len(resp.Result.Claims.PlatformData) > 0 {
+		if err := json.Unmarshal(resp.Result.Claims.PlatformData, &platform); err != nil {
+			return fmt.Errorf("%w: platform data unreadable: %w", ErrRTMRNotAllowed, err)
+		}
+	}
+	reported := [4]string{platform.RTMR0, platform.RTMR1, platform.RTMR2, platform.RTMR3}
+
+	for _, idx := range sortedRTMRIndices(pinned) {
+		want := pinned[idx]
+		if idx < 0 || idx >= len(reported) {
+			return fmt.Errorf("%w: RTMR[%d] does not exist", ErrRTMRNotAllowed, idx)
+		}
+		if reported[idx] == "" {
+			return fmt.Errorf("%w: RTMR[%d] pinned but not reported", ErrRTMRNotAllowed, idx)
+		}
+		got, err := hex.DecodeString(reported[idx])
+		if err != nil {
+			return fmt.Errorf("%w: RTMR[%d] is not hex: %w", ErrRTMRNotAllowed, idx, err)
+		}
+		if len(got) != launchMeasurementSize {
+			return fmt.Errorf("%w: RTMR[%d] is %d bytes, expected %d", ErrRTMRNotAllowed, idx, len(got), launchMeasurementSize)
+		}
+		if !bytes.Equal(got, want) {
+			return fmt.Errorf("%w: RTMR[%d] does not match", ErrRTMRNotAllowed, idx)
+		}
+	}
+	return nil
+}
+
+// sortedRTMRIndices keeps the error an operator sees stable across runs.
+func sortedRTMRIndices(pinned map[int][]byte) []int {
+	idx := make([]int, 0, len(pinned))
+	for i := range pinned {
+		idx = append(idx, i)
+	}
+	sort.Ints(idx)
+	return idx
 }
 
 // enforceLaunchMeasurement validates the verifier's normalized launch digest

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -20,9 +20,19 @@ import (
 type VerifyPolicy struct {
 	// Measurements is the set of acceptable launch measurements (48 bytes each).
 	// If empty, any measurement is accepted (UNSAFE — use only for development).
-	// For SNP this pins LAUNCH_DIGEST; for TDX it pins MRTD. TDX RTMRs are not
-	// covered by this policy, including the per-workload RTMR[3].
+	// For SNP this pins LAUNCH_DIGEST; for TDX it pins MRTD.
 	Measurements [][]byte
+
+	// RTMRs pins TDX runtime measurement registers by index. MRTD covers TDVF
+	// alone, so on TDX it is these — RTMR[1] for the guest kernel, RTMR[2] for
+	// the command line carrying the dm-verity root hash — that make the guest
+	// image itself attested. Ignored on SNP, where kernel-hashes folds the
+	// command line into the launch digest. Empty pins nothing.
+	//
+	// Leave RTMR[0] unpinned: it carries the TD HOB, so it varies with the
+	// pod's vCPU and memory shape. RTMR[3] is extended by in-guest software and
+	// so cannot speak to guest identity.
+	RTMRs map[int][]byte
 
 	// MinTCBVersion is the minimum acceptable platform TCB version.
 	// This is a packed uint64 where each byte represents a component
@@ -114,7 +124,7 @@ type VerifyResult struct {
 //     the TEE (and the report is fresh if nonce is set), plus the debug and
 //     minimum-TCB policy.
 //  2. The launch measurement it returns is checked against
-//     policy.Measurements here.
+//     policy.Measurements here, and any pinned TDX RTMRs against policy.RTMRs.
 func VerifyAttestation(pub crypto.PublicKey, att *Attestation, policy *VerifyPolicy, nonce []byte) (*VerifyResult, error) {
 	if policy == nil {
 		policy = &VerifyPolicy{}
@@ -291,6 +301,7 @@ func verifyEnvelopeOnline(evidence *types.AttestationEvidence, policy *VerifyPol
 		AllowDebug:         policy.AllowDebug,
 		MinTcb:             minTcb,
 		Measurements:       policy.Measurements,
+		RTMRs:              policy.RTMRs,
 	})
 	if err != nil {
 		return nil, mapVerifyError(evidence.Platform, err)


### PR DESCRIPTION
On TDX the launch measurement is MRTD, and MRTD is built from TDVF alone. The guest kernel is measured into RTMR[1] and the kernel command line — which carries the dm-verity root hash — into RTMR[2], neither of which anything checked. A host could boot a different vmlinuz, or the same one against a different verity root hash, produce a byte-identical MRTD, and satisfy every pin. That made the whole in-guest story advisory on TDX: the baked kata-agent policy, the allowlist seed, policy-monitor and /pause_bundle are protected by the verity root hash, and nothing attested it. Client-side verification does not catch it either — the substituted guest measures the same.

The registers were already there for the taking. attestation-rs puts the raw RTMRs in claims.platform_data as hex, so this is enforced client-side exactly the way the launch measurement already is, with no change to the attestation service and no new API surface: EvidencePolicy.RTMRs and ratls.VerifyPolicy.RTMRs, checked in enforceRTMRs.

A pinned register the evidence does not report is a refusal rather than a pass. That is what an SNP quote looks like, and what a verifier that stopped reporting them would look like; neither says the guest is the expected one.

`c8s verify --rtmr <index>=<sha384-hex>` is the operator surface. Indices 0 and 3 are rejected rather than accepted-and-ignored: RTMR[0] carries the TD HOB, so it tracks the pod's vCPU and memory shape and a fleet-wide pin would deny half the fleet; RTMR[3] is extended by in-guest software, so pinning it would look like guest identity while a substituted guest simply extends it with the expected value.

What this does NOT do is derive the expected values. `c8s kata measure --platform tdx` still emits MRTD only; deriving RTMR[1]/[2] means modelling how TDVF measures the kernel and command line, and a wrong predictor denies every TDX pod, so it wants hardware to validate against. Until then an operator pins values read off a boot they trust for other reasons — weaker than deriving them, and still strictly better than not pinning at all.

Docs: the measurement-model note and the claims section said the guest image is covered by the launch measurement, which was only true on SNP. They now say what holds on each platform, and the dangling G6 anchors left by the gap -section dedup in #254 are gone.