### PR TITLE
fix(earsigner): stop JWKS publishing a retired key past overlap

### DIFF
--- a/internal/server/jwks.go
+++ b/internal/server/jwks.go
@@ -8,9 +8,9 @@ import (
 )
 
 // HandleJWKS returns a handler that serves a JWKS document.
-// If jwksFunc is provided, it returns the pre-serialized JSON on each request
-// (for rotation mode with multiple keys). Otherwise it serves a static JWKS
-// built from the Issuer's current key.
+// If jwksFunc is provided, it supplies the body on each request (for rotation
+// mode with multiple keys). Otherwise it serves a static JWKS built from the
+// Issuer's current key.
 func HandleJWKS(iss ear.Issuer, jwksFunc func() []byte) http.HandlerFunc {
 	if jwksFunc != nil {
 		return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/earsigner/rotator.go
+++ b/pkg/earsigner/rotator.go
@@ -34,6 +34,11 @@ type managedKey struct {
 	notAfterT time.Time
 }
 
+// expired reports whether now is at or past the key's deadline.
+func (k *managedKey) expired(now time.Time) bool {
+	return !now.Before(k.notAfterT)
+}
+
 // SwapKeyFunc is called when the active signing key changes.
 type SwapKeyFunc func(key *ecdsa.PrivateKey, kid string)
 
@@ -94,7 +99,7 @@ func (r *Rotator) JWKSetJSON() []byte {
 	// Retiring keys are served until their overlap deadline, as in PublicKey.
 	now := time.Now()
 	for _, k := range r.retiring {
-		if !now.Before(k.notAfterT) {
+		if k.expired(now) {
 			continue
 		}
 		if jwk, err := jwks.FromPublicKey(&k.key.PublicKey); err == nil {
@@ -134,7 +139,7 @@ func (r *Rotator) PublicKey(kid string) (*ecdsa.PublicKey, error) {
 	now := time.Now()
 	for _, k := range r.retiring {
 		if k.kid == kid {
-			if !now.Before(k.notAfterT) {
+			if k.expired(now) {
 				return nil, fmt.Errorf("token-signer key for kid %q is retired (past overlap deadline)", kid)
 			}
 			return &k.key.PublicKey, nil
@@ -194,7 +199,7 @@ func (r *Rotator) rotate() {
 	// Evict expired retiring keys.
 	live := r.retiring[:0]
 	for _, k := range r.retiring {
-		if k.notAfterT.After(now) {
+		if !k.expired(now) {
 			live = append(live, k)
 		} else {
 			r.cfg.Logger.Info("evicted expired key", "kid", k.kid)

--- a/pkg/earsigner/rotator.go
+++ b/pkg/earsigner/rotator.go
@@ -11,7 +11,6 @@ import (
 	"log/slog"
 	mathrand "math/rand/v2"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -47,8 +46,6 @@ type Rotator struct {
 	mu       sync.RWMutex
 	active   *managedKey
 	retiring []*managedKey
-
-	jwksBody atomic.Pointer[[]byte]
 }
 
 // Generate creates a fresh P-256 private key and returns it as PEM bytes.
@@ -81,18 +78,37 @@ func NewRotator(cfg RotatorConfig, initialKeyPEM []byte, swapKey SwapKeyFunc) (*
 			notAfterT: now.Add(cfg.Interval + cfg.Overlap),
 		},
 	}
-	r.rebuildJWKS()
-
 	return r, nil
 }
 
-// JWKSetJSON returns the current pre-serialized JWKS response body.
+// JWKSetJSON serialises the current key set for the JWKS endpoint: the
+// active key plus retiring keys within their overlap window.
 func (r *Rotator) JWKSetJSON() []byte {
-	p := r.jwksBody.Load()
-	if p == nil {
+	r.mu.RLock()
+	var keys []jose.JSONWebKey
+	if r.active != nil {
+		if jwk, err := jwks.FromPublicKey(&r.active.key.PublicKey); err == nil {
+			keys = append(keys, jwk)
+		}
+	}
+	// Retiring keys are served until their overlap deadline, as in PublicKey.
+	now := time.Now()
+	for _, k := range r.retiring {
+		if !now.Before(k.notAfterT) {
+			continue
+		}
+		if jwk, err := jwks.FromPublicKey(&k.key.PublicKey); err == nil {
+			keys = append(keys, jwk)
+		}
+	}
+	r.mu.RUnlock()
+
+	body, err := jwks.MarshalSet(keys...)
+	if err != nil {
+		r.cfg.Logger.Error("failed to marshal JWKS", "error", err)
 		return []byte(`{"keys":[]}`)
 	}
-	return *p
+	return body
 }
 
 // PublicKey returns the ECDSA public key matching kid from the active or
@@ -192,39 +208,5 @@ func (r *Rotator) rotate() {
 	// Swap the signing key in the Issuer.
 	r.swapKey(newKey, newKid)
 
-	r.rebuildJWKS()
-
 	r.cfg.Logger.Info("rotation complete", "new_kid", newKid, "retiring_keys", len(r.retiring))
-}
-
-func (r *Rotator) rebuildJWKS() {
-	r.mu.RLock()
-	var keys []jose.JSONWebKey
-
-	// Active key first.
-	if r.active != nil {
-		if jwk, err := jwks.FromPublicKey(&r.active.key.PublicKey); err == nil {
-			keys = append(keys, jwk)
-		}
-	}
-	// Only publish retiring keys that are still within their overlap window, so
-	// the JWKS never advertises a key past its retirement deadline (mirrors the
-	// deadline check in PublicKey).
-	now := time.Now()
-	for _, k := range r.retiring {
-		if !now.Before(k.notAfterT) {
-			continue
-		}
-		if jwk, err := jwks.FromPublicKey(&k.key.PublicKey); err == nil {
-			keys = append(keys, jwk)
-		}
-	}
-	r.mu.RUnlock()
-
-	body, err := jwks.MarshalSet(keys...)
-	if err != nil {
-		r.cfg.Logger.Error("failed to marshal JWKS", "error", err)
-		return
-	}
-	r.jwksBody.Store(&body)
 }

--- a/pkg/earsigner/rotator_test.go
+++ b/pkg/earsigner/rotator_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -98,7 +100,7 @@ func TestJWKSetJSON_HasActiveKey(t *testing.T) {
 }
 
 // TestRun_Rotation drives the rotation loop with a tiny interval to exercise
-// rotate(), the swap callback, and JWKS rebuild including a retiring key.
+// rotate(), the swap callback, and JWKS serving of a retiring key.
 func TestRun_Rotation(t *testing.T) {
 	keyPEM, err := earsigner.Generate()
 	if err != nil {
@@ -357,8 +359,6 @@ func TestJWKSAgreesWithPublicKeyAcrossSchedule(t *testing.T) {
 		t.Helper()
 		select {
 		case kid := <-swaps:
-			// Let rotate() finish before sampling its observable state.
-			time.Sleep(25 * time.Millisecond)
 			return kid
 		case <-time.After(5 * time.Second):
 			t.Fatal("timed out waiting for rotation")
@@ -384,6 +384,85 @@ func TestJWKSAgreesWithPublicKeyAcrossSchedule(t *testing.T) {
 	assertAgree(k0, false, "after next rotate")
 	assertAgree(k1, true, "after next rotate")
 	assertAgree(k2, true, "after next rotate")
+}
+
+// TestJWKSetJSONConcurrentWithRotation hammers JWKSetJSON and PublicKey from
+// concurrent readers while the rotation loop runs, asserting every served
+// body is a complete valid JWKS and lookups stay correct mid-rotation.
+func TestJWKSetJSONConcurrentWithRotation(t *testing.T) {
+	keyPEM, err := earsigner.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Overlap is long compared to the reader run time, so the initial key
+	// must resolve via PublicKey throughout.
+	r, err := earsigner.NewRotator(earsigner.RotatorConfig{
+		Interval: 5 * time.Millisecond,
+		Overlap:  time.Second,
+		Jitter:   0,
+		Logger:   discardLogger(),
+	}, keyPEM, func(*ecdsa.PrivateKey, string) {})
+	if err != nil {
+		t.Fatalf("NewRotator: %v", err)
+	}
+	initialKid := firstKid(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+
+	const readers = 8
+	errs := make(chan error, readers)
+	var wg sync.WaitGroup
+	for i := 0; i < readers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			deadline := time.Now().Add(300 * time.Millisecond)
+			for time.Now().Before(deadline) {
+				var set struct {
+					Keys []jwkEntry `json:"keys"`
+				}
+				if err := json.Unmarshal(r.JWKSetJSON(), &set); err != nil {
+					errs <- fmt.Errorf("unmarshal served JWKS: %w", err)
+					return
+				}
+				if len(set.Keys) == 0 {
+					errs <- errors.New("served JWKS has no keys")
+					return
+				}
+				for _, k := range set.Keys {
+					if k.Kid == "" || k.Kty == "" || k.Crv == "" {
+						errs <- fmt.Errorf("served incomplete JWK entry: %+v", k)
+						return
+					}
+				}
+				if _, err := r.PublicKey(initialKid); err != nil {
+					errs <- fmt.Errorf("PublicKey(retiring kid) mid-rotation: %w", err)
+					return
+				}
+				if _, err := r.PublicKey("never-issued"); err == nil {
+					errs <- errors.New("PublicKey resolved an unknown kid")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
+	}
 }
 
 // firstTickIn starts Run with an already-cancelled context so it exits right

--- a/pkg/earsigner/rotator_test.go
+++ b/pkg/earsigner/rotator_test.go
@@ -233,6 +233,159 @@ func TestPublicKey_RetiringKeyExpires(t *testing.T) {
 	}
 }
 
+// TestJWKSDropsRetiredKeyPastOverlap proves the served JWKS drops a retiring
+// key once its overlap deadline passes, matching the lookup-time rejection in
+// PublicKey. The loop is stopped right after the first rotation so no later
+// rotate() can mask a stale served set.
+func TestJWKSDropsRetiredKeyPastOverlap(t *testing.T) {
+	keyPEM, err := earsigner.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	swapped := make(chan struct{}, 1)
+	r, err := earsigner.NewRotator(earsigner.RotatorConfig{
+		Interval: 100 * time.Millisecond,
+		Overlap:  400 * time.Millisecond,
+		Jitter:   0,
+		Logger:   discardLogger(),
+	}, keyPEM, func(_ *ecdsa.PrivateKey, _ string) {
+		select {
+		case swapped <- struct{}{}:
+		default:
+		}
+	})
+	if err != nil {
+		t.Fatalf("NewRotator: %v", err)
+	}
+	initialKid := firstKid(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+
+	select {
+	case <-swapped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first rotation")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+
+	// Inside the overlap window both views serve the retiring key.
+	if _, err := r.PublicKey(initialKid); err != nil {
+		t.Fatalf("PublicKey(retiring kid) inside overlap: %v", err)
+	}
+	if !jwksHasKid(parseJWKS(t, r.JWKSetJSON()), initialKid) {
+		t.Fatal("JWKS missing retiring key inside its overlap window")
+	}
+
+	// Past the overlap deadline, with no further rotation, both views must
+	// drop it.
+	time.Sleep(600 * time.Millisecond)
+
+	if _, err := r.PublicKey(initialKid); err == nil {
+		t.Error("PublicKey accepted a key past its overlap deadline")
+	}
+	if jwksHasKid(parseJWKS(t, r.JWKSetJSON()), initialKid) {
+		t.Error("JWKS still publishes a key past its overlap deadline")
+	}
+}
+
+// TestJWKSAgreesWithPublicKeyAcrossSchedule walks the rotation schedule —
+// initial, post-rotate inside overlap, past overlap expiry, next rotate — and
+// asserts PublicKey and the served JWKS agree on every key at every point.
+func TestJWKSAgreesWithPublicKeyAcrossSchedule(t *testing.T) {
+	keyPEM, err := earsigner.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	const (
+		interval = 600 * time.Millisecond
+		overlap  = 250 * time.Millisecond
+	)
+	swaps := make(chan string, 4)
+	r, err := earsigner.NewRotator(earsigner.RotatorConfig{
+		Interval: interval,
+		Overlap:  overlap,
+		Jitter:   0,
+		Logger:   discardLogger(),
+	}, keyPEM, func(_ *ecdsa.PrivateKey, kid string) { swaps <- kid })
+	if err != nil {
+		t.Fatalf("NewRotator: %v", err)
+	}
+	k0 := firstKid(t, r)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { r.Run(ctx); close(done) }()
+	defer func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("Run did not return after cancel")
+		}
+	}()
+
+	assertAgree := func(kid string, wantServed bool, when string) {
+		t.Helper()
+		_, pubErr := r.PublicKey(kid)
+		inJWKS := jwksHasKid(parseJWKS(t, r.JWKSetJSON()), kid)
+		if wantServed {
+			if pubErr != nil {
+				t.Errorf("%s: PublicKey(%q): %v", when, kid, pubErr)
+			}
+			if !inJWKS {
+				t.Errorf("%s: JWKS does not publish %q", when, kid)
+			}
+			return
+		}
+		if pubErr == nil {
+			t.Errorf("%s: PublicKey accepted retired key %q", when, kid)
+		}
+		if inJWKS {
+			t.Errorf("%s: JWKS publishes retired key %q", when, kid)
+		}
+	}
+	nextSwap := func() string {
+		t.Helper()
+		select {
+		case kid := <-swaps:
+			// Let rotate() finish before sampling its observable state.
+			time.Sleep(25 * time.Millisecond)
+			return kid
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for rotation")
+			return ""
+		}
+	}
+
+	// Initial: k0 active.
+	assertAgree(k0, true, "initial")
+
+	// First rotation: k0 retiring inside its overlap window, k1 active.
+	k1 := nextSwap()
+	assertAgree(k0, true, "inside overlap")
+	assertAgree(k1, true, "inside overlap")
+
+	// Past k0's overlap deadline but before the next rotation.
+	time.Sleep(overlap + 150*time.Millisecond)
+	assertAgree(k0, false, "past overlap")
+	assertAgree(k1, true, "past overlap")
+
+	// Second rotation: k0 evicted, k1 retiring inside overlap, k2 active.
+	k2 := nextSwap()
+	assertAgree(k0, false, "after next rotate")
+	assertAgree(k1, true, "after next rotate")
+	assertAgree(k2, true, "after next rotate")
+}
+
 // firstTickIn starts Run with an already-cancelled context so it exits right
 // after logging, and returns the first_tick_in duration from the startup log
 // record (the only observable form of the computed first tick).
@@ -316,6 +469,15 @@ func parseJWKS(t *testing.T, body []byte) []jwkEntry {
 		t.Fatalf("unmarshal JWKS %q: %v", body, err)
 	}
 	return set.Keys
+}
+
+func jwksHasKid(keys []jwkEntry, kid string) bool {
+	for _, k := range keys {
+		if k.Kid == kid {
+			return true
+		}
+	}
+	return false
 }
 
 func firstKid(t *testing.T, r *earsigner.Rotator) string {


### PR DESCRIPTION
## Summary

- `JWKSetJSON` served a pre-serialised JWKS body that was only rebuilt at rotation time. A key retired by a rotation has its overlap deadline at `now + Overlap`, so it was always published at rotate time and stayed published until the *next* rotation — with default `Interval=720h`/`Overlap=25h`, roughly 29 days — while `PublicKey` already refused it. Anything verifying against the JWKS (e.g. `issuer.JWKSKeyProvider` consumers of handoff EARs) would accept tokens signed by a key the signer itself considers retired.
- The endpoint now serialises per call under `RLock`, applying the same overlap-deadline check as `PublicKey` via a shared `managedKey.expired` predicate; the cached body and `rebuildJWKS` are deleted.
- Fail-closed edge change: on a marshal error the endpoint returns `{"keys":[]}` rather than a stale cached body.

## Tests

- First commit is tests-only and **fails on the unfixed code**; second commit fixes; third commit is review polish (shared predicate, concurrent-reader test).
- `TestJWKSDropsRetiredKeyPastOverlap` — retired kid disappears from both `PublicKey` and the served JWKS past the overlap deadline.
- `TestJWKSAgreesWithPublicKeyAcrossSchedule` — walks rotate → overlap expiry → next rotate, asserting `PublicKey` and JWKS agree at every sample.
- `TestJWKSetJSONConcurrentWithRotation` — concurrent readers vs a 5ms rotation loop under `-race`.
- `make test` green.

## Notes

- Serve cost per request: `RLock` + ≤3 key serialisations — negligible at the endpoint's fetch rate (~1/min per peer).
- Client-side (`JWKSKeyProvider`) caching is unchanged: a retired key can linger in a *peer's* cache up to its 60s TTL after the endpoint stops serving it. Inherent to client caching; bounded by the existing `Cache-Control: max-age=60`.
