### PR TITLE
test(ratls): fix TestProxyRunEndToEnd flake under coverage

### DIFF
--- a/internal/cmds/ratlsmesh/proxy_serve_test.go
+++ b/internal/cmds/ratlsmesh/proxy_serve_test.go
@@ -355,6 +355,12 @@ func TestProxyRunEndToEnd(t *testing.T) {
 	})
 
 	for i := range 3 {
+		// Both slots release in the handlers' deferred cleanup, after the
+		// client already saw EOF. Dialing again before they drain races the
+		// release and the accept loop rejects (RSTs) the new connection at
+		// the global limit.
+		assertEventually(t, 5*time.Second, func() bool { return len(f.p.connSem) == 0 },
+			"semaphore slots not released after the previous connection")
 		want := fmt.Sprintf(`hello from run-e2e (got "ping-%d")`, i)
 		if got := f.roundTrip(t, fmt.Sprintf("ping-%d", i)); got != want {
 			t.Fatalf("connection %d: got %q, want %q", i, got, want)


### PR DESCRIPTION
## Problem

TestProxyRunEndToEnd fails the Coverage gate (main's latest CI run included) with `read: connection reset by peer`. The test's sequential round trips assume both semaphore slots are free once the client sees EOF, but the slots release in the handler goroutines' deferred cleanup, which runs after that. The next dial races the release; at capacity 2 the accept loop rejects the new connection and closes it with the payload unread, which surfaces as an RST on the client read. Coverage instrumentation widens the window enough to hit it every run.

## Fix

Wait for the semaphore to drain (`len(connSem) == 0`) before each round trip, using the test file's existing assertEventually helper. Test-only change; the proxy's release-after-teardown behavior is intended.