### PR TITLE
kata-guest-base: re-pin a cached checkout's stale digest instead of dying

### DIFF
--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -340,11 +340,12 @@ PAUSE_VER="$(yq '.externals.pause.version' "${KATA_SRC}/versions.yaml")"
 
 # Pin osbuilder's rootfs-builder base structurally: rewrite its Dockerfile FROM (mutable ubuntu tag) to the digest, so a kata bump that reshapes the line dies here instead of silently unpinning.
 UBUNTU_DOCKERFILE="${OSBUILDER}/rootfs-builder/ubuntu/Dockerfile.in"
-if grep -qF 'FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@' "${UBUNTU_DOCKERFILE}"; then
-    sed -i 's|^FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@$|FROM ${IMAGE_REGISTRY}/ubuntu@'"${UBUNTU_BASE_DIGEST}"'|' "${UBUNTU_DOCKERFILE}"
+if ! grep -qF "FROM \${IMAGE_REGISTRY}/ubuntu@${UBUNTU_BASE_DIGEST}" "${UBUNTU_DOCKERFILE}"; then
+    # Tag form (pristine checkout) or a stale digest (cached checkout after a pin bump) both rewrite; anything else means kata reshaped the line.
+    grep -qE '^FROM \$\{IMAGE_REGISTRY\}/ubuntu[@:]' "${UBUNTU_DOCKERFILE}" \
+        || die "rootfs-builder Dockerfile.in FROM line is not the expected ubuntu form — kata ${KATA_SRC_COMMIT} moved; re-base the UBUNTU_BASE_DIGEST rewrite."
+    sed -i 's|^FROM ${IMAGE_REGISTRY}/ubuntu[@:].*$|FROM ${IMAGE_REGISTRY}/ubuntu@'"${UBUNTU_BASE_DIGEST}"'|' "${UBUNTU_DOCKERFILE}"
 fi
-grep -qF "FROM \${IMAGE_REGISTRY}/ubuntu@${UBUNTU_BASE_DIGEST}" "${UBUNTU_DOCKERFILE}" \
-    || die "rootfs-builder Dockerfile.in FROM line is not the expected ubuntu tag form — kata ${KATA_SRC_COMMIT} moved; re-base the UBUNTU_BASE_DIGEST rewrite."
 
 # osbuilder writes the rootfs tree and the image under paths we control,
 # so the overlay can be injected between the two phases.


### PR DESCRIPTION
Follow-up to #254 (the commit landed on that branch just after it merged). A persistent WORK_DIR keeps the rewritten kata source across builds, so after a digest bump the rewrite found neither the tag form nor the new digest and died blaming a kata move. Rewrite now handles the tag form and any previous digest; it dies only when the FROM line has a genuinely unexpected shape. Exercised all four cases (tag form, stale digest, current digest, reshaped line).