### PR TITLE
fix(install): request az-snp/az-tdx evidence from the attest sidecar under --cvm-mode=aks

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -1145,13 +1145,28 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 		)
 	}
 	// The tls-lb attestation sidecar is on by default (chart default); --attest=false
-	// omits it. When on, it advertises its TEE to the browser verifier: the chart
-	// default is snp/genoa, so on TDX override both to match the hardware.
-	// generation is AMD-only (Genoa/Milan/…); on TDX it is not a meaningful
-	// field, so we blank it rather than ship a stale AMD codename.
-	if !installAttestEnabled {
+	// omits it. When on, it passes this platform straight to the attestation-api
+	// as the evidence request, so the value must name the evidence SHAPE, not just
+	// the silicon: under aks the evidence is the Azure vTPM HCL report (az-snp /
+	// az-tdx), and the bare snp/tdx values would ask for /dev/sev-guest //dev/tdx_guest
+	// evidence that Azure CVM nodes cannot produce — every attest-pq/attest-lb call
+	// then fails 502 attestation_unavailable. generation is AMD-only (Genoa/Milan/…):
+	// az-snp auto-detects it from the report CPUID and TDX has no such concept, so
+	// every override blanks it rather than ship the chart-default codename (genoa)
+	// for hardware it never checked.
+	switch {
+	case !installAttestEnabled:
 		helmArgs = append(helmArgs, "--set", "tlsLb.attest.enabled=false")
-	} else if hardwarePlatform == "tdx" {
+	case cvmMode == "aks":
+		attestPlatform := "az-snp"
+		if hardwarePlatform == "tdx" {
+			attestPlatform = "az-tdx"
+		}
+		helmArgs = append(helmArgs,
+			"--set-string", "tlsLb.attest.platform="+attestPlatform,
+			"--set-string", "tlsLb.attest.generation=",
+		)
+	case hardwarePlatform == "tdx":
 		helmArgs = append(helmArgs,
 			"--set-string", "tlsLb.attest.platform=tdx",
 			"--set-string", "tlsLb.attest.generation=",

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1042,9 +1042,24 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 				"--set-string", "ratlsMesh.platform=tdx",
 			)
 		}
-		// TDX also overrides the tls-lb attestation sidecar's advertised
-		// platform (chart default snp/genoa) and blanks the AMD-only generation.
-		if platform == "tdx" {
+		// The attest sidecar's platform names the evidence shape the sidecar
+		// requests from the attestation-api: az-snp/az-tdx under aks (Azure
+		// vTPM HCL report — bare snp/tdx would probe guest devices AKS nodes
+		// do not expose), bare tdx on native TDX. sev-snp outside aks keeps
+		// the chart default (snp). Every override blanks the AMD-only
+		// generation.
+		switch {
+		case mode == "aks" && platform == "tdx":
+			out = append(out,
+				"--set-string", "tlsLb.attest.platform=az-tdx",
+				"--set-string", "tlsLb.attest.generation=",
+			)
+		case mode == "aks":
+			out = append(out,
+				"--set-string", "tlsLb.attest.platform=az-snp",
+				"--set-string", "tlsLb.attest.generation=",
+			)
+		case platform == "tdx":
 			out = append(out,
 				"--set-string", "tlsLb.attest.platform=tdx",
 				"--set-string", "tlsLb.attest.generation=",


### PR DESCRIPTION
## Problem

The `cds-attest` sidecar passes its `--platform` value straight to the attestation-api as the evidence request, so the value must name the **evidence shape**, not just the silicon. Under `--cvm-mode=aks` the only evidence source is the Azure vTPM HCL report (`az-snp` / `az-tdx`), but `appendCvmModeInstallArgs` emitted bare `tdx` for `--hardware-platform=tdx` and left the chart default `snp` for `sev-snp`. Both ask for guest-device evidence (`/dev/tdx_guest`, `/dev/sev-guest`) that Azure CVM nodes do not expose, so on Azure every `attest-pq`/`attest-lb` call failed out of the box:

```
GET /.well-known/c8s/attest-pq → 502 {"error":"attestation_unavailable"}
# sidecar log: attestation-api: API error (422): … open /dev/tdx_guest: No such file or directory
```

Because the value is emitted as `--set-string`, a `-f` values file could not even override it on the TDX side.

## Fix

Map `aks`+`tdx` → `az-tdx` and `aks`+`sev-snp` → `az-snp`, blanking the AMD-only `generation` on every override: az-snp auto-detects the generation from the report CPUID and TDX has no such concept, so advertising the chart default (`genoa`) for hardware the install never checked was misleading on Milan-based `DCas_v5` pools. Native shapes (`pod`/`node`/`gke`) are unchanged.

## Verification

- `TestAppendCvmModeInstallArgsSetsAttestationApiValue` extended: the aks rows now expect `az-snp`/`az-tdx` and a blanked generation.
- `golangci-lint run ./...` clean, `go test ./... -count=1` green.
- **Verified live** on a `Standard_DC4es_v6` CVM (single-node RKE2): a plain `c8s install --single-node --cvm-mode aks --hardware-platform tdx` now renders `--platform=az-tdx` and `GET /.well-known/c8s/attest-pq` returns the `c8s/attest-pq/v1` bundle (previously 502); the c8s-verify-js `connect()` flow and TEErminator `attest-lb` both verify against it.