### PR TITLE
chore(pins): C8S_REF to v0.1.0-rc2, kata CONFOS_REF to v0.4.1

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -86,7 +86,7 @@ env:
   # new pin means a new guest kernel and therefore a new SNP launch
   # measurement, and the committed kernel/config-x86_64.snapshot lockfile must
   # be refreshed in the same PR (kernel-snapshot.yml produces it).
-  CONFOS_REF: "3e6f858f93e1b85c6d1473aa4a031fdefb387710" # v0.3.0
+  CONFOS_REF: "f7d03b74c1d6a740d0dc2478ee127245da567249" # v0.4.1 — reproducible kernel (confos#85); rolls the kata kernel measurement once
 
 jobs:
   build:

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -60,8 +60,9 @@ C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SYNC_INPUTS/c8s-ref" 2>/dev/null || true)
-# Pinned published c8s commit (#177 merged; images published by docker.yml on main).
-C8S_REF="${C8S_REF:-78c034a}"
+# Pinned c8s release: bakes the same component versions the CLI ships as.
+# docker.yml publishes images under v* tags, so the tag itself is the ref.
+C8S_REF="${C8S_REF:-v0.1.0-rc2}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
 resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
     local d

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -60,8 +60,8 @@ C8S_REGISTRY="${C8S_REGISTRY:-ghcr.io/confidential-dot-ai}"
 NRI_REPO="${C8S_REGISTRY}/nri-image-policy"
 CDS_REPO="${C8S_REGISTRY}/cds"
 C8S_REF=$(cat "$SYNC_INPUTS/c8s-ref" 2>/dev/null || true)
-# Pinned published c8s commit matching the deployed CLI/node release (confidential-metal c8s_operator role, c8s#177 branch head); re-pin to main once #177 merges.
-C8S_REF="${C8S_REF:-3a2517b}"
+# Pinned published c8s commit (#177 merged; images published by docker.yml on main).
+C8S_REF="${C8S_REF:-78c034a}"
 echo "c8s sync: resolving nri-image-policy + cds at c8s ref ${C8S_REF}"
 resolve_digest() {  # <repo> <ref> -> prints sha256:... or FATALs
     local d


### PR DESCRIPTION
Two queued re-pins from #264's follow-ups:

- **`C8S_REF` → `v0.1.0-rc2`** (release tag): contains the #177-era governance work (allowlist/argv-denial/measurement-policy all in its history), and docker.yml publishes component images under `v*` tags, so the tag is directly resolvable and self-describing. Pinning the release rather than a main snapshot matches the pin's original intent — bake the component versions the deployed CLI ships as.
- **kata `CONFOS_REF` → v0.4.1** (`f7d03b7`): picks up the reproducible-kernel work. `container.config` enables no module signing, so the new builder invariant is inert for kata; **the kata kernel measurement rolls once** (seed pins), pairing with the queued reference-value re-seed.

Node-image `CONFOS_REF` is already at v0.4.1.