### PR TITLE
fix(kata-guest-base): deny AddSwapRequest in the baked agent policy

### DIFF
--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -41,7 +41,8 @@ import future.keywords.if
 import future.keywords.in
 
 default AddARPNeighborsRequest := true
-default AddSwapRequest := true
+# Swap never leaves TEE memory.
+default AddSwapRequest := false
 default CloseStdinRequest := true
 default DestroySandboxRequest := true
 default GetDiagnosticDataRequest := true

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -269,3 +269,7 @@ test_host_reach_in_rpcs_denied if {
 	not ReadStreamRequest
 	not WriteStreamRequest
 }
+
+test_add_swap_denied if {
+	not AddSwapRequest
+}


### PR DESCRIPTION
## Bug

The baked kata-agent policy allowed `AddSwapRequest` (`default AddSwapRequest := true`, kata-guest-base/extra/etc/kata-opa/default-policy.rego:44). kata-agent's `do_add_swap` (src/agent/src/rpc.rs) calls `swapon()` on the virtio-blk device at the request's PCI path, and the guest kernel is built with `CONFIG_SWAP=y` (kata-guest-base/kernel/config-x86_64.snapshot).

The host authors every RPC and is the VMM: it can hotplug a swap-formatted virtio-blk disk and call the RPC. Since the host also sizes the VM, it can drive the guest into memory pressure, at which point the guest kernel swaps TEE memory pages to the host's disk in plaintext — defeating SEV-SNP/TDX confidentiality through an explicitly allowed RPC.

## Solution

Flip the default to `false` with a one-line invariant comment. Swap outside the TEE memory boundary is never legitimate in this guest, so an unconditional deny is the minimal fix — no rule body, no conditions. `AddSwapPathRequest` was already denied (undefined RPCs fail closed), and nothing else in the policy or tests assumed AddSwap is allowed.

Added `test_add_swap_denied` to kata-guest-base/tests/default-policy_test.rego. Verified: `make policy-test OPA=/tmp/opa` passes 24/24 (baseline 23/23); the new test fails against the pre-fix policy, so it guards the regression.
