### PR TITLE
chore(deps): pin attestation-go v0.4.1 for its explicit Intel trust root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.3
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3
-	github.com/confidential-dot-ai/attestation-go v0.4.0
+	github.com/confidential-dot-ai/attestation-go v0.4.1
 	github.com/containerd/containerd/api v1.11.1
 	github.com/containerd/containerd/v2 v2.3.3
 	github.com/containerd/errdefs v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/confidential-dot-ai/attestation-go v0.4.0 h1:651L7UQZKXN4jX793Yv/xnuPWInnx0mBXG4soRNeCx0=
 github.com/confidential-dot-ai/attestation-go v0.4.0/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
+github.com/confidential-dot-ai/attestation-go v0.4.1 h1:97ZFNO2OJlwzCSdAPMtfXgZ97t2IAmmRFIsnAVe0g3c=
+github.com/confidential-dot-ai/attestation-go v0.4.1/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=
 github.com/containerd/cgroups/v3 v3.1.3/go.mod h1:PKZ2AcWmSBsY/tJUVhtS/rluX0b1uq1GmPO1ElCmbOw=
 github.com/containerd/containerd/api v1.11.1 h1:h8nfoDW9+fNsC/9TwiAHj8B1GzXKtR4eFtkhi/X5RLU=


### PR DESCRIPTION
Moves `github.com/confidential-dot-ai/attestation-go` from v0.4.0 to v0.4.1.

## What v0.4.1 is

One commit over v0.4.0 — "pin Intel attestation trust root explicitly". It embeds the Intel SGX Root CA in the module, validates it by SHA-256 fingerprint at load, and passes it as `tverify.Options.TrustedRoots` on the TDX verification paths. It also adds an optional `tdx.Options.TrustedRoots` so a consumer can supply its own pool.

## Why now, and why it is not urgent

This is hardening, not a fix for a live hole. go-tdx-guest with `TrustedRoots` unset falls back to *its own* embedded Intel root, not to system roots, so v0.4.0 already chained to the correct anchor. What changes is ownership: the anchor is now this module's, fingerprint-checked on every load, and cannot be silently swapped by a transitive dependency bump.

The reason to take it now is that c8s and TEErminator verify the same evidence and should agree on the trust anchor. TEErminator is bumping to the same version.

## Scope

Upstream the change is purely additive — one new internal package, one new optional field on `tdx.Options`, no signature or behaviour change on any path c8s calls. So this PR is the version line and `go.sum`, nothing else.

Verified locally: `go build ./...`, `go vet ./...`, `gofmt -l` clean, `golangci-lint run ./...` 0 issues, and `go test` green across `internal/localverify`, `pkg/attestationclient`, `pkg/ratls`, `pkg/ratls/cdsclient`, `internal/attestation`, `internal/cmds/verify` and `internal/cmds/getkubeconfig` — the packages that reach the engine.

## One thing deliberately left out

`go.mod` on main is untidy: `prometheus/common` is listed as indirect but is a direct dependency. `go mod tidy` corrects it, and the correction shows up on any branch that runs tidy. It predates this change and does not belong in a dependency bump, so it is not included here — worth a separate one-line PR.
