### PR TITLE
refactor(node-guest-image)!: one stack — drop the variant booleans entirely

### DIFF
--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -18,8 +18,8 @@ Layout:
   baselines stay in confos: a fragment request that conflicts with them
   fails the build (see the balloon catch in #263).
 - `build` — drop-in replacement for confos's `bin/build-c8s`: same env
-  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NO_GPU`,
-  `C8S_STOCK_ATTEST`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
+  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_VARIANT`,
+  `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
   and order; only the c8s profile content and kernel fragments come from
   here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
 
@@ -39,8 +39,6 @@ Migration state (see [#264] for the full plan):
    measurements; `c8s-image.yml`'s `gate=true` dispatch input reruns that
    A/B check against any confos ref.
 3. Remaining cleanup, so the inherited interface doesn't become canonical
-   by default: flatten the `C8S_NO_GPU`/`C8S_STOCK_ATTEST` boolean combos
-   (which silently ignore nonsense pairings) into a single variant
    selector.
 
 [confidential-os-builder]: https://github.com/confidential-dot-ai/confidential-os-builder

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -18,8 +18,7 @@ Layout:
   baselines stay in confos: a fragment request that conflicts with them
   fails the build (see the balloon catch in #263).
 - `build` — drop-in replacement for confos's `bin/build-c8s`: same env
-  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_VARIANT`,
-  `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
+  contract (`C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
   and order; only the c8s profile content and kernel fragments come from
   here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
 

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -26,13 +26,6 @@
 # not rebuild and clobber the tree the modules were built against.
 #
 # Knobs:
-#   C8S_VARIANT=...    profile stack, one of:
-#                      gpu (default)  — gpu + attest-gpu + c8s: the published
-#                        image; GPU driver stack and GPU (SPDM) evidence.
-#                      nogpu          — attest + c8s: GPU-less validation
-#                        image. Never publish: without the gpu profile nothing
-#                        latches kernel.modules_disabled=1, so module loading
-#                        stays enabled for the whole boot.
 #   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
 #                      (8250 serial re-enabled) + the dev profile
 #                      (console=ttyS0, passwordless serial autologin).
@@ -58,7 +51,6 @@
 #
 # Extra args are passed through to `confos build`, e.g.:
 #   node-guest-image/build --profile ssh          # + SSH for bring-up debugging
-#   C8S_VARIANT=nogpu node-guest-image/build --profile dev
 set -euo pipefail
 NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}
@@ -76,20 +68,9 @@ bin/confos kernel \
     --kernel-config-fragment "$FRAGMENT" \
     --module-signing-cert "$NGI_DIR/module-signing.crt" \
     --kernel-builder-package "$KB_PKGS"
-case "${C8S_VARIANT:-gpu}" in
-    gpu)
-        PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
-        MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
-        bin/confos-fetch-attest-gpu
-        ;;
-    nogpu)
-        PROFILES=(--profile attest --profile c8s)
-        ;;
-    *)
-        echo "node-guest-image/build: unknown C8S_VARIANT='${C8S_VARIANT}' (gpu|nogpu)" >&2
-        exit 1
-        ;;
-esac
+PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
+MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
+bin/confos-fetch-attest-gpu
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
     ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -29,9 +29,6 @@
 #   C8S_VARIANT=...    profile stack, one of:
 #                      gpu (default)  — gpu + attest-gpu + c8s: the published
 #                        image; GPU driver stack and GPU (SPDM) evidence.
-#                      stock-attest   — gpu + attest + c8s: same attestation-api
-#                        on :8400 (TDX+SNP quotes) but no GPU evidence. Use
-#                        when the build env lacks libnvat.
 #                      nogpu          — attest + c8s: GPU-less validation
 #                        image. Never publish: without the gpu profile nothing
 #                        latches kernel.modules_disabled=1, so module loading
@@ -85,15 +82,11 @@ case "${C8S_VARIANT:-gpu}" in
         MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
         bin/confos-fetch-attest-gpu
         ;;
-    stock-attest)
-        PROFILES=(--profile gpu --profile attest --profile c8s)
-        MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
-        ;;
     nogpu)
         PROFILES=(--profile attest --profile c8s)
         ;;
     *)
-        echo "node-guest-image/build: unknown C8S_VARIANT='${C8S_VARIANT}' (gpu|stock-attest|nogpu)" >&2
+        echo "node-guest-image/build: unknown C8S_VARIANT='${C8S_VARIANT}' (gpu|nogpu)" >&2
         exit 1
         ;;
 esac

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -26,19 +26,16 @@
 # not rebuild and clobber the tree the modules were built against.
 #
 # Knobs:
-#   C8S_NO_GPU=1       GPU-less validation image: `attest` + `c8s` profiles
-#                      only (attestation-api still baked; compose ssh/dev
-#                      manually via extra args). Validation-only, never
-#                      publish: without the gpu profile nothing latches
-#                      kernel.modules_disabled=1, so module loading stays
-#                      enabled for the whole boot.
-#   C8S_STOCK_ATTEST=1 compose the stock `attest` profile instead of
-#                      `attest-gpu`: same attestation-api service on :8400,
-#                      TDX+SNP quotes, but no GPU (SPDM) evidence collection.
-#                      Use when a build environment lacks libnvat / can't build
-#                      the nvidia-gpu-attest binary. The default (this var
-#                      unset) composes attest-gpu, which CI supports via a
-#                      vendored libnvat + confos-fetch-attest-gpu pre-stage.
+#   C8S_VARIANT=...    profile stack, one of:
+#                      gpu (default)  — gpu + attest-gpu + c8s: the published
+#                        image; GPU driver stack and GPU (SPDM) evidence.
+#                      stock-attest   — gpu + attest + c8s: same attestation-api
+#                        on :8400 (TDX+SNP quotes) but no GPU evidence. Use
+#                        when the build env lacks libnvat.
+#                      nogpu          — attest + c8s: GPU-less validation
+#                        image. Never publish: without the gpu profile nothing
+#                        latches kernel.modules_disabled=1, so module loading
+#                        stays enabled for the whole boot.
 #   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
 #                      (8250 serial re-enabled) + the dev profile
 #                      (console=ttyS0, passwordless serial autologin).
@@ -64,7 +61,7 @@
 #
 # Extra args are passed through to `confos build`, e.g.:
 #   node-guest-image/build --profile ssh          # + SSH for bring-up debugging
-#   C8S_NO_GPU=1 node-guest-image/build --profile dev
+#   C8S_VARIANT=nogpu node-guest-image/build --profile dev
 set -euo pipefail
 NGI_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 CONFOS_DIR=${CONFOS_DIR:-"$NGI_DIR/../../confidential-os-builder"}
@@ -82,16 +79,24 @@ bin/confos kernel \
     --kernel-config-fragment "$FRAGMENT" \
     --module-signing-cert "$NGI_DIR/module-signing.crt" \
     --kernel-builder-package "$KB_PKGS"
-if [ "${C8S_NO_GPU:-0}" = 1 ]; then
-    PROFILES=(--profile attest --profile c8s)
-elif [ "${C8S_STOCK_ATTEST:-0}" = 1 ]; then
-    PROFILES=(--profile gpu --profile attest --profile c8s)
-    MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
-else
-    PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
-    MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
-    bin/confos-fetch-attest-gpu
-fi
+case "${C8S_VARIANT:-gpu}" in
+    gpu)
+        PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
+        MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
+        bin/confos-fetch-attest-gpu
+        ;;
+    stock-attest)
+        PROFILES=(--profile gpu --profile attest --profile c8s)
+        MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
+        ;;
+    nogpu)
+        PROFILES=(--profile attest --profile c8s)
+        ;;
+    *)
+        echo "node-guest-image/build: unknown C8S_VARIANT='${C8S_VARIANT}' (gpu|stock-attest|nogpu)" >&2
+        exit 1
+        ;;
+esac
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \
     ${DEV_PROFILE[@]+"${DEV_PROFILE[@]}"} \

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -12,7 +12,7 @@
 # entrypoint: kernel build + GPU staging + `confos build` with the
 # gpu/attest-gpu/c8s profiles and the c8s kernel fragment). The profile also
 # builds standalone (no gpu profiles) for GPU-less validation:
-# C8S_NO_GPU=1 bin/build-c8s.
+# C8S_VARIANT=nogpu node-guest-image/build.
 #
 # Requires kernel/c8s.config (a superset of kernel/gpu.config — see its
 # header): kubelet/Cilium need the container/k8s symbols, all =y because

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -12,7 +12,7 @@
 # entrypoint: kernel build + GPU staging + `confos build` with the
 # gpu/attest-gpu/c8s profiles and the c8s kernel fragment). The profile also
 # builds standalone (no gpu profiles) for GPU-less validation:
-# C8S_VARIANT=nogpu node-guest-image/build.
+# composing `attest` + `c8s` without `gpu` via confos build directly.
 #
 # Requires kernel/c8s.config (a superset of kernel/gpu.config — see its
 # header): kubelet/Cilium need the container/k8s symbols, all =y because


### PR DESCRIPTION
Closes #264's last checklist item, by deletion rather than renaming: examination showed `C8S_NO_GPU` and `C8S_STOCK_ATTEST` have **no consumers anywhere** and obsolete rationales — `stock-attest` predates CI vendoring libnvat, and `nogpu` produces a never-publish footgun (nothing latches `kernel.modules_disabled=1`). With both gone there is exactly one stack, so no selector ships at all: the build always composes `gpu + attest-gpu + c8s`. `C8S_DEV` stays (orthogonal: dev fragment + serial console).

A genuine GPU-less product variant, if ever needed for GPU-less SNP/TDX nodes, deserves its own design (including a modules-disabled latch) — and niche compositions remain possible against `confos build` directly.

No measurement change: the (only) stack is byte-identical to before.

**Coordination**: #296 (`C8S_PLATFORM`) reshapes the same knob block — whichever merges second gets a trivial rebase, either direction.