### PR TITLE
fix(policy-monitor): install the sandbox-token signer once the pod ne…

### DIFF
--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -512,6 +512,12 @@ func fetchSandboxToken(ctx context.Context, cfg config, pub crypto.PublicKey, no
 	case errors.Is(err, workloadclaims.ErrSandboxUnsupported):
 		slog.Info("inventory does not serve the sandbox route; issuing without a sandbox ID")
 		return nil, nil
+	case errors.Is(err, workloadclaims.ErrSandboxNotReady):
+		// Retryable, not a shape to settle for. CDS binds sandbox to inventory
+		// first-write-wins at issuance, so a leaf taken without a sandbox ID
+		// keeps that binding until it is re-issued — and the injected renewal
+		// is hours away. The caller's initial-retry loop does the waiting.
+		return nil, fmt.Errorf("fetch sandbox token: %w", err)
 	case err != nil:
 		return nil, fmt.Errorf("fetch sandbox token: %w", err)
 	}

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -48,7 +48,7 @@ func startInventory(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
 	sidecar.SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -256,7 +256,7 @@ func startGuestInventory(t *testing.T) {
 		t.Skipf("guest token port %d unavailable here: %v", workloadclaims.GuestTokenPort, err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 }
 

--- a/internal/cmds/getvolume/flow_test.go
+++ b/internal/cmds/getvolume/flow_test.go
@@ -48,7 +48,7 @@ func startInventory(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
 	sidecar.SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })

--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -548,9 +548,13 @@ func startAdmissionInventory(ctx context.Context, logger *slog.Logger, inventory
 	if err != nil {
 		return err
 	}
+	// The node's signer is resolved before this point, so the holder is
+	// answering from the start: a nil one means this deployment issues no
+	// tokens at all, not that one is still coming.
+	signers := workloadclaims.NewSignerHolder(signer)
 	go func() {
-		logger.Info("starting admission inventory", "socket", socketPath, "sandbox_tokens", signer != nil)
-		if err := workloadclaims.ServeTokens(ctx, l, inventory, signer); err != nil {
+		logger.Info("starting admission inventory", "socket", socketPath, "sandbox_tokens", signers.Ready())
+		if err := workloadclaims.ServeTokens(ctx, l, inventory, signers); err != nil {
 			logger.Error("admission inventory error", "error", err)
 		}
 	}()

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -146,35 +146,54 @@ func sandboxIDFromAnnotations(annotations map[string]string) string {
 // disable tokens (nil signer) but never crash the monitor — the same
 // fail-open-to-degraded posture as runAllowlistRefresh; get-cert then issues
 // without a sandbox ID.
-func sandboxTokenSigner(cfg *Config, logger *slog.Logger) *workloadclaims.SandboxTokenSigner {
-	if cfg.CDSURL == "" {
-		logger.Warn("sandbox tokens disabled: no CDS URL configured")
-		return nil
-	}
+// installSandboxTokenSigner resolves the address this guest's sandbox tokens
+// commit to, starts the digests endpoint CDS calls back on, and only then hands
+// the signer to the token route.
+//
+// It runs after READY=1. The address comes from a routing-table lookup toward
+// CDS, and the pod network it needs is installed by kata-agent's
+// UpdateInterface RPC — a unit systemd holds behind this one. Resolving on the
+// startup path therefore cannot succeed, and blocking there is what
+// TimeoutStartSec + FailureAction=poweroff-force turns into a dead guest.
+//
+// Every failure disables the route rather than leaving it pending: a caller
+// waiting on a signer that is not coming is worse than one told to proceed
+// without a sandbox ID.
+func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Logger, inventory *admissionInventory, signers *workloadclaims.SignerHolder) {
 	// A parse failure is a typo and stays fail-closed; empty is the explicit
 	// dev opt-out, so tokens still flow and the guest can still be issued a
-	// sandbox-bound leaf. Unlike runAllowlistRefresh, disabling here does not
-	// degrade to a stricter state — it blocks issuance outright.
+	// sandbox-bound leaf.
 	measurements, err := ratls.ParseHexMeasurementsList(splitCSV(cfg.CDSMeasurements))
 	if err != nil {
 		logger.Error("sandbox tokens disabled: C8S_CDS_MEASUREMENTS invalid", "error", err)
-		return nil
+		signers.Disable()
+		return
 	}
 	if len(measurements) == 0 {
 		logger.Warn("C8S_CDS_MEASUREMENTS not set: the sandbox-digests endpoint answers ANY RA-TLS-attested caller, so any TEE that can reach this guest can read what it runs. UNSAFE outside development.")
 	}
-	host, err := resolveSandboxDigestsHostWithRetry(cfg, logger)
+	host, err := resolveSandboxDigestsHostLate(ctx, cfg, logger)
 	if err != nil {
 		logger.Error("sandbox tokens disabled: no reachable digests host", "error", err)
-		return nil
+		signers.Disable()
+		return
 	}
 	signer, err := workloadclaims.NewSandboxTokenSigner(host)
 	if err != nil {
 		logger.Error("sandbox tokens disabled: create signer failed", "error", err)
-		return nil
+		signers.Disable()
+		return
 	}
+	// Before the route answers, not after: a token names this endpoint, and CDS
+	// refuses one it cannot call back on. Issuing first would hand out tokens
+	// that are guaranteed to be rejected.
+	if err := startSandboxDigests(ctx, logger, cfg, inventory, signer); err != nil {
+		logger.Error("sandbox-digests endpoint disabled; issuing without a sandbox ID rather than tokens CDS would refuse", "error", err)
+		signers.Disable()
+		return
+	}
+	signers.Set(signer)
 	logger.Info("sandbox tokens enabled", "digests_host", host, "digests_port", workloadclaims.DigestsPort)
-	return signer
 }
 
 // sandboxDigestsHost is the guest IP every sandbox token names for CDS's
@@ -183,59 +202,59 @@ func sandboxDigestsHost(cfg *Config) (string, error) {
 	return workloadclaims.ResolveAdvertiseHost(cfg.SandboxDigestsAdvertiseHost, cfg.CDSURL)
 }
 
-// advertiseHostRetryBudget bounds the wait for the guest network to reach a
-// state where the routing-table lookup for CDS returns a real local IP.
+// The wait for the guest network to reach a state where the routing-table
+// lookup for CDS returns a real local IP.
 //
-// INVARIANT: advertiseHostStartupBudget must stay well under
-// policy-monitor.service's TimeoutStartSec. This lookup runs before the unit
-// signals READY=1, systemd fails the unit at TimeoutStartSec, and the unit's
-// FailureAction=poweroff-force turns that failure into a dead guest — so an
-// over-long budget here is a boot failure for every kata pod, not a slow start.
-// TestAdvertiseHostBudgetFitsUnitStartTimeout pins the two together.
+// INVARIANT: advertiseHostLateBudget is deliberately LONGER than
+// policy-monitor.service's TimeoutStartSec, which is only survivable because
+// this lookup runs after READY=1. Moving it back onto the startup path would
+// let systemd fail the unit at TimeoutStartSec, and FailureAction=poweroff-force
+// turns that into a dead guest for every kata pod (#258).
+// TestAdvertiseHostRunsOffTheStartupPath pins the two apart.
 //
 // Overridable in tests.
 var (
-	advertiseHostAttempts = 4
-	advertiseHostBackoff  = time.Second
-	// The authoritative bound: whatever the attempt/backoff product works out
-	// to, the lookup gives up once this much wall time has passed.
-	advertiseHostStartupBudget = 5 * time.Second
+	advertiseHostRetryInterval = 2 * time.Second
+	// Under get-cert's --initial-retry-timeout (2m), so the route has settled
+	// on an answer — signing, or 404 — before the caller stops asking. Equal
+	// budgets would make which one a pod gets a race.
+	advertiseHostLateBudget = 90 * time.Second
 )
 
-// resolveSandboxDigestsHostWithRetry retries the routing-table lookup while the
-// guest's network is still being configured, within a budget that cannot
-// outlast the unit's start timeout. It returns the last error when the budget
-// is exhausted — the caller then falls back to the same "sandbox tokens
-// disabled" posture it always had.
+// resolveSandboxDigestsHostLate retries the routing-table lookup until the pod
+// network exists. Unlike the startup-path version it replaced, waiting here can
+// actually succeed: kata-agent installs the network from a unit ordered behind
+// this one, so the route appears shortly after READY=1.
 //
-// The retry only covers a genuinely transient failure. Kata installs the pod
-// network from kata-agent's UpdateInterface RPC, and kata-agent is ordered
-// behind this unit, so a guest that has no route to CDS here will still have
-// none when the budget runs out; waiting longer cannot change that. Resolving
-// the host after READY=1 is what would, and needs the token route to accept a
-// signer installed later — see docs/kata-image-policy.md.
-func resolveSandboxDigestsHostWithRetry(cfg *Config, logger *slog.Logger) (string, error) {
+// It gives up at advertiseHostLateBudget so a guest that never gets a network
+// degrades to "issues without a sandbox ID" instead of holding every fetcher
+// open forever.
+func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slog.Logger) (string, error) {
 	// Explicit host bypasses inference entirely — no reason to wait.
 	if cfg.SandboxDigestsAdvertiseHost != "" {
 		return sandboxDigestsHost(cfg)
 	}
-	deadline := time.Now().Add(advertiseHostStartupBudget)
+	deadline := time.Now().Add(advertiseHostLateBudget)
 	var lastErr error
-	for i := 1; i <= advertiseHostAttempts; i++ {
+	for attempt := 1; ; attempt++ {
 		host, err := sandboxDigestsHost(cfg)
 		if err == nil {
-			if i > 1 {
-				logger.Info("advertise-host inference recovered", "attempt", i, "host", host)
+			if attempt > 1 {
+				logger.Info("advertise-host inference recovered", "attempt", attempt, "host", host)
 			}
 			return host, nil
 		}
 		lastErr = err
-		if i == advertiseHostAttempts || !time.Now().Add(advertiseHostBackoff).Before(deadline) {
+		if !time.Now().Add(advertiseHostRetryInterval).Before(deadline) {
 			break
 		}
 		logger.Warn("advertise-host inference failed; retrying",
-			"attempt", i, "of", advertiseHostAttempts, "retry_in", advertiseHostBackoff, "error", err)
-		time.Sleep(advertiseHostBackoff)
+			"attempt", attempt, "retry_in", advertiseHostRetryInterval, "error", err)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(advertiseHostRetryInterval):
+		}
 	}
 	return "", lastErr
 }
@@ -248,15 +267,15 @@ func resolveSandboxDigestsHostWithRetry(cfg *Config, logger *slog.Logger) (strin
 //
 // Loopback is sound here for the reason peer credentials are unnecessary: a
 // kata guest holds exactly one pod, so there is no caller to tell apart.
-func startAdmissionInventory(ctx context.Context, logger *slog.Logger, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner) error {
+func startAdmissionInventory(ctx context.Context, logger *slog.Logger, inventory *admissionInventory, signers *workloadclaims.SignerHolder) error {
 	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(workloadclaims.GuestTokenPort))
 	l, err := net.Listen("tcp", addr)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", addr, err)
 	}
 	go func() {
-		logger.Info("starting admission inventory", "addr", addr, "sandbox_tokens", signer != nil)
-		if err := workloadclaims.ServeTokens(ctx, l, inventory, signer); err != nil {
+		logger.Info("starting admission inventory", "addr", addr, "sandbox_tokens", signers.Ready())
+		if err := workloadclaims.ServeTokens(ctx, l, inventory, signers); err != nil {
 			logger.Error("admission inventory error", "error", err)
 		}
 	}()

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -4,6 +4,7 @@ package policymonitor
 
 import (
 	"bytes"
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -140,14 +141,10 @@ func TestKataInventoryArgvSeparatorDoesNotEraseAdmissions(t *testing.T) {
 
 // A configured advertise host bypasses retry entirely: the routing-table
 // lookup never happens, so the CDS URL not resolving does not matter.
-func TestResolveSandboxDigestsHostWithRetry_ExplicitHostSkipsRetry(t *testing.T) {
-	prev := advertiseHostAttempts
-	advertiseHostAttempts = 3
-	t.Cleanup(func() { advertiseHostAttempts = prev })
-
+func TestResolveSandboxDigestsHostLate_ExplicitHostSkipsRetry(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, nil))
-	got, err := resolveSandboxDigestsHostWithRetry(&Config{
+	got, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
 		SandboxDigestsAdvertiseHost: "10.2.3.4",
 		CDSURL:                      "https://cds.invalid:8443",
 	}, logger)
@@ -159,70 +156,82 @@ func TestResolveSandboxDigestsHostWithRetry_ExplicitHostSkipsRetry(t *testing.T)
 	}
 }
 
-// A CDS URL that does not resolve exhausts the retry budget rather than
-// latching tokens off on the first failure.
-func TestResolveSandboxDigestsHostWithRetry_ExhaustsBudget(t *testing.T) {
-	prevAttempts := advertiseHostAttempts
-	prevBackoff := advertiseHostBackoff
-	advertiseHostAttempts = 3
-	advertiseHostBackoff = time.Millisecond
+// A CDS URL that does not resolve keeps retrying to the budget rather than
+// latching tokens off on the first failure — the whole point of running late is
+// that the network arrives after the first attempt.
+func TestResolveSandboxDigestsHostLate_RetriesUntilBudget(t *testing.T) {
+	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
+	advertiseHostRetryInterval = time.Millisecond
+	advertiseHostLateBudget = 20 * time.Millisecond
 	t.Cleanup(func() {
-		advertiseHostAttempts = prevAttempts
-		advertiseHostBackoff = prevBackoff
+		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
 	})
 
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, nil))
-	_, err := resolveSandboxDigestsHostWithRetry(&Config{
+	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
 		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
 	}, logger)
 	if err == nil {
-		t.Fatal("want an error after retry budget exhausted")
+		t.Fatal("want an error after the budget is exhausted")
 	}
-	// Every attempt but the last logs a retry line — proves we did not latch
-	// off on the first failure the way the old code did.
-	if got := strings.Count(buf.String(), `"msg":"advertise-host inference failed; retrying"`); got != advertiseHostAttempts-1 {
-		t.Fatalf("got %d retry log lines, want %d; log:\n%s", got, advertiseHostAttempts-1, buf.String())
+	if got := strings.Count(buf.String(), `"msg":"advertise-host inference failed; retrying"`); got < 2 {
+		t.Fatalf("got %d retry log lines, want repeated retries; log:\n%s", got, buf.String())
 	}
 }
 
-// The budget is the authoritative bound, not the attempt/backoff product: an
-// attempt count that would run long stops at the deadline instead.
-func TestResolveSandboxDigestsHostWithRetry_StopsAtBudget(t *testing.T) {
-	prevAttempts := advertiseHostAttempts
-	prevBackoff := advertiseHostBackoff
-	prevBudget := advertiseHostStartupBudget
-	// 100 x 50ms would be 5s of backoff; the budget must cut it far shorter.
-	advertiseHostAttempts = 100
-	advertiseHostBackoff = 50 * time.Millisecond
-	advertiseHostStartupBudget = 200 * time.Millisecond
+// The budget bounds the wait: a guest that never gets a network must reach
+// "no signer" rather than hold every fetcher open indefinitely.
+func TestResolveSandboxDigestsHostLate_StopsAtBudget(t *testing.T) {
+	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
+	advertiseHostRetryInterval = 5 * time.Millisecond
+	advertiseHostLateBudget = 50 * time.Millisecond
 	t.Cleanup(func() {
-		advertiseHostAttempts = prevAttempts
-		advertiseHostBackoff = prevBackoff
-		advertiseHostStartupBudget = prevBudget
+		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
 	})
 
-	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 	start := time.Now()
-	if _, err := resolveSandboxDigestsHostWithRetry(&Config{
+	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
 		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
-	}, logger); err == nil {
-		t.Fatal("want an error once the budget is exhausted")
+	}, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)))
+	if err == nil {
+		t.Fatal("want an error after the budget is exhausted")
 	}
-	// Generous ceiling: the point is that it returns in fractions of a second
-	// rather than running all 100 attempts, not the exact stopping instant.
-	if elapsed := time.Since(start); elapsed > 2*time.Second {
-		t.Fatalf("lookup blocked for %s; the budget of %s should have cut it short", elapsed, advertiseHostStartupBudget)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ran for %s, want the %s budget to stop it", elapsed, advertiseHostLateBudget)
 	}
 }
 
-// The lookup runs before policy-monitor signals READY=1, and kata-agent
-// Requires= this unit, so blocking past TimeoutStartSec fails the unit —
-// whose FailureAction=poweroff-force then takes the whole guest down. This
-// asserts the Go budget and the shipped unit file cannot drift into that
-// state again: a previous change set the product to 12 x 5s against a 30s
-// timeout, and every kata pod stopped booting.
-func TestAdvertiseHostBudgetFitsUnitStartTimeout(t *testing.T) {
+// A cancelled context stops the wait, so guest shutdown is not held up by a
+// lookup that will never succeed.
+func TestResolveSandboxDigestsHostLate_StopsOnContextCancel(t *testing.T) {
+	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
+	advertiseHostRetryInterval = 10 * time.Millisecond
+	advertiseHostLateBudget = time.Hour
+	t.Cleanup(func() {
+		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	if _, err := resolveSandboxDigestsHostLate(ctx, &Config{
+		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
+	}, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))); err == nil {
+		t.Fatal("want an error when the context ends")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("ran for %s after cancellation", elapsed)
+	}
+}
+
+// Replaces TestAdvertiseHostBudgetFitsUnitStartTimeout, which pinned this
+// lookup UNDER the unit's start timeout because it ran before READY=1. It now
+// runs after, so the budget is deliberately longer - and that is only safe
+// while it stays off the startup path. If the lookup is ever moved back,
+// systemd fails the unit at TimeoutStartSec and FailureAction=poweroff-force
+// kills the guest, which is #258 all over again.
+func TestAdvertiseHostRunsOffTheStartupPath(t *testing.T) {
 	unit := filepath.Join("..", "..", "..", "kata-guest-base", "extra", "etc", "systemd", "system", "policy-monitor.service")
 	raw, err := os.ReadFile(unit)
 	if err != nil {
@@ -237,12 +246,9 @@ func TestAdvertiseHostBudgetFitsUnitStartTimeout(t *testing.T) {
 		t.Fatalf("parse TimeoutStartSec=%q: %v", m[1], err)
 	}
 
-	// A third of the window, so the rest of startup (kill-path self-test,
-	// allowlist load, listener bind) still has room even at the budget's worst
-	// case.
-	if limit := timeout / 3; advertiseHostStartupBudget > limit {
-		t.Fatalf("advertiseHostStartupBudget = %s exceeds %s (a third of the unit's TimeoutStartSec=%s); "+
-			"blocking this long before READY=1 fails the unit and poweroff-force kills the guest",
-			advertiseHostStartupBudget, limit, timeout)
+	if advertiseHostLateBudget <= timeout {
+		t.Fatalf("advertiseHostLateBudget = %s fits inside TimeoutStartSec=%s; either the lookup moved back onto "+
+			"the startup path, or the budget shrank to where waiting for the pod network no longer works",
+			advertiseHostLateBudget, timeout)
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -123,19 +123,18 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	{
 		m.inventory = newAdmissionInventory()
 		m.inventory.refresh = func() workloadclaims.AllowlistRefresh { return m.refresh.report(a.Size()) }
-		signer := sandboxTokenSigner(cfg, logger)
-		if err := startAdmissionInventory(ctx, logger, m.inventory, signer); err != nil {
-			return fmt.Errorf("start admission inventory: %w", err)
+		// The listener binds here, on the startup path, even though its signer
+		// cannot exist yet: containers share the guest's network namespace, so
+		// a workload that starts before this bind could claim
+		// 127.0.0.1:8401 and answer as the inventory. Binding early and
+		// signing later is what keeps that window shut (installSandboxTokenSigner).
+		m.signers = workloadclaims.NewPendingSignerHolder()
+		if cfg.CDSURL == "" {
+			logger.Warn("sandbox tokens disabled: no CDS URL configured")
+			m.signers.Disable()
 		}
-		// Only useful alongside tokens: the address CDS dials is signed into
-		// them, so without a signer nothing can direct CDS here.
-		// Fail-soft: a missing digests endpoint degrades issuance (CDS refuses
-		// tokens it cannot check), which is cheaper than taking the guest's
-		// only image-policy enforcer down with it.
-		if signer != nil {
-			if err := startSandboxDigests(ctx, logger, cfg, m.inventory, signer); err != nil {
-				logger.Error("sandbox-digests endpoint disabled; CDS will refuse requests carrying a sandbox token", "error", err)
-			}
+		if err := startAdmissionInventory(ctx, logger, m.inventory, m.signers); err != nil {
+			return fmt.Errorf("start admission inventory: %w", err)
 		}
 	}
 
@@ -152,6 +151,10 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		// with it.
 		go func() {
 			awaitInitDataMeasurements(ctx, logger, cfg)
+			// Both need the measurements the document carries, and neither may
+			// hold the other up: the signer waits on the pod network, the
+			// refresh only on CDS answering.
+			go installSandboxTokenSigner(ctx, cfg, logger, m.inventory, m.signers)
 			runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
 		}()
 	} else {
@@ -177,8 +180,9 @@ type monitor struct {
 	overlay               *policyOverlay // latest CDS pull's workload argv policy
 	refresh               *refreshState  // whether the allowlist still tracks CDS
 	killer                containerKiller
-	inventory             *admissionInventory // sandbox identity + digests (docs/ratls.md); always set
-	ready                 func() error        // systemd READY=1; nil outside the unit
+	inventory             *admissionInventory          // sandbox identity + digests (docs/ratls.md); always set
+	signers               *workloadclaims.SignerHolder // token signer, installed once the pod network resolves
+	ready                 func() error                 // systemd READY=1; nil outside the unit
 	readyOnce             sync.Once
 	fatal                 chan error // an enforcement failure the process must exit on
 	killEscalateAfter     time.Duration

--- a/internal/cmds/sidecar/do_test.go
+++ b/internal/cmds/sidecar/do_test.go
@@ -42,7 +42,7 @@ func startInventory(t *testing.T) {
 		t.Fatal(err)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
-	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, signer)
+	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
 	SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })

--- a/pkg/workloadclaims/signerholder.go
+++ b/pkg/workloadclaims/signerholder.go
@@ -1,0 +1,84 @@
+package workloadclaims
+
+import "sync"
+
+// Signer availability, as the token route reports it.
+//
+// Under kata the inventory listener must bind before the guest has a network:
+// containers share the guest's netns, so a listener bound after the workload
+// starts is one the workload can bind first and answer as. The signing key,
+// though, names the address CDS dials back on, which is only knowable once the
+// pod network exists. The route therefore outlives its own signer, and these
+// are the three answers it can give.
+type signerState int
+
+const (
+	// signerPending is "ask again": the address the signer commits to is not
+	// resolvable yet. Answered 503, retried by the caller.
+	signerPending signerState = iota
+
+	// signerReady is a usable signer.
+	signerReady
+
+	// signerUnsupported is "stop asking": this deployment issues no sandbox
+	// tokens at all. Answered 404, and the caller proceeds without a sandbox
+	// ID — the long-standing node-CVM behaviour when no CDS is configured.
+	signerUnsupported
+)
+
+// SignerHolder carries the sandbox-token signer for a listener that must serve
+// before the signer exists. Safe for concurrent use.
+type SignerHolder struct {
+	mu     sync.RWMutex
+	state  signerState
+	signer *SandboxTokenSigner
+}
+
+// NewSignerHolder returns a holder that already knows its answer: signer when
+// non-nil, otherwise "this deployment issues no tokens". For a caller that
+// resolves its signer later, use NewPendingSignerHolder.
+func NewSignerHolder(signer *SandboxTokenSigner) *SignerHolder {
+	if signer == nil {
+		return &SignerHolder{state: signerUnsupported}
+	}
+	return &SignerHolder{state: signerReady, signer: signer}
+}
+
+// NewPendingSignerHolder returns a holder whose signer arrives later. Until it
+// does the route answers 503, so a caller waits rather than issuing a leaf with
+// no sandbox ID — a binding CDS takes first-write-wins and will not revisit.
+func NewPendingSignerHolder() *SignerHolder {
+	return &SignerHolder{state: signerPending}
+}
+
+// Set installs the signer and makes the route answer.
+func (h *SignerHolder) Set(signer *SandboxTokenSigner) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.state, h.signer = signerReady, signer
+}
+
+// Disable records that no signer is coming, so callers stop waiting on one.
+// For a failure waiting cannot fix — no CDS configured, measurements that do
+// not parse — as distinct from a network that has not arrived yet.
+func (h *SignerHolder) Disable() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.state, h.signer = signerUnsupported, nil
+}
+
+// Ready reports whether a signer is installed, for the log line that tells an
+// operator which posture a guest came up in.
+func (h *SignerHolder) Ready() bool {
+	_, state := h.current()
+	return state == signerReady
+}
+
+func (h *SignerHolder) current() (*SandboxTokenSigner, signerState) {
+	if h == nil {
+		return nil, signerUnsupported
+	}
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.signer, h.state
+}

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -246,47 +246,60 @@ const maxSandboxRequestBytes = 64 << 10
 // by kernel peer credentials, and in the guest by the single-pod boundary.
 // Errors from the resolver are returned as 500s — get-cert fails closed on them.
 //
-// A nil signer serves nothing (404 on the route): no signer means no CDS to
-// attest the signing key against, and an unverifiable token is worse than none.
-func ServeTokens(ctx context.Context, l net.Listener, resolver SandboxResolver, signer *SandboxTokenSigner) error {
+// The route is registered whatever state signers is in, because under kata the
+// listener has to claim 127.0.0.1:8401 before any workload container starts —
+// containers share the guest's network namespace, so a listener bound late is
+// one a workload can bind first and answer as. What the signer's state changes
+// is the answer: see SignerHolder.
+func ServeTokens(ctx context.Context, l net.Listener, resolver SandboxResolver, signers *SignerHolder) error {
 	mux := http.NewServeMux()
-	if signer != nil {
-		mux.HandleFunc("POST "+SandboxPath, func(w http.ResponseWriter, r *http.Request) {
-			var req SandboxTokenRequest
-			if err := json.NewDecoder(io.LimitReader(r.Body, maxSandboxRequestBytes)).Decode(&req); err != nil {
-				http.Error(w, fmt.Sprintf("decode sandbox token request: %v", err), http.StatusBadRequest)
-				return
-			}
-			pub, err := x509.ParsePKIXPublicKey(req.PublicKey)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("parse requester key: %v", err), http.StatusBadRequest)
-				return
-			}
-			keyDigest, err := RequesterKeyDigest(pub)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			if len(req.Nonce) == 0 {
-				http.Error(w, "missing challenge nonce", http.StatusBadRequest)
-				return
-			}
-			peer := peerFromRequest(r)
-			defer peer.Close()
-			id, err := resolver.SandboxForPeer(peer)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("resolve caller sandbox: %v", err), http.StatusInternalServerError)
-				return
-			}
-			token, err := signer.Sign(id, keyDigest, req.Nonce)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("sign sandbox token: %v", err), http.StatusInternalServerError)
-				return
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(token)
-		})
-	}
+	mux.HandleFunc("POST "+SandboxPath, func(w http.ResponseWriter, r *http.Request) {
+		signer, state := signers.current()
+		switch state {
+		case signerUnsupported:
+			// No CDS to attest the signing key against, and an unverifiable
+			// token is worse than none. Terminal, so the caller is told to
+			// stop asking rather than to wait.
+			http.Error(w, "inventory serves no sandbox tokens", http.StatusNotFound)
+			return
+		case signerPending:
+			http.Error(w, "sandbox-token signer not installed yet", http.StatusServiceUnavailable)
+			return
+		}
+		var req SandboxTokenRequest
+		if err := json.NewDecoder(io.LimitReader(r.Body, maxSandboxRequestBytes)).Decode(&req); err != nil {
+			http.Error(w, fmt.Sprintf("decode sandbox token request: %v", err), http.StatusBadRequest)
+			return
+		}
+		pub, err := x509.ParsePKIXPublicKey(req.PublicKey)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("parse requester key: %v", err), http.StatusBadRequest)
+			return
+		}
+		keyDigest, err := RequesterKeyDigest(pub)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if len(req.Nonce) == 0 {
+			http.Error(w, "missing challenge nonce", http.StatusBadRequest)
+			return
+		}
+		peer := peerFromRequest(r)
+		defer peer.Close()
+		id, err := resolver.SandboxForPeer(peer)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("resolve caller sandbox: %v", err), http.StatusInternalServerError)
+			return
+		}
+		token, err := signer.Sign(id, keyDigest, req.Nonce)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("sign sandbox token: %v", err), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(token)
+	})
 	return serveUntil(ctx, l, mux)
 }
 
@@ -400,6 +413,14 @@ func inventoryDo(ctx context.Context, endpoint, method, route string, body io.Re
 // Callers proceed without a sandbox ID.
 var ErrSandboxUnsupported = errors.New("workloadclaims: inventory does not serve the sandbox route")
 
+// ErrSandboxNotReady reports that the inventory serves the route but has no
+// signer yet, because the address it commits to needs a pod network that is
+// still being configured. Distinct from ErrSandboxUnsupported because the
+// answer differs: this one is worth waiting for, and issuing without a sandbox
+// ID instead would bind the sandbox in CDS's ledger — first-write-wins — to a
+// leaf that has none.
+var ErrSandboxNotReady = errors.New("workloadclaims: inventory has no sandbox-token signer yet")
+
 // FetchSandboxToken asks the inventory at endpoint for a signed sandbox token
 // bound to requesterPub (the caller's CSR key) and nonce (the CDS challenge for
 // this issuance, which CDS re-checks for freshness). A 404 maps to
@@ -421,6 +442,9 @@ func FetchSandboxToken(ctx context.Context, endpoint string, timeout time.Durati
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrSandboxUnsupported
+	}
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, ErrSandboxNotReady
 	}
 	if resp.StatusCode != http.StatusOK {
 		errBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -66,7 +66,7 @@ func serveTokens(t *testing.T, resolver SandboxResolver, signer *SandboxTokenSig
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = ServeTokens(ctx, l, resolver, signer) }()
+	go func() { _ = ServeTokens(ctx, l, resolver, NewSignerHolder(signer)) }()
 	return sock
 }
 
@@ -185,7 +185,7 @@ func TestTokenRouteLoopbackHasNoPeerPID(t *testing.T) {
 	resolver := &fakeResolver{pid: -1, sandboxID: "sandbox-1"}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go func() { _ = ServeTokens(ctx, l, resolver, testSigner(t)) }()
+	go func() { _ = ServeTokens(ctx, l, resolver, NewSignerHolder(testSigner(t))) }()
 
 	requester := testRequesterKey(t)
 	pubDER, err := x509.MarshalPKIXPublicKey(&requester.PublicKey)
@@ -314,10 +314,11 @@ func TestServeDigestsServesIdentity(t *testing.T) {
 	_ = signer
 }
 
-// An inventory without a signer serves no token route; FetchSandboxToken maps
-// that to ErrSandboxUnsupported so get-cert can issue without a sandbox ID
-// instead of failing closed (an unverifiable token is worse than none).
-func TestSandboxRouteAbsentWithoutSigner(t *testing.T) {
+// An inventory constructed without a signer answers the token route 404;
+// FetchSandboxToken maps that to ErrSandboxUnsupported so get-cert can issue
+// without a sandbox ID instead of failing closed (an unverifiable token is
+// worse than none).
+func TestSandboxRouteUnsupportedWithoutSigner(t *testing.T) {
 	requester := testRequesterKey(t)
 	sock := serveTokens(t, &fakeResolver{sandboxID: "sandbox-1"}, nil)
 	if _, err := FetchSandboxToken(context.Background(), "unix://"+sock, 5*time.Second, &requester.PublicKey, testNonce); !errors.Is(err, ErrSandboxUnsupported) {
@@ -871,7 +872,7 @@ func TestGuestInventoryEndpointIsDialable(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	go func() { _ = ServeTokens(ctx, l, &fakeResolver{sandboxID: "sandbox-1"}, testSigner(t)) }()
+	go func() { _ = ServeTokens(ctx, l, &fakeResolver{sandboxID: "sandbox-1"}, NewSignerHolder(testSigner(t))) }()
 
 	requester := testRequesterKey(t)
 	token, err := FetchSandboxToken(ctx, GuestInventoryEndpoint(), 5*time.Second, &requester.PublicKey, testNonce)
@@ -938,5 +939,78 @@ func TestSandboxContainerKeyIsInjective(t *testing.T) {
 	// nil and empty argv are the same admission (json omits an empty list).
 	if (SandboxContainer{Digest: digest}).Key() != (SandboxContainer{Digest: digest, Argv: []string{}}).Key() {
 		t.Fatal("nil and empty argv must key alike")
+	}
+}
+
+// serveTokensWithHolder runs the token route against a holder the test drives,
+// so the pending window can be exercised the way a booting guest hits it.
+func serveTokensWithHolder(t *testing.T, resolver SandboxResolver, signers *SignerHolder) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "wc.sock")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = ServeTokens(ctx, l, resolver, signers) }()
+	return sock
+}
+
+// The route exists before its signer does, because under kata the listener has
+// to claim the port before any workload container could. "Not yet" must be
+// distinguishable from "never": issuing without a sandbox ID binds the sandbox
+// in CDS's ledger first-write-wins, so a caller that gives up early is stuck
+// with that binding.
+func TestPendingSignerIsRetryableNotUnsupported(t *testing.T) {
+	signers := NewPendingSignerHolder()
+	sock := serveTokensWithHolder(t, &fakeResolver{sandboxID: "sandbox-1"}, signers)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = FetchSandboxToken(context.Background(), "unix://"+sock, time.Second, key.Public(), []byte("nonce"))
+	if !errors.Is(err, ErrSandboxNotReady) {
+		t.Fatalf("err = %v, want ErrSandboxNotReady while the signer is pending", err)
+	}
+
+	// Once installed, the same route answers without the caller reconnecting
+	// to anything new.
+	signers.Set(testSigner(t))
+	token, err := FetchSandboxToken(context.Background(), "unix://"+sock, time.Second, key.Public(), []byte("nonce"))
+	if err != nil {
+		t.Fatalf("after Set: %v", err)
+	}
+	if len(token.Token) == 0 {
+		t.Fatal("empty token after the signer was installed")
+	}
+}
+
+// A deployment that issues no tokens at all keeps answering 404, so a caller
+// proceeds without a sandbox ID instead of waiting for a signer that is not
+// coming. This is the node-CVM posture and must not change.
+func TestDisabledSignerStaysUnsupported(t *testing.T) {
+	signers := NewPendingSignerHolder()
+	signers.Disable()
+	sock := serveTokensWithHolder(t, &fakeResolver{sandboxID: "sandbox-1"}, signers)
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = FetchSandboxToken(context.Background(), "unix://"+sock, time.Second, key.Public(), []byte("nonce"))
+	if !errors.Is(err, ErrSandboxUnsupported) {
+		t.Fatalf("err = %v, want ErrSandboxUnsupported for a disabled signer", err)
+	}
+}
+
+// NewSignerHolder(nil) is the node-CVM construction path: no signer configured
+// means unsupported, never pending.
+func TestNilSignerHolderIsUnsupported(t *testing.T) {
+	if h := NewSignerHolder(nil); h.Ready() {
+		t.Fatal("nil signer reported ready")
+	} else if _, state := h.current(); state != signerUnsupported {
+		t.Fatalf("state = %v, want signerUnsupported", state)
 	}
 }


### PR DESCRIPTION
…twork exists

sandboxTokenSigner ran on the startup path, but the address it commits to comes from a routing-table lookup toward CDS - and kata installs the pod network from kata-agent, a unit systemd holds behind this one. It could never succeed, so the signer was always nil, the token route was never registered, and get-cert issued without a sandbox ID. get-cert tolerates that; get-secret and get-volume do not, so no secret or encrypted volume could reach a kata pod.

Resolving later is not enough on its own, which is why #258 left it out of scope: the listener must claim 127.0.0.1:8401 before any workload container starts, because containers share the guest netns and a late bind is one a workload can take first and answer as. The route therefore now outlives its signer. SignerHolder adds a third answer - pending, 503, ErrSandboxNotReady, which callers retry - alongside the existing 404 for a deployment that issues no tokens at all. Resolution moves into the goroutine that already waits for init-data, bounded at 90s so the route settles before get-cert's 2m retry gives up.

The digests endpoint now starts before the signer is published: a token names it and CDS refuses one it cannot call back on.

node-CVM is unchanged - nri-image-policy resolves its signer before serving.

TestAdvertiseHostBudgetFitsUnitStartTimeout is rewritten rather than deleted: the budget is now deliberately over the unit's TimeoutStartSec, which is only safe while the lookup stays off the startup path.