### PR TITLE
fix(chart): deny hostPort, and evaluate ephemeral containers

### DIFF
--- a/internal/helmchart/c8s/templates/host-namespace-policy.yaml
+++ b/internal/helmchart/c8s/templates/host-namespace-policy.yaml
@@ -34,7 +34,10 @@ spec:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["pods"]
+        # pods/ephemeralcontainers is a separate resource to matchConstraints:
+        # "pods" alone leaves an ephemeral container unevaluated, and one can
+        # carry both a hostPath mount and a hostPort.
+        resources: ["pods", "pods/ephemeralcontainers"]
     namespaceSelector:
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -56,6 +59,14 @@ spec:
         !has(object.spec.hostIPC) || object.spec.hostIPC == false
       message: "hostIPC is denied for tenant pods."
     - expression: >-
+        (!has(object.spec.containers) || object.spec.containers.all(c,
+          !has(c.ports) || c.ports.all(p, !has(p.hostPort) || p.hostPort == 0))) &&
+        (!has(object.spec.initContainers) || object.spec.initContainers.all(c,
+          !has(c.ports) || c.ports.all(p, !has(p.hostPort) || p.hostPort == 0))) &&
+        (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c,
+          !has(c.ports) || c.ports.all(p, !has(p.hostPort) || p.hostPort == 0)))
+      message: "hostPort is reserved for c8s node components: workloadclaims.DigestsPort (1019) is the admission inventory's identity, and a hostPort publishes a pod on the node's address without hostNetwork — so a tenant pod could answer as the inventory and have CDS resolve its signing key."
+    - expression: >-
         !has(object.spec.volumes) ||
         object.spec.volumes.all(v, !has(v.hostPath) ||
           (v.hostPath.path == {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }} &&
@@ -63,6 +74,8 @@ spec:
            object.spec.containers.all(c, !has(c.volumeMounts) ||
              c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))) &&
            (!has(object.spec.initContainers) || object.spec.initContainers.all(c, !has(c.volumeMounts) ||
+             c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true)))) &&
+           (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c, !has(c.volumeMounts) ||
              c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))))))
       message: "hostPath volumes are denied, except a read-only mount of the admission inventory socket directory (the webhook-injected claims volume): a writable mount of the node filesystem could swap the inventory's socket (docs/getcert-workload-binding.md, Corner 7)."
 ---

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -609,6 +609,54 @@ func TestChartNriInstallerRendersSinglePullDaemonSet(t *testing.T) {
 	}
 }
 
+// workloadclaims.DigestsPort (1019) is the admission inventory's identity: CDS
+// resolves the inventory's signing key by dialling it at the node's address, so
+// anything that can answer there can have its own key accepted as the
+// inventory's and mint tokens naming any sandbox. hostNetwork is not the only
+// way to get there — a hostPort publishes a pod on the node's address with no
+// host namespace at all — so the VAP must deny both. PodSecurity baseline also
+// denies hostPort, but a namespace hosting CW pods cannot run at baseline (the
+// injected hostPath forces privileged), so this policy is the only control.
+func TestChartHostNamespacePolicyDeniesHostPort(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	var vap admissionregv1.ValidatingAdmissionPolicy
+	if !findDoc(t, out, "ValidatingAdmissionPolicy", "c8s-deny-host-namespaces", &vap) {
+		t.Fatal("ValidatingAdmissionPolicy c8s-deny-host-namespaces not rendered")
+	}
+	var expr string
+	for _, v := range vap.Spec.Validations {
+		if strings.Contains(v.Expression, "hostPort") {
+			expr = v.Expression
+		}
+	}
+	if expr == "" {
+		t.Fatal("no hostPort validation in c8s-deny-host-namespaces: a tenant pod with hostPort 1019 impersonates the admission inventory")
+	}
+	// Every container list, or the check is bypassed by putting the port on an
+	// init or ephemeral container.
+	for _, want := range []string{"spec.containers", "spec.initContainers", "spec.ephemeralContainers"} {
+		if !strings.Contains(expr, want) {
+			t.Errorf("hostPort validation does not cover %s; expression=%q", want, expr)
+		}
+	}
+	// An ephemeral container is an UPDATE on the subresource; "pods" alone
+	// leaves it unevaluated by this policy entirely.
+	var subresource bool
+	for _, r := range vap.Spec.MatchConstraints.ResourceRules {
+		for _, res := range r.Resources {
+			if res == "pods/ephemeralcontainers" {
+				subresource = true
+			}
+		}
+	}
+	if !subresource {
+		t.Error("matchConstraints does not name pods/ephemeralcontainers, so ephemeral containers bypass this policy")
+	}
+}
+
 // The webhook injects a read-only hostPath mount of the inventory socket dir
 // (nriImagePolicy.hostPaths.runtimeDir) into every CW pod, so the
 // deny-host-namespaces VAP must carve out exactly that dir — a blanket

--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -31,10 +31,15 @@ import (
 // DigestsPort is the port every inventory serves its digests endpoint on, and
 // the only port CDS will dial for one. It is fixed rather than carried in the
 // token, and it is privileged (<1024, IANA-unassigned), because that is what
-// makes it an identity: binding it requires the node's own network namespace,
-// which the chart's deny-host-namespaces policy withholds from tenant pods. A
-// pod can bind any port inside its own netns, so an unprivileged port would let
-// any workload answer as the inventory.
+// makes it an identity: answering on it at the node's address requires
+// hostNetwork or a hostPort, and the chart's deny-host-namespaces policy
+// withholds BOTH from tenant pods. A pod can bind any port inside its own
+// netns, so an unprivileged port would let any workload answer as the
+// inventory.
+//
+// Both halves are load-bearing. A hostPort needs no host namespace: the CNI
+// publishes the pod on the node's address, which is enough to be dialled here
+// and have CDS accept the responder's key as the inventory's.
 const DigestsPort = 1019
 
 // dialPort and listenPort are the ports the client connects to and the endpoint


### PR DESCRIPTION
workloadclaims.DigestsPort (1019) is the admission inventory's identity: CDS resolves the inventory's signing key by dialling it at the node's address, so anything answering there has its key accepted and can mint sandbox tokens naming any sandbox. deny-host-namespaces withheld only hostNetwork — but a hostPort publishes a pod on the node's address with no host namespace at all. Confirmed on a TDX node-CVM: a pod with an otherwise PodSecurity-restricted spec plus hostPort: 1019 answered in place of the inventory.

PodSecurity baseline denies hostPort, and that is what has been covering this — but only on clusters that enforce it. At the Kubernetes default every namespace is privileged, so the gap is open by default; and a namespace hosting node-CVM CW pods cannot run at baseline anyway, since the injected inventory-socket hostPath forces privileged.

matchConstraints named only "pods", leaving ephemeral containers unevaluated by the whole policy; they can carry both a hostPath mount and a hostPort. Adds the subresource and extends both expressions over ephemeralContainers.