### PR TITLE
fix(kata): unblock workload certificates and encrypted volumes under …

### DIFF
--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -55,12 +55,14 @@ config_changed=0
 #    on RKE2 the next config regen drops it once the managed template (step 4)
 #    is gone.
 for d in config-v3.toml.d config.toml.d; do
-  f="${CONTAINERD_DIR}/${d}/kata-deploy.toml"
-  if [ -f "$f" ]; then
-    rm -f "$f"
-    config_changed=1
-    echo "containerd drop-in removed: $f"
-  fi
+  for n in kata-deploy.toml zz-c8s-kata-annotations.toml; do
+    f="${CONTAINERD_DIR}/${d}/${n}"
+    if [ -f "$f" ]; then
+      rm -f "$f"
+      config_changed=1
+      echo "containerd drop-in removed: $f"
+    fi
+  done
 done
 [ "$config_changed" = "1" ] || echo "containerd drop-in already absent"
 

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -42,8 +42,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -530,8 +532,14 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// pull time, so there is no digest to check. The baked kata-agent
 		// policy rejects the same request earlier, so reaching here means the
 		// policy was not in force.
+		// Name the annotation keys, not just the missing reference: this denial
+		// also fires when the spec is not the one c8s expects at all (a pause
+		// container whose type marker is absent lands here and takes the whole
+		// sandbox down), and the keys are the only way to tell those apart from
+		// outside the guest. Keys only — values carry pod-identifying data.
 		m.logger.Warn("deny container: image reference is absent or not digest-pinned",
-			"cid", cid, "reference", spec.Annotations[kataspec.PullReferenceKey])
+			"cid", cid, "reference", spec.Annotations[kataspec.PullReferenceKey],
+			"annotation_keys", slices.Sorted(maps.Keys(spec.Annotations)))
 		m.deny(ctx, dir)
 		return
 	}
@@ -679,8 +687,23 @@ func (m *monitor) readConfigJSON(ctx context.Context, dir string) (*ociSpec, err
 	backedOff := false
 	for {
 		spec, err := readOCISpec(path)
-		if err == nil {
+		if err == nil && len(spec.Annotations) > 0 {
 			return spec, nil
+		}
+		if err == nil {
+			// Parses, but carries no annotations at all. Every CRI stamps
+			// several (containerd sets io.kubernetes.cri.* on every container,
+			// sandbox included), so an empty map is a spec written but not yet
+			// populated, not a container that has none — and judging it reads
+			// the pause as a workload with no image reference and kills it,
+			// which wedges the whole sandbox.
+			//
+			// Bounded exactly like a half-written file, and the caller still
+			// denies when the budget runs out, so a host that withholds
+			// annotations delays a denial rather than earning an admission. A
+			// spec with annotations but no CRI keys is a complete policy input
+			// and is decided immediately, as before.
+			err = errPartialJSON
 		}
 		if !errors.Is(err, os.ErrNotExist) && !isPartialJSON(err) {
 			// Unrecoverable: not a transient race. Return immediately.

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/kataspec"
 	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -852,5 +853,39 @@ func TestHandleNewContainer_AllowlistedImageIDDoesNotAdmit(t *testing.T) {
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, spoofedCID))
 	if calls := killer.snapshot(); len(calls) != 1 {
 		t.Fatalf("expected a kill: the allowlisted digest is not the reference the guest pulls, got %+v", calls)
+	}
+}
+
+// kata-agent's setup_bundle writes config.json and its annotations; c8s watches
+// for the file, so it can read one that parses with the annotations map still
+// empty. Deciding on that spec sees no container-type (so not the sandbox) and
+// no image reference, and denies — which for a pod's pause container kills the
+// sandbox and leaves it in containerd's SANDBOX_UNKNOWN, unrecoverable without
+// killing qemu and restarting containerd. Observed repeatedly on SEV-SNP:
+// "refused by policy-monitor: image not allowlisted" against the sandbox id.
+//
+// The wait is bounded and still ends in a denial, so withholding annotations
+// delays a deny rather than earning an allow.
+func TestReadConfigJSON_EmptyAnnotationsIsRetriedNotJudged(t *testing.T) {
+	m, _, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := testCID("emptyannotations")
+	writeConfigJSON(t, watchDir, cid, map[string]string{})
+	dir := filepath.Join(watchDir, cid)
+
+	// The populated spec lands after the first read, the way kata-agent's does.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		writeConfigJSON(t, watchDir, cid, map[string]string{
+			"io.kubernetes.cri.container-type": "sandbox",
+		})
+	}()
+
+	m.configReadDeadline = 2 * time.Second
+	spec, err := m.readConfigJSON(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("readConfigJSON: %v", err)
+	}
+	if !kataspec.IsSandbox(spec.Annotations) {
+		t.Fatalf("got annotations %v, want the sandbox spec kata wrote second", spec.Annotations)
 	}
 }

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -8,9 +8,24 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 )
+
+// cleanupTimeout bounds an unwind that no longer has a caller waiting on it.
+const cleanupTimeout = 30 * time.Second
+
+// cleanupContext detaches the unwind from the caller's cancellation.
+//
+// INVARIANT: every device-mapper target this daemon creates is either owned by
+// a live mount or removed. A fetcher whose request deadline expires mid-open
+// cancels ctx, and closing a mapping needs a live context to run cryptsetup —
+// so unwinding on the caller's ctx cannot remove what the open already created,
+// and the leaked mapper name fails every retry with "already exists".
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+}
 
 // DeviceOps are the privileged steps. Behind an interface so the orchestration
 // and every unwind path are exercised without device-mapper.
@@ -148,10 +163,12 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 	}
 	defer target.Close()
 
-	var undo []func()
+	var undo []func(context.Context)
 	fail := func(err error) (*mount, error) {
+		cleanup, cancel := cleanupContext(ctx)
+		defer cancel()
 		for i := len(undo) - 1; i >= 0; i-- {
-			undo[i]()
+			undo[i](cleanup)
 		}
 		return nil, err
 	}
@@ -160,13 +177,13 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 	if err := o.Ops.CryptOpen(ctx, req.Device, cryptMapper, key); err != nil {
 		return fail(fmt.Errorf("volumed: open dm-crypt: %w", err))
 	}
-	undo = append(undo, func() { _ = o.Ops.CryptClose(ctx, cryptMapper) })
+	undo = append(undo, func(ctx context.Context) { _ = o.Ops.CryptClose(ctx, cryptMapper) })
 
 	verityMapper := mapperName("verity", req.Pod.UID, req.Name)
 	if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, req.Blob.Verity); err != nil {
 		return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
 	}
-	undo = append(undo, func() { _ = o.Ops.VerityClose(ctx, verityMapper) })
+	undo = append(undo, func(ctx context.Context) { _ = o.Ops.VerityClose(ctx, verityMapper) })
 
 	if err := o.Ops.MountRO(ctx, devPath(verityMapper), target); err != nil {
 		return fail(fmt.Errorf("volumed: mount: %w", err))
@@ -221,9 +238,11 @@ func (o *Opener) ClosePod(ctx context.Context, podUID string) int {
 // device-mapper targets hold the key, so a failed unmount must not leave them
 // behind.
 func (o *Opener) teardown(ctx context.Context, m *mount) {
-	_ = o.Ops.Unmount(ctx, m.target)
-	_ = o.Ops.VerityClose(ctx, m.verityDev)
-	_ = o.Ops.CryptClose(ctx, m.cryptDev)
+	cleanup, cancel := cleanupContext(ctx)
+	defer cancel()
+	_ = o.Ops.Unmount(cleanup, m.target)
+	_ = o.Ops.VerityClose(cleanup, m.verityDev)
+	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
 }
 
 // Pods returns the distinct pods holding a volume, so teardown can ask which of

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -19,6 +19,11 @@ type fakeOps struct {
 	failOn string
 
 	cryptOpen, verityOpen, mounted map[string]bool
+
+	// honorCtx makes every op fail once its context is done.
+	honorCtx bool
+	// afterCryptOpen fires once the first privileged step has landed.
+	afterCryptOpen func()
 }
 
 func newOps() *fakeOps {
@@ -27,6 +32,16 @@ func newOps() *fakeOps {
 		verityOpen: map[string]bool{},
 		mounted:    map[string]bool{},
 	}
+}
+
+// ctxErr mirrors the real ops, which shell out to cryptsetup/veritysetup and
+// so cannot do anything once their context is done. Without this the fake
+// would unwind happily on a cancelled context and hide a leak.
+func (f *fakeOps) ctxErr(ctx context.Context) error {
+	if f.honorCtx {
+		return ctx.Err()
+	}
+	return nil
 }
 
 func (f *fakeOps) record(op string) error {
@@ -39,9 +54,12 @@ func (f *fakeOps) record(op string) error {
 	return nil
 }
 
-func (f *fakeOps) CryptOpen(_ context.Context, _, mapper string, key []byte) error {
+func (f *fakeOps) CryptOpen(ctx context.Context, _, mapper string, key []byte) error {
 	if len(key) != volume.KeyBytes {
 		return errors.New("wrong key length")
+	}
+	if err := f.ctxErr(ctx); err != nil {
+		return err
 	}
 	if err := f.record("CryptOpen"); err != nil {
 		return err
@@ -49,10 +67,16 @@ func (f *fakeOps) CryptOpen(_ context.Context, _, mapper string, key []byte) err
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cryptOpen[mapper] = true
+	if f.afterCryptOpen != nil {
+		f.afterCryptOpen()
+	}
 	return nil
 }
 
-func (f *fakeOps) CryptClose(_ context.Context, mapper string) error {
+func (f *fakeOps) CryptClose(ctx context.Context, mapper string) error {
+	if err := f.ctxErr(ctx); err != nil {
+		return err
+	}
 	if err := f.record("CryptClose"); err != nil {
 		return err
 	}
@@ -62,7 +86,10 @@ func (f *fakeOps) CryptClose(_ context.Context, mapper string) error {
 	return nil
 }
 
-func (f *fakeOps) VerityOpen(_ context.Context, _, mapper string, _ volume.Verity) error {
+func (f *fakeOps) VerityOpen(ctx context.Context, _, mapper string, _ volume.Verity) error {
+	if err := f.ctxErr(ctx); err != nil {
+		return err
+	}
 	if err := f.record("VerityOpen"); err != nil {
 		return err
 	}
@@ -72,7 +99,10 @@ func (f *fakeOps) VerityOpen(_ context.Context, _, mapper string, _ volume.Verit
 	return nil
 }
 
-func (f *fakeOps) VerityClose(_ context.Context, mapper string) error {
+func (f *fakeOps) VerityClose(ctx context.Context, mapper string) error {
+	if err := f.ctxErr(ctx); err != nil {
+		return err
+	}
 	if err := f.record("VerityClose"); err != nil {
 		return err
 	}
@@ -82,7 +112,10 @@ func (f *fakeOps) VerityClose(_ context.Context, mapper string) error {
 	return nil
 }
 
-func (f *fakeOps) MountRO(_ context.Context, _ string, target *os.File) error {
+func (f *fakeOps) MountRO(ctx context.Context, _ string, target *os.File) error {
+	if err := f.ctxErr(ctx); err != nil {
+		return err
+	}
 	if err := f.record("MountRO"); err != nil {
 		return err
 	}
@@ -94,7 +127,10 @@ func (f *fakeOps) MountRO(_ context.Context, _ string, target *os.File) error {
 	return nil
 }
 
-func (f *fakeOps) Unmount(_ context.Context, target string) error {
+func (f *fakeOps) Unmount(ctx context.Context, target string) error {
+	if err := f.ctxErr(ctx); err != nil {
+		return err
+	}
 	if err := f.record("Unmount"); err != nil {
 		return err
 	}
@@ -429,5 +465,29 @@ func TestZeroClearsTheBuffer(t *testing.T) {
 		if v != 0 {
 			t.Fatalf("byte %d = %d", i, v)
 		}
+	}
+}
+
+// A fetcher whose request deadline expires mid-open cancels the context the
+// open is running on. Unwinding on that context cannot remove what the open
+// already created — cryptsetup needs a live one — so the mapper name leaks and
+// every retry fails with "Device <name> already exists", which is terminal:
+// the fetcher retries for its whole budget and the pod never gets its volume.
+func TestOpenUnwindsAfterTheCallerContextIsCancelled(t *testing.T) {
+	ops := newOps()
+	ops.honorCtx = true
+	ops.failOn = "VerityOpen"
+	o := testOpener(t, ops)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	// Cancel the moment the first privileged step lands, the way a deadline
+	// expiring mid-open does.
+	ops.afterCryptOpen = cancel
+
+	if err := o.Open(ctx, testRequest(t)); err == nil {
+		t.Fatal("open succeeded despite a cancelled context")
+	}
+	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Errorf("leaked crypt=%d verity=%d mounts=%d after a cancelled open", c, v, m)
 	}
 }

--- a/internal/helmchart/c8s/files/scripts/containerd-prep.sh
+++ b/internal/helmchart/c8s/files/scripts/containerd-prep.sh
@@ -130,4 +130,30 @@ esac
 # Always make sure the drop-in dir exists so the installers can write to it.
 mkdir -p "$DIR/${dropin_name}"
 
+# Widen the CRI pod-annotation passthrough for the kata runtimes.
+#
+# containerd copies a pod annotation into the sandbox OCI spec only if it
+# matches this runtime's pod_annotations globs, and kata-deploy hardcodes
+# ["io.katacontainers.*"] (tools/packaging/kata-deploy/binary/src/runtime/
+# containerd.rs). kata-qemu-scratch-wrapper.sh reads
+# confidential.ai/c8s-volumes off that spec to decide which encrypted volume
+# devices to attach, so without this the annotation never reaches the wrapper
+# and a pod's volumes are silently never attached — the guest daemon then
+# answers "volume device is not present on this node".
+#
+# A separate file rather than an edit of kata-deploy.toml: kata-deploy rewrites
+# its own drop-in on every DaemonSet restart. containerd merges drop-ins in
+# lexical order with later files overriding, so the zz- prefix is what makes
+# this win.
+kata_annotations="$DIR/${dropin_name}/zz-c8s-kata-annotations.toml"
+{
+  echo "# Managed by c8s containerd-prep. See internal/helmchart/c8s/files/scripts/containerd-prep.sh."
+  for rt in kata-qemu-snp kata-qemu-nvidia-gpu-snp kata-qemu-tdx kata-qemu-nvidia-gpu-tdx; do
+    echo "[plugins.\"io.containerd.cri.v1.runtime\".containerd.runtimes.${rt}]"
+    echo 'pod_annotations = ["io.katacontainers.*", "confidential.ai/*"]'
+  done
+} > "${kata_annotations}.c8s-tmp"
+mv -f "${kata_annotations}.c8s-tmp" "${kata_annotations}"
+echo "  $(basename "${kata_annotations}"): pod_annotations widened to confidential.ai/*"
+
 echo "==> c8s containerd-prep done"

--- a/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
+++ b/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
@@ -170,7 +170,7 @@ while IFS= read -r vol; do
     if dev="$(device_for "$vol")"; then
         volume_args+=(
             -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
-            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol,read-only=on"
+            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol"
         )
         n=$((n + 1))
     fi

--- a/kata-guest-base/extra/etc/c8s/cloudinit.env
+++ b/kata-guest-base/extra/etc/c8s/cloudinit.env
@@ -28,4 +28,4 @@ C8S_LOG_LEVEL=info
 # this env is a single baked default, it applies to EVERY guest: a workload
 # listening on 8443 inside a kata pod is reachable without mesh mTLS: on kata
 # guests, inbound TCP port 8443 bypasses the mesh.
-C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443
+C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443,tcp:1019

--- a/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
+++ b/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
@@ -170,7 +170,7 @@ while IFS= read -r vol; do
     if dev="$(device_for "$vol")"; then
         volume_args+=(
             -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
-            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol,read-only=on"
+            -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol"
         )
         n=$((n + 1))
     fi


### PR DESCRIPTION
…--cvm-mode=pod

CDS bootstraps a workload's identity by dialling the pod's sandbox-digests endpoint at podIP:1019, but the in-guest mesh redirected that port into its own mTLS listener and dropped the call, so no injected pod ever got a certificate. 1019 is how a workload obtains the identity the mesh would demand of it, so it joins 8443 as a front door. Workloads now run and secrets release.

Encrypted volumes then failed three ways in turn. kata-deploy hardcodes pod_annotations to io.katacontainers.*, so confidential.ai/c8s-volumes never reached kata-qemu-scratch-wrapper.sh and no device was attached; the wrapper then emitted a read-only property virtio-blk-pci does not have, and qemu refused to start the sandbox at all; and volumed unwound a timed-out open on the caller's cancelled context, leaking the dm-crypt mapping so every retry hit "Device ... already exists".

Denials now log the spec's annotation keys, since the bundle is removed before anyone can read it.

Verified on SEV-SNP bare metal.