### PR TITLE
feat(node-guest-image): SEV-SNP node image — explicit platform, rendered by sync

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -152,7 +152,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/output/kernel
-          key: ${{ runner.os }}-kernel-${{ env.VARIANT }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/version','c8s/node-guest-image/build') }}
+          key: ${{ runner.os }}-kernel-${{ env.VARIANT }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
       - name: Cache base image tools
         uses: actions/cache@v5
@@ -241,7 +241,10 @@ jobs:
           # it to rebuild a published release. Definition lives in this repo:
           # the script stages ../c8s/node-guest-image/c8s via --profile-dir.
           export C8S_REF="${C8S_REF_INPUT:-${HEAD_SHA::7}}"
-          C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
+          # The build script requires an explicit platform (no default). This
+          # workflow publishes the TDX image; the snp variant is built on
+          # demand until M3 adds it to CI.
+          C8S_PLATFORM=tdx C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -12,13 +12,31 @@ Layout:
   `confos build --profile-dir` (confos ≥ the release carrying
   confidential-os-builder#81); the dir basename **is** the profile name, so
   it must stay `c8s`.
+- Platform: the profile is platform-neutral; `build` requires
+  `C8S_PLATFORM` (`tdx`|`snp`, no default) and `c8s/mkosi.sync` renders the
+  **entire** tdx/snp divergence — three files — from it: cred-release's
+  `Environment=CRED_PLATFORM` drop-in, the node's self-label
+  (`confidential.ai/tdx` / `confidential.ai/sev-snp`, the k8s vocabulary
+  `c8s install --hardware-platform` selects on), and the NRI floor's
+  `platform:`. The sync refuses to render a missing/invalid value, so the
+  fail-closed gate is at **build** time; `--platform=${CRED_PLATFORM}` in
+  the unit is boot-time defense in depth (cred-release opens no quote
+  device — quotes come from attestation-api over HTTP, the operator-key
+  RTMR read is sysfs). The guest kernel carries both TEEs' symbols via
+  confos `kernel/required.config`, so the images differ only by those
+  three rendered files — which keeps a one-image-serves-both design
+  (boot-time platform probe, confos `--platform both`) evaluable later.
+  NOTE: the operator credential-release flow itself is TDX-only today
+  (RTMR[3] binding; SNP has no runtime-extend equivalent) — an SNP image
+  boots and attests, but operator flows fail closed pending an SNP
+  binding design.
 - `kernel/` — the guest-kernel config fragments (`c8s.config`,
   `c8s-dev.config`), passed via `--kernel-config-fragment` exactly like
   kata-guest-base's `container.config`. confos's `required`/`hardening`
   baselines stay in confos: a fragment request that conflicts with them
   fails the build (see the balloon catch in #263).
 - `build` — drop-in replacement for confos's `bin/build-c8s`: same env
-  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
+  contract (`C8S_PLATFORM`, `C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
   and order; only the c8s profile content and kernel fragments come from
   here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
 

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -26,6 +26,13 @@
 # not rebuild and clobber the tree the modules were built against.
 #
 # Knobs:
+#   C8S_PLATFORM=      REQUIRED. tdx or snp — the CVM TEE this image launches
+#                      on. No default anywhere: the profile is platform-
+#                      neutral and mkosi.sync renders every platform-
+#                      dependent bit (cred-release platform, node label,
+#                      NRI floor platform) from this one value; the sync
+#                      refuses to run without it. The guest kernel carries
+#                      both TEEs' symbols via confos kernel/required.config.
 #   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
 #                      (8250 serial re-enabled) + the dev profile
 #                      (console=ttyS0, passwordless serial autologin).
@@ -50,8 +57,15 @@
 #                      is committed and measured — see MODULE-SIGNING.md.
 #
 # Extra args are passed through to `confos build`, e.g.:
-#   node-guest-image/build --profile ssh          # + SSH for bring-up debugging
+#   C8S_PLATFORM=tdx node-guest-image/build --profile ssh   # + SSH for bring-up
+#   C8S_PLATFORM=snp node-guest-image/build                  # SEV-SNP node image
 set -euo pipefail
+# Fail before any long step; mkosi.sync re-validates (the load-bearing gate,
+# reachable without this wrapper).
+case "${C8S_PLATFORM:-}" in
+tdx|snp) ;;
+*)  echo "node-guest-image/build: C8S_PLATFORM must be tdx or snp, got '${C8S_PLATFORM:-}'" >&2; exit 1 ;;
+esac
 NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}
 [ -x "$CONFOS_DIR/bin/confos" ] || { echo "node-guest-image/build: confos checkout not found at $CONFOS_DIR (set CONFOS_DIR)" >&2; exit 1; }
@@ -76,11 +90,12 @@ exec bin/confos build "${C8S_NAME:-c8s}" \
     ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \
     --profile-dir "$NGI_DIR/c8s" \
     --module-signing-cert "$NGI_DIR/module-signing.crt" \
+    --sync-input "platform=${C8S_PLATFORM}" \
     --sync-input "c8s-ref=${C8S_REF:-}" \
     --sync-input "c8s-registry=${C8S_REGISTRY:-}" \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \
     --cloud-init "$NGI_DIR/c8s/user-data" \
-    --platform tdx \
+    --platform "$C8S_PLATFORM" \
     --memory "${C8S_MEMORY:-16G}" \
     "$@"

--- a/node-guest-image/c8s/image-policy.yaml.in
+++ b/node-guest-image/c8s/image-policy.yaml.in
@@ -27,15 +27,15 @@
 #   - pull.url must be https, and attestation_api_url is then required.
 #   - empty cds_measurements = accept any RA-TLS-attested CDS (warns).
 
-# The CPU TEE this image boots on. bin/build-c8s composes the c8s profile with
-# `--platform tdx`, so this image is TDX-only and the value is fixed.
+# The CPU TEE this image boots on — rendered from the build's required
+# C8S_PLATFORM (no default; the sync hook refuses to render without it).
 #
 # It types the RA-TLS identity the admission inventory serves to CDS, and CDS
 # refuses a peer whose type disagrees with the evidence envelope the
 # attestation-api returns. The plugin defaults this to snp for backward
 # compatibility, so omitting it here denies every sandbox token on the node,
 # which denies every adopted workload a certificate.
-platform: "tdx"
+platform: "@PLATFORM@"
 
 plugin:
   health_addr: "unix:///var/run/nri-image-policy/health.sock"

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -48,11 +48,9 @@ tls-san:
 
 profile: cis
 pod-security-admission-config-file: /etc/rancher/rke2/psa-config.yaml
-# Self-label as a TDX confidential node so `c8s install --hardware-platform tdx`
-# finds a target without a manual `kubectl label`. This image is TDX-only
-# (RTMR[3] operator binding, TDX quotes); the label is always correct here.
-node-label:
-  - confidential.ai/tdx=true
+# The platform self-label (for `c8s install --hardware-platform`) is
+# rendered by mkosi.sync into a config.yaml.d drop-in — this base file is
+# platform-neutral.
 kubelet-arg:
   - max-pods=200
 kube-apiserver-arg:

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Attested RKE2 operator credential release
 Documentation=https://github.com/confidential-dot-ai/c8s
-# Bound restart storms: a persistent failure (e.g. RTMR[3] mismatch — the
-# on-disk pubkey doesn't match the measurement) should fail closed and stop,
+# Bound restart storms: a persistent failure (e.g. a runtime-measurement
+# mismatch — the on-disk pubkey doesn't match) should fail closed and stop,
 # not spin. 5 tries in 5 min, then give up until the next boot.
 StartLimitIntervalSec=300
 StartLimitBurst=5
 # Needs the RKE2 client-CA (to sign operator certs) and the attestation-api
-# (to fetch the RA-TLS serving cert's TDX quote from :8400). rke2-server
+# (to fetch the RA-TLS serving cert's quote from :8400). rke2-server
 # creates /var/lib/rancher/rke2/server/tls/client-ca.* only once it has
 # initialised, so we order after it and gate on the key existing (the Exec
 # startpre below), rather than racing a half-initialised control plane.
@@ -22,26 +22,29 @@ ConditionPathExists=/dev/disk/by-label/opkeydata
 
 [Service]
 Type=simple
-# The operator key is bound into RTMR[3] at launch; this service verifies the
-# on-disk pubkey against RTMR[3] at startup and refuses (exits non-zero) if it
-# was substituted — fail closed. Non-operator boots never reach here (the
-# ConditionPathExists above skips the unit).
+# The operator key is bound into the platform's runtime measurement at launch
+# (TDX RTMR[3] today — the binding is TDX-only, so on SNP this check fails
+# closed pending an SNP binding design); the service verifies the on-disk
+# pubkey against it and refuses (exits non-zero) if it was substituted.
+# Non-operator boots never reach here (ConditionPathExists skips the unit).
 # Waits bounded (10 min) rather than failing fast: on a slow first boot the
 # CA can take minutes to appear, and 5 quick ExecStartPre failures 10s apart
 # would exhaust StartLimitBurst in under a minute and give up until reboot.
 ExecStartPre=/bin/sh -c 'for _ in $(seq 1 120); do [ -r /var/lib/rancher/rke2/server/tls/client-ca.key ] && exit 0; sleep 5; done; exit 1'
 TimeoutStartSec=630
+# ${CRED_PLATFORM} comes from a drop-in the c8s sync hook renders from the
+# build's required C8S_PLATFORM. The `=` form matters: with the variable
+# unset systemd would elide a bare word, but --platform= expands to an empty
+# value, which platform validation rejects — fail closed, never a default.
 ExecStart=/usr/local/bin/c8s cred-release \
     --listen :8443 \
     --attestation-api-url http://127.0.0.1:8400 \
-    --platform tdx \
+    --platform=${CRED_PLATFORM} \
     --cert-ttl 24h \
     --cert-org system:masters \
     --cert-cn operator
 Restart=on-failure
 RestartSec=10
-# TDX runtime measurement (RTMR[3]) is read via the tdx_guest misc device.
-DeviceAllow=/dev/tdx_guest rwm
 # Reads two files: the initrd-staged operator pubkey (/etc/confai) and the
 # RKE2 client-CA key. No mount needed. Keep the rest of the FS read-only.
 ProtectSystem=strict

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -59,6 +59,36 @@ C8S_REGISTRY=$(cat "$SYNC_INPUTS/c8s-registry" 2>/dev/null || true)
 C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
+# The image's TEE platform, from build's --sync-input. Required: the NRI
+# floor types the RA-TLS identity CDS checks against attestation evidence,
+# so a wrong or defaulted value denies every adopted workload a certificate.
+PLATFORM=$(cat "$SYNC_INPUTS/platform" 2>/dev/null || true)
+case "$PLATFORM" in
+    tdx|snp) ;;
+    *) echo "c8s sync: FATAL platform sync-input must be tdx or snp, got '${PLATFORM}'" >&2; exit 1 ;;
+esac
+
+# Platform drop-ins rendered from the one sync-input: cred-release's
+# platform and the node self-label; the NRI floor's platform: is substituted
+# below together with the digests. Rendered paths must stay disjoint from
+# the profile's mkosi.extra tree (copy precedence between the two is
+# undocumented; today every rendered path is a new file).
+#
+# The label key is the one consumer with its own vocabulary: the chart
+# selector and c8s install use confidential.ai/sev-snp (NOT /snp — nothing
+# selects on that), while cred-release and the NRI floor normalize snp
+# themselves (ratls.NormalizePlatform).
+case "$PLATFORM" in
+    snp) LABEL_PLATFORM=sev-snp ;;
+    *)   LABEL_PLATFORM=$PLATFORM ;;
+esac
+mkdir -p "$STAGE_DIR/etc/systemd/system/cred-release.service.d" \
+         "$STAGE_DIR/etc/rancher/rke2/config.yaml.d"
+printf '[Service]\nEnvironment=CRED_PLATFORM=%s\n' "$PLATFORM" \
+    > "$STAGE_DIR/etc/systemd/system/cred-release.service.d/10-platform.conf"
+printf '# Self-label so `c8s install --hardware-platform %s` finds this node.\nnode-label:\n  - confidential.ai/%s=true\n' "$LABEL_PLATFORM" "$LABEL_PLATFORM" \
+    > "$STAGE_DIR/etc/rancher/rke2/config.yaml.d/50-platform.yaml"
+
 C8S_REF=$(cat "$SYNC_INPUTS/c8s-ref" 2>/dev/null || true)
 # Pinned c8s release: bakes the same component versions the CLI ships as.
 # docker.yml publishes images under v* tags, so the tag itself is the ref.
@@ -92,6 +122,7 @@ render_nri_floor() {
         -e "s|@NRI_IMAGE@|${NRI_IMAGE}|g" \
         -e "s|@CDS_DIGEST@|${CDS_DIGEST}|g" \
         -e "s|@CDS_IMAGE@|${CDS_REPO}@${CDS_DIGEST}|g" \
+        -e "s|@PLATFORM@|${PLATFORM}|g" \
         "$tmpl" > "$dst"
     echo "c8s sync: NRI floor rendered (nri ${NRI_DIGEST}, cds ${CDS_DIGEST})"
 }


### PR DESCRIPTION
## Problem

The node image only built for TDX — and not just in the build flags: `--platform tdx` was hardcoded, and **three** TDX values were baked into the image content (cred-release's platform, the NRI floor's `platform: "tdx"`, and the `confidential.ai/tdx=true` node self-label).

## Fix

`C8S_PLATFORM` is required (`tdx`|`snp`, **no default anywhere**), and one mechanism delivers every platform-dependent bit: `mkosi.sync` (which already renders the NRI floor) receives it via `--sync-input platform=…` — refusing to run without a valid value — and renders the **entire** tdx/snp divergence, three files:

- cred-release's `Environment=CRED_PLATFORM` drop-in. The unit runs `--platform=${CRED_PLATFORM}` (`=`-form: unset expands to an empty value that platform validation rejects — boot-time defense in depth behind the build-time gate). No quote-device `DeviceAllow`: cred-release opens no quote device (quotes come from attestation-api over HTTP; the operator-key measurement read is sysfs).
- the node's self-label — `confidential.ai/tdx` / **`confidential.ai/sev-snp`** (the key `c8s install --hardware-platform` actually selects on; the label is the one consumer with its own vocabulary — cred-release and the NRI floor normalize `snp` themselves).
- the NRI floor's `platform:` (a wrong value there makes CDS deny every adopted workload a certificate, hence the same no-default rule).

`confos build` gets `--platform "$C8S_PLATFORM"` for the measurement artifacts. No kernel change (confos `required.config` carries both TEEs' symbols) and no package delta (attestation-api probes both quote devices, `platforms = ["snp","tdx"]`). Since the three rendered files are the whole divergence, a one-image-serves-both design (boot-time probe + confos `--platform both`) stays evaluable later.

## SNP status — stated plainly

An SNP image **boots and attests**, but the **operator credential-release flow is TDX-only today**: the operator-key binding reads TDX RTMR[3], and SEV-SNP has no runtime-extend equivalent (`pkg/runtimemeasure`); the confos initrd also rejects an opkeydata disk on SNP. On SNP, cred-release fails closed. A working SNP operator flow needs its own binding design (HOSTDATA/ID_BLOCK or vTPM) — out of scope here.

## Measurement / CI

Rolls the TDX image measurement once (unit + rke2 config bytes) — riding the v0.4.1 reference re-seed already queued. `module-signing.crt` joins the kernel cache key (it's a kernel-fingerprint input). CI pins `C8S_PLATFORM=tdx`; SNP joins the matrix when wanted (note: an SNP build additionally needs SNP firmware at confos's `--firmware` path).

History note: rebased onto main as a single commit — earlier revisions (override drop-in, then symmetric `tdx/`/`snp/` profile-dir halves) were successively simplified away during review; the sync render replaced them all.