### PR TITLE
fix(kata-guest-base): constrain mount and storage sources in the baked agent policy

### DIFF
--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -184,6 +184,7 @@ layered_rootfs_storage(s) if {
 # is per-image knowledge that lives in the allowlist document, not here.
 mount_source_allowed(m) if {
 	not startswith(m.source, "/")
+	not bind_mount(m)
 }
 
 mount_source_allowed(m) if {
@@ -194,6 +195,23 @@ mount_source_allowed(m) if {
 
 no_traversal(path) if {
 	not regex.match(`(^|/)\.\.(/|$)`, path)
+}
+
+# rustjail resolves a bind source against the bundle directory, and the kernel
+# binds whenever MS_BIND is set — a bind/rbind option marks a bind regardless
+# of the declared type.
+bind_mount(m) if {
+	m.type_ == "bind"
+}
+
+bind_mount(m) if {
+	some o in m.options
+	o == "bind"
+}
+
+bind_mount(m) if {
+	some o in m.options
+	o == "rbind"
 }
 
 # kata's own switch is io.katacontainers.pkg.oci.container_type; the guest-pull
@@ -246,6 +264,7 @@ default CreateSandboxRequest := false
 CreateSandboxRequest if {
 	every s in input.storages {
 		not container_rootfs_shaped(s.mount_point)
+		sandbox_storage_source_allowed(s)
 	}
 	print("CreateSandboxRequest: allowed")
 }
@@ -255,12 +274,20 @@ default UpdateEphemeralMountsRequest := false
 UpdateEphemeralMountsRequest if {
 	every s in input.storages {
 		not container_rootfs_shaped(s.mount_point)
+		sandbox_storage_source_allowed(s)
 	}
 	print("UpdateEphemeralMountsRequest: allowed")
 }
 
 container_rootfs_shaped(mount_point) if {
 	regex.match("^/run/kata-containers/[^/]+/rootfs(/.*)?$", mount_point)
+}
+
+# The storages the runtime sends here mount guest-local tmpfs instances (the
+# sandbox shm, emptyDir resizes); their source is a filesystem token.
+sandbox_storage_source_allowed(s) if {
+	some token in ["", "shm", "tmpfs"]
+	s.source == token
 }
 
 # --- CopyFile ----------------------------------------------------------

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -186,8 +186,18 @@ test_sandbox_storage_shaped_like_a_rootfs_denied if {
 }
 
 test_sandbox_storage_elsewhere_allowed if {
-	CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/shared/containers/x"}]}
-	UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/y"}]}
+	CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/shm", "source": "shm"}]}
+	CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/shared/containers/x", "source": ""}]}
+	UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/y", "source": "tmpfs"}]}
+}
+
+# The runtime only ever sends fs tokens here; a path source is host-staged
+# content the ephemeral handler would mount verbatim.
+test_sandbox_storage_with_path_source_denied if {
+	every source in ["/", "/run", "/run/kata-containers/other/rootfs", "../.."] {
+		not CreateSandboxRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/x", "source": source}]}
+		not UpdateEphemeralMountsRequest with input as {"storages": [{"mount_point": "/run/kata-containers/sandbox/x", "source": source}]}
+	}
 }
 
 # --- mounts -------------------------------------------------------------
@@ -199,7 +209,7 @@ test_sandbox_storage_elsewhere_allowed if {
 honest_mounts := [
 	{"destination": "/proc", "source": "proc", "type_": "proc", "options": []},
 	{"destination": "/sys/fs/cgroup", "source": "cgroup", "type_": "cgroup", "options": []},
-	{"destination": "/dev/shm", "source": "/run/kata-containers/sandbox/shm", "type_": "bind", "options": []},
+	{"destination": "/dev/shm", "source": "/run/kata-containers/sandbox/shm", "type_": "bind", "options": ["rbind"]},
 	{"destination": "/etc/resolv.conf", "source": "/run/kata-containers/shared/containers/pod-resolv.conf", "type_": "bind", "options": []},
 	{"destination": "/data", "source": "/run/kata-containers/sandbox/storage/aGk", "type_": "bind", "options": []},
 ]
@@ -231,6 +241,26 @@ test_mount_source_traversal_denied if {
 	not CreateContainerRequest with input as with_mounts(array.concat(
 		honest_mounts,
 		[bind_from("/run/kata-containers/sandbox/../../c8s/ratls-mesh.env")],
+	))
+}
+
+# A relative bind source resolves against the bundle directory, so "../.."
+# reaches /run — whether the bind is marked by type or by option.
+test_relative_bind_source_denied if {
+	every m in [
+		{"destination": "/x", "source": "../..", "type_": "bind", "options": []},
+		{"destination": "/x", "source": "../..", "type_": "tmpfs", "options": ["rbind"]},
+		{"destination": "/x", "source": "../..", "type_": "", "options": ["bind"]},
+	] {
+		not CreateContainerRequest with input as with_mounts(array.concat(honest_mounts, [m]))
+	}
+}
+
+# Filesystem mounts carry a type, not a source path.
+test_fs_mount_without_source_allowed if {
+	CreateContainerRequest with input as with_mounts(array.concat(
+		honest_mounts,
+		[{"destination": "/x", "source": "", "type_": "tmpfs", "options": []}],
 	))
 }
 


### PR DESCRIPTION
## Bug

Two host-reachable escapes in the baked kata-agent policy let the host place arbitrary guest filesystem content inside an admitted container:

- `mount_source_allowed` (kata-guest-base/extra/etc/kata-opa/default-policy.rego:185) admitted any non-absolute mount source with no traversal check. rustjail canonicalizes a bind mount's source with `fs::canonicalize` (kata `src/agent/rustjail/src/mount.rs`) against the agent's cwd, and the agent chdirs into the bundle directory in `setup_bundle` and forks the rustjail child within that window — so an OCI mount `{type: "bind", source: "../.."}` resolves to `/run` (`"../../.."` to `/`) and is mounted into the container. The kernel performs a bind whenever MS_BIND is set, so a `bind`/`rbind` entry in `options` takes the same path regardless of the declared mount type.
- The `CreateSandboxRequest`/`UpdateEphemeralMountsRequest` rules (default-policy.rego:246, default-policy.rego:255) only rejected mount points shaped like a container rootfs and never constrained `storage.source`. The ephemeral storage handler mounts `storage.source` verbatim, so the host could stage `/run`, another container's rootfs, or in-guest decrypted volume content under an allowed-prefix path and then bind-mount it into a container.

Any image that passes admission can drive both paths, since admission binds the image digest, not the OCI mounts a request carries.

## Solution

- A mount is now treated as a bind when `type_` is `bind` or `options` contain `bind`/`rbind`, matching how rustjail derives MS_BIND (the policy input's mount-type field is `type_`, rust-protobuf's name for the OCI `type` field). Binds take the existing absolute-source branch unchanged — source under `/run/kata-containers/shared/containers/` or `/run/kata-containers/sandbox/`, traversal-free — and only non-bind mounts (proc, sysfs, tmpfs, …) may carry a non-absolute source.
- `CreateSandboxRequest`/`UpdateEphemeralMountsRequest` storages additionally require `source` to be one of the filesystem tokens the runtime actually sends on those RPCs — `shm` (the sandbox shm tmpfs) or `tmpfs` (emptyDir resize) — or empty. The honest flow sends no path here (verified against kata's `setupStorages` and `prepareEphemeralMounts`), so no path-shaped source is allowed; that also blocks staging another container's rootfs, which sits under `/run/kata-containers/` but outside the mount prefixes.

Verified: `make policy-test` passes 26/26 (23 baseline + 3 new). New tests cover relative bind sources denied whether marked by type or by option, fs mounts without a source still allowed, path-shaped sandbox/ephemeral storage sources denied (`/`, `/run`, another container's rootfs, `../..`), and the honest storages still admitted; the honest shm mount fixture now carries its real `rbind` option.