### PR TITLE
feat(node-guest-image): encrypt cross-node pod traffic with Cilium WireGuard

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml
@@ -4,7 +4,8 @@
 # and merges HelmChartConfig CRDs into the matching HelmChart spec it
 # already manages. For RKE2's cilium chart the chart name is `rke2-cilium`.
 #
-# Two important settings for this single-node, kube-proxy-replaced setup:
+# Two settings need explaining for this single-node, kube-proxy-replaced
+# setup:
 #
 #   1. kubeProxyReplacement: true
 #      Cilium provides cluster-IP service routing in eBPF instead of
@@ -36,6 +37,23 @@ spec:
     # reason about.
     bpf:
       masquerade: true
+
+    # WireGuard node-to-node encryption — cross-node pod traffic rides the
+    # untrusted host fabric. Peer keys ride CiliumNode objects, so peer trust
+    # is only as strong as apiserver admission. Inert on a single node.
+    encryption:
+      enabled: true
+      type: wireguard
+      # Fail closed while a peer key is unknown or either Cilium agent is
+      # restarting. The egress CIDR is the complete pod pool below; remote
+      # node identity lookup is required by Cilium's VXLAN tunnel mode.
+      strictMode:
+        egress:
+          enabled: true
+          cidr: 10.52.0.0/16
+          allowRemoteNodeIdentities: true
+        ingress:
+          enabled: true
 
     # Direct apiserver address — single-node uses the host loopback.
     # RKE2's kube-apiserver binds on 0.0.0.0:6443 so 127.0.0.1 works.

--- a/node-guest-image/kernel/c8s-dev.config
+++ b/node-guest-image/kernel/c8s-dev.config
@@ -108,6 +108,10 @@ CONFIG_BRIDGE_NETFILTER=y
 CONFIG_VXLAN=y
 CONFIG_GENEVE=y
 
+# WireGuard — Cilium's cross-node pod encryption; the inter-node fabric is
+# untrusted.
+CONFIG_WIREGUARD=y
+
 # TUN/TAP. Several CNIs and IPsec setups need it.
 CONFIG_TUN=y
 

--- a/node-guest-image/kernel/c8s.config
+++ b/node-guest-image/kernel/c8s.config
@@ -100,6 +100,10 @@ CONFIG_BRIDGE_NETFILTER=y
 CONFIG_VXLAN=y
 CONFIG_GENEVE=y
 
+# WireGuard — Cilium's cross-node pod encryption; the inter-node fabric is
+# untrusted.
+CONFIG_WIREGUARD=y
+
 # TUN/TAP. Several CNIs and IPsec setups need it.
 CONFIG_TUN=y
 


### PR DESCRIPTION
## Problem

Cross-node pod traffic would cross the inter-node fabric as cleartext VXLAN.

## Fix

`CONFIG_WIREGUARD=y` in both kernel fragments, and WireGuard node-to-node encryption with strict-mode egress and ingress (fail closed while a peer key is unknown or Cilium restarts; egress scoped to the 10.52.0.0/16 pod pool; `allowRemoteNodeIdentities` as required by VXLAN tunnel mode) in the baked Cilium HelmChartConfig. Inert on a single node. The confos-side kernel snapshot regen stays in confos and rides the next kernel build there. Supersedes confidential-os-builder#83.


Merge order: after the #264 phase-1 flip of `c8s-image.yml` to `node-guest-image/build` (which also removes the sync gate this PR currently fails). Until then, images still build from the frozen confos copy at the pinned `CONFOS_REF`, so this change must not appear merged-but-unshipped.
