### PR TITLE
e2e(snp-metal): configure sandbox inventory CIDRs so CDS stops denying CSRs

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -148,6 +148,8 @@ jobs:
                                   # resurfaces -> CDS Pending (run 29536583462).
             ratlsPlatform: sev-snp
             measurements: ["RUNTIME_MEASUREMENT"]
+            # NODE_CIDR placeholder: payload substitutes the node's InternalIP/32 (matching `c8s install`'s per-node host routes) — CDS fail-closes sandbox-token CSRs without it (#168; this lane writes raw values, so `c8s install` never fills it).
+            sandboxInventoryCIDRs: ["NODE_CIDR"]
           attestationApi:
             image:
               tag: "$AATAG"
@@ -200,7 +202,7 @@ jobs:
           CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
 
           # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
-          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' > /tmp/gate-vals.yaml
+          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' | sed 's|NODE_CIDR|10.0.0.1/32|' > /tmp/gate-vals.yaml
           helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
           echo "render gate: chart+values validate clean"
 
@@ -216,8 +218,11 @@ jobs:
           \$K create ns c8s-system >/dev/null 2>&1
           \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
           if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
+          NODEIP=\$(\$K get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
+          { printf '%s' "\$NODEIP" | grep -qE '^[0-9.]+\$'; } || { say FAIL_NODEIP; exit 0; }
+          say "NODE_CIDR \$NODEIP/32"
           { printf 'apiVersion: helm.cattle.io/v1\nkind: HelmChart\nmetadata:\n  name: c8s\n  namespace: kube-system\nspec:\n  chartContent: %s\n  targetNamespace: c8s-system\n  createNamespace: false\n  valuesContent: |\n' "\$CC"
-            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed 's/^/    /'
+            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed "s|NODE_CIDR|\$NODEIP/32|" | sed 's/^/    /'
           } | \$K apply -f - 2>&1 | sed 's/^/@@HCAPPLY /;s/\$/@@/'
           say \$MMARK
           HOK=0


### PR DESCRIPTION
The snp-metal cvm lane has failed on every run since #168 with `csr_denied: sandbox token presented but no inventory CIDRs are configured to bound the callback` — the demo workload's injected c8s-cert sidecar never gets its certificate, so it never reports PAYLOAD_OK (verified identical signature on yesterday's pre-v0.3.0 run, so unrelated to the confos bump).

Root cause: CDS fail-closes sandbox-token CSRs without configured inventory CIDRs (#168), and this lane writes raw chart values into a HelmChart CR — bypassing `c8s install`, which is what normally resolves and injects `cds.sandboxInventoryCIDRs` as per-node host routes. Same class of gap as the `deriveComponents` fix already documented in this file.

Fix, using the lane's existing placeholder+sed pattern (`RUNTIME_MEASUREMENT` precedent):
- values gain `sandboxInventoryCIDRs: ["NODE_CIDR"]`
- the in-guest payload substitutes the single node's `InternalIP/32` (exactly what `c8s install`'s `inferInventoryCIDRs` emits), with a `FAIL_NODEIP` marker if the lookup fails
- the runner-side render gate substitutes a dummy CIDR so `helm template` still validates the values

Tested via workflow_dispatch of `confidential-e2e` on this branch (run linked in comments once green).