### PR TITLE
fix(kataspec): align the sandbox exemption with the baked kata policy and pin the lockstep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,8 @@ test-e2e-ca-handoff:
 
 # Parse + decision tests for the baked kata-agent policy. The guest evaluates
 # it with regorus, which reads Rego v0 plus the future keywords, so the checks
-# run with --v0-compatible. Install with:
+# run with --v0-compatible. The fmt gate keeps the policy's layout normalised
+# for the Go lockstep tests that read its text. Install with:
 #   curl -fsSL -o opa https://openpolicyagent.org/downloads/$(OPA_VERSION)/opa_linux_amd64_static && chmod +x opa
 # Single source of the pinned version for CI's installer step.
 print-opa-version:
@@ -164,6 +165,7 @@ print-opa-version:
 
 policy-test:
 	@command -v $(OPA) >/dev/null 2>&1 || { echo "opa not found; see the policy-test comment in the Makefile"; exit 1; }
+	$(OPA) fmt --v0-compatible --diff --fail $(KATA_POLICY) $(KATA_POLICY_TESTS)
 	$(OPA) check --v0-compatible --strict $(KATA_POLICY)
 	$(OPA) test --v0-compatible $(KATA_POLICY) $(KATA_POLICY_TESTS)
 

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -505,15 +505,15 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		return
 	}
 
-	// The pod sandbox (pause) container is out of allowlist scope. In
-	// guest-pull mode (which c8s forces) kata-agent runs the pause baked
-	// into the dm-verity rootfs for any container it deems a sandbox (see
-	// isSandbox), so the sandbox's integrity comes from the launch
-	// measurement, not a digest on the allowlist — and the host can't
-	// substitute it. Skip it, identified exactly the way kata does so a
-	// mislabelled workload can't slip through (kata would run the measured
-	// pause for it, not the host's image). Checked before extractDigest
-	// because the pause carries no image-name annotation.
+	// The pod sandbox (pause) container is out of allowlist scope: in
+	// guest-pull mode kata-agent runs the pause baked into the dm-verity
+	// rootfs for any container the baked policy's sandbox_annotations rule
+	// accepts, so its integrity comes from the launch measurement, not a
+	// digest on the allowlist — and the host can't substitute it.
+	// IsSandbox mirrors that rule (policy_lockstep_test.go machine-compares
+	// the two), so a mislabelled workload gains nothing: kata runs the
+	// measured pause for it, not the host's image. Checked before
+	// PullDigest because the pause carries no image-name annotation.
 	// Every container (the pause included) names its pod sandbox in the CRI
 	// annotations; capture it for the inventory's sandbox-identity surface.
 	if m.inventory != nil {

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -362,14 +362,15 @@ func TestHandleNewContainer_MalformedConfigDenies(t *testing.T) {
 }
 
 func TestHandleNewContainer_SandboxSkipped(t *testing.T) {
-	// The pod sandbox (pause) container carries container-type=sandbox and
+	// The pod sandbox (pause) container carries the sandbox type markers and
 	// no image digest. kata runs the measured baked pause for it, so
 	// policy-monitor must skip it rather than deny — otherwise every pod's
 	// sandbox gets killed and no pod can start.
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := testCID("sandbox0")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
-		"io.kubernetes.cri.container-type": "sandbox",
+		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+		"io.kubernetes.cri.container-type":         "sandbox",
 	})
 
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
@@ -385,20 +386,43 @@ func TestHandleNewContainer_SandboxSkippedEvenWithUnallowlistedDigest(t *testing
 	// because kata-agent runs the measured baked pause for any sandbox
 	// regardless of the requested image, so a host that mislabels a
 	// workload as a sandbox to dodge enforcement gains nothing — its image
-	// never runs. policy-monitor identifies the sandbox the same way kata
-	// does (isSandbox), keeping the two in lockstep.
+	// never runs. policy-monitor identifies the sandbox the same way the
+	// baked kata-agent policy does (kataspec.IsSandbox), keeping the two in
+	// lockstep.
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := testCID("sandbox-evil")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
-		"io.kubernetes.cri.container-type": "sandbox",
-		"io.kubernetes.cri.image-name":     "ghcr.io/evil/badimage@sha256:" + denied,
+		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+		"io.kubernetes.cri.container-type":         "sandbox",
+		"io.kubernetes.cri.image-name":             "ghcr.io/evil/badimage@sha256:" + denied,
 	})
 
 	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
 
 	if calls := killer.snapshot(); len(calls) != 0 {
 		t.Fatalf("sandbox should be skipped even with a non-allowlisted digest, got %d kill calls: %+v", len(calls), calls)
+	}
+}
+
+func TestHandleNewContainer_CRIOSandboxMarkerDoesNotExempt(t *testing.T) {
+	// containerd never writes the CRI-O container-type key, and the baked
+	// kata-agent policy reads only the containerd one: a workload marker
+	// pair plus a CRI-O "sandbox" marker is a workload to kata, so
+	// policy-monitor must digest-check it, not exempt it.
+	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	cid := testCID("crionly-sb")
+	writeConfigJSON(t, watchDir, cid, map[string]string{
+		"io.kubernetes.cri.container-type":  "container",
+		"io.kubernetes.cri-o.ContainerType": "sandbox",
+		"io.kubernetes.cri.image-name":      "ghcr.io/evil/badimage@sha256:" + denied,
+	})
+
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	if calls := killer.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected the CRI-O-marked container to be digest-checked and killed, got %d kill calls: %+v", len(calls), calls)
 	}
 }
 
@@ -876,7 +900,8 @@ func TestReadConfigJSON_EmptyAnnotationsIsRetriedNotJudged(t *testing.T) {
 	go func() {
 		time.Sleep(30 * time.Millisecond)
 		writeConfigJSON(t, watchDir, cid, map[string]string{
-			"io.kubernetes.cri.container-type": "sandbox",
+			"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+			"io.kubernetes.cri.container-type":         "sandbox",
 		})
 	}()
 

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -406,10 +406,10 @@ func TestHandleNewContainer_SandboxSkippedEvenWithUnallowlistedDigest(t *testing
 }
 
 func TestHandleNewContainer_CRIOSandboxMarkerDoesNotExempt(t *testing.T) {
-	// containerd never writes the CRI-O container-type key, and the baked
-	// kata-agent policy reads only the containerd one: a workload marker
-	// pair plus a CRI-O "sandbox" marker is a workload to kata, so
-	// policy-monitor must digest-check it, not exempt it.
+	// The baked policy classifies on the containerd container-type marker
+	// and denies any request carrying the CRI-O one; if such a bundle ever
+	// reaches the guest anyway, policy-monitor must digest-check it, not
+	// exempt it.
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
 	cid := testCID("crionly-sb")

--- a/internal/cmds/policymonitor/verdict_test.go
+++ b/internal/cmds/policymonitor/verdict_test.go
@@ -50,7 +50,8 @@ func TestVerdict_AllowedContainer(t *testing.T) {
 func TestVerdict_SandboxContainer(t *testing.T) {
 	m, _, watchDir := newTestMonitor(t, []string{"sha256:" + strings.Repeat("a", 64)})
 	writeConfigJSON(t, watchDir, "sandbox-ctr", map[string]string{
-		"io.kubernetes.cri.container-type": "sandbox",
+		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+		"io.kubernetes.cri.container-type":         "sandbox",
 	})
 	dir := filepath.Join(watchDir, "sandbox-ctr")
 	m.handleNewContainer(context.Background(), dir)

--- a/internal/cmds/rtmr3measurer/measurer_test.go
+++ b/internal/cmds/rtmr3measurer/measurer_test.go
@@ -206,6 +206,24 @@ func TestSandboxContainerNotMeasured(t *testing.T) {
 	}
 }
 
+// The CRI-O container-type key is not a sandbox marker in this shape; a
+// container carrying only it is a workload and its digest is measured.
+func TestCRIOMarkedContainerIsMeasured(t *testing.T) {
+	watch, state := t.TempDir(), filepath.Join(t.TempDir(), "measured")
+	tdx := &fakeTDX{}
+	m := newTestMeasurer(t, watch, state, tdx)
+
+	writeConfigJSON(t, watch, cid1, map[string]string{
+		"io.kubernetes.cri.container-type":  "container",
+		"io.kubernetes.cri-o.ContainerType": "sandbox",
+		"io.kubernetes.cri.image-name":      "ghcr.io/confidential-dot-ai/app@sha256:" + hexA,
+	})
+	m.scanOnce()
+	if tdx.extends != 1 {
+		t.Fatalf("extends = %d, want 1 (the CRI-O marker does not exempt from measurement)", tdx.extends)
+	}
+}
+
 func TestUnpinnedImageNotMeasured(t *testing.T) {
 	watch, state := t.TempDir(), filepath.Join(t.TempDir(), "measured")
 	tdx := &fakeTDX{}

--- a/internal/cmds/rtmr3measurer/measurer_test.go
+++ b/internal/cmds/rtmr3measurer/measurer_test.go
@@ -197,7 +197,8 @@ func TestSandboxContainerNotMeasured(t *testing.T) {
 	m := newTestMeasurer(t, watch, state, tdx)
 
 	writeConfigJSON(t, watch, cid1, map[string]string{
-		"io.kubernetes.cri.container-type": "sandbox",
+		"io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+		"io.kubernetes.cri.container-type":         "sandbox",
 	})
 	m.scanOnce()
 	if tdx.extends != 0 {

--- a/internal/kataspec/kataspec.go
+++ b/internal/kataspec/kataspec.go
@@ -34,25 +34,22 @@ func PullDigest(annotations map[string]string) (string, bool) {
 	return "sha256:" + m[1], true
 }
 
-// containerTypeKeys mirrors kata-agent's K8S_CONTAINER_TYPE_KEYS: the
-// annotation keys a CRI runtime marks a container's type with.
-var containerTypeKeys = []string{
-	"io.kubernetes.cri.container-type",  // containerd CRI
-	"io.kubernetes.cri-o.ContainerType", // CRI-O
-}
+// The container-type markers the baked kata-agent policy conjoins in its
+// sandbox_annotations rule.
+const (
+	kataContainerTypeKey = "io.katacontainers.pkg.oci.container_type"
+	criContainerTypeKey  = "io.kubernetes.cri.container-type"
+)
 
 // IsSandbox reports whether the annotations mark this as the pod's sandbox
-// (pause) container. It mirrors kata-agent's own is_sandbox() exactly, and that
-// lockstep is load-bearing: in guest-pull mode kata runs the pause baked into
-// the dm-verity rootfs for any container it deems a sandbox, so the set c8s
-// exempts from digest enforcement must not be wider than kata's.
+// (pause) container. It mirrors the baked kata-agent policy's
+// sandbox_annotations rule, and the lockstep is load-bearing: in guest-pull
+// mode kata runs the pause baked into the dm-verity rootfs for any container
+// that rule accepts, so the set c8s exempts from digest enforcement must not
+// be wider. policy_lockstep_test.go machine-compares the two predicates.
 func IsSandbox(annotations map[string]string) bool {
-	for _, key := range containerTypeKeys {
-		if annotations[key] == "sandbox" {
-			return true
-		}
-	}
-	return false
+	return annotations[kataContainerTypeKey] == "pod_sandbox" &&
+		annotations[criContainerTypeKey] == "sandbox"
 }
 
 // containerID is the id set the baked kata-agent policy admits: the 32 random

--- a/internal/kataspec/kataspec.go
+++ b/internal/kataspec/kataspec.go
@@ -42,11 +42,8 @@ const (
 )
 
 // IsSandbox reports whether the annotations mark this as the pod's sandbox
-// (pause) container. It mirrors the baked kata-agent policy's
-// sandbox_annotations rule, and the lockstep is load-bearing: in guest-pull
-// mode kata runs the pause baked into the dm-verity rootfs for any container
-// that rule accepts, so the set c8s exempts from digest enforcement must not
-// be wider. policy_lockstep_test.go machine-compares the two predicates.
+// (pause) container, mirroring the baked kata-agent policy's
+// sandbox_annotations rule; policy_lockstep_test.go machine-compares the two.
 func IsSandbox(annotations map[string]string) bool {
 	return annotations[kataContainerTypeKey] == "pod_sandbox" &&
 		annotations[criContainerTypeKey] == "sandbox"

--- a/internal/kataspec/kataspec_test.go
+++ b/internal/kataspec/kataspec_test.go
@@ -95,9 +95,21 @@ func TestIsSandbox(t *testing.T) {
 		annotations map[string]string
 		want        bool
 	}{
-		{"containerd cri sandbox", map[string]string{"io.kubernetes.cri.container-type": "sandbox"}, true},
-		{"cri-o sandbox", map[string]string{"io.kubernetes.cri-o.ContainerType": "sandbox"}, true},
-		{"workload container", map[string]string{"io.kubernetes.cri.container-type": "container"}, false},
+		{"sandbox carries both markers", map[string]string{
+			kataContainerTypeKey: "pod_sandbox",
+			criContainerTypeKey:  "sandbox",
+		}, true},
+		{"kata marker alone", map[string]string{kataContainerTypeKey: "pod_sandbox"}, false},
+		{"containerd marker alone", map[string]string{criContainerTypeKey: "sandbox"}, false},
+		{"cri-o marker is not read", map[string]string{"io.kubernetes.cri-o.ContainerType": "sandbox"}, false},
+		{"workload container", map[string]string{
+			kataContainerTypeKey: "pod_container",
+			criContainerTypeKey:  "container",
+		}, false},
+		{"conflicting markers", map[string]string{
+			kataContainerTypeKey: "pod_sandbox",
+			criContainerTypeKey:  "container",
+		}, false},
 		{"no container-type annotation", map[string]string{PullReferenceKey: "ghcr.io/x:latest"}, false},
 		{"nil annotations", nil, false},
 	} {

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -92,6 +92,14 @@ func TestPullDigestAgreesWithBakedPolicy(t *testing.T) {
 	}
 }
 
+// containerd is the only CRI in this shape, so an honest CreateContainerRequest
+// never carries the CRI-O container-type key; the policy denies one that does.
+func TestBakedPolicyRejectsCRIOContainerTypeMarker(t *testing.T) {
+	if !strings.Contains(readPolicy(t), `not input.OCI.Annotations["io.kubernetes.cri-o.ContainerType"]`) {
+		t.Error("baked policy does not reject the CRI-O container-type marker")
+	}
+}
+
 // A rule that silently reverts to `default … := true` is a no-op with no
 // symptom, so pin the decisions the guest's integrity rests on.
 func TestBakedPolicyKeepsItsFailClosedDefaults(t *testing.T) {

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -92,11 +92,77 @@ func TestPullDigestAgreesWithBakedPolicy(t *testing.T) {
 	}
 }
 
+// ruleBodies extracts the bodies of the policy's top-level definitions of
+// name. The read is deliberately strict, and the lockstep tests below rely on
+// it: definitions are counted at column 0 so a second rule counts however it
+// is indented, each definition must be the braced, tab-indented shape these
+// tests parse, and an else chain after a body fails the test rather than
+// going unread.
+func ruleBodies(t *testing.T, policy, name string) []string {
+	t.Helper()
+	defs := regexp.MustCompile(`(?m)^`+regexp.QuoteMeta(name)+`\b`).FindAllStringIndex(policy, -1)
+	if len(defs) == 0 {
+		t.Fatalf("baked policy defines no %s rule", name)
+	}
+	body := regexp.MustCompile(regexp.QuoteMeta(name) + `[^\n{]*\{\n((?:\t[^\n]*\n|\n)+)\}`)
+	elseChain := regexp.MustCompile(`^\s*else\b`)
+	var bodies []string
+	for _, def := range defs {
+		m := body.FindStringSubmatchIndex(policy[def[0]:])
+		if m == nil || m[0] != 0 {
+			t.Fatalf("%s is not the braced, tab-indented rule this test reads", name)
+		}
+		if elseChain.MatchString(policy[def[0]+m[1]:]) {
+			t.Fatalf("%s continues in an else chain this test does not read", name)
+		}
+		bodies = append(bodies, policy[def[0]+m[2]:def[0]+m[3]])
+	}
+	return bodies
+}
+
 // containerd is the only CRI in this shape, so an honest CreateContainerRequest
-// never carries the CRI-O container-type key; the policy denies one that does.
+// never carries the CRI-O container-type key; the policy denies one that does,
+// in the OCI annotations and in the guest-pull metadata kata's handler reads
+// the marker from. The guards are pinned as lines of the CreateContainerRequest
+// body itself — a commented-out or relocated line would still contain the
+// substring.
 func TestBakedPolicyRejectsCRIOContainerTypeMarker(t *testing.T) {
-	if !strings.Contains(readPolicy(t), `not input.OCI.Annotations["io.kubernetes.cri-o.ContainerType"]`) {
-		t.Error("baked policy does not reject the CRI-O container-type marker")
+	bodies := ruleBodies(t, readPolicy(t), "CreateContainerRequest")
+	if len(bodies) != 1 {
+		t.Fatalf("baked policy has %d CreateContainerRequest rules, want exactly one", len(bodies))
+	}
+	for _, guard := range []string{
+		`not input.OCI.Annotations["io.kubernetes.cri-o.ContainerType"]`,
+		`not crio_pull_metadata(pull)`,
+	} {
+		line := regexp.MustCompile(`(?m)^\t` + regexp.QuoteMeta(guard) + `$`)
+		if !line.MatchString(bodies[0]) {
+			t.Errorf("CreateContainerRequest does not carry the guard line %q", guard)
+		}
+	}
+}
+
+// pull_source_bound decides what kata runs for an admitted request; its
+// sandbox branch is what makes it safe for policy-monitor to exempt the pause
+// from digest enforcement. Pin the admission shape that safety rests on:
+// exactly two branches, exactly one keyed on sandbox_annotations, and that
+// branch bound to the measured pause.
+func TestBakedPolicyBindsSandboxPullToPause(t *testing.T) {
+	bodies := ruleBodies(t, readPolicy(t), "pull_source_bound")
+	if len(bodies) != 2 {
+		t.Fatalf("baked policy has %d pull_source_bound branches, want exactly two (another would OR a second source binding past the admission contract)", len(bodies))
+	}
+	var sandbox []int
+	for i, b := range bodies {
+		if strings.Contains(b, "\tsandbox_annotations\n") {
+			sandbox = append(sandbox, i)
+		}
+	}
+	if len(sandbox) != 1 {
+		t.Fatalf("want exactly one pull_source_bound branch keyed on sandbox_annotations, got %d", len(sandbox))
+	}
+	if !strings.Contains(bodies[sandbox[0]], "\tpull.source == \"pause\"\n") {
+		t.Error("the sandbox branch of pull_source_bound does not bind pull.source to the measured pause")
 	}
 }
 
@@ -106,15 +172,13 @@ func TestBakedPolicyRejectsCRIOContainerTypeMarker(t *testing.T) {
 // predicate.
 func sandboxConjuncts(t *testing.T, policy string) map[string]string {
 	t.Helper()
-	rule := regexp.MustCompile(`sandbox_annotations if \{\n(?:\t[^\n]+\n)+\}`)
-	blocks := rule.FindAllString(policy, -1)
-	if len(blocks) != 1 {
-		t.Fatalf("baked policy has %d sandbox_annotations rules, want exactly one (a second one would OR another predicate past this test)", len(blocks))
+	bodies := ruleBodies(t, policy, "sandbox_annotations")
+	if len(bodies) != 1 {
+		t.Fatalf("baked policy has %d sandbox_annotations rules, want exactly one (a second one would OR another predicate past this test)", len(bodies))
 	}
-	block := regexp.MustCompile(`\{\n((?:\t[^\n]+\n)+)\}`).FindStringSubmatch(blocks[0])
 	equality := regexp.MustCompile(`^input\.OCI\.Annotations\["([^"]+)"\] == "([^"]+)"$`)
 	pairs := map[string]string{}
-	for _, l := range strings.Split(strings.TrimRight(block[1], "\n"), "\n") {
+	for _, l := range strings.Split(strings.TrimRight(bodies[0], "\n"), "\n") {
 		m := equality.FindStringSubmatch(strings.TrimPrefix(l, "\t"))
 		if m == nil {
 			t.Fatalf("sandbox_annotations carries a line the lockstep test cannot read: %q", l)
@@ -135,6 +199,20 @@ func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
 	conjuncts := sandboxConjuncts(t, readPolicy(t))
 	const crioKey = "io.kubernetes.cri-o.ContainerType"
 
+	check := func(annotations map[string]string) {
+		t.Helper()
+		policy := true
+		for key, want := range conjuncts {
+			if annotations[key] != want {
+				policy = false
+				break
+			}
+		}
+		if got := IsSandbox(annotations); got != policy {
+			t.Errorf("annotations %v: IsSandbox = %v, sandbox_annotations = %v", annotations, got, policy)
+		}
+	}
+
 	kataValues := []string{"", "pod_sandbox", "pod_container", "bogus"}
 	criValues := []string{"", "sandbox", "container", "SANDBOX"}
 	crioValues := []string{"", "sandbox", "container"}
@@ -152,18 +230,21 @@ func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
 						annotations[key] = value
 					}
 				}
-				policy := true
-				for key, want := range conjuncts {
-					if annotations[key] != want {
-						policy = false
-						break
-					}
-				}
-				if got := IsSandbox(annotations); got != policy {
-					t.Errorf("annotations %v: IsSandbox = %v, sandbox_annotations = %v", annotations, got, policy)
-				}
+				check(annotations)
 			}
 		}
+	}
+
+	// "" is the absent sentinel above; a marker present with an empty value
+	// is a distinct row the host can write.
+	for _, annotations := range []map[string]string{
+		{kataContainerTypeKey: ""},
+		{criContainerTypeKey: ""},
+		{kataContainerTypeKey: "", criContainerTypeKey: "sandbox"},
+		{kataContainerTypeKey: "pod_sandbox", criContainerTypeKey: ""},
+		{kataContainerTypeKey: "", criContainerTypeKey: "", crioKey: ""},
+	} {
+		check(annotations)
 	}
 }
 

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -26,7 +26,47 @@ func readPolicy(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("read baked policy: %v", err)
 	}
-	return string(body)
+	return stripComments(string(body))
+}
+
+// stripComments removes `#` comments, which carry no semantics: left in, a
+// comment line can hide an else chain from the extractors or pose as a rule.
+// String and raw-string literals are preserved.
+func stripComments(policy string) string {
+	var out strings.Builder
+	out.Grow(len(policy))
+	inString, inRaw := false, false
+	for i := 0; i < len(policy); i++ {
+		c := policy[i]
+		switch {
+		case inString:
+			out.WriteByte(c)
+			if c == '\\' && i+1 < len(policy) {
+				i++
+				out.WriteByte(policy[i])
+			} else if c == '"' {
+				inString = false
+			}
+		case inRaw:
+			out.WriteByte(c)
+			if c == '`' {
+				inRaw = false
+			}
+		case c == '"':
+			inString = true
+			out.WriteByte(c)
+		case c == '`':
+			inRaw = true
+			out.WriteByte(c)
+		case c == '#':
+			for i+1 < len(policy) && policy[i+1] != '\n' {
+				i++
+			}
+		default:
+			out.WriteByte(c)
+		}
+	}
+	return out.String()
 }
 
 // extractPattern pulls the single regex.match pattern applied to subject.
@@ -92,15 +132,15 @@ func TestPullDigestAgreesWithBakedPolicy(t *testing.T) {
 	}
 }
 
-// ruleBodies extracts the bodies of the policy's top-level definitions of
-// name. The read is deliberately strict, and the lockstep tests below rely on
-// it: definitions are counted at column 0 so a second rule counts however it
-// is indented, each definition must be the braced, tab-indented shape these
-// tests parse, and an else chain after a body fails the test rather than
-// going unread.
+// ruleBodies extracts the bodies of the policy's definitions of name from
+// comment-stripped text. The read is deliberately strict, and the lockstep
+// tests below rely on it: a definition counts however it is indented (the
+// fmt gate in make policy-test normalises heads to column 0), each
+// definition must be the braced, tab-indented shape these tests parse, and
+// an else chain after a body fails the test rather than going unread.
 func ruleBodies(t *testing.T, policy, name string) []string {
 	t.Helper()
-	defs := regexp.MustCompile(`(?m)^`+regexp.QuoteMeta(name)+`\b`).FindAllStringIndex(policy, -1)
+	defs := regexp.MustCompile(`(?m)^[ \t]*`+regexp.QuoteMeta(name)+`(\([^)]*\))?\s+(if|:=)`).FindAllStringIndex(policy, -1)
 	if len(defs) == 0 {
 		t.Fatalf("baked policy defines no %s rule", name)
 	}
@@ -144,9 +184,11 @@ func TestBakedPolicyRejectsCRIOContainerTypeMarker(t *testing.T) {
 
 // pull_source_bound decides what kata runs for an admitted request; its
 // sandbox branch is what makes it safe for policy-monitor to exempt the pause
-// from digest enforcement. Pin the admission shape that safety rests on:
-// exactly two branches, exactly one keyed on sandbox_annotations, and that
-// branch bound to the measured pause.
+// from digest enforcement, and its workload branch is the only place a
+// host-image source may bind. Pin the admission shape that safety rests on:
+// exactly two branches, the sandbox one keyed on sandbox_annotations and
+// bound to the measured pause, the workload one keyed on
+// workload_annotations.
 func TestBakedPolicyBindsSandboxPullToPause(t *testing.T) {
 	bodies := ruleBodies(t, readPolicy(t), "pull_source_bound")
 	if len(bodies) != 2 {
@@ -163,6 +205,20 @@ func TestBakedPolicyBindsSandboxPullToPause(t *testing.T) {
 	}
 	if !strings.Contains(bodies[sandbox[0]], "\tpull.source == \"pause\"\n") {
 		t.Error("the sandbox branch of pull_source_bound does not bind pull.source to the measured pause")
+	}
+	if !strings.Contains(bodies[1-sandbox[0]], "\tworkload_annotations\n") {
+		t.Error("the workload branch of pull_source_bound is not keyed on workload_annotations")
+	}
+}
+
+// A second workload_annotations definition would OR another predicate into
+// the branch that binds a host-image source — the widening half of the
+// admission contract. Counted and shape-checked exactly like
+// sandbox_annotations.
+func TestBakedPolicyDefinesOneWorkloadAnnotations(t *testing.T) {
+	bodies := ruleBodies(t, readPolicy(t), "workload_annotations")
+	if len(bodies) != 1 {
+		t.Fatalf("baked policy has %d workload_annotations rules, want exactly one (a second one would OR another predicate past the admission contract)", len(bodies))
 	}
 }
 

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -100,6 +100,73 @@ func TestBakedPolicyRejectsCRIOContainerTypeMarker(t *testing.T) {
 	}
 }
 
+// sandboxConjuncts extracts the annotation equalities the baked policy's
+// sandbox_annotations rule conjoins. The read is deliberately strict: a rule
+// edited into any other shape fails here rather than comparing a partial
+// predicate.
+func sandboxConjuncts(t *testing.T, policy string) map[string]string {
+	t.Helper()
+	rule := regexp.MustCompile(`sandbox_annotations if \{\n(?:\t[^\n]+\n)+\}`)
+	blocks := rule.FindAllString(policy, -1)
+	if len(blocks) != 1 {
+		t.Fatalf("baked policy has %d sandbox_annotations rules, want exactly one (a second one would OR another predicate past this test)", len(blocks))
+	}
+	block := regexp.MustCompile(`\{\n((?:\t[^\n]+\n)+)\}`).FindStringSubmatch(blocks[0])
+	equality := regexp.MustCompile(`^input\.OCI\.Annotations\["([^"]+)"\] == "([^"]+)"$`)
+	pairs := map[string]string{}
+	for _, l := range strings.Split(strings.TrimRight(block[1], "\n"), "\n") {
+		m := equality.FindStringSubmatch(strings.TrimPrefix(l, "\t"))
+		if m == nil {
+			t.Fatalf("sandbox_annotations carries a line the lockstep test cannot read: %q", l)
+		}
+		pairs[m[1]] = m[2]
+	}
+	return pairs
+}
+
+// IsSandbox decides which containers policy-monitor exempts from digest
+// enforcement, and the baked policy's sandbox_annotations decides which
+// containers kata runs the measured pause for; the two predicates must accept
+// identical annotation sets. Machine-compare them over every combination of
+// the type markers a host can write — including the CRI-O key, so a predicate
+// that reads it disagrees with the side that does not. A one-sided edit to
+// either predicate flips at least one row.
+func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
+	conjuncts := sandboxConjuncts(t, readPolicy(t))
+	const crioKey = "io.kubernetes.cri-o.ContainerType"
+
+	kataValues := []string{"", "pod_sandbox", "pod_container", "bogus"}
+	criValues := []string{"", "sandbox", "container", "SANDBOX"}
+	crioValues := []string{"", "sandbox", "container"}
+
+	for _, kata := range kataValues {
+		for _, cri := range criValues {
+			for _, crio := range crioValues {
+				annotations := map[string]string{}
+				for key, value := range map[string]string{
+					kataContainerTypeKey: kata,
+					criContainerTypeKey:  cri,
+					crioKey:              crio,
+				} {
+					if value != "" {
+						annotations[key] = value
+					}
+				}
+				policy := true
+				for key, want := range conjuncts {
+					if annotations[key] != want {
+						policy = false
+						break
+					}
+				}
+				if got := IsSandbox(annotations); got != policy {
+					t.Errorf("annotations %v: IsSandbox = %v, sandbox_annotations = %v", annotations, got, policy)
+				}
+			}
+		}
+	}
+}
+
 // A rule that silently reverts to `default … := true` is a no-op with no
 // symptom, so pin the decisions the guest's integrity rests on.
 func TestBakedPolicyKeepsItsFailClosedDefaults(t *testing.T) {

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -113,6 +113,10 @@ CreateContainerRequest if {
 	count(input.shared_mounts) == 0
 	print("CreateContainerRequest: no shared_mounts")
 
+	# containerd is the only CRI in this shape and never sets the CRI-O key.
+	not input.OCI.Annotations["io.kubernetes.cri-o.ContainerType"]
+	print("CreateContainerRequest: no foreign container-type marker")
+
 	pull := sole_guest_pull_storage
 	print("CreateContainerRequest: one image_guest_pull storage")
 

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -289,11 +289,14 @@ sandbox_pull_metadata(pull) if {
 }
 
 # containerd never writes the CRI-O key, so an honest request cannot carry it
-# in the serialised pull metadata either.
+# in the serialised pull metadata either. The key is checked after decoding,
+# the way the guest-pull handler reads it: a text match would miss a
+# JSON-escaped key.
 crio_pull_metadata(pull) if {
 	some opt in pull.driver_options
 	startswith(opt, "image_guest_pull=")
-	contains(opt, "io.kubernetes.cri-o.ContainerType")
+	metadata := json.unmarshal(trim_prefix(opt, "image_guest_pull="))
+	metadata["io.kubernetes.cri-o.ContainerType"]
 }
 
 # --- Sandbox and ephemeral storages ------------------------------------

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -41,23 +41,40 @@ import future.keywords.if
 import future.keywords.in
 
 default AddARPNeighborsRequest := true
+
 # Swap never leaves TEE memory.
 default AddSwapRequest := false
+
 default CloseStdinRequest := true
+
 default DestroySandboxRequest := true
+
 default GetDiagnosticDataRequest := true
+
 default GetMetricsRequest := true
+
 default GetOOMEventRequest := true
+
 default GuestDetailsRequest := true
+
 default ListInterfacesRequest := true
+
 default ListRoutesRequest := true
+
 default MemHotplugByProbeRequest := true
+
 default OnlineCPUMemRequest := true
+
 default PauseContainerRequest := true
+
 default PullImageRequest := true
+
 default RemoveContainerRequest := true
+
 default RemoveStaleVirtiofsShareMountsRequest := true
+
 default ReseedRandomDevRequest := true
+
 default ResumeContainerRequest := true
 
 # Load-bearing override. See header comment.
@@ -72,18 +89,29 @@ default SetPolicyRequest := false
 # boundary, so an in-guest shell/stream/file-copy would be a host-readable side
 # channel. Flip one back to `true` only with a one-line note on why it must stay.
 default ExecProcessRequest := false
+
 default ReadStreamRequest := false
+
 default WriteStreamRequest := false
 
 default SignalProcessRequest := true
+
 default StartContainerRequest := true
+
 default StartTracingRequest := true
+
 default StatsContainerRequest := true
+
 default StopTracingRequest := true
+
 default TtyWinResizeRequest := true
+
 default UpdateContainerRequest := true
+
 default UpdateInterfaceRequest := true
+
 default UpdateRoutesRequest := true
+
 default WaitProcessRequest := true
 
 # --- Container rootfs binding ------------------------------------------

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -120,6 +120,9 @@ CreateContainerRequest if {
 	pull := sole_guest_pull_storage
 	print("CreateContainerRequest: one image_guest_pull storage")
 
+	not crio_pull_metadata(pull)
+	print("CreateContainerRequest: no foreign marker in the pull metadata")
+
 	# add_storages skips a handler whose mount point is already registered
 	# sandbox-wide, and setup_bundle bind-mounts the host's spec.root.path
 	# when nothing is mounted at the rootfs. Pinning the mount point to this
@@ -221,8 +224,9 @@ bind_mount(m) if {
 
 # kata's own switch is io.katacontainers.pkg.oci.container_type; the guest-pull
 # handler's is the container-type copied into the storage's driver_options
-# metadata; policy-monitor's is the CRI annotation. A container runs what all
-# three agree on, or it does not run.
+# metadata; policy-monitor's is this same sandbox_annotations pair (a Go
+# lockstep test machine-compares them). A container runs what all three agree
+# on, or it does not run.
 pull_source_bound(pull) if {
 	sandbox_annotations
 	sandbox_pull_metadata(pull)
@@ -254,6 +258,14 @@ sandbox_pull_metadata(pull) if {
 	some opt in pull.driver_options
 	startswith(opt, "image_guest_pull=")
 	contains(opt, "\"io.kubernetes.cri.container-type\":\"sandbox\"")
+}
+
+# containerd never writes the CRI-O key, so an honest request cannot carry it
+# in the serialised pull metadata either.
+crio_pull_metadata(pull) if {
+	some opt in pull.driver_options
+	startswith(opt, "image_guest_pull=")
+	contains(opt, "io.kubernetes.cri-o.ContainerType")
 }
 
 # --- Sandbox and ephemeral storages ------------------------------------

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -178,6 +178,27 @@ test_sandbox_source_must_be_pause if {
 	)
 }
 
+# object.union is shallow, so merge at each level to keep the rest of the
+# fixture — with the base fixtures admitted, only the override can deny.
+with_annotations(base, extra) := object.union(base, {"OCI": object.union(
+	base.OCI,
+	{"Annotations": object.union(base.OCI.Annotations, extra)},
+)})
+
+# containerd never sets the CRI-O marker; a request carrying one is denied
+# rather than classified, whatever the honest markers say.
+test_crio_container_type_marker_denied if {
+	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": "sandbox"})
+	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": "container"})
+	not CreateContainerRequest with input as with_annotations(sandbox_input, {"io.kubernetes.cri-o.ContainerType": "sandbox"})
+}
+
+# The two type markers the policy conjoins must agree with each other.
+test_conflicting_container_type_markers_denied if {
+	not CreateContainerRequest with input as with_annotations(sandbox_input, {"io.kubernetes.cri.container-type": "container"})
+	not CreateContainerRequest with input as with_annotations(workload_input, {"io.katacontainers.pkg.oci.container_type": "pod_sandbox"})
+}
+
 # --- sandbox and ephemeral storages -------------------------------------
 
 test_sandbox_storage_shaped_like_a_rootfs_denied if {

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -178,6 +178,18 @@ test_sandbox_source_must_be_pause if {
 	)
 }
 
+# An image-name annotation must not give a sandbox-annotated request's pull
+# source a second way to bind: the sandbox branch runs the measured pause.
+test_sandbox_source_stays_pause_with_image_name if {
+	not CreateContainerRequest with input as object.union(sandbox_input, {
+		"storages": [object.union(sandbox_input.storages[0], {"source": digest_ref})],
+		"OCI": {"Annotations": object.union(
+			sandbox_input.OCI.Annotations,
+			{"io.kubernetes.cri.image-name": digest_ref},
+		)},
+	})
+}
+
 # object.union is shallow, so merge at each level to keep the rest of the
 # fixture — with the base fixtures admitted, only the override can deny.
 with_annotations(base, extra) := object.union(base, {"OCI": object.union(
@@ -186,11 +198,28 @@ with_annotations(base, extra) := object.union(base, {"OCI": object.union(
 )})
 
 # containerd never sets the CRI-O marker; a request carrying one is denied
-# rather than classified, whatever the honest markers say.
+# rather than classified, whatever the honest markers say. The guard is on
+# the key's presence, so an empty or garbage value denies too.
 test_crio_container_type_marker_denied if {
 	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": "sandbox"})
 	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": "container"})
 	not CreateContainerRequest with input as with_annotations(sandbox_input, {"io.kubernetes.cri-o.ContainerType": "sandbox"})
+	not CreateContainerRequest with input as with_annotations(sandbox_input, {"io.kubernetes.cri-o.ContainerType": "container"})
+	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": ""})
+	not CreateContainerRequest with input as with_annotations(workload_input, {"io.kubernetes.cri-o.ContainerType": "garbage"})
+}
+
+# The guest-pull handler reads the container type from the serialised pull
+# metadata as well; the CRI-O marker is denied there too.
+test_crio_marker_in_pull_metadata_denied if {
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": [object.union(
+		workload_input.storages[0],
+		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri-o.ContainerType\":\"sandbox\"}"]},
+	)]})
+	not CreateContainerRequest with input as object.union(sandbox_input, {"storages": [object.union(
+		sandbox_input.storages[0],
+		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri-o.ContainerType\":\"sandbox\"}"]},
+	)]})
 }
 
 # The two type markers the policy conjoins must agree with each other.

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -176,6 +176,36 @@ test_sandbox_source_must_be_pause if {
 		sandbox_input,
 		{"storages": [object.union(sandbox_input.storages[0], {"source": digest_ref})]},
 	)
+	not CreateContainerRequest with input as object.union(
+		sandbox_input,
+		{"storages": [object.union(sandbox_input.storages[0], {"source": "ghcr.io/confidential-dot-ai/assam:latest"})]},
+	)
+}
+
+# Sandbox annotations without the sandbox marker in the pull metadata admit
+# no pull: the sandbox branch runs the measured pause and the workload branch
+# is keyed on workload_annotations, so neither may bind the host's image.
+test_sandbox_annotations_without_sandbox_metadata_denied if {
+	not CreateContainerRequest with input as object.union(sandbox_input, {
+		"storages": [object.union(sandbox_input.storages[0], {
+			"source": digest_ref,
+			"driver_options": ["image_guest_pull={}"],
+		})],
+		"OCI": {"Annotations": object.union(
+			sandbox_input.OCI.Annotations,
+			{"io.kubernetes.cri.image-name": digest_ref},
+		)},
+	})
+	not CreateContainerRequest with input as object.union(sandbox_input, {
+		"storages": [object.union(sandbox_input.storages[0], {
+			"source": digest_ref,
+			"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"container\"}"],
+		})],
+		"OCI": {"Annotations": object.union(
+			sandbox_input.OCI.Annotations,
+			{"io.kubernetes.cri.image-name": digest_ref},
+		)},
+	})
 }
 
 # An image-name annotation must not give a sandbox-annotated request's pull

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -210,16 +210,36 @@ test_crio_container_type_marker_denied if {
 }
 
 # The guest-pull handler reads the container type from the serialised pull
-# metadata as well; the CRI-O marker is denied there too.
+# metadata as well; the CRI-O marker is denied there too, plain or
+# JSON-escaped.
 test_crio_marker_in_pull_metadata_denied if {
 	not CreateContainerRequest with input as object.union(workload_input, {"storages": [object.union(
 		workload_input.storages[0],
 		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri-o.ContainerType\":\"sandbox\"}"]},
 	)]})
+	not CreateContainerRequest with input as object.union(workload_input, {"storages": [object.union(
+		workload_input.storages[0],
+		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri-o.\\u0043ontainerType\":\"sandbox\"}"]},
+	)]})
 	not CreateContainerRequest with input as object.union(sandbox_input, {"storages": [object.union(
 		sandbox_input.storages[0],
 		{"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri-o.ContainerType\":\"sandbox\"}"]},
 	)]})
+}
+
+# The veto reads decoded metadata keys, so an annotation value that merely
+# mentions the key string is not the marker.
+test_crio_key_string_in_annotation_value_allowed if {
+	CreateContainerRequest with input as object.union(workload_input, {
+		"storages": [object.union(
+			workload_input.storages[0],
+			{"driver_options": ["image_guest_pull={\"io.kubernetes.cri.container-type\":\"container\",\"example.com/note\":\"mentions io.kubernetes.cri-o.ContainerType\"}"]},
+		)],
+		"OCI": {"Annotations": object.union(
+			workload_input.OCI.Annotations,
+			{"example.com/note": "mentions io.kubernetes.cri-o.ContainerType"},
+		)},
+	})
 }
 
 # The two type markers the policy conjoins must agree with each other.


### PR DESCRIPTION
## Summary

`policy-monitor`'s sandbox exemption and the baked kata-agent policy now agree on exactly which containers skip digest enforcement, and the agreement is machine-pinned so the two sides cannot silently diverge again.

- **`IsSandbox()` narrowed to the baked policy's conjunction** (`io.katacontainers.pkg.oci.container_type == pod_sandbox` **and** `io.kubernetes.cri.container-type == sandbox`); the CRI-O container-type key is dropped from the enforcer — containerd is the only CRI in this shape and never sets it.
- **The baked Rego rejects conflicting markers**: a `CreateContainerRequest` carrying the CRI-O container-type key is denied, whether it arrives in OCI annotations or in the (decoded) guest-pull metadata, so the two enforcers cannot drift apart through a side channel.
- **Lockstep regime**: a table test machine-compares the Go predicate against the baked policy across the annotation universe, pins the admission contract (branch count, keying, sandbox pull source stays the pause image), and an `opa fmt --check` gate (now part of `make policy-test` — load-bearing) plus comment-stripping/whitespace-tolerant extraction keep one-sided Rego edits loud: reshaping either predicate (`else` chains, extra rules, re-indentation, metadata side channels) fails CI.

## Tests

- 48-row Go⇔Rego lockstep table (containerd-only, CRI-O-only, both, conflicting, neither, present-empty…).
- Rego unit tests: mismatched/extra container-type markers denied; metadata veto; admission-binding fixtures.
- Regression: the mismatch annotation pair results in the container being digest-checked (and rejected when unallowlisted).
- `go test -race ./...` green (63 packages); `make policy-test` 36/36 including the fmt gate.

## Notes

- No behavioural change for honest traffic: the exemption set is unchanged for every container the baked policy already admitted, and the metadata veto matches what the honest flow already copies from annotations.
- The lockstep test deliberately asserts on the *baked* policy file as shipped in the guest image, so a one-sided edit to either enforcer fails the build.
