### PR TITLE
refactor(policy-monitor): pass the advertise-host lookup as a parameter

### DIFF
--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -172,7 +172,7 @@ func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Lo
 	if len(measurements) == 0 {
 		logger.Warn("C8S_CDS_MEASUREMENTS not set: the sandbox-digests endpoint answers ANY RA-TLS-attested caller, so any TEE that can reach this guest can read what it runs. UNSAFE outside development.")
 	}
-	host, err := resolveSandboxDigestsHostLate(ctx, cfg, logger)
+	host, err := resolveSandboxDigestsHostLate(ctx, cfg, logger, sandboxDigestsHost)
 	if err != nil {
 		logger.Error("sandbox tokens disabled: no reachable digests host", "error", err)
 		signers.Disable()
@@ -219,10 +219,6 @@ var (
 	// on an answer — signing, or 404 — before the caller stops asking. Equal
 	// budgets would make which one a pod gets a race.
 	advertiseHostLateBudget = 90 * time.Second
-	// The retried lookup. A test that counts retries replaces it, so the count
-	// follows from the budget rather than from how long the runner's resolver
-	// takes to fail.
-	advertiseHostLookup = sandboxDigestsHost
 )
 
 // resolveSandboxDigestsHostLate retries the routing-table lookup until the pod
@@ -233,15 +229,18 @@ var (
 // It gives up at advertiseHostLateBudget so a guest that never gets a network
 // degrades to "issues without a sandbox ID" instead of holding every fetcher
 // open forever.
-func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slog.Logger) (string, error) {
+//
+// lookup is sandboxDigestsHost; injected so tests can drive the retry loop
+// without the resolver.
+func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slog.Logger, lookup func(*Config) (string, error)) (string, error) {
 	// Explicit host bypasses inference entirely — no reason to wait.
 	if cfg.SandboxDigestsAdvertiseHost != "" {
-		return sandboxDigestsHost(cfg)
+		return lookup(cfg)
 	}
 	deadline := time.Now().Add(advertiseHostLateBudget)
 	var lastErr error
 	for attempt := 1; ; attempt++ {
-		host, err := advertiseHostLookup(cfg)
+		host, err := lookup(cfg)
 		if err == nil {
 			if attempt > 1 {
 				logger.Info("advertise-host inference recovered", "attempt", attempt, "host", host)

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -148,7 +148,7 @@ func TestResolveSandboxDigestsHostLate_ExplicitHostSkipsRetry(t *testing.T) {
 	got, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
 		SandboxDigestsAdvertiseHost: "10.2.3.4",
 		CDSURL:                      "https://cds.invalid:8443",
-	}, logger)
+	}, logger, sandboxDigestsHost)
 	if err != nil || got != "10.2.3.4" {
 		t.Fatalf("host = %q, err = %v; want 10.2.3.4 with no error", got, err)
 	}
@@ -157,29 +157,35 @@ func TestResolveSandboxDigestsHostLate_ExplicitHostSkipsRetry(t *testing.T) {
 	}
 }
 
+// failingLookup fails every inference attempt instantly, so a test's retry
+// count follows from the budget rather than from resolver latency.
+func failingLookup(*Config) (string, error) {
+	return "", errors.New("no route to the CDS host")
+}
+
+func shortAdvertiseHostWait(t *testing.T, budget, interval time.Duration) {
+	t.Helper()
+	prevBudget, prevInterval := advertiseHostLateBudget, advertiseHostRetryInterval
+	advertiseHostLateBudget, advertiseHostRetryInterval = budget, interval
+	t.Cleanup(func() { advertiseHostLateBudget, advertiseHostRetryInterval = prevBudget, prevInterval })
+}
+
 // A lookup that keeps failing keeps retrying to the budget rather than latching
 // tokens off on the first failure — the whole point of running late is that the
 // network arrives after the first attempt.
 //
 // The lookup is stubbed rather than pointed at an unresolvable host: a real
 // resolver makes each attempt cost whatever the runner's DNS takes, so the
-// retries a millisecond budget affords vary by machine (CI saw one). That an
-// unresolvable CDS URL fails at all is covered by _StopsAtBudget.
+// retries a millisecond budget affords vary by machine (CI saw one). The
+// budget dwarfs the interval for the same reason: a scheduler stall must not
+// eat every retry. That an unresolvable CDS URL fails at all is covered by
+// _StopsAtBudget.
 func TestResolveSandboxDigestsHostLate_RetriesUntilBudget(t *testing.T) {
-	prevInterval, prevBudget, prevLookup := advertiseHostRetryInterval, advertiseHostLateBudget, advertiseHostLookup
-	advertiseHostRetryInterval = time.Millisecond
-	advertiseHostLateBudget = 20 * time.Millisecond
-	advertiseHostLookup = func(*Config) (string, error) { return "", errors.New("no route to the CDS host") }
-	t.Cleanup(func() {
-		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
-		advertiseHostLookup = prevLookup
-	})
+	shortAdvertiseHostWait(t, 250*time.Millisecond, time.Millisecond)
 
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewJSONHandler(buf, nil))
-	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
-		CDSURL: "https://cds.example:8443",
-	}, logger)
+	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{}, logger, failingLookup)
 	if err == nil {
 		t.Fatal("want an error after the budget is exhausted")
 	}
@@ -191,17 +197,11 @@ func TestResolveSandboxDigestsHostLate_RetriesUntilBudget(t *testing.T) {
 // The budget bounds the wait: a guest that never gets a network must reach
 // "no signer" rather than hold every fetcher open indefinitely.
 func TestResolveSandboxDigestsHostLate_StopsAtBudget(t *testing.T) {
-	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
-	advertiseHostRetryInterval = 5 * time.Millisecond
-	advertiseHostLateBudget = 50 * time.Millisecond
-	t.Cleanup(func() {
-		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
-	})
+	shortAdvertiseHostWait(t, 50*time.Millisecond, 5*time.Millisecond)
 
 	start := time.Now()
-	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{
-		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
-	}, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)))
+	_, err := resolveSandboxDigestsHostLate(context.Background(), &Config{},
+		slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), failingLookup)
 	if err == nil {
 		t.Fatal("want an error after the budget is exhausted")
 	}
@@ -213,19 +213,13 @@ func TestResolveSandboxDigestsHostLate_StopsAtBudget(t *testing.T) {
 // A cancelled context stops the wait, so guest shutdown is not held up by a
 // lookup that will never succeed.
 func TestResolveSandboxDigestsHostLate_StopsOnContextCancel(t *testing.T) {
-	prevInterval, prevBudget := advertiseHostRetryInterval, advertiseHostLateBudget
-	advertiseHostRetryInterval = 10 * time.Millisecond
-	advertiseHostLateBudget = time.Hour
-	t.Cleanup(func() {
-		advertiseHostRetryInterval, advertiseHostLateBudget = prevInterval, prevBudget
-	})
+	shortAdvertiseHostWait(t, time.Hour, 10*time.Millisecond)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
 	defer cancel()
 	start := time.Now()
-	if _, err := resolveSandboxDigestsHostLate(ctx, &Config{
-		CDSURL: "https://this.host.does.not.resolve.invalid:8443",
-	}, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))); err == nil {
+	if _, err := resolveSandboxDigestsHostLate(ctx, &Config{},
+		slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), failingLookup); err == nil {
 		t.Fatal("want an error when the context ends")
 	}
 	if elapsed := time.Since(start); elapsed > time.Second {


### PR DESCRIPTION
## Problem

The advertise-host retry loop's lookup is injected through a mutable package-level `var advertiseHostLookup`, which hides the dependency, needs save/restore in tests, and races under parallel tests. Only one of the three retry tests uses it; `_StopsAtBudget` and `_StopsOnContextCancel` still resolve `this.host.does.not.resolve.invalid` for real each attempt, so their wall-clock assertions ride on the runner's resolver.

## Fix

`resolveSandboxDigestsHostLate` takes the lookup as an explicit parameter (its one production caller passes `sandboxDigestsHost`), all three retry tests pass an instantly-failing stub, and the triplicated knob save/restore collapses into `shortAdvertiseHostWait`, matching `shortInitDataWait`. `_RetriesUntilBudget`'s budget grows to 250ms against a 1ms interval so a scheduler stall cannot starve its lower-bound retry assertion. Production behavior is unchanged.

Verified with `go test -race -count=20 -run TestResolveSandboxDigestsHostLate` and a full package run on linux.