### PR TITLE
node-guest-image: own the node-image definition here (phase 0 of #264)

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -50,7 +50,7 @@ env:
   # SHA (checkout fetches it as a ref). Pinned, not main: bumping it changes
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main.
-  CONFOS_REF: "3e6f858f93e1b85c6d1473aa4a031fdefb387710" # v0.3.0
+  CONFOS_REF: "01539a8c8e139228918b76215a1d5168bc22f9a6" # post-v0.3.0 main: --profile-dir/--sync-input (#81 in confos)
 
 jobs:
   build-and-push:

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -1,0 +1,97 @@
+# PERMANENT lint for node-guest-image/ — the four invariants that moved here
+# with the c8s profile from confos bin/lint (c8s#264). Unlike the TEMP
+# node-guest-image-sync workflow (byte-diff, deleted at the flip), these
+# outlive the migration: they lint content this repo owns. The fragment
+# superset checks compare against confos's gpu/dev fragments at the pinned
+# CONFOS_REF — the exact tree the image builds with.
+name: node-guest-image lint
+
+on:
+  pull_request:
+    paths:
+      - "node-guest-image/**"
+      - ".github/workflows/node-guest-image-lint.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: node-guest-image invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Resolve pinned CONFOS_REF
+        id: ref
+        run: |
+          ref=$(grep -oE 'CONFOS_REF: "[0-9a-f]{40}"' .github/workflows/c8s-image.yml | grep -oE '[0-9a-f]{40}')
+          [ -n "$ref" ] || { echo "::error::could not extract CONFOS_REF from c8s-image.yml"; exit 1; }
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          repository: confidential-dot-ai/confidential-os-builder
+          ref: ${{ steps.ref.outputs.ref }}
+          path: confos
+
+      - name: Fragment supersets, NRI floor template, nested pod CIDRs
+        run: |
+          set -euo pipefail
+          ngi=node-guest-image
+
+          # kernel/c8s.config must be a superset of confos kernel/gpu.config:
+          # only one --kernel-config-fragment is accepted per build, so the
+          # c8s fragment duplicates the gpu lines verbatim. Catch drift when
+          # gpu.config changes under the pinned CONFOS_REF.
+          missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' confos/kernel/gpu.config \
+                    | grep -vFxf "$ngi/kernel/c8s.config" || true)
+          if [ -n "$missing" ]; then
+            echo "::error::$ngi/kernel/c8s.config must contain every effective line of confos kernel/gpu.config; missing:"
+            echo "$missing"
+            exit 1
+          fi
+
+          # c8s-dev.config (C8S_DEV=1 demo builds) is the union of c8s.config
+          # and confos dev.config, committed verbatim for the same one-fragment
+          # reason.
+          for src in "$ngi/kernel/c8s.config" confos/kernel/dev.config; do
+            missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' "$src" \
+                      | grep -vFxf "$ngi/kernel/c8s-dev.config" || true)
+            if [ -n "$missing" ]; then
+              echo "::error::$ngi/kernel/c8s-dev.config must contain every effective line of $src; missing:"
+              echo "$missing"
+              exit 1
+            fi
+          done
+
+          # The baked NRI floor is a template whose always_allow entries are
+          # @-tokens the sync fills with ref-resolved digests; a hardcoded
+          # sha256 would bake a stale digest the fail-closed floor can't
+          # reconcile with the ref.
+          policy="$ngi/c8s/image-policy.yaml.in"
+          [ -f "$policy" ] || { echo "::error::NRI floor template $policy not found"; exit 1; }
+          if grep -qE '^[[:space:]]*"sha256:[a-f0-9]{64}"[[:space:]]*:' "$policy"; then
+            echo "::error::$policy has a hardcoded always_allow digest; use @NRI_DIGEST@/@CDS_DIGEST@ tokens (rendered from C8S_REF by mkosi.sync)"
+            exit 1
+          fi
+
+          # The c8s node is normally nested in an outer RKE2 cluster: its pod
+          # CIDR must not fall back to the outer cluster's default, and
+          # Cilium's pool must exactly match the RKE2 server setting or pods
+          # receive unroutable IPs.
+          rke2_config="$ngi/c8s/mkosi.extra/etc/rancher/rke2/config.yaml"
+          cilium_config="$ngi/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml"
+          rke2_pod_cidr=$(sed -n 's/^cluster-cidr:[[:space:]]*//p' "$rke2_config")
+          cilium_pod_cidr=$(sed -n '/clusterPoolIPv4PodCIDRList:/,/^[^[:space:]]/s/^[[:space:]]*-[[:space:]]*//p' "$cilium_config" | head -n 1)
+          if [ -z "$rke2_pod_cidr" ] || [ "$rke2_pod_cidr" = "10.42.0.0/16" ]; then
+            echo "::error::c8s RKE2 cluster-cidr must be explicit and must not overlap the outer RKE2 default"
+            exit 1
+          fi
+          if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
+            echo "::error::c8s RKE2 cluster-cidr ($rke2_pod_cidr) must match Cilium IPAM ($cilium_pod_cidr)"
+            exit 1
+          fi
+
+          echo "all node-guest-image invariants hold at CONFOS_REF ${{ steps.ref.outputs.ref }}"

--- a/.github/workflows/node-guest-image-sync.yml
+++ b/.github/workflows/node-guest-image-sync.yml
@@ -1,0 +1,53 @@
+# TEMP guard for the c8s#264 transition window: while the c8s profile exists
+# both here (node-guest-image/) and in confidential-os-builder, nothing else
+# enforces that the two stay byte-identical — the phase-0 measurement gate is
+# only honest if the copies never drift. Delete this workflow in the flip PR
+# that switches c8s-image.yml to node-guest-image/build (phase 1 removes the
+# confos copy, after which this diff has nothing to compare).
+name: node-guest-image sync
+
+on:
+  pull_request:
+    paths:
+      - "node-guest-image/**"
+      - ".github/workflows/node-guest-image-sync.yml"
+  # Weekly: catches drift introduced on the confos side, which no c8s PR
+  # would otherwise trigger on.
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  diff:
+    name: node-guest-image matches confos at pinned CONFOS_REF
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      # The pin in c8s-image.yml names the confos this repo builds with; that
+      # is the tree the copies must match.
+      - name: Resolve pinned CONFOS_REF
+        id: ref
+        run: |
+          ref=$(grep -oE 'CONFOS_REF: "[0-9a-f]{40}"' .github/workflows/c8s-image.yml | grep -oE '[0-9a-f]{40}')
+          [ -n "$ref" ] || { echo "::error::could not extract CONFOS_REF from c8s-image.yml"; exit 1; }
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          repository: confidential-dot-ai/confidential-os-builder
+          ref: ${{ steps.ref.outputs.ref }}
+          path: confos
+
+      - name: Diff profile and kernel fragments
+        run: |
+          set -euo pipefail
+          fail=0
+          diff -ru confos/mkosi/base/mkosi.profiles/c8s node-guest-image/c8s || fail=1
+          diff -u confos/kernel/c8s.config node-guest-image/kernel/c8s.config || fail=1
+          diff -u confos/kernel/c8s-dev.config node-guest-image/kernel/c8s-dev.config || fail=1
+          [ "$fail" = 0 ] || { echo "::error::node-guest-image drifted from confos at the pinned CONFOS_REF — sync the copies (or, post phase-1, delete this workflow)"; exit 1; }
+          echo "byte-identical at CONFOS_REF ${{ steps.ref.outputs.ref }}"

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -25,7 +25,7 @@ Layout:
 
 Migration state (see [#264] for the full plan):
 
-1. Content here is a verbatim copy of confos main at v0.3.0 (`3e6f858`);
+1. Content here is a verbatim copy of confos main at `01539a8` (post-v0.3.0: the merged --profile-dir/--sync-input revision);
    nothing consumes it yet. While both copies exist, the
    `node-guest-image sync` workflow (PR-triggered + weekly) fails on any
    byte drift between this dir and confos at the pinned `CONFOS_REF` —

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -29,7 +29,11 @@ Migration state (see [#264] for the full plan):
    nothing consumes it yet. While both copies exist, the
    `node-guest-image sync` workflow (PR-triggered + weekly) fails on any
    byte drift between this dir and confos at the pinned `CONFOS_REF` —
-   delete that workflow in the flip PR.
+   delete that workflow in the flip PR. The `node-guest-image lint`
+   workflow is permanent: it carries the four invariants that moved here
+   from confos `bin/lint` (fragment supersets vs confos's gpu/dev
+   fragments at the pinned ref, the NRI floor template's no-hardcoded-
+   digest rule, and the nested RKE2/Cilium pod-CIDR match).
 2. `--profile-dir` refuses to shadow an in-tree profile, so building from
    here requires a confos ref with `mkosi.profiles/c8s` deleted (the
    phase-1 confos PR). The switch gate: build the same c8s ref both ways

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -26,7 +26,10 @@ Layout:
 Migration state (see [#264] for the full plan):
 
 1. Content here is a verbatim copy of confos main at v0.3.0 (`3e6f858`);
-   nothing consumes it yet.
+   nothing consumes it yet. While both copies exist, the
+   `node-guest-image sync` workflow (PR-triggered + weekly) fails on any
+   byte drift between this dir and confos at the pinned `CONFOS_REF` —
+   delete that workflow in the flip PR.
 2. `--profile-dir` refuses to shadow an in-tree profile, so building from
    here requires a confos ref with `mkosi.profiles/c8s` deleted (the
    phase-1 confos PR). The switch gate: build the same c8s ref both ways

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -35,6 +35,10 @@ Migration state (see [#264] for the full plan):
    (its kernel cache key must hash the fragment paths here instead of
    confos's), confos deletes its copy, and profile changes become one-PR
    changes in this repo.
+4. Post-flip cleanup, so the inherited interface doesn't become canonical
+   by default: flatten the `C8S_NO_GPU`/`C8S_STOCK_ATTEST` boolean combos
+   (which silently ignore nonsense pairings) into a single variant
+   selector.
 
 [confidential-os-builder]: https://github.com/confidential-dot-ai/confidential-os-builder
 [#264]: https://github.com/confidential-dot-ai/c8s/issues/264

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -1,0 +1,40 @@
+# node-guest-image
+
+The c8s node image (`c8s-base`, `rke2[-cdi]-*` tags), defined in THIS repo
+and built by [confidential-os-builder] acting purely as a builder — the same
+ownership split `kata-guest-base/` already has with confos as a pinned tool.
+Tracking issue: [#264].
+
+Layout:
+
+- `c8s/` — the mkosi profile (config, `mkosi.extra/`, `mkosi.sync`,
+  cloud-init `user-data`). Staged into the confos build via
+  `confos build --profile-dir` (confos ≥ the release carrying
+  confidential-os-builder#81); the dir basename **is** the profile name, so
+  it must stay `c8s`.
+- `kernel/` — the guest-kernel config fragments (`c8s.config`,
+  `c8s-dev.config`), passed via `--kernel-config-fragment` exactly like
+  kata-guest-base's `container.config`. confos's `required`/`hardening`
+  baselines stay in confos: a fragment request that conflicts with them
+  fails the build (see the balloon catch in #263).
+- `build` — drop-in replacement for confos's `bin/build-c8s`: same env
+  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NO_GPU`,
+  `C8S_STOCK_ATTEST`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
+  and order; only the c8s profile content and kernel fragments come from
+  here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
+
+Migration state (see [#264] for the full plan):
+
+1. Content here is a verbatim copy of confos main at v0.3.0 (`3e6f858`);
+   nothing consumes it yet.
+2. `--profile-dir` refuses to shadow an in-tree profile, so building from
+   here requires a confos ref with `mkosi.profiles/c8s` deleted (the
+   phase-1 confos PR). The switch gate: build the same c8s ref both ways
+   and require identical `manifest.json` measurements.
+3. After the gate passes, `c8s-image.yml` flips to `node-guest-image/build`
+   (its kernel cache key must hash the fragment paths here instead of
+   confos's), confos deletes its copy, and profile changes become one-PR
+   changes in this repo.
+
+[confidential-os-builder]: https://github.com/confidential-dot-ai/confidential-os-builder
+[#264]: https://github.com/confidential-dot-ai/c8s/issues/264

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Build the c8s node image from THIS repo's profile, using a
+# confidential-os-builder checkout purely as the builder (c8s#264).
+# Drop-in replacement for confos's bin/build-c8s: same env contract
+# (C8S_REF, C8S_REGISTRY, C8S_DEV, C8S_NO_GPU, C8S_STOCK_ATTEST, C8S_NAME,
+# C8S_MEMORY), same profile stack and order — only the c8s profile content
+# and kernel fragments come from ./c8s and ./kernel here.
+set -euo pipefail
+NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}
+[ -x "$CONFOS_DIR/bin/confos" ] || { echo "node-guest-image/build: confos checkout not found at $CONFOS_DIR (set CONFOS_DIR)" >&2; exit 1; }
+cd "$CONFOS_DIR"
+mkdir -p mkosi/base/mkosi.local
+printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
+printf '%s\n' "${C8S_REGISTRY:-}" > mkosi/base/mkosi.local/c8s-registry
+FRAGMENT="$NGI_DIR/kernel/c8s.config"
+DEV_PROFILE=()
+if [ "${C8S_DEV:-0}" = 1 ]; then
+    FRAGMENT="$NGI_DIR/kernel/c8s-dev.config"
+    DEV_PROFILE=(--profile dev)
+    : "${C8S_NAME:=c8s-dev}"
+fi
+KB_PKGS=dwarves,python3,pkg-config,zlib1g-dev
+bin/confos kernel \
+    --kernel-config-fragment "$FRAGMENT" \
+    --kernel-builder-package "$KB_PKGS"
+if [ "${C8S_NO_GPU:-0}" = 1 ]; then
+    PROFILES=(--profile attest --profile c8s)
+elif [ "${C8S_STOCK_ATTEST:-0}" = 1 ]; then
+    PROFILES=(--profile gpu --profile attest --profile c8s)
+    bin/steep-fetch-gpu
+else
+    PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
+    bin/steep-fetch-gpu
+    bin/steep-fetch-attest-gpu
+fi
+exec bin/confos build "${C8S_NAME:-c8s}" \
+    "${PROFILES[@]}" \
+    ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
+    --profile-dir "$NGI_DIR/c8s" \
+    --kernel-config-fragment "$FRAGMENT" \
+    --kernel-builder-package "$KB_PKGS" \
+    --cloud-init "$NGI_DIR/c8s/user-data" \
+    --platform tdx \
+    --memory "${C8S_MEMORY:-16G}" \
+    "$@"

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -1,10 +1,65 @@
 #!/usr/bin/env bash
 # Build the c8s node image from THIS repo's profile, using a
 # confidential-os-builder checkout purely as the builder (c8s#264).
-# Drop-in replacement for confos's bin/build-c8s: same env contract
-# (C8S_REF, C8S_REGISTRY, C8S_DEV, C8S_NO_GPU, C8S_STOCK_ATTEST, C8S_NAME,
-# C8S_MEMORY), same profile stack and order — only the c8s profile content
-# and kernel fragments come from ./c8s and ./kernel here.
+# Drop-in replacement for confos's bin/build-c8s: same env contract and
+# profile stack/order — only the c8s profile content (./c8s, staged via
+# --profile-dir) and the kernel fragments (./kernel) come from here, and
+# C8S_REF / C8S_REGISTRY reach the profile's mkosi.sync via --sync-input
+# (an exported var never reaches the sync: mkosi runs under sudo, which
+# strips the env).
+#
+# The full GPU node image is base + gpu + attest-gpu + c8s. That takes
+# four ordered steps because all host-side staging must precede one
+# `confos build` (the Rust driver wipes mkosi.local on build exit) and the
+# NVIDIA modules must compile against the already-built kernel tree:
+#
+#   1. confos kernel          — build/cache the kernel with kernel/c8s.config
+#   2. bin/steep-fetch-gpu    — build+sign NVIDIA modules, stage userspace
+#   3. bin/steep-fetch-attest-gpu — pre-stage the GPU attestation-api binary
+#      + libnvat into mkosi.local (set ATTEST_GPU_BIN + LIBNVAT; CI builds the
+#      binary with --features nvidia-gpu-attest against a vendored libnvat)
+#   4. confos build           — the c8s profile's own mkosi.sync fetches
+#      rke2 + airgap bundles + nri-image-policy during this step
+#
+# The final build hits the kernel cache (same fragment fingerprint — the
+# fingerprint hashes the fragment's content, wherever it lives) so it does
+# not rebuild and clobber the tree the modules were built against.
+#
+# Knobs:
+#   C8S_NO_GPU=1       GPU-less validation image: `attest` + `c8s` profiles
+#                      only (attestation-api still baked; compose ssh/dev
+#                      manually via extra args). Validation-only, never
+#                      publish: without the gpu profile nothing latches
+#                      kernel.modules_disabled=1, so module loading stays
+#                      enabled for the whole boot.
+#   C8S_STOCK_ATTEST=1 compose the stock `attest` profile instead of
+#                      `attest-gpu`: same attestation-api service on :8400,
+#                      TDX+SNP quotes, but no GPU (SPDM) evidence collection.
+#                      Use when a build environment lacks libnvat / can't build
+#                      the nvidia-gpu-attest binary. The default (this var
+#                      unset) composes attest-gpu, which CI supports via a
+#                      vendored libnvat + steep-fetch-attest-gpu pre-stage.
+#   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
+#                      (8250 serial re-enabled) + the dev profile
+#                      (console=ttyS0, passwordless serial autologin).
+#                      Different measurement, root shell on the host-visible
+#                      serial socket — never ship. Default name: c8s-dev.
+#   C8S_NAME=...       output name (default c8s → output/c8s/)
+#   C8S_MEMORY=...     default-memory recorded in the manifest / used by
+#                      `confos run` (default 16G — etcd OOMs at the 4G default)
+#   C8S_REF=...        bake the c8s components (nri plugin + the CDS digest in
+#                      the NRI floor) from a specific c8s COMMIT (short SHA)
+#                      instead of the pin in the c8s profile's mkosi.sync,
+#                      which resolves nri-image-policy:<ref> and cds:<ref> to
+#                      digests. The images must be published first (c8s
+#                      docker.yml on main, or workflow_dispatch for a branch).
+#                      Use to test an unmerged c8s build end-to-end.
+#   CONFOS_DIR=...     confos checkout to build with (default: sibling of this
+#                      repo's checkout).
+#
+# Extra args are passed through to `confos build`, e.g.:
+#   node-guest-image/build --profile ssh          # + SSH for bring-up debugging
+#   C8S_NO_GPU=1 node-guest-image/build --profile dev
 set -euo pipefail
 NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Build the c8s node image from THIS repo's profile, using a
 # confidential-os-builder checkout purely as the builder (c8s#264).
 # Drop-in replacement for confos's bin/build-c8s: same env contract
@@ -10,9 +10,6 @@ NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}
 [ -x "$CONFOS_DIR/bin/confos" ] || { echo "node-guest-image/build: confos checkout not found at $CONFOS_DIR (set CONFOS_DIR)" >&2; exit 1; }
 cd "$CONFOS_DIR"
-mkdir -p mkosi/base/mkosi.local
-printf '%s\n' "${C8S_REF:-}" > mkosi/base/mkosi.local/c8s-ref
-printf '%s\n' "${C8S_REGISTRY:-}" > mkosi/base/mkosi.local/c8s-registry
 FRAGMENT="$NGI_DIR/kernel/c8s.config"
 DEV_PROFILE=()
 if [ "${C8S_DEV:-0}" = 1 ]; then
@@ -38,6 +35,8 @@ exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
     ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
     --profile-dir "$NGI_DIR/c8s" \
+    --sync-input "c8s-ref=${C8S_REF:-}" \
+    --sync-input "c8s-registry=${C8S_REGISTRY:-}" \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \
     --cloud-init "$NGI_DIR/c8s/user-data" \

--- a/node-guest-image/c8s/image-policy.yaml.in
+++ b/node-guest-image/c8s/image-policy.yaml.in
@@ -1,0 +1,103 @@
+# nri-image-policy boot config — the MEASURED boot-time floor. TEMPLATE:
+# mkosi.sync renders this to etc/nri/conf.d/image-policy.yaml at build time,
+# substituting @NRI_DIGEST@/@NRI_IMAGE@ and @CDS_DIGEST@/@CDS_IMAGE@ with the
+# C8S_REF-resolved digests (see render_nri_floor). Edit this file, not the
+# generated one.
+#
+# The plugin binary is baked at /opt/nri/plugins/10-nri-image-policy and
+# containerd launches it pre-registered (see the NRI drop-in under
+# /var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/). This file
+# is the config it boots with, before c8s is installed.
+#
+# TRUST POSTURE: this baked copy is measured; after `c8s install` the
+# chart's installer DaemonSet overwrites it (on the unmeasured overlay
+# upper) with the values-rendered version — real cds_measurements pins, the
+# full image-digest floor. That is deliberate: the measured invariants are
+# the plugin BINARY and the fail-closed NRI registration
+# (required_plugins), while the policy DATA arrives via the CDS RA-TLS +
+# attestation chain and may be updated without an image rebuild. Expect
+# exactly one rke2-server restart from the installer when the config diff
+# lands.
+#
+# Field names/semantics validated against the plugin's config loader
+# (c8s internal/cmds/nri-image-policy/config.go). Notable constraints:
+#   - always_allow MUST be non-empty when pull.url is set (cold-boot
+#     baseline) — validation fails otherwise and the plugin never
+#     registers, which with required_plugins blocks ALL container creation.
+#   - pull.url must be https, and attestation_api_url is then required.
+#   - empty cds_measurements = accept any RA-TLS-attested CDS (warns).
+
+# The CPU TEE this image boots on. bin/build-c8s composes the c8s profile with
+# `--platform tdx`, so this image is TDX-only and the value is fixed.
+#
+# It types the RA-TLS identity the admission inventory serves to CDS, and CDS
+# refuses a peer whose type disagrees with the evidence envelope the
+# attestation-api returns. The plugin defaults this to snp for backward
+# compatibility, so omitting it here denies every sandbox token on the node,
+# which denies every adopted workload a certificate.
+platform: "tdx"
+
+plugin:
+  health_addr: "unix:///var/run/nri-image-policy/health.sock"
+
+# The node-CVM admission inventory (c8s docs/ratls.md, "Sandbox identity").
+# get-cert dials this socket for its pod's digests before CDS will issue a
+# certificate. In --cvm-mode=node the chart's nri-image-policy installer is
+# disabled, so nothing rewrites this file after boot and the section must be
+# baked in; without it the socket is never created and every adopted workload
+# hangs waiting for a certificate that cannot be issued.
+workload_claims:
+  socket_dir: "/var/run/nri-image-policy"
+  # The plugin is launched by containerd on the host, so its /proc is the
+  # host's — a caller PID from SO_PEERCRED resolves directly.
+  proc_root: "/proc"
+  # Empty falls back to NodeIPFile (node-ip in socket_dir). On a Kubernetes-
+  # hosted install the chart's installer writes that from its own status.hostIP;
+  # a node-as-CVM has no installer, so nri-node-ip.service writes it at boot
+  # instead. Without either, this resolves to 127.0.0.1 and the plugin refuses
+  # to start with "inventory host is not a routable unicast address".
+  advertise_host: ""
+
+allowlist:
+  # Cold-boot floor, both entries resolved from C8S_REF by mkosi.sync:
+  #   - the plugin's own image (self-allow), and
+  #   - CDS, so it can start against this fail-closed plugin and then serve the
+  #     live allowlist the pull loop below fetches. Without CDS admitted here,
+  #     no allowlist is ever served and `c8s install` deadlocks.
+  # Everything else at boot is in an exempt namespace.
+  always_allow:
+    "@NRI_DIGEST@": "@NRI_IMAGE@"
+    "@CDS_DIGEST@": "@CDS_IMAGE@"
+  pull:
+    # CDS NodePort, node-local. No CDS is listening until c8s install; the
+    # pull loop retries and the plugin stays Ready on the floor above.
+    url: "https://127.0.0.1:30808"
+    interval: "30s"
+    timeout: "30s"
+    # The BAKED attestation-api (attest/attest-gpu profile, host service on
+    # :8400) — not the c8s chart's NodePort. The plugin runs in the host
+    # netns as a containerd child, so loopback reaches it.
+    attestation_api_url: "http://127.0.0.1:8400"
+    # Deploy-time values; the installer's post-install config refresh pins
+    # them. Empty = accept any RA-TLS-attested CDS measurement (logged).
+    cds_measurements: []
+
+containerd:
+  socket: "/run/k3s/containerd/containerd.sock"
+  namespace: "k8s.io"
+
+policy:
+  mode: "fail-closed"
+  enforce_existing: true
+  deny_missing_annotation: true
+  exempt_namespaces:
+    # Cluster bootstrap must not be blocked: cilium, coredns, metrics.
+    - kube-system
+    # Baked local-path-provisioner + its busybox helper pods (digest-pinned
+    # in the manifest, but pulled from Docker Hub — not in the airgap
+    # bundles) run pre-CDS.
+    - local-path-storage
+  label_rules: []
+
+logging:
+  level: "info"

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -1,0 +1,55 @@
+# Profile: c8s
+#
+# Measured CVM node image for c8s: a single-node RKE2 server (kubelet +
+# containerd via the pinned RKE2 release) plus the nri-image-policy NRI
+# plugin, all baked into the dm-verity root — so the components that today
+# reach nodes via privileged installer DaemonSets are covered by the launch
+# measurement instead. attestation-api is NOT baked here; it comes from
+# composing the attest (or attest-gpu) profile, whose service the baked NRI
+# plugin config points at (127.0.0.1:8400).
+#
+# The full GPU node composition is `bin/build-c8s` (the canonical
+# entrypoint: kernel build + GPU staging + `confos build` with the
+# gpu/attest-gpu/c8s profiles and the c8s kernel fragment). The profile also
+# builds standalone (no gpu profiles) for GPU-less validation:
+# C8S_NO_GPU=1 bin/build-c8s.
+#
+# Requires kernel/c8s.config (a superset of kernel/gpu.config — see its
+# header): kubelet/Cilium need the container/k8s symbols, all =y because
+# nvidia-modules-latch.service disables module loading after boot.
+#
+# LAUNCH REQUIREMENTS (unlike the gpu image these are hard):
+#   - a virtio-blk disk with serial=confai-scratch, >=64G — the default 2G
+#     tmpfs overlay upper cannot hold RKE2's /var/lib/rancher
+#   - ideally a second disk labeled `containerd` (virtio-scsi preferred) so
+#     the image cache stays off guest RAM (containerd-data-disk.service)
+# See docs/C8S-IMAGE.md.
+
+[Content]
+Packages=
+    # The portmap CNI plugin execs `iptables` from the host mount ns for
+    # hostPort pods (ingress-nginx, c8s tee-proxy). RKE2's bundled iptables
+    # lives in its data dir, not on PATH, so portmap can't find it without
+    # this. Hard-learned on the base-images rke2 image.
+    iptables
+    # containerd-data-disk.service: in-guest encryption + mkfs for the
+    # LABEL=containerd disk. The base ships util-linux (blkid/mount) but
+    # neither of these.
+    cryptsetup-bin
+    e2fsprogs
+    # rke2-killall.sh + general node admin.
+    psmisc
+    procps
+    # On-node debugging of rke2/NRI state (kubectl -o json plumbing etc.).
+    jq
+    # NTP: the guest clock free-runs off the TDX TSC and drifts ~60-70s behind
+    # the operator's, which trips cred-release's JWT clock-skew check
+    # ("token used before issued") on get-kubeconfig. timesyncd (enabled via
+    # the preset below) syncs it over the CVM's masquerade egress.
+    systemd-timesyncd
+
+[Build]
+# oras + jq: mkosi.sync pulls the nri-image-policy OCI image by digest and
+# extracts the plugin binary from its layers. curl + ca-certificates: it
+# downloads the pinned RKE2 release artifacts.
+ToolsTreePackages=oras,jq,curl,ca-certificates

--- a/node-guest-image/c8s/mkosi.extra/etc/profile.d/rke2-path.sh
+++ b/node-guest-image/c8s/mkosi.extra/etc/profile.d/rke2-path.sh
@@ -1,0 +1,9 @@
+# Convenience for interactive shells: put rke2's bundled kubectl/ctr/crictl
+# on PATH and point KUBECONFIG at the supervisor's generated kubeconfig.
+# Sourced by /etc/profile for login shells.
+if [ -d /var/lib/rancher/rke2/bin ]; then
+    export PATH="/var/lib/rancher/rke2/bin:$PATH"
+fi
+if [ -f /etc/rancher/rke2/rke2.yaml ]; then
+    export KUBECONFIG=/etc/rancher/rke2/rke2.yaml
+fi

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/audit-policy.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/audit-policy.yaml
@@ -1,0 +1,24 @@
+# Audit policy applied via /etc/rancher/rke2/config.yaml
+# (kube-apiserver-arg: audit-policy-file=/etc/rancher/rke2/audit-policy.yaml).
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+  # Log secret access at Metadata level (no request/response body)
+  - level: Metadata
+    resources:
+      - group: ""
+        resources: ["secrets"]
+  # Log all changes to security-relevant resources
+  - level: RequestResponse
+    verbs: ["create", "update", "patch", "delete"]
+    resources:
+      - group: ""
+        resources: ["serviceaccounts", "namespaces"]
+      - group: "rbac.authorization.k8s.io"
+        resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+      - group: "networking.k8s.io"
+        resources: ["networkpolicies"]
+  # Default: log metadata for everything else
+  - level: Metadata
+    omitStages:
+      - "RequestReceived"

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -1,0 +1,63 @@
+# RKE2 server config — single-node cluster, Cilium CNI.
+#
+# Baked into the verity root so it's in place before rke2-server.service
+# starts at boot. Per-host overrides (cluster join token, alternate
+# encryption key, registries auth) belong in /etc/rancher/rke2/config.yaml.d/
+# at runtime — rke2 merges drop-ins from that dir on top of this file.
+
+# CNI: Cilium. RKE2 deploys it via its bundled helm chart; values overrides
+# live at var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+# (HelmChartConfig CRD that the rke2 supervisor reads on startup).
+#
+# `disable-kube-proxy: true` removes the in-tree kube-proxy DaemonSet so
+# Cilium can handle service-IP routing in eBPF (kubeProxyReplacement).
+# Two benefits over keeping kube-proxy:
+#   1. Less reliance on the nftables NAT symbol set (kernel/c8s.config has
+#      it, but the eBPF path doesn't depend on it).
+#   2. One CNI does all the work — no kube-proxy ↔ Cilium ordering races,
+#      no double-NAT, no nftables-vs-iptables backend mismatch.
+cni: cilium
+disable-kube-proxy: true
+
+# This node cluster normally runs inside a KubeVirt pod on an outer RKE2
+# cluster. Do not reuse RKE2's 10.42.0.0/16 pod and 10.43.0.0/16 service
+# defaults: KubeVirt masquerade preserves the outer client source address, so
+# overlapping routes make the guest send replies into its own Cilium network
+# after Cilium starts. Keep these values in lockstep with the Cilium IPAM pool
+# in rke2-cilium-config.yaml. Deployments that need different ranges can
+# override all three values in config.yaml.d/.
+cluster-cidr: 10.52.0.0/16
+service-cidr: 10.53.0.0/16
+cluster-dns: 10.53.0.10
+
+# Drop RKE2's bundled ingress-nginx: it binds hostPorts 80/443, which collide
+# with c8s tls-lb's hostPort 443 (the attested front door for workloads —
+# `c8s install` preflights this exact conflict). The node image's external
+# surface is tls-lb, not a generic ingress.
+disable:
+  - rke2-ingress-nginx
+
+# Add a stable hostname SAN to the apiserver serving cert. The operator
+# reaches the guest at a per-launch KubeVirt-assigned IP that RKE2 can't know
+# to include as a SAN, so the released kubeconfig can't verify against the IP.
+# Instead the kubeconfig dials the IP but sets tls-server-name=c8s-cvm (this
+# SAN), so verification passes without --insecure-skip-tls-verify. See
+# `c8s get-kubeconfig` (it defaults tls-server-name to this).
+tls-san:
+  - c8s-cvm
+
+profile: cis
+pod-security-admission-config-file: /etc/rancher/rke2/psa-config.yaml
+# Self-label as a TDX confidential node so `c8s install --hardware-platform tdx`
+# finds a target without a manual `kubectl label`. This image is TDX-only
+# (RTMR[3] operator binding, TDX quotes); the label is always correct here.
+node-label:
+  - confidential.ai/tdx=true
+kubelet-arg:
+  - max-pods=200
+kube-apiserver-arg:
+  - audit-log-path=/var/log/kube-audit/audit.log
+  - audit-log-maxage=30
+  - audit-log-maxbackup=10
+  - audit-log-maxsize=100
+  - audit-policy-file=/etc/rancher/rke2/audit-policy.yaml

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
@@ -1,0 +1,32 @@
+# PodSecurity admission config applied via
+# /etc/rancher/rke2/config.yaml: pod-security-admission-config-file=...
+#
+# Restricted enforcement by default. kube-system and local-path-storage are
+# exempt (they ship privileged daemonsets / hostPath helpers); add more
+# namespaces here for any privileged platform component you deploy. Workload
+# namespaces inherit the restricted policy unless explicitly labelled
+# otherwise.
+apiVersion: apiserver.config.k8s.io/v1
+kind: AdmissionConfiguration
+plugins:
+  - name: PodSecurity
+    configuration:
+      apiVersion: pod-security.admission.config.k8s.io/v1
+      kind: PodSecurityConfiguration
+      defaults:
+        enforce: "restricted"
+        enforce-version: "latest"
+        audit: "restricted"
+        audit-version: "latest"
+        warn: "restricted"
+        warn-version: "latest"
+      exemptions:
+        usernames: []
+        runtimeClasses: []
+        namespaces:
+          - kube-system
+          - local-path-storage
+          # `default` is exempted because smoke tests run there. Move
+          # workloads to dedicated namespaces in production and drop this
+          # exemption.
+          - default

--- a/node-guest-image/c8s/mkosi.extra/etc/sysctl.d/90-rke2.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/sysctl.d/90-rke2.conf
@@ -1,0 +1,21 @@
+# Sysctls RKE2 expects on a node. The CIS profile (enabled in
+# /etc/rancher/rke2/config.yaml) refuses to start the supervisor without
+# these.
+
+# CIS profile requirements
+vm.panic_on_oom=0
+vm.overcommit_memory=1
+kernel.panic=10
+kernel.panic_on_oops=1
+
+# Generic k8s node tuning — bump inotify watches so kubelet/cilium/
+# observability stacks don't run into "too many open files" errors at
+# moderate pod counts.
+fs.inotify.max_user_instances=8192
+fs.inotify.max_user_watches=1048576
+
+# Required for k8s pod networking with bridges (CNI bridge plugin).
+# Cilium doesn't strictly need it but no harm.
+net.bridge.bridge-nf-call-iptables=1
+net.bridge.bridge-nf-call-ip6tables=1
+net.ipv4.ip_forward=1

--- a/node-guest-image/c8s/mkosi.extra/etc/sysctl.d/99-c8s-bpf.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/sysctl.d/99-c8s-bpf.conf
@@ -1,0 +1,12 @@
+# BPF hardening for the c8s kernel. The base image omits these keys
+# (see 99-kspp-hardening.conf) because its kernel compiles BPF out; the
+# c8s kernel enables CONFIG_BPF_SYSCALL/BPF_JIT for Cilium, so the
+# runtime locks apply here. Cilium loads its programs privileged and is
+# unaffected by either setting.
+
+# 1 is one-way for the rest of boot; the Ubuntu default of 2 can be
+# flipped back off at runtime by CAP_SYS_ADMIN.
+kernel.unprivileged_bpf_disabled = 1
+
+# Blind JIT constants against constant-spray gadget attacks.
+net.core.bpf_jit_harden = 2

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/resolved.conf.d/10-upstream.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/resolved.conf.d/10-upstream.conf
@@ -1,0 +1,12 @@
+# Static DNS upstream baked into the measured root.
+#
+# Under KubeVirt-style launches the guest can come up with the cluster
+# CoreDNS service IP as its only resolver, which is circular at boot: kubelet
+# can't pull images until DNS resolves, but DNS won't resolve until CoreDNS
+# is running. Pinning real upstreams here breaks the loop so node-level
+# resolution works before the in-cluster DNS exists. (With the airgap
+# bundles baked, first boot needs no pulls at all — this matters for
+# anything fetched after bring-up.)
+[Resolve]
+DNS=1.1.1.1 8.8.8.8
+Domains=~.

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/containerd-data-disk.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/containerd-data-disk.service
@@ -1,0 +1,60 @@
+# Mount /var/lib/rancher/rke2/agent/containerd on a real (non-overlay) filesystem
+# before rke2 starts. Containerd's overlay snapshotter cannot stack on overlayfs,
+# and the initrd mounts the whole rootfs as an overlay (verity lower +
+# tmpfs/scratch-disk upper), so /var/lib/rancher/* is overlayfs by default —
+# containerd's "multiple-lowerdir-check" probe fails when its snapshotter tries
+# to use that as an upperdir. The mount must therefore escape the overlay onto
+# its own FS.
+#
+# Backing, in preference order:
+#   1. a LABEL=containerd block device → ephemeral, encrypted in-guest with a
+#      random per-boot key (the untrusted host sees only ciphertext; contents do
+#      not survive a reboot, which is fine — the image cache is re-pullable).
+#      This is what keeps the multi-GiB image cache OUT of guest RAM.
+#   2. no such device → a tmpfs (writes lost on reboot, and counted against guest
+#      memory — attach a LABEL=containerd disk to avoid).
+#
+# Scope is JUST the containerd data dir, NOT the broader /var/lib/rancher: an
+# empty mount there would shadow the baked HelmChartConfig under
+# server/manifests/, the airgap bundles under agent/images/, and the NRI
+# drop-in under agent/etc/containerd/.
+#
+# A oneshot service (not a .mount unit) because the backing choice needs runtime
+# detection + cryptsetup/mkfs, which a static .mount cannot express. RemainAfterExit
+# keeps the mount's lifecycle tied to the unit. Ordered Before rke2 so the dir is
+# ready when containerd starts.
+[Unit]
+Description=Back containerd data dir with a LABEL=containerd disk (encrypted) or tmpfs
+DefaultDependencies=no
+Conflicts=umount.target
+Before=local-fs.target rke2-server.service rke2-agent.service
+After=systemd-udevd.service
+# Order After=systemd-udevd so udevd is at least started before we touch dm. We
+# still do NOT hard-Require it nor wait for udev-settle (deprecated / may be
+# absent on systemd 259, and a dep on the by-label device unit would hang when no
+# disk is attached, breaking the tmpfs fallback). The script polls for the label.
+# Belt-and-suspenders with DM_DISABLE_UDEV below: this unit runs ~6s into boot,
+# the same moment udevd is still coming up, and cryptsetup's default post-creation
+# udev-cookie wait deadlocks in D-state if udevd isn't serving yet.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Make libdevmapper create the /dev/mapper node directly instead of waiting for a
+# udev cookie. Without this, `cryptsetup open` deadlocks in uninterruptible
+# D-state at early boot (this unit runs the same second udevd is still starting),
+# blowing past every timeout. With it, the open/mkfs/mount sequence finishes in
+# seconds. The node still gets udev-processed once udevd catches up.
+Environment=DM_DISABLE_UDEV=1
+ExecStart=/usr/local/bin/containerd-data-disk.sh
+# Fail-safe: this unit is Before=local-fs.target, so a hang here wedges the whole
+# boot. Cap total runtime; the script wraps each risky step (cryptsetup/mkfs) in
+# its own `timeout` and always ends by ensuring the dir is mounted (tmpfs if the
+# disk path failed), so rke2 can start regardless. Failure is non-fatal to boot.
+TimeoutStartSec=180
+SuccessExitStatus=0 1
+# Best-effort unwind on stop; the tmpfs/dm device is torn down at shutdown anyway.
+ExecStop=-/bin/sh -c 'umount /var/lib/rancher/rke2/agent/containerd 2>/dev/null; cryptsetup close containerd 2>/dev/null; true'
+
+[Install]
+WantedBy=local-fs.target

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Attested RKE2 operator credential release
+Documentation=https://github.com/confidential-dot-ai/c8s
+# Bound restart storms: a persistent failure (e.g. RTMR[3] mismatch — the
+# on-disk pubkey doesn't match the measurement) should fail closed and stop,
+# not spin. 5 tries in 5 min, then give up until the next boot.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+# Needs the RKE2 client-CA (to sign operator certs) and the attestation-api
+# (to fetch the RA-TLS serving cert's TDX quote from :8400). rke2-server
+# creates /var/lib/rancher/rke2/server/tls/client-ca.* only once it has
+# initialised, so we order after it and gate on the key existing (the Exec
+# startpre below), rather than racing a half-initialised control plane.
+After=network-online.target rke2-server.service attestation-api.service
+Wants=network-online.target
+Requires=attestation-api.service
+# Only run on operator boots. A VM launched without --operator-key has no
+# opkeydata disk; the condition makes systemd SKIP the unit (not fail it), so
+# there's no restart-loop on non-operator nodes. The launcher attaches the
+# disk with ISO label "opkeydata".
+ConditionPathExists=/dev/disk/by-label/opkeydata
+
+[Service]
+Type=simple
+# The operator key is bound into RTMR[3] at launch; this service verifies the
+# on-disk pubkey against RTMR[3] at startup and refuses (exits non-zero) if it
+# was substituted — fail closed. Non-operator boots never reach here (the
+# ConditionPathExists above skips the unit).
+# Waits bounded (10 min) rather than failing fast: on a slow first boot the
+# CA can take minutes to appear, and 5 quick ExecStartPre failures 10s apart
+# would exhaust StartLimitBurst in under a minute and give up until reboot.
+ExecStartPre=/bin/sh -c 'for _ in $(seq 1 120); do [ -r /var/lib/rancher/rke2/server/tls/client-ca.key ] && exit 0; sleep 5; done; exit 1'
+TimeoutStartSec=630
+ExecStart=/usr/local/bin/c8s cred-release \
+    --listen :8443 \
+    --attestation-api-url http://127.0.0.1:8400 \
+    --platform tdx \
+    --cert-ttl 24h \
+    --cert-org system:masters \
+    --cert-cn operator
+Restart=on-failure
+RestartSec=10
+# TDX runtime measurement (RTMR[3]) is read via the tdx_guest misc device.
+DeviceAllow=/dev/tdx_guest rwm
+# Reads two files: the initrd-staged operator pubkey (/etc/confai) and the
+# RKE2 client-CA key. No mount needed. Keep the rest of the FS read-only.
+ProtectSystem=strict
+ReadOnlyPaths=/etc/confai /var/lib/rancher/rke2/server/tls
+ReadWritePaths=/run
+ProtectHome=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/models-disk.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/models-disk.service
@@ -1,0 +1,33 @@
+# Mount a pre-populated read-only weights disk (serial=confai-models) at
+# /var/lib/models before rke2 starts, so large model weights persist across CVM
+# relaunches instead of re-downloading. See models-disk.sh for the why.
+#
+# The disk is public (weights), so unlike containerd-data-disk.service there is
+# no encryption and no per-boot mkfs — the filesystem is mounted read-only as-is.
+# Absent disk → clean no-op (GPU-less / no-weights boots).
+#
+# A oneshot (not a .mount unit) because the device is matched by serial at
+# runtime, which a static .mount cannot express. RemainAfterExit ties the mount
+# lifecycle to the unit. Ordered Before rke2 so /var/lib/models is ready when
+# pods start.
+[Unit]
+Description=Mount the read-only weights disk (serial=confai-models) at /var/lib/models
+DefaultDependencies=no
+Conflicts=umount.target
+Before=rke2-server.service rke2-agent.service
+After=systemd-udevd.service
+# Order After=systemd-udevd so udevd has started before we resolve /dev/disk/by-id.
+# NOT a hard Require, and no udev-settle: a dep on the by-id device unit would hang
+# when no disk is attached, breaking the no-op path. The script polls for the serial.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/models-disk.sh
+# Non-fatal to boot: the script wraps the mount in `timeout` and always exits 0
+# (a missing/failed disk just means a cold cache). Cap total runtime as a backstop.
+TimeoutStartSec=60
+ExecStop=-/bin/sh -c 'umount /var/lib/models 2>/dev/null; true'
+
+[Install]
+WantedBy=local-fs.target

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/nri-node-ip.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/nri-node-ip.service
@@ -1,0 +1,22 @@
+# Publish this node's address for nri-image-policy's admission inventory.
+#
+# Must run before rke2 starts containerd, because containerd launches the
+# baked plugin as a child and the plugin reads the file during startup. See
+# nri-node-ip.sh for why a node-as-CVM has no other writer.
+[Unit]
+Description=Publish the node address for the nri-image-policy admission inventory
+Before=rke2-server.service rke2-agent.service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/nri-node-ip.sh
+# Never block boot. The script exits 0 when it cannot resolve an address; the
+# plugin then fails its own advertise_host check with a message that names the
+# cause, which is a better failure than a node that will not boot.
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-server.service.d/no-modprobe.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-server.service.d/no-modprobe.conf
@@ -1,0 +1,14 @@
+# Upstream rke2-server.service has
+#   ExecStartPre=-/sbin/modprobe br_netfilter
+#   ExecStartPre=-/sbin/modprobe overlay
+# These are intentionally failure-tolerant (the `-` prefix means "don't
+# error on non-zero exit"), but on this image they can never succeed and
+# only log noise: the only loadable modules are the signed NVIDIA ones, and
+# once nvidia-modules-latch.service sets kernel.modules_disabled=1 any
+# modprobe attempt fails outright. The features themselves are built-in:
+#   - br_netfilter functionality: CONFIG_BRIDGE_NETFILTER=y (kernel/c8s.config)
+#   - overlay functionality:      CONFIG_OVERLAY_FS=y       (required.config)
+# So we override the ExecStartPre to a no-op. The empty `ExecStartPre=` in
+# a drop-in CLEARS the list, then we don't re-add anything.
+[Service]
+ExecStartPre=

--- a/node-guest-image/c8s/mkosi.extra/etc/sysusers.d/confos-rke2.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/sysusers.d/confos-rke2.conf
@@ -1,0 +1,10 @@
+# systemd-sysusers.d declarations applied at first boot by
+# systemd-sysusers.service (runs early, before rke2-server).
+#
+# RKE2's `profile: cis` validation expects an `etcd` system user to exist
+# even though the embedded etcd actually runs as root inside the
+# rke2-server process. Without this entry, the CIS check writes a
+# warning (or fails, depending on rke2 version).
+#
+# Type | Name | UID  | GECOS               | Home | Shell
+u       etcd  -     "RKE2 etcd (CIS profile)"  -      /usr/sbin/nologin

--- a/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
@@ -1,0 +1,11 @@
+# systemd-tmpfiles applied early at boot by systemd-tmpfiles-setup.service.
+# Creates / fixes ownership of directories rke2-server expects to exist
+# before it starts kube-apiserver / kubelet.
+#
+# Format: Type Path Mode User Group Age Argument
+d /var/log/kube-audit 0750 root root - -
+# nri-image-policy's health socket dir (health_addr in
+# /etc/nri/conf.d/image-policy.yaml). /run is tmpfs and the plugin does not
+# mkdir it; without this the plugin exits at startup and the fail-closed
+# NRI validator blocks every container on the node.
+d /run/nri-image-policy 0755 root root - -

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -1,0 +1,41 @@
+# Presets are processed by `systemctl preset-all` during the mkosi build.
+# Each `enable`/`disable` line creates the corresponding
+# /etc/systemd/system/... symlink at bake time so it's measured into the
+# verity root. The rke2 units live in /usr/local/lib/systemd/system (staged
+# there by this profile's mkosi.sync), which is on systemd's unit search
+# path.
+#
+# Why we need this file at all: Ubuntu's default preset policy enables
+# every unit that ships with a `[Install] WantedBy=…`. rke2's release
+# tarball ships both rke2-server.service AND rke2-agent.service, so
+# without an explicit `disable rke2-agent.service` here, both get enabled —
+# which is bad because:
+#   - rke2-agent has no `server: https://...` for a single-node cluster,
+#     so it crashes with "Error: --server is required" on every start.
+#   - It hits Restart=always → tight restart loop.
+#   - rke2-server has an `ExecCondition` that bails when rke2-agent is
+#     `is-active`. Racing between the two units leaves etcd half-started
+#     → the persistent "Failed to test etcd connection" loop in the
+#     journal.
+#
+# Single-node only for now. To convert this image to an agent later,
+# flip the last two lines (disable server, enable agent) and add a
+# `server: https://<server-ip>:9345` + `token:` to config.yaml.
+enable containerd-data-disk.service
+# Read-only weights disk (serial=confai-models). Enabled always; a no-op boot
+# when the disk isn't attached (GPU-less / no-weights launches).
+enable models-disk.service
+# Publish the node address the nri-image-policy admission inventory advertises
+# to CDS. Ordered before rke2 so the file exists when containerd launches the
+# baked plugin.
+enable nri-node-ip.service
+enable rke2-server.service
+disable rke2-agent.service
+# NTP: sync the free-running TDX guest clock so it doesn't drift behind the
+# operator and trip cred-release's JWT clock-skew check. Egress is via the
+# CVM's masquerade NAT.
+enable systemd-timesyncd.service
+# Attested operator credential release. Enabled always, but its
+# ConditionPathExists on the opkeydata disk means it only starts on operator
+# boots — a no-op on nodes launched without --operator-key.
+enable cred-release.service

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/containerd-data-disk.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Back /var/lib/rancher/rke2/agent/containerd with a real (non-overlay) FS before
+# rke2 starts. Run by containerd-data-disk.service. See that unit for the why.
+#
+# A LABEL=containerd block device → ephemeral encrypted ext4 (random per-boot key,
+# never persisted). No such device, or any failure on the encrypted path → tmpfs
+# (the historical RAM-backed default). Either way the dir ends up on a filesystem
+# containerd's overlay snapshotter can use as an upperdir.
+#
+# THREAT MODEL: the host (L0) is untrusted and can read/write the backing block
+# device. The aes-xts-plain64 encryption gives CONFIDENTIALITY only — the host
+# cannot read which image layers are cached or their content. It does NOT give
+# integrity: plain-mode dm-crypt has no MAC, so the host can tamper with
+# ciphertext and the guest will decrypt attacker-chosen plaintext silently.
+# Image-content integrity instead rests on containerd's content-addressed store:
+# layer blobs are sha256-verified on pull/unpack, so a tampered cached blob fails
+# its digest check before use. (Caveat: an already-EXTRACTED snapshot rootfs is
+# not re-verified per read — out of scope here; the cache is ephemeral and
+# re-pullable.) Mirrors the initrd's confai-scratch overlay, same plain-mode
+# stance.
+#
+# This unit is Before=local-fs.target, so it must NEVER hang or hard-fail: every
+# risky step is wrapped in `timeout`, and the function always returns. The final
+# guarantee (ensure_tmpfs) makes the dir usable even if the disk path fell over.
+set -u
+
+DIR=/var/lib/rancher/rke2/agent/containerd
+SIZE_TMPFS=32G
+# Per cryptsetup/mkfs/mount step. Three steps + the tmpfs fallback must finish
+# under the unit's TimeoutStartSec (180s), or systemd SIGKILLs the script before
+# the fallback runs and the dir is left on overlay. 30s × 3 = 90s leaves ample
+# headroom. (A step in uninterruptible D-state ignores the SIGTERM `timeout`
+# sends — the real defense is the fast mkfs below, which removes the only step
+# observed to hang; this bound is the backstop.)
+STEP_TIMEOUT=30
+
+mkdir -p "$DIR"
+
+ensure_tmpfs() {
+    mountpoint -q "$DIR" && return 0
+    echo "containerd-data-disk: backing $DIR with tmpfs (size=$SIZE_TMPFS)"
+    mount -t tmpfs -o "size=$SIZE_TMPFS,nodev,nosuid,mode=0700" tmpfs "$DIR"
+}
+
+# Already mounted (service re-run / RemainAfterExit) → nothing to do.
+if mountpoint -q "$DIR"; then
+    echo "containerd-data-disk: $DIR already mounted"
+    exit 0
+fi
+
+# Find the containerd data disk. vda is the verity rootfs. Prefer the SCSI bus
+# (sd*): under SEV-SNP/KubeVirt a secondary virtio-blk disk wedges on every I/O
+# (raw dd hangs in uninterruptible D-state — iommu=on is forced on all virtio
+# devices and the virtio-blk DMA path is broken for hot-attached data disks;
+# virtio-scsi works). Scan sd* first, then vd* as a fallback for launches
+# without that quirk. Poll briefly (~10s) so a slow udev probe doesn't make us
+# miss it.
+#
+# Two ways a device qualifies:
+#   1. filesystem LABEL=containerd — a host-prepared, pre-labelled disk.
+#   2. device SERIAL=confai-containerd — a BLANK disk confai attaches with that
+#      serial (mirrors the confai-scratch datadisk). This is the confai path:
+#      the disk carries no filesystem, so the encrypted mkfs below lays one down
+#      per boot. `blkid -p` probes the device directly (not the stale udev
+#      cache); the serial comes from sysfs.
+DEV=""
+for _ in $(seq 1 20); do
+    # by-id first: virtio-scsi (KubeVirt Bus: scsi) surfaces the serial ONLY in
+    # /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_<serial>, NOT in
+    # /sys/block/<dev>/serial (empty on SCSI). This is the confai path
+    # (--containerd-disk-gi attaches a scsi disk serial=confai-containerd).
+    for l in /dev/disk/by-id/*confai-containerd*; do
+        [ -e "$l" ] || continue
+        DEV="$(readlink -f "$l")"; break
+    done
+    [ -n "$DEV" ] && break
+    for d in /dev/sd? /dev/vd?; do
+        [ -b "$d" ] || continue
+        # virtio-blk surfaces the serial in sysfs (SCSI does not — see above).
+        # Checked first: a sysfs read cannot wedge, a device probe can.
+        if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-containerd" ]; then
+            DEV="$d"; break
+        fi
+        # host-prepared disk with a real filesystem LABEL. The probe reads the
+        # device itself, so timeout-bound it: this unit is Before=local-fs.target
+        # and must not hang on a wedged disk (SEV-SNP virtio-blk reads have
+        # gone D-state before; the bound is best-effort, D-state ignores it).
+        if [ "$(timeout 5 blkid -p -s LABEL -o value "$d" 2>/dev/null || true)" = "containerd" ]; then
+            DEV="$d"; break
+        fi
+    done
+    [ -n "$DEV" ] && break
+    sleep 0.5
+done
+
+if [ -z "$DEV" ]; then
+    echo "containerd-data-disk: no LABEL=containerd disk — using tmpfs (image cache counts against guest RAM)"
+    ensure_tmpfs
+    exit $?
+fi
+
+echo "containerd-data-disk: found LABEL=containerd at $DEV — encrypted ephemeral overlay backing"
+# Random per-boot key, kept only in (TEE-encrypted) RAM, never persisted.
+KEY=/run/containerd-data.key
+( umask 077; head -c 64 /dev/urandom > "$KEY" )
+
+# Encrypted path, fully guarded: every step is `timeout`-wrapped (incl. mount —
+# a wedged dm device must not block boot to the unit-level TimeoutStartSec), so
+# any timeout/failure (e.g. a kernel missing dm-crypt/XTS) degrades to tmpfs
+# rather than hanging or aborting the boot.
+#
+# The per-boot random key means last boot's ext4 is unreadable noise this boot,
+# so we mkfs the freshly-opened mapper every boot. That mkfs MUST be near-instant
+# regardless of device size: a full mkfs across a multi-GiB device writes the
+# whole inode table, and in a CVM every guest I/O page is encrypted onto a
+# sparse host-backed disk — slow enough to block in uninterruptible D-state past
+# both the step `timeout` and the unit's TimeoutStartSec, killing the unit and
+# leaving the dir on overlay (containerd snapshotter then loops "not supported
+# as upperdir"). lazy_itable_init/lazy_journal_init defer the table writes to
+# the kernel, ^has_journal drops the journal (ephemeral re-pullable cache needs
+# no crash-consistency), and nodiscard skips a full-device TRIM — so mkfs
+# touches only the superblock + group descriptors.
+MKFS_OPTS="-F -q -m0 -O ^has_journal -E lazy_itable_init=1,lazy_journal_init=1,nodiscard"
+if timeout "$STEP_TIMEOUT" cryptsetup open --batch-mode --type plain \
+        --cipher aes-xts-plain64 --key-size 512 -d "$KEY" "$DEV" containerd \
+   && timeout "$STEP_TIMEOUT" mkfs.ext4 $MKFS_OPTS /dev/mapper/containerd \
+   && timeout "$STEP_TIMEOUT" mount -o nodev,nosuid /dev/mapper/containerd "$DIR"; then
+    rm -f "$KEY"
+    echo "containerd-data-disk: mounted encrypted $DEV at $DIR"
+    exit 0
+fi
+
+rm -f "$KEY"
+echo "containerd-data-disk: encrypted path failed (kernel missing dm-crypt/XTS?) — falling back to tmpfs" >&2
+cryptsetup close containerd 2>/dev/null || true
+ensure_tmpfs
+exit $?

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/models-disk.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/models-disk.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Mount a pre-populated, read-only weights disk at /var/lib/models before rke2
+# starts, so large model weights (an HF cache of hundreds of GiB) survive a CVM
+# relaunch instead of re-downloading. Run by models-disk.service.
+#
+# Unlike containerd-data-disk.sh this disk is NOT encrypted and NOT mkfs'd: it
+# already carries an ext4 filesystem with the cache. Weights are public — the
+# guarantee wanted is integrity, not secrecy, and integrity rests on the
+# workload verifying model digests, not on dm-crypt. The host (L0) can read the
+# disk; that is fine because the content is public.
+#
+# Absent disk → no-op (GPU-less / no-weights boots): the workload just downloads
+# to its own store. No tmpfs fallback — a cold cache is acceptable, wasting guest
+# RAM on it is not.
+#
+# Ordered Before rke2 so the mount exists when pods start. Read-only, nodev,
+# nosuid, noexec: the guest never writes it, and nothing on a host-writable
+# disk may execute in the guest — workloads read weights, not binaries.
+set -u
+
+DIR=/var/lib/models
+# Per mount step. A wedged device must not block boot past the unit's
+# TimeoutStartSec (60s); mirrors containerd-data-disk.sh's step bound.
+STEP_TIMEOUT=30
+
+mkdir -p "$DIR"
+
+# Already mounted (service re-run / RemainAfterExit) → nothing to do.
+if mountpoint -q "$DIR"; then
+    echo "models-disk: $DIR already mounted"
+    exit 0
+fi
+
+# Find the models disk by serial=confai-models. virtio-scsi (KubeVirt Bus:
+# scsi) surfaces the serial ONLY in /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_
+# <serial>, NOT in /sys/block/<dev>/serial (empty on SCSI) — same matching as
+# containerd-data-disk.sh. Poll briefly (~10s) so a slow udev probe doesn't make
+# us miss it. virtio-blk is scanned as a fallback via its sysfs serial.
+DEV=""
+for _ in $(seq 1 20); do
+    for l in /dev/disk/by-id/*confai-models*; do
+        [ -e "$l" ] || continue
+        DEV="$(readlink -f "$l")"; break
+    done
+    [ -n "$DEV" ] && break
+    for d in /dev/sd? /dev/vd?; do
+        [ -b "$d" ] || continue
+        if [ "$(cat "/sys/block/$(basename "$d")/serial" 2>/dev/null || true)" = "confai-models" ]; then
+            DEV="$d"; break
+        fi
+    done
+    [ -n "$DEV" ] && break
+    sleep 0.5
+done
+
+if [ -z "$DEV" ]; then
+    echo "models-disk: no serial=confai-models disk — skipping (workload will download weights)"
+    exit 0
+fi
+
+echo "models-disk: found weights disk at $DEV — mounting read-only at $DIR"
+if timeout "$STEP_TIMEOUT" mount -o ro,nodev,nosuid,noexec "$DEV" "$DIR"; then
+    echo "models-disk: mounted $DEV read-only at $DIR"
+    exit 0
+fi
+
+echo "models-disk: mount of $DEV failed — skipping (workload will download weights)" >&2
+exit 0

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/nri-node-ip.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/nri-node-ip.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Write this node's address where nri-image-policy looks for it.
+#
+# The plugin's admission inventory advertises an address CDS dials back on
+# (workload_claims.advertise_host). On a Kubernetes-hosted install the chart's
+# installer DaemonSet writes it from its own status.hostIP. A node-as-CVM has
+# no such installer — the plugin is a containerd child on the host — so with
+# the value unset it resolves to 127.0.0.1 and the plugin refuses to start:
+#
+#   workloadclaims: inventory host "127.0.0.1" is not a routable unicast address
+#
+# The address is a dial target, not a trust input. CDS still requires whatever
+# answers to pass mutually-attested RA-TLS on a privileged port, so naming the
+# wrong one fails closed rather than opening anything.
+set -eu
+
+DIR=/var/run/nri-image-policy
+# The plugin creates this at startup, but this unit is ordered before rke2
+# brings containerd up, so it does not exist yet.
+mkdir -p "$DIR"
+
+# The source address of the default route: the one interface a CDS elsewhere in
+# the cluster can reach. `ip route get` resolves it without assuming an
+# interface name, which differs across launch shapes.
+ADDR=$(ip -4 route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([0-9.]*\).*/\1/p' | head -1)
+
+if [ -z "$ADDR" ]; then
+    # No default route yet. Leave the file absent rather than writing a
+    # loopback address: the plugin's own check rejects that with a message
+    # naming the cause, which beats advertising an address nothing can reach.
+    echo "nri-node-ip: no IPv4 default route; leaving $DIR/node-ip unwritten" >&2
+    exit 0
+fi
+
+printf '%s\n' "$ADDR" > "$DIR/node-ip"
+echo "nri-node-ip: advertised $ADDR"

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/nri-image-policy.toml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/nri-image-policy.toml
@@ -1,0 +1,10 @@
+[plugins."io.containerd.nri.v1.nri"]
+  disable = false
+  plugin_path = "/opt/nri/plugins"
+  plugin_config_path = "/etc/nri/conf.d"
+  plugin_registration_timeout = "10s"
+  plugin_request_timeout = "2s"
+  socket_path = "/var/run/nri/nri.sock"
+[plugins."io.containerd.nri.v1.nri.default_validator"]
+  enable = true
+  required_plugins = ["nri-image-policy"]

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.tmpl
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.tmpl
@@ -1,0 +1,4 @@
+{{/* c8s-containerd-prep:managed-template */}}
+imports = ["/var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/*.toml"]
+
+{{ template "base" . }}

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/local-path-storage.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/local-path-storage.yaml
@@ -1,0 +1,175 @@
+# Baked into server/manifests so RKE2 auto-applies it at boot. RKE2's `cis`
+# profile (config.yaml) does NOT ship local-path-provisioner, so without this
+# the confidential node has no StorageClass and any PVC (e.g. c8s tee-proxy
+# certs, CDI rootdisks) stays Pending forever. v0.0.30 matches the ansible
+# local-path-provisioner role on the outer clusters.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-path-storage
+  # CIS profile defaults the cluster to restricted PodSecurity; the provisioner
+  # helper pods need hostPath + run as root, so this namespace opts out.
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: local-path-provisioner-role
+  namespace: local-path-storage
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: local-path-provisioner-bind
+  namespace: local-path-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner-bind
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner-role
+subjects:
+  - kind: ServiceAccount
+    name: local-path-provisioner-service-account
+    namespace: local-path-storage
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: local-path-storage
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: rancher/local-path-provisioner:v0.0.36@sha256:1eba82e9c386038b4af6d69cca7519fac738c28c42735ed48ce70c882ad0d80f
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_MOUNT_PATH
+              value: /etc/config/
+      volumes:
+        - name: config-volume
+          configMap:
+            name: local-path-config
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-path
+  # Default class: c8s (tee-proxy certs) and CDI rootdisk PVCs omit
+  # storageClassName, so without a default they never bind.
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Delete
+
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: local-path-config
+  namespace: local-path-storage
+data:
+  config.json: |-
+    {
+            "nodePathMap":[
+            {
+                    "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                    "paths":["/opt/local-path-provisioner"]
+            }
+            ]
+    }
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
+      containers:
+      - name: helper-pod
+        image: busybox:1.38.0@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d
+        imagePullPolicy: IfNotPresent

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -1,0 +1,84 @@
+# NVIDIA device plugin — makes passed-through GPUs schedulable as
+# `nvidia.com/gpu` on the inner cluster. CDI end to end: the gpu profile's
+# nvidia-cdi-generate.service writes /var/run/cdi/nvidia.yaml at boot; the
+# plugin discovers the driver files under CONTAINER_DRIVER_ROOT, advertises the
+# GPUs, and containerd 2.x (CDI on by default) injects the CDI devices at pod
+# creation — no nvidia-container-runtime wrapper anywhere.
+#
+# kube-system placement is deliberate: PSA-exempt (privileged + hostPath to
+# reach the driver root and /dev) and NRI-allowlist-exempt, so the plugin can
+# start before CDS is up. Digest-pinned like every other baked component.
+#
+# The plugin discovers NVML/libcuda + the CDI hooks from the measured root
+# mounted at /driver-root. It MUST NOT put the guest lib dir on LD_LIBRARY_PATH
+# — /usr/lib/x86_64-linux-gnu holds the guest's libc/libpthread, which would
+# shadow the container's own and crash the Go runtime with
+# "pthread_create failed: Invalid argument". Instead NVIDIA_DRIVER_ROOT=/ +
+# CONTAINER_DRIVER_ROOT=/driver-root let the plugin's own resolver find the libs.
+#
+# DEVICE_LIST_STRATEGY=cdi-annotations (v0.19.3 does NOT accept cdi-cri).
+# FAIL_ON_INIT_ERROR=false keeps GPU-less boots degraded-nothing.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nvidia-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: nvidia-device-plugin
+    app.kubernetes.io/part-of: c8s-node-image
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: nvidia-device-plugin
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: nvidia-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: nvidia-device-plugin
+          image: nvcr.io/nvidia/k8s-device-plugin:v0.19.3@sha256:25cc340fe6fd53c101e16fc452f503e7a92c219c64a80ed5381784b522dbbf77
+          env:
+            - name: FAIL_ON_INIT_ERROR
+              value: "false"
+            - name: DEVICE_LIST_STRATEGY
+              value: cdi-annotations
+            - name: DEVICE_ID_STRATEGY
+              value: uuid
+            - name: NVIDIA_DRIVER_ROOT
+              value: /
+            - name: CONTAINER_DRIVER_ROOT
+              value: /driver-root
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: all
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: cdi-dir
+              mountPath: /var/run/cdi
+            - name: driver-root
+              mountPath: /driver-root
+              readOnly: true
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: cdi-dir
+          hostPath:
+            path: /var/run/cdi
+            type: DirectoryOrCreate
+        - name: driver-root
+          hostPath:
+            path: /
+        - name: dev
+          hostPath:
+            path: /dev

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
@@ -1,0 +1,62 @@
+# Cilium values override for RKE2's bundled chart.
+#
+# RKE2's supervisor reads /var/lib/rancher/rke2/server/manifests/ at start
+# and merges HelmChartConfig CRDs into the matching HelmChart spec it
+# already manages. For RKE2's cilium chart the chart name is `rke2-cilium`.
+#
+# Two important settings for this single-node, kube-proxy-replaced setup:
+#
+#   1. kubeProxyReplacement: true
+#      Cilium provides cluster-IP service routing in eBPF instead of
+#      kube-proxy's nftables/iptables NAT.
+#
+#   2. k8sServiceHost / k8sServicePort = 127.0.0.1 : 6443
+#      Cilium agent + install-cni would normally dial the cluster service
+#      IP (10.53.0.1:443) to reach kube-apiserver. With kube-proxy disabled
+#      AND Cilium not yet running, that IP has no DNAT — chicken-and-egg.
+#      Pointing Cilium directly at the apiserver's loopback bypasses the
+#      service mesh during Cilium's own bootstrap. For multi-node, set
+#      this to an external load balancer or to each node's local apiserver
+#      IP via per-node values.
+
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: rke2-cilium
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    # eBPF service handling — REQUIRED with disable-kube-proxy.
+    kubeProxyReplacement: true
+
+    # eBPF masquerade — the recommended pairing with kubeProxyReplacement.
+    # Keeps masquerade/NAT entirely in the eBPF datapath instead of Cilium's
+    # iptables backend, which is the right call on this minimal confidential
+    # guest: less leaning on the netfilter symbol set, one datapath to
+    # reason about.
+    bpf:
+      masquerade: true
+
+    # Direct apiserver address — single-node uses the host loopback.
+    # RKE2's kube-apiserver binds on 0.0.0.0:6443 so 127.0.0.1 works.
+    k8sServiceHost: 127.0.0.1
+    k8sServicePort: 6443
+
+    # Pod CIDR — matches the non-default nested-cluster range in config.yaml.
+    # The outer RKE2 cluster uses 10.42.0.0/16; overlapping it breaks replies
+    # through KubeVirt masquerade as soon as the inner Cilium route appears.
+    ipam:
+      operator:
+        clusterPoolIPv4PodCIDRList:
+          - 10.52.0.0/16
+
+    # Hubble observability. Disable both fields if you care about
+    # minimizing in-cluster pods (Hubble adds relay+ui+metrics).
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+
+    # Single-replica operator for single-node. Bump for HA control plane.
+    operator:
+      replicas: 1

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# mkosi sync hook for the c8s profile.
+#
+# Same mechanism as the attest profile's sync (see its header for the oras +
+# layer-extract approach and the mkosi.local staging convention). Stages
+# three pinned artifact sets into mkosi.local/mkosi.extra/:
+#
+#   1. RKE2 release tarball      -> usr/local/  (rke2 binary, systemd units
+#      under usr/local/lib/systemd/system/ — on systemd's unit search path)
+#   2. RKE2 airgap image bundles -> var/lib/rancher/rke2/agent/images/
+#      Baked deliberately: the measurement then covers the exact bytes of
+#      every control-plane image (kube-* static pods, Cilium, CoreDNS) and
+#      the node boots with zero registry dependency. Costs ~1.6G of disk.raw.
+#   3. nri-image-policy plugin   -> opt/nri/plugins/10-nri-image-policy
+#
+# Bumping any pin below changes the launch measurement of any
+# `--profile c8s` build — intended behaviour.
+#
+# RKE2 pins: bump RKE2_VERSION and the three sha256s together, from
+# sha256sum-amd64.txt at
+#   https://github.com/rancher/rke2/releases/tag/<RKE2_VERSION>
+# After a bump, re-verify on first boot that the rendered containerd
+# config.toml has exactly ONE `imports` line — see the baked
+# config-v3.toml.tmpl in this profile's mkosi.extra for why.
+#
+# c8s components (nri plugin binary + the CDS digest in the baked NRI floor)
+# are NOT hardcoded: both resolve from a single c8s ref (C8S_REF, default: the
+# pinned commit below) so they always match each other and the chart's images.
+#
+# Downloads are cached under mkosi.pkgcache/c8s/ — that dir survives across
+# builds; mkosi.local does NOT (the confos Rust driver wipes it on build
+# exit, see MkosiLocalCleanup in src/commands/build.rs).
+
+set -euo pipefail
+
+STAGE_DIR="$SRCDIR/mkosi.local/mkosi.extra"
+CACHE_DIR="$SRCDIR/mkosi.pkgcache/c8s"
+mkdir -p "$STAGE_DIR" "$CACHE_DIR" "${TMPDIR:=/tmp}"
+
+RKE2_VERSION="v1.34.5+rke2r1"
+RKE2_TARBALL_SHA256="c156a562573c1e3a5c57e816caac5237c451473b0417f903491dc0d810fbae00"
+RKE2_IMAGES_CORE_SHA256="0916003d2cb70501fffd58f278a8b24a1f2c991a9b5d9013b4ba7e8aef92e577"
+RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c16049340ede6c1"
+
+# The baked c8s components — the nri plugin binary AND the CDS digest in the NRI
+# floor — resolve from a single c8s ref, so they never drift from each other or
+# from the images the chart later deploys. C8S_REF pins a specific commit (short
+# SHA) for testing an unmerged build; it arrives via $SRCDIR/mkosi.local/c8s-ref
+# (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
+# runs under sudo, stripping the env). Empty = the pinned default below. The
+# tag must be published (c8s docker.yml on main, or workflow_dispatch for a
+# feature branch).
+# The registry the two component images resolve from. Overridable via
+# $SRCDIR/mkosi.local/c8s-registry (written by bin/build-c8s from C8S_REGISTRY)
+# so an unmerged or air-gapped build can bake components from a local registry
+# without publishing them. Defaults to the published org.
+C8S_REGISTRY=$(cat "$SRCDIR/mkosi.local/c8s-registry" 2>/dev/null || true)
+C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
+NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
+CDS_REPO="${C8S_REGISTRY}/cds"
+C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
+# Pinned published c8s commit matching the deployed CLI/node release (confidential-metal c8s_operator role, c8s#177 branch head); re-pin to main once #177 merges.
+C8S_REF="${C8S_REF:-3a2517b}"
+echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
+resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
+    local d
+    d=$(oras manifest fetch --descriptor "$1:$2" 2>/dev/null | jq -r '.digest')
+    case "$d" in
+        sha256:*) printf '%s' "$d" ;;
+        *) echo "c8s sync: FATAL cannot resolve $1:$2 (is the image published? run c8s docker.yml for the branch)" >&2; exit 1 ;;
+    esac
+}
+NRI_DIGEST=$(resolve_digest "$NRI_REPO" "$C8S_REF")
+CDS_DIGEST=$(resolve_digest "$CDS_REPO" "$C8S_REF")
+NRI_IMAGE="${NRI_REPO}@${NRI_DIGEST}"
+echo "c8s sync: ref ${C8S_REF} -> nri ${NRI_DIGEST}, cds ${CDS_DIGEST}"
+
+# Render the NRI floor template into the stage tree, substituting the resolved
+# nri + cds digests into always_allow. The template lives outside mkosi.extra
+# (image-policy.yaml.in) so mkosi never copies the raw template; this rendered
+# copy is the only one at etc/nri/conf.d/image-policy.yaml, so it lands with no
+# extra-tree precedence ambiguity. Both digests track C8S_REF.
+render_nri_floor() {
+    local tmpl="$SRCDIR/mkosi.profiles/c8s/image-policy.yaml.in"
+    local dst="$STAGE_DIR/etc/nri/conf.d/image-policy.yaml"
+    [ -f "$tmpl" ] || { echo "c8s sync: FATAL floor template $tmpl missing" >&2; exit 1; }
+    mkdir -p "$(dirname "$dst")"
+    sed \
+        -e "s|@NRI_DIGEST@|${NRI_DIGEST}|g" \
+        -e "s|@NRI_IMAGE@|${NRI_IMAGE}|g" \
+        -e "s|@CDS_DIGEST@|${CDS_DIGEST}|g" \
+        -e "s|@CDS_IMAGE@|${CDS_REPO}@${CDS_DIGEST}|g" \
+        "$tmpl" > "$dst"
+    echo "c8s sync: NRI floor rendered (nri ${NRI_DIGEST}, cds ${CDS_DIGEST})"
+}
+
+# Download <url> to <dest>, verifying its sha256. Skip if dest exists and
+# already matches (this is what makes the pkgcache a cache).
+fetch() {
+    local url="$1" dest="$2" expected="$3" actual
+    if [ -f "$dest" ]; then
+        actual="$(sha256sum "$dest" | awk '{print $1}')"
+        if [ "$actual" = "$expected" ]; then
+            echo "c8s sync: cached ${dest##*/}"
+            return
+        fi
+        echo "c8s sync: stale (sha mismatch), re-downloading ${dest##*/}"
+        rm -f "$dest"
+    fi
+    echo "c8s sync: downloading $url"
+    curl -fL --retry 3 --retry-delay 5 --output "$dest" "$url"
+    actual="$(sha256sum "$dest" | awk '{print $1}')"
+    if [ "$actual" != "$expected" ]; then
+        echo "c8s sync: FATAL sha256 mismatch for ${dest##*/}" >&2
+        echo "  expected: $expected" >&2
+        echo "  actual:   $actual" >&2
+        exit 1
+    fi
+}
+
+# Place a cached artifact into the stage tree. Hardlink when possible (same
+# filesystem — mkosi only reads extra trees), copy otherwise.
+stage() {
+    local src="$1" dest="$2"
+    mkdir -p "$(dirname "$dest")"
+    rm -f "$dest"
+    ln "$src" "$dest" 2>/dev/null || cp "$src" "$dest"
+}
+
+# --- 1. RKE2 release tarball --------------------------------------------
+
+VERSION_URL_SAFE="${RKE2_VERSION//+/%2B}"   # '+' must be %2B in release URLs
+CACHE_VER="${RKE2_VERSION//+/-}"            # '+' unsafe in cache filenames
+BASE_URL="https://github.com/rancher/rke2/releases/download/${VERSION_URL_SAFE}"
+
+fetch "${BASE_URL}/rke2.linux-amd64.tar.gz" \
+      "$CACHE_DIR/rke2-${CACHE_VER}.tar.gz" \
+      "$RKE2_TARBALL_SHA256"
+# Default install prefix. systemd's unit search path includes
+# /usr/local/lib/systemd/system, so the bundled rke2-server/agent units
+# need no relocation; the profile's 50-rke2.preset enables/disables them.
+mkdir -p "$STAGE_DIR/usr/local"
+tar -xzf "$CACHE_DIR/rke2-${CACHE_VER}.tar.gz" -C "$STAGE_DIR/usr/local"
+chmod 0755 "$STAGE_DIR/usr/local/bin/rke2" \
+           "$STAGE_DIR/usr/local/bin/rke2-killall.sh" \
+           "$STAGE_DIR/usr/local/bin/rke2-uninstall.sh"
+# Marker for inspecting a built image.
+echo "$RKE2_VERSION" > "$STAGE_DIR/usr/local/share/rke2/.confos-baked-version"
+
+# --- 2. Airgap image bundles (core + cilium) -----------------------------
+
+AIRGAP_DIR="$STAGE_DIR/var/lib/rancher/rke2/agent/images"
+fetch "${BASE_URL}/rke2-images-core.linux-amd64.tar.zst" \
+      "$CACHE_DIR/rke2-images-core-${CACHE_VER}.tar.zst" \
+      "$RKE2_IMAGES_CORE_SHA256"
+fetch "${BASE_URL}/rke2-images-cilium.linux-amd64.tar.zst" \
+      "$CACHE_DIR/rke2-images-cilium-${CACHE_VER}.tar.zst" \
+      "$RKE2_IMAGES_CILIUM_SHA256"
+stage "$CACHE_DIR/rke2-images-core-${CACHE_VER}.tar.zst" \
+      "$AIRGAP_DIR/rke2-images-core.linux-amd64.tar.zst"
+stage "$CACHE_DIR/rke2-images-cilium-${CACHE_VER}.tar.zst" \
+      "$AIRGAP_DIR/rke2-images-cilium.linux-amd64.tar.zst"
+
+# --- 3. nri-image-policy plugin binary ------------------------------------
+
+PLUGIN_TARGET="$STAGE_DIR/opt/nri/plugins/10-nri-image-policy"
+# The same multi-command binary, also staged under its own name so the
+# cred-release systemd unit can invoke `c8s cred-release` (argv[0]="c8s"
+# falls through to normal cobra dispatch — only get-cert/nri-image-policy/
+# ratls-mesh are argv-aliased).
+C8S_TARGET="$STAGE_DIR/usr/local/bin/c8s"
+# Content-addressed by the image digest: a cached copy skips the GHCR pull
+# entirely (oras digest-verifies the blobs on the pull that populates it).
+PLUGIN_CACHE="$CACHE_DIR/nri-image-policy-${NRI_IMAGE##*@sha256:}"
+if [ -f "$PLUGIN_CACHE" ]; then
+    echo "c8s sync: cached nri-image-policy (${NRI_IMAGE##*@})"
+    install -D -m 0755 "$PLUGIN_CACHE" "$PLUGIN_TARGET"
+    install -D -m 0755 "$PLUGIN_CACHE" "$C8S_TARGET"
+    render_nri_floor
+    echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"
+    exit 0
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+EXTRACT="$TMP/rootfs"
+mkdir -p "$EXTRACT"
+
+REPO="${NRI_IMAGE%@*}"
+MANIFEST=$(oras manifest fetch "$NRI_IMAGE")
+
+# The pinned digest is an OCI image index (amd64 image + provenance
+# manifest); descend to the amd64 child. Plain single-arch manifests pass
+# through unchanged so the pin can point at either form.
+case "$(echo "$MANIFEST" | jq -r '.mediaType')" in
+*.index.v1+json | *.manifest.list.v2+json)
+    CHILD=$(echo "$MANIFEST" | jq -r '[.manifests[] | select(.platform.architecture == "amd64")][0].digest')
+    if [ -z "$CHILD" ] || [ "$CHILD" = "null" ]; then
+        echo "c8s sync: no amd64 manifest in index $NRI_IMAGE" >&2
+        exit 1
+    fi
+    MANIFEST=$(oras manifest fetch "${REPO}@${CHILD}")
+    ;;
+esac
+
+# Fetch every gzipped tar layer in manifest order and extract into a single
+# staging dir; later layers shadow earlier ones (same flattening containerd
+# performs). See attest/mkosi.sync for the full rationale. tar failures stay
+# loud but non-fatal (layers legitimately carry entries we can't recreate,
+# e.g. device nodes); the binary-presence check below is the gate.
+LAYERS=$(echo "$MANIFEST" | jq -r '.layers[] | select(.mediaType | test("tar.?gzip$")) | .digest')
+if [ -z "$LAYERS" ]; then
+    echo "c8s sync: no tar+gzip layers in $NRI_IMAGE (zstd or unexpected media types?)" >&2
+    echo "$MANIFEST" | jq -r '.layers[].mediaType' >&2
+    exit 1
+fi
+echo "$LAYERS" | while read -r layer; do
+    echo "c8s sync: fetching layer $layer" >&2
+    oras blob fetch --output "$TMP/layer.tar.gz" "${REPO}@${layer}"
+    tar -xzf "$TMP/layer.tar.gz" -C "$EXTRACT" || true
+    rm -f "$TMP/layer.tar.gz"
+done
+
+# In the image /usr/local/bin/nri-image-policy is a symlink to the
+# multi-command c8s binary (argv[0] dispatch handles the 10- prefix, and
+# the chart installs the same content — byte-identity holds). Resolve the
+# link inside the extracted tree; absolute targets must not escape to the
+# sandbox rootfs.
+BIN="$EXTRACT/usr/local/bin/nri-image-policy"
+if [ -L "$BIN" ]; then
+    TARGET=$(readlink "$BIN")
+    case "$TARGET" in
+        /*) BIN="$EXTRACT$TARGET" ;;
+        *)  BIN="$(dirname "$BIN")/$TARGET" ;;
+    esac
+fi
+if [ ! -f "$BIN" ]; then
+    echo "c8s sync: nri-image-policy binary not found in image" >&2
+    find "$EXTRACT" -name 'nri-image-policy*' -o -name 'c8s' >&2
+    exit 1
+fi
+install -D -m 0644 "$BIN" "$PLUGIN_CACHE"
+install -D -m 0755 "$BIN" "$PLUGIN_TARGET"
+install -D -m 0755 "$BIN" "$C8S_TARGET"
+
+render_nri_floor
+
+echo "c8s sync: staged rke2 ${RKE2_VERSION} + airgap bundles + nri-image-policy + c8s"

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -45,20 +45,21 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # The baked c8s components — the nri plugin binary AND the CDS digest in the NRI
 # floor — resolve from a single c8s ref, so they never drift from each other or
 # from the images the chart later deploys. C8S_REF pins a specific commit (short
-# SHA) for testing an unmerged build; it arrives via $SRCDIR/mkosi.local/c8s-ref
-# (written by bin/build-c8s — an exported var never reaches this sandbox: mkosi
-# runs under sudo, stripping the env). Empty = the pinned default below. The
-# tag must be published (c8s docker.yml on main, or workflow_dispatch for a
-# feature branch).
+# SHA) for testing an unmerged build; it arrives via
+# `confos build --sync-input c8s-ref=...` (passed by bin/build-c8s — an
+# exported var never reaches this sandbox: mkosi runs under sudo, stripping
+# the env). Empty = the pinned default below. The tag must be published (c8s
+# docker.yml on main, or workflow_dispatch for a feature branch).
 # The registry the two component images resolve from. Overridable via
-# $SRCDIR/mkosi.local/c8s-registry (written by bin/build-c8s from C8S_REGISTRY)
+# `--sync-input c8s-registry=...` (passed by bin/build-c8s from C8S_REGISTRY)
 # so an unmerged or air-gapped build can bake components from a local registry
 # without publishing them. Defaults to the published org.
-C8S_REGISTRY=$(cat "$SRCDIR/mkosi.local/c8s-registry" 2>/dev/null || true)
+SYNC_INPUTS="$SRCDIR/mkosi.local/.confos-sync-inputs"
+C8S_REGISTRY=$(cat "$SYNC_INPUTS/c8s-registry" 2>/dev/null || true)
 C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
-C8S_REF=$(cat "$SRCDIR/mkosi.local/c8s-ref" 2>/dev/null || true)
+C8S_REF=$(cat "$SYNC_INPUTS/c8s-ref" 2>/dev/null || true)
 # Pinned published c8s commit matching the deployed CLI/node release (confidential-metal c8s_operator role, c8s#177 branch head); re-pin to main once #177 merges.
 C8S_REF="${C8S_REF:-3a2517b}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"

--- a/node-guest-image/c8s/user-data
+++ b/node-guest-image/c8s/user-data
@@ -1,0 +1,26 @@
+#cloud-config
+# c8s node image — node-as-CVM, single-node cluster.
+#
+# This payload is BAKED INTO the verity root at build time (via
+# bin/build-c8s passing --cloud-init) and therefore measured into the
+# launch digest. Anything per-host (hostname, secrets, IPs) that needs to
+# differ between deployments belongs in NoCloud `meta-data` (which lives
+# outside the measurement) or in a config drop-in on a data disk.
+#
+# The bulk of node setup is baked rather than scripted at first boot — see
+# this profile's mkosi.extra/ tree. rke2-server is started by the
+# 50-rke2.preset (via WantedBy=multi-user.target); cloud-init does NOT need
+# to enable/start it. The only thing left for cloud-init is per-instance
+# setup — currently just the hostname.
+#
+# If a deployment needs to override rke2 config, the operator drops a
+# /etc/rancher/rke2/config.yaml.d/*.yaml fragment at runtime — rke2 merges
+# drop-ins on top of the baked /etc/rancher/rke2/config.yaml without
+# rebuilding the image.
+
+# Hostname is settable per-deployment via NoCloud meta-data's
+# `local-hostname`. Default below applies when meta-data doesn't override.
+preserve_hostname: false
+hostname: c8s-node
+
+final_message: "c8s node cloud-init complete. rke2-server was started by the preset at boot; give it ~60s, then `kubectl get nodes` should report Ready."

--- a/node-guest-image/kernel/c8s-dev.config
+++ b/node-guest-image/kernel/c8s-dev.config
@@ -1,0 +1,286 @@
+# Combined kernel fragment for C8S_DEV=1 demo/debug builds of the c8s image:
+# every line of kernel/c8s.config plus kernel/dev.config's opt-ins (8250
+# serial for KubeVirt's ttyS0 console, open debugfs). Only one
+# --kernel-config-fragment is accepted per build, so the union is committed
+# verbatim; bin/lint enforces both superset invariants. Images built from
+# this fragment have a different measurement and a serial root shell —
+# never ship them.
+
+# c8s kernel config fragment — the GPU fragment plus the Kubernetes/container
+# runtime symbols the c8s node image needs.
+#
+# Applied for the c8s node image, via
+#   bin/confos kernel --kernel-config-fragment kernel/c8s.config
+#   bin/confos build  --kernel-config-fragment kernel/c8s.config \
+#       --profile gpu --profile attest-gpu --profile c8s
+# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# per build, so this file is a superset: it contains every effective line of
+# kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
+# gpu.config first, then mirror here), followed by the container/k8s set.
+#
+# The container/k8s section is ported from base-images rke2/kernel/
+# container.config, which was validated end-to-end under c8s (RKE2 v1.34 +
+# Cilium + ratls-mesh) on the SNP rke2 image. Comments preserved — each one
+# encodes a real failure mode.
+#
+# NOT ported from container.config (KubeVirt-SNP launch stack specifics; the
+# confos TDX base boots without them — re-add if a launch stack needs them):
+#   CONFIG_VIRTIO_IOMMU        (KubeVirt forces iommu_platform under SEV-SNP)
+#   CONFIG_SERIAL_8250(_CONSOLE) (kernel/dev.config is the serial opt-in here)
+
+# ===========================================================================
+# kernel/gpu.config — verbatim effective lines. Full rationale (ephemeral
+# module signing, LKCA for NVIDIA SPDM, vsock quote path + unit-level
+# fencing) lives in that file; keep the two in lockstep.
+# ===========================================================================
+
+CONFIG_MODULES=y
+# CONFIG_MODULE_UNLOAD is not set
+
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_FORCE=y
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_SHA512=y
+
+CONFIG_CRYPTO_ECC=y
+CONFIG_CRYPTO_ECDH=y
+CONFIG_CRYPTO_ECDSA=y
+CONFIG_CRYPTO_KPP=y
+
+CONFIG_VSOCKETS=y
+CONFIG_VIRTIO_VSOCKETS=y
+
+# With CONFIG_MODULES=y + DEBUG_INFO_BTF (below), Kconfig defaults
+# DEBUG_INFO_BTF_MODULES on, which drags pahole into the out-of-tree NVIDIA
+# module build (bin/steep-fetch-gpu) and risks BTF-mismatch noise at modprobe.
+# Cilium only needs vmlinux BTF; module BTF stays off.
+# CONFIG_DEBUG_INFO_BTF_MODULES is not set
+
+# ===========================================================================
+# Container/Kubernetes runtime prerequisites (from base-images
+# rke2/kernel/container.config). Widen the hardened kernel just enough that
+# kubelet, containerd, runc, and Cilium all start cleanly. Everything =y —
+# nothing here may require a runtime modprobe (nvidia-modules-latch sets
+# kernel.modules_disabled=1 after the NVIDIA driver loads).
+# ===========================================================================
+
+# --- Container runtime essentials ----------------------------------------
+
+# kubelet refuses to start without memory cgroup support.
+CONFIG_MEMCG=y
+
+# User namespaces. Required by several container runtimes (runc rootless
+# mode, several BPF features).
+CONFIG_USER_NS=y
+
+# Pod CPU limits (CFS quota/period). Without this, `resources.limits.cpu`
+# silently has no effect.
+CONFIG_CFS_BANDWIDTH=y
+
+# Runtimes that watch container filesystems for events (falco, auditd
+# integrations, observability tools).
+CONFIG_FANOTIFY=y
+
+# kubelet credential cache.
+CONFIG_PERSISTENT_KEYRINGS=y
+
+# --- Pod networking devices ----------------------------------------------
+
+# Virtual ethernet pairs — every pod is connected to the host via veth.
+CONFIG_VETH=y
+
+# Linux bridge — used by the default CNI bridge plugin and as the underlying
+# device for VXLAN/Geneve overlays.
+CONFIG_BRIDGE=y
+# Netfilter hooks on bridge traffic (br_netfilter). Required for two reasons:
+#   1. Packets bridged between veth pairs BYPASS iptables/nftables unless
+#      br_netfilter is active — service-IP DNAT silently never fires.
+#   2. Creates /proc/sys/net/bridge/ where the bridge-nf-call-iptables
+#      sysctls live (set in the c8s profile's etc/sysctl.d/90-rke2.conf).
+CONFIG_BRIDGE_NETFILTER=y
+
+# Overlay encapsulation (Cilium VXLAN default; Geneve as the alternative).
+CONFIG_VXLAN=y
+CONFIG_GENEVE=y
+
+# TUN/TAP. Several CNIs and IPsec setups need it.
+CONFIG_TUN=y
+
+# Additional veth-style plugins (Multus, custom CNI chains).
+CONFIG_MACVLAN=y
+CONFIG_IPVLAN=y
+
+# Dummy interface — Cilium uses this for the host network namespace's
+# reverse-path verification flow.
+CONFIG_DUMMY=y
+
+# --- Modern netfilter backend --------------------------------------------
+
+# nftables — kube-proxy's default backend since k8s 1.31. Legacy iptables is
+# already in required.config.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_NETDEV=y
+
+# Per-feature nftables symbols. Without them `nft add rule ... dnat to ...`
+# fails silently and service IP traffic isn't NATed. NAT: DNAT/SNAT chains
+# (service IP redirect). MASQ: outbound pod masquerading. REDIR: local-port
+# redirect. REJECT: services with no endpoints. CT: conntrack match.
+# LIMIT: rate limits. FIB: route-lookup expression.
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_REJECT_INET=y
+CONFIG_NFT_REJECT_IPV4=y
+CONFIG_NFT_REJECT_IPV6=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_LIMIT=y
+CONFIG_NFT_FIB=y
+CONFIG_NFT_FIB_INET=y
+CONFIG_NFT_FIB_IPV4=y
+CONFIG_NFT_FIB_IPV6=y
+# Compatibility shim — `iptables-nft` translates legacy iptables commands to
+# nftables. RKE2 ships iptables-nft as its bundled `iptables` binary, and
+# many CNI plugins shell out to it. Without NFT_COMPAT the translation fails.
+CONFIG_NFT_COMPAT=y
+
+# Conntrack netlink — kube-proxy flushes stale entries via this when service
+# endpoints change.
+CONFIG_NF_CT_NETLINK=y
+
+# NAT helper the MASQUERADE target depends on for the actual masquerade work.
+CONFIG_NF_NAT_MASQUERADE=y
+
+# Individual xt_ matches that NetworkPolicy enforcement uses.
+#
+# NETFILTER_ADVANCED gates most xt_ matches (incl. OWNER, RECENT, STATISTIC
+# below): the hardened base leaves it unset, so olddefconfig SILENTLY DROPS
+# any xt_ match whose Kconfig `depends on NETFILTER_ADVANCED` — the option
+# just vanishes from the built kernel with no error. Must be =y for the
+# matches below to actually compile in.
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_RECENT=y
+CONFIG_NETFILTER_XT_MATCH_STATISTIC=y
+CONFIG_NETFILTER_XT_MATCH_MARK=y
+# owner match (-m owner --uid-owner): c8s ratls-mesh's iptables-sync skips its
+# own mesh-UID traffic with it. Without xt_owner the rule append fails ("owner
+# revision 0 not supported, missing kernel module" → RULE_APPEND failed), the
+# RATLS-MESH nat chains are left half-built, and pod egress to ClusterIPs
+# (incl. CoreDNS) returns EPERM — cascading every c8s component.
+CONFIG_NETFILTER_XT_MATCH_OWNER=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_TPROXY_IPV4=y
+# Cilium's iptables datapath targets/matches (audited against Cilium 1.19's
+# system-requirements). xt_CT is the proven blocker (the VXLAN-tunnel
+# raw-table `-j CT --notrack` rule — its failure breaks host↔pod overlay
+# traffic, so kubelet probes to pod IPs time out and CoreDNS/everything
+# crashloops); the other three (MARK target, SOCKET match, TPROXY target) are
+# the rest of Cilium's documented netfilter set. (NOT added: XFRM/CRYPTO —
+# IPsec, unused; NETKIT — veth mode; NET_SCH_FQ — bandwidth manager,
+# disabled.) Deps satisfied: NETFILTER_ADVANCED, NFT_COMPAT, NF_TPROXY_IPV4
+# present; XT_MATCH_SOCKET auto-selects NF_SOCKET_IPV4.
+CONFIG_NETFILTER_XT_TARGET_CT=y
+CONFIG_NETFILTER_XT_TARGET_MARK=y
+CONFIG_NETFILTER_XT_MATCH_SOCKET=y
+CONFIG_NETFILTER_XT_TARGET_TPROXY=y
+
+# --- kube-proxy IPVS mode ------------------------------------------------
+
+CONFIG_IP_VS=y
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=y
+CONFIG_IP_VS_WRR=y
+CONFIG_IP_VS_SH=y
+
+# ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
+# glue that lets iptables rules reference a set via `-m set --match-set` —
+# c8s ratls-mesh's REDIRECT/DNAT rules need it ("set revision 0 not
+# supported" without it).
+CONFIG_IP_SET=y
+CONFIG_IP_SET_HASH_IP=y
+CONFIG_IP_SET_HASH_NET=y
+CONFIG_NETFILTER_XT_SET=y
+
+# --- BPF (Cilium, kubelet, observability) --------------------------------
+
+# eBPF syscall + JIT. Cilium won't load without these, and modern kubelet
+# uses BPF for several functions even with non-BPF CNIs.
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+
+# BPF programs attached to cgroup events (Cilium's egress connect hooks,
+# systemd's BPF firewall, etc.).
+CONFIG_CGROUP_BPF=y
+
+# BPF in tc — Cilium's datapath is built on these.
+CONFIG_NET_CLS_BPF=y
+CONFIG_NET_ACT_BPF=y
+CONFIG_NET_SCH_INGRESS=y
+
+# --- Encrypted containerd data disk (containerd-data-disk.service) -------
+
+# containerd-data-disk.service backs /var/lib/rancher/rke2/agent/containerd
+# (the image cache) with a LABEL=containerd disk it encrypts in-guest,
+# keeping several GiB of image layers off guest RAM (the tmpfs default). It
+# uses `cryptsetup open --type plain --cipher aes-xts-plain64`, which needs
+# dm-crypt + the XTS template + AES in the BOOTED kernel — without them
+# cryptsetup HANGS at boot (the device-mapper target never appears). The
+# service has a fail-safe timeout, but the encrypted path only actually
+# works with these on.
+CONFIG_DM_CRYPT=y
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+
+# --- Filesystem extras ---------------------------------------------------
+
+# Several snapshotters (stargz, soci, nydus) use FUSE.
+CONFIG_FUSE_FS=y
+
+# squashfs — useful on every image for inspecting kata images.
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_SQUASHFS_ZSTD=y
+
+# --- Socket diagnostics --------------------------------------------------
+
+# `ss`, `netstat`, several observability agents read these.
+CONFIG_INET_DIAG=y
+CONFIG_INET_TCP_DIAG=y
+CONFIG_INET_UDP_DIAG=y
+CONFIG_INET_RAW_DIAG=y
+CONFIG_INET_DIAG_DESTROY=y
+
+# --- BTF (Cilium socket-LB) ----------------------------------------------
+
+# pahole turns the kernel's DWARF into BTF, which eBPF CO-RE needs. Without
+# it /sys/kernel/btf/vmlinux is absent and Cilium's socket-LB can't
+# translate ClusterIP service VIPs: connect() to any Service IP (CoreDNS,
+# kube-api) returns EPERM, breaking c8s (cds → attestation-api .svc).
+# Overrides hardening.config's `# CONFIG_DEBUG_INFO is not set`. Requires
+# dwarves (pahole) in the kernel-builder tools tree — hence
+# --kernel-builder-package dwarves,python3,pkg-config,zlib1g-dev.
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_DWARF5=y
+CONFIG_DEBUG_INFO_BTF=y
+
+# DEBUG_INFO_BTF depends on !GCC_PLUGIN_RANDSTRUCT — pahole cannot describe
+# randomized struct layouts. Overrides hardening.config's RANDSTRUCT_FULL:
+# the c8s kernel trades struct-layout randomization for BTF, the same trade
+# every BTF-shipping distro kernel makes.
+# CONFIG_RANDSTRUCT_FULL is not set
+CONFIG_RANDSTRUCT_NONE=y
+
+# --- kernel/dev.config opt-ins (verbatim; merged last so they win) ---
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_SERIAL_8250_PCI=y
+CONFIG_SERIAL_8250_NR_UARTS=4
+CONFIG_SERIAL_8250_RUNTIME_UARTS=4
+CONFIG_DEBUG_FS_ALLOW_ALL=y

--- a/node-guest-image/kernel/c8s.config
+++ b/node-guest-image/kernel/c8s.config
@@ -1,0 +1,270 @@
+# c8s kernel config fragment — the GPU fragment plus the Kubernetes/container
+# runtime symbols the c8s node image needs.
+#
+# Applied for the c8s node image, via
+#   bin/confos kernel --kernel-config-fragment kernel/c8s.config
+#   bin/confos build  --kernel-config-fragment kernel/c8s.config \
+#       --profile gpu --profile attest-gpu --profile c8s
+# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# per build, so this file is a superset: it contains every effective line of
+# kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
+# gpu.config first, then mirror here), followed by the container/k8s set.
+#
+# The container/k8s section is ported from base-images rke2/kernel/
+# container.config, which was validated end-to-end under c8s (RKE2 v1.34 +
+# Cilium + ratls-mesh) on the SNP rke2 image. Comments preserved — each one
+# encodes a real failure mode.
+#
+# NOT ported from container.config (KubeVirt-SNP launch stack specifics; the
+# confos TDX base boots without them — re-add if a launch stack needs them):
+#   CONFIG_VIRTIO_IOMMU        (KubeVirt forces iommu_platform under SEV-SNP)
+#   CONFIG_SERIAL_8250(_CONSOLE) (kernel/dev.config is the serial opt-in here)
+
+# ===========================================================================
+# kernel/gpu.config — verbatim effective lines. Full rationale (ephemeral
+# module signing, LKCA for NVIDIA SPDM, vsock quote path + unit-level
+# fencing) lives in that file; keep the two in lockstep.
+# ===========================================================================
+
+CONFIG_MODULES=y
+# CONFIG_MODULE_UNLOAD is not set
+
+CONFIG_MODULE_SIG=y
+CONFIG_MODULE_SIG_FORCE=y
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_SHA512=y
+
+CONFIG_CRYPTO_ECC=y
+CONFIG_CRYPTO_ECDH=y
+CONFIG_CRYPTO_ECDSA=y
+CONFIG_CRYPTO_KPP=y
+
+CONFIG_VSOCKETS=y
+CONFIG_VIRTIO_VSOCKETS=y
+
+# With CONFIG_MODULES=y + DEBUG_INFO_BTF (below), Kconfig defaults
+# DEBUG_INFO_BTF_MODULES on, which drags pahole into the out-of-tree NVIDIA
+# module build (bin/steep-fetch-gpu) and risks BTF-mismatch noise at modprobe.
+# Cilium only needs vmlinux BTF; module BTF stays off.
+# CONFIG_DEBUG_INFO_BTF_MODULES is not set
+
+# ===========================================================================
+# Container/Kubernetes runtime prerequisites (from base-images
+# rke2/kernel/container.config). Widen the hardened kernel just enough that
+# kubelet, containerd, runc, and Cilium all start cleanly. Everything =y —
+# nothing here may require a runtime modprobe (nvidia-modules-latch sets
+# kernel.modules_disabled=1 after the NVIDIA driver loads).
+# ===========================================================================
+
+# --- Container runtime essentials ----------------------------------------
+
+# kubelet refuses to start without memory cgroup support.
+CONFIG_MEMCG=y
+
+# User namespaces. Required by several container runtimes (runc rootless
+# mode, several BPF features).
+CONFIG_USER_NS=y
+
+# Pod CPU limits (CFS quota/period). Without this, `resources.limits.cpu`
+# silently has no effect.
+CONFIG_CFS_BANDWIDTH=y
+
+# Runtimes that watch container filesystems for events (falco, auditd
+# integrations, observability tools).
+CONFIG_FANOTIFY=y
+
+# kubelet credential cache.
+CONFIG_PERSISTENT_KEYRINGS=y
+
+# --- Pod networking devices ----------------------------------------------
+
+# Virtual ethernet pairs — every pod is connected to the host via veth.
+CONFIG_VETH=y
+
+# Linux bridge — used by the default CNI bridge plugin and as the underlying
+# device for VXLAN/Geneve overlays.
+CONFIG_BRIDGE=y
+# Netfilter hooks on bridge traffic (br_netfilter). Required for two reasons:
+#   1. Packets bridged between veth pairs BYPASS iptables/nftables unless
+#      br_netfilter is active — service-IP DNAT silently never fires.
+#   2. Creates /proc/sys/net/bridge/ where the bridge-nf-call-iptables
+#      sysctls live (set in the c8s profile's etc/sysctl.d/90-rke2.conf).
+CONFIG_BRIDGE_NETFILTER=y
+
+# Overlay encapsulation (Cilium VXLAN default; Geneve as the alternative).
+CONFIG_VXLAN=y
+CONFIG_GENEVE=y
+
+# TUN/TAP. Several CNIs and IPsec setups need it.
+CONFIG_TUN=y
+
+# Additional veth-style plugins (Multus, custom CNI chains).
+CONFIG_MACVLAN=y
+CONFIG_IPVLAN=y
+
+# Dummy interface — Cilium uses this for the host network namespace's
+# reverse-path verification flow.
+CONFIG_DUMMY=y
+
+# --- Modern netfilter backend --------------------------------------------
+
+# nftables — kube-proxy's default backend since k8s 1.31. Legacy iptables is
+# already in required.config.
+CONFIG_NF_TABLES=y
+CONFIG_NF_TABLES_INET=y
+CONFIG_NF_TABLES_NETDEV=y
+
+# Per-feature nftables symbols. Without them `nft add rule ... dnat to ...`
+# fails silently and service IP traffic isn't NATed. NAT: DNAT/SNAT chains
+# (service IP redirect). MASQ: outbound pod masquerading. REDIR: local-port
+# redirect. REJECT: services with no endpoints. CT: conntrack match.
+# LIMIT: rate limits. FIB: route-lookup expression.
+CONFIG_NFT_NAT=y
+CONFIG_NFT_MASQ=y
+CONFIG_NFT_REDIR=y
+CONFIG_NFT_REJECT=y
+CONFIG_NFT_REJECT_INET=y
+CONFIG_NFT_REJECT_IPV4=y
+CONFIG_NFT_REJECT_IPV6=y
+CONFIG_NFT_CT=y
+CONFIG_NFT_LIMIT=y
+CONFIG_NFT_FIB=y
+CONFIG_NFT_FIB_INET=y
+CONFIG_NFT_FIB_IPV4=y
+CONFIG_NFT_FIB_IPV6=y
+# Compatibility shim — `iptables-nft` translates legacy iptables commands to
+# nftables. RKE2 ships iptables-nft as its bundled `iptables` binary, and
+# many CNI plugins shell out to it. Without NFT_COMPAT the translation fails.
+CONFIG_NFT_COMPAT=y
+
+# Conntrack netlink — kube-proxy flushes stale entries via this when service
+# endpoints change.
+CONFIG_NF_CT_NETLINK=y
+
+# NAT helper the MASQUERADE target depends on for the actual masquerade work.
+CONFIG_NF_NAT_MASQUERADE=y
+
+# Individual xt_ matches that NetworkPolicy enforcement uses.
+#
+# NETFILTER_ADVANCED gates most xt_ matches (incl. OWNER, RECENT, STATISTIC
+# below): the hardened base leaves it unset, so olddefconfig SILENTLY DROPS
+# any xt_ match whose Kconfig `depends on NETFILTER_ADVANCED` — the option
+# just vanishes from the built kernel with no error. Must be =y for the
+# matches below to actually compile in.
+CONFIG_NETFILTER_ADVANCED=y
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=y
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
+CONFIG_NETFILTER_XT_MATCH_COMMENT=y
+CONFIG_NETFILTER_XT_MATCH_MULTIPORT=y
+CONFIG_NETFILTER_XT_MATCH_RECENT=y
+CONFIG_NETFILTER_XT_MATCH_STATISTIC=y
+CONFIG_NETFILTER_XT_MATCH_MARK=y
+# owner match (-m owner --uid-owner): c8s ratls-mesh's iptables-sync skips its
+# own mesh-UID traffic with it. Without xt_owner the rule append fails ("owner
+# revision 0 not supported, missing kernel module" → RULE_APPEND failed), the
+# RATLS-MESH nat chains are left half-built, and pod egress to ClusterIPs
+# (incl. CoreDNS) returns EPERM — cascading every c8s component.
+CONFIG_NETFILTER_XT_MATCH_OWNER=y
+CONFIG_NETFILTER_XT_TARGET_REDIRECT=y
+CONFIG_NETFILTER_XT_NAT=y
+CONFIG_NF_NAT_REDIRECT=y
+CONFIG_NF_TPROXY_IPV4=y
+# Cilium's iptables datapath targets/matches (audited against Cilium 1.19's
+# system-requirements). xt_CT is the proven blocker (the VXLAN-tunnel
+# raw-table `-j CT --notrack` rule — its failure breaks host↔pod overlay
+# traffic, so kubelet probes to pod IPs time out and CoreDNS/everything
+# crashloops); the other three (MARK target, SOCKET match, TPROXY target) are
+# the rest of Cilium's documented netfilter set. (NOT added: XFRM/CRYPTO —
+# IPsec, unused; NETKIT — veth mode; NET_SCH_FQ — bandwidth manager,
+# disabled.) Deps satisfied: NETFILTER_ADVANCED, NFT_COMPAT, NF_TPROXY_IPV4
+# present; XT_MATCH_SOCKET auto-selects NF_SOCKET_IPV4.
+CONFIG_NETFILTER_XT_TARGET_CT=y
+CONFIG_NETFILTER_XT_TARGET_MARK=y
+CONFIG_NETFILTER_XT_MATCH_SOCKET=y
+CONFIG_NETFILTER_XT_TARGET_TPROXY=y
+
+# --- kube-proxy IPVS mode ------------------------------------------------
+
+CONFIG_IP_VS=y
+CONFIG_IP_VS_NFCT=y
+CONFIG_IP_VS_RR=y
+CONFIG_IP_VS_WRR=y
+CONFIG_IP_VS_SH=y
+
+# ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
+# glue that lets iptables rules reference a set via `-m set --match-set` —
+# c8s ratls-mesh's REDIRECT/DNAT rules need it ("set revision 0 not
+# supported" without it).
+CONFIG_IP_SET=y
+CONFIG_IP_SET_HASH_IP=y
+CONFIG_IP_SET_HASH_NET=y
+CONFIG_NETFILTER_XT_SET=y
+
+# --- BPF (Cilium, kubelet, observability) --------------------------------
+
+# eBPF syscall + JIT. Cilium won't load without these, and modern kubelet
+# uses BPF for several functions even with non-BPF CNIs.
+CONFIG_BPF_SYSCALL=y
+CONFIG_BPF_JIT=y
+
+# BPF programs attached to cgroup events (Cilium's egress connect hooks,
+# systemd's BPF firewall, etc.).
+CONFIG_CGROUP_BPF=y
+
+# BPF in tc — Cilium's datapath is built on these.
+CONFIG_NET_CLS_BPF=y
+CONFIG_NET_ACT_BPF=y
+CONFIG_NET_SCH_INGRESS=y
+
+# --- Encrypted containerd data disk (containerd-data-disk.service) -------
+
+# containerd-data-disk.service backs /var/lib/rancher/rke2/agent/containerd
+# (the image cache) with a LABEL=containerd disk it encrypts in-guest,
+# keeping several GiB of image layers off guest RAM (the tmpfs default). It
+# uses `cryptsetup open --type plain --cipher aes-xts-plain64`, which needs
+# dm-crypt + the XTS template + AES in the BOOTED kernel — without them
+# cryptsetup HANGS at boot (the device-mapper target never appears). The
+# service has a fail-safe timeout, but the encrypted path only actually
+# works with these on.
+CONFIG_DM_CRYPT=y
+CONFIG_CRYPTO_XTS=y
+CONFIG_CRYPTO_AES_NI_INTEL=y
+
+# --- Filesystem extras ---------------------------------------------------
+
+# Several snapshotters (stargz, soci, nydus) use FUSE.
+CONFIG_FUSE_FS=y
+
+# squashfs — useful on every image for inspecting kata images.
+CONFIG_SQUASHFS=y
+CONFIG_SQUASHFS_XATTR=y
+CONFIG_SQUASHFS_ZSTD=y
+
+# --- Socket diagnostics --------------------------------------------------
+
+# `ss`, `netstat`, several observability agents read these.
+CONFIG_INET_DIAG=y
+CONFIG_INET_TCP_DIAG=y
+CONFIG_INET_UDP_DIAG=y
+CONFIG_INET_RAW_DIAG=y
+CONFIG_INET_DIAG_DESTROY=y
+
+# --- BTF (Cilium socket-LB) ----------------------------------------------
+
+# pahole turns the kernel's DWARF into BTF, which eBPF CO-RE needs. Without
+# it /sys/kernel/btf/vmlinux is absent and Cilium's socket-LB can't
+# translate ClusterIP service VIPs: connect() to any Service IP (CoreDNS,
+# kube-api) returns EPERM, breaking c8s (cds → attestation-api .svc).
+# Overrides hardening.config's `# CONFIG_DEBUG_INFO is not set`. Requires
+# dwarves (pahole) in the kernel-builder tools tree — hence
+# --kernel-builder-package dwarves,python3,pkg-config,zlib1g-dev.
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_INFO_DWARF5=y
+CONFIG_DEBUG_INFO_BTF=y
+
+# DEBUG_INFO_BTF depends on !GCC_PLUGIN_RANDSTRUCT — pahole cannot describe
+# randomized struct layouts. Overrides hardening.config's RANDSTRUCT_FULL:
+# the c8s kernel trades struct-layout randomization for BTF, the same trade
+# every BTF-shipping distro kernel makes.
+# CONFIG_RANDSTRUCT_FULL is not set
+CONFIG_RANDSTRUCT_NONE=y


### PR DESCRIPTION
Phase 0 of #264. Adds `node-guest-image/`:

- `c8s/` — verbatim copy (diff-verified) of confos `mkosi/base/mkosi.profiles/c8s/**` at v0.3.0 (`3e6f858`). The dir basename is the profile name, so it stays `c8s`; `mkosi.sync`'s only self-reference (`$SRCDIR/mkosi.profiles/c8s/image-policy.yaml.in`) resolves to the staged copy unchanged.
- `kernel/` — verbatim `c8s.config` / `c8s-dev.config`, passed via `--kernel-config-fragment` (kata-guest-base precedent).
- `build` — drop-in for confos `bin/build-c8s`: same env contract, same profile stack and **order** (`gpu, attest[-gpu], c8s, dev` — preserved via confidential-dot-ai/confidential-os-builder#81's rule that a `--profile` position wins for a staged `--profile-dir`).
- README documenting the layout, migration state, and the switch gate.

Nothing consumes this yet — `c8s-image.yml` is untouched, so this PR cannot affect the measured publish path. Next steps (tracked in #264): confos phase-1 PR deletes the in-tree profile (required — `--profile-dir` refuses to shadow an in-tree profile), a dispatch build compares `manifest.json` measurements between the two paths at the same c8s ref, and only then does `c8s-image.yml` flip (including re-pointing its kernel cache key at the fragments here).

Depends on confidential-dot-ai/confidential-os-builder#81.