### PR TITLE
fix(kata-guest-base): stop logging container OCI specs to the guest console

### DIFF
--- a/kata-guest-base/patches/0005-agent-stop-logging-the-createcontainer-spec.patch
+++ b/kata-guest-base/patches/0005-agent-stop-logging-the-createcontainer-spec.patch
@@ -1,0 +1,28 @@
+Subject: [PATCH] agent: stop logging the createcontainer spec and storages
+
+do_create_container logged the full OCI spec and the request's storage list
+at info level, the agent's default log level is info, and the shipped unit
+sends stdout to the guest console. The spec carries the container's argv and
+env -- including values sourced from Kubernetes secrets -- so every pod start
+wrote the workload's configuration to the console, which on a confidential
+guest is wired to the host.
+
+Log the container id instead. The full request remains available at trace
+level via trace_rpc_call!.
+
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -230,11 +230,8 @@ impl AgentService {
+ 
+         let container_name = k8s::container_name(&oci);
+ 
+-        info!(sl(), "receive createcontainer, spec: {:?}", &oci);
+-        info!(
+-            sl(),
+-            "receive createcontainer, storages: {:?}", &req.storages
+-        );
++        // c8s: the guest console is host-visible; the spec carries env/argv.
++        info!(sl(), "receive createcontainer, cid: {}", &cid);
+ 
+         // Some devices need some extra processing (the ones invoked with
+         // --device for instance), and that's what this call is doing. It

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -231,6 +231,8 @@ done
 [[ -f "${PATCH_DIR}/0001-agent-refuse-an-init-data-supplied-policy.patch" ]] || die "the init-data policy patch is missing from ${PATCH_DIR}."
 # Without it policy-monitor's decision races the container's execve.
 [[ -f "${PATCH_DIR}/0002-agent-wait-for-the-admission-verdict.patch" ]] || die "the admission-verdict patch is missing from ${PATCH_DIR}."
+# Without it every pod start logs the container's env/argv to the host console.
+[[ -f "${PATCH_DIR}/0005-agent-stop-logging-the-createcontainer-spec.patch" ]] || die "the createcontainer spec-log patch is missing from ${PATCH_DIR}."
 
 # A prior run's images must not survive to publish time: CI pushes the output
 # dirs verbatim (oras push ./*), and on a persistent runner the root-owned


### PR DESCRIPTION
## Bug

kata-agent's `do_create_container` handler logs the entire OCI spec and the request's storage list at info level — `info!(sl(), "receive createcontainer, spec: {:?}", &oci);` and the matching `storages: {:?}` line (kata `src/agent/src/rpc.rs:233-237` at the pinned `KATA_SRC_COMMIT` 86e5975, `kata-guest-base/scripts/build.sh:85`). The spec carries the container's argv and env, including values sourced from Kubernetes secrets.

Every pod start reaches this handler. The agent's default log level is `Info` (kata `src/agent/src/config.rs:65`), the shipped unit sets `StandardOutput=tty` (kata `src/agent/kata-agent.service.in:15`), and the guest console is on the measured kernel cmdline (`console=hvc0 console=hvc1`, `internal/cmds/katameasure/cmdline.go:25`), wired host-side — so the host operator, adversarial in the c8s threat model, receives every container's env (secret-derived values, credentials, tokens) and argv across the TEE boundary, for every pod, with no RPC involved. The baked policy's Exec/ReadStream denials do not cover this path.

## Solution

New kata patch `kata-guest-base/patches/0005-agent-stop-logging-the-createcontainer-spec.patch` (next number after the existing set, same header style) replaces the two `info!` dumps with a single line logging the container id only; `trace_rpc_call!` (trace level, off by default) is untouched. `build.sh` gains a presence check for 0005 matching the existing 0001/0002 guards, so a guest cannot be built silently without it.

Minimal because it is one hunk in one file with no behavior change beyond log content. A grep of the handler family for other info-level dumps of host-influenced pod data (`spec: {:?}`, env/argv/annotations) found no others: `do_exec_process` logs only cid/eid, and ExecProcessRequest is denied by the baked policy regardless. `cid`, `oci` and `req.storages` all remain in use after the edit, so the patched tree introduces no new warnings.

Verified: the patch applies with `patch -p1` — alone and as part of the full `patches/*.patch` glob series in build order — against kata 86e5975ad6a20f091ed686e492672c70496d0400 with no fuzz, and `cargo check` of the patched kata-agent tree passes clean.
