### PR TITLE
fix(kata): fixed volume wedge on startup

### DIFF
--- a/internal/cmds/volumed/systemops.go
+++ b/internal/cmds/volumed/systemops.go
@@ -218,5 +218,7 @@ func (s SystemOps) run(ctx context.Context, name string, extra []*os.File, args 
 func execRunner(ctx context.Context, name string, extra []*os.File, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.ExtraFiles = extra
+	// No udev services dm events in the guest; without this the dm handshake blocks forever (see scratch-setup.sh).
+	cmd.Env = append(os.Environ(), "DM_DISABLE_UDEV=1")
 	return cmd.CombinedOutput()
 }

--- a/internal/cmds/volumed/systemops_test.go
+++ b/internal/cmds/volumed/systemops_test.go
@@ -313,6 +313,13 @@ func TestCryptOpenReportsAFailedTool(t *testing.T) {
 	}
 }
 
+func TestExecRunnerDisablesUdevSync(t *testing.T) {
+	out, err := execRunner(context.Background(), "printenv", nil, "DM_DISABLE_UDEV")
+	if err != nil || strings.TrimSpace(string(out)) != "1" {
+		t.Fatalf("DM_DISABLE_UDEV = %q, err = %v", out, err)
+	}
+}
+
 func TestExecRunnerWiresOutputAndFailure(t *testing.T) {
 	out, err := execRunner(context.Background(), "sh", nil, "-c", "echo hello")
 	if err != nil || strings.TrimSpace(string(out)) != "hello" {

--- a/kata-guest-base/extra/etc/c8s/bootstrap-allowlist.json.template
+++ b/kata-guest-base/extra/etc/c8s/bootstrap-allowlist.json.template
@@ -3,6 +3,7 @@
   "sha256_digests": [
     "@@CDS_DIGEST@@",
     "@@GET_CERT_DIGEST@@",
-    "@@C8S_OPERATOR_DIGEST@@"
+    "@@C8S_OPERATOR_DIGEST@@",
+    "@@TLS_LB_NGINX_DIGEST@@"
   ]
 }

--- a/kata-guest-base/patches/0006-agent-leave-the-bundle-config-to-setup_bundle.patch
+++ b/kata-guest-base/patches/0006-agent-leave-the-bundle-config-to-setup_bundle.patch
@@ -1,0 +1,27 @@
+Subject: [PATCH] agent: leave the container bundle's config.json to setup_bundle
+
+unpack_pause_image copied /pause_bundle/config.json into the container's
+bundle at CONTAINER_BASE/<cid>/config.json, and setup_bundle writes the
+spec the container actually runs to the same path moments later. In-guest
+admission readers (c8s's policy-monitor, rtmr3-measurer) watch the bundle
+dir and read config.json as soon as it appears, so they race the
+overwrite: judged on the pause image's config -- three OCI image
+annotations, no CRI container-type marker, no image reference -- the
+pause container is denied as an unallowlisted workload, and the sandbox
+dies with it.
+
+Nothing in the agent reads the planted copy: the container is created
+from the in-memory spec, and the pause process comes from get_process.
+Drop the copy so the bundle's config.json has a single writer and always
+carries the spec the container runs.
+
+--- a/src/agent/src/confidential_data_hub/image.rs
++++ b/src/agent/src/confidential_data_hub/image.rs
+@@ -108,7 +108,6 @@
+     fs::create_dir_all(&pause_rootfs)?;
+     info!(sl(), "pause_rootfs {:?}", pause_rootfs);
+ 
+-    copy_if_not_exists(&guest_pause_config, &pause_bundle.join(CONFIG_JSON))?;
+     let arg_path = Path::new(&args[0]).strip_prefix("/")?;
+     copy_if_not_exists(
+         &guest_pause_bundle.join("rootfs").join(arg_path),

--- a/kata-guest-base/patches/0007-agent-pull-guest-images-into-a-bundle-subdirectory.patch
+++ b/kata-guest-base/patches/0007-agent-pull-guest-images-into-a-bundle-subdirectory.patch
@@ -1,0 +1,65 @@
+Subject: [PATCH] agent: keep the pulled image config out of the bundle's config path
+
+CDH unpacks the pulled image at the bundle path it is given, including
+the image's own config.json. Handing it CONTAINER_BASE/<cid> therefore
+planted the image config at <cid>/config.json until setup_bundle wrote
+the real spec to the same path. In-guest admission readers (c8s's
+policy-monitor, rtmr3-measurer) read that file as soon as the bundle dir
+appears; judged on the image config -- OCI image annotations, no CRI
+container-type, no pull reference -- a workload container could be
+denied as unallowlisted, the denial racing the real spec.
+
+Pull into <cid>/images instead, then answer the bundle's rootfs path
+with a bind of the unpacked rootfs, detaching the original mount (a move
+is unsupported: /run is a shared mount). The bundle's config.json keeps
+its single writer, and the rest of the pull stays out of the watched
+path.
+
+--- a/src/agent/src/storage/image_pull_handler.rs
++++ b/src/agent/src/storage/image_pull_handler.rs
+@@ -13,6 +13,7 @@
+ use kata_types::mount::{ImagePullVolume, StorageDevice};
+ use protocols::agent::Storage;
+ use safe_path::scoped_join;
++use std::fs;
+ use std::sync::Arc;
+ use tracing::instrument;
+ 
+@@ -66,9 +67,11 @@
+             return new_device(mount_path);
+         }
+ 
+-        // generated bundles with rootfs and config.json will store under CONTAINER_BASE/cid/images.
+-        let bundle_path = scoped_join(CONTAINER_BASE, &cid)?;
+-        let bundle_path = match confidential_data_hub::pull_image(image_name, bundle_path).await {
++        // Pull into CONTAINER_BASE/cid/images: the image's own config.json
++        // must never occupy the bundle's config.json path, whose single
++        // writer is setup_bundle.
++        let bundle_path = scoped_join(CONTAINER_BASE, &cid)?.join("images");
++        let pulled_rootfs = match confidential_data_hub::pull_image(image_name, bundle_path).await {
+             Ok(path) => {
+                 info!(
+                     ctx.logger,
+@@ -86,7 +89,21 @@
+             }
+         };
+ 
+-        new_device(bundle_path)
++        // Answer the bundle's rootfs path with a bind of the pulled
++        // rootfs, detaching the original (a move is unsupported under
++        // /run's shared mount); the rest of the pull stays under images/.
++        let rootfs_path = scoped_join(CONTAINER_BASE, &cid)?.join("rootfs");
++        fs::create_dir_all(&rootfs_path)?;
++        nix::mount::mount(
++            Some(pulled_rootfs.as_str()),
++            &rootfs_path,
++            None::<&str>,
++            nix::mount::MsFlags::MS_BIND,
++            None::<&str>,
++        )?;
++        nix::mount::umount2(pulled_rootfs.as_str(), nix::mount::MntFlags::MNT_DETACH)?;
++
++        new_device(rootfs_path.display().to_string())
+     }
+ }
+ 

--- a/kata-guest-base/scripts/fetch.sh
+++ b/kata-guest-base/scripts/fetch.sh
@@ -27,9 +27,11 @@
 # This script also materialises /etc/c8s/bootstrap-allowlist.json — the
 # in-VM policy-monitor's image-digest allowlist — from the template at
 # extra/etc/c8s/bootstrap-allowlist.json.template by substituting the
-# SHA-256 digests of three container images: the c8s-repo images cds,
+# SHA-256 digests of four container images: the c8s-repo images cds,
 # get-cert and c8s-operator (resolved at IMAGE_TAG, this commit's short
-# SHA). The digests are resolved against GHCR via
+# SHA), plus tls-lb's nginx (the chart's pin — chart pods get no
+# initdata, so the seed is the only allowlist their guests ever see).
+# The c8s digests are resolved against GHCR via
 # `oras manifest fetch`; a missing/unfetchable image is fatal — we never
 # proceed with an empty or placeholder-bearing allowlist, because that
 # would silently lock kata-qemu-snp pods out of every CDS bootstrap
@@ -281,6 +283,15 @@ echo "    get-cert:     ${GET_CERT_DIGEST}"
 C8S_OPERATOR_DIGEST="${C8S_OPERATOR_DIGEST:-$(resolve_digest "${IMAGE_REGISTRY}/c8s-operator:${IMAGE_TAG}")}"
 echo "    c8s-operator: ${C8S_OPERATOR_DIGEST}"
 
+# tls-lb's nginx digest is the chart's pin, not a registry lookup: the seed
+# must cover exactly what the chart deploys.
+TLS_LB_NGINX_DIGEST="${TLS_LB_NGINX_DIGEST:-$(yq '.tlsLb.nginx.image.digest' "${C8S_DIR}/internal/helmchart/c8s/values.yaml")}"
+[[ "${TLS_LB_NGINX_DIGEST}" =~ ^sha256:[a-f0-9]{64}$ ]] || {
+    echo "FATAL: tls-lb nginx digest '${TLS_LB_NGINX_DIGEST}' is not a sha256 pin — check .tlsLb.nginx.image.digest in the chart values" >&2
+    exit 1
+}
+echo "    tls-lb nginx: ${TLS_LB_NGINX_DIGEST}"
+
 # Substitute placeholders into the template. We use sed with explicit
 # delimiters and `--` so a digest-like value can never be misparsed as
 # a regex metacharacter. Atomic via temp-file + mv so the build step
@@ -292,6 +303,7 @@ sed \
     -e "s|@@CDS_DIGEST@@|${CDS_DIGEST}|g" \
     -e "s|@@GET_CERT_DIGEST@@|${GET_CERT_DIGEST}|g" \
     -e "s|@@C8S_OPERATOR_DIGEST@@|${C8S_OPERATOR_DIGEST}|g" \
+    -e "s|@@TLS_LB_NGINX_DIGEST@@|${TLS_LB_NGINX_DIGEST}|g" \
     "${ALLOWLIST_TEMPLATE}" > "${TMP_ALLOWLIST}"
 
 # Belt-and-braces: refuse to ship a file that still has a placeholder.
@@ -314,6 +326,7 @@ echo "==> bootstrap allowlist: ${ALLOWLIST_DST}"
     printf 'allowlist_cds_digest: %s\n' "${CDS_DIGEST}"
     printf 'allowlist_get_cert_digest: %s\n' "${GET_CERT_DIGEST}"
     printf 'allowlist_c8s_operator_digest: %s\n' "${C8S_OPERATOR_DIGEST}"
+    printf 'allowlist_tls_lb_nginx_digest: %s\n' "${TLS_LB_NGINX_DIGEST}"
 } >> "${EXTRA_DIR}/usr/local/share/c8s/.kata-guest-base-baked"
 
 echo "==> Done. Run scripts/build.sh next."


### PR DESCRIPTION
pause container denied (the wedge). The guest-side "missing CRI annotations" mystery: kata-agent writes /run/kata-containers/<cid>/config.json twice. unpack_pause_image first plants the baked pause image's config (exactly the three OCI annotations from the deny log — verified byte-for-byte in the rootfs), and setup_bundle overwrites it with the real spec tens of ms later. policy-monitor acts on the dir's IN_CREATE and ignores later writes, so it usually judged the placeholder → deny → wedged sandbox → leaked shim/inotify. The guest-to-guest variability was pure scheduling. Same pattern for workloads: the CDH guest-pull unpacked the image's own config.json at the same path (the ten-annotation deny). Fixed by two new kata patches: 0006 drops the pause-config copy, 0007 pulls into <cid>/images and binds the rootfs back to <cid>/rootfs (recorded dead ends: rename → EBUSY on a mountpoint, MS_MOVE → EINVAL under /run's shared mount).

Additionally:
encrypted volumes. The already exists leak was deeper than the context bug f0c3335 fixed: cryptsetup/veritysetup block forever on the dm udev handshake in the guest — the mapping gets created, the fetcher's POST deadline fires, and the unwind's cryptsetup close hangs on the same handshake. scratch-setup.sh already carried the answer (DM_DISABLE_UDEV=1); volumed's execRunner now sets it too, with a pinning test.

tls-lb never Ready. Chart-managed kata pods get no initdata (the webhook excludes the release namespace), so their guests enforce only the baked seed — which lacked nginx-unprivileged. fetch.sh now seeds it from the chart's own pin.