### PR TITLE
feat(install): add --volumes to deploy the encrypted-volume node agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
   practice — encrypted at rest on host-visible storage (erofs, dm-verity,
   dm-crypt) and opened only inside the TEE. The key travels as a secret
   through the release path above, so possession of the volume implies nothing
-  without attestation. Node-as-CVM only; `volumed` ships disabled.
+  without attestation. Node-as-CVM only; the `volumed` node agent ships
+  disabled — `c8s install --volumes` deploys it.
 
 - **Fail-closed admission.** A mutating webhook injects certificate sidecars
   and Kata RuntimeClasses; a ValidatingAdmissionPolicy rejects anything that

--- a/cmd/c8s/exec_fake_test.go
+++ b/cmd/c8s/exec_fake_test.go
@@ -108,7 +108,7 @@ func resetCLIState(t *testing.T) {
 		installWait, installCRDs, installGetCertRunAsNonRoot, installKataDebug       bool
 		installSingleNode, installForce, installResolveDigests, installAttestEnabled bool
 		uninstallWait, uninstallKataSweep, uninstallHostSweepOnly, uninstallForce    bool
-		uninstallDeleteCRDs, uninstallDeleteNamespace                                bool
+		uninstallDeleteCRDs, uninstallDeleteNamespace, installVolumes                bool
 		installCertFSGroup, installGetCertRunAsUser, installGetCertRunAsGroup        int64
 		installGetCertRenewInterval                                                  time.Duration
 	}{
@@ -121,7 +121,7 @@ func resetCLIState(t *testing.T) {
 		installWait, installCRDs, installGetCertRunAsNonRoot, installKataDebug,
 		installSingleNode, installForce, installResolveDigests, installAttestEnabled,
 		uninstallWait, uninstallKataSweep, uninstallHostSweepOnly, uninstallForce,
-		uninstallDeleteCRDs, uninstallDeleteNamespace,
+		uninstallDeleteCRDs, uninstallDeleteNamespace, installVolumes,
 		installCertFSGroup, installGetCertRunAsUser, installGetCertRunAsGroup,
 		installGetCertRenewInterval,
 	}
@@ -136,6 +136,7 @@ func resetCLIState(t *testing.T) {
 		installSingleNode, installForce, installResolveDigests, installAttestEnabled = saved.installSingleNode, saved.installForce, saved.installResolveDigests, saved.installAttestEnabled
 		uninstallWait, uninstallKataSweep, uninstallHostSweepOnly, uninstallForce = saved.uninstallWait, saved.uninstallKataSweep, saved.uninstallHostSweepOnly, saved.uninstallForce
 		uninstallDeleteCRDs, uninstallDeleteNamespace = saved.uninstallDeleteCRDs, saved.uninstallDeleteNamespace
+		installVolumes = saved.installVolumes
 		installCertFSGroup, installGetCertRunAsUser, installGetCertRunAsGroup = saved.installCertFSGroup, saved.installGetCertRunAsUser, saved.installGetCertRunAsGroup
 		installGetCertRenewInterval = saved.installGetCertRenewInterval
 	})
@@ -147,6 +148,7 @@ func resetCLIState(t *testing.T) {
 	installGetCertRunAsUser, installGetCertRunAsGroup, installGetCertRunAsNonRoot = 65532, 65532, true
 	installKataDebug, installCvmMode, installHardwarePlatform = false, "", "sev-snp"
 	installSingleNode, installImagePullSecret, installImageTag = false, "", ""
+	installVolumes = false
 	installOperatorKeys, installForce = "", false
 	installUpstream, installWorkloadRefs = "", nil
 	installResolveDigests, installAttestEnabled, installMeasurements = true, true, nil

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -53,6 +53,7 @@ var (
 	installCvmMode          string
 	installHardwarePlatform string
 	installSingleNode       bool
+	installVolumes          bool
 	installImagePullSecret  string
 	installImageTag         string
 	installOperatorKeys     string
@@ -611,6 +612,10 @@ the kata-guest-base artifact (override: kata.guestImage.pullerAuthSecret).
 This is the cluster-side (kubelet) credential; digest resolution runs locally
 via crane and uses your local docker login.
 
+--volumes deploys volumed, the node agent that opens a pod's encrypted volumes
+into its mount namespace (docs/volumes.md). Under --cvm-mode=pod it deploys
+nothing: volumed runs inside each guest, baked into the kata-guest-base image.
+
 To adopt already-running workloads, pass --workload-ref <id>=<namespace>/<kind>/<name>[:<port>].
 The release namespace is excluded from workload injection, so adopted workloads
 must live in a separate namespace. After the chart is ready, install patches each
@@ -700,6 +705,9 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		}
 		if installKataDebug {
 			fmt.Fprintln(os.Stdout, "+ kata guest image: DEBUG variant — container logs/exec are host-readable; SNP launch measurement differs from the locked image")
+		}
+		if installVolumes && cvmModeIsPod(installCvmMode) {
+			fmt.Fprintln(os.Stdout, "+ encrypted volumes: served by `volumed --guest` inside each kata guest; no host DaemonSet is deployed")
 		}
 		// The sandbox-digests callback dials node addresses and nothing else.
 		// Resolve them here, where the cluster is reachable, so a default
@@ -1353,6 +1361,18 @@ func appendSingleNodeInstallArgs(helmArgs []string, singleNode bool) []string {
 	)
 }
 
+// appendVolumedInstallArgs turns on the node agent that opens encrypted volumes
+// (docs/volumes.md) for --volumes. Nothing is emitted under --cvm-mode=pod:
+// there volumed runs inside the guest from the kata-guest-base image, and the
+// chart's enforce_host_components validation rejects the host DaemonSet
+// alongside kata.
+func appendVolumedInstallArgs(setArgs []string, volumes bool, cvmMode string) []string {
+	if !volumes || cvmModeIsPod(cvmMode) {
+		return setArgs
+	}
+	return append(setArgs, "--set", "volumed.enabled=true")
+}
+
 type workloadRef struct {
 	kind      string
 	name      string
@@ -1717,7 +1737,7 @@ func appendResolvedDigestArgs(ctx context.Context, chartPath string, helmArgs []
 // enabledPath, given the chart defaults, the operator's -f values files, and the
 // --set overrides assembled so far — in helm's precedence order (defaults < -f
 // files in order < --set). Getting the -f files right matters for a component
-// that defaults to disabled and is turned on only through -f (e.g.
+// that defaults to disabled and is turned on through -f (e.g.
 // volumed.enabled): without them the resolver would treat it as off and skip
 // pinning its digest, and the render then fails with no image ref. The merged
 // tree is built once and shared across the per-component calls.
@@ -1865,6 +1885,7 @@ func init() {
 	installCmd.Flags().Int64Var(&installGetCertRunAsGroup, "webhook-get-cert-run-as-group", 65532, "runAsGroup for injected get-cert containers")
 	installCmd.Flags().BoolVar(&installGetCertRunAsNonRoot, "webhook-get-cert-run-as-non-root", true, "set runAsNonRoot for injected get-cert containers")
 	installCmd.Flags().BoolVar(&installSingleNode, "single-node", false, "single-node / single-CVM cluster: clear the dedicated-CDS-node selector and taint toleration so every node is CDS-eligible (no role=cds label or dedicated node needed). Sets cds.node.selector={} and cds.node.tolerations=[]")
+	installCmd.Flags().BoolVar(&installVolumes, "volumes", false, "serve encrypted volumes (docs/volumes.md): deploy volumed, the node agent that opens a pod's volume devices, and pin its image into the NRI allowlist. Off by default — it runs privileged, with hostPID and a writable bind of the kubelet directory. Under --cvm-mode=pod volumes are served by the in-guest volumed baked into kata-guest-base, so nothing is deployed")
 	installCmd.Flags().StringSliceVar(&installWorkloadRefs, flagWorkloadRef, nil, "existing workload to adopt as a c8s confidential workload, as <cw-id>=<namespace>/<kind>/<name>[:<port>]; repeatable. Kind is any resource exposing a pod template at spec.template (deployment, statefulset, daemonset, or an operator CRD such as <kind>.<group>). The optional :<port> is the tls-lb upstream port, needed on the ref --upstream selects")
 	installCmd.Flags().StringVar(&installUpstream, flagUpstream, "", "confidential.ai/cw id of the adopted --workload-ref workload tls-lb routes its catch-all to; derives the mesh-wrapped upstream c8s-<id>.<ns>.svc.cluster.local:<port> from that ref's :<port>. Without this or a verified-https tlsLb.upstream, tls-lb renders no catch-all route until one is attached")
 	installCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "", "CVM deployment shape (REQUIRED; orthogonal to --hardware-platform): pod (per-pod confidential VMs via the Kata runtime — every workload pod is a kata CVM, host-side attestation-api/nri/ratls-mesh served by the in-guest counterparts), node (generalized node-as-CVM: our own TDX/SNP nodes are themselves confidential VMs, pods run as ordinary processes, attestation-api + nri baked into the node image), gke (GKE managed confidential VMs), or aks (vTPM /dev/tpm0)")

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -838,6 +838,8 @@ func TestInstallNodeModeHappyPath(t *testing.T) {
 	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/ratls-mesh:main")
 	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/attestation-api")
 	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/nri-image-policy")
+	// volumed stays off without --volumes.
+	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/volumed")
 
 	// --force without operator keys must say what it is giving up.
 	if !strings.Contains(stderr, "allowlist writes DISABLED") {
@@ -885,6 +887,47 @@ func TestInstallImageTagOverridesResolveRef(t *testing.T) {
 	calls := s.f.calls(t)
 	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/c8s-operator:v9.9.9")
 	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/c8s-operator:main")
+}
+
+// --volumes must reach helm as volumed.enabled, and must do so before digest
+// resolution: the daemon's own image is pinned only for a component the
+// effective values enable, and that pin is what derives it into the NRI floor
+// that would otherwise deny it.
+func TestInstallVolumesEnablesTheNodeAgent(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+	if err := runC8s(t, "install", "--cvm-mode=node", "--wait=false", "--force", "--volumes"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	mustContainLine(t, s.f.calls(t), "crane digest ghcr.io/confidential-dot-ai/volumed:main")
+
+	tree := readYAMLTree(t, s.computed)
+	if got := treeAt(t, tree, "volumed", "enabled"); got != true {
+		t.Errorf("volumed.enabled = %#v, want true", got)
+	}
+	if got := treeAt(t, tree, "volumed", "image", "digest"); got != testDigest {
+		t.Errorf("volumed.image.digest = %#v, want %s", got, testDigest)
+	}
+}
+
+// Under --cvm-mode=pod the daemon is inside the guest, so --volumes must leave
+// the host DaemonSet alone — enabling it there fails the chart render
+// (enforce_host_components).
+func TestInstallVolumesPodModeLeavesHostDaemonSetOff(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+	stdout := captureStdout(t, func() {
+		if err := runC8s(t, "install", "--cvm-mode=pod", "--wait=false", "--force", "--resolve-digests=false", "--volumes"); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+	})
+	volumed, _ := readYAMLTree(t, s.computed)["volumed"].(map[string]any)
+	if got, ok := volumed["enabled"]; ok {
+		t.Errorf("computed values enable the host volumed DaemonSet under --cvm-mode=pod: %#v", got)
+	}
+	if !strings.Contains(stdout, "volumed --guest") {
+		t.Errorf("stdout does not say where volumes are served:\n%s", stdout)
+	}
 }
 
 func TestInstallFailsFastWhenCDSNodeUnlabelled(t *testing.T) {

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -299,6 +299,26 @@ func TestAppendSingleNodeInstallArgsClearsCDSNodePinning(t *testing.T) {
 	})
 }
 
+func TestAppendVolumedInstallArgsDisabledIsNoOp(t *testing.T) {
+	got := appendVolumedInstallArgs([]string{"upgrade"}, false, "node")
+	assertArgsEqual(t, got, []string{"upgrade"})
+}
+
+func TestAppendVolumedInstallArgsEnablesTheNodeAgent(t *testing.T) {
+	for _, mode := range []string{"node", "gke", "aks"} {
+		got := appendVolumedInstallArgs([]string{"upgrade"}, true, mode)
+		assertArgsEqual(t, got, []string{"upgrade", "--set", "volumed.enabled=true"})
+	}
+}
+
+func TestAppendVolumedInstallArgsPodModeServesVolumesInGuest(t *testing.T) {
+	// kata-guest-base bakes `volumed --guest`, and the chart's
+	// enforce_host_components validation fails the render if the host DaemonSet
+	// is enabled alongside kata — so --volumes must emit nothing here.
+	got := appendVolumedInstallArgs([]string{"upgrade"}, true, "pod")
+	assertArgsEqual(t, got, []string{"upgrade"})
+}
+
 func TestParseWorkloadRef(t *testing.T) {
 	tests := []struct {
 		ref     string

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -186,6 +186,9 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, c
 	}
 	setArgs = appendKataInstallArgs(setArgs, installCvmMode, installKataDebug)
 	setArgs = appendSingleNodeInstallArgs(setArgs, installSingleNode)
+	// Ahead of resolveDigests, which pins a component's image only while the
+	// effective values enable it.
+	setArgs = appendVolumedInstallArgs(setArgs, installVolumes, installCvmMode)
 	// --upstream derives a c8s-<id>.<ns>.svc.cluster.local address; the chart
 	// recognizes that headless-Service shape as mesh-wrapped and admits plaintext
 	// http. Empty means "not plumbed" so an operator's -f (or the chart's
@@ -391,6 +394,7 @@ func init() {
 	renderValuesCmd.Flags().BoolVar(&installCRDs, "install-crds", true, "emit values for chart CRDs (false sets statusMirror.enabled=false, matching install --install-crds=false)")
 	renderValuesCmd.Flags().StringVar(&renderValuesDistro, "distro", "", "host Kubernetes distro (k8s | rke2) — install autodetects this from the cluster; render-values has no cluster, so pass it explicitly when you need it pinned. Unset leaves the chart default")
 	renderValuesCmd.Flags().BoolVar(&installSingleNode, "single-node", false, "single-node / single-CVM cluster: clear the dedicated-CDS-node selector and toleration (cds.node.selector={}, cds.node.tolerations=[])")
+	renderValuesCmd.Flags().BoolVar(&installVolumes, "volumes", false, "emit volumed.enabled=true, deploying the node agent that opens encrypted volumes (docs/volumes.md). Emits nothing under --cvm-mode=pod, where volumed runs in-guest")
 	renderValuesCmd.Flags().StringVar(&installCvmMode, flagCvmMode, "", "CVM deployment shape (REQUIRED; orthogonal to --hardware-platform): pod (per-pod kata CVMs; disables host-side ratls-mesh/attestation-api/nri-image-policy) or node (generalized node-as-CVM native TEE device) or gke (GKE managed CVMs) or aks (vTPM /dev/tpm0)")
 	renderValuesCmd.Flags().StringVar(&installHardwarePlatform, flagHardwarePlatform, "sev-snp", "CPU-level TEE hardware (orthogonal to --cvm-mode): sev-snp (default, /dev/sev-guest) or tdx (Intel TDX, /dev/tdx-guest). Ignored when --cvm-mode=aks")
 	renderValuesCmd.Flags().StringSliceVar(&installMeasurements, "measurements", nil, "expected hex launch measurement(s) of the CVM components that speak to CDS (repeatable/comma-separated). Emits cds.measurements + ratlsMesh.measurements; empty = no pinning (UNSAFE). Under --cvm-mode=node/gke/aks this is the node image's manifest.json value; under --cvm-mode=pod it is the kata guest launch digest from `c8s kata measure`")

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -189,7 +189,9 @@ Where volumed runs, and how the sidecar reaches it, depends on the shape:
 
 The node-CVM DaemonSet is **off by default**: it runs privileged, with `hostPID`
 and a writable bind of the kubelet directory. Turn it on with
-`volumed.enabled=true` where volumes are served. A pod requesting a volume on a
+`c8s install --volumes` where volumes are served, or `volumed.enabled=true` for a
+chart consumer. Under kata the flag deploys nothing — the guest image carries the
+daemon — so it is safe to pass in either shape. A pod requesting a volume on a
 cluster with neither shape — `nri-image-policy` disabled and not kata — is
 refused at admission rather than left waiting on a mount that can never land.
 

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -219,6 +219,10 @@ var (
 	// on an answer — signing, or 404 — before the caller stops asking. Equal
 	// budgets would make which one a pod gets a race.
 	advertiseHostLateBudget = 90 * time.Second
+	// The retried lookup. A test that counts retries replaces it, so the count
+	// follows from the budget rather than from how long the runner's resolver
+	// takes to fail.
+	advertiseHostLookup = sandboxDigestsHost
 )
 
 // resolveSandboxDigestsHostLate retries the routing-table lookup until the pod
@@ -237,7 +241,7 @@ func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slo
 	deadline := time.Now().Add(advertiseHostLateBudget)
 	var lastErr error
 	for attempt := 1; ; attempt++ {
-		host, err := sandboxDigestsHost(cfg)
+		host, err := advertiseHostLookup(cfg)
 		if err == nil {
 			if attempt > 1 {
 				logger.Info("advertise-host inference recovered", "attempt", attempt, "host", host)

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -5,6 +5,7 @@ package policymonitor
 import (
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -156,21 +157,28 @@ func TestResolveSandboxDigestsHostLate_ExplicitHostSkipsRetry(t *testing.T) {
 	}
 }
 
-// A CDS URL that does not resolve keeps retrying to the budget rather than
-// latching tokens off on the first failure — the whole point of running late is
-// that the network arrives after the first attempt.
+// A lookup that keeps failing keeps retrying to the budget rather than latching
+// tokens off on the first failure — the whole point of running late is that the
+// network arrives after the first attempt.
+//
+// The lookup is stubbed rather than pointed at an unresolvable host: a real
+// resolver makes each attempt cost whatever the runner's DNS takes, so the
+// retries a millisecond budget affords vary by machine (CI saw one). That an
+// unresolvable CDS URL fails at all is covered by _StopsAtBudget.
 func TestResolveSandboxDigestsHostLate_RetriesUntilBudget(t *testing.T) {
-	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
+	prevInterval, prevBudget, prevLookup := advertiseHostRetryInterval, advertiseHostLateBudget, advertiseHostLookup
 	advertiseHostRetryInterval = time.Millisecond
 	advertiseHostLateBudget = 20 * time.Millisecond
+	advertiseHostLookup = func(*Config) (string, error) { return "", errors.New("no route to the CDS host") }
 	t.Cleanup(func() {
 		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
+		advertiseHostLookup = prevLookup
 	})
 
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, nil))
 	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
-		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
+		CDSURL: "https://cds.example:8443",
 	}, logger)
 	if err == nil {
 		t.Fatal("want an error after the budget is exhausted")


### PR DESCRIPTION
Turning on encrypted volumes meant hand-writing a values file for volumed.enabled. --volumes sets it, ahead of digest resolution so the daemon's image is pinned and derived into the NRI floor. Under --cvm-mode=pod it emits nothing: volumed runs in-guest from kata-guest-base, and the chart rejects the host DaemonSet alongside kata.