### PR TITLE
fix(nri-image-policy): separate an argv denial from an unlisted image

### DIFF
--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -387,16 +387,24 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	// where it sees the CRI container rather than a guest's mount table, and an
 	// unobserved field is not a violation (allowlist.RunningContainer).
 	if !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
-		log.Warn("image not admitted by allowlist", "digest", digest, "argv", argv)
+		// INVARIANT: the returned reason reaches a namespace-readable kubelet
+		// event, so it names only the image — argv can carry credentials and
+		// stays in the node-local log.
+		reason, denial := "not_in_allowlist", fmt.Sprintf("image not in allowlist: %s", imageRef)
+		if listed := snap.index.AdmitsDigest(digest); listed {
+			reason = "argv_not_admitted"
+			denial = fmt.Sprintf("image %s is allowlisted, but its command satisfies no workload entry's argv policy", imageRef)
+		}
+		log.Warn("image not admitted by allowlist", "digest", digest, "argv", argv, "reason", reason)
 		p.audit.Log(audit.Event{
 			Action:    "deny",
-			Reason:    "not_in_allowlist",
+			Reason:    reason,
 			Namespace: namespace,
 			Pod:       podName,
 			Container: containerName,
 			Image:     imageRef,
 		})
-		return verdictDeny, fmt.Sprintf("image not in allowlist: %s", imageRef)
+		return verdictDeny, denial
 	}
 
 	// All checks passed

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/confidential-dot-ai/c8s/internal/audit"
@@ -681,6 +682,25 @@ func TestCheckImage_WorkloadDigest_ArgvMismatchDenies(t *testing.T) {
 		"registry/repo@"+pushDigestB, []string{"/bin/evil"})
 	if verdict != verdictDeny {
 		t.Fatalf("non-matching argv should deny workload digest, got %d", verdict)
+	}
+}
+
+// The two denials need different fixes — allowlist the image, versus correct the
+// entry's argv policy — so the reason has to tell them apart.
+func TestCheckImage_DenialSeparatesUnlistedFromArgvMismatch(t *testing.T) {
+	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}},
+		workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"}))
+
+	_, argvMismatch := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
+		"registry/repo@"+pushDigestB, []string{"/bin/evil"})
+	if !strings.Contains(argvMismatch, "satisfies no workload entry's argv policy") {
+		t.Fatalf("a listed digest denied on argv should say so, got %q", argvMismatch)
+	}
+
+	_, unlisted := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
+		"registry/repo@"+pushDigestC, []string{"/bin/app"})
+	if !strings.Contains(unlisted, "image not in allowlist") {
+		t.Fatalf("an unlisted digest should keep the floor denial, got %q", unlisted)
 	}
 }
 

--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -20,9 +20,11 @@ import (
 var errNoInitData = errors.New("policy-monitor: no init-data document")
 
 // The in-guest attestation service has not answered yet. Like errNoInitData
-// this is a "too early" condition rather than a verdict, so the caller waits
-// on it; a digest mismatch or an unparseable document is neither and stops the
-// wait immediately.
+// this is a "too early" condition rather than a verdict.
+//
+// applyInitDataMeasurements reads once and treats every other error as a
+// verdict. awaitInitDataMeasurements re-reads a few times first, because a
+// document still being written presents as one (initDataSettleReads).
 var errAttestUnavailable = errors.New("policy-monitor: attestation service unavailable")
 
 // Bounds the self-attestation; on expiry the caller falls back to the seed.
@@ -101,6 +103,14 @@ var (
 	initDataWaitInterval = 2 * time.Second
 )
 
+// A digest mismatch is re-read this many times, this far apart, before it counts
+// as a verdict. Covers a document caught mid-write without letting a genuinely
+// uncommitted one hold the guest off its seed for the whole budget.
+const (
+	initDataSettleReads = 3
+	initDataSettleDelay = 100 * time.Millisecond
+)
+
 // awaitInitDataMeasurements is applyInitDataMeasurements for a caller running
 // after READY=1: it waits for the document rather than reading once.
 //
@@ -118,6 +128,7 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 	}
 	deadline := time.Now().Add(initDataWaitBudget)
 	var lastErr error
+	settling := 0
 	for {
 		measurements, err := resolveInitDataMeasurements(ctx, cfg)
 		switch {
@@ -127,20 +138,37 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 				"key", initdata.KeyCDSMeasurements)
 			return
 		case err == nil:
+			// The digest matched, so this is the launch-committed document
+			// itself: it carries no measurements and a later read cannot
+			// change that.
 			logger.Warn("init-data carries no CDS measurements; allowlist refresh will stay disabled",
 				"key", initdata.KeyCDSMeasurements)
 			return
-		case !errors.Is(err, errNoInitData) && !errors.Is(err, errAttestUnavailable):
-			// A verdict, not a timing problem: host tampering or a document we
-			// cannot parse. Waiting cannot change either.
-			logger.Error("init-data rejected; enforcing the baked seed alone", "error", err)
-			return
 		}
 		lastErr = err
-		if !time.Now().Add(initDataWaitInterval).Before(deadline) {
+
+		wait := initDataWaitInterval
+		if errors.Is(err, errNoInitData) || errors.Is(err, errAttestUnavailable) {
+			settling = 0
+		} else {
+			// kata-agent writes the document in place, so a read that lands
+			// mid-write sees a short file whose digest cannot match the
+			// launch-committed one — the same shape as a document the host
+			// tampered with. Re-read after a beat: a write in flight resolves,
+			// tampering reproduces. The grace is its own short delay so a real
+			// verdict still lands promptly instead of costing the whole budget.
+			settling++
+			if settling > initDataSettleReads {
+				logger.Error("init-data rejected; enforcing the baked seed alone", "error", err)
+				return
+			}
+			wait = initDataSettleDelay
+		}
+
+		if !time.Now().Add(wait).Before(deadline) {
 			break
 		}
-		time.Sleep(initDataWaitInterval)
+		time.Sleep(wait)
 	}
 	logger.Warn("no init-data document within the wait budget; CDS measurements unset, so allowlist refresh will stay disabled",
 		"path", initdata.GuestDocumentPath, "waited", initDataWaitBudget, "error", lastErr)

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -294,11 +294,14 @@ func TestAwaitInitDataMeasurementsWaitsForKataAgent(t *testing.T) {
 	path := pointInitDataAt(t)
 	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
 
-	// Written a beat late, the way kata-agent does.
+	// Written a beat late, in place, the way kata-agent does.
+	written := make(chan struct{})
 	go func() {
+		defer close(written)
 		time.Sleep(50 * time.Millisecond)
 		_ = os.WriteFile(path, raw, 0o644)
 	}()
+	t.Cleanup(func() { <-written })
 
 	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
 	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
@@ -308,8 +311,38 @@ func TestAwaitInitDataMeasurementsWaitsForKataAgent(t *testing.T) {
 	}
 }
 
+// kata-agent writes the document in place, so a poll can catch it half-written.
+// That short file's digest cannot match the launch-committed one, which is also
+// what tampering looks like — the wait has to outlast it rather than call it a
+// verdict on the first read.
+func TestAwaitInitDataMeasurementsOutlastsAPartialWrite(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	digest := initdata.Digest(raw)
+	path := pointInitDataAt(t)
+	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
+
+	// The half-written document is already there; the whole one lands a beat later.
+	if err := os.WriteFile(path, raw[:len(raw)/2], 0o644); err != nil {
+		t.Fatalf("seed a half-written document: %v", err)
+	}
+	written := make(chan struct{})
+	go func() {
+		defer close(written)
+		time.Sleep(50 * time.Millisecond)
+		_ = os.WriteFile(path, raw, 0o644)
+	}()
+	t.Cleanup(func() { <-written })
+
+	cfg := &Config{AttestationServiceURL: attesterServing(t, digest[:])}
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "aabb,ccdd" {
+		t.Fatalf("CDSMeasurements = %q, want the wait to outlast a half-written document", cfg.CDSMeasurements)
+	}
+}
+
 // A document HOST_DATA does not commit is a verdict, not a timing problem, so
-// the wait must abandon it immediately rather than retry until the budget runs
+// the wait must abandon it promptly rather than retry until the budget runs
 // out — otherwise a tampering host delays every guest's refresh.
 func TestAwaitInitDataMeasurementsStopsOnUncommittedDocument(t *testing.T) {
 	writeInitData(t, testDocument(t, "aabb"))

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -516,8 +516,44 @@ func (inj *injection) validate() error {
 	if err := inj.Discovery.validate(); err != nil {
 		return err
 	}
+	if err := inj.Secrets.validate(); err != nil {
+		return err
+	}
 	if err := inj.Volumes.validate(); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validate checks each NAME=/store/path pair against the rules get-secret
+// enforces, so a spec the fetcher could never satisfy is a rejected manifest
+// rather than a Running pod whose fetcher crash-loops. The name becomes a
+// filename in the secret dir.
+func (s secretsSpec) validate() error {
+	seen := map[string]bool{}
+	for _, spec := range s.Specs {
+		name, path, ok := strings.Cut(spec, "=")
+		if !ok {
+			return fmt.Errorf("%w: %s entry %q must be NAME=/store/path",
+				errInvalidInjectionAnnotation, AnnotationSecrets, spec)
+		}
+		name = strings.TrimSpace(name)
+		if name == "" || strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+			return fmt.Errorf("%w: %s name %q must be non-empty and not a path",
+				errInvalidInjectionAnnotation, AnnotationSecrets, name)
+		}
+		if seen[name] {
+			return fmt.Errorf("%w: %s names %q twice; each names a distinct file",
+				errInvalidInjectionAnnotation, AnnotationSecrets, name)
+		}
+		seen[name] = true
+		if _, err := pkgallowlist.CanonicalSecretPath(strings.TrimSpace(path)); err != nil {
+			return fmt.Errorf("%w: %s %q: %s", errInvalidInjectionAnnotation, AnnotationSecrets, name, err)
+		}
+	}
+	if s.Dir != "" && !strings.HasPrefix(s.Dir, "/") {
+		return fmt.Errorf("%w: %s must be an absolute path",
+			errInvalidInjectionAnnotation, AnnotationSecretDir)
 	}
 	return nil
 }

--- a/internal/webhook/pod_mutator_secrets_test.go
+++ b/internal/webhook/pod_mutator_secrets_test.go
@@ -285,3 +285,38 @@ func TestEphemeralContainerCannotMountReservedVolumes(t *testing.T) {
 		})
 	}
 }
+
+// get-secret enforces these at pod start. Admission enforces them here too, so a
+// typo in the annotation is a rejected manifest rather than a Running pod whose
+// c8s-secret container crash-loops.
+func TestSecretsSpecValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		specs   []string
+		dir     string
+		wantErr bool
+	}{
+		{name: "pair", specs: []string{"DB=/tenant-a/db", "HF=/tenant-a/hf-token"}},
+		{name: "absolute dir", specs: []string{"DB=/tenant-a/db"}, dir: "/run/secrets"},
+		{name: "no equals", specs: []string{"DB"}, wantErr: true},
+		{name: "name with separator", specs: []string{"sub/DB=/tenant-a/db"}, wantErr: true},
+		{name: "name is dotdot", specs: []string{"..=/tenant-a/db"}, wantErr: true},
+		{name: "empty name", specs: []string{"=/tenant-a/db"}, wantErr: true},
+		{name: "repeated name", specs: []string{"DB=/tenant-a/db", "DB=/tenant-a/other"}, wantErr: true},
+		{name: "relative path", specs: []string{"DB=tenant-a/db"}, wantErr: true},
+		{name: "trailing slash", specs: []string{"DB=/tenant-a/db/"}, wantErr: true},
+		{name: "wildcard path", specs: []string{"DB=/tenant-a/*"}, wantErr: true},
+		{name: "uncanonical path", specs: []string{"DB=/tenant-a/../db"}, wantErr: true},
+		{name: "relative dir", specs: []string{"DB=/tenant-a/db"}, dir: "run/secrets", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := secretsSpec{Specs: tc.specs, Dir: tc.dir}.validate()
+			if tc.wantErr && err == nil {
+				t.Fatal("admitted a spec get-secret would reject")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("rejected a valid spec: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
  A container whose digest is listed by a workload entry but whose argv
  satisfies no entry was denied with 'image not in allowlist', sending the
  operator after a missing digest when the entry's command policy is what
  needs fixing. Split the two, and validate the secrets annotation at
  admission the way the volumes annotation already was, so a malformed
  NAME=/store/path pair is a rejected manifest rather than a crash-looping
  c8s-secret container.