### PR TITLE
test(cds): shared attestation stub; assert /attest and /attest-key bind report data

### DIFF
--- a/internal/attestation/handler_test.go
+++ b/internal/attestation/handler_test.go
@@ -681,6 +681,13 @@ func TestAttestKeyBindsChallengeAndOperatorPolicyIntoReportData(t *testing.T) {
 				t.Fatalf("expected_report_data = %x (%d bytes), want the 48-byte binding %x",
 					got, len(got), want[:sha512.Size384])
 			}
+			// The caller's evidence envelope must reach the verifier intact.
+			if reqs[0].Platform != "snp" {
+				t.Fatalf("/verify platform = %q, want the submitted envelope's snp", reqs[0].Platform)
+			}
+			if got := string(reqs[0].Evidence); got != `{"quote":"abc"}` {
+				t.Fatalf(`/verify evidence = %s, want the submitted envelope's {"quote":"abc"}`, got)
+			}
 		})
 	}
 }
@@ -716,6 +723,9 @@ func TestAttestKeyRejectsReplayedChallenge(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("replayed challenge: status = %d, want 400", resp.StatusCode)
+	}
+	if got := len(stub.VerifyRequests()); got != 1 {
+		t.Fatalf("/verify calls = %d, want 1: the replay must die before the verifier round-trip", got)
 	}
 }
 

--- a/internal/attestation/handler_test.go
+++ b/internal/attestation/handler_test.go
@@ -1,17 +1,18 @@
 package attestation_test
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -22,7 +23,9 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/attestation"
 	"github.com/confidential-dot-ai/c8s/internal/ear"
 	"github.com/confidential-dot-ai/c8s/internal/earclaims"
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -36,17 +39,6 @@ func testKeyPEM() []byte {
 		panic(err)
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
-}
-
-func mockVerifyResponse(signatureValid, reportDataMatch bool) string {
-	return mustJSON(types.VerifyResponse{
-		Result: types.VerificationResult{
-			Platform:        "snp",
-			SignatureValid:  signatureValid,
-			Claims:          types.Claims{},
-			ReportDataMatch: &reportDataMatch,
-		},
-	})
 }
 
 func mustJSON(v any) string {
@@ -144,13 +136,9 @@ func TestAuthenticateRejectsGetMethod(t *testing.T) {
 
 func TestAttestKeyReturnsEARForAttestedPubkey(t *testing.T) {
 	const operatorKeysHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	mockAS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, mockVerifyResponse(true, true))
-	}))
-	defer mockAS.Close()
+	stub := testattest.New(t)
 
-	app := httptest.NewServer(testAppWithOperatorPolicy(mockAS.URL, operatorKeysHash))
+	app := httptest.NewServer(testAppWithOperatorPolicy(stub.URL, operatorKeysHash))
 	defer app.Close()
 
 	challenge := authenticate(t, app.URL)
@@ -209,13 +197,9 @@ func TestAttestKeyReturnsEARForAttestedPubkey(t *testing.T) {
 // TestAttestKeyEmbedsSubmittedEvidence: the issued EAR's ear_raw_evidence must
 // carry the evidence envelope the caller submitted, verbatim.
 func TestAttestKeyEmbedsSubmittedEvidence(t *testing.T) {
-	mockAS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, mockVerifyResponse(true, true))
-	}))
-	defer mockAS.Close()
+	stub := testattest.New(t)
 
-	app := httptest.NewServer(testApp(mockAS.URL))
+	app := httptest.NewServer(testApp(stub.URL))
 	defer app.Close()
 
 	challenge := authenticate(t, app.URL)
@@ -588,13 +572,12 @@ func attestKeyBody(t *testing.T, appURL string) string {
 }
 
 func TestAttestKeySignatureInvalid(t *testing.T) {
-	mockAS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, mockVerifyResponse(false, true))
-	}))
-	defer mockAS.Close()
+	stub := testattest.New(t)
+	verdict := testattest.PassingVerdict("")
+	verdict.SignatureValid = false
+	stub.SetVerdict(verdict)
 
-	app := httptest.NewServer(testApp(mockAS.URL))
+	app := httptest.NewServer(testApp(stub.URL))
 	defer app.Close()
 
 	resp := postAttestKey(t, app.URL, attestKeyBody(t, app.URL))
@@ -605,13 +588,13 @@ func TestAttestKeySignatureInvalid(t *testing.T) {
 }
 
 func TestAttestKeyReportDataMismatch(t *testing.T) {
-	mockAS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, mockVerifyResponse(true, false))
-	}))
-	defer mockAS.Close()
+	stub := testattest.New(t)
+	verdict := testattest.PassingVerdict("")
+	match := false
+	verdict.ReportDataMatch = &match
+	stub.SetVerdict(verdict)
 
-	app := httptest.NewServer(testApp(mockAS.URL))
+	app := httptest.NewServer(testApp(stub.URL))
 	defer app.Close()
 
 	resp := postAttestKey(t, app.URL, attestKeyBody(t, app.URL))
@@ -623,26 +606,116 @@ func TestAttestKeyReportDataMismatch(t *testing.T) {
 
 func TestAttestKeyReportDataMatchNil(t *testing.T) {
 	// ReportDataMatch omitted (nil) should be treated as a mismatch.
-	mockAS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, mustJSON(types.VerifyResponse{
-			Result: types.VerificationResult{
-				Platform:       "snp",
-				SignatureValid: true,
-				Claims:         types.Claims{},
-				// ReportDataMatch left nil
-			},
-		}))
-	}))
-	defer mockAS.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.Verdict{SignatureValid: true})
 
-	app := httptest.NewServer(testApp(mockAS.URL))
+	app := httptest.NewServer(testApp(stub.URL))
 	defer app.Close()
 
 	resp := postAttestKey(t, app.URL, attestKeyBody(t, app.URL))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+// The verify request must bind this request's public key, challenge, and
+// operator-keys hash: an EAR minted against anything weaker attests a key the
+// caller does not hold or a policy the caller did not commit to.
+func TestAttestKeyBindsChallengeAndOperatorPolicyIntoReportData(t *testing.T) {
+	const operatorKeysHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	for _, tc := range []struct {
+		name string
+		hash string
+	}{
+		{"with operator policy", operatorKeysHash},
+		{"without operator policy", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := testattest.New(t)
+			app := httptest.NewServer(testApp(stub.URL))
+			defer app.Close()
+
+			challenge := authenticate(t, app.URL)
+			key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+			if err != nil {
+				t.Fatalf("generate key: %v", err)
+			}
+			pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+			if err != nil {
+				t.Fatalf("marshal pubkey: %v", err)
+			}
+			body := mustJSON(types.AttestKeyRequestBody{
+				Challenge: challenge,
+				Evidence: types.AttestationEvidence{
+					Platform: "snp",
+					Evidence: json.RawMessage(`{"quote":"abc"}`),
+				},
+				PublicKey:        base64.StdEncoding.EncodeToString(pubDER),
+				OperatorKeysHash: tc.hash,
+			})
+
+			resp := postAttestKey(t, app.URL, body)
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				respBody, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, respBody)
+			}
+
+			reqs := stub.VerifyRequests()
+			if len(reqs) != 1 {
+				t.Fatalf("/verify called %d times, want 1", len(reqs))
+			}
+			if reqs[0].Params == nil || reqs[0].Params.ExpectedReportData == nil {
+				t.Fatal("/verify carried no expected_report_data")
+			}
+			challengeBytes, err := base64.StdEncoding.DecodeString(challenge)
+			if err != nil {
+				t.Fatalf("decode challenge: %v", err)
+			}
+			want, err := ratls.ReportDataForKeyWithContext(&key.PublicKey, challengeBytes, []byte(tc.hash))
+			if err != nil {
+				t.Fatalf("ReportDataForKeyWithContext: %v", err)
+			}
+			if got := reqs[0].Params.ExpectedReportData.Bytes(); !bytes.Equal(got, want[:sha512.Size384]) {
+				t.Fatalf("expected_report_data = %x (%d bytes), want the 48-byte binding %x",
+					got, len(got), want[:sha512.Size384])
+			}
+		})
+	}
+}
+
+// A consumed challenge must not attest twice: replaying it denies the second
+// EAR even when every other field is fresh.
+func TestAttestKeyRejectsReplayedChallenge(t *testing.T) {
+	stub := testattest.New(t)
+	app := httptest.NewServer(testApp(stub.URL))
+	defer app.Close()
+
+	challenge := authenticate(t, app.URL)
+	body := func() string {
+		pubDER, err := x509.MarshalPKIXPublicKey(generateAttestKeyPubKey(t))
+		if err != nil {
+			t.Fatalf("marshal pubkey: %v", err)
+		}
+		return mustJSON(types.AttestKeyRequestBody{
+			Challenge: challenge,
+			Evidence:  types.AttestationEvidence{Platform: "snp", Evidence: json.RawMessage(`{}`)},
+			PublicKey: base64.StdEncoding.EncodeToString(pubDER),
+		})
+	}
+
+	resp := postAttestKey(t, app.URL, body())
+	first, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("first attest-key: status = %d, want 200; body=%s", resp.StatusCode, first)
+	}
+
+	resp = postAttestKey(t, app.URL, body())
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("replayed challenge: status = %d, want 400", resp.StatusCode)
 	}
 }
 

--- a/internal/cmds/cds/attest_binding_test.go
+++ b/internal/cmds/cds/attest_binding_test.go
@@ -22,7 +22,7 @@ func (r *recordingBinder) Record(sandboxID, inventoryHost string) bool {
 // requester names.
 func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	csrPEM, _ := generateCSR(t)
@@ -47,7 +47,7 @@ func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
 // whole certificate lifetime. The refusal lands on the secrets path instead.
 func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.SandboxBindings = &recordingBinder{refuse: true}
 	csrPEM, _ := generateCSR(t)
 
@@ -61,7 +61,7 @@ func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
 // bind, and issuance is unchanged.
 func TestAttest_NoTokenBindsNothing(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL)
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	csrPEM, _ := generateCSR(t)
@@ -78,7 +78,7 @@ func TestAttest_NoTokenBindsNothing(t *testing.T) {
 // a requester that never obtains a certificate could still claim a sandbox ID.
 func TestAttest_FailedIssuanceBindsNothing(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	// Pin a measurement the stub does not report, so the request fails after

--- a/internal/cmds/cds/attest_binding_test.go
+++ b/internal/cmds/cds/attest_binding_test.go
@@ -21,14 +21,14 @@ func (r *recordingBinder) Record(sandboxID, inventoryHost string) bool {
 // so the secrets path later asks that same inventory rather than one a
 // requester names.
 func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge)); w.Code != http.StatusOK {
+	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID)); w.Code != http.StatusOK {
 		t.Fatalf("status %d, body=%s", w.Code, w.Body.String())
 	}
 	if len(binder.calls) != 1 {
@@ -46,13 +46,13 @@ func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
 // token-less retry, so denying here would let one pre-claim wedge a pod for a
 // whole certificate lifetime. The refusal lands on the secrets path instead.
 func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.SandboxBindings = &recordingBinder{refuse: true}
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge)); w.Code != http.StatusOK {
+	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID)); w.Code != http.StatusOK {
 		t.Fatalf("a refused binding blocked issuance: status %d, body=%s", w.Code, w.Body.String())
 	}
 }
@@ -60,7 +60,7 @@ func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
 // A request carrying no sandbox token gets no binding — there is no sandbox to
 // bind, and issuance is unchanged.
 func TestAttest_NoTokenBindsNothing(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
@@ -77,7 +77,7 @@ func TestAttest_NoTokenBindsNothing(t *testing.T) {
 // A request that fails a later gate must not leave a binding behind: otherwise
 // a requester that never obtains a certificate could still claim a sandbox ID.
 func TestAttest_FailedIssuanceBindsNothing(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
@@ -87,7 +87,7 @@ func TestAttest_FailedIssuanceBindsNothing(t *testing.T) {
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge)); w.Code == http.StatusOK {
+	if w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID)); w.Code == http.StatusOK {
 		t.Fatal("expected the measurement gate to refuse issuance")
 	}
 	if len(binder.calls) != 0 {

--- a/internal/cmds/cds/attest_binding_test.go
+++ b/internal/cmds/cds/attest_binding_test.go
@@ -21,8 +21,8 @@ func (r *recordingBinder) Record(sandboxID, inventoryHost string) bool {
 // so the secrets path later asks that same inventory rather than one a
 // requester names.
 func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	csrPEM, _ := generateCSR(t)
@@ -46,8 +46,8 @@ func TestAttest_BindsSandboxToInventoryOnSuccess(t *testing.T) {
 // token-less retry, so denying here would let one pre-claim wedge a pod for a
 // whole certificate lifetime. The refusal lands on the secrets path instead.
 func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.SandboxBindings = &recordingBinder{refuse: true}
 	csrPEM, _ := generateCSR(t)
 
@@ -60,8 +60,8 @@ func TestAttest_ConflictingBindingStillIssues(t *testing.T) {
 // A request carrying no sandbox token gets no binding — there is no sandbox to
 // bind, and issuance is unchanged.
 func TestAttest_NoTokenBindsNothing(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
 	csrPEM, _ := generateCSR(t)
@@ -77,11 +77,11 @@ func TestAttest_NoTokenBindsNothing(t *testing.T) {
 // A request that fails a later gate must not leave a binding behind: otherwise
 // a requester that never obtains a certificate could still claim a sandbox ID.
 func TestAttest_FailedIssuanceBindsNothing(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	binder := &recordingBinder{}
 	h.SandboxBindings = binder
-	// Pin a measurement the mock does not report, so the request fails after
+	// Pin a measurement the stub does not report, so the request fails after
 	// the sandbox token has been verified.
 	h.Measurements = map[string]bool{"00": true}
 	csrPEM, _ := generateCSR(t)

--- a/internal/cmds/cds/attest_matchedworkload_test.go
+++ b/internal/cmds/cds/attest_matchedworkload_test.go
@@ -50,7 +50,7 @@ func issueWithInventory(t *testing.T, store policyStore, digests []string, conta
 
 func leafFromInventory(t *testing.T, store policyStore, digests []string, containers []workloadclaims.SandboxContainer, tune func(*AttestHandler)) *x509.Certificate {
 	t.Helper()
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{
@@ -63,7 +63,7 @@ func leafFromInventory(t *testing.T, store policyStore, digests []string, contai
 	}
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}

--- a/internal/cmds/cds/attest_matchedworkload_test.go
+++ b/internal/cmds/cds/attest_matchedworkload_test.go
@@ -50,8 +50,8 @@ func issueWithInventory(t *testing.T, store policyStore, digests []string, conta
 
 func leafFromInventory(t *testing.T, store policyStore, digests []string, containers []workloadclaims.SandboxContainer, tune func(*AttestHandler)) *x509.Certificate {
 	t.Helper()
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{
 		digests:    map[string][]string{testSandboxID: digests},

--- a/internal/cmds/cds/attest_matchedworkload_test.go
+++ b/internal/cmds/cds/attest_matchedworkload_test.go
@@ -51,7 +51,7 @@ func issueWithInventory(t *testing.T, store policyStore, digests []string, conta
 func leafFromInventory(t *testing.T, store policyStore, digests []string, containers []workloadclaims.SandboxContainer, tune func(*AttestHandler)) *x509.Certificate {
 	t.Helper()
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{
 		digests:    map[string][]string{testSandboxID: digests},

--- a/internal/cmds/cds/attest_sandbox_test.go
+++ b/internal/cmds/cds/attest_sandbox_test.go
@@ -59,17 +59,12 @@ func (f fakeDigests) FetchSandbox(_ context.Context, host, sandboxID string) (wo
 	}, nil
 }
 
-// newSandboxTestEnv wires an AttestHandler that can validate inventory EARs, and
-// an inventory signer whose EARs that handler accepts: the signer's EAR source
 // newSandboxTestEnv wires an AttestHandler that resolves an inventory key the
-// way production does — from the inventory's own endpoint — and the signer
-// holding that key. launchDigest is unused now that the key's provenance is the
-// privileged-port callback rather than an EAR, but is kept in the signature so
-// the call sites read the same.
-func newSandboxTestEnv(t *testing.T, mockURL, launchDigest string) (AttestHandler, *workloadclaims.SandboxTokenSigner) {
+// way production does — from the inventory's own endpoint — and returns the
+// signer holding that key.
+func newSandboxTestEnv(t *testing.T, stubURL string) (AttestHandler, *workloadclaims.SandboxTokenSigner) {
 	t.Helper()
-	_ = launchDigest
-	h := newTestAttestHandler(t, mockURL, nil)
+	h := newTestAttestHandler(t, stubURL, nil)
 
 	signer, err := workloadclaims.NewSandboxTokenSigner(testInventoryHost)
 	if err != nil {
@@ -139,7 +134,7 @@ func postAttestSandbox(t *testing.T, h AttestHandler, challenge, csrPEM string, 
 // A valid inventory token gets its sandbox ID stamped into the signed leaf.
 func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
@@ -159,7 +154,7 @@ func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
 // No token ⇒ no extension (the pre-sandbox flow is unchanged).
 func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL)
 	csrPEM, _ := generateCSR(t)
 
 	w := postAttest(t, h, issueChallenge(t, h), csrPEM)
@@ -175,7 +170,7 @@ func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
 // get-cert holding the bound key may redeem the token.
 func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	victimCSR, _ := generateCSR(t)
 	attackerCSR, _ := generateCSR(t)
 
@@ -191,9 +186,9 @@ func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
 // rejected: provenance from a CDS-attested inventory key is the whole point.
 func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL)
 	// A second env with its own EAR issuer the handler does not trust.
-	_, foreignSigner := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	_, foreignSigner := newSandboxTestEnv(t, stub.URL)
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
@@ -210,7 +205,7 @@ func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
 // privileged-port endpoint, so the impostor's own key never matches.
 func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL)
 
 	// An attacker signs its own token for someone else's sandbox.
 	impostor, err := workloadclaims.NewSandboxTokenSigner(testInventoryHost)
@@ -230,7 +225,7 @@ func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
 // callback at its own pod IP and answering as its node's inventory.
 func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	hosts, err := workloadclaims.ParseInventoryHosts([]string{"192.168.99.0/24"}) // not testInventoryHost
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +244,7 @@ func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
 // outright rather than dialing wherever it is pointed.
 func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.InventoryHosts = nil
 
 	csrPEM, _ := generateCSR(t)
@@ -265,7 +260,7 @@ func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
 // pre-signed token cannot be replayed against a fresh challenge.
 func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	csrPEM, _ := generateCSR(t)
 
 	// Token is bound to a different challenge than the request carries.
@@ -280,7 +275,7 @@ func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
 // request that carries one rather than stamp it unverified.
 func TestAttest_SandboxToken_RejectsWhenUnverifiable(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.SandboxDigests = nil
 	csrPEM, _ := generateCSR(t)
 
@@ -304,7 +299,7 @@ func TestAttest_SandboxToken_RejectsMalformedEnvelope(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := newStubAttestationApi(t, "deadbeef")
-			h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+			h, _ := newSandboxTestEnv(t, stub.URL)
 			csrPEM, _ := generateCSR(t)
 			w := postAttestSandbox(t, h, issueChallenge(t, h), csrPEM, tc.token)
 			if w.Code != http.StatusForbidden {
@@ -332,7 +327,7 @@ func TestAttest_SandboxToken_RejectsMalformedSandboxID(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL)
 			// The inventory answers for the malformed ID, so the ID check is
 			// the only thing between this token and issuance.
 			h.SandboxDigests = fakeDigests{

--- a/internal/cmds/cds/attest_sandbox_test.go
+++ b/internal/cmds/cds/attest_sandbox_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/confidential-dot-ai/c8s/internal/attestation"
@@ -90,10 +91,10 @@ func newSandboxTestEnv(t *testing.T, mockURL, launchDigest string) (AttestHandle
 	return h, signer
 }
 
-// signedSandboxToken issues an inventory token for the CSR key behind csrPEM,
-// bound to the same base64 challenge the request will carry (CDS re-checks the
-// token nonce against the challenge it consumes).
-func signedSandboxToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner, csrPEM, challenge string) json.RawMessage {
+// signedSandboxToken issues an inventory token for sandboxID and the CSR key
+// behind csrPEM, bound to the same base64 challenge the request will carry
+// (CDS re-checks the token nonce against the challenge it consumes).
+func signedSandboxToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner, csrPEM, challenge, sandboxID string) json.RawMessage {
 	t.Helper()
 	csr, err := attestation.ParseAndVerifyCSR(csrPEM)
 	if err != nil {
@@ -107,7 +108,7 @@ func signedSandboxToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner,
 	if err != nil {
 		t.Fatal(err)
 	}
-	token, err := signer.Sign(testSandboxID, keyDigest, nonce)
+	token, err := signer.Sign(sandboxID, keyDigest, nonce)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -137,12 +138,12 @@ func postAttestSandbox(t *testing.T, h AttestHandler, challenge, csrPEM string, 
 
 // A valid inventory token gets its sandbox ID stamped into the signed leaf.
 func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status %d, body=%s", w.Code, w.Body.String())
 	}
@@ -157,7 +158,7 @@ func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
 
 // No token ⇒ no extension (the pre-sandbox flow is unchanged).
 func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
@@ -173,14 +174,14 @@ func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
 // A token bound to a different key than the CSR's must be rejected: only the
 // get-cert holding the bound key may redeem the token.
 func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	victimCSR, _ := generateCSR(t)
 	attackerCSR, _ := generateCSR(t)
 
 	// Token issued for the victim's key, replayed with the attacker's CSR.
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, attackerCSR, signedSandboxToken(t, signer, victimCSR, challenge))
+	w := postAttestSandbox(t, h, challenge, attackerCSR, signedSandboxToken(t, signer, victimCSR, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -189,14 +190,14 @@ func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
 // A token whose EAR the CDS cannot validate (unknown signer) must be
 // rejected: provenance from a CDS-attested inventory key is the whole point.
 func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	// A second env with its own EAR issuer the handler does not trust.
 	_, foreignSigner := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, foreignSigner, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, foreignSigner, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -208,7 +209,7 @@ func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
 // another pod's sandbox. CDS resolves the key from the inventory's own
 // privileged-port endpoint, so the impostor's own key never matches.
 func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 
 	// An attacker signs its own token for someone else's sandbox.
@@ -218,7 +219,7 @@ func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
 	}
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, impostor, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, impostor, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -228,7 +229,7 @@ func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
 // anything is dialed — that boundary is what stops a workload pointing the
 // callback at its own pod IP and answering as its node's inventory.
 func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	hosts, err := workloadclaims.ParseInventoryHosts([]string{"192.168.99.0/24"}) // not testInventoryHost
 	if err != nil {
@@ -238,7 +239,7 @@ func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -247,13 +248,13 @@ func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
 // With no CIDRs configured CDS has no boundary to apply, so it refuses tokens
 // outright rather than dialing wherever it is pointed.
 func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.InventoryHosts = nil
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -263,13 +264,13 @@ func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
 // challenge — not the one this request consumes — is rejected, so a captured or
 // pre-signed token cannot be replayed against a fresh challenge.
 func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	// Token is bound to a different challenge than the request carries.
 	staleChallenge := base64.StdEncoding.EncodeToString([]byte("a-different-challenge"))
-	w := postAttestSandbox(t, h, issueChallenge(t, h), csrPEM, signedSandboxToken(t, signer, csrPEM, staleChallenge))
+	w := postAttestSandbox(t, h, issueChallenge(t, h), csrPEM, signedSandboxToken(t, signer, csrPEM, staleChallenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -278,13 +279,13 @@ func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
 // A CDS with no EAR key provider cannot verify tokens and must reject a
 // request that carries one rather than stamp it unverified.
 func TestAttest_SandboxToken_RejectsWhenUnverifiable(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.SandboxDigests = nil
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status %d, want 403; body=%s", w.Code, w.Body.String())
 	}
@@ -302,12 +303,56 @@ func TestAttest_SandboxToken_RejectsMalformedEnvelope(t *testing.T) {
 		{"token bytes are not DER", json.RawMessage(`{"token":"bm90LWRlcg==","signature":"AA=="}`)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newMockAttestationApi(t, "deadbeef")
+			mock := newStubAttestationApi(t, "deadbeef")
 			h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 			csrPEM, _ := generateCSR(t)
 			w := postAttestSandbox(t, h, issueChallenge(t, h), csrPEM, tc.token)
 			if w.Code != http.StatusForbidden {
 				t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+// A token carrying an ID ValidateSandboxID rejects is refused at token
+// verification — before the evidence round-trip and before any ledger write —
+// so a garbage ID can never be bound to an inventory or stamped on a leaf.
+// (A non-IA5 ID like "sandbox-🙂" is unrepresentable: the token's IA5String
+// marshal refuses it. ValidateSandboxID's own test pins that case.)
+func TestAttest_SandboxToken_RejectsMalformedSandboxID(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"path traversal", "../../etc"},
+		{"embedded slash", "a/b"},
+		{"embedded space", "sandbox id"},
+		{"over 128 chars", strings.Repeat("a", 129)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := newStubAttestationApi(t, "deadbeef")
+			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+			// The inventory answers for the malformed ID, so the ID check is
+			// the only thing between this token and issuance.
+			h.SandboxDigests = fakeDigests{
+				digests: map[string][]string{tc.id: {wlDigestA}},
+				key:     signer.PublicKey(),
+			}
+			binder := &recordingBinder{}
+			h.SandboxBindings = binder
+			csrPEM, _ := generateCSR(t)
+
+			challenge := issueChallenge(t, h)
+			w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, tc.id))
+			if w.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
+			}
+			if len(binder.calls) != 0 {
+				t.Fatalf("Record called %d times for a rejected sandbox ID, want 0", len(binder.calls))
+			}
+			if got := len(mock.VerifyRequests()); got != 0 {
+				t.Fatalf("/verify called %d times for a rejected sandbox ID, want 0", got)
 			}
 		})
 	}

--- a/internal/cmds/cds/attest_sandbox_test.go
+++ b/internal/cmds/cds/attest_sandbox_test.go
@@ -138,8 +138,8 @@ func postAttestSandbox(t *testing.T, h AttestHandler, challenge, csrPEM string, 
 
 // A valid inventory token gets its sandbox ID stamped into the signed leaf.
 func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
@@ -158,8 +158,8 @@ func TestAttest_SandboxToken_StampedOnLeaf(t *testing.T) {
 
 // No token ⇒ no extension (the pre-sandbox flow is unchanged).
 func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	w := postAttest(t, h, issueChallenge(t, h), csrPEM)
@@ -174,8 +174,8 @@ func TestAttest_SandboxToken_AbsentWhenNotRequested(t *testing.T) {
 // A token bound to a different key than the CSR's must be rejected: only the
 // get-cert holding the bound key may redeem the token.
 func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	victimCSR, _ := generateCSR(t)
 	attackerCSR, _ := generateCSR(t)
 
@@ -190,10 +190,10 @@ func TestAttest_SandboxToken_RejectsWrongRequesterKey(t *testing.T) {
 // A token whose EAR the CDS cannot validate (unknown signer) must be
 // rejected: provenance from a CDS-attested inventory key is the whole point.
 func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	// A second env with its own EAR issuer the handler does not trust.
-	_, foreignSigner := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	_, foreignSigner := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	challenge := issueChallenge(t, h)
@@ -209,8 +209,8 @@ func TestAttest_SandboxToken_RejectsForeignInventoryEAR(t *testing.T) {
 // another pod's sandbox. CDS resolves the key from the inventory's own
 // privileged-port endpoint, so the impostor's own key never matches.
 func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 
 	// An attacker signs its own token for someone else's sandbox.
 	impostor, err := workloadclaims.NewSandboxTokenSigner(testInventoryHost)
@@ -229,8 +229,8 @@ func TestAttest_SandboxToken_RejectsKeyTheInventoryDoesNotHold(t *testing.T) {
 // anything is dialed — that boundary is what stops a workload pointing the
 // callback at its own pod IP and answering as its node's inventory.
 func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	hosts, err := workloadclaims.ParseInventoryHosts([]string{"192.168.99.0/24"}) // not testInventoryHost
 	if err != nil {
 		t.Fatal(err)
@@ -248,8 +248,8 @@ func TestAttest_SandboxToken_RejectsHostOutsideNodeCIDRs(t *testing.T) {
 // With no CIDRs configured CDS has no boundary to apply, so it refuses tokens
 // outright rather than dialing wherever it is pointed.
 func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.InventoryHosts = nil
 
 	csrPEM, _ := generateCSR(t)
@@ -264,8 +264,8 @@ func TestAttest_SandboxToken_RejectsWithoutConfiguredCIDRs(t *testing.T) {
 // challenge — not the one this request consumes — is rejected, so a captured or
 // pre-signed token cannot be replayed against a fresh challenge.
 func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	csrPEM, _ := generateCSR(t)
 
 	// Token is bound to a different challenge than the request carries.
@@ -279,8 +279,8 @@ func TestAttest_SandboxToken_RejectsStaleNonce(t *testing.T) {
 // A CDS with no EAR key provider cannot verify tokens and must reject a
 // request that carries one rather than stamp it unverified.
 func TestAttest_SandboxToken_RejectsWhenUnverifiable(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.SandboxDigests = nil
 	csrPEM, _ := generateCSR(t)
 
@@ -303,8 +303,8 @@ func TestAttest_SandboxToken_RejectsMalformedEnvelope(t *testing.T) {
 		{"token bytes are not DER", json.RawMessage(`{"token":"bm90LWRlcg==","signature":"AA=="}`)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newStubAttestationApi(t, "deadbeef")
-			h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+			stub := newStubAttestationApi(t, "deadbeef")
+			h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 			csrPEM, _ := generateCSR(t)
 			w := postAttestSandbox(t, h, issueChallenge(t, h), csrPEM, tc.token)
 			if w.Code != http.StatusForbidden {
@@ -331,8 +331,8 @@ func TestAttest_SandboxToken_RejectsMalformedSandboxID(t *testing.T) {
 		{"over 128 chars", strings.Repeat("a", 129)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+			stub := newStubAttestationApi(t, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 			// The inventory answers for the malformed ID, so the ID check is
 			// the only thing between this token and issuance.
 			h.SandboxDigests = fakeDigests{
@@ -351,7 +351,7 @@ func TestAttest_SandboxToken_RejectsMalformedSandboxID(t *testing.T) {
 			if len(binder.calls) != 0 {
 				t.Fatalf("Record called %d times for a rejected sandbox ID, want 0", len(binder.calls))
 			}
-			if got := len(mock.VerifyRequests()); got != 0 {
+			if got := len(stub.VerifyRequests()); got != 0 {
 				t.Fatalf("/verify called %d times for a rejected sandbox ID, want 0", got)
 			}
 		})

--- a/internal/cmds/cds/attest_sandboxworkload_test.go
+++ b/internal/cmds/cds/attest_sandboxworkload_test.go
@@ -82,8 +82,8 @@ func workloadEntry(t *testing.T, initDigests, mainDigests []string) pkgallowlist
 // requester sent no image list: everything checked here came from the inventory
 // the token named.
 func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA, wlDigestB)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -99,8 +99,8 @@ func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
 // issuance — the gate now runs on every token-bearing request, including the
 // first one, where a self-reported claim used to be empty.
 func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -115,8 +115,8 @@ func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
 // An inventory that does not know the sandbox is fail-closed: CDS cannot
 // establish what the pod runs, which is exactly when it must not issue.
 func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}, key: signer.PublicKey()} // knows no sandbox
 
@@ -134,8 +134,8 @@ func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
 // reaches this state legitimately while it is still syncing, so issuance must
 // wait rather than proceed unchecked.
 func TestAttest_SandboxWorkload_EmptySandboxFailsClosed(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {}}, key: signer.PublicKey()}
 
@@ -158,8 +158,8 @@ func TestAttest_SandboxWorkload_RejectsWhenGateUnwired(t *testing.T) {
 		{"no digests client", func(h *AttestHandler) { h.SandboxDigests = nil }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+			stub := newStubAttestationApi(t, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 			tc.wire(&h)
 
 			csrPEM, _ := generateCSR(t)
@@ -196,8 +196,8 @@ func TestAttest_SandboxWorkload_PartialLifecycleStatesIssue(t *testing.T) {
 		{"a container transiently evicted while restarting", []string{wlDigestA}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+			stub := newStubAttestationApi(t, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 			h.AllowlistStore = store
 			h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: tc.running}, key: signer.PublicKey()}
 
@@ -218,8 +218,8 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 		floor:     map[string]bool{wlDigestC: true},
 		workloads: map[string]pkgallowlist.Workload{"api": workloadEntry(t, []string{wlDigestA}, nil)},
 	}
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestC, wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -234,8 +234,8 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 // A request with no sandbox token is issued without a sandbox ID and without
 // the workload gate: it gets a leaf no workload authorizer will accept.
 func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.AllowlistStore = floorStore() // admits nothing
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}}
 
@@ -252,8 +252,8 @@ func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
 // what an empty allowlist already means for /attest itself. Losing the whole
 // flow here would break issuance for every workload on an unpinned cluster.
 func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.Measurements = nil // dev: --measurements empty
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA}}, key: signer.PublicKey()}
@@ -277,8 +277,8 @@ func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
 // The allowlist gate still bites on an unpinned cluster: dropping the
 // measurement pin must not also drop the image check.
 func TestAttest_SandboxWorkload_UnpinnedStillEnforcesAllowlist(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
+	stub := newStubAttestationApi(t, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
 	h.Measurements = nil
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}

--- a/internal/cmds/cds/attest_sandboxworkload_test.go
+++ b/internal/cmds/cds/attest_sandboxworkload_test.go
@@ -82,14 +82,14 @@ func workloadEntry(t *testing.T, initDigests, mainDigests []string) pkgallowlist
 // requester sent no image list: everything checked here came from the inventory
 // the token named.
 func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA, wlDigestB)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -99,14 +99,14 @@ func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
 // issuance — the gate now runs on every token-bearing request, including the
 // first one, where a self-reported claim used to be empty.
 func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 	}
@@ -115,14 +115,14 @@ func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
 // An inventory that does not know the sandbox is fail-closed: CDS cannot
 // establish what the pod runs, which is exactly when it must not issue.
 func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}, key: signer.PublicKey()} // knows no sandbox
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 	}
@@ -134,14 +134,14 @@ func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
 // reaches this state legitimately while it is still syncing, so issuance must
 // wait rather than proceed unchecked.
 func TestAttest_SandboxWorkload_EmptySandboxFailsClosed(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {}}, key: signer.PublicKey()}
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 	}
@@ -158,13 +158,13 @@ func TestAttest_SandboxWorkload_RejectsWhenGateUnwired(t *testing.T) {
 		{"no digests client", func(h *AttestHandler) { h.SandboxDigests = nil }},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newMockAttestationApi(t, "deadbeef")
+			mock := newStubAttestationApi(t, "deadbeef")
 			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 			tc.wire(&h)
 
 			csrPEM, _ := generateCSR(t)
 			challenge := issueChallenge(t, h)
-			w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+			w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 			if w.Code != http.StatusForbidden {
 				t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 			}
@@ -196,14 +196,14 @@ func TestAttest_SandboxWorkload_PartialLifecycleStatesIssue(t *testing.T) {
 		{"a container transiently evicted while restarting", []string{wlDigestA}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			mock := newMockAttestationApi(t, "deadbeef")
+			mock := newStubAttestationApi(t, "deadbeef")
 			h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 			h.AllowlistStore = store
 			h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: tc.running}, key: signer.PublicKey()}
 
 			csrPEM, _ := generateCSR(t)
 			challenge := issueChallenge(t, h)
-			w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+			w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 			if w.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
 			}
@@ -218,14 +218,14 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 		floor:     map[string]bool{wlDigestC: true},
 		workloads: map[string]pkgallowlist.Workload{"api": workloadEntry(t, []string{wlDigestA}, nil)},
 	}
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestC, wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 	}
@@ -234,7 +234,7 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 // A request with no sandbox token is issued without a sandbox ID and without
 // the workload gate: it gets a leaf no workload authorizer will accept.
 func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, _ := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.AllowlistStore = floorStore() // admits nothing
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}}
@@ -252,7 +252,7 @@ func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
 // what an empty allowlist already means for /attest itself. Losing the whole
 // flow here would break issuance for every workload on an unpinned cluster.
 func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.Measurements = nil // dev: --measurements empty
 	h.AllowlistStore = floorStore(wlDigestA)
@@ -260,7 +260,7 @@ func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
 	}
@@ -277,7 +277,7 @@ func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
 // The allowlist gate still bites on an unpinned cluster: dropping the
 // measurement pin must not also drop the image check.
 func TestAttest_SandboxWorkload_UnpinnedStillEnforcesAllowlist(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h, signer := newSandboxTestEnv(t, mock.URL, "deadbeef")
 	h.Measurements = nil
 	h.AllowlistStore = floorStore(wlDigestA)
@@ -285,7 +285,7 @@ func TestAttest_SandboxWorkload_UnpinnedStillEnforcesAllowlist(t *testing.T) {
 
 	csrPEM, _ := generateCSR(t)
 	challenge := issueChallenge(t, h)
-	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge))
+	w := postAttestSandbox(t, h, challenge, csrPEM, signedSandboxToken(t, signer, csrPEM, challenge, testSandboxID))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("status = %d, want 403; body = %s", w.Code, w.Body.String())
 	}

--- a/internal/cmds/cds/attest_sandboxworkload_test.go
+++ b/internal/cmds/cds/attest_sandboxworkload_test.go
@@ -83,7 +83,7 @@ func workloadEntry(t *testing.T, initDigests, mainDigests []string) pkgallowlist
 // the token named.
 func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = floorStore(wlDigestA, wlDigestB)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -100,7 +100,7 @@ func TestAttest_SandboxWorkload_AllowsFloorOnlySandbox(t *testing.T) {
 // first one, where a self-reported claim used to be empty.
 func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -116,7 +116,7 @@ func TestAttest_SandboxWorkload_RejectsUnallowlistedImage(t *testing.T) {
 // establish what the pod runs, which is exactly when it must not issue.
 func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}, key: signer.PublicKey()} // knows no sandbox
 
@@ -135,7 +135,7 @@ func TestAttest_SandboxWorkload_UnreachableInventoryFailsClosed(t *testing.T) {
 // wait rather than proceed unchecked.
 func TestAttest_SandboxWorkload_EmptySandboxFailsClosed(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {}}, key: signer.PublicKey()}
 
@@ -159,7 +159,7 @@ func TestAttest_SandboxWorkload_RejectsWhenGateUnwired(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL)
 			tc.wire(&h)
 
 			csrPEM, _ := generateCSR(t)
@@ -197,7 +197,7 @@ func TestAttest_SandboxWorkload_PartialLifecycleStatesIssue(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stub := newStubAttestationApi(t, "deadbeef")
-			h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+			h, signer := newSandboxTestEnv(t, stub.URL)
 			h.AllowlistStore = store
 			h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: tc.running}, key: signer.PublicKey()}
 
@@ -219,7 +219,7 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 		workloads: map[string]pkgallowlist.Workload{"api": workloadEntry(t, []string{wlDigestA}, nil)},
 	}
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = store
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestC, wlDigestA, wlDigestB}}, key: signer.PublicKey()}
 
@@ -235,7 +235,7 @@ func TestAttest_SandboxWorkload_MembershipStillBitesMidLifecycle(t *testing.T) {
 // the workload gate: it gets a leaf no workload authorizer will accept.
 func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, _ := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, _ := newSandboxTestEnv(t, stub.URL)
 	h.AllowlistStore = floorStore() // admits nothing
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{}}
 
@@ -253,7 +253,7 @@ func TestAttest_SandboxWorkload_NoTokenSkipsGate(t *testing.T) {
 // flow here would break issuance for every workload on an unpinned cluster.
 func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.Measurements = nil // dev: --measurements empty
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA}}, key: signer.PublicKey()}
@@ -278,7 +278,7 @@ func TestAttest_SandboxWorkload_UnpinnedMeasurementsStillIssue(t *testing.T) {
 // measurement pin must not also drop the image check.
 func TestAttest_SandboxWorkload_UnpinnedStillEnforcesAllowlist(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
-	h, signer := newSandboxTestEnv(t, stub.URL, "deadbeef")
+	h, signer := newSandboxTestEnv(t, stub.URL)
 	h.Measurements = nil
 	h.AllowlistStore = floorStore(wlDigestA)
 	h.SandboxDigests = fakeDigests{digests: map[string][]string{testSandboxID: {wlDigestA, wlDigestB}}, key: signer.PublicKey()}

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -66,7 +66,7 @@ func generateCSRWith(t *testing.T, subject pkix.Name, dnsNames []string, ips []n
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})), key
 }
 
-func newTestAttestHandler(t *testing.T, mockURL string, allowedMeasurements map[string]bool) AttestHandler {
+func newTestAttestHandler(t *testing.T, stubURL string, allowedMeasurements map[string]bool) AttestHandler {
 	t.Helper()
 	ca, err := issuer.NewCA("test ca", 2*issuer.MaxLeafTTL)
 	if err != nil {
@@ -75,7 +75,7 @@ func newTestAttestHandler(t *testing.T, mockURL string, allowedMeasurements map[
 	store := attestation.NewChallengeStore(30 * time.Second)
 	return AttestHandler{
 		Challenges:        &store,
-		AttestationClient: attestationclient.NewClient(mockURL),
+		AttestationClient: attestationclient.NewClient(stubURL),
 		CA:                ca,
 		CAChainPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		CertTTL:           time.Hour,
@@ -316,6 +316,13 @@ func TestAttest_BindsReportDataToCSRKeyAndChallenge(t *testing.T) {
 	if got := reqs[0].Params.ExpectedReportData.Bytes(); !bytes.Equal(got, want[:sha512.Size384]) {
 		t.Fatalf("expected_report_data = %x (%d bytes), want SHA-384(key||challenge) %x",
 			got, len(got), want[:sha512.Size384])
+	}
+	// The caller's evidence envelope must reach the verifier intact.
+	if reqs[0].Platform != "snp" {
+		t.Fatalf("/verify platform = %q, want the submitted envelope's snp", reqs[0].Platform)
+	}
+	if got := string(reqs[0].Evidence); got != `{"test":true}` {
+		t.Fatalf(`/verify evidence = %s, want the submitted envelope's {"test":true}`, got)
 	}
 }
 

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -118,8 +118,8 @@ func leafFromAttestResponse(t *testing.T, w *httptest.ResponseRecorder) *x509.Ce
 }
 
 func TestAttest_InProcessSignAndReturnsChain(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -151,8 +151,8 @@ func TestAttest_InProcessSignAndReturnsChain(t *testing.T) {
 }
 
 func TestAttest_ClampsCertTTLBeforeSigning(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	base := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "deadbeef")
+	base := newTestAttestHandler(t, stub.URL, nil)
 	for _, tc := range []struct {
 		name       string
 		configured time.Duration
@@ -183,8 +183,8 @@ func TestAttest_ClampsCertTTLBeforeSigning(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistAllowed(t *testing.T) {
-	mock := newStubAttestationApi(t, "approved-digest")
-	h := newTestAttestHandler(t, mock.URL, map[string]bool{"approved-digest": true})
+	stub := newStubAttestationApi(t, "approved-digest")
+	h := newTestAttestHandler(t, stub.URL, map[string]bool{"approved-digest": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -195,8 +195,8 @@ func TestAttest_LaunchDigestAllowlistAllowed(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistCaseInsensitive(t *testing.T) {
-	mock := newStubAttestationApi(t, "DEADBEEF")
-	h := newTestAttestHandler(t, mock.URL, map[string]bool{"deadbeef": true})
+	stub := newStubAttestationApi(t, "DEADBEEF")
+	h := newTestAttestHandler(t, stub.URL, map[string]bool{"deadbeef": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -207,8 +207,8 @@ func TestAttest_LaunchDigestAllowlistCaseInsensitive(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistDenied(t *testing.T) {
-	mock := newStubAttestationApi(t, "unknown-digest")
-	h := newTestAttestHandler(t, mock.URL, map[string]bool{"approved-digest": true})
+	stub := newStubAttestationApi(t, "unknown-digest")
+	h := newTestAttestHandler(t, stub.URL, map[string]bool{"approved-digest": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -271,8 +271,8 @@ func TestAttest_TimeoutBeforeSigningReturns504(t *testing.T) {
 }
 
 func TestAttest_ConsumedChallengeRejectsReplay(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -341,8 +341,8 @@ func TestAttest_ReportDataMismatchReturns401(t *testing.T) {
 }
 
 func TestAttest_BadCSRRejected(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 
 	w := postAttest(t, h, challenge, "not a pem")
@@ -352,8 +352,8 @@ func TestAttest_BadCSRRejected(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithUnconfiguredDNSSAN(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "node"}, []string{"foo.mesh.svc"}, nil)
 
@@ -367,8 +367,8 @@ func TestAttest_RejectsCSRWithUnconfiguredDNSSAN(t *testing.T) {
 }
 
 func TestAttest_AcceptsCSRWithAllowedDNSSAN(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	h.Policy.DNSSANPatterns = []*regexp.Regexp{regexp.MustCompile(`^[a-z]+\.mesh\.svc$`)}
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "node"}, []string{"foo.mesh.svc"}, nil)
@@ -380,8 +380,8 @@ func TestAttest_AcceptsCSRWithAllowedDNSSAN(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithBadCN(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	h.Policy.AllowedCNPattern = regexp.MustCompile(`^ratls-mesh-[0-9.]+$`)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "evil"}, nil, nil)
@@ -393,8 +393,8 @@ func TestAttest_RejectsCSRWithBadCN(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithMismatchedSourceIP(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	h.SANValidation = true
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "node"}, nil, []net.IP{net.ParseIP("10.0.0.99")})
@@ -416,8 +416,8 @@ func TestAttest_RejectsCSRWithMismatchedSourceIP(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithIPSANWhenSANValidationDisabled(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	// SANValidation defaults to false, leaving Policy.SourceIP empty.
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "node"}, nil, []net.IP{net.ParseIP("10.0.0.99")})
@@ -585,8 +585,8 @@ func TestAttestHandler_caChainPEM(t *testing.T) {
 }
 
 func TestAttest_RejectsUnknownJSONFields(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/attest", bytes.NewReader([]byte(`{"unknown":true}`)))
 	w := httptest.NewRecorder()
@@ -597,8 +597,8 @@ func TestAttest_RejectsUnknownJSONFields(t *testing.T) {
 }
 
 func TestAttest_RejectsMalformedChallengeEncoding(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	csrPEM, _ := generateCSR(t)
 
 	body, err := json.Marshal(types.AttestRequestBody{
@@ -618,8 +618,8 @@ func TestAttest_RejectsMalformedChallengeEncoding(t *testing.T) {
 }
 
 func TestAttest_RejectsValidBase64UnknownChallenge(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	csrPEM, _ := generateCSR(t)
 
 	// Valid base64 but never issued, so Consume returns false.
@@ -641,8 +641,8 @@ func TestAttest_RejectsValidBase64UnknownChallenge(t *testing.T) {
 
 // A CSR whose public key is not ECDSA must be rejected before verification.
 func TestAttest_RejectsNonECDSACSR(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 
 	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -666,8 +666,8 @@ func TestAttest_RejectsNonECDSACSR(t *testing.T) {
 // An unloaded CA makes in-process signing fail after all validation passed.
 // Also exercises the RequestTimeout>0 wrapping.
 func TestAttest_SignFailureReturns500(t *testing.T) {
-	mock := newStubAttestationApi(t, "x")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "x")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	h.CA = &issuer.CA{} // no cert/key loaded: SignCSR fails
 	h.RequestTimeout = time.Second
 	challenge := issueChallenge(t, h)
@@ -687,8 +687,8 @@ func TestAttest_SignFailureReturns500(t *testing.T) {
 // leaf, and this line is what an operator reconciles against expected
 // workloads afterwards. The serial has to match the leaf actually returned.
 func TestAttest_IssuanceIsRecorded(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h := newTestAttestHandler(t, mock.URL, nil)
+	stub := newStubAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, stub.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 
@@ -727,8 +727,8 @@ func TestAttest_IssuanceIsRecorded(t *testing.T) {
 // A denial and the issuance that follows it have to be correlatable, or a run
 // of probes against CDS cannot be tied to the leaf that eventually succeeded.
 func TestAttest_MeasurementDenialRecordsPeer(t *testing.T) {
-	mock := newStubAttestationApi(t, "deadbeef")
-	h := newTestAttestHandler(t, mock.URL, map[string]bool{"cafe": true})
+	stub := newStubAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, stub.URL, map[string]bool{"cafe": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
 

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
@@ -26,8 +27,10 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/attestation"
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -37,28 +40,11 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-func newMockAttestationApi(t *testing.T, launchDigest string) *httptest.Server {
+func newStubAttestationApi(t *testing.T, launchDigest string) *testattest.Stub {
 	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/verify" {
-			t.Errorf("unexpected path %q", r.URL.Path)
-			http.NotFound(w, r)
-			return
-		}
-		match := true
-		resp := types.VerifyResponse{
-			Result: types.VerificationResult{
-				Platform:        "snp",
-				SignatureValid:  true,
-				ReportDataMatch: &match,
-				Claims:          types.Claims{LaunchDigest: launchDigest},
-			},
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	t.Cleanup(srv.Close)
-	return srv
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(launchDigest))
+	return stub
 }
 
 func generateCSR(t *testing.T) (string, *ecdsa.PrivateKey) {
@@ -132,7 +118,7 @@ func leafFromAttestResponse(t *testing.T, w *httptest.ResponseRecorder) *x509.Ce
 }
 
 func TestAttest_InProcessSignAndReturnsChain(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -165,7 +151,7 @@ func TestAttest_InProcessSignAndReturnsChain(t *testing.T) {
 }
 
 func TestAttest_ClampsCertTTLBeforeSigning(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	base := newTestAttestHandler(t, mock.URL, nil)
 	for _, tc := range []struct {
 		name       string
@@ -197,7 +183,7 @@ func TestAttest_ClampsCertTTLBeforeSigning(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistAllowed(t *testing.T) {
-	mock := newMockAttestationApi(t, "approved-digest")
+	mock := newStubAttestationApi(t, "approved-digest")
 	h := newTestAttestHandler(t, mock.URL, map[string]bool{"approved-digest": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -209,7 +195,7 @@ func TestAttest_LaunchDigestAllowlistAllowed(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistCaseInsensitive(t *testing.T) {
-	mock := newMockAttestationApi(t, "DEADBEEF")
+	mock := newStubAttestationApi(t, "DEADBEEF")
 	h := newTestAttestHandler(t, mock.URL, map[string]bool{"deadbeef": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -221,7 +207,7 @@ func TestAttest_LaunchDigestAllowlistCaseInsensitive(t *testing.T) {
 }
 
 func TestAttest_LaunchDigestAllowlistDenied(t *testing.T) {
-	mock := newMockAttestationApi(t, "unknown-digest")
+	mock := newStubAttestationApi(t, "unknown-digest")
 	h := newTestAttestHandler(t, mock.URL, map[string]bool{"approved-digest": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -285,7 +271,7 @@ func TestAttest_TimeoutBeforeSigningReturns504(t *testing.T) {
 }
 
 func TestAttest_ConsumedChallengeRejectsReplay(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -299,8 +285,63 @@ func TestAttest_ConsumedChallengeRejectsReplay(t *testing.T) {
 	}
 }
 
+// The verify request must bind this request's CSR key and challenge:
+// anything weaker signs a leaf for whoever holds any verifiable TEE report.
+func TestAttest_BindsReportDataToCSRKeyAndChallenge(t *testing.T) {
+	stub := newStubAttestationApi(t, "deadbeef")
+	h := newTestAttestHandler(t, stub.URL, nil)
+	challenge := issueChallenge(t, h)
+	csrPEM, csrKey := generateCSR(t)
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify called %d times, want 1", len(reqs))
+	}
+	if reqs[0].Params == nil || reqs[0].Params.ExpectedReportData == nil {
+		t.Fatal("/verify carried no expected_report_data")
+	}
+	challengeBytes, err := base64.StdEncoding.DecodeString(challenge)
+	if err != nil {
+		t.Fatalf("decode challenge: %v", err)
+	}
+	want, err := ratls.ReportDataForKey(&csrKey.PublicKey, challengeBytes)
+	if err != nil {
+		t.Fatalf("ReportDataForKey: %v", err)
+	}
+	if got := reqs[0].Params.ExpectedReportData.Bytes(); !bytes.Equal(got, want[:sha512.Size384]) {
+		t.Fatalf("expected_report_data = %x (%d bytes), want SHA-384(key||challenge) %x",
+			got, len(got), want[:sha512.Size384])
+	}
+}
+
+// A verifier reporting that the evidence binds different report data must
+// deny issuance: the report attests some other key or challenge.
+func TestAttest_ReportDataMismatchReturns401(t *testing.T) {
+	stub := newStubAttestationApi(t, "deadbeef")
+	verdict := testattest.PassingVerdict("deadbeef")
+	match := false
+	verdict.ReportDataMatch = &match
+	stub.SetVerdict(verdict)
+	h := newTestAttestHandler(t, stub.URL, nil)
+	challenge := issueChallenge(t, h)
+	csrPEM, _ := generateCSR(t)
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, want 401; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), types.ErrorCodeVerificationFailed) {
+		t.Errorf("body should mention %s; got %s", types.ErrorCodeVerificationFailed, w.Body.String())
+	}
+}
+
 func TestAttest_BadCSRRejected(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 
@@ -311,7 +352,7 @@ func TestAttest_BadCSRRejected(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithUnconfiguredDNSSAN(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSRWith(t, pkix.Name{CommonName: "node"}, []string{"foo.mesh.svc"}, nil)
@@ -326,7 +367,7 @@ func TestAttest_RejectsCSRWithUnconfiguredDNSSAN(t *testing.T) {
 }
 
 func TestAttest_AcceptsCSRWithAllowedDNSSAN(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	h.Policy.DNSSANPatterns = []*regexp.Regexp{regexp.MustCompile(`^[a-z]+\.mesh\.svc$`)}
 	challenge := issueChallenge(t, h)
@@ -339,7 +380,7 @@ func TestAttest_AcceptsCSRWithAllowedDNSSAN(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithBadCN(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	h.Policy.AllowedCNPattern = regexp.MustCompile(`^ratls-mesh-[0-9.]+$`)
 	challenge := issueChallenge(t, h)
@@ -352,7 +393,7 @@ func TestAttest_RejectsCSRWithBadCN(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithMismatchedSourceIP(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	h.SANValidation = true
 	challenge := issueChallenge(t, h)
@@ -375,7 +416,7 @@ func TestAttest_RejectsCSRWithMismatchedSourceIP(t *testing.T) {
 }
 
 func TestAttest_RejectsCSRWithIPSANWhenSANValidationDisabled(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	// SANValidation defaults to false, leaving Policy.SourceIP empty.
 	challenge := issueChallenge(t, h)
@@ -544,7 +585,7 @@ func TestAttestHandler_caChainPEM(t *testing.T) {
 }
 
 func TestAttest_RejectsUnknownJSONFields(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/attest", bytes.NewReader([]byte(`{"unknown":true}`)))
@@ -556,7 +597,7 @@ func TestAttest_RejectsUnknownJSONFields(t *testing.T) {
 }
 
 func TestAttest_RejectsMalformedChallengeEncoding(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	csrPEM, _ := generateCSR(t)
 
@@ -577,7 +618,7 @@ func TestAttest_RejectsMalformedChallengeEncoding(t *testing.T) {
 }
 
 func TestAttest_RejectsValidBase64UnknownChallenge(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	csrPEM, _ := generateCSR(t)
 
@@ -600,7 +641,7 @@ func TestAttest_RejectsValidBase64UnknownChallenge(t *testing.T) {
 
 // A CSR whose public key is not ECDSA must be rejected before verification.
 func TestAttest_RejectsNonECDSACSR(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 
@@ -625,7 +666,7 @@ func TestAttest_RejectsNonECDSACSR(t *testing.T) {
 // An unloaded CA makes in-process signing fail after all validation passed.
 // Also exercises the RequestTimeout>0 wrapping.
 func TestAttest_SignFailureReturns500(t *testing.T) {
-	mock := newMockAttestationApi(t, "x")
+	mock := newStubAttestationApi(t, "x")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	h.CA = &issuer.CA{} // no cert/key loaded: SignCSR fails
 	h.RequestTimeout = time.Second
@@ -646,7 +687,7 @@ func TestAttest_SignFailureReturns500(t *testing.T) {
 // leaf, and this line is what an operator reconciles against expected
 // workloads afterwards. The serial has to match the leaf actually returned.
 func TestAttest_IssuanceIsRecorded(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h := newTestAttestHandler(t, mock.URL, nil)
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)
@@ -686,7 +727,7 @@ func TestAttest_IssuanceIsRecorded(t *testing.T) {
 // A denial and the issuance that follows it have to be correlatable, or a run
 // of probes against CDS cannot be tied to the leaf that eventually succeeded.
 func TestAttest_MeasurementDenialRecordsPeer(t *testing.T) {
-	mock := newMockAttestationApi(t, "deadbeef")
+	mock := newStubAttestationApi(t, "deadbeef")
 	h := newTestAttestHandler(t, mock.URL, map[string]bool{"cafe": true})
 	challenge := issueChallenge(t, h)
 	csrPEM, _ := generateCSR(t)

--- a/internal/testattest/testattest.go
+++ b/internal/testattest/testattest.go
@@ -80,7 +80,8 @@ func (s *Stub) SetVerdict(v Verdict) {
 }
 
 // SetPlatform sets the platform the stub reports detecting: what /attest
-// resolves an "auto" or empty request platform to.
+// resolves an "auto" or empty request platform to. The evidence bytes stay
+// an SNP report whatever the platform label.
 func (s *Stub) SetPlatform(p types.Platform) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/testattest/testattest.go
+++ b/internal/testattest/testattest.go
@@ -1,12 +1,22 @@
-// Package testattest serves a fake attestation-api for tests. POST /attest
-// records its request and returns fake SNP evidence; POST /verify decodes
-// the types.VerifyRequest, records it (Params.ExpectedReportData included),
-// and answers with the configured Verdict. Tests assert on the recorded
-// requests, so the report-data binding production code asks the verifier to
-// check is pinned rather than answered blindly.
+// Package testattest serves a fake attestation-api for tests.
+//
+// POST /attest records its request and answers fake SNP evidence: a report of
+// ratls.SNPReportSize bytes with the requested report data clamped into the
+// 64-byte REPORTDATA field, carried under attestation_report as standard
+// base64 — the shape production evidence extraction
+// (attestclient.ExtractSNPReport) consumes.
+// The response platform resolves like the real api's: an explicit request
+// platform is honored; "auto" or empty resolves to the platform the stub
+// detects — snp, unless SetPlatform says otherwise.
+//
+// POST /verify decodes the types.VerifyRequest, records it
+// (Params.ExpectedReportData included), and answers the configured Verdict.
+// Tests assert on the recorded requests, so the report-data binding
+// production code asks the verifier to check is pinned.
 package testattest
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -16,10 +26,10 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// Verdict is what the stub's /verify answers for every request. The fields
-// map onto types.VerificationResult; ReportDataMatch is a pointer so a test
-// can send the omitted-field shape the real api returns when no
-// expected_report_data was checked.
+// Verdict is what the stub's /verify answers for every request; the response
+// platform echoes the request's, like the real api. The fields map onto
+// types.VerificationResult; ReportDataMatch is a pointer so the no-check wire
+// shape (the real api's explicit null) is expressible next to true and false.
 type Verdict struct {
 	SignatureValid  bool
 	ReportDataMatch *bool
@@ -38,20 +48,22 @@ func PassingVerdict(launchDigest string) Verdict {
 }
 
 // Stub is an httptest.Server speaking the attestation-api wire protocol. The
-// default verdict is PassingVerdict(""); change it with SetVerdict.
+// default verdict is PassingVerdict("") and the detected platform snp; change
+// them with SetVerdict and SetPlatform.
 type Stub struct {
 	*httptest.Server
 
-	mu      sync.Mutex
-	verdict Verdict
-	attest  []types.AttestRequest
-	verify  []types.VerifyRequest
+	mu       sync.Mutex
+	verdict  Verdict
+	platform types.Platform
+	attest   []types.AttestRequest
+	verify   []types.VerifyRequest
 }
 
 // New starts a stub attestation-api, closed at test cleanup.
 func New(t testing.TB) *Stub {
 	t.Helper()
-	s := &Stub{verdict: PassingVerdict("")}
+	s := &Stub{verdict: PassingVerdict(""), platform: types.PlatformSnp}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /attest", s.handleAttest)
 	mux.HandleFunc("POST /verify", s.handleVerify)
@@ -65,6 +77,14 @@ func (s *Stub) SetVerdict(v Verdict) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.verdict = v
+}
+
+// SetPlatform sets the platform the stub reports detecting: what /attest
+// resolves an "auto" or empty request platform to.
+func (s *Stub) SetPlatform(p types.Platform) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.platform = p
 }
 
 // AttestRequests returns the /attest requests received so far, in order.
@@ -89,22 +109,30 @@ func (s *Stub) handleAttest(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Lock()
 	s.attest = append(s.attest, req)
+	platform := s.platform
 	s.mu.Unlock()
 
-	// The fake evidence carries the report data it was minted over, so what a
-	// caller asked to bind stays visible in the evidence itself.
-	evidence, err := json.Marshal(map[string]any{
-		"report_data": req.ReportData,
-		"stub":        true,
-	})
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, err.Error())
-		return
+	if req.Platform != "" && req.Platform != types.PlatformAuto {
+		platform = req.Platform
 	}
 	writeJSON(w, types.AttestResponse{
-		Platform: string(types.PlatformSnp),
-		Evidence: evidence,
+		Platform: string(platform),
+		Evidence: fakeSNPEvidence(req.ReportData.Bytes()),
 	})
+}
+
+// fakeSNPEvidence wraps a minimal SEV-SNP report — version 2, SMT-allowed
+// policy, the requested report data in the 64-byte REPORTDATA field at
+// 0x50 — in the attestation_report envelope ExtractSNPReport reads.
+func fakeSNPEvidence(reportData []byte) json.RawMessage {
+	report := make([]byte, 1184) // AMD SEV-SNP report size (ratls.SNPReportSize)
+	report[0] = 0x02
+	report[0x0A] = 0x03
+	copy(report[0x50:0x90], reportData)
+	evidence, _ := json.Marshal(map[string]string{
+		"attestation_report": base64.StdEncoding.EncodeToString(report),
+	})
+	return evidence
 }
 
 func (s *Stub) handleVerify(w http.ResponseWriter, r *http.Request) {

--- a/internal/testattest/testattest.go
+++ b/internal/testattest/testattest.go
@@ -1,0 +1,140 @@
+// Package testattest serves a fake attestation-api for tests. POST /attest
+// records its request and returns fake SNP evidence; POST /verify decodes
+// the types.VerifyRequest, records it (Params.ExpectedReportData included),
+// and answers with the configured Verdict. Tests assert on the recorded
+// requests, so the report-data binding production code asks the verifier to
+// check is pinned rather than answered blindly.
+package testattest
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// Verdict is what the stub's /verify answers for every request. The fields
+// map onto types.VerificationResult; ReportDataMatch is a pointer so a test
+// can send the omitted-field shape the real api returns when no
+// expected_report_data was checked.
+type Verdict struct {
+	SignatureValid  bool
+	ReportDataMatch *bool
+	Claims          types.Claims
+}
+
+// PassingVerdict is the verdict for evidence that verified: signature valid,
+// REPORTDATA bound, and launchDigest reported as claims.launch_digest.
+func PassingVerdict(launchDigest string) Verdict {
+	match := true
+	return Verdict{
+		SignatureValid:  true,
+		ReportDataMatch: &match,
+		Claims:          types.Claims{LaunchDigest: launchDigest},
+	}
+}
+
+// Stub is an httptest.Server speaking the attestation-api wire protocol. The
+// default verdict is PassingVerdict(""); change it with SetVerdict.
+type Stub struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	verdict Verdict
+	attest  []types.AttestRequest
+	verify  []types.VerifyRequest
+}
+
+// New starts a stub attestation-api, closed at test cleanup.
+func New(t testing.TB) *Stub {
+	t.Helper()
+	s := &Stub{verdict: PassingVerdict("")}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /attest", s.handleAttest)
+	mux.HandleFunc("POST /verify", s.handleVerify)
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// SetVerdict swaps the verdict /verify answers with.
+func (s *Stub) SetVerdict(v Verdict) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.verdict = v
+}
+
+// AttestRequests returns the /attest requests received so far, in order.
+func (s *Stub) AttestRequests() []types.AttestRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]types.AttestRequest(nil), s.attest...)
+}
+
+// VerifyRequests returns the /verify requests received so far, in order.
+func (s *Stub) VerifyRequests() []types.VerifyRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]types.VerifyRequest(nil), s.verify...)
+}
+
+func (s *Stub) handleAttest(w http.ResponseWriter, r *http.Request) {
+	var req types.AttestRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.mu.Lock()
+	s.attest = append(s.attest, req)
+	s.mu.Unlock()
+
+	// The fake evidence carries the report data it was minted over, so what a
+	// caller asked to bind stays visible in the evidence itself.
+	evidence, err := json.Marshal(map[string]any{
+		"report_data": req.ReportData,
+		"stub":        true,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	writeJSON(w, types.AttestResponse{
+		Platform: string(types.PlatformSnp),
+		Evidence: evidence,
+	})
+}
+
+func (s *Stub) handleVerify(w http.ResponseWriter, r *http.Request) {
+	var req types.VerifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.mu.Lock()
+	s.verify = append(s.verify, req)
+	verdict := s.verdict
+	s.mu.Unlock()
+
+	writeJSON(w, types.VerifyResponse{
+		Result: types.VerificationResult{
+			Platform:        req.Platform,
+			SignatureValid:  verdict.SignatureValid,
+			ReportDataMatch: verdict.ReportDataMatch,
+			Claims:          verdict.Claims,
+		},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "bad_request", Message: message})
+}

--- a/internal/testattest/testattest_test.go
+++ b/internal/testattest/testattest_test.go
@@ -116,11 +116,16 @@ func TestStubVerifyRecordsAndAnswersVerdict(t *testing.T) {
 
 	expected := types.NewBase64Bytes([]byte("expected-report-data"))
 	req := types.VerifyReportData(types.AttestationEvidence{
-		Platform: "snp",
+		Platform: "gcp-snp",
 		Evidence: []byte(`{"quote":"x"}`),
 	}, expected)
-	if _, err := client.VerifyEnforced(context.Background(), req); err != nil {
+	resp, err := client.VerifyEnforced(context.Background(), req)
+	if err != nil {
 		t.Fatalf("VerifyEnforced against a passing verdict: %v", err)
+	}
+	// The response platform echoes the request's.
+	if resp.Result.Platform != req.Platform {
+		t.Fatalf("response platform = %q, want the request's %q", resp.Result.Platform, req.Platform)
 	}
 
 	reqs := stub.VerifyRequests()
@@ -133,8 +138,8 @@ func TestStubVerifyRecordsAndAnswersVerdict(t *testing.T) {
 	if got := reqs[0].Params.ExpectedReportData.Bytes(); string(got) != string(expected.Bytes()) {
 		t.Fatalf("recorded expected_report_data = %x, want %x", got, expected.Bytes())
 	}
-	if reqs[0].Platform != "snp" {
-		t.Fatalf("recorded platform = %q, want snp", reqs[0].Platform)
+	if reqs[0].Platform != "gcp-snp" {
+		t.Fatalf("recorded platform = %q, want gcp-snp", reqs[0].Platform)
 	}
 }
 

--- a/internal/testattest/testattest_test.go
+++ b/internal/testattest/testattest_test.go
@@ -1,0 +1,113 @@
+package testattest_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func TestStubAttestRecordsAndReturnsSNPEvidence(t *testing.T) {
+	stub := testattest.New(t)
+	client := attestationclient.NewClient(stub.URL)
+
+	reportData := types.NewBase64Bytes([]byte("0123456789abcdef0123456789abcdef0123456789abcdef"))
+	resp, err := client.Attest(context.Background(), types.AttestRequest{
+		ReportData: reportData,
+		Platform:   types.PlatformAuto,
+	})
+	if err != nil {
+		t.Fatalf("Attest: %v", err)
+	}
+	if resp.Platform != string(types.PlatformSnp) {
+		t.Fatalf("platform = %q, want snp", resp.Platform)
+	}
+	if !strings.Contains(string(resp.Evidence), "report_data") {
+		t.Fatalf("evidence does not carry the report data: %s", resp.Evidence)
+	}
+
+	reqs := stub.AttestRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/attest calls = %d, want 1", len(reqs))
+	}
+	if got := reqs[0].ReportData.Bytes(); string(got) != string(reportData.Bytes()) {
+		t.Fatalf("recorded report_data = %x, want %x", got, reportData.Bytes())
+	}
+}
+
+func TestStubVerifyRecordsAndAnswersVerdict(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict("deadbeef"))
+	client := attestationclient.NewClient(stub.URL)
+
+	expected := types.NewBase64Bytes([]byte("expected-report-data"))
+	req := types.VerifyReportData(types.AttestationEvidence{
+		Platform: "snp",
+		Evidence: []byte(`{"quote":"x"}`),
+	}, expected)
+	if _, err := client.VerifyEnforced(context.Background(), req); err != nil {
+		t.Fatalf("VerifyEnforced against a passing verdict: %v", err)
+	}
+
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify calls = %d, want 1", len(reqs))
+	}
+	if reqs[0].Params == nil || reqs[0].Params.ExpectedReportData == nil {
+		t.Fatal("recorded request carries no expected_report_data")
+	}
+	if got := reqs[0].Params.ExpectedReportData.Bytes(); string(got) != string(expected.Bytes()) {
+		t.Fatalf("recorded expected_report_data = %x, want %x", got, expected.Bytes())
+	}
+	if reqs[0].Platform != "snp" {
+		t.Fatalf("recorded platform = %q, want snp", reqs[0].Platform)
+	}
+}
+
+func TestStubVerifyMismatchFailsEnforcement(t *testing.T) {
+	stub := testattest.New(t)
+	verdict := testattest.PassingVerdict("")
+	match := false
+	verdict.ReportDataMatch = &match
+	stub.SetVerdict(verdict)
+	client := attestationclient.NewClient(stub.URL)
+
+	expected := types.NewBase64Bytes([]byte("expected-report-data"))
+	req := types.VerifyReportData(types.AttestationEvidence{Platform: "snp", Evidence: []byte(`{}`)}, expected)
+	_, err := client.VerifyEnforced(context.Background(), req)
+	if !errors.Is(err, attestationclient.ErrReportDataMismatch) {
+		t.Fatalf("err = %v, want ErrReportDataMismatch", err)
+	}
+}
+
+func TestStubRejectsUnknownPaths(t *testing.T) {
+	stub := testattest.New(t)
+	resp, err := http.Post(stub.URL+"/nope", "application/json", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestStubRejectsUndecodableBody(t *testing.T) {
+	stub := testattest.New(t)
+	resp, err := http.Post(stub.URL+"/verify", "application/json", strings.NewReader(`not json`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	if got := len(stub.VerifyRequests()); got != 0 {
+		t.Fatalf("an undecodable body was recorded as %d request(s)", got)
+	}
+}

--- a/internal/testattest/testattest_test.go
+++ b/internal/testattest/testattest_test.go
@@ -1,6 +1,7 @@
 package testattest_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -9,9 +10,14 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
+// The stub's /attest evidence must pass the production evidence-extraction
+// path: an adopting test drives attestclient against the stub without a local
+// fake.
 func TestStubAttestRecordsAndReturnsSNPEvidence(t *testing.T) {
 	stub := testattest.New(t)
 	client := attestationclient.NewClient(stub.URL)
@@ -27,8 +33,18 @@ func TestStubAttestRecordsAndReturnsSNPEvidence(t *testing.T) {
 	if resp.Platform != string(types.PlatformSnp) {
 		t.Fatalf("platform = %q, want snp", resp.Platform)
 	}
-	if !strings.Contains(string(resp.Evidence), "report_data") {
-		t.Fatalf("evidence does not carry the report data: %s", resp.Evidence)
+
+	report, err := attestclient.ExtractSNPReport(resp)
+	if err != nil {
+		t.Fatalf("ExtractSNPReport: %v", err)
+	}
+	if len(report) != ratls.SNPReportSize {
+		t.Fatalf("report = %d bytes, want %d", len(report), ratls.SNPReportSize)
+	}
+	var wantReportData [64]byte
+	copy(wantReportData[:], reportData.Bytes())
+	if got := []byte(report[0x50:0x90]); !bytes.Equal(got, wantReportData[:]) {
+		t.Fatalf("REPORTDATA = %x, want %x", got, wantReportData)
 	}
 
 	reqs := stub.AttestRequests()
@@ -38,6 +54,59 @@ func TestStubAttestRecordsAndReturnsSNPEvidence(t *testing.T) {
 	if got := reqs[0].ReportData.Bytes(); string(got) != string(reportData.Bytes()) {
 		t.Fatalf("recorded report_data = %x, want %x", got, reportData.Bytes())
 	}
+}
+
+func TestStubAttestClampsReportDataToTheField(t *testing.T) {
+	stub := testattest.New(t)
+	client := attestationclient.NewClient(stub.URL)
+
+	oversize := types.NewBase64Bytes(bytes.Repeat([]byte{0xAB}, 100))
+	resp, err := client.Attest(context.Background(), types.AttestRequest{
+		ReportData: oversize,
+		Platform:   types.PlatformAuto,
+	})
+	if err != nil {
+		t.Fatalf("Attest: %v", err)
+	}
+	report, err := attestclient.ExtractSNPReport(resp)
+	if err != nil {
+		t.Fatalf("ExtractSNPReport: %v", err)
+	}
+	if got := []byte(report[0x50:0x90]); !bytes.Equal(got, oversize.Bytes()[:64]) {
+		t.Fatalf("REPORTDATA = %x, want the leading 64 bytes %x", got, oversize.Bytes()[:64])
+	}
+}
+
+func TestStubAttestPlatformResolution(t *testing.T) {
+	client := func(s *testattest.Stub) attestationclient.Client { return attestationclient.NewClient(s.URL) }
+	attest := func(t *testing.T, s *testattest.Stub, platform types.Platform) string {
+		t.Helper()
+		resp, err := client(s).Attest(context.Background(), types.AttestRequest{
+			ReportData: types.NewBase64Bytes([]byte("x")),
+			Platform:   platform,
+		})
+		if err != nil {
+			t.Fatalf("Attest: %v", err)
+		}
+		return resp.Platform
+	}
+
+	t.Run("auto resolves to the detected platform", func(t *testing.T) {
+		stub := testattest.New(t)
+		if got := attest(t, stub, types.PlatformAuto); got != string(types.PlatformSnp) {
+			t.Fatalf("platform = %q, want snp", got)
+		}
+		stub.SetPlatform(types.PlatformTdx)
+		if got := attest(t, stub, types.PlatformAuto); got != string(types.PlatformTdx) {
+			t.Fatalf("platform = %q after SetPlatform(tdx), want tdx", got)
+		}
+	})
+	t.Run("explicit platform is honored", func(t *testing.T) {
+		stub := testattest.New(t)
+		if got := attest(t, stub, types.PlatformGcpSnp); got != string(types.PlatformGcpSnp) {
+			t.Fatalf("platform = %q, want gcp-snp", got)
+		}
+	})
 }
 
 func TestStubVerifyRecordsAndAnswersVerdict(t *testing.T) {

--- a/pkg/ratls/cdsclient/client_test.go
+++ b/pkg/ratls/cdsclient/client_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -52,8 +53,7 @@ func TestNewClientDefaultTransport(t *testing.T) {
 }
 
 func TestCreateCSRDNSSAN(t *testing.T) {
-	as := fakeASEvidence(t)
-	defer as.Close()
+	as := testattest.New(t)
 
 	tests := []struct {
 		name   string

--- a/pkg/ratls/cdsclient/provider_test.go
+++ b/pkg/ratls/cdsclient/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -39,17 +40,7 @@ func mockServersWithLeafValidity(t *testing.T, caKey *ecdsa.PrivateKey, caCert *
 		caBundle = []*x509.Certificate{caCert}
 	}
 
-	// attestation-api: returns mock evidence for any request.
-	attestSvc = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/attest" {
-			http.NotFound(w, r)
-			return
-		}
-		json.NewEncoder(w).Encode(types.AttestResponse{
-			Platform: "snp",
-			Evidence: testSNPEvidence(t),
-		})
-	}))
+	attestSvc = testattest.New(t).Server
 
 	// CDS: authenticate returns challenge, attest verifies and returns cert.
 	// These tests cover the cdsclient HTTP plumbing in isolation; the
@@ -130,18 +121,6 @@ func mockServersWithLeafValidity(t *testing.T, caKey *ecdsa.PrivateKey, caCert *
 	}))
 
 	return cdsSrv, attestSvc, issuer
-}
-
-func testSNPEvidence(t *testing.T) json.RawMessage {
-	t.Helper()
-	report := make([]byte, ratls.SNPReportSize)
-	data, err := json.Marshal(map[string]string{
-		"attestation_report": base64.StdEncoding.EncodeToString(report),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return data
 }
 
 func hasExtension(cert *x509.Certificate, oid asn1.ObjectIdentifier) bool {
@@ -722,17 +701,7 @@ func TestProviderProvisionRejectsBundleWhoseFirstCADoesNotSignLeaf(t *testing.T)
 func TestProviderProvisionRejectsLeafForDifferentKey(t *testing.T) {
 	caKey, caCert := testCA(t)
 
-	attestSvc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/attest" {
-			http.NotFound(w, r)
-			return
-		}
-		json.NewEncoder(w).Encode(types.AttestResponse{
-			Platform: "snp",
-			Evidence: testSNPEvidence(t),
-		})
-	}))
-	defer attestSvc.Close()
+	attestSvc := testattest.New(t)
 
 	cdsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/pkg/ratls/cdsclient/ratls_test.go
+++ b/pkg/ratls/cdsclient/ratls_test.go
@@ -8,8 +8,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
-	"encoding/json"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -17,31 +15,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
-	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
-
-// fakeASEvidence stands up a minimal attestation-api stub that returns
-// canned SNP evidence for any /attest call. Required because RequestCert
-// dials the AS to embed an attestation report into the CSR before talking
-// to CDS — we want the test to fail at the CDS TLS handshake, not at
-// CSR construction.
-func fakeASEvidence(t *testing.T) *httptest.Server {
-	t.Helper()
-	report := make([]byte, ratls.SNPReportSize)
-	evidence, err := json.Marshal(map[string]string{
-		"attestation_report": base64.StdEncoding.EncodeToString(report),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(types.AttestResponse{
-			Platform: "snp",
-			Evidence: evidence,
-		})
-	}))
-}
 
 // TestProviderRATLSRejectsUnattestedCDS proves the cdsclient's default
 // (no HTTPClient override) http.Client refuses to talk to an CDS server
@@ -50,8 +26,7 @@ func fakeASEvidence(t *testing.T) *httptest.Server {
 // cannot present a TEE-attested cert with an allowed measurement, so the TLS
 // handshake fails before any cert-issuance bytes flow.
 func TestProviderRATLSRejectsUnattestedCDS(t *testing.T) {
-	as := fakeASEvidence(t)
-	defer as.Close()
+	as := testattest.New(t)
 
 	// Plain HTTPS server with a regular self-signed cert (no RA-TLS extension).
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -89,8 +64,7 @@ func TestProviderRATLSRejectsUnattestedCDS(t *testing.T) {
 // a well-known x509 path (not self-signed by httptest), and confirms the
 // cdsclient still rejects it because the cert lacks the RA-TLS extension.
 func TestProviderRATLSRejectsCertWithoutAttestationExtension(t *testing.T) {
-	as := fakeASEvidence(t)
-	defer as.Close()
+	as := testattest.New(t)
 
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/pkg/ratls/ratls_test.go
+++ b/pkg/ratls/ratls_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -603,34 +604,6 @@ func embeddedAzureCert(t *testing.T) (*x509.Certificate, [64]byte) {
 	return embeddedEnvelopeCert(t, types.PlatformAzSnp, json.RawMessage(`{"hcl_report":"fake","tpm_quote":{"message":"fake"}}`))
 }
 
-// verifyResponse is a minimal builder for an attestation-api /verify
-// response. Tests mutate the returned map then JSON-encode it.
-func verifyResponse(measurement []byte) map[string]any {
-	result := map[string]any{
-		"platform":          string(types.PlatformAzSnp),
-		"signature_valid":   true,
-		"report_data_match": true,
-		"claims":            map[string]any{},
-	}
-	if measurement != nil {
-		result["claims"] = map[string]any{
-			"launch_digest": hex.EncodeToString(measurement),
-		}
-	}
-	return map[string]any{"result": result}
-}
-
-// newMockedVerifySrv returns a mocked attestation-api whose /verify always
-// responds with body.
-func newMockedVerifySrv(t *testing.T, body any) *httptest.Server {
-	t.Helper()
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewEncoder(w).Encode(body); err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-	}))
-}
-
 func TestVerifyCertEmbeddedAzureEvidenceUsesAttestationApi(t *testing.T) {
 	key, expectedReportData, err := GenerateKeyPair()
 	if err != nil {
@@ -655,60 +628,39 @@ func TestVerifyCertEmbeddedAzureEvidenceUsesAttestationApi(t *testing.T) {
 	}
 
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-	var sawVerify bool
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/verify" {
-			t.Fatalf("path = %s, want /verify", r.URL.Path)
-		}
-		var req types.VerifyRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode verify request: %v", err)
-		}
-		sawVerify = true
-		// attestation-api wants platform at the top level and Evidence as the
-		// platform-specific evidence, not a nested AttestationEvidence envelope.
-		if req.Platform != string(types.PlatformAzSnp) {
-			t.Fatalf("platform = %q, want az-snp", req.Platform)
-		}
-		if string(req.Evidence) != string(evidenceJSON) {
-			t.Fatalf("evidence = %s, want the platform-specific evidence %s (not a nested envelope)", req.Evidence, evidenceJSON)
-		}
-		if req.Params == nil || req.Params.ExpectedReportData == nil {
-			t.Fatal("missing expected report data")
-		}
-		// az-snp binds via a TPM quote whose nonce is the 48-byte SHA-384
-		// digest, so exactly those 48 bytes must be sent — not the zero-padded
-		// 64-byte form, which fails attestation-api with a nonce-length error.
-		if got := req.Params.ExpectedReportData.Bytes(); !bytes.Equal(got, expectedReportData[:sha512.Size384]) {
-			t.Fatalf("expected_report_data = %x (%d bytes), want %x (%d bytes)", got, len(got), expectedReportData[:sha512.Size384], sha512.Size384)
-		}
-
-		resp := map[string]any{
-			"result": map[string]any{
-				"platform":          string(types.PlatformAzSnp),
-				"signature_valid":   true,
-				"report_data_match": true,
-				"claims": map[string]any{
-					"launch_digest": hex.EncodeToString(measurement),
-					"platform_data": map[string]any{"source": "test"},
-				},
-			},
-		}
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-	}))
-	defer srv.Close()
+	stub := testattest.New(t)
+	verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))
+	verdict.Claims.PlatformData = json.RawMessage(`{"source":"test"}`)
+	stub.SetVerdict(verdict)
 
 	result, err := VerifyCert(cert, &VerifyPolicy{
-		AttestationApiURL: srv.URL,
+		AttestationApiURL: stub.URL,
 		Measurements:      [][]byte{measurement},
 	}, nil)
 	if err != nil {
 		t.Fatalf("VerifyCert: %v", err)
 	}
-	if !sawVerify {
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
 		t.Fatal("attestation-api /verify was not called")
+	}
+	req := reqs[0]
+	// attestation-api wants platform at the top level and Evidence as the
+	// platform-specific evidence, not a nested AttestationEvidence envelope.
+	if req.Platform != string(types.PlatformAzSnp) {
+		t.Fatalf("platform = %q, want az-snp", req.Platform)
+	}
+	if string(req.Evidence) != string(evidenceJSON) {
+		t.Fatalf("evidence = %s, want the platform-specific evidence %s (not a nested envelope)", req.Evidence, evidenceJSON)
+	}
+	if req.Params == nil || req.Params.ExpectedReportData == nil {
+		t.Fatal("missing expected report data")
+	}
+	// az-snp binds via a TPM quote whose nonce is the 48-byte SHA-384 digest,
+	// so exactly those 48 bytes must be sent — not the zero-padded 64-byte
+	// form, which fails attestation-api with a nonce-length error.
+	if got := req.Params.ExpectedReportData.Bytes(); !bytes.Equal(got, expectedReportData[:sha512.Size384]) {
+		t.Fatalf("expected_report_data = %x (%d bytes), want %x (%d bytes)", got, len(got), expectedReportData[:sha512.Size384], sha512.Size384)
 	}
 	if !bytes.Equal(result.ReportData[:], expectedReportData[:]) {
 		t.Fatalf("ReportData = %x, want %x", result.ReportData, expectedReportData)
@@ -722,27 +674,22 @@ func TestVerifyCertEmbeddedTDXEvidenceEnforcesMRTD(t *testing.T) {
 	cert, expectedReportData := embeddedEnvelopeCert(t, types.PlatformTdx, json.RawMessage(`{"quote":"fake"}`))
 	mrtd := bytes.Repeat([]byte{0x42}, sha512.Size384)
 
-	var observed types.VerifyRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&observed); err != nil {
-			t.Fatalf("decode verify request: %v", err)
-		}
-		resp := verifyResponse(mrtd)
-		resp["result"].(map[string]any)["platform"] = string(types.PlatformTdx)
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-	}))
-	defer srv.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(mrtd)))
 
 	result, err := VerifyCert(cert, &VerifyPolicy{
-		AttestationApiURL: srv.URL,
+		AttestationApiURL: stub.URL,
 		Measurements:      [][]byte{mrtd},
 		MinTCBVersion:     1,
 	}, nil)
 	if err != nil {
 		t.Fatalf("VerifyCert: %v", err)
 	}
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify calls = %d, want 1", len(reqs))
+	}
+	observed := reqs[0]
 	if observed.Platform != string(types.PlatformTdx) {
 		t.Fatalf("platform = %q, want tdx", observed.Platform)
 	}
@@ -767,7 +714,7 @@ func TestVerifyCertEmbeddedTDXEvidenceEnforcesMRTD(t *testing.T) {
 
 	wrongMRTD := bytes.Repeat([]byte{0x99}, sha512.Size384)
 	_, err = VerifyCert(cert, &VerifyPolicy{
-		AttestationApiURL: srv.URL,
+		AttestationApiURL: stub.URL,
 		Measurements:      [][]byte{wrongMRTD},
 	}, nil)
 	if !errors.Is(err, ErrPolicyViolation) {
@@ -783,25 +730,21 @@ func TestVerifyCertEmbeddedGcpSnpEvidenceUsesAttestationApi(t *testing.T) {
 	cert, _ := embeddedEnvelopeCert(t, types.PlatformGcpSnp, json.RawMessage(`{"attestation_report":"fake"}`))
 
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-	var observed types.VerifyRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&observed); err != nil {
-			t.Fatalf("decode verify request: %v", err)
-		}
-		if err := json.NewEncoder(w).Encode(verifyResponse(measurement)); err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-	}))
-	defer srv.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 
 	if _, err := VerifyCert(cert, &VerifyPolicy{
-		AttestationApiURL: srv.URL,
+		AttestationApiURL: stub.URL,
 		Measurements:      [][]byte{measurement},
 	}, nil); err != nil {
 		t.Fatalf("VerifyCert: %v", err)
 	}
-	if observed.Platform != string(types.PlatformGcpSnp) {
-		t.Fatalf("platform = %q, want gcp-snp", observed.Platform)
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify calls = %d, want 1", len(reqs))
+	}
+	if reqs[0].Platform != string(types.PlatformGcpSnp) {
+		t.Fatalf("platform = %q, want gcp-snp", reqs[0].Platform)
 	}
 }
 
@@ -816,33 +759,35 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 	allowedMeasurements := [][]byte{measurement}
 
 	t.Run("signature_valid=false maps to ErrSignatureInvalid", func(t *testing.T) {
-		resp := verifyResponse(measurement)
-		resp["result"].(map[string]any)["signature_valid"] = false
-		srv := newMockedVerifySrv(t, resp)
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))
+		verdict.SignatureValid = false
+		stub.SetVerdict(verdict)
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrSignatureInvalid) {
 			t.Fatalf("got %v, want ErrSignatureInvalid", err)
 		}
 	})
 
 	t.Run("report_data_match=nil maps to ErrKeyBinding", func(t *testing.T) {
-		resp := verifyResponse(measurement)
-		delete(resp["result"].(map[string]any), "report_data_match")
-		srv := newMockedVerifySrv(t, resp)
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.Verdict{
+			SignatureValid: true,
+			Claims:         types.Claims{LaunchDigest: hex.EncodeToString(measurement)},
+		})
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrKeyBinding) {
 			t.Fatalf("got %v, want ErrKeyBinding", err)
 		}
 	})
 
 	t.Run("report_data_match=false maps to ErrKeyBinding", func(t *testing.T) {
-		resp := verifyResponse(measurement)
-		resp["result"].(map[string]any)["report_data_match"] = false
-		srv := newMockedVerifySrv(t, resp)
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))
+		match := false
+		verdict.ReportDataMatch = &match
+		stub.SetVerdict(verdict)
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrKeyBinding) {
 			t.Fatalf("got %v, want ErrKeyBinding", err)
 		}
@@ -856,43 +801,35 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 	})
 
 	t.Run("launch_digest missing with pinned measurements is rejected", func(t *testing.T) {
-		srv := newMockedVerifySrv(t, verifyResponse(nil))
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrPolicyViolation) {
 			t.Fatalf("got %v, want ErrPolicyViolation", err)
 		}
 	})
 
 	t.Run("launch_digest not in allowed set is rejected", func(t *testing.T) {
-		other := bytes.Repeat([]byte{0x99}, SNPMeasurementSize)
-		srv := newMockedVerifySrv(t, verifyResponse(other))
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(bytes.Repeat([]byte{0x99}, SNPMeasurementSize))))
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrPolicyViolation) {
 			t.Fatalf("got %v, want ErrPolicyViolation", err)
 		}
 	})
 
 	t.Run("launch_digest not hex is rejected", func(t *testing.T) {
-		resp := verifyResponse(measurement)
-		resp["result"].(map[string]any)["claims"] = map[string]any{"launch_digest": "not-hex"}
-		srv := newMockedVerifySrv(t, resp)
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict("not-hex"))
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrInvalidReport) {
 			t.Fatalf("got %v, want ErrInvalidReport", err)
 		}
 	})
 
 	t.Run("launch_digest wrong length is rejected", func(t *testing.T) {
-		resp := verifyResponse(measurement)
-		resp["result"].(map[string]any)["claims"] = map[string]any{
-			"launch_digest": hex.EncodeToString(bytes.Repeat([]byte{0x11}, 32)),
-		}
-		srv := newMockedVerifySrv(t, resp)
-		defer srv.Close()
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(bytes.Repeat([]byte{0x11}, 32))))
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrInvalidReport) {
 			t.Fatalf("got %v, want ErrInvalidReport", err)
 		}
@@ -910,9 +847,16 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 	})
 
 	t.Run("AttestationVerifyTimeout bounds the call", func(t *testing.T) {
+		match := true
+		slow := types.VerifyResponse{Result: types.VerificationResult{
+			Platform:        string(types.PlatformAzSnp),
+			SignatureValid:  true,
+			ReportDataMatch: &match,
+			Claims:          types.Claims{LaunchDigest: hex.EncodeToString(measurement)},
+		}}
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			time.Sleep(200 * time.Millisecond)
-			_ = json.NewEncoder(w).Encode(verifyResponse(measurement))
+			_ = json.NewEncoder(w).Encode(slow)
 		}))
 		defer srv.Close()
 		start := time.Now()
@@ -931,25 +875,24 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 	})
 
 	t.Run("MinTCBVersion is forwarded as unpacked components", func(t *testing.T) {
-		var observed types.VerifyRequest
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := json.NewDecoder(r.Body).Decode(&observed); err != nil {
-				t.Fatalf("decode: %v", err)
-			}
-			_ = json.NewEncoder(w).Encode(verifyResponse(measurement))
-		}))
-		defer srv.Close()
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 		// Packed layout: bootloader=0x11, tee=0x22, snp=0x33 (byte 6),
 		// microcode=0x44 (byte 7). Reserved bytes stay zero.
 		packed := uint64(0x44_33_00_00_00_00_22_11)
 		_, err := VerifyCert(cert, &VerifyPolicy{
-			AttestationApiURL: srv.URL,
+			AttestationApiURL: stub.URL,
 			Measurements:      allowedMeasurements,
 			MinTCBVersion:     packed,
 		}, nil)
 		if err != nil {
 			t.Fatalf("VerifyCert: %v", err)
 		}
+		reqs := stub.VerifyRequests()
+		if len(reqs) != 1 {
+			t.Fatalf("/verify calls = %d, want 1", len(reqs))
+		}
+		observed := reqs[0]
 		if observed.Params == nil || observed.Params.MinTcb == nil {
 			t.Fatal("MinTcb was not forwarded to /verify")
 		}
@@ -982,9 +925,9 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ParseCertificate: %v", err)
 		}
-		srv := newMockedVerifySrv(t, verifyResponse(measurement))
-		defer srv.Close()
-		_, err = VerifyCert(tdxCert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: allowedMeasurements}, nil)
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
+		_, err = VerifyCert(tdxCert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
 		if !errors.Is(err, ErrUnsupportedTEE) {
 			t.Fatalf("got %v, want ErrUnsupportedTEE", err)
 		}
@@ -1000,26 +943,21 @@ func TestVerifyCertEmbeddedAzTdxEvidence(t *testing.T) {
 		json.RawMessage(`{"hcl_report":"fake","td_quote":"fake","tpm_quote":{"message":"fake"}}`))
 	mrtd := bytes.Repeat([]byte{0x42}, sha512.Size384)
 
-	var observed types.VerifyRequest
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := json.NewDecoder(r.Body).Decode(&observed); err != nil {
-			t.Fatalf("decode verify request: %v", err)
-		}
-		resp := verifyResponse(mrtd)
-		resp["result"].(map[string]any)["platform"] = string(types.PlatformAzTdx)
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			t.Fatalf("encode response: %v", err)
-		}
-	}))
-	defer srv.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(mrtd)))
 
 	result, err := VerifyCert(cert, &VerifyPolicy{
-		AttestationApiURL: srv.URL,
+		AttestationApiURL: stub.URL,
 		Measurements:      [][]byte{mrtd},
 	}, nil)
 	if err != nil {
 		t.Fatalf("VerifyCert: %v", err)
 	}
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify calls = %d, want 1", len(reqs))
+	}
+	observed := reqs[0]
 	// az-tdx binds via the 48-byte vTPM nonce, not the full 64-byte REPORTDATA.
 	if got := observed.Params.ExpectedReportData.Bytes(); !bytes.Equal(got, expectedReportData[:sha512.Size384]) {
 		t.Fatalf("expected_report_data = %x (%d bytes), want the 48-byte digest %x", got, len(got), expectedReportData[:sha512.Size384])
@@ -1032,7 +970,7 @@ func TestVerifyCertEmbeddedAzTdxEvidence(t *testing.T) {
 	}
 
 	wrongMRTD := bytes.Repeat([]byte{0x99}, sha512.Size384)
-	_, err = VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{wrongMRTD}}, nil)
+	_, err = VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{wrongMRTD}}, nil)
 	if !errors.Is(err, ErrPolicyViolation) {
 		t.Fatalf("wrong MRTD: got %v, want ErrPolicyViolation", err)
 	}
@@ -1053,23 +991,18 @@ func TestVerifyCertBareSNPUsesAttestationApi(t *testing.T) {
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
 
 	t.Run("raw report is wrapped in the snp envelope", func(t *testing.T) {
-		var observed types.VerifyRequest
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if err := json.NewDecoder(r.Body).Decode(&observed); err != nil {
-				t.Fatalf("decode verify request: %v", err)
-			}
-			resp := verifyResponse(measurement)
-			resp["result"].(map[string]any)["platform"] = string(types.PlatformSnp)
-			if err := json.NewEncoder(w).Encode(resp); err != nil {
-				t.Fatalf("encode response: %v", err)
-			}
-		}))
-		defer srv.Close()
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 
-		result, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}}, nil)
+		result, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}}, nil)
 		if err != nil {
 			t.Fatalf("VerifyCert: %v", err)
 		}
+		reqs := stub.VerifyRequests()
+		if len(reqs) != 1 {
+			t.Fatalf("/verify calls = %d, want 1", len(reqs))
+		}
+		observed := reqs[0]
 		if observed.Platform != string(types.PlatformSnp) {
 			t.Fatalf("platform = %q, want snp", observed.Platform)
 		}
@@ -1231,10 +1164,9 @@ func TestPublicKeyFromCertCurves(t *testing.T) {
 
 func TestVerifyAttestationUnsupportedKey(t *testing.T) {
 	_, att := testKeyAndAttestation(t)
-	srv := newMockedVerifySrv(t, verifyResponse(nil))
-	defer srv.Close()
+	stub := testattest.New(t)
 
-	_, err := VerifyAttestation("not-a-key", att, &VerifyPolicy{AttestationApiURL: srv.URL}, nil)
+	_, err := VerifyAttestation("not-a-key", att, &VerifyPolicy{AttestationApiURL: stub.URL}, nil)
 	if err == nil || !strings.Contains(err.Error(), "compute expected REPORTDATA") {
 		t.Fatalf("got %v, want REPORTDATA computation error", err)
 	}
@@ -1245,21 +1177,18 @@ func TestVerifyResultPlatformInfo(t *testing.T) {
 	newPolicy := func(url string) *VerifyPolicy {
 		return &VerifyPolicy{AttestationApiURL: url, Measurements: [][]byte{measurement}}
 	}
-	withPlatformData := func(platform string, platformData any) map[string]any {
-		resp := verifyResponse(measurement)
-		result := resp["result"].(map[string]any)
-		result["platform"] = platform
-		result["claims"] = map[string]any{
-			"launch_digest": hex.EncodeToString(measurement),
-			"platform_data": platformData,
-		}
-		return resp
+	stubWithPlatformData := func(t *testing.T, platformData json.RawMessage) *testattest.Stub {
+		t.Helper()
+		stub := testattest.New(t)
+		verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))
+		verdict.Claims.PlatformData = platformData
+		stub.SetVerdict(verdict)
+		return stub
 	}
 
 	t.Run("SNP platform data is surfaced", func(t *testing.T) {
 		cert, _ := embeddedAzureCert(t)
-		srv := newMockedVerifySrv(t, withPlatformData(string(types.PlatformAzSnp), map[string]any{"source": "unit"}))
-		defer srv.Close()
+		srv := stubWithPlatformData(t, json.RawMessage(`{"source":"unit"}`))
 		result, err := VerifyCert(cert, newPolicy(srv.URL), nil)
 		if err != nil {
 			t.Fatalf("VerifyCert: %v", err)
@@ -1277,8 +1206,7 @@ func TestVerifyResultPlatformInfo(t *testing.T) {
 
 	t.Run("null SNP platform data is dropped", func(t *testing.T) {
 		cert, _ := embeddedAzureCert(t)
-		srv := newMockedVerifySrv(t, withPlatformData(string(types.PlatformAzSnp), nil))
-		defer srv.Close()
+		srv := stubWithPlatformData(t, nil)
 		result, err := VerifyCert(cert, newPolicy(srv.URL), nil)
 		if err != nil {
 			t.Fatalf("VerifyCert: %v", err)
@@ -1290,8 +1218,7 @@ func TestVerifyResultPlatformInfo(t *testing.T) {
 
 	t.Run("TDX platform data is not surfaced", func(t *testing.T) {
 		cert, _ := embeddedEnvelopeCert(t, types.PlatformTdx, json.RawMessage(`{"quote":"fake"}`))
-		srv := newMockedVerifySrv(t, withPlatformData(string(types.PlatformTdx), map[string]any{"source": "unit"}))
-		defer srv.Close()
+		srv := stubWithPlatformData(t, json.RawMessage(`{"source":"unit"}`))
 		result, err := VerifyCert(cert, newPolicy(srv.URL), nil)
 		if err != nil {
 			t.Fatalf("VerifyCert: %v", err)

--- a/pkg/ratls/sandbox_test.go
+++ b/pkg/ratls/sandbox_test.go
@@ -64,7 +64,7 @@ func TestValidateSandboxID(t *testing.T) {
 			t.Errorf("ValidateSandboxID(%q) = %v, want nil", ok, err)
 		}
 	}
-	for _, bad := range []string{"", "with space", "slash/id", "semi;colon", strings.Repeat("a", 129)} {
+	for _, bad := range []string{"", "with space", "slash/id", "semi;colon", strings.Repeat("a", 129), "sandbox-🙂"} {
 		if err := ValidateSandboxID(bad); err == nil {
 			t.Errorf("ValidateSandboxID(%q) accepted", bad)
 		}

--- a/pkg/ratls/tls_test.go
+++ b/pkg/ratls/tls_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math/big"
@@ -18,6 +19,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 )
 
 // fakeAttestFunc returns an AttestFunc that parses hex-encoded REPORTDATA
@@ -794,12 +797,12 @@ func TestDualVerifyPeerCallback_RATLSSelfSigned(t *testing.T) {
 	_, _, ratlsCert := testAttestedCert(t, &CertOptions{TTL: 1 * time.Hour})
 
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-	srv := newMockedVerifySrv(t, verifyResponse(measurement))
-	defer srv.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 
 	_, caCert := generateCACert(t)
 	verifyFunc := dualVerifyPeerCallback(
-		&VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}},
+		&VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}},
 		newSharedCACerts([]*x509.Certificate{caCert}),
 	)
 
@@ -1031,8 +1034,8 @@ func TestDualVerifyPeerCallback_RequireCAEvidence(t *testing.T) {
 	caKey, caCert := generateCACert(t)
 	shared := newSharedCACerts([]*x509.Certificate{caCert})
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-	srv := newMockedVerifySrv(t, verifyResponse(measurement))
-	defer srv.Close()
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 
 	// caSignedLeaf builds a CA-signed leaf over key, optionally carrying the
 	// RA-TLS .1.1 evidence extension.
@@ -1073,14 +1076,14 @@ func TestDualVerifyPeerCallback_RequireCAEvidence(t *testing.T) {
 	leafWithEvidence := caSignedLeaf(t, key, &ext)
 
 	t.Run("accepts CA leaf with re-verifiable evidence", func(t *testing.T) {
-		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		policy := &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
 		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err != nil {
 			t.Fatalf("valid CA leaf with embedded evidence rejected: %v", err)
 		}
 	})
 
 	t.Run("rejects CA leaf without embedded evidence", func(t *testing.T) {
-		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
+		policy := &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}, RequireCAEvidence: true}
 		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err == nil {
 			t.Fatal("CA leaf without embedded evidence accepted in production mode")
 		}
@@ -1088,14 +1091,14 @@ func TestDualVerifyPeerCallback_RequireCAEvidence(t *testing.T) {
 
 	t.Run("rejects CA leaf whose measurement is not pinned", func(t *testing.T) {
 		other := bytes.Repeat([]byte{0x99}, SNPMeasurementSize)
-		policy := &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{other}, RequireCAEvidence: true}
+		policy := &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{other}, RequireCAEvidence: true}
 		if err := dualVerifyPeerCallback(policy, shared)([][]byte{leafWithEvidence}, nil); err == nil {
 			t.Fatal("CA leaf with an unpinned launch measurement accepted in production mode")
 		}
 	})
 
 	t.Run("legacy mode still accepts CA leaf without evidence", func(t *testing.T) {
-		policy := &VerifyPolicy{AttestationApiURL: srv.URL} // RequireCAEvidence: false
+		policy := &VerifyPolicy{AttestationApiURL: stub.URL} // RequireCAEvidence: false
 		if err := dualVerifyPeerCallback(policy, shared)([][]byte{caSignedLeaf(t, freshKey(t), nil)}, nil); err != nil {
 			t.Fatalf("legacy CA-only mode rejected a CA-signed leaf: %v", err)
 		}
@@ -1474,9 +1477,9 @@ func TestClientTLSConfigWithoutCACertStaysRATLSOnly(t *testing.T) {
 
 func TestVerifyPeerCallback(t *testing.T) {
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-	srv := newMockedVerifySrv(t, verifyResponse(measurement))
-	defer srv.Close()
-	cb := verifyPeerCallback(&VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}})
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
+	cb := verifyPeerCallback(&VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}})
 
 	_, _, attested := testAttestedCert(t, nil)
 	plain := generateSimpleCert(t)

--- a/pkg/ratls/validity_test.go
+++ b/pkg/ratls/validity_test.go
@@ -9,15 +9,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"errors"
 	"math/big"
-	"net/http"
-	"net/http/httptest"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 )
 
@@ -49,53 +48,39 @@ func attestedCertWithWindow(t *testing.T, notBefore, notAfter time.Time) *x509.C
 	return cert
 }
 
-// countingVerifySrv is an attestation-api stub that records whether it was
-// consulted at all — the validity window is checked before the evidence
-// round-trip, so a cert outside it must never cost a /verify call.
-func countingVerifySrv(t *testing.T) (*httptest.Server, *atomic.Int32) {
-	t.Helper()
-	var calls atomic.Int32
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	t.Cleanup(srv.Close)
-	return srv, &calls
-}
-
 func TestVerifyCertEnforcesValidity(t *testing.T) {
 	now := time.Now()
 
 	t.Run("expired rejected before the evidence round-trip", func(t *testing.T) {
-		srv, calls := countingVerifySrv(t)
+		stub := testattest.New(t)
 		cert := attestedCertWithWindow(t, now.Add(-2*time.Hour), now.Add(-time.Hour))
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL}, nil)
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL}, nil)
 		if !errors.Is(err, ErrCertValidity) {
 			t.Fatalf("err = %v, want errors.Is ErrCertValidity", err)
 		}
-		if got := calls.Load(); got != 0 {
+		if got := len(stub.VerifyRequests()); got != 0 {
 			t.Fatalf("an expired certificate consumed %d attestation-api call(s), want 0", got)
 		}
 	})
 
 	t.Run("not yet valid beyond skew rejected", func(t *testing.T) {
-		srv, calls := countingVerifySrv(t)
+		stub := testattest.New(t)
 		cert := attestedCertWithWindow(t, now.Add(certutil.LeafValiditySkew+time.Minute), now.Add(2*time.Hour))
-		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL}, nil)
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL}, nil)
 		if !errors.Is(err, ErrCertValidity) {
 			t.Fatalf("err = %v, want errors.Is ErrCertValidity", err)
 		}
-		if got := calls.Load(); got != 0 {
+		if got := len(stub.VerifyRequests()); got != 0 {
 			t.Fatalf("a not-yet-valid certificate consumed %d attestation-api call(s), want 0", got)
 		}
 	})
 
 	t.Run("NotBefore within skew accepted", func(t *testing.T) {
 		measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
-		srv := newMockedVerifySrv(t, verifyResponse(measurement))
-		defer srv.Close()
+		stub := testattest.New(t)
+		stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
 		cert := attestedCertWithWindow(t, now.Add(certutil.LeafValiditySkew-time.Minute), now.Add(2*time.Hour))
-		if _, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL, Measurements: [][]byte{measurement}}, nil); err != nil {
+		if _, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: [][]byte{measurement}}, nil); err != nil {
 			t.Fatalf("NotBefore within the skew allowance must pass: %v", err)
 		}
 	})
@@ -106,19 +91,19 @@ func TestVerifyCertEnforcesValidity(t *testing.T) {
 // evidence has, so an expired peer must be refused — and cheaply, before any
 // attestation-api round-trip.
 func TestDualVerifyPeerCallbackRejectsExpiredSelfSigned(t *testing.T) {
-	srv, calls := countingVerifySrv(t)
+	stub := testattest.New(t)
 	cert := attestedCertWithWindow(t, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour))
 	_, caCert := generateCACert(t)
 
 	verify := dualVerifyPeerCallback(
-		&VerifyPolicy{AttestationApiURL: srv.URL},
+		&VerifyPolicy{AttestationApiURL: stub.URL},
 		newSharedCACerts([]*x509.Certificate{caCert}),
 	)
 	err := verify([][]byte{cert.Raw}, nil)
 	if !errors.Is(err, ErrCertValidity) {
 		t.Fatalf("err = %v, want errors.Is ErrCertValidity", err)
 	}
-	if got := calls.Load(); got != 0 {
+	if got := len(stub.VerifyRequests()); got != 0 {
 		t.Fatalf("an expired peer consumed %d attestation-api call(s), want 0", got)
 	}
 }
@@ -301,7 +286,7 @@ func TestDualVerifyPeerCallbackSharesTheSkewWindow(t *testing.T) {
 // rewritable under a genuine attestation. That check belongs here, not only
 // in the callers that happen to run certutil.AuthenticateLeafBody themselves.
 func TestVerifyCertAuthenticatesTheLeafBody(t *testing.T) {
-	srv, calls := countingVerifySrv(t)
+	stub := testattest.New(t)
 	now := time.Now()
 
 	// Same attested key, body signed by a different key: a self-issued leaf
@@ -331,11 +316,11 @@ func TestVerifyCertAuthenticatesTheLeafBody(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = VerifyCert(cert, &VerifyPolicy{AttestationApiURL: srv.URL}, nil)
+	_, err = VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL}, nil)
 	if err == nil || !strings.Contains(err.Error(), "does not verify with its own key") {
 		t.Fatalf("err = %v, want the self-signature rejection", err)
 	}
-	if got := calls.Load(); got != 0 {
+	if got := len(stub.VerifyRequests()); got != 0 {
 		t.Fatalf("a re-signed body consumed %d attestation-api call(s), want 0", got)
 	}
 }


### PR DESCRIPTION
## Summary

Test-only change: one shared attestation-api stub (`internal/testattest`) replacing the private per-package fakes, plus the binding/negative assertions that were asserted by nothing before.

- `/attest` serves SNP-report-shaped fake evidence carrying the requested report data (consumable by the production evidence-ingestion paths — verified against `MakeSNPRATLSAttestFunc`→`ExtractSNPReport` and the get-kubeconfig TDX-gated flow), with platform resolution (`auto` → `SetPlatform`).
- `/verify` decodes the real `types.VerifyRequest`, records `Params.ExpectedReportData` per call, and returns a configurable verdict (including `ReportDataMatch:false`).
- Adopted in `internal/cmds/cds`, `internal/cmds/attestation`, `internal/cdsclient`, and `pkg/ratls` (whose private fixtures were the source the stub was lifted from). Remaining private fixtures are enumerated in the tree-wide census with reasons (out of scope or not convertible).
- New negative pins: `/attest` report-data binding to CSR key + challenge; `ReportDataMatch:false` → 401; `/attest-key` challenge + operator-policy binding (incl. empty-hash); challenge replay rejection; sandbox-ID rejection set.

## Mutation evidence (each negative test kills its mutation)

| Production line | Mutation | Result |
|---|---|---|
| attest.go:169 `ratls.ReportDataForKey(csrPubKey, challengeBytes)` | pass `nil` challenge | TestAttest_BindsReportDataToCSRKeyAndChallenge FAILS |
| attest.go:182 `[:sha512.Size384]` | `[:sha512.Size]` (64 bytes) | TestAttest_BindsReportDataToCSRKeyAndChallenge FAILS |
| attest.go classifyVerifyError `ErrReportDataMismatch` arm | return 502 instead of 401 | TestAttest_ReportDataMismatchReturns401 FAILS |
| attest.go verifySandboxToken `ratls.ValidateSandboxID(...)` | delete the call | TestAttest_SandboxToken_RejectsMalformedSandboxID FAILS |
| handler.go:92 `ReportDataForKeyWithContext(pub, challenge, []byte(req.OperatorKeysHash))` | pass `nil` context | TestAttestKeyBindsChallengeAndOperatorPolicyIntoReportData FAILS (with-policy case) |
| handler.go `h.Challenges.Consume(challengeBytes)` | never consume | TestAttestKeyRejectsReplayedChallenge FAILS (second request gets 200) |
| attestationclient/verify.go az-snp 48-byte nonce | send 64 bytes | TestVerifyCertEmbeddedAzureEvidenceUsesAttestationApi FAILS |

## Notes

- No production behaviour changes; the only non-test file is the test-helper package.
- Deviation: a non-IA5String sandbox ID (`sandbox-🙂`) is unrepresentable in a signed token (ASN.1 marshal rejects it); that case is pinned at `ratls.TestValidateSandboxID` instead, with the handler-level gate pinned by the remaining cases.
- Follow-up (after the CI testing-import guard lands separately): extend that guard to name `internal/testattest` explicitly so the helper can never enter a shipped dep graph.
- `make test` green (`-race`, 64 packages); golangci-lint clean.
