### PR TITLE
obs(mesh): record what was granted and what is still guarded

### DIFF
--- a/cmd/ratls-mesh/DESIGN.md
+++ b/cmd/ratls-mesh/DESIGN.md
@@ -442,6 +442,9 @@ folds that snapshot into the same Prometheus text output on `GET /metrics`.
 | `ratls_mesh_iptables_jump_position_violations_total` | counter | — | Watchdog confirmed and repaired a demoted base-chain jump |
 | `ratls_mesh_iptables_jump_position_check_errors_total` | counter | — | Watchdog could not read jump position and reinserted defensively |
 | `ratls_mesh_iptables_ipset_overflow_total` | counter | — | Reconcile saw more pod IPs than `--ipset-maxelem` and left the set stale |
+| `ratls_mesh_iptables_pod_ipset_members` | gauge | — | Pod IPs in the interception ipset (v4+v6). Interception is membership-driven, so a fall means those pods stopped being redirected through the proxy |
+| `ratls_mesh_iptables_cw_ipset_members` | gauge | — | Confidential-workload pod IPs in the cw guard ipset (v4+v6). The guard only drops plaintext to addresses in this set, so zero is enforcement off, not a quiet node |
+| `ratls_mesh_iptables_cw_ipset_shrink_total` | counter | — | Reconciles where the cw ipset came back smaller than the previous one. Expected on a scale-down; unexplained increments mean cw pods stopped being reported by the Kubernetes API |
 | `ratls_mesh_iptables_metrics_file_updated_at_seconds` | gauge | — | Unix-seconds timestamp of the last sidecar metrics snapshot read by the proxy |
 | `ratls_mesh_resolver_cache_entries` | gauge | — | Pod→node cache size |
 | `ratls_mesh_resolver_local_cidrs` | gauge | — | Host-discovered pod-network CIDRs guarding inbound local dials |

--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"math/big"
 	"net/http"
 	"slices"
 	"strings"
@@ -159,7 +160,7 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 	if len(req.SandboxToken) > 0 {
 		sandbox, err = h.verifySandboxToken(ctx, req.SandboxToken, csrPubKey, challengeBytes)
 		if err != nil {
-			slog.Warn("sandbox token rejected", "error", err)
+			slog.Warn("sandbox token rejected", "error", err, "remote_addr", r.RemoteAddr)
 			attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeCSRDenied, err.Error())
 			return
 		}
@@ -183,15 +184,18 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 	verifyResp, err := h.AttestationClient.VerifyEnforced(ctx, verifyReq)
 	if err != nil {
 		status, code, msg := classifyVerifyError(err)
-		slog.Warn("attestation verification failed", "status", status, "error", err)
+		slog.Warn("attestation verification failed", "status", status, "error", err, "remote_addr", r.RemoteAddr)
 		attestation.WriteError(w, status, code, msg)
 		return
 	}
 
+	// Read outside the pinning branch: with h.Measurements empty every
+	// measurement is admitted, so the digest a leaf was issued against is the
+	// only record of what actually attested.
+	launchDigest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest)
 	if len(h.Measurements) > 0 {
-		digest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest)
-		if !h.Measurements[digest] {
-			slog.Warn("measurement not in allowlist", "launch_digest", digest)
+		if !h.Measurements[launchDigest] {
+			slog.Warn("measurement not in allowlist", "launch_digest", launchDigest, "remote_addr", r.RemoteAddr)
 			attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
 			return
 		}
@@ -218,7 +222,8 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 		// the address CDS just dialled, so echoing what happened there would
 		// hand it a reachability oracle for CDS's network position.
 		slog.Warn("sandbox workload rejected",
-			"sandbox_id", sandbox.SandboxID, "inventory_addr", sandbox.InventoryHost, "error", err)
+			"sandbox_id", sandbox.SandboxID, "inventory_addr", sandbox.InventoryHost, "error", err,
+			"remote_addr", r.RemoteAddr)
 		attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeCSRDenied, "sandbox workload not authorized")
 		return
 	}
@@ -259,7 +264,7 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 		}
 		ttl = issuer.CapTTL(ttl, namedTTL)
 	}
-	certPEM, _, err := h.CA.SignCSR(issuer.SignCSRParams{
+	certPEM, serial, err := h.CA.SignCSR(issuer.SignCSRParams{
 		CSR:             csr,
 		TTL:             ttl,
 		Evidence:        evidenceJSON,
@@ -278,13 +283,26 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Naming a leaf is the audit-relevant event: it is what a relying party
-	// later authorizes on. Record which name was stamped, under which policy,
-	// and for which sandbox, so a disputed identity can be reconstructed from
-	// the log alone. The unnamed cases already log their reason above.
-	issued := []any{"cn", csr.Subject.CommonName, "ttl", ttl}
+	// The issuance record is the audit-relevant event: a mesh identity is only
+	// as accountable as what was written down when it was granted, and a leaf
+	// obtained through a forged verdict still reconstructs from this line alone.
+	// serial names the certificate, the SANs name the identity it carries (the
+	// CN does not — the mesh matches on SANs), launch_digest names what attested
+	// for it, and remote_addr says where the request came from — rejections
+	// above carry it too, so a run of denials and the issuance that follows
+	// correlate. A named leaf additionally records the workload, the policy
+	// version it matched under, and the sandbox that vouched, so a disputed
+	// name reconstructs from the log alone.
+	issued := []any{
+		"cn", csr.Subject.CommonName,
+		"sans", csr.DNSNames,
+		"serial", serialHex(serial),
+		"ttl", ttl,
+		"launch_digest", launchDigest,
+		"remote_addr", r.RemoteAddr,
+	}
 	if sandbox.SandboxID != "" {
-		issued = append(issued, "sandbox_id", sandbox.SandboxID)
+		issued = append(issued, "sandbox_id", sandbox.SandboxID, "inventory_addr", sandbox.InventoryHost)
 	}
 	if matched != nil {
 		issued = append(issued,
@@ -295,6 +313,15 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 	slog.Info("certificate issued (in-process)", issued...)
 	w.Header().Set("Content-Type", "application/x-pem-file")
 	w.Write(slices.Concat(certPEM, caChainPEM))
+}
+
+// serialHex renders a certificate serial the way `openssl x509 -serial` does,
+// so an issuance record can be matched against a leaf in hand.
+func serialHex(serial *big.Int) string {
+	if serial == nil {
+		return ""
+	}
+	return fmt.Sprintf("%X", serial)
 }
 
 // verifySandboxToken verifies an inventory-signed sandbox token and returns its

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -637,5 +638,73 @@ func TestAttest_SignFailureReturns500(t *testing.T) {
 	}
 	if !strings.Contains(w.Body.String(), types.ErrorCodeSignFailed) {
 		t.Errorf("body should mention %s; got %s", types.ErrorCodeSignFailed, w.Body.String())
+	}
+}
+
+// The issuance record is the only durable trace that a mesh identity was
+// granted: a forged verdict or a compromised verifier still produces a real
+// leaf, and this line is what an operator reconciles against expected
+// workloads afterwards. The serial has to match the leaf actually returned.
+func TestAttest_IssuanceIsRecorded(t *testing.T) {
+	mock := newMockAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, mock.URL, nil)
+	challenge := issueChallenge(t, h)
+	csrPEM, _ := generateCSR(t)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	chain, err := certutil.ParsePEMCertificates(w.Body.Bytes())
+	if err != nil {
+		t.Fatalf("parse chain: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "certificate issued") {
+		t.Fatalf("no issuance record: %s", logs)
+	}
+	// Names the certificate, so the record can be matched to a leaf in hand.
+	if want := fmt.Sprintf("%X", chain[0].SerialNumber); !strings.Contains(logs, want) {
+		t.Errorf("issuance record omits the leaf serial %s: %s", want, logs)
+	}
+	// Names what attested for it. Logged even with pinning off, which is when
+	// it is the only record of what was admitted.
+	if !strings.Contains(logs, "deadbeef") {
+		t.Errorf("issuance record omits the launch digest: %s", logs)
+	}
+	if !strings.Contains(logs, "launch_digest") || !strings.Contains(logs, "remote_addr") {
+		t.Errorf("issuance record missing expected keys: %s", logs)
+	}
+}
+
+// A denial and the issuance that follows it have to be correlatable, or a run
+// of probes against CDS cannot be tied to the leaf that eventually succeeded.
+func TestAttest_MeasurementDenialRecordsPeer(t *testing.T) {
+	mock := newMockAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, mock.URL, map[string]bool{"cafe": true})
+	challenge := issueChallenge(t, h)
+	csrPEM, _ := generateCSR(t)
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403", w.Code)
+	}
+	logs := buf.String()
+	if !strings.Contains(logs, "measurement not in allowlist") {
+		t.Fatalf("no denial record: %s", logs)
+	}
+	if !strings.Contains(logs, "remote_addr") {
+		t.Errorf("denial record omits the peer: %s", logs)
 	}
 }

--- a/internal/cmds/ratlsmesh/iptables_metrics.go
+++ b/internal/cmds/ratlsmesh/iptables_metrics.go
@@ -25,6 +25,14 @@ type iptablesMetricsSnapshot struct {
 	JumpPositionCheckErrors int64 `json:"jump_position_check_errors"`
 	IPSetOverflows          int64 `json:"ipset_overflows"`
 	CWInboundDrops          int64 `json:"cw_inbound_drops"`
+	// Membership is what the guard and the interception rules key on, so a set
+	// that empties is enforcement that stopped without anything failing. The
+	// sizes make the level observable; CWIPSetShrinks makes the transition
+	// alertable, since a steady zero and a drop to zero read the same on a
+	// gauge scraped every 30s.
+	PodIPSetMembers int64 `json:"pod_ipset_members"`
+	CWIPSetMembers  int64 `json:"cw_ipset_members"`
+	CWIPSetShrinks  int64 `json:"cw_ipset_shrinks"`
 	// UpdatedAtUnixNano is the wall-clock time the sidecar wrote this
 	// snapshot, used by the proxy to expose a freshness gauge so a wedged
 	// iptables-sync (file not advancing) shows up as a stale-timestamp
@@ -51,6 +59,9 @@ func currentIptablesMetricsSnapshot() iptablesMetricsSnapshot {
 		JumpPositionCheckErrors: iptablesJumpPositionCheckErrors(),
 		IPSetOverflows:          iptablesIPSetOverflows(),
 		CWInboundDrops:          iptablesCWInboundDrops(),
+		PodIPSetMembers:         podIPSetMemberCount(),
+		CWIPSetMembers:          cwIPSetMemberCount(),
+		CWIPSetShrinks:          cwIPSetShrinks(),
 		UpdatedAtUnixNano:       time.Now().UnixNano(),
 	}
 }

--- a/internal/cmds/ratlsmesh/metrics.go
+++ b/internal/cmds/ratlsmesh/metrics.go
@@ -45,6 +45,9 @@ type metrics struct {
 	iptablesJumpViolations   prometheus.Gauge
 	iptablesJumpCheckErrors  prometheus.Gauge
 	iptablesIPSetOverflows   prometheus.Gauge
+	iptablesPodIPSetMembers  prometheus.Gauge
+	iptablesCWIPSetMembers   prometheus.Gauge
+	iptablesCWIPSetShrinks   prometheus.Gauge
 	iptablesCWInboundDrops   prometheus.Gauge
 	iptablesMetricsTimestamp prometheus.Gauge
 	resolverCacheSize        prometheus.Gauge
@@ -134,6 +137,18 @@ func newMetrics() *metrics {
 		Name: "ratls_mesh_iptables_ipset_overflow_total",
 		Help: "Sidecar-reported reconcile cycles where pod count exceeded --ipset-maxelem.",
 	})
+	m.iptablesPodIPSetMembers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ratls_mesh_iptables_pod_ipset_members",
+		Help: "Sidecar-reported pod IPs in the interception ipset (v4+v6). Interception is membership-driven, so a drop means those pods stopped being redirected through the proxy.",
+	})
+	m.iptablesCWIPSetMembers = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ratls_mesh_iptables_cw_ipset_members",
+		Help: "Sidecar-reported confidential-workload pod IPs in the cw guard ipset (v4+v6). The guard only drops plaintext to addresses in this set, so a drop to zero is enforcement off, not quiet.",
+	})
+	m.iptablesCWIPSetShrinks = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ratls_mesh_iptables_cw_ipset_shrink_total",
+		Help: "Sidecar-reported reconciles where the cw ipset came back smaller than the previous one. Expected on a scale-down; unexplained increments mean cw pods stopped being reported by the Kubernetes API.",
+	})
 	m.iptablesCWInboundDrops = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ratls_mesh_iptables_cw_inbound_drops_total",
 		Help: "Sidecar-reported packets dropped by the cw guard chain: non-mesh traffic that tried to reach a confidential-workload pod (Service VIP bypass, excluded-namespace or direct-to-pod-IP dials).",
@@ -209,6 +224,9 @@ func newMetrics() *metrics {
 		m.iptablesJumpViolations,
 		m.iptablesJumpCheckErrors,
 		m.iptablesIPSetOverflows,
+		m.iptablesPodIPSetMembers,
+		m.iptablesCWIPSetMembers,
+		m.iptablesCWIPSetShrinks,
 		m.iptablesCWInboundDrops,
 		m.iptablesMetricsTimestamp,
 		m.resolverCacheSize,
@@ -340,6 +358,9 @@ func (m *metrics) refreshIptablesMetrics(path string) error {
 	m.iptablesJumpViolations.Set(float64(snap.JumpPositionViolations))
 	m.iptablesJumpCheckErrors.Set(float64(snap.JumpPositionCheckErrors))
 	m.iptablesIPSetOverflows.Set(float64(snap.IPSetOverflows))
+	m.iptablesPodIPSetMembers.Set(float64(snap.PodIPSetMembers))
+	m.iptablesCWIPSetMembers.Set(float64(snap.CWIPSetMembers))
+	m.iptablesCWIPSetShrinks.Set(float64(snap.CWIPSetShrinks))
 	m.iptablesCWInboundDrops.Set(float64(snap.CWInboundDrops))
 	if snap.UpdatedAtUnixNano > 0 {
 		m.iptablesMetricsTimestamp.Set(float64(snap.UpdatedAtUnixNano / int64(time.Second)))

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -36,6 +36,37 @@ func iptablesIPSetOverflows() int64 {
 	return ipsetOverflows.Load()
 }
 
+// Membership levels for the last reconcile, plus a count of reconciles that
+// shrank the cw set. Absence from these sets is what silently removes
+// interception and the cw guard, so it has to be visible: a gauge alone cannot
+// distinguish "no cw pods on this node" from "the cw pods stopped being
+// reported", and the shrink counter separates them.
+var (
+	lastPodIPSetMembers atomic.Int64
+	lastCWIPSetMembers  atomic.Int64
+	cwIPSetShrinkages   atomic.Int64
+)
+
+func podIPSetMemberCount() int64 { return lastPodIPSetMembers.Load() }
+func cwIPSetMemberCount() int64  { return lastCWIPSetMembers.Load() }
+func cwIPSetShrinks() int64      { return cwIPSetShrinkages.Load() }
+
+// recordIPSetMembership publishes this reconcile's membership levels and counts
+// a cw set that came back smaller than the last one. The first reconcile has no
+// predecessor, so it establishes the level rather than counting a shrink.
+func recordIPSetMembership(logger *slog.Logger, podMembers, cwMembers int) {
+	lastPodIPSetMembers.Store(int64(podMembers))
+	prev := lastCWIPSetMembers.Swap(int64(cwMembers))
+	if prev > int64(cwMembers) {
+		cwIPSetShrinkages.Add(1)
+		// Warn, not Info: every IP that left the set is a confidential workload
+		// the guard no longer drops plaintext to. Routine on a scale-down,
+		// which is why this reports rather than acts.
+		logger.Warn("cw pod ipset shrank; those pods are no longer guarded",
+			"previous_members", prev, "members", cwMembers)
+	}
+}
+
 func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 	if err := validatePort("--outbound-port", cfg.outboundPort); err != nil {
 		return err
@@ -271,6 +302,7 @@ func reconcilePodIPSets(store cache.Store, nodeIPs []string, excludedSourceNames
 			return nil, fmt.Errorf("sync %s: %w", spec.label, err)
 		}
 	}
+	recordIPSetMembership(logger, len(sets.allIPv4)+len(sets.allIPv6), len(sets.cwIPv4)+len(sets.cwIPv6))
 	logger.Debug("pod ipsets reconciled", "ipv4", len(sets.allIPv4), "ipv6", len(sets.allIPv6), "local_ipv4", len(sets.localIPv4), "local_ipv6", len(sets.localIPv6), "cw_ipv4", len(sets.cwIPv4), "cw_ipv6", len(sets.cwIPv6))
 	return append(append([]string{}, sets.cwIPv4...), sets.cwIPv6...), nil
 }

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux_test.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux_test.go
@@ -5,6 +5,7 @@ package ratlsmesh
 import (
 	"errors"
 	"io/fs"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -393,5 +394,74 @@ Header: family inet6 hashsize 1024 maxelem 1024
 				t.Fatalf("maxelem = %d; want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+// Membership is what the cw guard keys on, so a set that empties is
+// enforcement that stopped. The counter is what separates that from a node
+// that never had cw pods.
+func TestRecordIPSetMembership_CountsShrinkNotSteadyState(t *testing.T) {
+	lastPodIPSetMembers.Store(0)
+	lastCWIPSetMembers.Store(0)
+	cwIPSetShrinkages.Store(0)
+	logger := slog.New(slog.DiscardHandler)
+
+	// First reconcile establishes the level; there is no predecessor to shrink
+	// from, so an initial zero must not read as a shrink.
+	recordIPSetMembership(logger, 0, 0)
+	if got := cwIPSetShrinks(); got != 0 {
+		t.Fatalf("shrinks after first reconcile = %d, want 0", got)
+	}
+
+	recordIPSetMembership(logger, 5, 3)
+	if got := cwIPSetMemberCount(); got != 3 {
+		t.Errorf("cw members = %d, want 3", got)
+	}
+	if got := podIPSetMemberCount(); got != 5 {
+		t.Errorf("pod members = %d, want 5", got)
+	}
+	if got := cwIPSetShrinks(); got != 0 {
+		t.Errorf("growth counted as a shrink: %d", got)
+	}
+
+	// The case the metric exists for: the set comes back smaller, so those pods
+	// are no longer guarded.
+	recordIPSetMembership(logger, 5, 0)
+	if got := cwIPSetShrinks(); got != 1 {
+		t.Errorf("shrinks = %d, want 1", got)
+	}
+	if got := cwIPSetMemberCount(); got != 0 {
+		t.Errorf("cw members = %d, want 0", got)
+	}
+
+	// A steady zero is not a repeated shrink — otherwise the counter climbs on
+	// every reconcile of an idle node and the signal is worthless.
+	recordIPSetMembership(logger, 5, 0)
+	if got := cwIPSetShrinks(); got != 1 {
+		t.Errorf("steady zero counted again: shrinks = %d, want 1", got)
+	}
+}
+
+// The snapshot the proxy reads must carry the membership levels, or the
+// gauges sit at zero while the sidecar knows better.
+func TestIptablesMetricsSnapshot_CarriesIPSetMembership(t *testing.T) {
+	lastPodIPSetMembers.Store(7)
+	lastCWIPSetMembers.Store(2)
+	cwIPSetShrinkages.Store(4)
+	t.Cleanup(func() {
+		lastPodIPSetMembers.Store(0)
+		lastCWIPSetMembers.Store(0)
+		cwIPSetShrinkages.Store(0)
+	})
+
+	snap := currentIptablesMetricsSnapshot()
+	if snap.PodIPSetMembers != 7 {
+		t.Errorf("PodIPSetMembers = %d, want 7", snap.PodIPSetMembers)
+	}
+	if snap.CWIPSetMembers != 2 {
+		t.Errorf("CWIPSetMembers = %d, want 2", snap.CWIPSetMembers)
+	}
+	if snap.CWIPSetShrinks != 4 {
+		t.Errorf("CWIPSetShrinks = %d, want 4", snap.CWIPSetShrinks)
 	}
 }


### PR DESCRIPTION
Two trust decisions were made without leaving anything to reconcile against. CDS logged a mesh leaf as a CN and nothing else -- not the SANs the mesh actually matches
  on, not the measurement that attested for it, not the serial that names it -- so a leaf obtained through a forged /verify verdict was indistinguishable from a legitimate one
  afterwards, and it stays valid for cds.certTTL with no revocation. The launch digest is now read outside the pinning branch: with cds.measurements empty, which is the shipping
  default, it is the only record of what was admitted. The rejection paths carry the peer address so a run of denials and the issuance that followed correlate.

ratls-mesh's interception and cw guard are both keyed on ipset membership rebuilt wholesale from informer state, so a pod that stops being reported silently loses both
  -- traffic to it is delivered in plaintext and nothing fails. Membership levels are now exported, plus a counter for reconciles where the cw set came back smaller: a gauge
  alone cannot separate an idle node from one whose cw pods vanished, and a drop-and-restore between scrapes shows up on neither.

Both are observability. Neither makes the underlying gap harder to exploit -- that needs a signed verify response and a cw guard that denies on absence of proof rather
  than granting on presence.