### PR TITLE
fix(policy-monitor): bound the advertise-host lookup so the guest still boots

### DIFF
--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -184,24 +184,42 @@ func sandboxDigestsHost(cfg *Config) (string, error) {
 }
 
 // advertiseHostRetryBudget bounds the wait for the guest network to reach a
-// state where the routing-table lookup for CDS returns a real local IP. Kata
-// brings the pod network up after policy-monitor starts, so the first attempts
-// hit `network is unreachable`; that must not permanently latch tokens off.
+// state where the routing-table lookup for CDS returns a real local IP.
+//
+// INVARIANT: advertiseHostStartupBudget must stay well under
+// policy-monitor.service's TimeoutStartSec. This lookup runs before the unit
+// signals READY=1, systemd fails the unit at TimeoutStartSec, and the unit's
+// FailureAction=poweroff-force turns that failure into a dead guest — so an
+// over-long budget here is a boot failure for every kata pod, not a slow start.
+// TestAdvertiseHostBudgetFitsUnitStartTimeout pins the two together.
+//
 // Overridable in tests.
 var (
-	advertiseHostAttempts = 12
-	advertiseHostBackoff  = 5 * time.Second
+	advertiseHostAttempts = 4
+	advertiseHostBackoff  = time.Second
+	// The authoritative bound: whatever the attempt/backoff product works out
+	// to, the lookup gives up once this much wall time has passed.
+	advertiseHostStartupBudget = 5 * time.Second
 )
 
-// resolveSandboxDigestsHostWithRetry keeps retrying the routing-table lookup
-// while the guest's network is still being configured. It returns the last
-// error only when every attempt in the budget failed — the caller then falls
-// back to the same "sandbox tokens disabled" posture it always had.
+// resolveSandboxDigestsHostWithRetry retries the routing-table lookup while the
+// guest's network is still being configured, within a budget that cannot
+// outlast the unit's start timeout. It returns the last error when the budget
+// is exhausted — the caller then falls back to the same "sandbox tokens
+// disabled" posture it always had.
+//
+// The retry only covers a genuinely transient failure. Kata installs the pod
+// network from kata-agent's UpdateInterface RPC, and kata-agent is ordered
+// behind this unit, so a guest that has no route to CDS here will still have
+// none when the budget runs out; waiting longer cannot change that. Resolving
+// the host after READY=1 is what would, and needs the token route to accept a
+// signer installed later — see docs/kata-image-policy.md.
 func resolveSandboxDigestsHostWithRetry(cfg *Config, logger *slog.Logger) (string, error) {
 	// Explicit host bypasses inference entirely — no reason to wait.
 	if cfg.SandboxDigestsAdvertiseHost != "" {
 		return sandboxDigestsHost(cfg)
 	}
+	deadline := time.Now().Add(advertiseHostStartupBudget)
 	var lastErr error
 	for i := 1; i <= advertiseHostAttempts; i++ {
 		host, err := sandboxDigestsHost(cfg)
@@ -212,11 +230,12 @@ func resolveSandboxDigestsHostWithRetry(cfg *Config, logger *slog.Logger) (strin
 			return host, nil
 		}
 		lastErr = err
-		if i < advertiseHostAttempts {
-			logger.Warn("advertise-host inference failed; retrying",
-				"attempt", i, "of", advertiseHostAttempts, "retry_in", advertiseHostBackoff, "error", err)
-			time.Sleep(advertiseHostBackoff)
+		if i == advertiseHostAttempts || !time.Now().Add(advertiseHostBackoff).Before(deadline) {
+			break
 		}
+		logger.Warn("advertise-host inference failed; retrying",
+			"attempt", i, "of", advertiseHostAttempts, "retry_in", advertiseHostBackoff, "error", err)
+		time.Sleep(advertiseHostBackoff)
 	}
 	return "", lastErr
 }

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -5,6 +5,9 @@ package policymonitor
 import (
 	"bytes"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -180,5 +183,66 @@ func TestResolveSandboxDigestsHostWithRetry_ExhaustsBudget(t *testing.T) {
 	// off on the first failure the way the old code did.
 	if got := strings.Count(buf.String(), `"msg":"advertise-host inference failed; retrying"`); got != advertiseHostAttempts-1 {
 		t.Fatalf("got %d retry log lines, want %d; log:\n%s", got, advertiseHostAttempts-1, buf.String())
+	}
+}
+
+// The budget is the authoritative bound, not the attempt/backoff product: an
+// attempt count that would run long stops at the deadline instead.
+func TestResolveSandboxDigestsHostWithRetry_StopsAtBudget(t *testing.T) {
+	prevAttempts := advertiseHostAttempts
+	prevBackoff := advertiseHostBackoff
+	prevBudget := advertiseHostStartupBudget
+	// 100 x 50ms would be 5s of backoff; the budget must cut it far shorter.
+	advertiseHostAttempts = 100
+	advertiseHostBackoff = 50 * time.Millisecond
+	advertiseHostStartupBudget = 200 * time.Millisecond
+	t.Cleanup(func() {
+		advertiseHostAttempts = prevAttempts
+		advertiseHostBackoff = prevBackoff
+		advertiseHostStartupBudget = prevBudget
+	})
+
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	start := time.Now()
+	if _, err := resolveSandboxDigestsHostWithRetry(&Config{
+		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
+	}, logger); err == nil {
+		t.Fatal("want an error once the budget is exhausted")
+	}
+	// Generous ceiling: the point is that it returns in fractions of a second
+	// rather than running all 100 attempts, not the exact stopping instant.
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("lookup blocked for %s; the budget of %s should have cut it short", elapsed, advertiseHostStartupBudget)
+	}
+}
+
+// The lookup runs before policy-monitor signals READY=1, and kata-agent
+// Requires= this unit, so blocking past TimeoutStartSec fails the unit —
+// whose FailureAction=poweroff-force then takes the whole guest down. This
+// asserts the Go budget and the shipped unit file cannot drift into that
+// state again: a previous change set the product to 12 x 5s against a 30s
+// timeout, and every kata pod stopped booting.
+func TestAdvertiseHostBudgetFitsUnitStartTimeout(t *testing.T) {
+	unit := filepath.Join("..", "..", "..", "kata-guest-base", "extra", "etc", "systemd", "system", "policy-monitor.service")
+	raw, err := os.ReadFile(unit)
+	if err != nil {
+		t.Fatalf("read %s: %v", unit, err)
+	}
+	m := regexp.MustCompile(`(?m)^TimeoutStartSec=(\S+)$`).FindSubmatch(raw)
+	if m == nil {
+		t.Fatalf("no TimeoutStartSec= in %s; if the unit no longer bounds startup, this test needs rewriting rather than deleting", unit)
+	}
+	timeout, err := time.ParseDuration(string(m[1]))
+	if err != nil {
+		t.Fatalf("parse TimeoutStartSec=%q: %v", m[1], err)
+	}
+
+	// A third of the window, so the rest of startup (kill-path self-test,
+	// allowlist load, listener bind) still has room even at the budget's worst
+	// case.
+	if limit := timeout / 3; advertiseHostStartupBudget > limit {
+		t.Fatalf("advertiseHostStartupBudget = %s exceeds %s (a third of the unit's TimeoutStartSec=%s); "+
+			"blocking this long before READY=1 fails the unit and poweroff-force kills the guest",
+			advertiseHostStartupBudget, limit, timeout)
 	}
 }


### PR DESCRIPTION
The advertise-host retry added in #247 runs before policy-monitor signals READY=1, and its budget is 12 attempts x 5s = 55s of blocking sleep. 
policy-monitor.service sets TimeoutStartSec=30s with FailureAction=poweroff-force, and kata-agent.service Requires= + After= the unit, so systemd fails the unit at 30s and the guest powers itself off before kata-agent ever starts. Guest console, captured off the qemu console socket:

  [ 1.607] systemd[1]: Starting policy-monitor.service ...
  [ 1.723] advertise-host inference failed; retrying attempt=1 of=12 retry_in=5s
  [56.761] systemd[1]: policy-monitor.service: Failed with result 'timeout'
  [56.762] systemd[1]: Dependency failed for kata-agent.service
  [56.763] systemd[1]: Shutting down.

Every kata pod is affected: the sandbox VM boots, never answers on vsock:1024, and the shim reports "Cannot start VM ... timed out connecting to vsock". A fresh `c8s install --cvm-mode=pod` cannot converge, and #249's heal cannot help because the replacement sandboxes fail the same way.

The lookup now stops at advertiseHostStartupBudget whatever the attempt/backoff product works out to, which restores the boot.

Retrying at all buys little here, and the comment now says so: kata installs the pod network from kata-agent's UpdateInterface RPC, and kata-agent is ordered behind this unit, so a guest with no route to CDS at this point still has none when the budget expires. Resolving the host after READY=1 is what would fix that, and it needs the token route to accept a signer installed later. Binding the listener late instead is not an option - containers share the pod netns, so a workload could squat on 127.0.0.1:8401 before policy-monitor claims it. That work is deliberately out of scope here; this change is scoped to unbreaking the boot.

TestAdvertiseHostBudgetFitsUnitStartTimeout reads TimeoutStartSec out of the shipped unit file and fails if the budget grows past a third of it, so the Go constant and the unit cannot drift apart again. It fails on the 55s value.