### PR TITLE
feat(node-guest-image): runtime role dispatch and operator-provisioned join

### DIFF
--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -4,6 +4,9 @@
 # outlive the migration: they lint content this repo owns. The fragment
 # superset checks compare against confos's gpu/dev fragments at the pinned
 # CONFOS_REF — the exact tree the image builds with.
+#
+# The rke2-role jobs run the role-dispatch tests (script and systemd
+# level, node-guest-image/tests/).
 name: node-guest-image lint
 
 on:
@@ -11,6 +14,9 @@ on:
     paths:
       - "node-guest-image/**"
       - ".github/workflows/node-guest-image-lint.yml"
+      # The rke2-role job runs via make; a broken/renamed target must fail
+      # here, not on the next node-guest-image change.
+      - "Makefile"
   workflow_dispatch:
 
 permissions:
@@ -97,4 +103,34 @@ jobs:
             exit 1
           fi
 
+          # The rke2-role drop-ins only bind if mkosi.sync keeps staging the
+          # rke2 tarball's units under /usr/local (systemd's search path);
+          # the systemd harness installs its fakes at the same prefix.
+          if ! grep -q 'tar -xzf .* -C "\$STAGE_DIR/usr/local"' "$ngi/c8s/mkosi.sync"; then
+            echo "::error::mkosi.sync no longer stages rke2 under /usr/local; rke2-role drop-ins and the systemd harness depend on that unit dir"
+            exit 1
+          fi
+
           echo "all node-guest-image invariants hold at CONFOS_REF ${{ steps.ref.outputs.ref }}"
+
+  rke2-role:
+    name: rke2-role dispatch (script)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Install genisoimage
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends genisoimage
+
+      - name: Run the script-level harness
+        # Root: loop mounts + /run/confos writes; the runner VM is disposable.
+        run: sudo make test-node-guest-image-role
+
+  rke2-role-systemd:
+    name: rke2-role dispatch (systemd)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - name: Run the systemd-level harness
+        run: make test-node-guest-image-role-systemd

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-node-guest-image-role test-node-guest-image-role-systemd test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -126,6 +126,16 @@ test:
 
 test-integration:
 	./test/integration/run.sh
+
+# The byte-exact rke2-role.sh against real ISO9660 loop devices. Root (loop
+# mounts, writes /run/confos) — sudo on a disposable box.
+test-node-guest-image-role:
+	./node-guest-image/tests/rke2-role-test.sh
+
+# Role-gated unit wiring under real systemd in a privileged container.
+# Needs only docker.
+test-node-guest-image-role-systemd:
+	./node-guest-image/tests/rke2-role-systemd-test.sh
 
 # Advisory mutation testing of code changed vs BASE (default origin/main).
 mutation-check:

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -11,14 +11,16 @@ StartLimitBurst=5
 # creates /var/lib/rancher/rke2/server/tls/client-ca.* only once it has
 # initialised, so we order after it and gate on the key existing (the Exec
 # startpre below), rather than racing a half-initialised control plane.
-After=network-online.target rke2-server.service attestation-api.service
+After=network-online.target rke2-role.service rke2-server.service attestation-api.service
 Wants=network-online.target
-Requires=attestation-api.service
+Requires=rke2-role.service attestation-api.service
 # Only run on operator boots. A VM launched without --operator-key has no
 # opkeydata disk; the condition makes systemd SKIP the unit (not fail it), so
 # there's no restart-loop on non-operator nodes. The launcher attaches the
 # disk with ISO label "opkeydata".
 ConditionPathExists=/dev/disk/by-label/opkeydata
+# Server role only: agent nodes have no client CA to sign with.
+ConditionPathExists=/run/confos/role-server
 
 [Service]
 Type=simple

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-agent.service.d/20-role.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-agent.service.d/20-role.conf
@@ -1,0 +1,6 @@
+# Agent role only. rke2-role.service stages the token and config fragment
+# from the joindata disk before the agent may start.
+[Unit]
+ConditionPathExists=/run/confos/role-agent
+Requires=rke2-role.service
+After=rke2-role.service

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-agent.service.d/no-modprobe.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-agent.service.d/no-modprobe.conf
@@ -1,0 +1,6 @@
+# Upstream rke2-agent.service carries the same failure-tolerant modprobe
+# ExecStartPre lines as rke2-server; see rke2-server.service.d/no-modprobe.conf.
+# This clears EVERY upstream ExecStartPre — on rke2 version bumps, re-check
+# the upstream unit for new pre-starts this would silently drop.
+[Service]
+ExecStartPre=

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-role.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-role.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=RKE2 role dispatch from the joindata disk
+# Role-gated units Requires= + After= this unit and condition on the
+# /run/confos/role-* verdict it writes. Requires=, not just After=: a failed
+# dispatch fails them visibly; the unselected role still condition-skips.
+
+[Service]
+Type=oneshot
+# Stays active (exited) so Requires= dependents bind to a live unit.
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/rke2-role.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-server.service.d/20-role.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/rke2-server.service.d/20-role.conf
@@ -1,0 +1,11 @@
+# Server role only (also the no-joindata single-node default); agent boots
+# SKIP this unit via the condition rather than failing it.
+[Unit]
+ConditionPathExists=/run/confos/role-server
+Requires=rke2-role.service
+After=rke2-role.service
+
+[Service]
+# Keep the credential agent-only. Without an explicit value, RKE2 aliases
+# server/agent-token to the privileged server token.
+Environment=RKE2_AGENT_TOKEN_FILE=/run/confos/rke2-agent-token

--- a/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
@@ -9,3 +9,7 @@ d /var/log/kube-audit 0750 root root - -
 # mkdir it; without this the plugin exits at startup and the fail-closed
 # NRI validator blocks every container on the node.
 d /run/nri-image-policy 0755 root root - -
+# Role dispatch staging; config.yaml.d must exist before rke2-role.service
+# writes the role fragment there.
+d /run/confos 0755 root root - -
+d /etc/rancher/rke2/config.yaml.d 0755 root root - -

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -5,22 +5,10 @@
 # there by this profile's mkosi.sync), which is on systemd's unit search
 # path.
 #
-# Why we need this file at all: Ubuntu's default preset policy enables
-# every unit that ships with a `[Install] WantedBy=…`. rke2's release
-# tarball ships both rke2-server.service AND rke2-agent.service, so
-# without an explicit `disable rke2-agent.service` here, both get enabled —
-# which is bad because:
-#   - rke2-agent has no `server: https://...` for a single-node cluster,
-#     so it crashes with "Error: --server is required" on every start.
-#   - It hits Restart=always → tight restart loop.
-#   - rke2-server has an `ExecCondition` that bails when rke2-agent is
-#     `is-active`. Racing between the two units leaves etcd half-started
-#     → the persistent "Failed to test etcd connection" loop in the
-#     journal.
-#
-# Single-node only for now. To convert this image to an agent later,
-# flip the last two lines (disable server, enable agent) and add a
-# `server: https://<server-ip>:9345` + `token:` to config.yaml.
+# Both rke2-server AND rke2-agent are enabled: rke2-role.service decides
+# the role at runtime (joindata disk, strictly either/or) and each rke2
+# unit conditions on the matching /run/confos/role-* verdict; the other is
+# SKIPPED, not failed. No joindata disk => server (single-node default).
 enable containerd-data-disk.service
 # Read-only weights disk (serial=confai-models). Enabled always; a no-op boot
 # when the disk isn't attached (GPU-less / no-weights launches).
@@ -29,8 +17,10 @@ enable models-disk.service
 # to CDS. Ordered before rke2 so the file exists when containerd launches the
 # baked plugin.
 enable nri-node-ip.service
+# Role dispatch + the role-gated rke2 pair.
+enable rke2-role.service
 enable rke2-server.service
-disable rke2-agent.service
+enable rke2-agent.service
 # NTP: sync the free-running TDX guest clock so it doesn't drift behind the
 # operator and trip cred-release's JWT clock-skew check. Egress is via the
 # CVM's masquerade NAT.

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# Role dispatch, run by rke2-role.service before any role-gated unit.
+# Reads an optional `joindata` disk and stages the RKE2 role, tokens, and
+# node addresses. No disk => server (the single-node default).
+#
+# joindata is host-controlled: worst case is DoS (residual surface: the
+# kernel's iso9660 parser; the mount pins the type, ro,nodev,nosuid,noexec).
+# Disk text is never sourced or evaluated; a malformed disk fails this unit
+# and every role-gated unit stays down.
+#
+# joindata contract (v0), all files a single <=256-byte ASCII line (edge
+# whitespace tolerated and trimmed; interior whitespace rejected):
+#   role              server|agent            (both roles)
+#   node-ip           routable IPv4           (both roles)
+#   node-external-ip  routable IPv4, optional (both roles)
+#   server            IPv4, no scheme/port    (agent only; forbidden on server)
+#   server-token      64 lowercase hex        (server only; forbidden on agent)
+#   agent-token       64 lowercase hex        (both roles)
+set -euo pipefail
+
+RUN=/run/confos
+DEV=/dev/disk/by-label/joindata
+MNT=$RUN/joindata
+FRAG=/etc/rancher/rke2/config.yaml.d/50-role.yaml
+
+# Re-dispatch starts clean: a stale verdict or fragment from an earlier run
+# this boot must never let both role conditions pass or mix roles.
+rm -f "$RUN/role-server" "$RUN/role-agent" \
+      "$RUN/rke2-server-token" "$RUN/rke2-agent-token" "$FRAG" \
+      "$RUN"/.rke2-*-token.* "${FRAG%/*}/.${FRAG##*/}".*
+
+fail() { echo "rke2-role: $1" >&2; exit 1; }
+
+# read_field FILE — echo the single validated line of MNT/FILE.
+read_field() {
+    local path="$MNT/$1" line size
+    [[ -f "$path" && ! -L "$path" ]] || fail "$1: missing or not a regular file"
+    size=$(stat -c%s "$path")
+    # Bound before slurping: a huge host file must not fill RAM.
+    (( size <= 257 )) || fail "$1: larger than one 256-byte line"
+    # tr, not grep: a NUL can't be a grep pattern argument.
+    (( $(tr -d '\0' < "$path" | wc -c) == size )) || fail "$1: contains NUL"
+    # One line plus an optional trailing newline = at most one newline total.
+    (( $(tr -cd '\n' < "$path" | wc -c) <= 1 )) || fail "$1: more than one line"
+    IFS= read -r line < "$path" || true
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    (( ${#line} <= 256 )) || fail "$1: line exceeds 256 bytes"
+    [[ "$line" == *[[:space:]]* ]] && fail "$1: interior whitespace"
+    printf '%s' "$line"
+}
+
+is_hex_token() { [[ "$1" =~ ^[0-9a-f]{64}$ ]]; }
+
+is_ipv4() {
+    local ip="$1" o IFS=.
+    # No leading zeros: bash arithmetic reads them as octal and rke2's
+    # Go-side net.ParseIP rejects them.
+    [[ "$ip" =~ ^(0|[1-9][0-9]{0,2})(\.(0|[1-9][0-9]{0,2})){3}$ ]] || return 1
+    for o in $ip; do (( o <= 255 )) || return 1; done
+}
+
+# allow_only NAME... — reject any disk entry outside this role's list.
+allow_only() {
+    local f name a allowed
+    for f in "$MNT"/* "$MNT"/.[!.]* "$MNT"/..?*; do
+        # Unmatched globs stay literal; -L keeps dangling symlinks rejectable.
+        [[ -e "$f" || -L "$f" ]] || continue
+        name=${f##*/}
+        allowed=no
+        for a in "$@"; do
+            if [[ "$name" == "$a" ]]; then allowed=yes; break; fi
+        done
+        # fixed message: the name is host text
+        if [[ "$allowed" != yes ]]; then fail "unexpected file for this role"; fi
+    done
+}
+
+# write_atomic PATH MODE < content
+write_atomic() {
+    local dest="$1" mode="$2" tmp
+    tmp=$(mktemp "${dest%/*}/.${dest##*/}.XXXXXX")
+    cat > "$tmp"
+    chmod "$mode" "$tmp"
+    mv -f "$tmp" "$dest"
+}
+
+# Common address fields, validated the same way for both roles.
+stage_addresses() {
+    local node_ip node_ext
+    node_ip=$(read_field node-ip)
+    is_ipv4 "$node_ip" || fail "node-ip: not IPv4"
+    NODE_IP="$node_ip"
+    NODE_EXT=""
+    # -L: a dangling symlink must be rejected in read_field, not read as absent.
+    if [[ -e "$MNT/node-external-ip" || -L "$MNT/node-external-ip" ]]; then
+        node_ext=$(read_field node-external-ip)
+        is_ipv4 "$node_ext" || fail "node-external-ip: not IPv4"
+        NODE_EXT="$node_ext"
+    fi
+}
+
+# Infallible: runs inside the fragment pipe, where a failure would stage a
+# truncated fragment. Everything fallible (stage_addresses) runs before it.
+emit_node_addr_lines() {
+    printf 'node-ip: %s\n' "$NODE_IP"
+    # `if`, not `&&`: a bare `[[…]] && printf` as last statement returns 1
+    # when NODE_EXT is empty, aborting the pipe under set -e for every node
+    # without an external IP.
+    if [[ -n "$NODE_EXT" ]]; then
+        printf 'node-external-ip: %s\n' "$NODE_EXT"
+    fi
+}
+
+set_server_role() {
+    local server_token agent_token
+    allow_only role node-ip node-external-ip server-token agent-token
+    server_token=$(read_field server-token)
+    agent_token=$(read_field agent-token)
+    is_hex_token "$server_token" || fail "server-token: not 64 lowercase hex"
+    is_hex_token "$agent_token" || fail "agent-token: not 64 lowercase hex"
+    [[ "$server_token" != "$agent_token" ]] || fail "server-token equals agent-token"
+    stage_addresses
+
+    printf '%s' "$server_token" | write_atomic "$RUN/rke2-server-token" 0600
+    printf '%s' "$agent_token" | write_atomic "$RUN/rke2-agent-token" 0600
+    # No agent-token-file here: rke2-server.service.d/20-role.conf wires it via
+    # RKE2_AGENT_TOKEN_FILE for every server boot, disk or legacy alike.
+    {
+        printf 'token-file: %s\n' "$RUN/rke2-server-token"
+        emit_node_addr_lines
+    } | write_atomic "$FRAG" 0600
+    : > "$RUN/role-server"
+}
+
+set_agent_role() {
+    local server_addr agent_token
+    allow_only role node-ip node-external-ip server agent-token
+    server_addr=$(read_field server)
+    agent_token=$(read_field agent-token)
+    is_ipv4 "$server_addr" || fail "server: not IPv4"
+    is_hex_token "$agent_token" || fail "agent-token: not 64 lowercase hex"
+    stage_addresses
+
+    printf '%s' "$agent_token" | write_atomic "$RUN/rke2-agent-token" 0600
+    {
+        printf 'token-file: %s\n' "$RUN/rke2-agent-token"
+        printf 'server: https://%s:9345\n' "$server_addr"
+        emit_node_addr_lines
+    } | write_atomic "$FRAG" 0600
+    : > "$RUN/role-agent"
+}
+
+# No-disk fallback: legacy single-node server. Generate a boot-local agent
+# token so RKE2 doesn't alias agent-token to the privileged server token;
+# 20-role.conf wires it via RKE2_AGENT_TOKEN_FILE, same as the disk path.
+set_legacy_server_role() {
+    local token
+    token=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n') || fail "token generation failed"
+    is_hex_token "$token" || fail "generated agent token malformed"
+    printf '%s' "$token" | write_atomic "$RUN/rke2-agent-token" 0600
+    : > "$RUN/role-server"
+}
+
+# Drain the udev queue so a late disk can't default an agent boot to server.
+# A settle timeout fails the unit (possible on a busy diskless boot); recover
+# with `systemctl restart rke2-role rke2-server` — failed units aren't retried.
+[[ -e "$DEV" ]] || udevadm settle --timeout=10
+
+if [[ ! -e "$DEV" ]]; then
+    set_legacy_server_role
+    echo "rke2-role: no joindata disk, defaulting to server"
+    exit 0
+fi
+
+mkdir -p "$MNT"
+# Host-controlled device: pin the fs parser, bound a wedged mount.
+timeout 10 mount -t iso9660 -o ro,nodev,nosuid,noexec "$DEV" "$MNT"
+trap 'umount "$MNT" 2>/dev/null || true' EXIT
+
+role=$(read_field role)
+case "$role" in
+server) set_server_role ;;
+agent)  set_agent_role ;;
+*)      fail "invalid role" ;;  # fixed message: the value is host text
+esac
+echo "rke2-role: role=${role}"

--- a/node-guest-image/c8s/user-data
+++ b/node-guest-image/c8s/user-data
@@ -1,5 +1,6 @@
 #cloud-config
-# c8s node image — node-as-CVM, single-node cluster.
+# c8s node image — node-as-CVM. Single-node server by default; a joindata
+# disk selects the role at runtime (see rke2-role.sh).
 #
 # This payload is BAKED INTO the verity root at build time (via
 # bin/build-c8s passing --cloud-init) and therefore measured into the
@@ -8,10 +9,10 @@
 # outside the measurement) or in a config drop-in on a data disk.
 #
 # The bulk of node setup is baked rather than scripted at first boot — see
-# this profile's mkosi.extra/ tree. rke2-server is started by the
-# 50-rke2.preset (via WantedBy=multi-user.target); cloud-init does NOT need
-# to enable/start it. The only thing left for cloud-init is per-instance
-# setup — currently just the hostname.
+# this profile's mkosi.extra/ tree. The role-gated rke2 units are started
+# by the 50-rke2.preset (via WantedBy=multi-user.target); cloud-init does
+# NOT need to enable/start them. The only thing left for cloud-init is
+# per-instance setup — currently just the hostname.
 #
 # If a deployment needs to override rke2 config, the operator drops a
 # /etc/rancher/rke2/config.yaml.d/*.yaml fragment at runtime — rke2 merges
@@ -23,4 +24,4 @@
 preserve_hostname: false
 hostname: c8s-node
 
-final_message: "c8s node cloud-init complete. rke2-server was started by the preset at boot; give it ~60s, then `kubectl get nodes` should report Ready."
+final_message: "c8s node cloud-init complete. The preset started the role-gated rke2 unit at boot; give it ~60s, then `kubectl get nodes` should report the node Ready."

--- a/node-guest-image/tests/lib.sh
+++ b/node-guest-image/tests/lib.sh
@@ -1,0 +1,93 @@
+# Shared fixtures for the rke2-role harnesses. Unlike test/e2e/lib.sh's
+# fail-fast fail(), ok() counts and keeps going; the "FAIL:" prefix stays
+# aligned with that lib (CI greps it).
+
+RUN=/run/confos
+MNT=$RUN/joindata
+FRAGDIR=/etc/rancher/rke2/config.yaml.d
+FRAG=$FRAGDIR/50-role.yaml
+BYLABEL=/dev/disk/by-label
+DEVLINK=$BYLABEL/joindata
+
+STOK=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa11111111
+ATOK=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb22222222
+JOIN_PORT=9345  # rke2 supervisor port the staged fragment must name
+
+PASS=0; FAIL=0
+declare -a FAILURES
+
+note() { printf '%s\n' "$*"; }
+
+# ok DESC cmd... — count an assertion, attributed to $CASE.
+ok() {
+    local desc="$1"; shift
+    if "$@"; then PASS=$((PASS+1)); else
+        FAIL=$((FAIL+1)); FAILURES+=("$CASE: $desc"); note "  FAIL: $CASE: $desc"
+    fi
+}
+
+# summarize TITLE — print totals; exit 1 if anything failed.
+summarize() {
+    note ""
+    note "==== $1 ===="
+    note "PASS: $PASS  FAIL: $FAIL"
+    if (( FAIL > 0 )); then
+        note "-- failures:"
+        local f; for f in "${FAILURES[@]}"; do note "   $f"; done
+        exit 1
+    fi
+}
+
+file_mode() { stat -c %a "$1" 2>/dev/null || echo MISSING; }
+
+# Joindata disk fixtures. write_f DIR NAME CONTENT (printf %s, no newline).
+write_f() { printf '%s' "$3" > "$1/$2"; }
+
+server_dir() { # server_dir DIR [with_ext]
+    local d="$1"
+    rm -rf "$d"; mkdir -p "$d"
+    write_f "$d" role server
+    write_f "$d" node-ip 192.168.7.10
+    write_f "$d" server-token "$STOK"
+    write_f "$d" agent-token "$ATOK"
+    [[ "${2:-}" == with_ext ]] && write_f "$d" node-external-ip 203.0.113.10
+    return 0
+}
+agent_dir() { # agent_dir DIR [with_ext]
+    local d="$1"
+    rm -rf "$d"; mkdir -p "$d"
+    write_f "$d" role agent
+    write_f "$d" server 192.168.7.10
+    write_f "$d" node-ip 192.168.7.11
+    write_f "$d" agent-token "$ATOK"
+    [[ "${2:-}" == with_ext ]] && write_f "$d" node-external-ip 203.0.113.11
+    return 0
+}
+
+# make_iso DIR — build an ISO (Rock Ridge, so symlinks/dirs survive), attach
+# to a loop device, link it at /dev/disk/by-label/joindata. Uses $WORK.
+declare -a OUR_LOOPS=()
+make_iso() {
+    local dir="$1" img loop
+    img=$WORK/disk.iso
+    rm -f "$img"
+    genisoimage -quiet -R -o "$img" "$dir" 2>/dev/null || { note "genisoimage failed"; return 1; }
+    attach_disk "$img"
+}
+
+# attach_disk IMG — loop-attach IMG and expose it at the joindata label path.
+attach_disk() {
+    local loop
+    loop=$(losetup --find --show "$1") || return 1
+    OUR_LOOPS+=("$loop")
+    mkdir -p "$BYLABEL"
+    ln -sf "$loop" "$DEVLINK"
+}
+
+release_disk() {
+    umount "$MNT" 2>/dev/null || true
+    local d
+    for d in "${OUR_LOOPS[@]:-}"; do [[ -n "$d" ]] && losetup -d "$d" 2>/dev/null || true; done
+    OUR_LOOPS=()
+    rm -f "$DEVLINK"
+}

--- a/node-guest-image/tests/rke2-role-systemd-test.sh
+++ b/node-guest-image/tests/rke2-role-systemd-test.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# Boots real systemd in a privileged container with the production units,
+# drop-ins, preset, tmpfiles config, and rke2-role.sh (fake sleep-infinity
+# rke2 payloads), and asserts the gating:
+# only the selected role's unit runs, a failed dispatch fails both visibly,
+# preset applies, restart/role-switch behavior is pinned down.
+#
+# Driver mode (default) needs only docker; --inside runs the assertions.
+set -u
+
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+if [[ "${1:-}" != "--inside" ]]; then
+    command -v docker >/dev/null 2>&1 || { echo "docker required"; exit 2; }
+    IMG=rke2-role-systemd-test
+    CTR=rke2-role-systemd-$$
+    docker build -q -t "$IMG" - <<'EOF' >/dev/null || { echo "image build failed"; exit 2; }
+FROM debian:12
+RUN apt-get update -qq && apt-get install -y -qq --no-install-recommends \
+    systemd systemd-sysv udev genisoimage && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+CMD ["/sbin/init"]
+EOF
+    trap 'docker rm -f "$CTR" >/dev/null 2>&1' EXIT
+    docker run -d --privileged --cgroupns=host \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+        --tmpfs /run --tmpfs /run/lock \
+        --name "$CTR" "$IMG" >/dev/null || { echo "container start failed"; exit 2; }
+    # Poll rather than a single `--wait`: right after `docker run`, exec can
+    # land before systemd has its D-Bus socket and returns nothing.
+    state=""
+    for _ in $(seq 1 30); do
+        state=$(docker exec "$CTR" systemctl is-system-running 2>/dev/null || true)
+        # degraded is normal: no getty/network units in a container
+        case "$state" in running|degraded) break ;; esac
+        sleep 1
+    done
+    case "$state" in
+    running|degraded) ;;
+    *) echo "systemd failed to reach a settled state: '$state'"; exit 2 ;;
+    esac
+    docker cp "$TESTS_DIR/.." "$CTR":/ngi >/dev/null
+    docker exec "$CTR" bash /ngi/tests/rke2-role-systemd-test.sh --inside
+    exit $?
+fi
+
+# ---- inside: real systemd is PID 1 ----
+. "$TESTS_DIR/lib.sh"
+
+EXTRA=$TESTS_DIR/../c8s/mkosi.extra
+WORK=/tmp/systemd-test-work
+# rke2 tarball unit dir; mkosi.sync stages the units there (the lint job
+# tripwires on that staying true).
+UNITDIR=/usr/local/lib/systemd/system
+mkdir -p "$WORK"
+
+# Production pieces, installed exactly where the image puts them.
+for p in etc/systemd/system/rke2-role.service \
+         etc/systemd/system/rke2-server.service.d/20-role.conf \
+         etc/systemd/system/rke2-agent.service.d/20-role.conf \
+         etc/systemd/system/rke2-agent.service.d/no-modprobe.conf \
+         etc/tmpfiles.d/confos-rke2.conf \
+         usr/lib/systemd/system-preset/50-rke2.preset; do
+    install -D -m644 "$EXTRA/$p" "/$p"
+done
+install -D -m755 "$EXTRA/usr/local/bin/rke2-role.sh" /usr/local/bin/rke2-role.sh
+
+# Fake rke2 payloads in the tarball's unit dir: gating, not rke2, is under
+# test.
+for u in rke2-server rke2-agent; do
+    install -D -m644 /dev/stdin "$UNITDIR/$u.service" <<EOF
+[Unit]
+Description=fake $u payload
+[Service]
+ExecStart=/bin/sleep infinity
+[Install]
+WantedBy=multi-user.target
+EOF
+done
+
+systemctl daemon-reload
+
+active()       { systemctl is-active --quiet "$1"; }
+not_active()   { ! systemctl is-active --quiet "$1"; }
+cond_skipped() { [[ "$(systemctl show -p ConditionResult --value "$1")" == no ]]; }
+unit_failed()  { systemctl is-failed --quiet "$1"; }
+
+# Boot simulation: start both role-gated units, as the preset would at boot;
+# Requires= pulls in rke2-role first, conditions evaluate after it.
+boot_roles() { systemctl start rke2-server.service rke2-agent.service; }
+
+# assert_role_won ROLE — dispatch done, ROLE's unit runs, the other skipped.
+assert_role_won() {
+    local win=$1 lose=rke2-agent
+    if [[ $win == rke2-agent ]]; then lose=rke2-server; fi
+    ok "dispatch active" active rke2-role
+    ok "$win active" active "$win"
+    ok "$lose not active" not_active "$lose"
+    ok "$lose was condition-skipped" cond_skipped "$lose"
+    ok "verdict role-${win#rke2-}" test -f "$RUN/role-${win#rke2-}"
+}
+
+scenario_reset() {
+    systemctl stop rke2-agent rke2-server rke2-role >/dev/null 2>&1 || true
+    systemctl reset-failed >/dev/null 2>&1 || true
+    release_disk
+    rm -rf "$RUN" "$FRAGDIR"
+    systemd-tmpfiles --create /etc/tmpfiles.d/confos-rke2.conf >/dev/null 2>&1 || true
+}
+
+# ---------------------------------------------------------------- bake parity
+CASE="preset"
+ok "preset applies to the role-gated trio" \
+   systemctl preset rke2-role.service rke2-server.service rke2-agent.service
+for u in rke2-role rke2-server rke2-agent; do
+    ok "$u enabled by preset" systemctl is-enabled --quiet "$u.service"
+done
+CASE="tmpfiles"
+systemd-tmpfiles --create /etc/tmpfiles.d/confos-rke2.conf >/dev/null 2>&1 || true
+ok "tmpfiles created $RUN" test -d "$RUN"
+ok "tmpfiles created $FRAGDIR" test -d "$FRAGDIR"
+
+# ---------------------------------------------------------------- boot: no disk
+CASE="boot-no-disk"
+scenario_reset
+ok "boot start succeeds" boot_roles
+assert_role_won rke2-server
+ok "generated agent token 0600" test "$(file_mode "$RUN/rke2-agent-token")" = 600
+
+# ---------------------------------------------------------------- boot: server disk
+CASE="boot-server-disk"
+scenario_reset
+server_dir "$WORK/d"; make_iso "$WORK/d"
+ok "boot start succeeds" boot_roles
+assert_role_won rke2-server
+ok "server token staged 0600" test "$(file_mode "$RUN/rke2-server-token")" = 600
+ok "fragment staged" test -f "$FRAG"
+
+# ---------------------------------------------------------------- boot: agent disk
+CASE="boot-agent-disk"
+scenario_reset
+agent_dir "$WORK/d"; make_iso "$WORK/d"
+ok "boot start succeeds" boot_roles
+assert_role_won rke2-agent
+ok "fragment names the join URL" grep -qx "server: https://192.168.7.10:$JOIN_PORT" "$FRAG"
+
+# ---------------------------------------------------------------- boot: broken disk
+CASE="boot-broken-disk"
+scenario_reset
+server_dir "$WORK/d"; write_f "$WORK/d" server-token not-a-token
+make_iso "$WORK/d"
+ok "boot start FAILS (Requires= propagates)" bash -c '! systemctl start rke2-server.service rke2-agent.service 2>/dev/null'
+ok "dispatch unit failed (visible)" unit_failed rke2-role
+ok "server not active" not_active rke2-server
+ok "agent not active" not_active rke2-agent
+ok "no verdict staged" bash -c "test ! -e $RUN/role-server && test ! -e $RUN/role-agent"
+
+# ---------------------------------------------------------------- restart, same disk
+CASE="restart-same-disk"
+scenario_reset
+server_dir "$WORK/d"; make_iso "$WORK/d"
+boot_roles
+ok "server active before restart" active rke2-server
+systemctl restart rke2-role.service
+srv_after=$(systemctl is-active rke2-server.service 2>/dev/null || true)
+note "  observed: rke2-server is '$srv_after' after rke2-role restart (Requires= propagation)"
+ok "dispatch re-ran clean" active rke2-role
+ok "verdict still role-server" test -f "$RUN/role-server"
+ok "never both roles active" \
+   bash -c '! (systemctl is-active --quiet rke2-server && systemctl is-active --quiet rke2-agent)'
+# The documented remedy must restore service regardless of propagation.
+ok "remedy restores the server" bash -c 'systemctl start rke2-server.service && systemctl is-active --quiet rke2-server'
+
+# ---------------------------------------------------------------- restart, swapped disk
+# Unsupported operation (role changes ride a reboot); recorded, not asserted.
+CASE="restart-swapped-disk"
+release_disk
+agent_dir "$WORK/d"; make_iso "$WORK/d"
+systemctl restart rke2-role.service
+ok "verdict followed the disk" test -f "$RUN/role-agent"
+ok "stale verdict removed" test ! -e "$RUN/role-server"
+srv=$(systemctl is-active rke2-server.service 2>/dev/null || true)
+agt=$(systemctl is-active rke2-agent.service 2>/dev/null || true)
+note "  observed after swap+restart: rke2-server='$srv' rke2-agent='$agt' (design doc: role changes require a reboot)"
+
+# ---------------------------------------------------------------- summary
+scenario_reset
+summarize "rke2-role systemd-level summary"

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+# Runs the byte-exact production rke2-role.sh (its own `set -euo pipefail`,
+# never a weakened copy) against real ISO9660 loop devices: happy paths, the
+# full rejection matrix, re-dispatch, injection, write-boundary fault shims,
+# token-leak greps. Unit gating lives in rke2-role-systemd-test.sh.
+#
+# Needs root and genisoimage; mutates /run/confos and /etc/rancher/rke2 —
+# run `make test-node-guest-image-role` on a disposable machine, or in a
+# privileged debian:12 container (+ e2fsprogs udev).
+set -u
+
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$TESTS_DIR/lib.sh"
+SCRIPT=${RKE2_ROLE_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/rke2-role.sh"}
+WORK=/tmp/rke2-role-test-work
+SHIMDIR=/tmp/rke2-role-test-shims
+FAULTDIR=/tmp/rke2-role-test-fault
+
+[[ $EUID -eq 0 ]] || { echo "must run as root (mount/losetup)"; exit 2; }
+command -v genisoimage >/dev/null || { echo "genisoimage required"; exit 2; }
+[[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
+
+no_tokens_in() { ! grep -qE '[0-9a-f]{64}' "$1"; }
+
+# reset_artifacts — clear staging + fault state, keep any attached disk.
+reset_artifacts() {
+    rm -rf "$RUN" "$FRAGDIR"
+    # tmpfiles.d/confos-rke2.conf parity: both dirs exist before the unit runs.
+    mkdir -p "$RUN" "$FRAGDIR" "$BYLABEL"
+    rm -rf "$FAULTDIR"; mkdir -p "$FAULTDIR"
+}
+reset_state() {
+    release_disk
+    reset_artifacts
+    rm -f /tmp/pwned-*
+}
+
+# write_stub FILE BODY — tiny executable /bin/sh stub for PATH shimming.
+write_stub() {
+    mkdir -p "${1%/*}"
+    printf '#!/bin/sh\n%s\n' "$2" > "$1"
+    chmod +x "$1"
+}
+
+RC=0; OUT=$WORK/out.txt
+run_script() {
+    local prefix="${1:-}"
+    if [[ -n "$prefix" ]]; then
+        PATH="$prefix:/usr/sbin:/usr/bin:/sbin:/bin" "$SCRIPT" >"$OUT" 2>&1
+    else
+        "$SCRIPT" >"$OUT" 2>&1
+    fi
+    RC=$?
+}
+
+assert_rejected() {
+    ok "exits nonzero" test "$RC" -ne 0
+    ok "no role-server verdict" test ! -e "$RUN/role-server"
+    ok "no role-agent verdict" test ! -e "$RUN/role-agent"
+    ok "no server token staged" test ! -e "$RUN/rke2-server-token"
+    ok "no agent token staged" test ! -e "$RUN/rke2-agent-token"
+    ok "no fragment written" test ! -e "$FRAG"
+}
+
+# ---------------------------------------------------------------- sanity
+mkdir -p "$WORK"
+CASE=sanity
+reset_state
+d=$WORK/sanity; mkdir -p "$d" "$MNT"; echo hi > "$d/x"
+if ! make_iso "$d" || ! timeout 10 mount -t iso9660 -o ro "$DEVLINK" "$MNT"; then
+    note "SANITY: cannot loop-mount ISO9660 here; aborting"
+    exit 2
+fi
+umount "$MNT"
+# Prefer the real settle where udevd runs (CI runners); shim only where not.
+if ! udevadm settle --timeout=2; then
+    note "SANITY: udevadm settle fails here (no udevd); no-disk cases will shim it"
+    UDEV_SHIM=1
+else
+    UDEV_SHIM=0
+fi
+write_stub "$SHIMDIR-udev/udevadm" 'exit 0'
+
+# ---------------------------------------------------------------- happy: server
+CASE="server-disk"
+reset_state; server_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "role-server verdict" test -f "$RUN/role-server"
+ok "no role-agent verdict" test ! -e "$RUN/role-agent"
+ok "server token file 0600" test "$(file_mode "$RUN/rke2-server-token")" = 600
+ok "agent token file 0600" test "$(file_mode "$RUN/rke2-agent-token")" = 600
+ok "server token exact" test "$(cat "$RUN/rke2-server-token")" = "$STOK"
+ok "agent token exact" test "$(cat "$RUN/rke2-agent-token")" = "$ATOK"
+ok "fragment 0600" test "$(file_mode "$FRAG")" = 600
+ok "fragment exact (token paths only)" \
+   test "$(cat "$FRAG")" = "token-file: $RUN/rke2-server-token
+node-ip: 192.168.7.10"
+ok "no token value in fragment" no_tokens_in "$FRAG"
+ok "no token value in output" no_tokens_in "$OUT"
+
+CASE="server-disk+external-ip"
+reset_state; server_dir "$WORK/d" with_ext; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment has external ip" grep -qx 'node-external-ip: 203.0.113.10' "$FRAG"
+ok "role-server verdict" test -f "$RUN/role-server"
+
+# ---------------------------------------------------------------- happy: agent
+CASE="agent-disk"
+reset_state; agent_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "role-agent verdict" test -f "$RUN/role-agent"
+ok "no role-server verdict" test ! -e "$RUN/role-server"
+ok "agent token 0600" test "$(file_mode "$RUN/rke2-agent-token")" = 600
+ok "agent token exact" test "$(cat "$RUN/rke2-agent-token")" = "$ATOK"
+ok "server token NOT staged" test ! -e "$RUN/rke2-server-token"
+ok "fragment exact (url + addrs)" \
+   test "$(cat "$FRAG")" = "token-file: $RUN/rke2-agent-token
+server: https://192.168.7.10:$JOIN_PORT
+node-ip: 192.168.7.11"
+ok "no token value in fragment" no_tokens_in "$FRAG"
+ok "no token value in output" no_tokens_in "$OUT"
+
+CASE="agent-disk+external-ip"
+reset_state; agent_dir "$WORK/d" with_ext; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment has external ip" grep -qx 'node-external-ip: 203.0.113.11' "$FRAG"
+
+# ---------------------------------------------------------------- happy: no disk
+CASE="no-disk-legacy-server"
+reset_state
+if [[ "$UDEV_SHIM" == 1 ]]; then run_script "$SHIMDIR-udev"; else run_script; fi
+ok "exit 0" test "$RC" -eq 0
+ok "role-server verdict" test -f "$RUN/role-server"
+ok "no role-agent verdict" test ! -e "$RUN/role-agent"
+ok "generated agent token 0600" test "$(file_mode "$RUN/rke2-agent-token")" = 600
+ok "generated token is 64 lowercase hex" \
+   grep -qxE '[0-9a-f]{64}' "$RUN/rke2-agent-token"
+ok "no server token file" test ! -e "$RUN/rke2-server-token"
+ok "no fragment (legacy defaults untouched)" test ! -e "$FRAG"
+ok "says defaulting to server" grep -q 'no joindata disk, defaulting to server' "$OUT"
+ok "generated token not logged" no_tokens_in "$OUT"
+
+# ---------------------------------------------------------------- re-dispatch
+# Same-boot re-runs must not leak the previous run's staging.
+CASE="redispatch-server-then-agent"
+reset_state; server_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "first run (server) exit 0" test "$RC" -eq 0
+release_disk
+agent_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "second run (agent) exit 0" test "$RC" -eq 0
+ok "role-agent verdict" test -f "$RUN/role-agent"
+ok "stale role-server verdict removed" test ! -e "$RUN/role-server"
+ok "stale server token removed" test ! -e "$RUN/rke2-server-token"
+ok "fragment is agent-shaped" grep -qx "server: https://192.168.7.10:$JOIN_PORT" "$FRAG"
+
+CASE="redispatch-success-then-broken"
+reset_state; server_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "first run (server) exit 0" test "$RC" -eq 0
+release_disk
+server_dir "$WORK/d"; write_f "$WORK/d" server-token not-a-token; make_iso "$WORK/d"; run_script
+assert_rejected
+
+# ---------------------------------------------------------------- rejections
+reject_case() {
+    CASE="$1"
+    reset_state
+    "$2" "$WORK/d"
+    make_iso "$WORK/d"
+    run_script
+    assert_rejected
+}
+
+m_wrong_role()        { server_dir "$1"; write_f "$1" role bogus; }
+m_role_missing()      { server_dir "$1"; rm "$1/role"; }
+m_forbid_server()     { server_dir "$1"; write_f "$1" server 192.168.7.9; }
+m_forbid_stok()       { agent_dir "$1";  write_f "$1" server-token "$STOK"; }
+m_extra_file_server() { server_dir "$1"; write_f "$1" foo bar; }
+m_extra_file_agent()  { agent_dir "$1";  write_f "$1" foo bar; }
+m_equal_tokens()      { server_dir "$1"; write_f "$1" server-token "$ATOK"; }
+m_tok_63()            { server_dir "$1"; write_f "$1" server-token "${STOK:0:63}"; }
+m_tok_upper()         { server_dir "$1"; write_f "$1" server-token "$(tr a A <<<"$STOK" | tr -d '\n')"; }
+m_tok_nonhex()        { agent_dir "$1";  write_f "$1" agent-token "${ATOK:0:63}g"; }
+m_ip_range()          { server_dir "$1"; write_f "$1" node-ip 999.1.1.1; }
+m_ip_short()          { server_dir "$1"; write_f "$1" node-ip 1.2.3; }
+m_ip_leading_zero()   { server_dir "$1"; write_f "$1" node-ip 010.2.3.4; }
+m_ip_octet_08()       { server_dir "$1"; write_f "$1" node-ip 1.2.3.08; }
+m_srv_scheme()        { agent_dir "$1";  write_f "$1" server https://192.168.7.10; }
+m_srv_port()          { agent_dir "$1";  write_f "$1" server "192.168.7.10:$JOIN_PORT"; }
+m_interior_ws()       { server_dir "$1"; write_f "$1" node-ip '1.2.3.4 x'; }
+m_multiline()         { server_dir "$1"; printf 'server\nagent\n' > "$1/role"; }
+m_oversize_file()     { server_dir "$1"; head -c 300 /dev/zero | tr '\0' a > "$1/role"; }
+m_oversize_line()     { server_dir "$1"; { head -c 257 /dev/zero | tr '\0' a; } > "$1/role"; }
+m_nul_byte()          { server_dir "$1"; printf 'ser\0ver' > "$1/role"; }
+m_symlink()           { server_dir "$1"; rm "$1/role"; ln -s /etc/hostname "$1/role"; }
+m_dangling_ext_ip()   { server_dir "$1"; ln -s /nonexistent-target "$1/node-external-ip"; }
+m_nonregular_dir()    { server_dir "$1"; rm "$1/role"; mkdir "$1/role"; }
+m_empty_ext_ip()      { server_dir "$1"; write_f "$1" node-external-ip ''; }
+m_agent_no_server()   { agent_dir "$1"; rm "$1/server"; }
+m_server_no_atok()    { server_dir "$1"; rm "$1/agent-token"; }
+
+for c in wrong_role role_missing forbid_server forbid_stok extra_file_server \
+         extra_file_agent equal_tokens tok_63 tok_upper tok_nonhex ip_range \
+         ip_short ip_leading_zero ip_octet_08 srv_scheme srv_port interior_ws \
+         multiline oversize_file oversize_line nul_byte symlink \
+         dangling_ext_ip nonregular_dir empty_ext_ip agent_no_server \
+         server_no_atok; do
+    reject_case "reject-$c" "m_$c"
+done
+
+# The regex, not bash arithmetic (invalid octal), must catch leading zeros.
+CASE="reject-ip-octet-08-clean"
+reset_state; m_ip_octet_08 "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "no bash arithmetic noise" bash -c '! grep -q "value too great" "'"$OUT"'"'
+
+# ---------------------------------------------------------------- injection
+CASE="injection-not-evaluated"
+reset_state
+d=$WORK/d; server_dir "$d"
+write_f "$d" role '$(touch$IFS/tmp/pwned-role)'
+write_f "$d" node-ip '`touch$IFS/tmp/pwned-ip`'
+write_f "$d" server-token ';touch$IFS/tmp/pwned-tok;'
+make_iso "$d"; run_script
+assert_rejected
+ok "no command from role field ran" test ! -e /tmp/pwned-role
+ok "no command from ip field ran" test ! -e /tmp/pwned-ip
+ok "no command from token field ran" test ! -e /tmp/pwned-tok
+
+# Host-supplied role text (terminal escapes included) must not reach logs.
+CASE="invalid-role-not-echoed"
+reset_state; server_dir "$WORK/d"; write_f "$WORK/d" role 'EVILMARKER123'; make_iso "$WORK/d"; run_script
+assert_rejected
+ok "supplied role text absent from output" bash -c '! grep -q EVILMARKER123 "'"$OUT"'"'
+
+# ---------------------------------------------------------------- non-ISO fs
+CASE="reject-non-iso"
+reset_state
+img=$WORK/ext4.img; rm -f "$img"
+dd if=/dev/zero of="$img" bs=1M count=4 status=none
+mke2fs -q -t ext4 -L joindata "$img"
+attach_disk "$img"
+run_script
+assert_rejected
+
+# ---------------------------------------------------------------- mount timeout (simulated)
+CASE="reject-mount-timeout"
+reset_state; server_dir "$WORK/d"; make_iso "$WORK/d"
+# exec: otherwise timeout's kill orphans the sleep for the remaining 50s.
+write_stub "$SHIMDIR-hang/mount" 'exec sleep 60'
+run_script "$SHIMDIR-hang"
+assert_rejected
+ok "timeout fired (rc 124 path, <60s)" test "$RC" -eq 124
+
+# ---------------------------------------------------------------- fault injection
+# Fail the Nth invocation of one staging command; the canonical artifacts must
+# each be absent-or-complete and the verdict must be absent.
+make_shims() { # make_shims CMD N
+    local cmd="$1" n="$2" real
+    rm -rf "$SHIMDIR"; mkdir -p "$SHIMDIR"
+    real=$(command -v "$cmd")
+    # Builtins only: a shimmed `cat` calling cat would recurse via PATH.
+    cat > "$SHIMDIR/$cmd" <<EOF
+#!/bin/bash
+c=0
+[[ -f $FAULTDIR/count ]] && read -r c < $FAULTDIR/count
+c=\$((c+1)); printf '%s\n' "\$c" > $FAULTDIR/count
+if [[ \$c -eq $n ]]; then echo "fault: $cmd call \$c" >&2; exit 1; fi
+exec $real "\$@"
+EOF
+    chmod +x "$SHIMDIR/$cmd"
+}
+
+assert_no_partial() {
+    local f
+    ok "no role-server verdict" test ! -e "$RUN/role-server"
+    ok "no role-agent verdict" test ! -e "$RUN/role-agent"
+    for f in "$RUN/rke2-server-token:$STOK" "$RUN/rke2-agent-token:$ATOK"; do
+        local path="${f%%:*}" want="${f#*:}"
+        if [[ -e "$path" ]]; then
+            ok "${path##*/} complete if visible" test "$(cat "$path")" = "$want"
+        fi
+    done
+    if [[ -e "$FRAG" ]]; then
+        ok "fragment complete if visible" grep -q '^token-file: ' "$FRAG"
+        ok "fragment has no token value" no_tokens_in "$FRAG"
+    fi
+}
+
+# Only the shim varies, so each role's ISO is built once (server stages 3
+# write_atomic calls, agent 2).
+for spec in server:3 agent:2; do
+    kind=${spec%:*}; writes=${spec#*:}
+    reset_state; "${kind}_dir" "$WORK/d"; make_iso "$WORK/d"
+    for cmd in mv cat chmod mktemp; do
+        for (( n=1; n<=writes; n++ )); do
+            CASE="fault-$kind-$cmd-$n"
+            reset_artifacts
+            make_shims "$cmd" "$n"
+            run_script "$SHIMDIR"
+            if grep -q "fault: $cmd call $n" "$OUT"; then
+                ok "script fails on injected fault" test "$RC" -ne 0
+                assert_no_partial
+            else
+                ok "fault $n beyond $cmd call count (script succeeded untouched)" test "$RC" -eq 0
+            fi
+        done
+    done
+done
+# Legacy path: od failure must fail closed.
+CASE="fault-legacy-od"
+reset_state
+make_shims od 1
+[[ "$UDEV_SHIM" == 1 ]] && write_stub "$SHIMDIR/udevadm" 'exit 0'
+run_script "$SHIMDIR"
+ok "od failure fails the unit" test "$RC" -ne 0
+ok "no verdict on od failure" test ! -e "$RUN/role-server"
+
+# ---------------------------------------------------------------- summary
+release_disk
+summarize "rke2-role script-level summary"


### PR DESCRIPTION
## Problem

The node image is hard-wired single-node: the preset enables rke2-server and disables rke2-agent, and joining a second machine would mean an rke2 token on host-readable storage with no defined contract. The multinode role dispatch landed on confidential-os-builder#82, but the image definition moved here (#266) and confos removed its copy, so that PR targets deleted files.

## Fix

`rke2-role.service` parses a per-host `joindata` disk (role, server, server-token, agent-token, node-ip, node-external-ip) with strict per-role validation: hex-64 distinct tokens, IPv4 checks, single bounded ASCII line, reject NUL/symlinks/multi-line. It stages tokens on tmpfs (fragments carry paths, never values) and role-gates `rke2-server`/`rke2-agent`: fail-closed by marker absence, visible failure via `Requires=`, no disk defaults to the single-node server. Agents join with rke2's `agent-token`, which cannot add a control-plane node. Supersedes confidential-os-builder#82.


Merge order: after the #264 phase-1 flip of `c8s-image.yml` to `node-guest-image/build` (which also removes the sync gate this PR currently fails). Until then, images still build from the frozen confos copy at the pinned `CONFOS_REF`, so this change must not appear merged-but-unshipped.
