### PR TITLE
docs: organize Inference API reference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ New to confidential computing at large? Start with the [Confidential Computing P
 
 ## Product APIs
 
-- **[Confidential Inference API](inference-api.md)**: OpenAI-compatible confidential inference and attestation API.
+- **[Inference API](inference-api/README.md)**: OpenAI-compatible confidential inference and attestation API.
 
 ## Whitepapers
 
@@ -19,7 +19,7 @@ New to confidential computing at large? Start with the [Confidential Computing P
 - **[Introduction to TEEs](intro-to-tees.md)**: A high-level introduction to Trusted Execution Environments: what they are, how they work, and their limitations.
 - **[Attestable Builds](attestable-builds/)**: Learn what attestable builds are, why they matter, and how TEEs make software verification possible.
 - **[Zero Knowledge](zk.md)**: Learn about zero-knowledge (ZK) proofs and their applications.
-- **[Confidential Inference API](inference-api.md)**: Reference for the public confidential inference API.
+- **[Inference API Spec](inference-api/reference.md)**: Every public inference endpoint, response, error, receipt, and attestation verification step.
 
 ## Need Help?
 

--- a/docs/inference-api/README.md
+++ b/docs/inference-api/README.md
@@ -1,0 +1,55 @@
+# Inference API
+
+The Confidential Inference API provides OpenAI-compatible chat completions at
+`https://api.confidential.ai`. The public gateway validates your API key and
+forwards requests to the confidential inference service. It does not forward
+your API key to the inference node.
+
+## Quickstart
+
+Set your API key and base URL:
+
+```bash
+export CONFIDENTIAL_API_KEY='replace-with-your-api-key'
+export CONFIDENTIAL_API_BASE='https://api.confidential.ai'
+```
+
+List the models available to your key:
+
+```bash
+curl --fail --silent "$CONFIDENTIAL_API_BASE/v1/models" | jq .
+```
+
+Use a returned model ID to request a completion:
+
+```bash
+curl --fail --silent "$CONFIDENTIAL_API_BASE/v1/chat/completions" \
+  -H "Authorization: Bearer $CONFIDENTIAL_API_KEY" \
+  -H 'Content-Type: application/json' \
+  --data '{
+    "model": "MODEL_ID_FROM_V1_MODELS",
+    "messages": [{"role": "user", "content": "Reply with one word: ready."}],
+    "stream": false
+  }' | jq .
+```
+
+The completion response includes an `x-request-id` header. Save it if you need
+to fetch a signed receipt for that request.
+
+## Authentication
+
+Inference requests require a Bearer API key:
+
+```http
+Authorization: Bearer <api-key>
+```
+
+The health, model, receipt, and attestation endpoints do not require a caller
+API key. Do not put an API key in an attestation request or browser code.
+
+## Next steps
+
+- [API Spec](reference.md) — every endpoint, request field, response shape,
+  error code, receipt, and attestation verification step.
+- [Attestation](reference.md#attestation) — verify that the gateway and
+  inference node evidence are fresh and correctly bound.

--- a/docs/inference-api/reference.md
+++ b/docs/inference-api/reference.md
@@ -1,34 +1,13 @@
-# Confidential Inference API
+# Inference API Specification
 
 The Confidential Inference API provides OpenAI-compatible chat completions at
 `https://api.confidential.ai`. The gateway validates the caller key at the
 public boundary. It does not forward that key to the inference node.
 
+New here? [Get started](README.md) sends a first completion.
+
 All endpoints use HTTPS. Every response contains an `x-request-id` header.
 Save this value when you need to fetch a completion receipt.
-
-## Quickstart
-
-Set your API key and read the available model list. Use a model ID from that
-list in a completion request.
-
-```bash
-export CONFIDENTIAL_API_KEY='replace-with-your-api-key'
-export CONFIDENTIAL_API_BASE='https://api.confidential.ai'
-
-curl --fail --silent "$CONFIDENTIAL_API_BASE/v1/models" | jq .
-```
-
-```bash
-curl --fail --silent "$CONFIDENTIAL_API_BASE/v1/chat/completions" \
-  -H "Authorization: Bearer $CONFIDENTIAL_API_KEY" \
-  -H 'Content-Type: application/json' \
-  --data '{
-    "model": "MODEL_ID_FROM_V1_MODELS",
-    "messages": [{"role": "user", "content": "Reply with one word: ready."}],
-    "stream": false
-  }' | jq .
-```
 
 ## Authentication
 
@@ -47,7 +26,17 @@ All JSON errors use this shape:
 {"error":{"code":"machine_readable_code"}}
 ```
 
-## Endpoints
+## Endpoint index
+
+| Endpoint | Purpose | Authentication |
+| --- | --- | --- |
+| [`POST /v1/chat/completions`](#post-v1chatcompletions) | Generate an OpenAI-compatible completion. | Bearer API key |
+| [`GET /v1/models`](#get-v1models) | Read the configured model catalog. | None |
+| [Attestation](#get-v1aciattestationnoncebase64url) | Verify the gateway and linked inference node. | None |
+| [`GET /v1/aci/receipts/{request_id}`](#get-v1acireceiptsrequest_id) | Read signed evidence for one completed request. | None |
+| [`GET /health`](#get-health) | Read gateway readiness. | None |
+
+## API reference
 
 ### `GET /health`
 

--- a/website/app/docs/page.tsx
+++ b/website/app/docs/page.tsx
@@ -15,7 +15,7 @@ const SECTIONS: { title: string; href: string; file: string }[] = [
   { title: "Kettle: Attested Builds", href: "/docs/kettle-whitepaper", file: "kettle-whitepaper.md" },
   { title: "Attestable Builds", href: "/docs/attestable-builds", file: "attestable-builds/README.md" },
   { title: "Zero Knowledge", href: "/docs/zk", file: "zk.md" },
-  { title: "Confidential Inference API", href: "/docs/inference-api", file: "inference-api.md" },
+  { title: "Inference API", href: "/docs/inference-api", file: "inference-api/README.md" },
 ];
 
 function buildDocsToc(): TocItem[] {


### PR DESCRIPTION
## Summary

- add an Inference API get-started page
- move the full specification to `/docs/inference-api/reference`
- update Docs navigation and links

## Verification

- `npm --prefix website run build`

This is a draft PR for a Vercel preview only.