### PR TITLE
test(ratlsmesh): fix the TestProxyRunEndToEnd flake

### DIFF
--- a/internal/cmds/ratlsmesh/proxy_serve_test.go
+++ b/internal/cmds/ratlsmesh/proxy_serve_test.go
@@ -345,6 +345,31 @@ func (f *proxyRunFixture) roundTrip(t *testing.T, payload string) string {
 	return string(got)
 }
 
+// waitForConnSlots blocks until every global semaphore slot has been returned.
+//
+// A slot is released by the deferred send in Serve's per-connection goroutine,
+// which runs only after handler() returns — strictly later than the client
+// observing EOF on its own read. Dialing again the instant roundTrip returns
+// therefore races that release: at capacity the next connection is rejected
+// and closed, and the client sees a reset rather than a reply. Waiting here
+// asserts the release the test is about, instead of assuming it already
+// happened.
+func (f *proxyRunFixture) waitForConnSlots(t *testing.T) {
+	t.Helper()
+	const timeout = 5 * time.Second
+	deadline := time.Now().Add(timeout)
+	for {
+		held := len(f.p.connSem)
+		if held == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d semaphore slot(s) still held after %v; Serve must return them once the handler finishes", held, timeout)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 // End-to-end through Run: plain outbound listener, TLS inbound listener, and
 // the global semaphore released after every finished connection.
 func TestProxyRunEndToEnd(t *testing.T) {
@@ -359,6 +384,9 @@ func TestProxyRunEndToEnd(t *testing.T) {
 		if got := f.roundTrip(t, fmt.Sprintf("ping-%d", i)); got != want {
 			t.Fatalf("connection %d: got %q, want %q", i, got, want)
 		}
+		// Both legs must give their slots back before the next dial, or the
+		// sequential-reuse property under test cannot be observed at all.
+		f.waitForConnSlots(t)
 	}
 	if v := testutil.ToFloat64(f.p.metrics.connLimitRejected); v != 0 {
 		t.Errorf("connLimitRejected = %v after sequential connections, want 0 (slots must be released)", v)


### PR DESCRIPTION
`TestProxyRunEndToEnd` fails intermittently with `read: connection reset by peer`. On one machine it reproduced 2 times in 40 runs; the same binary built from this branch ran 60 times without a failure.

## What races

The test dials three connections in sequence through a global semaphore sized to admit exactly one at a time (capacity 2, two slots per app connection — outbound leg plus inbound leg). The point is to show that a finished connection gives its slots back, which is also what the `connLimitRejected == 0` assertion at the end checks.

But it dialled again the moment `roundTrip` returned. A slot is returned by the deferred send in `Serve`'s per-connection goroutine:

```go
go func() {
    defer func() {
        ...
        if p.connSem != nil {
            <-p.connSem
        }
        p.activeConns.Done()
    }()
    handler(ctx, conn)
}()
```

That defer runs only after `handler` returns, which is strictly later than the client observing EOF on its own read — the handler closes the write side from inside `handler`. So the next dial can arrive while both slots are still held. `Serve` then takes the `default` branch on the semaphore, counts a rejection, and closes the connection, and the client reads a reset instead of a reply.

The proxy is behaving correctly here: rejecting at capacity is the intended backpressure. The wrong assumption is the test's, that the release is observable the instant the client sees EOF.

## The fix

Wait for the slots to come back between connections, bounded at 5s and failing with the number still held. A real leak stays a test failure rather than becoming a hang, and the release the test exists to demonstrate is now asserted directly instead of being assumed by timing.

No production code changes.
