### PR TITLE
fix(webhook): reject kata hypervisor-config annotations on in-scope pods

### DIFF
--- a/internal/webhook/initdata.go
+++ b/internal/webhook/initdata.go
@@ -46,6 +46,25 @@ func stampInitData(pod *corev1.Pod, kataClass string, measurements []string) err
 	return nil
 }
 
+// kataHypervisorAnnotationPrefix is the pod-annotation family the kata shim
+// turns into hypervisor settings (kernel_params, default_vcpus, enable_iommu,
+// kernel_verity_params, ...).
+const kataHypervisorAnnotationPrefix = "io.katacontainers.config.hypervisor."
+
+// rejectKataHypervisorAnnotations denies a pod carrying any annotation under
+// kataHypervisorAnnotationPrefix other than the cc_init_data document
+// stampInitData manages: the shim applies them to the guest on every kata
+// class, so a pod author must not set them.
+func rejectKataHypervisorAnnotations(pod *corev1.Pod) error {
+	for key := range pod.Annotations {
+		if key != initdata.AnnotationKey && strings.HasPrefix(key, kataHypervisorAnnotationPrefix) {
+			return fmt.Errorf("%w: %s configures the kata hypervisor and must not be supplied by the pod author",
+				errInvalidInjectionAnnotation, key)
+		}
+	}
+	return nil
+}
+
 // initDataAnnotation renders the value, or "" when the shape carries none.
 func initDataAnnotation(kataClass string, measurements []string) (string, error) {
 	if _, ok := confidentialKataClasses[kataClass]; !ok {

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -723,6 +723,15 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	getCertNeeded := inj != nil && m.cfg.GetCertImage != ""
 	kataClass := kataRuntimeClassFor(pod, m.cfg)
 
+	// Covers a pod that set its own runtimeClassName too: injection skips it,
+	// but the shim still honors the annotations. Host-namespace pods are
+	// exempt like they are from class injection (kataIncompatible).
+	if m.cfg.KataEnforce && !kataIncompatible(pod) {
+		if err := rejectKataHypervisorAnnotations(pod); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+
 	if inj == nil && kataClass == "" {
 		return admission.Allowed("no c8s annotation — passthrough")
 	}

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1218,6 +1219,111 @@ func TestHandleGetCertOnlyLeavesRuntimeClassUnset(t *testing.T) {
 	if got := runtimeClassPatch(t, resp); got != "" {
 		t.Fatalf("runtimeClassName patch = %q, want none without kata enforcement", got)
 	}
+}
+
+// The kata shim applies io.katacontainers.config.hypervisor.* pod annotations
+// to the guest on every kata class, so under kata enforcement the webhook
+// rejects them — on the injection path and the explicit-runtimeClassName path
+// alike. cc_init_data stays governed by stampInitData alone.
+func TestHandleRejectsKataHypervisorAnnotations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	m := &podMutator{
+		decoder: admission.NewDecoder(scheme),
+		cfg: Config{
+			GetCertImage:    "ghcr.io/confidential-dot-ai/c8s-operator:test",
+			CDSURL:          "http://cds.c8s-system.svc:8443",
+			KataEnforce:     true,
+			CDSMeasurements: testMeasurements,
+		}.withDefaults(),
+	}
+	handle := func(t *testing.T, pod *corev1.Pod) admission.Response {
+		t.Helper()
+		raw, err := json.Marshal(pod)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m.Handle(context.Background(), admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{Namespace: "default", Object: runtime.RawExtension{Raw: raw}},
+		})
+	}
+	podWith := func(annotations map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		}
+	}
+
+	for _, key := range []string{
+		"io.katacontainers.config.hypervisor.kernel_params",
+		"io.katacontainers.config.hypervisor.enable_iommu",
+		"io.katacontainers.config.hypervisor.default_vcpus",
+		"io.katacontainers.config.hypervisor.kernel_verity_params",
+	} {
+		t.Run("rejects "+key, func(t *testing.T) {
+			resp := handle(t, podWith(map[string]string{key: "1"}))
+			if resp.Allowed {
+				t.Fatalf("Handle admitted a pod setting %s; want denial", key)
+			}
+			if resp.Result == nil || !strings.Contains(resp.Result.Message, key) {
+				t.Fatalf("denial message = %+v, want it to name %s", resp.Result, key)
+			}
+		})
+	}
+
+	// A pod requesting its own kata class skips injection (and stampInitData)
+	// but still runs under the shim: same rejection.
+	t.Run("rejects on explicit runtimeClassName", func(t *testing.T) {
+		pod := podWith(map[string]string{"io.katacontainers.config.hypervisor.kernel_params": "agent.debug_console"})
+		pod.Spec.RuntimeClassName = ptr.To(kataSnpRuntimeClass)
+		if resp := handle(t, pod); resp.Allowed {
+			t.Fatal("Handle admitted an explicit-class pod setting kernel_params; want denial")
+		}
+	})
+
+	// cc_init_data is unchanged: the webhook's own stamp passes, an
+	// author-chosen document is still rejected by stampInitData.
+	t.Run("accepts the stamped cc_init_data value", func(t *testing.T) {
+		want, err := initDataAnnotation(kataSnpRuntimeClass, testMeasurements)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pod := podWith(map[string]string{AnnotationWorkload: "api", initdata.AnnotationKey: want})
+		if resp := handle(t, pod); !resp.Allowed {
+			t.Fatalf("Handle denied a pod carrying the webhook's own cc_init_data stamp: %+v", resp.Result)
+		}
+	})
+	t.Run("rejects an author-supplied cc_init_data value", func(t *testing.T) {
+		pod := podWith(map[string]string{AnnotationWorkload: "api", initdata.AnnotationKey: "rogue"})
+		if resp := handle(t, pod); resp.Allowed {
+			t.Fatal("Handle admitted an author-supplied cc_init_data document; want denial")
+		}
+	})
+
+	t.Run("allows an annotation-free pod", func(t *testing.T) {
+		if resp := handle(t, podWith(nil)); !resp.Allowed {
+			t.Fatalf("Handle denied an annotation-free pod: %+v", resp.Result)
+		}
+	})
+	t.Run("allows an explicit-class pod with no hypervisor annotations", func(t *testing.T) {
+		pod := podWith(nil)
+		pod.Spec.RuntimeClassName = ptr.To(kataSnpRuntimeClass)
+		if resp := handle(t, pod); !resp.Allowed {
+			t.Fatalf("Handle denied an explicit-class pod: %+v", resp.Result)
+		}
+	})
+
+	// Host-namespace pods are exempt like they are from class injection: the
+	// shim never launches them, so the annotations are inert.
+	t.Run("allows a host-namespace pod", func(t *testing.T) {
+		pod := podWith(map[string]string{"io.katacontainers.config.hypervisor.kernel_params": "quiet"})
+		pod.Spec.HostNetwork = true
+		if resp := handle(t, pod); !resp.Allowed {
+			t.Fatalf("Handle denied an exempt host-namespace pod: %+v", resp.Result)
+		}
+	})
 }
 
 func TestWorkloadServiceFQDN(t *testing.T) {


### PR DESCRIPTION
## Bug

The kata shims c8s installs honor `io.katacontainers.config.hypervisor.*` pod annotations — `kernel_params`, `kernel_verity_params`, `enable_iommu`, `default_vcpus`, `default_memory`, and `cc_init_data` (the shim's `enable_annotations` set). A pod author can set them, they reach the shim verbatim, and the shim applies them to the guest on every kata class.

The pod webhook managed exactly one of these keys: `stampInitData` (internal/webhook/initdata.go:30) rejects an author-supplied `cc_init_data` document and stamps its own. Every other key in the family passed through unexamined, and even the `cc_init_data` check ran only on the injection path — a pod that sets its own `runtimeClassName` gets `kataClass == ""` (internal/webhook/pod_mutator.go:724; kataRuntimeClassFor, :868) and skips `stampInitData` entirely, since the call is gated on `kataClass != ""` (:760).

Impact is worst on TDX: the guest kernel command line lands in RTMR[2], which nothing in the c8s verification path pins (MRTD covers TDVF only), so a tenant could add `agent.debug_console` — handing the host a shell inside the TEE — or enforcement-neutralizing kernel parameters, with zero attestation delta. On SNP the cmdline is measured, but the annotations still let a tenant move their own launch measurement or poke holes (IOMMU, vCPU/memory sizing).

## Solution

When kata enforcement is on, the webhook now rejects any in-scope pod creation carrying an `io.katacontainers.config.hypervisor.*` annotation other than the `cc_init_data` key it manages itself (`rejectKataHypervisorAnnotations`, internal/webhook/initdata.go:58). The check sits before the passthrough return in `Handle` (internal/webhook/pod_mutator.go:729), so the explicit-runtimeClassName path is covered as well as the injection path. `cc_init_data` handling is untouched: the webhook's own stamp is accepted, an author-supplied value is still rejected by `stampInitData`.

Host-namespace pods (hostNetwork/hostPID/hostIPC) stay exempt, consistent with class injection (`kataIncompatible`) and the kata-enforcement ValidatingAdmissionPolicy, which exempt them the same way: a VM cannot share the host's namespaces, so the shim never launches them and the annotations are inert. I chose the exemption over blanket rejection to keep the webhook's enforcement scope identical to the VAP's. No config knob: these keys are off-limits on every in-scope pod, so there is nothing to tune.

Verified: `go test ./internal/webhook/` — the new `TestHandleRejectsKataHypervisorAnnotations` covers rejection of `kernel_params` / `enable_iommu` / `default_vcpus` / `kernel_verity_params`, rejection on the explicit-runtimeClassName path, unchanged `cc_init_data` behavior (webhook stamp accepted, author value rejected), admission of annotation-free and clean explicit-class pods, and the host-namespace exemption. `make lint` is clean.

Residual, stated honestly: a host can still rewrite pod annotations between admission and the shim, which admission control alone cannot close. On SNP the measured cmdline completes the story; on TDX the host-side closure needs RTMR[1]/[2] pinning, out of scope for this fix.
