### PR TITLE
fix(policy-monitor): settle the sandbox signer inside get-cert's first-issue window

### DIFF
--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -520,7 +520,10 @@ func digestsAdvertiseHost(cfg *config) (string, error) {
 	if host == "" {
 		host = strings.TrimSpace(os.Getenv("C8S_SANDBOX_DIGESTS_ADVERTISE_HOST"))
 	}
-	return workloadclaims.ResolveAdvertiseHost(host, cfg.Allowlist.Pull.URL)
+	// Bounds the resolver; runs once at startup with no caller ctx to inherit.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return workloadclaims.ResolveAdvertiseHost(ctx, host, cfg.Allowlist.Pull.URL)
 }
 
 // startSandboxDigests serves the CDS-facing digests endpoint over

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -140,15 +140,11 @@ func sandboxIDFromAnnotations(annotations map[string]string) string {
 	return ""
 }
 
-// sandboxTokenSigner builds the guest's sandbox-token signer. The key needs no
-// credential of its own: CDS reads it from this guest's digests endpoint on a
-// privileged port, which is what establishes whose key it is. Config problems
-// disable tokens (nil signer) but never crash the monitor — the same
-// fail-open-to-degraded posture as runAllowlistRefresh; get-cert then issues
-// without a sandbox ID.
 // installSandboxTokenSigner resolves the address this guest's sandbox tokens
 // commit to, starts the digests endpoint CDS calls back on, and only then hands
-// the signer to the token route.
+// the signer to the token route. The key needs no credential of its own: CDS
+// reads it from that endpoint on a privileged port, which is what establishes
+// whose key it is.
 //
 // It runs after READY=1. The address comes from a routing-table lookup toward
 // CDS, and the pod network it needs is installed by kata-agent's

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -185,7 +185,7 @@ func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Lo
 	// Before the route answers, not after: a token names this endpoint, and CDS
 	// refuses one it cannot call back on. Issuing first would hand out tokens
 	// that are guaranteed to be rejected.
-	if err := startSandboxDigests(ctx, logger, cfg, inventory, signer); err != nil {
+	if err := startSandboxDigests(ctx, logger, cfg, inventory, signer, measurements); err != nil {
 		logger.Error("sandbox-digests endpoint disabled; issuing without a sandbox ID rather than tokens CDS would refuse", "error", err)
 		signers.Disable()
 		return
@@ -286,11 +286,7 @@ func startAdmissionInventory(ctx context.Context, logger *slog.Logger, inventory
 
 // startSandboxDigests serves the CDS-facing digests endpoint inside the guest
 // over mutually-attested RA-TLS (docs/ratls.md, "Sandbox identity").
-func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *Config, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner) error {
-	measurements, err := ratls.ParseHexMeasurementsList(splitCSV(cfg.CDSMeasurements))
-	if err != nil {
-		return fmt.Errorf("parse CDS measurements: %w", err)
-	}
+func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *Config, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner, measurements [][]byte) error {
 	return workloadclaims.StartDigestsEndpoint(ctx, logger, inventory, signer.PublicKeyDER(),
 		string(types.PlatformSnp),
 		attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), cfg.AttestationServiceURL),

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -159,7 +159,7 @@ func sandboxIDFromAnnotations(annotations map[string]string) string {
 // Every failure disables the route rather than leaving it pending: a caller
 // waiting on a signer that is not coming is worse than one told to proceed
 // without a sandbox ID.
-func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Logger, inventory *admissionInventory, signers *workloadclaims.SignerHolder) {
+func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Logger, inventory *admissionInventory, signers *workloadclaims.SignerHolder, settle time.Time) {
 	// A parse failure is a typo and stays fail-closed; empty is the explicit
 	// dev opt-out, so tokens still flow and the guest can still be issued a
 	// sandbox-bound leaf.
@@ -172,7 +172,9 @@ func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Lo
 	if len(measurements) == 0 {
 		logger.Warn("C8S_CDS_MEASUREMENTS not set: the sandbox-digests endpoint answers ANY RA-TLS-attested caller, so any TEE that can reach this guest can read what it runs. UNSAFE outside development.")
 	}
-	host, err := resolveSandboxDigestsHostLate(ctx, cfg, logger, sandboxDigestsHost)
+	resolveCtx, cancel := context.WithDeadline(ctx, settle)
+	host, err := resolveSandboxDigestsHostLate(resolveCtx, cfg, logger, sandboxDigestsHost)
+	cancel()
 	if err != nil {
 		logger.Error("sandbox tokens disabled: no reachable digests host", "error", err)
 		signers.Disable()
@@ -215,10 +217,11 @@ func sandboxDigestsHost(cfg *Config) (string, error) {
 // Overridable in tests.
 var (
 	advertiseHostRetryInterval = 2 * time.Second
-	// Under get-cert's --initial-retry-timeout (2m), so the route has settled
-	// on an answer — signing, or 404 — before the caller stops asking. Equal
-	// budgets would make which one a pod gets a race.
 	advertiseHostLateBudget = 90 * time.Second
+	// Bounds the serial initdata wait + advertise-host lookup (90s+90s alone
+	// overshoots) under get-cert's 2m --initial-retry-timeout, so the token
+	// route settles before the caller stops asking.
+	signerSettleBudget = 110 * time.Second
 )
 
 // resolveSandboxDigestsHostLate retries the routing-table lookup until the pod

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -200,8 +200,8 @@ func installSandboxTokenSigner(ctx context.Context, cfg *Config, logger *slog.Lo
 
 // sandboxDigestsHost is the guest IP every sandbox token names for CDS's
 // digests callback.
-func sandboxDigestsHost(cfg *Config) (string, error) {
-	return workloadclaims.ResolveAdvertiseHost(cfg.SandboxDigestsAdvertiseHost, cfg.CDSURL)
+func sandboxDigestsHost(ctx context.Context, cfg *Config) (string, error) {
+	return workloadclaims.ResolveAdvertiseHost(ctx, cfg.SandboxDigestsAdvertiseHost, cfg.CDSURL)
 }
 
 // The wait for the guest network to reach a state where the routing-table
@@ -217,7 +217,7 @@ func sandboxDigestsHost(cfg *Config) (string, error) {
 // Overridable in tests.
 var (
 	advertiseHostRetryInterval = 2 * time.Second
-	advertiseHostLateBudget = 90 * time.Second
+	advertiseHostLateBudget    = 90 * time.Second
 	// Bounds the serial initdata wait + advertise-host lookup (90s+90s alone
 	// overshoots) under get-cert's 2m --initial-retry-timeout, so the token
 	// route settles before the caller stops asking.
@@ -235,15 +235,15 @@ var (
 //
 // lookup is sandboxDigestsHost; injected so tests can drive the retry loop
 // without the resolver.
-func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slog.Logger, lookup func(*Config) (string, error)) (string, error) {
+func resolveSandboxDigestsHostLate(ctx context.Context, cfg *Config, logger *slog.Logger, lookup func(context.Context, *Config) (string, error)) (string, error) {
 	// Explicit host bypasses inference entirely — no reason to wait.
 	if cfg.SandboxDigestsAdvertiseHost != "" {
-		return lookup(cfg)
+		return lookup(ctx, cfg)
 	}
 	deadline := time.Now().Add(advertiseHostLateBudget)
 	var lastErr error
 	for attempt := 1; ; attempt++ {
-		host, err := lookup(cfg)
+		host, err := lookup(ctx, cfg)
 		if err == nil {
 			if attempt > 1 {
 				logger.Info("advertise-host inference recovered", "attempt", attempt, "host", host)

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -254,3 +254,14 @@ func TestAdvertiseHostRunsOffTheStartupPath(t *testing.T) {
 			advertiseHostLateBudget, timeout)
 	}
 }
+
+// The settle budget must fit under get-cert's 2m --initial-retry-timeout and
+// leave the lookup time after a full initdata wait.
+func TestSignerSettleBudgetCoversTheSerialChain(t *testing.T) {
+	if signerSettleBudget >= 2*time.Minute {
+		t.Fatalf("signerSettleBudget %s must settle before get-cert's 2m --initial-retry-timeout", signerSettleBudget)
+	}
+	if signerSettleBudget <= initDataWaitBudget {
+		t.Fatalf("signerSettleBudget %s leaves the advertise-host lookup no time after a full %s initdata wait", signerSettleBudget, initDataWaitBudget)
+	}
+}

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -108,14 +108,14 @@ func TestKataInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 // The advertise host CDS dials back: explicit config wins, and a host it could
 // never reach is rejected where it is configured rather than at issuance.
 func TestSandboxDigestsHost(t *testing.T) {
-	got, err := sandboxDigestsHost(&Config{
+	got, err := sandboxDigestsHost(context.Background(), &Config{
 		SandboxDigestsAdvertiseHost: "10.2.3.4",
 		CDSURL:                      "https://cds.invalid:8443",
 	})
 	if err != nil || got != "10.2.3.4" {
 		t.Fatalf("host = %q, err = %v; want 10.2.3.4", got, err)
 	}
-	if _, err := sandboxDigestsHost(&Config{
+	if _, err := sandboxDigestsHost(context.Background(), &Config{
 		SandboxDigestsAdvertiseHost: "127.0.0.1",
 		CDSURL:                      "https://cds.invalid:8443",
 	}); err == nil {
@@ -159,7 +159,7 @@ func TestResolveSandboxDigestsHostLate_ExplicitHostSkipsRetry(t *testing.T) {
 
 // failingLookup fails every inference attempt instantly, so a test's retry
 // count follows from the budget rather than from resolver latency.
-func failingLookup(*Config) (string, error) {
+func failingLookup(context.Context, *Config) (string, error) {
 	return "", errors.New("no route to the CDS host")
 }
 

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -265,3 +265,26 @@ func TestSignerSettleBudgetCoversTheSerialChain(t *testing.T) {
 		t.Fatalf("signerSettleBudget %s leaves the advertise-host lookup no time after a full %s initdata wait", signerSettleBudget, initDataWaitBudget)
 	}
 }
+
+// Inference that recovers mid-budget returns the host instead of latching off.
+func TestResolveSandboxDigestsHostLate_RecoversAfterTransientFailure(t *testing.T) {
+	shortAdvertiseHostWait(t, 250*time.Millisecond, time.Millisecond)
+
+	calls := 0
+	lookup := func(context.Context, *Config) (string, error) {
+		calls++
+		if calls < 3 {
+			return "", errors.New("no route yet")
+		}
+		return "10.9.8.7", nil
+	}
+	buf := &bytes.Buffer{}
+	host, err := resolveSandboxDigestsHostLate(context.Background(), &Config{},
+		slog.New(slog.NewJSONHandler(buf, nil)), lookup)
+	if err != nil || host != "10.9.8.7" {
+		t.Fatalf("host = %q, err = %v; want recovery on attempt 3", host, err)
+	}
+	if !strings.Contains(buf.String(), `"msg":"advertise-host inference recovered"`) {
+		t.Fatalf("no recovery log line; log:\n%s", buf.String())
+	}
+}

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -149,12 +149,14 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 		// behind this unit's READY=1. cfg.CDSMeasurements is written only in
 		// this goroutine, after the synchronous readers above have finished
 		// with it.
+		// Before the initdata wait: the budget bounds the serial chain.
+		settle := time.Now().Add(signerSettleBudget)
 		go func() {
 			awaitInitDataMeasurements(ctx, logger, cfg)
 			// Both need the measurements the document carries, and neither may
 			// hold the other up: the signer waits on the pod network, the
 			// refresh only on CDS answering.
-			go installSandboxTokenSigner(ctx, cfg, logger, m.inventory, m.signers)
+			go installSandboxTokenSigner(ctx, cfg, logger, m.inventory, m.signers, settle)
 			runAllowlistRefresh(ctx, logger, cfg, a, m.overlay, m.refresh)
 		}()
 	} else {

--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -124,13 +124,15 @@ func (h InventoryHosts) Contains(host string) bool {
 // CDS is reached over loopback — which the chart's own default does, since the
 // plugin dials the CDS NodePort on 127.0.0.1 — so it fails loudly rather than
 // advertising something CDS could never dial back.
-func ResolveAdvertiseHost(host, cdsEndpoint string) (string, error) {
+// ctx bounds the lookup's name resolution, which net.Dial would otherwise
+// block on without limit.
+func ResolveAdvertiseHost(ctx context.Context, host, cdsEndpoint string) (string, error) {
 	if u, err := url.Parse(cdsEndpoint); err == nil && u.Host != "" {
 		cdsEndpoint = u.Host
 	}
 	if host == "" {
 		var err error
-		if host, err = outboundHost(cdsEndpoint); err != nil {
+		if host, err = outboundHost(ctx, cdsEndpoint); err != nil {
 			return "", fmt.Errorf("workloadclaims: infer the inventory advertise host (set it explicitly): %w", err)
 		}
 	}
@@ -140,11 +142,11 @@ func ResolveAdvertiseHost(host, cdsEndpoint string) (string, error) {
 // outboundHost reports the local IP the kernel would source from when talking
 // to target. The UDP socket is unconnected on the wire — no packet is sent —
 // so this is a routing-table lookup, not a reachability test.
-func outboundHost(target string) (string, error) {
+func outboundHost(ctx context.Context, target string) (string, error) {
 	if !strings.Contains(target, ":") {
 		target = net.JoinHostPort(target, "443")
 	}
-	conn, err := net.Dial("udp", target)
+	conn, err := (&net.Dialer{}).DialContext(ctx, "udp", target)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workloadclaims/digests_integration_test.go
+++ b/pkg/workloadclaims/digests_integration_test.go
@@ -242,7 +242,7 @@ func (e errTest) Error() string { return string(e) }
 // lookup, not a reachability test, so it answers for an address nothing is
 // listening on — and fails for one that cannot be parsed.
 func TestOutboundHost(t *testing.T) {
-	got, err := outboundHost("192.0.2.1:9")
+	got, err := outboundHost(context.Background(), "192.0.2.1:9")
 	if err != nil {
 		t.Fatalf("outboundHost: %v", err)
 	}
@@ -250,10 +250,10 @@ func TestOutboundHost(t *testing.T) {
 		t.Fatalf("outboundHost returned %q, want an IP", got)
 	}
 	// A bare host gets the default port appended rather than erroring.
-	if _, err := outboundHost("192.0.2.1"); err != nil {
+	if _, err := outboundHost(context.Background(), "192.0.2.1"); err != nil {
 		t.Fatalf("bare host: %v", err)
 	}
-	if _, err := outboundHost("not a host:::"); err == nil {
+	if _, err := outboundHost(context.Background(), "not a host:::"); err == nil {
 		t.Fatal("unparseable target accepted")
 	}
 }
@@ -261,7 +261,7 @@ func TestOutboundHost(t *testing.T) {
 // With no explicit host, ResolveAdvertiseHost falls back to the route lookup
 // and still validates the result.
 func TestResolveAdvertiseHostInfers(t *testing.T) {
-	got, err := ResolveAdvertiseHost("", "192.0.2.1:9")
+	got, err := ResolveAdvertiseHost(context.Background(), "", "192.0.2.1:9")
 	if err != nil {
 		t.Fatalf("ResolveAdvertiseHost: %v", err)
 	}

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -570,7 +570,7 @@ func TestFetchRejectsForgedAddrBeforeDialing(t *testing.T) {
 }
 
 func TestResolveAdvertiseHostPrefersExplicitHost(t *testing.T) {
-	host, err := ResolveAdvertiseHost("10.1.2.3", "cds.invalid:8443")
+	host, err := ResolveAdvertiseHost(context.Background(), "10.1.2.3", "cds.invalid:8443")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +584,7 @@ func TestResolveAdvertiseHostPrefersExplicitHost(t *testing.T) {
 // somewhere useless.
 func TestResolveAdvertiseHostRejectsUnreachableHost(t *testing.T) {
 	for _, host := range []string{"127.0.0.1", "::1", "169.254.169.254", "inventory.example"} {
-		if _, err := ResolveAdvertiseHost(host, "cds.invalid:8443"); err == nil {
+		if _, err := ResolveAdvertiseHost(context.Background(), host, "cds.invalid:8443"); err == nil {
 			t.Fatalf("advertise host %q accepted", host)
 		}
 	}


### PR DESCRIPTION
## Problem

The sandbox-signer install runs the initdata wait (90s budget) and the advertise-host lookup (90s budget) serially, so worst case the token route stays `signerPending` for ~180s while get-cert stops asking at its 2m `--initial-retry-timeout`: the init container crashes in exactly the scenario the budgets were sized to prevent. Independently, the lookup ends in `net.Dial("udp", ...)` whose name resolution nothing bounds, so one slow resolver call can overshoot any budget or eat it whole. The recovery branch of the retry loop (fail, then the network arrives) had no coverage, a doc block still described the deleted `sandboxTokenSigner`, and `CDSMeasurements` was parsed twice on one path with a dead error branch.

## Fix

One commit per issue:

- `signerSettleBudget` (110s) starts before the initdata wait and bounds the serial chain end to end via a context deadline on the lookup; a test pins it under 2m and above the initdata budget.
- `ResolveAdvertiseHost`/`outboundHost` take a context and dial via `DialContext`, so resolution respects the deadline; nri-image-policy bounds its one startup call at 10s.
- New test drives the lookup fail→fail→succeed and asserts the recovered host and log line.
- Stale doc block dropped; its one surviving fact folded into the real one.
- Measurements parsed once in `installSandboxTokenSigner` and passed to `startSandboxDigests`, deleting the dead re-parse branch.

Verified with `go test -race` on policymonitor, nri-image-policy, and workloadclaims on linux.
