### PR TITLE
fix(kata-guest-base): scope CopyFile symlinks to the sandbox seeding tree

### DIFF
--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -280,5 +280,18 @@ default CopyFileRequest := false
 CopyFileRequest if {
 	startswith(input.path, "/run/kata-containers/shared/containers/")
 	no_traversal(input.path)
+	symlink_target_in_tree
 	print("CopyFileRequest: allowed")
+}
+
+# Writes through the link resolve its target; relative and traversal-free
+# keeps resolution inside the seeding tree.
+symlink_target_in_tree if {
+	input.file_type == "Symlink"
+	not startswith(input.symlink_target, "/")
+	no_traversal(input.symlink_target)
+}
+
+symlink_target_in_tree if {
+	input.file_type != "Symlink"
 }

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -245,20 +245,40 @@ test_mount_allows_projected_volume_names if {
 # --- CopyFile -----------------------------------------------------------
 
 test_copyfile_scoped_to_the_seeding_dir if {
-	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/etc/hosts"}
-	not CopyFileRequest with input as {"path": "/run/kata-containers/foo/rootfs/bin/sh"}
-	not CopyFileRequest with input as {"path": "/etc/passwd"}
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/etc/hosts", "file_type": "Regular"}
+	not CopyFileRequest with input as {"path": "/run/kata-containers/foo/rootfs/bin/sh", "file_type": "Regular"}
+	not CopyFileRequest with input as {"path": "/etc/passwd", "file_type": "Regular"}
 }
 
 test_copyfile_rejects_traversal if {
-	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/../../foo/rootfs/x"}
-	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/.."}
+	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/../../foo/rootfs/x", "file_type": "Regular"}
+	not CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/..", "file_type": "Regular"}
 }
 
 # Projected volumes legitimately carry `..data` and `..<timestamp>` names.
 test_copyfile_allows_projected_volume_names if {
-	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..data/token"}
-	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..2026_08_05_12_00_00/token"}
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..data/token", "file_type": "Regular"}
+	CopyFileRequest with input as {"path": "/run/kata-containers/shared/containers/pod/..2026_08_05_12_00_00/token", "file_type": "Regular"}
+}
+
+symlink_input(target) := {
+	"path": "/run/kata-containers/shared/containers/pod-vol/..data",
+	"file_type": "Symlink",
+	"symlink_target": target,
+}
+
+test_copyfile_symlink_absolute_target_denied if {
+	not CopyFileRequest with input as symlink_input("/run")
+}
+
+test_copyfile_symlink_traversal_target_denied if {
+	not CopyFileRequest with input as symlink_input("../../../c8s")
+	not CopyFileRequest with input as symlink_input("sub/../../c8s/ratls-mesh.env")
+}
+
+# Projected volumes seed `..data` as a link to a `..<timestamp>` name.
+test_copyfile_symlink_relative_target_allowed if {
+	CopyFileRequest with input as symlink_input("..2026_08_10_12_00_00.123456789")
 }
 
 # --- host-as-adversary RPCs ---------------------------------------------


### PR DESCRIPTION
## Bug

The baked kata-agent policy gates `CopyFileRequest` only by destination-path string: the rule at `kata-guest-base/extra/etc/kata-opa/default-policy.rego:280` requires the `/run/kata-containers/shared/containers/` prefix plus a `..`-component check. But kata-agent's `do_copy_file` also *creates* symlinks — the `S_IFLNK` branch runs `symlinkat(req.data, path)` with the target taken verbatim from the request (kata-containers `src/agent/src/rpc.rs:2257-2272`, dispatched at `do_copy_file` `:2198`; the agent's own check at `:2201` is a string prefix compare with no symlink resolution).

The host authors every CopyFile RPC over the vsock channel, so it can:

1. `CopyFile{path: .../shared/containers/x, file_type: Symlink, data: "/run"}` — passes the policy (prefix ok, no `..`), plants `x -> /run` inside the allowed tree.
2. `CopyFile{path: .../shared/containers/x/kata-containers/<cid>/c8s-verdict, ...}` — the regular-file write resolves through the link and lands outside the seeding tree.

That is an arbitrary file write anywhere in the guest as in-guest root, reachable purely by host-crafted RPCs: forge an `allow` verdict for a denied image (defeats the exec gate), rewrite an admitted container's rootfs after admission so the admitted digest no longer describes the executed bytes, or overwrite `/run/c8s/ratls-mesh.env`.

## Solution

Scope symlink creation in the policy rule: when `input.file_type == "Symlink"`, require `input.symlink_target` to be relative (no leading `/`) and to pass the existing `no_traversal` component check. A relative, traversal-free target resolves inside the directory the link lands in, so resolution stays within the seeding tree. Regular-file and directory writes are unchanged, and the legitimate projected-volume pattern (`..data` -> `..<timestamp>`) is exactly such a relative link — `..data` is a name, not a traversal component, which `no_traversal` already distinguishes. Field names/values match what the agent serializes into the policy input (`src/agent/policy/src/policy.rs:302-337`: `file_type` as `"Symlink"`, `symlink_target` as a string); `file_type` is a non-optional struct field, so it is always present in real input and the rule stays fail-closed on its absence. The existing CopyFile tests were updated to carry `file_type` accordingly.

Verified: `make policy-test OPA=/tmp/opa` — `opa check --v0-compatible --strict` clean, 26/26 tests pass (baseline 23/23 plus symlink absolute-target denied, symlink `..`-target denied, relative `..data`-pattern target allowed). `opa eval` of the attack input (symlink to `/run` under the allowed prefix) returns `true` on main's policy and `false` on this one.
