### PR TITLE
fix(sidecar): keep the test-only inventory override out of the shipped binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,19 @@ jobs:
       - name: Build macOS CLI
         run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/c8s-darwin ./cmd/c8s
 
+      # testing must stay out of the measured binaries. c8s_node changes the
+      # graph, so it is listed separately.
+      - name: Guard testing out of shipped binaries
+        run: |
+          if go list -deps ./cmd/... | grep -qx testing; then
+            echo "testing is in the dep graph of a shipped binary" >&2
+            exit 1
+          fi
+          if go list -tags c8s_node -deps ./cmd/c8s | grep -qx testing; then
+            echo "testing is in the dep graph of the c8s_node binary" >&2
+            exit 1
+          fi
+
       - name: Test
         run: make test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,15 +95,17 @@ jobs:
       - name: Build macOS CLI
         run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/c8s-darwin ./cmd/c8s
 
-      # testing must stay out of the measured binaries. c8s_node changes the
-      # graph, so it is listed separately.
+      # testing must stay out of the measured binaries. CGO_ENABLED=0 matches the
+      # shipped builds; c8s_node changes the graph, so it is listed separately.
       - name: Guard testing out of shipped binaries
         run: |
-          if go list -deps ./cmd/... | grep -qx testing; then
+          deps=$(CGO_ENABLED=0 go list -deps ./cmd/...)
+          if grep -qx testing <<<"$deps"; then
             echo "testing is in the dep graph of a shipped binary" >&2
             exit 1
           fi
-          if go list -tags c8s_node -deps ./cmd/c8s | grep -qx testing; then
+          node_deps=$(CGO_ENABLED=0 go list -tags c8s_node -deps ./cmd/c8s)
+          if grep -qx testing <<<"$node_deps"; then
             echo "testing is in the dep graph of the c8s_node binary" >&2
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
 - [confidential.ai](https://confidential.ai), the company behind c8s
 - [Documentation](https://confidential.ai/docs/c8s), the full user-facing docs
 - [Whitepaper](https://confidential.ai/docs/whitepapers/c8s), the c8s architecture paper (also on [arXiv](https://arxiv.org/abs/2604.26974))
-- [Setting up a confidential VM](https://confidential.ai/docs/c8s/tutorials/azure-e2e), an end-to-end tutorial from bare cloud account to verified confidential workload
+- [Your first confidential cluster](https://confidential.ai/docs/c8s/tutorials/first-confidential-cluster), an end-to-end tutorial from bare cloud account to verified confidential workload
 - [c8s-verify](https://github.com/confidential-dot-ai/c8s-verify-js), verify a c8s cluster from a browser
 - [attestation-rs](https://github.com/confidential-dot-ai/attestation-rs), the TEE evidence verification service c8s uses
 - [RA-TLS](docs/ratls.md), how attested TLS works in c8s — the handshake step by step, the guarantees, and which certificate is used where
@@ -70,21 +70,26 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
 - **Container image and command-line allowlisting.** Every container is
   enforced against a CDS-served allowlist with two layers: a floor of image
   digests admitted by digest alone, and named workload entries that
-  additionally pin the command line each image may run with. Enforced by an
+  additionally pin the command line each image may run with — and, in the
+  guest, the bind-mount destinations and environment variable names.
+  Enforced by an
   NRI plugin on the host under node-as-CVM, and by an in-guest
   `policy-monitor` under pod-as-CVM, where the host cannot tamper with it.
 
 - **Attestation-gated secrets.** CDS releases an application secret only once
   a pod's running containers resolve to a single allowlist entry carrying a
   grant for that path. An injected sidecar writes the values to a
-  memory-backed volume every container mounts read-only. Node-as-CVM only.
+  memory-backed volume every container mounts read-only. Works in both
+  shapes: the sidecar redeems its sandbox token from the node's admission
+  inventory, or from the in-guest `policy-monitor` under pod-as-CVM.
 
 - **Encrypted volumes.** Data too large to be a secret — model weights, in
   practice — encrypted at rest on host-visible storage (erofs, dm-verity,
   dm-crypt) and opened only inside the TEE. The key travels as a secret
   through the release path above, so possession of the volume implies nothing
-  without attestation. Node-as-CVM only; the `volumed` node agent ships
-  disabled — `c8s install --volumes` deploys it.
+  without attestation. On node-as-CVM the `volumed` node agent ships
+  disabled — `c8s install --volumes` deploys it; under pod-as-CVM `volumed`
+  runs inside each guest, baked into the measured image.
 
 - **Fail-closed admission.** A mutating webhook injects certificate sidecars
   and Kata RuntimeClasses; a ValidatingAdmissionPolicy rejects anything that
@@ -179,7 +184,7 @@ trust everything on it), pod-as-CVM is the mutual-distrust model (the
 platform and the workloads do not trust each other, and each pod attests
 independently). The full comparison, including density, latency, and platform
 support, is in the
-[docs](https://confidential.ai/docs/c8s/runtime/pod-vs-node-cvm) and
+[docs](https://confidential.ai/docs/c8s/concepts/trust-boundaries) and
 [docs/install-flows.md](docs/install-flows.md).
 
 ## Quickstart
@@ -187,7 +192,7 @@ support, is in the
 Install c8s onto an existing cluster. The full walkthrough is
 [docs/QUICKSTART.md](docs/QUICKSTART.md); the hosted version with
 provisioning guides is at
-[confidential.ai/docs/c8s](https://confidential.ai/docs/c8s/install/installation).
+[confidential.ai/docs/c8s](https://confidential.ai/docs/c8s/how-to/install).
 
 ### Prerequisites
 
@@ -195,7 +200,7 @@ provisioning guides is at
 - Nodes with the TEE hardware for your chosen shape: an AMD SEV-SNP or Intel
   TDX host for pod-as-CVM, or SEV-SNP / TDX confidential VMs as nodes for
   node-as-CVM
-  (see the [CVM setup guide](https://confidential.ai/docs/c8s/tutorials/azure-e2e)).
+  (see the [first-cluster tutorial](https://confidential.ai/docs/c8s/tutorials/first-confidential-cluster)).
   Node kernels must be recent enough for the TEE (AMD SEV-SNP ≥ 6.11, Intel TDX
   ≥ 6.16), which also satisfies the Linux ≥ 6.5 `SO_PEERPIDFD` the admission
   inventory relies on — see [docs/QUICKSTART.md](docs/QUICKSTART.md).
@@ -251,10 +256,14 @@ attestation-bound certificate from CDS and renews it. Certificates land in
 ### Pod-as-CVM
 
 `--cvm-mode=pod` installs the Kata runtime and enforces it: every in-scope workload
-pod becomes a confidential VM, and non-Kata pods are rejected at admission.
+pod becomes a confidential VM, and non-Kata pods are rejected at admission. Pin the
+kata guest launch digest(s) from `c8s kata measure` — one per pod shape you run —
+because an in-guest `get-cert` refuses to reach a CDS no measurement pins, so an
+unpinned pod-mode install leaves workloads dead at init:
 
 ```sh
 c8s install --cvm-mode=pod --namespace c8s-system \
+  --measurements <cds-guest-digest>,<workload-guest-digest> \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 \
   --upstream vllm
 ```
@@ -313,7 +322,7 @@ attestation and reports the operator keys it pins.
 | [`cmd/ratls-mesh`](cmd/ratls-mesh/) | Transparent L4 proxy wrapping inter-node K8s traffic in RA-TLS | [README](cmd/ratls-mesh/README.md) |
 | [`cmd/nri-image-policy`](cmd/nri-image-policy/) | NRI plugin enforcing the image and argv allowlist on the host; also the node's admission inventory | [allowlist](docs/allowlist-and-capabilities.md) |
 | [`cmd/policy-monitor`](cmd/policy-monitor/) | The same enforcement and inventory in-guest, baked into the pod-as-CVM image | [image policy](docs/kata-image-policy.md) |
-| [`cmd/volumed`](cmd/volumed/) | Node agent that opens encrypted volumes into a pod's mount namespace | [volumes](docs/volumes.md) |
+| [`cmd/volumed`](cmd/volumed/) | Encrypted-volume agent — opens volumes into a pod's mount namespace, as a node DaemonSet or in-guest (`--guest`) under pod-as-CVM | [volumes](docs/volumes.md) |
 
 ## Libraries
 
@@ -347,6 +356,8 @@ internal/          Operator, webhook, attestation, mesh CA, secret store,
                    embedded Helm chart
 pkg/               Public Go libraries (see Libraries above)
 kata-guest-base/   Confidential guest image recipe for pod-as-CVM
+node-guest-image/  The node-image definition for node-as-CVM (new home;
+                   phase 0 — nothing consumes it from here yet)
 docs/              Design and operator docs
 samples/           Example manifests
 scripts/           Dev and CI helpers
@@ -496,8 +507,9 @@ than let you discover them:
   for demos, mandatory homework for production.
 
 - **CDS is a singleton by default.** The mesh CA key lives only in CDS process
-  memory; a restart mints a new CA and workloads re-bootstrap. Active/active
-  handoff exists behind `cds.handoff.enabled`.
+  memory; a restart mints a new CA and workloads re-bootstrap. Attested
+  handoff to a successor replica exists behind `cds.handoff.enabled` —
+  one active CDS at a time, not active/active.
 
 - **Mesh peers are verified by CA chain, not per-peer measurement.** Leaves
   carry the evidence CDS verified at issuance, and `VerifyPolicy` has a
@@ -513,16 +525,20 @@ than let you discover them:
 
 - **The image allowlist gates digest and command line, not the rest of the
   pod spec.** Each container's `command` prefix and `args` remainder are
-  enforced against the effective argv; env, mounts, capabilities, and the
+  enforced against the effective argv, and bind-mount destinations and env
+  variable names are enforceable in the guest; capabilities and the
   remaining pod-spec fields are not. Nothing enforces which images run
   *together* — every running image must be allowlisted, but no gate requires
   the set in one pod to match a single workload entry.
 
-- **Secrets and encrypted volumes are node-as-CVM only.** Both injected
-  fetchers redeem their sandbox token over the node's admission-inventory
-  socket, which a Kata guest does not have, so the webhook rejects
-  `confidential.ai/c8s-secrets` and `confidential.ai/c8s-volumes` at admission
-  under pod-as-CVM rather than admitting a pod that would block forever.
+- **Secrets and encrypted volumes under pod-as-CVM carry weaker guarantees
+  than on a node.** Both work — the injected fetchers redeem their sandbox
+  token from the in-guest `policy-monitor` over loopback, and `volumed
+  --guest` opens devices inside the pod's own CVM — but the sandbox ID a
+  release is gated on is a host-written CRI annotation there, not a value the
+  kernel read, and the allowlist enforcement it consults is in-guest software
+  rather than a host hook. A deployment whose threat model cannot accept
+  either should stay on node-as-CVM.
 
 - **Init containers cannot consume a released secret.** The secret volume is
   mounted into every container in the pod, but CDS releases only once *every*
@@ -534,16 +550,20 @@ than let you discover them:
   injected fetcher is a native sidecar for this reason: it is the one entry in
   `initContainers` that keeps running alongside the workload.
 
-- **`c8s allowlist` writes do not reach running confidential pods.** In-guest
-  `policy-monitor` refuses to refresh from CDS unless `C8S_CDS_MEASUREMENTS`
-  pins the CDS launch digest, and no shipping path delivers that pin — baking
-  it is self-referential under pod-as-CVM, and per-pod cloud-init is
-  host-controlled. Refresh is therefore disabled on every default install:
-  each guest enforces only the seed baked into its measured image, so
-  admitting a new workload image inside a confidential pod means rebuilding
-  the guest image. Deliberately fail-closed — "any attested TEE" is not good
-  enough here, because the host can boot its own CVM from the same guest image
-  and serve an allowlist of its choosing.
+- **On TDX, `c8s allowlist` writes do not reach running confidential pods.**
+  In-guest `policy-monitor` refuses to refresh from CDS unless
+  `C8S_CDS_MEASUREMENTS` pins the CDS launch digest. On SEV-SNP the webhook
+  delivers that pin in the pod's launch-committed init-data document and
+  running guests pick up writes within one refresh interval; on TDX the
+  digest lands in a register the guest does not read back, so refresh stays
+  disabled and each guest enforces only the seed baked into its measured
+  image — admitting a new workload image inside a TDX confidential pod means
+  rebuilding the guest image. Installs with no pinned measurements, and the
+  chart-managed pods in the release namespace (which get no init-data),
+  enforce the seed alone on either platform. The gating is deliberately
+  fail-closed — "any attested TEE" is not good enough here, because the host
+  can boot its own CVM from the same guest image and serve an allowlist of
+  its choosing.
 
 - **Root workloads can bypass the in-guest mesh.** UID-0 egress is exempted
   so the attestation service can reach AMD KDS. Run workloads as non-root.
@@ -575,11 +595,6 @@ The direction of travel:
 - **GPU attestation end to end.** Collect GPU evidence in the guest and
   require it at certificate issuance, so a positive GPU attestation reaches
   the relying party rather than stopping at the attestation service.
-
-- **Secrets and encrypted volumes under pod-as-CVM.** Give the in-guest
-  fetchers a path to the admission inventory, so attestation-gated release
-  works in the shape with the strongest boundary rather than only the
-  node-as-CVM one.
 
 - **In-TEE volume encryption.** Stream plaintext into a CVM that generates the
   key, writes the encrypted volume, and commits the key straight to the secret

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -34,9 +34,9 @@ func (stubResolver) DigestsForSandbox(string) ([]string, []workloadclaims.Sandbo
 	return nil, nil, false, nil
 }
 
-// startInventory serves the real token route on a unix socket and points the
-// sidecar at it.
-func startInventory(t *testing.T) {
+// startInventory serves the real token route on a unix socket and returns its
+// endpoint.
+func startInventory(t *testing.T) string {
 	t.Helper()
 	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
 	if err != nil {
@@ -51,7 +51,7 @@ func startInventory(t *testing.T) {
 	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
-	sidecar.SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })
+	return "unix://" + sock
 }
 
 // fakeCDS records what it was asked and answers from a scripted sequence.
@@ -129,11 +129,11 @@ func testKey(t *testing.T) *ecdsa.PublicKey {
 
 // An existing secret is read and returned without a create.
 func TestFetchOneReadsExisting(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db": {{status: http.StatusOK, value: "existing"}},
 	})
-	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/api/db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -148,12 +148,12 @@ func TestFetchOneReadsExisting(t *testing.T) {
 // A path the store does not hold yet is created by the workload that finds it
 // empty.
 func TestFetchOneCreatesWhenAbsent(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db":  {{status: http.StatusNotFound}},
 		"POST /secrets/api/db": {{status: http.StatusCreated, value: "minted"}},
 	})
-	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/api/db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,12 +169,12 @@ func TestFetchOneCreatesWhenAbsent(t *testing.T) {
 // recovers by reading — otherwise it would hold nothing while its sibling holds
 // the secret.
 func TestFetchOneRereadsAfterLosingCreateRace(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db":  {{status: http.StatusNotFound}, {status: http.StatusOK, value: "winner"}},
 		"POST /secrets/api/db": {{status: http.StatusConflict}},
 	})
-	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db")
+	got, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/api/db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,11 +189,11 @@ func TestFetchOneRereadsAfterLosingCreateRace(t *testing.T) {
 
 // A denial is not a create: only 404 means the path is free.
 func TestFetchOneDoesNotCreateOnDenial(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db": {{status: http.StatusForbidden}},
 	})
-	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db"); err == nil {
+	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/api/db"); err == nil {
 		t.Fatal("a denial was treated as success")
 	}
 	for _, r := range cds.requests {
@@ -206,12 +206,12 @@ func TestFetchOneDoesNotCreateOnDenial(t *testing.T) {
 // Every request takes its own challenge and its own token: both are single-use,
 // so reusing either would be refused by CDS.
 func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db":  {{status: http.StatusNotFound}, {status: http.StatusOK, value: "v"}},
 		"POST /secrets/api/db": {{status: http.StatusConflict}},
 	})
-	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/api/db"); err != nil {
+	if _, err := fetchOne(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/api/db"); err != nil {
 		t.Fatal(err)
 	}
 	if cds.challenges != len(cds.requests) {
@@ -233,7 +233,7 @@ func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
 // is running — so a denial that later clears must succeed rather than fail the
 // pod.
 func TestFetchWithRetryRecoversOnceReleased(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db": {
 			{status: http.StatusForbidden},
@@ -248,7 +248,7 @@ func TestFetchWithRetryRecoversOnceReleased(t *testing.T) {
 	var values map[string][]byte
 	err := sidecar.Retry(context.Background(), cfg.Config, "secret", func(ctx context.Context) error {
 		var err error
-		values, err = fetchAllWith(ctx, cfg, http.DefaultClient, pub)
+		values, err = fetchAllWith(ctx, cfg, http.DefaultClient, pub, endpoint)
 		return err
 	})
 	if err != nil {
@@ -265,7 +265,7 @@ func TestFetchWithRetryRecoversOnceReleased(t *testing.T) {
 // A bounded run that never gets released fails rather than idling in a Running
 // pod with no secret.
 func TestFetchWithRetryGivesUp(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db": {{status: http.StatusForbidden}, {status: http.StatusForbidden}},
 	})
@@ -276,7 +276,7 @@ func TestFetchWithRetryGivesUp(t *testing.T) {
 	attempts := 0
 	err := sidecar.Retry(context.Background(), cfg.Config, "secret", func(ctx context.Context) error {
 		attempts++
-		_, err := fetchAllWith(ctx, cfg, http.DefaultClient, pub)
+		_, err := fetchAllWith(ctx, cfg, http.DefaultClient, pub, endpoint)
 		return err
 	})
 	if err == nil {

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -104,14 +104,14 @@ func fetchAll(ctx context.Context, cfg config, measurements [][]byte) (map[strin
 	if err != nil {
 		return nil, err
 	}
-	return fetchAllWith(ctx, cfg, client, pub)
+	return fetchAllWith(ctx, cfg, client, pub, cfg.Endpoint())
 }
 
 // fetchAllWith is fetchAll once the client and the key it is bound to exist.
-func fetchAllWith(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey) (map[string][]byte, error) {
+func fetchAllWith(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, endpoint string) (map[string][]byte, error) {
 	out := make(map[string][]byte, len(cfg.Secrets))
 	for _, s := range cfg.Secrets {
-		value, err := fetchOne(ctx, cfg, client, pub, s.Path)
+		value, err := fetchOne(ctx, cfg, client, pub, endpoint, s.Path)
 		if err != nil {
 			return nil, fmt.Errorf("secret %s: %w", s.Path, err)
 		}
@@ -125,8 +125,8 @@ func fetchAllWith(ctx context.Context, cfg config, client *http.Client, pub cryp
 // A workload that starts and finds its path empty is the one that creates it,
 // so 404 means "create". A 409 on that create means another replica won the
 // race, and the value is read back rather than returned by the create.
-func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, path string) ([]byte, error) {
-	value, status, err := sidecar.Do(ctx, cfg.Config, client, pub, http.MethodGet, path)
+func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, endpoint, path string) ([]byte, error) {
+	value, status, err := sidecar.Do(ctx, cfg.Config, client, pub, endpoint, http.MethodGet, path)
 	switch {
 	case err != nil && status != http.StatusNotFound:
 		return nil, err
@@ -134,7 +134,7 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 		return value, nil
 	}
 
-	value, status, err = sidecar.Do(ctx, cfg.Config, client, pub, http.MethodPost, path)
+	value, status, err = sidecar.Do(ctx, cfg.Config, client, pub, endpoint, http.MethodPost, path)
 	switch {
 	case status == http.StatusCreated:
 		return value, nil
@@ -142,7 +142,7 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 		return nil, err
 	}
 
-	value, status, err = sidecar.Do(ctx, cfg.Config, client, pub, http.MethodGet, path)
+	value, status, err = sidecar.Do(ctx, cfg.Config, client, pub, endpoint, http.MethodGet, path)
 	if status != http.StatusOK {
 		return nil, fmt.Errorf("created by another replica but not readable: %w", err)
 	}

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -103,7 +103,7 @@ func startDaemon(t *testing.T, dir string) *recordingOps {
 // inventory, reads the blob from CDS, and hands it to a real volumed, which
 // opens the device and mounts it into the pod's own emptyDir.
 func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testBlobJSON(t)}},
 	})
@@ -114,7 +114,7 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 	cfg := flowConfig(t, url)
 	cfg.SocketDir = socketDir
 	daemon, daemonBase := daemonClient(cfg)
-	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err != nil {
 		t.Fatalf("open: %v", err)
 	}
 
@@ -157,7 +157,7 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 // A restarted sidecar re-sends its request; the daemon must not open a second
 // mapping for it.
 func TestSidecarRepeatIsIdempotent(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {
 			{status: http.StatusOK, value: testBlobJSON(t)},
@@ -172,7 +172,7 @@ func TestSidecarRepeatIsIdempotent(t *testing.T) {
 	cfg.SocketDir = socketDir
 	for i := 0; i < 2; i++ {
 		daemon, daemonBase := daemonClient(cfg)
-		if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
+		if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err != nil {
 			t.Fatalf("attempt %d: %v", i, err)
 		}
 	}
@@ -187,7 +187,7 @@ func TestSidecarRepeatIsIdempotent(t *testing.T) {
 // The daemon's refusal reaches the sidecar as a failure rather than being
 // mistaken for success.
 func TestSidecarReportsADaemonRefusal(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testBlobJSON(t)}},
 	})
@@ -200,7 +200,7 @@ func TestSidecarReportsADaemonRefusal(t *testing.T) {
 	// A volume the pod has no emptyDir for: the daemon has nowhere to mount it.
 	cfg.Volumes = []volumeRequest{{Name: "absent", Path: "/tenant-a/volumes/weights"}}
 	daemon, daemonBase := daemonClient(cfg)
-	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err == nil {
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err == nil {
 		t.Fatal("a refused open was reported as success")
 	}
 }
@@ -244,7 +244,7 @@ func startGuestDaemon(t *testing.T) *recordingOps {
 }
 
 // startGuestInventory serves the token route on the compiled guest loopback
-// port, which is where the sidecar redeems under kata and is not overridable.
+// port, which is where the sidecar redeems under kata.
 func startGuestInventory(t *testing.T) {
 	t.Helper()
 	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
@@ -276,7 +276,7 @@ func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
 	cfg.SocketDir = "" // nothing is mounted in a guest
 
 	daemon, daemonBase := daemonClient(cfg)
-	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), daemon, daemonBase); err != nil {
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), cfg.Endpoint(), daemon, daemonBase); err != nil {
 		t.Fatalf("open: %v", err)
 	}
 

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -262,8 +262,8 @@ func startGuestInventory(t *testing.T) {
 
 // The kata path end to end, with nothing mounted: the sidecar redeems its token
 // on guest loopback, reads the blob from CDS, and hands it to an in-guest
-// volumed that mounts into kata's ephemeral directory. This is the whole of
-// what the host unix socket used to carry.
+// volumed that mounts into kata's ephemeral directory — the same delivery the
+// node path runs over the host unix sockets.
 func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
 	startGuestInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{

--- a/internal/cmds/getvolume/flow_test.go
+++ b/internal/cmds/getvolume/flow_test.go
@@ -34,9 +34,9 @@ func (stubResolver) DigestsForSandbox(string) ([]string, []workloadclaims.Sandbo
 	return nil, nil, false, nil
 }
 
-// startInventory serves the real token route on a unix socket and points the
-// sidecar at it.
-func startInventory(t *testing.T) {
+// startInventory serves the real token route on a unix socket and returns its
+// endpoint.
+func startInventory(t *testing.T) string {
 	t.Helper()
 	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
 	if err != nil {
@@ -51,7 +51,7 @@ func startInventory(t *testing.T) {
 	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
-	sidecar.SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })
+	return "unix://" + sock
 }
 
 // fakeCDS records what it was asked and answers from a scripted sequence.
@@ -168,12 +168,12 @@ func testKey(t *testing.T) *ecdsa.PublicKey {
 }
 
 func TestFetchBlobReadsTheStore(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testBlobJSON(t)}},
 	})
 
-	got, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/tenant-a/volumes/weights")
+	got, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/tenant-a/volumes/weights")
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -187,12 +187,12 @@ func TestFetchBlobReadsTheStore(t *testing.T) {
 // would squat the path with random bytes that decrypt nothing and leave the
 // real key unwritable behind a 409.
 func TestFetchBlobNeverCreates(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	f, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusNotFound}},
 	})
 
-	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/tenant-a/volumes/weights"); err == nil {
+	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/tenant-a/volumes/weights"); err == nil {
 		t.Fatal("an absent key was accepted")
 	}
 	for _, req := range f.seen() {
@@ -205,12 +205,12 @@ func TestFetchBlobNeverCreates(t *testing.T) {
 // A denial is not a reason to write either: release is refused until every main
 // container is admitted, so 403 is the normal early answer.
 func TestFetchBlobDoesNotWriteOnDenial(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	f, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusForbidden}},
 	})
 
-	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/tenant-a/volumes/weights"); err == nil {
+	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/tenant-a/volumes/weights"); err == nil {
 		t.Fatal("a denial was accepted")
 	}
 	if got := f.seen(); len(got) != 1 || got[0] != "GET /secrets/tenant-a/volumes/weights" {
@@ -220,12 +220,12 @@ func TestFetchBlobDoesNotWriteOnDenial(t *testing.T) {
 
 // A value that is not a key blob is refused rather than handed to the daemon.
 func TestFetchBlobRejectsANonBlob(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	_, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: []byte(`{"type":"something/else"}`)}},
 	})
 
-	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), "/tenant-a/volumes/weights"); err == nil {
+	if _, err := fetchBlob(context.Background(), flowConfig(t, url), http.DefaultClient, testKey(t), endpoint, "/tenant-a/volumes/weights"); err == nil {
 		t.Fatal("a foreign document was accepted as a key blob")
 	}
 }
@@ -233,7 +233,7 @@ func TestFetchBlobRejectsANonBlob(t *testing.T) {
 // Each request carries its own challenge and its own token; both are single-use
 // at CDS, so a reused pair is a replayed request.
 func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
-	startInventory(t)
+	endpoint := startInventory(t)
 	f, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/tenant-a/volumes/weights": {
 			{status: http.StatusForbidden},
@@ -243,7 +243,7 @@ func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
 	cfg := flowConfig(t, url)
 
 	for i := 0; i < 2; i++ {
-		_, _ = fetchBlob(context.Background(), cfg, http.DefaultClient, testKey(t), "/tenant-a/volumes/weights")
+		_, _ = fetchBlob(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, "/tenant-a/volumes/weights")
 	}
 
 	f.mu.Lock()

--- a/internal/cmds/getvolume/run.go
+++ b/internal/cmds/getvolume/run.go
@@ -105,13 +105,13 @@ func openAll(ctx context.Context, cfg config, measurements [][]byte) error {
 		return err
 	}
 	daemon, base := daemonClient(cfg)
-	return openAllWith(ctx, cfg, client, pub, daemon, base)
+	return openAllWith(ctx, cfg, client, pub, cfg.Endpoint(), daemon, base)
 }
 
 // openAllWith is openAll once the clients exist.
-func openAllWith(ctx context.Context, cfg config, cds *http.Client, pub crypto.PublicKey, daemon *http.Client, daemonBase string) error {
+func openAllWith(ctx context.Context, cfg config, cds *http.Client, pub crypto.PublicKey, endpoint string, daemon *http.Client, daemonBase string) error {
 	for _, v := range cfg.Volumes {
-		blob, err := fetchBlob(ctx, cfg, cds, pub, v.Path)
+		blob, err := fetchBlob(ctx, cfg, cds, pub, endpoint, v.Path)
 		if err != nil {
 			return fmt.Errorf("volume %s: %w", v.Name, err)
 		}
@@ -129,8 +129,8 @@ func openAllWith(ctx context.Context, cfg config, cds *http.Client, pub crypto.P
 // never minted: the operator put it there with `c8s volume create`, and a POST
 // here would squat the path with random bytes that decrypt nothing, leaving the
 // real key unwritable behind a 409.
-func fetchBlob(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, path string) (volume.Blob, error) {
-	value, _, err := sidecar.Do(ctx, cfg.Config, client, pub, http.MethodGet, path)
+func fetchBlob(ctx context.Context, cfg config, client *http.Client, pub crypto.PublicKey, endpoint, path string) (volume.Blob, error) {
+	value, _, err := sidecar.Do(ctx, cfg.Config, client, pub, endpoint, http.MethodGet, path)
 	if err != nil {
 		return volume.Blob{}, err
 	}

--- a/internal/cmds/sidecar/client.go
+++ b/internal/cmds/sidecar/client.go
@@ -57,15 +57,15 @@ func NewClient(cfg Config, measurements [][]byte) (*http.Client, crypto.PublicKe
 	}, parsed.PublicKey, nil
 }
 
-// Do performs one store request: a fresh challenge, a sandbox token bound to
-// it and to this pod's leaf key, then the request itself. Both are single-use,
-// so every call takes its own.
-func Do(ctx context.Context, cfg Config, client *http.Client, pub crypto.PublicKey, method, path string) ([]byte, int, error) {
+// Do performs one store request: a fresh challenge, a sandbox token redeemed
+// at endpoint and bound to the challenge and this pod's leaf key, then the
+// request itself. Both are single-use, so every call takes its own.
+func Do(ctx context.Context, cfg Config, client *http.Client, pub crypto.PublicKey, endpoint, method, path string) ([]byte, int, error) {
 	challenge, err := fetchChallenge(ctx, cfg, client)
 	if err != nil {
 		return nil, 0, err
 	}
-	token, err := workloadclaims.FetchSandboxToken(ctx, cfg.endpoint(), cfg.InventoryTimeout, pub, challenge)
+	token, err := workloadclaims.FetchSandboxToken(ctx, endpoint, cfg.InventoryTimeout, pub, challenge)
 	if err != nil {
 		return nil, 0, fmt.Errorf("redeem sandbox token: %w", err)
 	}

--- a/internal/cmds/sidecar/do_test.go
+++ b/internal/cmds/sidecar/do_test.go
@@ -28,9 +28,9 @@ func (stubResolver) DigestsForSandbox(string) ([]string, []workloadclaims.Sandbo
 	return nil, nil, false, nil
 }
 
-// startInventory serves the real token route on a unix socket and points the
-// sidecar at it.
-func startInventory(t *testing.T) {
+// startInventory serves the real token route on a unix socket and returns its
+// endpoint.
+func startInventory(t *testing.T) string {
 	t.Helper()
 	signer, err := workloadclaims.NewSandboxTokenSigner("10.0.0.7")
 	if err != nil {
@@ -45,7 +45,7 @@ func startInventory(t *testing.T) {
 	go workloadclaims.ServeTokens(ctx, l, stubResolver{}, workloadclaims.NewSignerHolder(signer))
 	t.Cleanup(func() { cancel(); l.Close() })
 
-	SetInventoryEndpointForTest(t, func() string { return "unix://" + sock })
+	return "unix://" + sock
 }
 
 func testPubKey(t *testing.T) *ecdsa.PublicKey {
@@ -67,7 +67,7 @@ func TestSecretResponseMustBeDecodable(t *testing.T) {
 		{"value not base64", `{"value":"!!!"}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			startInventory(t)
+			endpoint := startInventory(t)
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/secrets" {
 					w.Write([]byte(`{"challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`))
@@ -76,7 +76,7 @@ func TestSecretResponseMustBeDecodable(t *testing.T) {
 				w.Write([]byte(tc.body))
 			}))
 			defer srv.Close()
-			_, _, err := Do(context.Background(), testConfig(srv.URL), http.DefaultClient, testPubKey(t), http.MethodGet, "/api/db")
+			_, _, err := Do(context.Background(), testConfig(srv.URL), http.DefaultClient, testPubKey(t), endpoint, http.MethodGet, "/api/db")
 			if err == nil {
 				t.Fatal("an undecodable body was accepted as a secret")
 			}
@@ -87,13 +87,13 @@ func TestSecretResponseMustBeDecodable(t *testing.T) {
 // The inventory is where the sandbox token comes from; without it there is no
 // request to make.
 func TestUnreachableInventoryFails(t *testing.T) {
-	SetInventoryEndpointForTest(t, func() string { return "unix://" + filepath.Join(t.TempDir(), "absent.sock") })
+	endpoint := "unix://" + filepath.Join(t.TempDir(), "absent.sock")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte(`{"challenge":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="}`))
 	}))
 	defer srv.Close()
-	_, _, err := Do(context.Background(), testConfig(srv.URL), http.DefaultClient, testPubKey(t), http.MethodGet, "/api/db")
+	_, _, err := Do(context.Background(), testConfig(srv.URL), http.DefaultClient, testPubKey(t), endpoint, http.MethodGet, "/api/db")
 	if err == nil || !strings.Contains(err.Error(), "sandbox token") {
 		t.Fatalf("err = %v, want a sandbox-token failure", err)
 	}

--- a/internal/cmds/sidecar/endpoint_test.go
+++ b/internal/cmds/sidecar/endpoint_test.go
@@ -21,9 +21,9 @@ func TestEndpointSelectsCompiledShape(t *testing.T) {
 	if want := workloadclaims.GuestInventoryEndpoint(); guest != want {
 		t.Errorf("kata endpoint = %q, want the compiled guest loopback %q", guest, want)
 	}
-	// workloadclaims refuses anything that is not one of the two compiled
-	// endpoints, so a shape it rejects would fail every redemption. Use a real
-	// key: a nil one fails at marshalling, short of the endpoint check.
+	// workloadclaims only accepts a unix socket or the compiled guest loopback,
+	// so a shape it refuses would fail every redemption. Use a real key: a nil
+	// one fails at marshalling, short of the endpoint check.
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/cmds/sidecar/endpoint_test.go
+++ b/internal/cmds/sidecar/endpoint_test.go
@@ -14,10 +14,10 @@ import (
 // an address, so a wrong setting fails closed against a port nothing serves
 // rather than redirecting redemption to a rogue inventory.
 func TestEndpointSelectsCompiledShape(t *testing.T) {
-	if got, want := (Config{}).endpoint(), workloadclaims.InventoryEndpoint(); got != want {
+	if got, want := (Config{}).Endpoint(), workloadclaims.InventoryEndpoint(); got != want {
 		t.Errorf("node-CVM endpoint = %q, want the compiled unix socket %q", got, want)
 	}
-	guest := Config{WorkloadClaimsGuest: true}.endpoint()
+	guest := Config{WorkloadClaimsGuest: true}.Endpoint()
 	if want := workloadclaims.GuestInventoryEndpoint(); guest != want {
 		t.Errorf("kata endpoint = %q, want the compiled guest loopback %q", guest, want)
 	}

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -20,23 +19,6 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
-
-// inventoryEndpoint is where the sandbox token is redeemed. A package variable
-// only so tests can point it at a socket they control; production always uses
-// the compiled path, which is what stops a control-plane value redirecting the
-// redemption to a rogue inventory (docs/getcert-workload-binding.md, Corner 5).
-// Unexported so that guarantee holds by visibility; tests use
-// SetInventoryEndpointForTest.
-var inventoryEndpoint = workloadclaims.InventoryEndpoint
-
-// SetInventoryEndpointForTest points the redemption endpoint at a socket the
-// test controls, restoring the compiled path on cleanup. Requiring a
-// testing.TB keeps the override out of reach of production code.
-func SetInventoryEndpointForTest(t testing.TB, f func() string) {
-	prev := inventoryEndpoint
-	inventoryEndpoint = f
-	t.Cleanup(func() { inventoryEndpoint = prev })
-}
 
 // Config is the release plumbing every sidecar needs. The webhook renders all
 // of it; each command adds its own fields for what it fetches and where it
@@ -60,13 +42,15 @@ type Config struct {
 	InventoryTimeout time.Duration
 }
 
-// endpoint is the compiled inventory endpoint for this sidecar's shape. The
-// flag selects between two baked values, never an address.
-func (c Config) endpoint() string {
+// Endpoint is the compiled inventory endpoint: where the sandbox token is
+// redeemed. The flag selects between two baked values, never an address, so a
+// control-plane value cannot redirect the redemption to a rogue inventory
+// (docs/getcert-workload-binding.md, Corner 5).
+func (c Config) Endpoint() string {
 	if c.WorkloadClaimsGuest {
 		return workloadclaims.GuestInventoryEndpoint()
 	}
-	return inventoryEndpoint()
+	return workloadclaims.InventoryEndpoint()
 }
 
 // BindFlags registers the flags shared by every sidecar, with get-secret's


### PR DESCRIPTION
## Summary

- `internal/cmds/sidecar` imported `testing` in production code so tests could rebind the inventory endpoint — where the sandbox token is redeemed — via an exported setter. `&testing.T{}` is constructible from any package, so the setter was effectively callable production API, and `testing` linked into the shipped multi-mode binary that every per-role image `COPY`s in and that is measured into attestations.
- The override is deleted outright rather than moved to `export_test.go`: the getsecret/getvolume tests call it cross-package, which `export_test.go` cannot serve. `Config.Endpoint()` returns the compiled endpoint (still only the two baked values — a control-plane value cannot redirect redemption) and it is threaded explicitly through the fetch path; tests pass their own endpoint. No override mechanism ships in any form.
- `go list -deps` no longer lists `testing` for any shipped graph (`./cmd/c8s` and the node/guest binaries, computed `CGO_ENABLED=0` to match the release builds). `regexp` and `runtime/pprof` remain, arriving via legitimate production dependencies (grpc, cobra, k8s.io).

## CI guard

- A new CI step fails the build if `testing` reappears in any shipped dep graph. It computes both graphs under `CGO_ENABLED=0` (a `//go:build !cgo` re-add would otherwise slip past a CGO-on check) and fails loudly if `go list` itself errors.
- Demonstrated failing on a deliberate re-add — direct, indirect, and `!cgo`-tagged — then passing on a clean tree.
- Note: `.golangci.yml` enables only `unused` today, so this guard is the sole regression catcher until the linter set expands.

## Tests

Existing sidecar/getsecret/getvolume tests compile and pass with no behaviour change (test inventory identical); full suite green under `-race`.