### PR TITLE
fix(policy-monitor): read the init-data document after kata-agent writes it

### DIFF
--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -19,6 +19,12 @@ import (
 // plane, that is a host that tampered.
 var errNoInitData = errors.New("policy-monitor: no init-data document")
 
+// The in-guest attestation service has not answered yet. Like errNoInitData
+// this is a "too early" condition rather than a verdict, so the caller waits
+// on it; a digest mismatch or an unparseable document is neither and stops the
+// wait immediately.
+var errAttestUnavailable = errors.New("policy-monitor: attestation service unavailable")
+
 // Bounds the self-attestation; on expiry the caller falls back to the seed.
 const initDataTimeout = 15 * time.Second
 
@@ -42,7 +48,7 @@ func resolveInitDataMeasurements(ctx context.Context, cfg *Config) (string, erro
 
 	hostData, err := selfHostData(ctx, cfg)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("%w: %w", errAttestUnavailable, err)
 	}
 	want := initdata.Digest(raw)
 	if subtle.ConstantTimeCompare(hostData, want[:]) != 1 {
@@ -84,6 +90,60 @@ func applyInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 	cfg.CDSMeasurements = measurements
 	logger.Info("CDS measurements taken from the launch-committed init-data document",
 		"key", initdata.KeyCDSMeasurements)
+}
+
+// initDataWaitBudget bounds how long the guest waits for kata-agent to write
+// the document and for the in-guest attestation service to answer. It runs
+// after READY=1, so it delays only the first allowlist refresh, never the
+// unit's start. Overridable in tests.
+var (
+	initDataWaitBudget   = 90 * time.Second
+	initDataWaitInterval = 2 * time.Second
+)
+
+// awaitInitDataMeasurements is applyInitDataMeasurements for a caller running
+// after READY=1: it waits for the document rather than reading once.
+//
+// kata-agent writes /run/confidential-containers/initdata/initdata.toml during
+// its own startup, and systemd orders kata-agent.service behind this unit
+// (kata-agent.service.d/10-c8s-policy-monitor.conf Requires= + After=). A read
+// on the startup path is therefore always a read of a file the writer has not
+// been allowed to create yet.
+//
+// Waiting is bounded and every outcome still falls back to the baked seed, so
+// a guest whose host delivers no document behaves exactly as before.
+func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Config) {
+	if cfg.CDSMeasurements != "" {
+		return
+	}
+	deadline := time.Now().Add(initDataWaitBudget)
+	var lastErr error
+	for {
+		measurements, err := resolveInitDataMeasurements(ctx, cfg)
+		switch {
+		case err == nil && measurements != "":
+			cfg.CDSMeasurements = measurements
+			logger.Info("CDS measurements taken from the launch-committed init-data document",
+				"key", initdata.KeyCDSMeasurements)
+			return
+		case err == nil:
+			logger.Warn("init-data carries no CDS measurements; allowlist refresh will stay disabled",
+				"key", initdata.KeyCDSMeasurements)
+			return
+		case !errors.Is(err, errNoInitData) && !errors.Is(err, errAttestUnavailable):
+			// A verdict, not a timing problem: host tampering or a document we
+			// cannot parse. Waiting cannot change either.
+			logger.Error("init-data rejected; enforcing the baked seed alone", "error", err)
+			return
+		}
+		lastErr = err
+		if !time.Now().Add(initDataWaitInterval).Before(deadline) {
+			break
+		}
+		time.Sleep(initDataWaitInterval)
+	}
+	logger.Warn("no init-data document within the wait budget; CDS measurements unset, so allowlist refresh will stay disabled",
+		"path", initdata.GuestDocumentPath, "waited", initDataWaitBudget, "error", lastErr)
 }
 
 // selfHostData reads HOST_DATA from a fresh report for this guest. Report data

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -262,5 +263,82 @@ func TestSelfHostDataRejectsUnparseableReport(t *testing.T) {
 
 	if _, err := selfHostData(context.Background(), &Config{AttestationServiceURL: srv.URL}); err == nil {
 		t.Fatal("accepted a report that does not parse")
+	}
+}
+
+// pointInitDataAt aims initDataDocumentPath at a path that does not exist yet,
+// the state every guest is in until kata-agent writes the document.
+func pointInitDataAt(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "initdata.toml")
+	old := initDataDocumentPath
+	initDataDocumentPath = path
+	t.Cleanup(func() { initDataDocumentPath = old })
+	return path
+}
+
+func shortInitDataWait(t *testing.T, budget, interval time.Duration) {
+	t.Helper()
+	prevBudget, prevInterval := initDataWaitBudget, initDataWaitInterval
+	initDataWaitBudget, initDataWaitInterval = budget, interval
+	t.Cleanup(func() { initDataWaitBudget, initDataWaitInterval = prevBudget, prevInterval })
+}
+
+// The regression this fixes: kata-agent writes the document during its own
+// startup, and systemd orders kata-agent.service behind this unit's READY=1,
+// so a single read on the startup path could only ever miss it. The wait has
+// to survive an initially-absent file.
+func TestAwaitInitDataMeasurementsWaitsForKataAgent(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	digest := initdata.Digest(raw)
+	path := pointInitDataAt(t)
+	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
+
+	// Written a beat late, the way kata-agent does.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(path, raw, 0o644)
+	}()
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "aabb,ccdd" {
+		t.Fatalf("CDSMeasurements = %q, want it picked up once kata-agent wrote the document", cfg.CDSMeasurements)
+	}
+}
+
+// A document HOST_DATA does not commit is a verdict, not a timing problem, so
+// the wait must abandon it immediately rather than retry until the budget runs
+// out — otherwise a tampering host delays every guest's refresh.
+func TestAwaitInitDataMeasurementsStopsOnUncommittedDocument(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+	other := initdata.Digest(testDocument(t, "deadbeef"))
+	// A budget that would dominate the test if the tamper path retried.
+	shortInitDataWait(t, time.Minute, 10*time.Second)
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, other[:])}
+	start := time.Now()
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "" {
+		t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed onto the baked seed", cfg.CDSMeasurements)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("tamper verdict took %s; it must not consume the wait budget", elapsed)
+	}
+}
+
+// A host that delivers no document at all leaves the guest exactly where it
+// was before: seed-only enforcement, no measurements.
+func TestAwaitInitDataMeasurementsBudgetExhausted(t *testing.T) {
+	pointInitDataAt(t)
+	shortInitDataWait(t, 100*time.Millisecond, 10*time.Millisecond)
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, 48))}
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "" {
+		t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed onto the baked seed", cfg.CDSMeasurements)
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -145,8 +145,15 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	// *allowlist with m, whose merge is mutex-guarded. No CDS URL →
 	// baked-seed-only and the network is never touched.
 	if cfg.CDSURL != "" {
-		applyInitDataMeasurements(ctx, logger, cfg)
-		go runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
+		// Both steps run here rather than on the startup path because the
+		// document they need is written by kata-agent, which systemd holds
+		// behind this unit's READY=1. cfg.CDSMeasurements is written only in
+		// this goroutine, after the synchronous readers above have finished
+		// with it.
+		go func() {
+			awaitInitDataMeasurements(ctx, logger, cfg)
+			runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
+		}()
 	} else {
 		// Info, not Error: seed-only is the configured intent here, unlike the
 		// failure paths in runAllowlistRefresh. Still recorded, so denies and


### PR DESCRIPTION
applyInitDataMeasurements ran on the startup path, before READY=1. The document it reads is written by kata-agent during kata-agent's own startup, and kata-agent.service.d/10-c8s-policy-monitor.conf makes that unit Requires= + After= policy-monitor.service. The reader was ordered ahead of the writer that unblocks it, so the file could never exist, and every guest logged

  no init-data document; CDS measurements unset, so allowlist refresh will
  stay disabled

for its whole life. This is deterministic, not a race - no boot could ever win it. With C8S_CDS_MEASUREMENTS unset the refresh stays off and the guest enforces only the baked bootstrap seed, so `c8s allowlist add` never reaches enforcement: an operator-signed grant that CDS accepts and serves changes nothing inside the guest. Confirmed on a live SNP cluster - a pod whose image is in the baked seed ran to completion, while an image added with `c8s allowlist add` was refused with its init PID killed.

Resolution moves into the refresh goroutine, which already runs after READY=1, and waits for the document rather than reading once. awaitInitDataMeasurements retries while the answer is "too early" - the file absent, or the in-guest attestation service not yet answering, which needed a sentinel of its own since it was previously indistinguishable from a verdict - and stops immediately on a digest mismatch or an unparseable document, which waiting cannot change. Every failure path still leaves cfg.CDSMeasurements empty, so the fallback is the baked seed exactly as before.

The wait is bounded and runs after the notify, so it delays only the first allowlist refresh, never the unit's start.

Not addressed here: #246 makes the agent wait for a verdict before exec, and a pod's own container is created seconds after its VM boots, so a legitimately allowlisted workload can still be denied if the first refresh has not landed yet. Gating the verdict on "refresh settled" is a follow-up worth deciding deliberately rather than folding in.