### PR TITLE
fix(chart): make the attestation-api node-local only, behind a render guard

### DIFF
--- a/.github/workflows/confidential-e2e.yml
+++ b/.github/workflows/confidential-e2e.yml
@@ -46,9 +46,8 @@ jobs:
     # the trailing @main tag is a human label only.
     uses: ./.github/workflows/e2e-c8s.yml
     with:
-      # Test the merge head. The pin existed because cvmMode=node (#88) dials a
-      # node-baked attestation-api on $(HOST_IP):8400 that the staged rke2 image
-      # does not bake; e2e-c8s.yml now aligns the AA port with the NodePort the
-      # chart already publishes, so $(HOST_IP) reaches the node's own AA pod and
-      # no baked-AA image is required.
+      # Test the merge head. The metal lane installs the chart's own
+      # attestation-api DaemonSet + attest-proxy socket as the node-local
+      # endpoint, so the staged rke2 image needs no baked AA for cvmMode=node
+      # (#88).
       c8s_ref: ${{ inputs.c8s_ref || github.event.workflow_run.head_sha }}

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -153,20 +153,12 @@ jobs:
           attestationApi:
             image:
               tag: "$AATAG"
-            # UN-PIN: keep cvmMode=node (what we actually ship on metal) and make
-            # $(HOST_IP) routing resolve. Our image predates the baked host
-            # attestation-api, but when nriImagePolicy is on the chart already
-            # publishes the AA as a NodePort for exactly this reason ("NodePort used
-            # by host-process components such as nri-image-policy"). Aligning the AA
-            # port with that NodePort makes $(HOST_IP):<port> hit the node's own AA
-            # pod (both traffic policies are Local, so it never leaves the node).
-            # Verified by helm template at HEAD: all 4 consumers (cds, operator, both
-            # tls-lb sidecars) render http://$(HOST_IP):30840, and the Service exposes
-            # port 30840 -> targetPort http -> containerPort 30840.
+            # cvmMode=node (what we ship on metal), but this node image
+            # predates the baked host attestation-api — so the chart's own
+            # DaemonSet + attest-proxy sidecar supplies the node-local
+            # endpoint on its Unix socket, and no $(HOST_IP)/NodePort
+            # alignment is needed.
             cvmMode: node
-            port: 30840
-            service:
-              nodePort: 30840
             teeDevices:
               sevGuest: true
               tdxGuest: false

--- a/cmd/c8s/attest_proxy.go
+++ b/cmd/c8s/attest_proxy.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/attestproxy"
+
+func init() {
+	rootCmd.AddCommand(attestproxy.NewCmd())
+}

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -316,9 +316,10 @@ underlying issue. On a node-as-CVM (non-kata) cluster, `make
 test-e2e-ca-handoff` proves the full path end to end: it runs an attested
 in-cluster probe (`c8s cds request-handoff`) that pulls the CA over `/handoff`
 and verifies it against the served `/ca`. (The probe pod reuses CDS's own
-`--attestation-api-url` — the node-local Unix socket on node-as-CVM, mounted
-from the host; under kata that endpoint is in-guest loopback, so the script
-does not support kata mode.)
+`--attestation-api-url`, mounting the socket directory from the host when it
+is a `unix://` one — the gke/aks-style install shape. Under kata the endpoint
+is in-guest loopback and under cvmMode=node the URL is an unexpanded
+$(HOST_IP) one, so the script supports neither.)
 
 ### Operator-added allowlist entries across restarts
 
@@ -414,6 +415,24 @@ approaches the same expiry wall. CDS reports `not_after` at startup and
 not shipped. Plan a deliberate re-bootstrap (and workload re-provisioning)
 before expiry, and choose `cds.ca.certValidity` with that maintenance horizon
 in mind on the initial cold start.
+
+## Attestation-api
+
+The attestation-api DaemonSet binds pod loopback and is served to on-node
+consumers by its attest-proxy sidecar over a Unix socket in
+`nriImagePolicy.hostPaths.runtimeDir`; no Service renders by default.
+
+Two operational notes:
+
+- **Upgrading from a release that rendered the attestation-api Service
+  deletes it.** Already-running cw pods keep their old
+  `--attestation-api-url`, and their get-cert renewals fail once the Service
+  is gone — roll cw-annotated workload pods after the upgrade so the webhook
+  re-injects the socket URL. New pods are unaffected.
+- **A wedged attestation-api does not self-restart.** Its health signal is
+  the attest-proxy's exec probe, so a hung (not crashed) API process shows as
+  a NotReady `c8s-attestation-api` pod with a crash-looping attest-proxy
+  container; delete the pod to restart the pair.
 
 ## Verifying attestation after install
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -315,9 +315,10 @@ restart-fragility window above applies until the operator fixes the
 underlying issue. On a node-as-CVM (non-kata) cluster, `make
 test-e2e-ca-handoff` proves the full path end to end: it runs an attested
 in-cluster probe (`c8s cds request-handoff`) that pulls the CA over `/handoff`
-and verifies it against the served `/ca`. (The probe pod dials the local
-attestation-api Service; under kata that service is in-guest loopback, so the
-script does not support kata mode.)
+and verifies it against the served `/ca`. (The probe pod reuses CDS's own
+`--attestation-api-url` — the node-local Unix socket on node-as-CVM, mounted
+from the host; under kata that endpoint is in-guest loopback, so the script
+does not support kata mode.)
 
 ### Operator-added allowlist entries across restarts
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -420,7 +420,7 @@ in mind on the initial cold start.
 
 The attestation-api DaemonSet binds pod loopback and is served to on-node
 consumers by its attest-proxy sidecar over a Unix socket in
-`nriImagePolicy.hostPaths.runtimeDir`; no Service renders by default.
+`nriImagePolicy.hostPaths.runtimeDir`; no Service renders.
 
 Two operational notes:
 

--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -323,9 +323,10 @@ What it does **not** guarantee:
 - **A trustworthy verdict from an untrusted verifier.** The attestation-api's
   `/verify` response is **unsigned**; whoever can impersonate the configured
   `AttestationApiURL` forges "valid". Every deployment therefore keeps the
-  verifier in the same TCB as the verifying component: a same-node DaemonSet
-  behind `internalTrafficPolicy: Local` (node-as-CVM) or an in-guest loopback
-  service (pod-as-CVM). Do not point it across a trust boundary.
+  verifier in the same TCB as the verifying component: the node-local Unix
+  socket the DaemonSet's attest-proxy serves (node-as-CVM — the client checks
+  the socket's owner and mode on every dial) or an in-guest loopback service
+  (pod-as-CVM). Do not point it across a trust boundary.
 - **Per-handshake measurement of CA-verified peers.** See "Dual verification"
   above: after the CDS upgrade, mesh peers are verified by CA chain only.
 - **Full TDX runtime measurement, in-cluster.** The mesh `VerifyPolicy` pins
@@ -769,9 +770,11 @@ confidentiality.)
 
 - **Evidence source:** the per-node attestation-api DaemonSet mounts the host
   TEE interface (`/dev/sev-guest`; TSM ConfigFS reports on TDX hosts; vTPM on
-  AKS). Its Service uses `internalTrafficPolicy: Local` so `/attest` always
-  produces evidence for the *caller's own node* — and so `/verify` verdicts
-  never cross a node boundary.
+  AKS). The API binds pod loopback and its attest-proxy sidecar serves it on a
+  node-local Unix socket, so `/attest` is reachable only by on-node callers
+  and always produces evidence for the *caller's own node* — nothing
+  routable can request evidence, and `/verify` verdicts never cross a node
+  boundary.
 - **RA-TLS endpoints:** ratls-mesh runs as a host-network DaemonSet
   (outbound :15001, inbound :15006). iptables/ipset interception DNATs
   pod-to-pod TCP through it; the node-to-node leg is attested mTLS; the final

--- a/internal/cmds/attestproxy/cmd.go
+++ b/internal/cmds/attestproxy/cmd.go
@@ -33,9 +33,7 @@ import (
 const (
 	defaultUpstream          = "http://127.0.0.1:8400"
 	defaultReadHeaderTimeout = 5 * time.Second
-	// upstreamResponseHeaderTimeout covers the slowest evidence generation
-	// (TDX ConfigFS TSM ~1s, vTPM HCL reports, NRAS collateral fetches on
-	// cache miss).
+	// upstreamResponseHeaderTimeout bounds the slowest evidence generation.
 	upstreamResponseHeaderTimeout = 30 * time.Second
 	healthcheckTimeout            = 3 * time.Second
 )

--- a/internal/cmds/attestproxy/cmd.go
+++ b/internal/cmds/attestproxy/cmd.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"os/signal"
 	"path"
-	"strings"
 	"syscall"
 	"time"
 
@@ -42,7 +41,6 @@ type config struct {
 	socket            string
 	socketGID         int
 	upstream          string
-	apiKeyFile        string
 	readHeaderTimeout time.Duration
 }
 
@@ -64,7 +62,6 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.socket, "socket", "", "Unix socket path to serve on (absolute; created 0660, chgrp'd to --socket-gid)")
 	f.IntVar(&cfg.socketGID, "socket-gid", workloadclaims.InventorySocketGID, "group that may connect to the socket (0 = keep the process group)")
 	f.StringVar(&cfg.upstream, "upstream", defaultUpstream, "attestation-api base URL (the pod-loopback listener in the same pod)")
-	f.StringVar(&cfg.apiKeyFile, "api-key-file", "", "file holding the API key the upstream requires; injected as an Authorization: Bearer header on every proxied request")
 	f.DurationVar(&cfg.readHeaderTimeout, "read-header-timeout", defaultReadHeaderTimeout, "HTTP request-header timeout on the socket listener")
 	cmd.AddCommand(newHealthcheckCmd())
 	return cmd
@@ -119,7 +116,7 @@ func runContext(ctx context.Context, cfg config) error {
 	}
 	go cmdsutil.ShutdownOnDone(ctx, srv, 5*time.Second)
 
-	slog.Info("attestation proxy listening", "socket", cfg.socket, "upstream", cfg.upstream, "auth_inject", cfg.apiKeyFile != "")
+	slog.Info("attestation proxy listening", "socket", cfg.socket, "upstream", cfg.upstream)
 	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 		return err
 	}
@@ -140,17 +137,6 @@ func newProxy(cfg config) (http.Handler, error) {
 	if target.Scheme != "http" && target.Scheme != "https" {
 		return nil, fmt.Errorf("--upstream must use http or https, got scheme %q", target.Scheme)
 	}
-	var apiKey string
-	if cfg.apiKeyFile != "" {
-		key, err := os.ReadFile(cfg.apiKeyFile)
-		if err != nil {
-			return nil, fmt.Errorf("read --api-key-file: %w", err)
-		}
-		apiKey = strings.TrimSpace(string(key))
-		if apiKey == "" {
-			return nil, fmt.Errorf("--api-key-file %s is empty", cfg.apiKeyFile)
-		}
-	}
 	transport := &http.Transport{
 		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
 		ResponseHeaderTimeout: upstreamResponseHeaderTimeout,
@@ -164,9 +150,6 @@ func newProxy(cfg config) (http.Handler, error) {
 			pr.Out.URL.RawPath = pr.In.URL.RawPath
 			pr.Out.URL.RawQuery = pr.In.URL.RawQuery
 			pr.Out.Host = target.Host
-			if apiKey != "" {
-				pr.Out.Header.Set("Authorization", "Bearer "+apiKey)
-			}
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			slog.Error("attestation proxy request failed", "method", r.Method, "path", r.URL.Path, "error", err)

--- a/internal/cmds/attestproxy/cmd.go
+++ b/internal/cmds/attestproxy/cmd.go
@@ -1,0 +1,179 @@
+// Package attestproxy implements the node-local front door to the
+// attestation-api. The attestation-api binds pod loopback only; this proxy
+// serves its API on a hostPath Unix socket so exactly the on-node consumers
+// (the host NRI plugin, c8s node components, and pods the webhook mounts the
+// socket directory into) can request evidence, while nothing routable —
+// another pod, or an off-node host — can reach /attest. Socket ownership and
+// mode gate reachability; callers additionally re-check them on every dial
+// (pkg/attestationclient).
+package attestproxy
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+	"os/signal"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+const (
+	defaultUpstream          = "http://127.0.0.1:8400"
+	defaultReadHeaderTimeout = 5 * time.Second
+	// upstreamResponseHeaderTimeout covers the slowest evidence generation
+	// (TDX ConfigFS TSM ~1s, vTPM HCL reports, NRAS collateral fetches on
+	// cache miss).
+	upstreamResponseHeaderTimeout = 30 * time.Second
+	healthcheckTimeout            = 3 * time.Second
+)
+
+type config struct {
+	socket            string
+	socketGID         int
+	upstream          string
+	apiKeyFile        string
+	readHeaderTimeout time.Duration
+}
+
+// NewCmd returns the attest-proxy subcommand. It runs as a sidecar in the
+// attestation-api DaemonSet pod, publishing the pod-loopback API on the
+// node-local socket.
+func NewCmd() *cobra.Command {
+	var cfg config
+	cmd := &cobra.Command{
+		Use:          "attest-proxy",
+		Short:        "Serve the pod-local attestation-api on a node-local Unix socket",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return run(cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cfg.socket, "socket", "", "Unix socket path to serve on (absolute; created 0660, chgrp'd to --socket-gid)")
+	f.IntVar(&cfg.socketGID, "socket-gid", workloadclaims.InventorySocketGID, "group that may connect to the socket (0 = keep the process group)")
+	f.StringVar(&cfg.upstream, "upstream", defaultUpstream, "attestation-api base URL (the pod-loopback listener in the same pod)")
+	f.StringVar(&cfg.apiKeyFile, "api-key-file", "", "file holding the API key the upstream requires; injected as an Authorization: Bearer header on every proxied request")
+	f.DurationVar(&cfg.readHeaderTimeout, "read-header-timeout", defaultReadHeaderTimeout, "HTTP request-header timeout on the socket listener")
+	cmd.AddCommand(newHealthcheckCmd())
+	return cmd
+}
+
+// newHealthcheckCmd returns the probe subcommand the DaemonSet's exec probes
+// run: it dials the socket through the attestation client (owner/mode checks
+// included), so a passing probe covers socket, proxy, and upstream at once.
+func newHealthcheckCmd() *cobra.Command {
+	var socket string
+	cmd := &cobra.Command{
+		Use:          "healthcheck",
+		Short:        "Exit 0 iff GET /health over the socket succeeds",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if socket == "" {
+				return fmt.Errorf("--socket is required")
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), healthcheckTimeout)
+			defer cancel()
+			if _, err := attestationclient.NewClient("unix://" + socket).Health(ctx); err != nil {
+				return fmt.Errorf("healthcheck over %s: %w", socket, err)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&socket, "socket", "", "Unix socket path to probe")
+	return cmd
+}
+
+func run(cfg config) error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	return runContext(ctx, cfg)
+}
+
+func runContext(ctx context.Context, cfg config) error {
+	proxy, err := newProxy(cfg)
+	if err != nil {
+		return err
+	}
+	listener, err := workloadclaims.ListenUnix(cfg.socket, cfg.socketGID)
+	if err != nil {
+		return err
+	}
+	defer listener.Close()
+
+	srv := &http.Server{
+		Handler:           proxy,
+		ReadHeaderTimeout: cfg.readHeaderTimeout,
+	}
+	go cmdsutil.ShutdownOnDone(ctx, srv, 5*time.Second)
+
+	slog.Info("attestation proxy listening", "socket", cfg.socket, "upstream", cfg.upstream, "auth_inject", cfg.apiKeyFile != "")
+	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func newProxy(cfg config) (http.Handler, error) {
+	if !path.IsAbs(cfg.socket) {
+		return nil, fmt.Errorf("--socket must be an absolute path, got %q", cfg.socket)
+	}
+	if cfg.readHeaderTimeout <= 0 {
+		return nil, fmt.Errorf("--read-header-timeout must be positive")
+	}
+	target, err := url.Parse(cfg.upstream)
+	if err != nil || target.Host == "" {
+		return nil, fmt.Errorf("invalid --upstream %q", cfg.upstream)
+	}
+	if target.Scheme != "http" && target.Scheme != "https" {
+		return nil, fmt.Errorf("--upstream must use http or https, got scheme %q", target.Scheme)
+	}
+	var apiKey string
+	if cfg.apiKeyFile != "" {
+		key, err := os.ReadFile(cfg.apiKeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("read --api-key-file: %w", err)
+		}
+		apiKey = strings.TrimSpace(string(key))
+		if apiKey == "" {
+			return nil, fmt.Errorf("--api-key-file %s is empty", cfg.apiKeyFile)
+		}
+	}
+	transport := &http.Transport{
+		DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+		ResponseHeaderTimeout: upstreamResponseHeaderTimeout,
+	}
+	proxy := &httputil.ReverseProxy{
+		Transport: transport,
+		Rewrite: func(pr *httputil.ProxyRequest) {
+			pr.Out.URL.Scheme = target.Scheme
+			pr.Out.URL.Host = target.Host
+			pr.Out.URL.Path = pr.In.URL.Path
+			pr.Out.URL.RawPath = pr.In.URL.RawPath
+			pr.Out.URL.RawQuery = pr.In.URL.RawQuery
+			pr.Out.Host = target.Host
+			if apiKey != "" {
+				pr.Out.Header.Set("Authorization", "Bearer "+apiKey)
+			}
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			slog.Error("attestation proxy request failed", "method", r.Method, "path", r.URL.Path, "error", err)
+			http.Error(w, "attestation-api unavailable", http.StatusBadGateway)
+		},
+	}
+	return proxy, nil
+}

--- a/internal/cmds/attestproxy/cmd_test.go
+++ b/internal/cmds/attestproxy/cmd_test.go
@@ -1,0 +1,153 @@
+package attestproxy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// startUpstream returns a running fake attestation-api and its URL.
+func startUpstream(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// serveProxy runs the proxy on a temp socket until the test ends.
+func serveProxy(t *testing.T, cfg config) string {
+	t.Helper()
+	sock := filepath.Join(t.TempDir(), "attest.sock")
+	cfg.socket = sock
+	if cfg.readHeaderTimeout == 0 {
+		cfg.readHeaderTimeout = time.Second
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- runContext(ctx, cfg) }()
+	t.Cleanup(func() {
+		cancel()
+		if err := <-done; err != nil {
+			t.Errorf("proxy serve: %v", err)
+		}
+	})
+	// Wait for the socket to appear rather than sleeping a fixed interval.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(sock); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("socket did not appear")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return sock
+}
+
+func TestProxyForwardsOverSocket(t *testing.T) {
+	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/attest" {
+			t.Errorf("upstream saw path %s, want /attest", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want none forwarded without --api-key-file", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"platform":"snp","evidence":{}}`))
+	}))
+	sock := serveProxy(t, config{upstream: upstream, socketGID: 0})
+
+	if _, err := attestationclient.NewClient("unix://" + sock).Attest(context.Background(), types.AttestRequest{}); err != nil {
+		t.Fatalf("Attest over proxy socket: %v", err)
+	}
+}
+
+func TestProxyInjectsAPIKey(t *testing.T) {
+	keyFile := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(keyFile, []byte("s3cret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer s3cret" {
+			t.Errorf("Authorization = %q, want Bearer s3cret (trailing newline trimmed)", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	sock := serveProxy(t, config{upstream: upstream, apiKeyFile: keyFile, socketGID: 0})
+
+	if _, err := attestationclient.NewClient("unix://" + sock).Health(context.Background()); err != nil {
+		t.Fatalf("Health over proxy socket: %v", err)
+	}
+}
+
+func TestProxySocketPermissions(t *testing.T) {
+	upstream := startUpstream(t, http.NotFoundHandler())
+	sock := serveProxy(t, config{upstream: upstream, socketGID: os.Getegid()})
+
+	fi, err := os.Lstat(sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("%s is not a socket (mode %s)", sock, fi.Mode())
+	}
+	if got := fi.Mode().Perm(); got != 0o660 {
+		t.Fatalf("socket mode = %#o, want 0660", got)
+	}
+	if st, ok := fi.Sys().(*syscall.Stat_t); ok && int(st.Gid) != os.Getegid() {
+		t.Fatalf("socket gid = %d, want %d", st.Gid, os.Getegid())
+	}
+}
+
+func TestProxyReportsUpstreamDown(t *testing.T) {
+	// Nothing listens on the upstream; the proxy must answer 502, not hang.
+	sock := serveProxy(t, config{upstream: "http://127.0.0.1:1", socketGID: 0})
+	_, err := attestationclient.NewClient("unix://" + sock).Health(context.Background())
+	var unexpErr *attestationclient.UnexpectedError
+	if err == nil {
+		t.Fatal("Health succeeded against a dead upstream")
+	}
+	if !errors.As(err, &unexpErr) || unexpErr.Status != http.StatusBadGateway {
+		t.Fatalf("err = %v, want 502", err)
+	}
+}
+
+func TestNewProxyRejectsBadConfig(t *testing.T) {
+	upstream := startUpstream(t, http.NotFoundHandler())
+	for _, tc := range []struct {
+		name string
+		cfg  config
+	}{
+		{"relative socket", config{socket: "rel.sock", upstream: upstream, readHeaderTimeout: time.Second}},
+		{"bad upstream scheme", config{socket: "/tmp/x.sock", upstream: "ftp://x", readHeaderTimeout: time.Second}},
+		{"missing key file", config{socket: "/tmp/x.sock", upstream: upstream, apiKeyFile: "/nonexistent", readHeaderTimeout: time.Second}},
+		{"empty key file", config{socket: "/tmp/x.sock", upstream: upstream, apiKeyFile: writeKeyFile(t, "  \n"), readHeaderTimeout: time.Second}},
+		{"nonpositive header timeout", config{socket: "/tmp/x.sock", upstream: upstream}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := newProxy(tc.cfg); err == nil {
+				t.Fatal("newProxy succeeded, want rejection")
+			}
+		})
+	}
+}
+
+func writeKeyFile(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "key")
+	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}

--- a/internal/cmds/attestproxy/cmd_test.go
+++ b/internal/cmds/attestproxy/cmd_test.go
@@ -67,7 +67,7 @@ func TestProxyForwardsOverSocket(t *testing.T) {
 	}))
 	sock := serveProxy(t, config{upstream: upstream, socketGID: 0})
 
-	if _, err := attestationclient.NewClient("unix://" + sock).Attest(context.Background(), types.AttestRequest{}); err != nil {
+	if _, err := attestationclient.NewClient("unix://"+sock).Attest(context.Background(), types.AttestRequest{}); err != nil {
 		t.Fatalf("Attest over proxy socket: %v", err)
 	}
 }

--- a/internal/cmds/attestproxy/cmd_test.go
+++ b/internal/cmds/attestproxy/cmd_test.go
@@ -3,7 +3,6 @@ package attestproxy
 import (
 	"context"
 	"errors"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -60,9 +59,6 @@ func TestProxyForwardsOverSocket(t *testing.T) {
 		if r.URL.Path != "/attest" {
 			t.Errorf("upstream saw path %s, want /attest", r.URL.Path)
 		}
-		if got := r.Header.Get("Authorization"); got != "" {
-			t.Errorf("Authorization = %q, want none forwarded without --api-key-file", got)
-		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"platform":"snp","evidence":{}}`))
 	}))
@@ -70,25 +66,6 @@ func TestProxyForwardsOverSocket(t *testing.T) {
 
 	if _, err := attestationclient.NewClient("unix://"+sock).Attest(context.Background(), types.AttestRequest{}); err != nil {
 		t.Fatalf("Attest over proxy socket: %v", err)
-	}
-}
-
-func TestProxyInjectsAPIKey(t *testing.T) {
-	keyFile := filepath.Join(t.TempDir(), "key")
-	if err := os.WriteFile(keyFile, []byte("s3cret\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer s3cret" {
-			t.Errorf("Authorization = %q, want Bearer s3cret (trailing newline trimmed)", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{}`))
-	}))
-	sock := serveProxy(t, config{upstream: upstream, apiKeyFile: keyFile, socketGID: 0})
-
-	if _, err := attestationclient.NewClient("unix://" + sock).Health(context.Background()); err != nil {
-		t.Fatalf("Health over proxy socket: %v", err)
 	}
 }
 
@@ -132,8 +109,6 @@ func TestNewProxyRejectsBadConfig(t *testing.T) {
 	}{
 		{"relative socket", config{socket: "rel.sock", upstream: upstream, readHeaderTimeout: time.Second}},
 		{"bad upstream scheme", config{socket: "/tmp/x.sock", upstream: "ftp://x", readHeaderTimeout: time.Second}},
-		{"missing key file", config{socket: "/tmp/x.sock", upstream: upstream, apiKeyFile: "/nonexistent", readHeaderTimeout: time.Second}},
-		{"empty key file", config{socket: "/tmp/x.sock", upstream: upstream, apiKeyFile: writeKeyFile(t, "  \n"), readHeaderTimeout: time.Second}},
 		{"nonpositive header timeout", config{socket: "/tmp/x.sock", upstream: upstream}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -165,47 +140,4 @@ func TestHealthcheckCmd(t *testing.T) {
 	if err := missing.Execute(); err == nil {
 		t.Fatal("healthcheck succeeded against a missing socket")
 	}
-}
-
-// A caller-supplied Authorization header must not survive the proxy: the
-// injected key overwrites it (Header.Set), so socket callers cannot smuggle
-// a stale or foreign key to the upstream.
-func TestProxyOverwritesInboundAuthorization(t *testing.T) {
-	keyFile := writeKeyFile(t, "s3cret")
-	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if got := r.Header.Get("Authorization"); got != "Bearer s3cret" {
-			t.Errorf("Authorization = %q, want the injected key overwriting the inbound header", got)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
-	}))
-	sock := serveProxy(t, config{upstream: upstream, apiKeyFile: keyFile, socketGID: 0})
-
-	client := &http.Client{Transport: &http.Transport{
-		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
-			return (&net.Dialer{}).DialContext(ctx, "unix", sock)
-		},
-	}}
-	req, err := http.NewRequest(http.MethodGet, "http://unix/health", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Authorization", "Bearer caller-supplied")
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("GET over proxy socket: %v", err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
-	}
-}
-
-func writeKeyFile(t *testing.T, contents string) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "key")
-	if err := os.WriteFile(p, []byte(contents), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return p
 }

--- a/internal/cmds/attestproxy/cmd_test.go
+++ b/internal/cmds/attestproxy/cmd_test.go
@@ -3,6 +3,7 @@ package attestproxy
 import (
 	"context"
 	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -140,6 +141,63 @@ func TestNewProxyRejectsBadConfig(t *testing.T) {
 				t.Fatal("newProxy succeeded, want rejection")
 			}
 		})
+	}
+}
+
+// The healthcheck subcommand is the DaemonSet's only liveness signal: it
+// must succeed against a live proxied upstream and fail against a missing
+// socket.
+func TestHealthcheckCmd(t *testing.T) {
+	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	sock := serveProxy(t, config{upstream: upstream, socketGID: 0})
+
+	cmd := newHealthcheckCmd()
+	cmd.SetArgs([]string{"--socket", sock})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("healthcheck against live proxied upstream: %v", err)
+	}
+
+	missing := newHealthcheckCmd()
+	missing.SetArgs([]string{"--socket", filepath.Join(t.TempDir(), "gone.sock")})
+	if err := missing.Execute(); err == nil {
+		t.Fatal("healthcheck succeeded against a missing socket")
+	}
+}
+
+// A caller-supplied Authorization header must not survive the proxy: the
+// injected key overwrites it (Header.Set), so socket callers cannot smuggle
+// a stale or foreign key to the upstream.
+func TestProxyOverwritesInboundAuthorization(t *testing.T) {
+	keyFile := writeKeyFile(t, "s3cret")
+	upstream := startUpstream(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer s3cret" {
+			t.Errorf("Authorization = %q, want the injected key overwriting the inbound header", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	sock := serveProxy(t, config{upstream: upstream, apiKeyFile: keyFile, socketGID: 0})
+
+	client := &http.Client{Transport: &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+		},
+	}}
+	req, err := http.NewRequest(http.MethodGet, "http://unix/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer caller-supplied")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("GET over proxy socket: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
 }
 

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -47,7 +47,7 @@ func run(cfg config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := cmdsutil.ValidateHTTPURL("--attestation-api-url", cfg.attestationApiURL); err != nil {
+	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", cfg.attestationApiURL); err != nil {
 		return err
 	}
 	if err := validateConfig(cfg); err != nil {

--- a/internal/cmds/cmdsutil/cmdsutil.go
+++ b/internal/cmds/cmdsutil/cmdsutil.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"time"
 )
@@ -34,6 +35,19 @@ func ValidateHTTPURL(flagName, u string) error {
 		return fmt.Errorf("%s %q must start with http:// or https://", flagName, u)
 	}
 	return nil
+}
+
+// ValidateAttestationAPIURL returns an error if u is not an attestation-api
+// URL: http(s):// for a network endpoint, or unix:// plus an absolute socket
+// path for the node-local socket the chart wires in every non-kata mode.
+func ValidateAttestationAPIURL(flagName, u string) error {
+	if socket, ok := strings.CutPrefix(u, "unix://"); ok {
+		if !path.IsAbs(socket) {
+			return fmt.Errorf("%s %q must name an absolute socket path after unix://", flagName, u)
+		}
+		return nil
+	}
+	return ValidateHTTPURL(flagName, u)
 }
 
 // ParseFlags is the standard fs.Parse(args) call used by every Run-style

--- a/internal/cmds/cmdsutil/cmdsutil_test.go
+++ b/internal/cmds/cmdsutil/cmdsutil_test.go
@@ -124,3 +124,27 @@ func TestCheckCDSPinned(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateAttestationAPIURL(t *testing.T) {
+	cases := []struct {
+		url     string
+		wantErr bool
+	}{
+		{"http://localhost:8400", false},
+		{"https://attestation-api:8400", false},
+		{"unix:///var/run/nri-image-policy/attestation-api.sock", false},
+		{"unix://relative.sock", true},
+		{"unix://", true},
+		{"ftp://example.com", true},
+		{"", true},
+	}
+	for _, c := range cases {
+		err := ValidateAttestationAPIURL("--attestation-api-url", c.url)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ValidateAttestationAPIURL(%q) err = %v, wantErr = %v", c.url, err, c.wantErr)
+		}
+		if err != nil && !contains(err.Error(), "--attestation-api-url") {
+			t.Errorf("error %q should mention flag name", err.Error())
+		}
+	}
+}

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -119,7 +119,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags := cmd.Flags()
 	flags.StringVar(&cfg.CDSURL, "cds-url", "", "URL of the CDS service (e.g. https://cds:8443)")
 	flags.StringVar(&cfg.CDSMeasurements, "cds-measurements", "", "comma-separated SHA-384 hex launch measurements for CDS RA-TLS verification (empty = accept any attested CDS)")
-	flags.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "URL of the local attestation-api (e.g. http://localhost:8400)")
+	flags.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "URL of the node-local attestation-api (http://localhost:8400, or unix:// plus the on-node socket path the chart wires)")
 	flags.StringVarP(&cfg.OutPath, "out", "o", "", "Path to write the signed certificate chain PEM (prints to stdout if omitted)")
 	flags.StringVar(&cfg.CAOutPath, "ca-out", "", "Path to write just the mesh CA bundle PEM (the issuer certs trailing the leaf in the CDS chain), e.g. for nginx to serve at a discovery endpoint without a separate ConfigMap")
 	flags.StringVar(&cfg.KeyPath, "key", "", "Path to a PEM private key to use for the CSR (generates an ephemeral key if omitted)")
@@ -585,7 +585,7 @@ func validateConfig(cfg config) error {
 	if err := cmdsutil.ValidateHTTPURL("--cds-url", cfg.CDSURL); err != nil {
 		return err
 	}
-	if err := cmdsutil.ValidateHTTPURL("--attestation-api-url", cfg.AttestationApiURL); err != nil {
+	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", cfg.AttestationApiURL); err != nil {
 		return err
 	}
 	if err := validateSAN(cfg.SAN); err != nil {

--- a/internal/cmds/nri-image-policy/config_test.go
+++ b/internal/cmds/nri-image-policy/config_test.go
@@ -1,11 +1,16 @@
 package nriimagepolicy
 
 import (
+	"context"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 )
 
 func validConfig() config {
@@ -345,6 +350,52 @@ func TestValidate_LabelRuleRejectsInvalidKubernetesLabelValue(t *testing.T) {
 	}
 	if err := cfg.Validate(); err == nil {
 		t.Fatal("expected Kubernetes label selector validation to reject invalid value")
+	}
+}
+
+// The chart's rendered boot config points attestation_api_url at the
+// attest-proxy's node-local socket; pin that exact string loading through
+// validation and driving the evidence client over a real socket (the
+// construction path main.go uses for the CDS pull handshake).
+func TestLoadConfig_UnixAttestationAPIURL(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "attestation-api.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/attest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"platform":"snp","evidence":{}}`))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	yaml := `
+allowlist:
+  always_allow:
+    "sha256:0000000000000000000000000000000000000000000000000000000000000001": "installer"
+  pull:
+    url: https://127.0.0.1:30808
+    attestation_api_url: unix://` + sock + `
+`
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("unix attestation_api_url must load and validate: %v", err)
+	}
+	resp, err := attestclient.NewClient("").GenerateEvidenceContext(
+		context.Background(), cfg.Allowlist.Pull.AttestationApiURL, make([]byte, 48))
+	if err != nil {
+		t.Fatalf("evidence request over the configured unix socket: %v", err)
+	}
+	if resp.Platform != "snp" {
+		t.Fatalf("evidence platform = %q, want snp (fake upstream)", resp.Platform)
 	}
 }
 

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -619,8 +620,8 @@ func validateConfig(attestationApiURL string, outboundPort, inboundPort, healthP
 	if attestationApiURL == "" {
 		return fmt.Errorf("--attestation-api-url is required")
 	}
-	if !strings.HasPrefix(attestationApiURL, "http://") && !strings.HasPrefix(attestationApiURL, "https://") {
-		return fmt.Errorf("--attestation-api-url %q must start with http:// or https://", attestationApiURL)
+	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", attestationApiURL); err != nil {
+		return err
 	}
 	if err := validatePort("--outbound-port", outboundPort); err != nil {
 		return err

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -100,6 +100,9 @@ func (c *Config) Validate() error {
 	if c.AttestationApiURL == "" {
 		return fmt.Errorf("--attestation-api-url is required to verify CDS")
 	}
+	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", c.AttestationApiURL); err != nil {
+		return err
+	}
 	if c.Attempts <= 0 {
 		return fmt.Errorf("--attempts must be positive")
 	}

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -346,16 +346,6 @@ pod (read-only) and the one the webhook mounts into get-cert sidecars.
 {{- end -}}
 
 {{- /*
-c8s.attestationApiKey — the configured Bearer key, normalized: the `with`
-reads a null auth block or key as "key absent", and the trim shares the
-attest-proxy's strings.TrimSpace, so the render guard and the proxy agree
-on which keys are blank.
-*/ -}}
-{{- define "c8s.attestationApiKey" -}}
-{{- with .Values.attestationApi.auth -}}{{- .apiKey | default "" | toString | trim -}}{{- end -}}
-{{- end -}}
-
-{{- /*
 c8s.attestationApiHostSocket — "true" when consumers reach the chart-managed
 attestation-api over the on-node Unix socket, i.e. the DaemonSet renders and
 the in-guest (kata) endpoint does not apply.
@@ -568,23 +558,12 @@ seccompProfile:
 {{- define "c8s.attestationApiConfig" -}}
 {{- $root := .root -}}
 [server]
-{{- if ne (int $root.Values.attestationApi.service.nodePort) 0 }}
-# Routable by operator opt-in (attestationApi.service.nodePort); the [auth]
-# block is mandatory in this shape — see validations.yaml.
-bind = "0.0.0.0:{{ $root.Values.attestationApi.port }}"
-{{- else }}
 # Pod loopback only: consumers enter through the attest-proxy sidecar's
 # node-local Unix socket; nothing routable can reach /attest.
 bind = "127.0.0.1:{{ $root.Values.attestationApi.port }}"
-{{- end }}
 
 [server.tls]
 enabled = false
-{{- with include "c8s.attestationApiKey" $root }}
-
-[auth]
-api_keys = [{{ . | quote }}]
-{{- end }}
 
 [attestation]
 enabled = true

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -306,34 +306,88 @@ and CDS. Three shapes:
   - kata.enabled: the kata-guest-base image bakes an in-guest attestation-service
     on loopback, and the consumers (the operator's get-cert sidecars and CDS) run
     INSIDE the CVM, so they dial 127.0.0.1 — not the (absent) host Service.
-  - cvmMode=node: the node image bakes a HOST attestation-api on the node's
-    loopback :8400 (no in-cluster Service). Pod-netns consumers cannot reach host
-    loopback, so they dial the node's own IP via the $(HOST_IP) downward-API env
-    var (c8s.attestationApiHostIPEnv), which the kubelet expands per-node before
-    the process sees the arg. The operator forwards this string verbatim to the
-    tenant get-cert sidecars it injects, so it must stay unexpanded there (the
-    operator container deliberately omits HOST_IP); each tenant pod expands it
-    against its own node.
-  - otherwise: the in-cluster host Service DNS.
+  - otherwise, when attestationApi.enabled (every non-kata shape where the
+    chart DaemonSet renders — gke/aks, and raw values without a mode): the
+    on-node Unix socket its attest-proxy sidecar serves
+    (c8s.attestationApiSocket). Evidence generation is never published on a
+    routable address: the API binds pod loopback, and only on-node callers —
+    host processes, and pods the socket directory is mounted into — can
+    reach it. Chart components mount the directory at its host path, so this
+    URL is verbatim everywhere; the webhook rebases it for injected sidecars,
+    which see the directory at workloadclaims.SidecarSocketDir.
+  - otherwise (attestationApi.enabled=false outside kata, i.e. cvmMode=node —
+    require_attestation_api forbids it elsewhere): the node image bakes a HOST
+    attestation-api on the node's loopback :8400. Pod-netns consumers cannot
+    reach host loopback, so they dial the node's own IP via the $(HOST_IP)
+    downward-API env var (c8s.attestationApiHostIPEnv), which the kubelet
+    expands per-node before the process sees the arg. The operator forwards
+    this string verbatim to the tenant get-cert sidecars it injects, so it
+    must stay unexpanded there (the operator container deliberately omits
+    HOST_IP); each tenant pod expands it against its own node.
 */ -}}
 {{- define "c8s.attestationApiURL" -}}
 {{- if .Values.kata.enabled -}}
 http://127.0.0.1:{{ .Values.attestationApi.port }}
-{{- else if eq .Values.attestationApi.cvmMode "node" -}}
-http://$(HOST_IP):{{ .Values.attestationApi.port }}
+{{- else if .Values.attestationApi.enabled -}}
+unix://{{ include "c8s.attestationApiSocket" . }}
 {{- else -}}
-http://{{ include "c8s.attestationApiName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.attestationApi.port }}
+http://$(HOST_IP):{{ .Values.attestationApi.port }}
 {{- end -}}
 {{- end -}}
 
 {{- /*
+c8s.attestationApiSocket — the node-local socket the attest-proxy sidecar
+serves the attestation-api on. It lives in the admission inventory's socket
+directory: that dir is already the one hostPath the deny-host-namespaces
+policy admits into a cw pod (read-only) and the one the webhook mounts into
+get-cert sidecars, so a second directory would only add a second carve-out.
+*/ -}}
+{{- define "c8s.attestationApiSocket" -}}
+{{ .Values.nriImagePolicy.hostPaths.runtimeDir }}/attestation-api.sock
+{{- end -}}
+
+{{- /*
+c8s.attestationApiHostSocket — "true" when consumers reach the chart-managed
+attestation-api over the on-node Unix socket, i.e. the DaemonSet renders and
+the in-guest (kata) endpoint does not apply.
+*/ -}}
+{{- define "c8s.attestationApiHostSocket" -}}
+{{- if and .Values.attestationApi.enabled (not .Values.kata.enabled) -}}true{{- end -}}
+{{- end -}}
+
+{{- /*
+c8s.attestationApiSocketVolume / Mount — the hostPath pair a chart component
+pod needs to reach the on-node socket. Mounted at the host path so
+c8s.attestationApiURL is verbatim in-container. ReadOnly on the mount;
+DirectoryOrCreate so a consumer scheduled before the DaemonSet does not wedge
+(the socket file's own mode gates connect, not the dir's).
+*/ -}}
+{{- define "c8s.attestationApiSocketVolume" -}}
+{{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
+- name: attestation-api-socket
+  hostPath:
+    path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+    type: DirectoryOrCreate
+{{- end }}
+{{- end -}}
+
+{{- define "c8s.attestationApiSocketMount" -}}
+{{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
+- name: attestation-api-socket
+  mountPath: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+  readOnly: true
+{{- end }}
+{{- end -}}
+
+{{- /*
 c8s.attestationApiHostIPEnv — the HOST_IP downward-API env var that expands the
-$(HOST_IP) placeholder in c8s.attestationApiURL. Rendered only under
-cvmMode=node, where pod-netns consumers reach the node-baked host attestation-api
-via the node's own IP. Empty in every other mode.
+$(HOST_IP) placeholder in c8s.attestationApiURL. Rendered only when that URL
+carries the placeholder: cvmMode=node with the chart DaemonSet off, where
+pod-netns consumers reach the node-baked host attestation-api via the node's
+own IP. Empty in every other shape.
 */ -}}
 {{- define "c8s.attestationApiHostIPEnv" -}}
-{{- if and (not .Values.kata.enabled) (eq .Values.attestationApi.cvmMode "node") -}}
+{{- if and (not .Values.kata.enabled) (not .Values.attestationApi.enabled) (eq .Values.attestationApi.cvmMode "node") -}}
 - name: HOST_IP
   valueFrom:
     fieldRef:
@@ -505,11 +559,23 @@ seccompProfile:
 {{- define "c8s.attestationApiConfig" -}}
 {{- $root := .root -}}
 [server]
+{{- if ne (int $root.Values.attestationApi.service.nodePort) 0 }}
+# Routable by operator opt-in (attestationApi.service.nodePort); the [auth]
+# block is mandatory in this shape — see validations.yaml.
 bind = "0.0.0.0:{{ $root.Values.attestationApi.port }}"
-mode = "hosted"
+{{- else }}
+# Pod loopback only: consumers enter through the attest-proxy sidecar's
+# node-local Unix socket; nothing routable can reach /attest.
+bind = "127.0.0.1:{{ $root.Values.attestationApi.port }}"
+{{- end }}
 
 [server.tls]
 enabled = false
+{{- with $root.Values.attestationApi.auth.apiKey }}
+
+[auth]
+api_keys = [{{ . | quote }}]
+{{- end }}
 
 [attestation]
 enabled = true

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -346,13 +346,13 @@ pod (read-only) and the one the webhook mounts into get-cert sidecars.
 {{- end -}}
 
 {{- /*
-c8s.attestationApiKey — the configured Bearer key, normalized: a YAML null
-coalesces to "key absent" (nil) and a whitespace-only key is unusable, so
-null/empty/whitespace all read as "no key" everywhere (render guard, [auth]
-block, proxy key file).
+c8s.attestationApiKey — the configured Bearer key, normalized: the `with`
+reads a null auth block or key as "key absent", and the trim shares the
+attest-proxy's strings.TrimSpace, so the render guard and the proxy agree
+on which keys are blank.
 */ -}}
 {{- define "c8s.attestationApiKey" -}}
-{{- .Values.attestationApi.auth.apiKey | default "" | toString | trimAll " \t" -}}
+{{- with .Values.attestationApi.auth -}}{{- .apiKey | default "" | toString | trim -}}{{- end -}}
 {{- end -}}
 
 {{- /*

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -306,9 +306,9 @@ and CDS. Three shapes:
   - kata.enabled: the kata-guest-base image bakes an in-guest attestation-service
     on loopback, and the consumers (the operator's get-cert sidecars and CDS) run
     INSIDE the CVM, so they dial 127.0.0.1 — not the (absent) host Service.
-  - otherwise, when attestationApi.enabled (every non-kata shape where the
-    chart DaemonSet renders — gke/aks, and raw values without a mode): the
-    on-node Unix socket its attest-proxy sidecar serves
+  - otherwise, when attestationApi.enabled=true (the chart DaemonSet shape —
+    the raw-values default, kept by gke/aks installs): the on-node Unix socket
+    its attest-proxy sidecar serves
     (c8s.attestationApiSocket). Evidence generation is never published on a
     routable address: the API binds pod loopback, and only on-node callers —
     host processes, and pods the socket directory is mounted into — can
@@ -317,13 +317,13 @@ and CDS. Three shapes:
     which see the directory at workloadclaims.SidecarSocketDir.
   - otherwise (attestationApi.enabled=false outside kata, i.e. cvmMode=node —
     require_attestation_api forbids it elsewhere): the node image bakes a HOST
-    attestation-api on the node's loopback :8400. Pod-netns consumers cannot
-    reach host loopback, so they dial the node's own IP via the $(HOST_IP)
-    downward-API env var (c8s.attestationApiHostIPEnv), which the kubelet
-    expands per-node before the process sees the arg. The operator forwards
-    this string verbatim to the tenant get-cert sidecars it injects, so it
-    must stay unexpanded there (the operator container deliberately omits
-    HOST_IP); each tenant pod expands it against its own node.
+    attestation-api serving :8400 in the host network namespace. Pod-netns
+    consumers dial the node's own IP via the $(HOST_IP) downward-API env var
+    (c8s.attestationApiHostIPEnv), which the kubelet expands per-node before
+    the process sees the arg. The operator forwards this string verbatim to
+    the tenant get-cert sidecars it injects, so it must stay unexpanded there
+    (the operator container deliberately omits HOST_IP); each tenant pod
+    expands it against its own node.
 */ -}}
 {{- define "c8s.attestationApiURL" -}}
 {{- if .Values.kata.enabled -}}
@@ -338,12 +338,21 @@ http://$(HOST_IP):{{ .Values.attestationApi.port }}
 {{- /*
 c8s.attestationApiSocket — the node-local socket the attest-proxy sidecar
 serves the attestation-api on. It lives in the admission inventory's socket
-directory: that dir is already the one hostPath the deny-host-namespaces
-policy admits into a cw pod (read-only) and the one the webhook mounts into
-get-cert sidecars, so a second directory would only add a second carve-out.
+directory: the one hostPath the deny-host-namespaces policy admits into a cw
+pod (read-only) and the one the webhook mounts into get-cert sidecars.
 */ -}}
 {{- define "c8s.attestationApiSocket" -}}
 {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}/attestation-api.sock
+{{- end -}}
+
+{{- /*
+c8s.attestationApiKey — the configured Bearer key, normalized: a YAML null
+coalesces to "key absent" (nil) and a whitespace-only key is unusable, so
+null/empty/whitespace all read as "no key" everywhere (render guard, [auth]
+block, proxy key file).
+*/ -}}
+{{- define "c8s.attestationApiKey" -}}
+{{- .Values.attestationApi.auth.apiKey | default "" | toString | trimAll " \t" -}}
 {{- end -}}
 
 {{- /*
@@ -571,7 +580,7 @@ bind = "127.0.0.1:{{ $root.Values.attestationApi.port }}"
 
 [server.tls]
 enabled = false
-{{- with $root.Values.attestationApi.auth.apiKey }}
+{{- with include "c8s.attestationApiKey" $root }}
 
 [auth]
 api_keys = [{{ . | quote }}]

--- a/internal/helmchart/c8s/templates/attestation-api.yaml
+++ b/internal/helmchart/c8s/templates/attestation-api.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.attestationApi.enabled }}
-{{- $nri := .Values.nriImagePolicy -}}
 {{- $attestationNodePort := int .Values.attestationApi.service.nodePort -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -22,7 +21,18 @@ metadata:
 data:
   config.toml: |
 {{ include "c8s.attestationApiConfig" (dict "root" .) | indent 4 }}
+  {{- with .Values.attestationApi.auth.apiKey }}
+  # Bearer key the attest-proxy injects for on-node socket callers; rendered
+  # only with attestationApi.service.nodePort (the render guard gates on it).
+  auth-key: {{ . | quote }}
+  {{- end }}
 ---
+{{- if ne $attestationNodePort 0 }}
+# Deliberate operator opt-in (attestationApi.service.nodePort): publishes the
+# attestation-api on every node IP. The render guard requires
+# attestationApi.auth.apiKey with it, so the exposed listener is always
+# authenticated. Local: evidence describes the node it was generated on, so a
+# cross-node hop would attest the wrong node.
 apiVersion: v1
 kind: Service
 metadata:
@@ -32,26 +42,20 @@ metadata:
 {{ include "c8s.commonLabels" . | indent 4 }}
     app.kubernetes.io/component: attestation-api
 spec:
-  {{- if $nri.enabled }}
   type: NodePort
   externalTrafficPolicy: Local
-  {{- end }}
   selector:
     app.kubernetes.io/name: c8s-operator
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: attestation-api
-  # Local: pods always hit their same-node attestation-api replica.
-  # /attest generates evidence for the LOCAL TEE, so a cross-node hop
-  # would produce evidence against the wrong node.
   internalTrafficPolicy: Local
   ports:
     - name: http
       port: {{ .Values.attestationApi.port }}
       targetPort: http
-      {{- if $nri.enabled }}
       nodePort: {{ $attestationNodePort }}
-      {{- end }}
 ---
+{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -109,6 +113,9 @@ spec:
             {{- else }}
 {{ fail (printf "attestationApi.cvmMode must be one of pod, node, gke, aks (got %q)" .Values.attestationApi.cvmMode) }}
             {{- end }}
+          # No kubelet probes here: the API binds pod loopback, which kubelet
+          # cannot dial. The attest-proxy's exec probe covers the whole chain
+          # (socket, proxy, upstream /health).
           volumeMounts:
             - name: config
               mountPath: /etc/attestation-api
@@ -138,14 +145,50 @@ spec:
             - name: tpmrm
               mountPath: /dev/tpmrm0
             {{- end }}
-          readinessProbe:
-            httpGet: { path: /health, port: http }
-            initialDelaySeconds: 2
-          livenessProbe:
-            httpGet: { path: /health, port: http }
-            periodSeconds: 30
           resources:
 {{ toYaml .Values.attestationApi.resources | indent 12 }}
+        # The on-node front door: publishes the pod-loopback API on a
+        # hostPath Unix socket next to the admission inventory's socket, so
+        # exactly host processes and pods the socket dir is mounted into can
+        # request evidence.
+        - name: attest-proxy
+          image: {{ include "c8s.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - attest-proxy
+            - --socket={{ include "c8s.attestationApiSocket" . }}
+            - --upstream=http://127.0.0.1:{{ .Values.attestationApi.port }}
+            {{- with .Values.attestationApi.auth.apiKey }}
+            - --api-key-file=/etc/attestation-api/auth-key
+            {{- end }}
+          # uid 0 so the socket is root-owned (callers reject a socket owned
+          # by anyone but root or themselves); runAsGroup is the socket's
+          # group so the chgrp needs no CAP_CHOWN.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 65532
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault
+          readinessProbe:
+            exec:
+              command: [/c8s, attest-proxy, healthcheck, --socket, {{ include "c8s.attestationApiSocket" . }}]
+            initialDelaySeconds: 2
+          livenessProbe:
+            exec:
+              command: [/c8s, attest-proxy, healthcheck, --socket, {{ include "c8s.attestationApiSocket" . }}]
+            periodSeconds: 30
+          volumeMounts:
+            - name: config
+              mountPath: /etc/attestation-api
+              readOnly: true
+            - name: socket-dir
+              mountPath: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+          resources:
+{{ toYaml .Values.attestationApi.proxy.resources | indent 12 }}
       volumes:
         - name: config
           configMap:
@@ -182,4 +225,38 @@ spec:
             path: /dev/tpmrm0
             type: CharDevice
         {{- end }}
+        # The socket directory is shared with the admission inventory: it is
+        # the one hostPath the deny-host-namespaces policy admits into cw
+        # pods, and the one the webhook mounts into get-cert sidecars.
+        - name: socket-dir
+          hostPath:
+            path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+            type: DirectoryOrCreate
+---
+# The API binds pod loopback, so nothing on the pod network can reach it; this
+# policy is the second line, keeping even an accidental rebind pod-unreachable.
+# It denies all ingress by default; the nodePort opt-in opens exactly the API
+# port (authenticated per the render guard).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "c8s.attestationApiName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+    app.kubernetes.io/component: attestation-api
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: attestation-api
+  policyTypes:
+    - Ingress
+  {{- if ne $attestationNodePort 0 }}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.attestationApi.port }}
+  {{- end }}
 {{- end }}

--- a/internal/helmchart/c8s/templates/attestation-api.yaml
+++ b/internal/helmchart/c8s/templates/attestation-api.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.attestationApi.enabled }}
-{{- $attestationNodePort := int .Values.attestationApi.service.nodePort -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,53 +9,18 @@ metadata:
     app.kubernetes.io/component: attestation-api
 {{ include "c8s.serviceAccountImagePullSecrets" . }}
 ---
-# config.toml carries the [auth] Bearer key under the nodePort opt-in, so
-# the config renders as a Secret; auth-key feeds the same key to the proxy.
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
   name: {{ include "c8s.attestationApiName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "c8s.commonLabels" . | indent 4 }}
     app.kubernetes.io/component: attestation-api
-stringData:
+data:
   config.toml: |
 {{ include "c8s.attestationApiConfig" (dict "root" .) | indent 4 }}
-  {{- with include "c8s.attestationApiKey" . }}
-  # Bearer key the attest-proxy injects for on-node socket callers.
-  auth-key: {{ . | quote }}
-  {{- end }}
 ---
-{{- if ne $attestationNodePort 0 }}
-# Deliberate operator opt-in (attestationApi.service.nodePort): publishes the
-# attestation-api on every node IP. The render guard requires
-# attestationApi.auth.apiKey with it, so the exposed listener is always
-# authenticated. Local: evidence describes the node it was generated on, so a
-# cross-node hop would attest the wrong node.
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "c8s.attestationApiName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "c8s.commonLabels" . | indent 4 }}
-    app.kubernetes.io/component: attestation-api
-spec:
-  type: NodePort
-  externalTrafficPolicy: Local
-  selector:
-    app.kubernetes.io/name: c8s-operator
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/component: attestation-api
-  internalTrafficPolicy: Local
-  ports:
-    - name: http
-      port: {{ .Values.attestationApi.port }}
-      targetPort: http
-      nodePort: {{ $attestationNodePort }}
----
-{{- end }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -158,9 +122,6 @@ spec:
             - attest-proxy
             - --socket={{ include "c8s.attestationApiSocket" . }}
             - --upstream=http://127.0.0.1:{{ .Values.attestationApi.port }}
-            {{- with include "c8s.attestationApiKey" . }}
-            - --api-key-file=/etc/attestation-api/auth-key
-            {{- end }}
           # uid 0 so the socket is root-owned (callers reject a socket owned
           # by anyone but root or themselves); runAsGroup is the socket's
           # group so the chgrp needs no CAP_CHOWN.
@@ -194,8 +155,8 @@ spec:
 {{ toYaml .Values.attestationApi.proxy.resources | indent 12 }}
       volumes:
         - name: config
-          secret:
-            secretName: {{ include "c8s.attestationApiName" . }}
+          configMap:
+            name: {{ include "c8s.attestationApiName" . }}
         # hostPath.type=CharDevice forces a hard failure on nodes that
         # lack the device, instead of silently mounting an empty file —
         # attestation evidence would then be silently bogus. Toggle each
@@ -236,8 +197,6 @@ spec:
 ---
 # The API binds pod loopback, so nothing on the pod network can reach it; this
 # policy is the second line, keeping even an accidental rebind pod-unreachable.
-# It denies all ingress by default; the nodePort opt-in opens exactly the API
-# port (authenticated per the render guard).
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -254,10 +213,4 @@ spec:
       app.kubernetes.io/component: attestation-api
   policyTypes:
     - Ingress
-  {{- if ne $attestationNodePort 0 }}
-  ingress:
-    - ports:
-        - protocol: TCP
-          port: {{ .Values.attestationApi.port }}
-  {{- end }}
 {{- end }}

--- a/internal/helmchart/c8s/templates/attestation-api.yaml
+++ b/internal/helmchart/c8s/templates/attestation-api.yaml
@@ -10,20 +10,21 @@ metadata:
     app.kubernetes.io/component: attestation-api
 {{ include "c8s.serviceAccountImagePullSecrets" . }}
 ---
+# config.toml carries the [auth] Bearer key under the nodePort opt-in, so
+# the config renders as a Secret; auth-key feeds the same key to the proxy.
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: {{ include "c8s.attestationApiName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "c8s.commonLabels" . | indent 4 }}
     app.kubernetes.io/component: attestation-api
-data:
+stringData:
   config.toml: |
 {{ include "c8s.attestationApiConfig" (dict "root" .) | indent 4 }}
-  {{- with .Values.attestationApi.auth.apiKey }}
-  # Bearer key the attest-proxy injects for on-node socket callers; rendered
-  # only with attestationApi.service.nodePort (the render guard gates on it).
+  {{- with include "c8s.attestationApiKey" . }}
+  # Bearer key the attest-proxy injects for on-node socket callers.
   auth-key: {{ . | quote }}
   {{- end }}
 ---
@@ -113,9 +114,8 @@ spec:
             {{- else }}
 {{ fail (printf "attestationApi.cvmMode must be one of pod, node, gke, aks (got %q)" .Values.attestationApi.cvmMode) }}
             {{- end }}
-          # No kubelet probes here: the API binds pod loopback, which kubelet
-          # cannot dial. The attest-proxy's exec probe covers the whole chain
-          # (socket, proxy, upstream /health).
+          # The API's health signal is the attest-proxy's exec probe: the API
+          # binds pod loopback, which kubelet cannot dial.
           volumeMounts:
             - name: config
               mountPath: /etc/attestation-api
@@ -158,7 +158,7 @@ spec:
             - attest-proxy
             - --socket={{ include "c8s.attestationApiSocket" . }}
             - --upstream=http://127.0.0.1:{{ .Values.attestationApi.port }}
-            {{- with .Values.attestationApi.auth.apiKey }}
+            {{- with include "c8s.attestationApiKey" . }}
             - --api-key-file=/etc/attestation-api/auth-key
             {{- end }}
           # uid 0 so the socket is root-owned (callers reject a socket owned
@@ -177,10 +177,13 @@ spec:
             exec:
               command: [/c8s, attest-proxy, healthcheck, --socket, {{ include "c8s.attestationApiSocket" . }}]
             initialDelaySeconds: 2
+            # Above the healthcheck's internal 3s budget (kubelet default is 1s).
+            timeoutSeconds: 5
           livenessProbe:
             exec:
               command: [/c8s, attest-proxy, healthcheck, --socket, {{ include "c8s.attestationApiSocket" . }}]
             periodSeconds: 30
+            timeoutSeconds: 5
           volumeMounts:
             - name: config
               mountPath: /etc/attestation-api
@@ -191,8 +194,8 @@ spec:
 {{ toYaml .Values.attestationApi.proxy.resources | indent 12 }}
       volumes:
         - name: config
-          configMap:
-            name: {{ include "c8s.attestationApiName" . }}
+          secret:
+            secretName: {{ include "c8s.attestationApiName" . }}
         # hostPath.type=CharDevice forces a hard failure on nodes that
         # lack the device, instead of silently mounting an empty file —
         # attestation evidence would then be silently bogus. Toggle each
@@ -225,9 +228,7 @@ spec:
             path: /dev/tpmrm0
             type: CharDevice
         {{- end }}
-        # The socket directory is shared with the admission inventory: it is
-        # the one hostPath the deny-host-namespaces policy admits into cw
-        # pods, and the one the webhook mounts into get-cert sidecars.
+        # Shared with the admission inventory — see c8s.attestationApiSocket.
         - name: socket-dir
           hostPath:
             path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -294,6 +294,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data
+            {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
             {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
             - name: allowlist-seed
               mountPath: /etc/cds
@@ -325,6 +326,7 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- include "c8s.attestationApiSocketVolume" . | nindent 8 }}
         {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
         - name: allowlist-seed
           configMap:

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -182,9 +182,7 @@ spec:
           args:
             - --port={{ .Values.cds.port }}
             - --log-level={{ .Values.cds.logLevel }}
-            # c8s.attestationApiURL resolves to the in-guest loopback endpoint
-            # under kata.enabled (CDS runs inside the CVM where the baked
-            # attestation-service listens) and to the host Service otherwise.
+            # Per-mode resolution: see c8s.attestationApiURL.
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
             - --allowlist-db={{ .Values.cds.allowlistDB }}
             - --allowlist-persistent={{ .Values.cds.persistence.enabled }}

--- a/internal/helmchart/c8s/templates/host-namespace-policy.yaml
+++ b/internal/helmchart/c8s/templates/host-namespace-policy.yaml
@@ -77,7 +77,7 @@ spec:
              c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true)))) &&
            (!has(object.spec.ephemeralContainers) || object.spec.ephemeralContainers.all(c, !has(c.volumeMounts) ||
              c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))))))
-      message: "hostPath volumes are denied, except a read-only mount of the admission inventory socket directory (the webhook-injected claims volume): a writable mount of the node filesystem could swap the inventory's socket (docs/getcert-workload-binding.md, Corner 7)."
+      message: "hostPath volumes are denied, except a read-only mount of the admission inventory socket directory (the webhook-injected claims volume; it also holds the attestation-api socket): a writable mount of the node filesystem could swap those sockets (docs/getcert-workload-binding.md, Corner 7)."
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
@@ -178,7 +178,6 @@ install image + CDS digest so chart upgrades can roll.
 */}}
 {{- define "nri-image-policy.bootConfig" -}}
 {{- $root := .root -}}
-{{- $attestationNodePort := int $root.Values.attestationApi.service.nodePort -}}
 {{/* Must stay the value CDS runs with: the two ends of one mutually-attested connection. */}}
 platform: {{ $root.Values.cds.ratlsPlatform | quote }}
 plugin:
@@ -194,7 +193,8 @@ allowlist:
     url: {{ required "cds.url is required" $root.Values.nriImagePolicy.cds.url | quote }}
     interval: {{ $root.Values.nriImagePolicy.refresh.interval | quote }}
     timeout: "30s"
-    attestation_api_url: {{ printf "http://localhost:%d" $attestationNodePort | quote }}
+    # Node-local socket served by the DaemonSet's attest-proxy sidecar.
+    attestation_api_url: {{ printf "unix://%s" (include "c8s.attestationApiSocket" $root) | quote }}
     cds_measurements:
 {{- range $root.Values.cds.measurements }}
       - {{ . | quote }}

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -70,6 +70,12 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+        {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
+        # workloadclaims.InventorySocketGID: the attest-proxy's socket is
+        # group-owned by it; the mesh runs as uid 1337 and needs the group to
+        # connect.
+        supplementalGroups: [65532]
+        {{- end }}
       {{- include "c8s.imagePullSecrets" (dict "root" $ "local" .Values.ratlsMesh.imagePullSecrets) | nindent 6 }}
       tolerations:
         - operator: "Exists"
@@ -85,6 +91,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Mi
+        {{- include "c8s.attestationApiSocketVolume" . | nindent 8 }}
       initContainers:
         # Native sidecar (K8s 1.29+): cleanup runs last on shutdown because
         # sidecars stop in reverse initContainer order.
@@ -219,6 +226,7 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
           args:
             - --platform
             - {{ .Values.ratlsMesh.platform | quote }}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -261,6 +261,7 @@ spec:
             - name: tls-certs
               mountPath: {{ .Values.tlsLb.tlsMountPath }}
               readOnly: true
+            {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
             {{- if .Values.tlsLb.publicTLS.secretName }}
             # cds-attest reads the same public leaf nginx serves
             # (--serving-cert-file).
@@ -301,6 +302,10 @@ spec:
           # attestation-api, reached from this pod via its node IP.
           env:
             {{- . | nindent 12 }}
+          {{- end }}
+          {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
+          volumeMounts:
+            {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -360,15 +365,20 @@ spec:
             path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
             type: Directory
         {{- end }}
+        # The attestation socket shares the inventory's directory; get-cert,
+        # cds-attest, and the allowlist proxy all dial it. Mounted at the host
+        # path so c8s.attestationApiURL is verbatim in-container.
+        {{- include "c8s.attestationApiSocketVolume" . | nindent 8 }}
       securityContext:
         runAsNonRoot: {{ .Values.tlsLb.nginx.runAsNonRoot }}
         fsGroup: {{ include "c8s.int" .Values.tlsLb.nginx.runAsGroup }}
-        {{- if eq (include "tls-lb.mountInventorySocket" .) "true" }}
-        # workloadclaims.InventorySocketGID: the inventory chgrps its socket to
-        # this group so the non-root get-cert sidecar can connect. get-cert
-        # itself must stay on the nginx uid — it SIGHUPs nginx on renewal, and
-        # a different uid gets "operation not permitted", after which nginx
-        # serves a stale leaf that every exact-DER client correctly refuses.
+        {{- if or (eq (include "tls-lb.mountInventorySocket" .) "true") (eq (include "c8s.attestationApiHostSocket" .) "true") }}
+        # workloadclaims.InventorySocketGID: the inventory and attest-proxy
+        # chgrp their sockets to this group so the non-root get-cert sidecar
+        # (on the nginx uid) can connect. get-cert must stay on the nginx uid —
+        # it SIGHUPs nginx on renewal, and a different uid gets "operation not
+        # permitted", after which nginx serves a stale leaf that every
+        # exact-DER client correctly refuses.
         supplementalGroups: [65532]
         {{- end }}
         seccompProfile:

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -365,9 +365,7 @@ spec:
             path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
             type: Directory
         {{- end }}
-        # The attestation socket shares the inventory's directory; get-cert,
-        # cds-attest, and the allowlist proxy all dial it. Mounted at the host
-        # path so c8s.attestationApiURL is verbatim in-container.
+        {{- /* Shares the admission inventory's socket directory — see c8s.attestationApiSocket. */}}
         {{- include "c8s.attestationApiSocketVolume" . | nindent 8 }}
       securityContext:
         runAsNonRoot: {{ .Values.tlsLb.nginx.runAsNonRoot }}

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -520,6 +520,9 @@ list.
 {{- if .Values.tlsLb.discovery.enabled -}}
 {{- $mounts = append $mounts (printf "- name: discovery\n  mountPath: %s" .Values.tlsLb.discovery.mountPath) -}}
 {{- end -}}
+{{- if eq (include "c8s.attestationApiHostSocket" .) "true" -}}
+{{- $mounts = append $mounts (printf "- name: attestation-api-socket\n  mountPath: %s\n  readOnly: true" .Values.nriImagePolicy.hostPaths.runtimeDir) -}}
+{{- end -}}
 {{- $extraArgs := include "tls-lb.getCertCommonArgs" . | fromYamlArray -}}
 {{- if .Values.tlsLb.attest.expectedWorkload -}}
 {{- /* The readiness gate (cds-attest /readyz) demands a matched-workload

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -1,7 +1,6 @@
 {{- $tlsLB := .Values.tlsLb -}}
 {{- $nri := .Values.nriImagePolicy -}}
 {{- $nriCDSURL := tpl (default "" $nri.cds.url) . -}}
-{{- $attestationNodePort := int .Values.attestationApi.service.nodePort -}}
 {{- /*
   Helm silently ignores values keys the chart no longer reads, so a values
   file carried over from a release that still had tee-proxy would drop its
@@ -97,21 +96,6 @@
 {{- end -}}
 {{- if and $nri.enabled (not (hasPrefix "https://" $nriCDSURL)) -}}
 {{- fail (printf "nriImagePolicy.cds.url must start with https:// when nriImagePolicy.enabled=true (got %q): the host plugin must fetch the allowlist over RA-TLS" $nriCDSURL) -}}
-{{- end -}}
-{{- /*
-  The default-deny posture for evidence generation: the API is reachable only
-  over the on-node Unix socket. nodePort=0 keeps it that way; any nodePort
-  value publishes /attest on every node IP, which is an evidence oracle for
-  anything with L3 reach unless the listener requires the API key — so the
-  two must be set together.
-*/ -}}
-{{- if and .Values.attestationApi.enabled (ne $attestationNodePort 0) -}}
-{{- if or (lt $attestationNodePort 30000) (gt $attestationNodePort 32767) -}}
-{{- fail (printf "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 (got %d)" $attestationNodePort) -}}
-{{- end -}}
-{{- if empty (include "c8s.attestationApiKey" .) -}}
-{{- fail "VALIDATION_ERROR kind=attestation_api_exposed_unauthenticated: attestationApi.service.nodePort publishes evidence generation on every node IP, but attestationApi.auth.apiKey is empty — an unauthenticated routable /attest lets any host with L3 reach mint genuine node evidence over caller-chosen REPORTDATA and redeem it at CDS for a mesh leaf. Set attestationApi.auth.apiKey, or set nodePort back to 0 (the default: node-local Unix socket only)." -}}
-{{- end -}}
 {{- end -}}
 {{- /*
   The mirror of require_host_image_policy for evidence: off kata and node,

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -98,8 +98,29 @@
 {{- if and $nri.enabled (not (hasPrefix "https://" $nriCDSURL)) -}}
 {{- fail (printf "nriImagePolicy.cds.url must start with https:// when nriImagePolicy.enabled=true (got %q): the host plugin must fetch the allowlist over RA-TLS" $nriCDSURL) -}}
 {{- end -}}
-{{- if and $nri.enabled (or (lt $attestationNodePort 30000) (gt $attestationNodePort 32767)) -}}
-{{- fail (printf "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 when nriImagePolicy.enabled=true (got %d)" $attestationNodePort) -}}
+{{- /*
+  The default-deny posture for evidence generation: the API is reachable only
+  over the on-node Unix socket. nodePort=0 keeps it that way; any nodePort
+  value publishes /attest on every node IP, which is an evidence oracle for
+  anything with L3 reach unless the listener requires the API key — so the
+  two must be set together.
+*/ -}}
+{{- if and .Values.attestationApi.enabled (ne $attestationNodePort 0) -}}
+{{- if or (lt $attestationNodePort 30000) (gt $attestationNodePort 32767) -}}
+{{- fail (printf "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 (got %d)" $attestationNodePort) -}}
+{{- end -}}
+{{- if eq .Values.attestationApi.auth.apiKey "" -}}
+{{- fail "VALIDATION_ERROR kind=attestation_api_exposed_unauthenticated: attestationApi.service.nodePort publishes evidence generation on every node IP, but attestationApi.auth.apiKey is empty — an unauthenticated routable /attest lets any host with L3 reach mint genuine node evidence over caller-chosen REPORTDATA and redeem it at CDS for a mesh leaf. Set attestationApi.auth.apiKey, or set nodePort back to 0 (the default: node-local Unix socket only)." -}}
+{{- end -}}
+{{- end -}}
+{{- /*
+  The mirror of require_host_image_policy for evidence: off kata and node,
+  the host attestation-api DaemonSet is the only evidence source for
+  get-cert, ratls-mesh, and CDS. Disabling it there renders a cluster whose
+  attestation consumers all point at a socket nothing serves.
+*/ -}}
+{{- if and (not .Values.attestationApi.enabled) (not .Values.kata.enabled) (ne .Values.attestationApi.cvmMode "node") -}}
+{{- fail "VALIDATION_ERROR kind=require_attestation_api: attestationApi.enabled=false requires kata.enabled=true or attestationApi.cvmMode=node. On a non-kata, non-node cluster the host attestation-api DaemonSet is the only evidence source for get-cert/ratls-mesh/CDS (`c8s install --cvm-mode=pod` and `--cvm-mode=node` set attestationApi.enabled=false for you)." -}}
 {{- end -}}
 {{- /*
   Catch-all upstream check. No upstream is a legal state: tls-lb installs and

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -109,7 +109,7 @@
 {{- if or (lt $attestationNodePort 30000) (gt $attestationNodePort 32767) -}}
 {{- fail (printf "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 (got %d)" $attestationNodePort) -}}
 {{- end -}}
-{{- if eq .Values.attestationApi.auth.apiKey "" -}}
+{{- if empty (include "c8s.attestationApiKey" .) -}}
 {{- fail "VALIDATION_ERROR kind=attestation_api_exposed_unauthenticated: attestationApi.service.nodePort publishes evidence generation on every node IP, but attestationApi.auth.apiKey is empty — an unauthenticated routable /attest lets any host with L3 reach mint genuine node evidence over caller-chosen REPORTDATA and redeem it at CDS for a mesh leaf. Set attestationApi.auth.apiKey, or set nodePort back to 0 (the default: node-local Unix socket only)." -}}
 {{- end -}}
 {{- end -}}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -341,18 +341,6 @@ attestationApi:
   ## Evidence generation is node-local only: the API binds pod loopback and
   ## the attest-proxy sidecar serves it on a hostPath Unix socket in
   ## nriImagePolicy.hostPaths.runtimeDir (0660, root:65532).
-  auth:
-    ## Bearer key, required when service.nodePort exposes the listener
-    ## (enforced at render). Generate it high-entropy: the config checksum
-    ## covering it appears in a pod annotation.
-    apiKey: ""
-  service:
-    ## Opt-in re-exposure for debugging: renders a NodePort Service and binds
-    ## the API on 0.0.0.0. Requires auth.apiKey (enforced at render); the
-    ## on-node socket path keeps working — the proxy injects the key for it.
-    ## 0 (the default) renders no Service at all.
-    nodePort: 0
-  ## attest-proxy sidecar (the Unix-socket front door).
   proxy:
     resources:
       requests:

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -340,17 +340,10 @@ attestationApi:
   port: 8400
   ## Evidence generation is node-local only: the API binds pod loopback and
   ## the attest-proxy sidecar serves it on a hostPath Unix socket in
-  ## nriImagePolicy.hostPaths.runtimeDir (0660, root-owned, group 65532 —
-  ## the same directory and reachability model as the admission inventory
-  ## socket). Consumers — the host NRI plugin, ratls-mesh, CDS, tls-lb, and
-  ## webhook-injected get-cert sidecars — dial that socket; nothing routable
-  ## can reach /attest, so a party in no TEE cannot mint evidence over
-  ## caller-chosen REPORTDATA and redeem it at CDS for a mesh leaf.
+  ## nriImagePolicy.hostPaths.runtimeDir (0660, root:65532).
   auth:
-    ## Bearer key the attestation-api requires when the listener is exposed.
-    ## Empty with the default node-local shape: the socket needs no key. The
-    ## render fails if nodePort is set without a key — an unauthenticated
-    ## routable /attest is an evidence oracle for any host with L3 reach.
+    ## Bearer key, required when service.nodePort exposes the listener
+    ## (enforced at render).
     apiKey: ""
   service:
     ## Opt-in re-exposure for debugging: renders a NodePort Service and binds

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -338,10 +338,35 @@ attestationApi:
     digest: ""
     pullPolicy: IfNotPresent
   port: 8400
+  ## Evidence generation is node-local only: the API binds pod loopback and
+  ## the attest-proxy sidecar serves it on a hostPath Unix socket in
+  ## nriImagePolicy.hostPaths.runtimeDir (0660, root-owned, group 65532 —
+  ## the same directory and reachability model as the admission inventory
+  ## socket). Consumers — the host NRI plugin, ratls-mesh, CDS, tls-lb, and
+  ## webhook-injected get-cert sidecars — dial that socket; nothing routable
+  ## can reach /attest, so a party in no TEE cannot mint evidence over
+  ## caller-chosen REPORTDATA and redeem it at CDS for a mesh leaf.
+  auth:
+    ## Bearer key the attestation-api requires when the listener is exposed.
+    ## Empty with the default node-local shape: the socket needs no key. The
+    ## render fails if nodePort is set without a key — an unauthenticated
+    ## routable /attest is an evidence oracle for any host with L3 reach.
+    apiKey: ""
   service:
-    ## NodePort used by host-process components such as nri-image-policy.
-    ## Rendered only when nri-image-policy.enabled=true.
-    nodePort: 30840
+    ## Opt-in re-exposure for debugging: renders a NodePort Service and binds
+    ## the API on 0.0.0.0. Requires auth.apiKey (enforced at render); the
+    ## on-node socket path keeps working — the proxy injects the key for it.
+    ## 0 (the default) renders no Service at all.
+    nodePort: 0
+  ## attest-proxy sidecar (the Unix-socket front door).
+  proxy:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 100m
+        memory: 64Mi
   ## Per-device hostPath mounts. hostPath.type=CharDevice fails the pod if
   ## the device node doesn't exist on the host, so disable for nodes that
   ## lack the corresponding hardware.

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -324,7 +324,7 @@ cds:
 
 ## DaemonSet running the attestation-api image from github.com/confidential-dot-ai/attestation-rs.
 attestationApi:
-  ## Render the host-side attestation-api DaemonSet/Service. Disable on
+  ## Render the host-side attestation-api DaemonSet. Disable on
   ## clusters where every workload pod runs as a kata-qemu-snp CVM — the
   ## in-guest attestation-service is baked into kata-guest-base on loopback,
   ## so the host DaemonSet is redundant (and crashloops on bare-metal nodes
@@ -343,7 +343,8 @@ attestationApi:
   ## nriImagePolicy.hostPaths.runtimeDir (0660, root:65532).
   auth:
     ## Bearer key, required when service.nodePort exposes the listener
-    ## (enforced at render).
+    ## (enforced at render). Generate it high-entropy: the config checksum
+    ## covering it appears in a pod annotation.
     apiKey: ""
   service:
     ## Opt-in re-exposure for debugging: renders a NodePort Service and binds

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1341,6 +1341,7 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 	if renderedManifestHasNamedKind(t, out, "Service", "c8s-attestation-api") {
 		t.Fatalf("default render must not create an attestation-api Service (evidence generation is node-local only)\n%s", out)
 	}
+	assertNoLegacyAttestationStrings(t, out)
 
 	var np networkingv1.NetworkPolicy
 	if !findDoc(t, out, "NetworkPolicy", "c8s-attestation-api", &np) {
@@ -1353,8 +1354,13 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 		t.Fatalf("NetworkPolicy policyTypes = %v, want Ingress", np.Spec.PolicyTypes)
 	}
 
-	cm := renderedConfigMap(t, out, "c8s-attestation-api")
-	cfg := cm.Data["config.toml"]
+	// The config is a Secret, not a ConfigMap: with the nodePort opt-in it
+	// carries the [auth] Bearer key (TestChartAttestationApiNodePortWithAuthRenders).
+	if renderedManifestHasNamedKind(t, out, "ConfigMap", "c8s-attestation-api") {
+		t.Fatalf("attestation-api config must render as a Secret, not a ConfigMap\n%s", out)
+	}
+	sec := renderedSecret(t, out, "c8s-attestation-api")
+	cfg := sec.StringData["config.toml"]
 	if !strings.Contains(cfg, `bind = "127.0.0.1:8400"`) {
 		t.Fatalf("default config must bind pod loopback; got:\n%s", cfg)
 	}
@@ -1362,21 +1368,75 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 		t.Fatalf("default config must not render [auth] (nothing routable to protect); got:\n%s", cfg)
 	}
 
+	ds := renderedDaemonSet(t, out, "c8s-attestation-api")
 	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
 	assertContainerArgs(t, proxy,
 		"attest-proxy",
 		"--socket=/var/run/nri-image-policy/attestation-api.sock",
 		"--upstream=http://127.0.0.1:8400",
 	)
+	// The proxy publishes into the socket-dir hostPath, and both it and the
+	// API read their config from the Secret — dropping either renders fine
+	// and only fails at runtime.
+	assertPodVolume(t, &ds.Spec.Template.Spec, "socket-dir", func(v corev1.Volume) bool {
+		return v.HostPath != nil && v.HostPath.Path == "/var/run/nri-image-policy"
+	})
+	assertPodVolume(t, &ds.Spec.Template.Spec, "config", func(v corev1.Volume) bool {
+		return v.Secret != nil && v.Secret.SecretName == "c8s-attestation-api"
+	})
+	assertContainerMount(t, proxy, "socket-dir", "/var/run/nri-image-policy")
 	if proxy.ReadinessProbe == nil || proxy.ReadinessProbe.Exec == nil {
 		t.Fatalf("attest-proxy must carry an exec readiness probe (the API's loopback bind is not kubelet-dialable); got %+v", proxy.ReadinessProbe)
 	}
-	// The API container's old httpGet probes would never pass against a
-	// loopback bind, so the proxy's exec probe is the only health signal.
+	if proxy.LivenessProbe == nil || proxy.LivenessProbe.Exec == nil {
+		t.Fatalf("attest-proxy must carry an exec liveness probe (it is the evidence path's only liveness signal); got %+v", proxy.LivenessProbe)
+	}
+	// Kubelet's 1s default probe timeout would flap the healthcheck's 3s
+	// internal budget.
+	if proxy.ReadinessProbe.TimeoutSeconds != 5 || proxy.LivenessProbe.TimeoutSeconds != 5 {
+		t.Fatalf("exec probes must set timeoutSeconds=5; got readiness %d / liveness %d", proxy.ReadinessProbe.TimeoutSeconds, proxy.LivenessProbe.TimeoutSeconds)
+	}
+	// An httpGet probe would never pass against the loopback bind, so the
+	// proxy's exec probe is the only health signal.
 	api := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attestation-api")
 	if api.ReadinessProbe != nil || api.LivenessProbe != nil {
 		t.Fatalf("attestation-api container must not carry kubelet probes against its loopback bind; got %+v / %+v", api.ReadinessProbe, api.LivenessProbe)
 	}
+}
+
+// assertNoLegacyAttestationStrings keeps the routable shapes the hardening
+// removed out of every render: the old NodePort, a wildcard bind, and the
+// deleted Service's DNS name.
+func assertNoLegacyAttestationStrings(t *testing.T, manifest string) {
+	t.Helper()
+	for _, legacy := range []string{"30840", "0.0.0.0", "c8s-attestation-api.c8s-system.svc"} {
+		if strings.Contains(manifest, legacy) {
+			t.Fatalf("render must not contain legacy routable-attestation string %q", legacy)
+		}
+	}
+}
+
+func assertPodVolume(t *testing.T, spec *corev1.PodSpec, name string, ok func(corev1.Volume) bool) {
+	t.Helper()
+	for _, v := range spec.Volumes {
+		if v.Name == name {
+			if !ok(v) {
+				t.Fatalf("volume %q has the wrong source: %+v", name, v.VolumeSource)
+			}
+			return
+		}
+	}
+	t.Fatalf("pod spec missing volume %q; volumes %+v", name, spec.Volumes)
+}
+
+func assertContainerMount(t *testing.T, c corev1.Container, name, mountPath string) {
+	t.Helper()
+	for _, m := range c.VolumeMounts {
+		if m.Name == name && m.MountPath == mountPath {
+			return
+		}
+	}
+	t.Fatalf("container %s missing mount of volume %q at %q; mounts %+v", c.Name, name, mountPath, c.VolumeMounts)
 }
 
 // The host NRI plugin is a host process: it reaches the attestation-api over
@@ -1415,16 +1475,16 @@ func TestChartAttestationApiNodePortWithAuthRenders(t *testing.T) {
 		t.Fatalf("attestation-api nodePort = %d, want 31040", got)
 	}
 
-	cm := renderedConfigMap(t, out, "c8s-attestation-api")
-	cfg := cm.Data["config.toml"]
+	sec := renderedSecret(t, out, "c8s-attestation-api")
+	cfg := sec.StringData["config.toml"]
 	if !strings.Contains(cfg, `bind = "0.0.0.0:8400"`) {
 		t.Fatalf("exposed config must bind 0.0.0.0 for the NodePort to forward to; got:\n%s", cfg)
 	}
 	if !strings.Contains(cfg, `api_keys = ["test-key"]`) {
 		t.Fatalf("exposed config must carry the API key; got:\n%s", cfg)
 	}
-	if got := cm.Data["auth-key"]; got != "test-key" {
-		t.Fatalf("ConfigMap auth-key = %q, want the injected key for the proxy", got)
+	if got := sec.StringData["auth-key"]; got != "test-key" {
+		t.Fatalf("Secret auth-key = %q, want the injected key for the proxy", got)
 	}
 	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
 	assertContainerArgs(t, proxy, "--api-key-file=/etc/attestation-api/auth-key")
@@ -1508,6 +1568,58 @@ func TestChartRejectsExposedUnauthenticatedAttestationApi(t *testing.T) {
 	}
 	if msg := helmFailMessage(t, out); !strings.Contains(msg, "attestationApi.auth.apiKey") {
 		t.Fatalf("fail message must name the value to fix (attestationApi.auth.apiKey); got %q", msg)
+	}
+}
+
+// The guard must also catch the empty-key shapes a plain `eq … ""` check
+// misses: a YAML null (values file, or --set-json) coalesces to "key
+// absent", and a whitespace-only key is unusable. Each must fail the render
+// naming the value to fix — nodePort + null key is byte-for-byte the
+// unauthenticated routable shape otherwise.
+func TestChartRejectsExposedAttestationApiNullOrBlankKey(t *testing.T) {
+	nullValues := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(nullValues, []byte("attestationApi:\n  service:\n    nodePort: 30840\n  auth:\n    apiKey: null\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"null key via values file", []string{"-f", nullValues}},
+		{"null key via --set-json", []string{"--set", "attestationApi.service.nodePort=30840", "--set-json", "attestationApi.auth.apiKey=null"}},
+		{"whitespace-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=  "}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := helmTemplate(t, tc.args...)
+			if err == nil {
+				t.Fatalf("helm template succeeded with a routable unauthenticated attestation-api, want failure\n%s", out)
+			}
+			if kind := parseValidationErrorKind(out); kind != "attestation_api_exposed_unauthenticated" {
+				t.Fatalf("validation error kind = %q, want attestation_api_exposed_unauthenticated\n%s", kind, out)
+			}
+			if msg := helmFailMessage(t, out); !strings.Contains(msg, "attestationApi.auth.apiKey") {
+				t.Fatalf("fail message must name the value to fix (attestationApi.auth.apiKey); got %q", msg)
+			}
+		})
+	}
+}
+
+// The key is normalized (trimmed) before render, so the key the proxy
+// injects is byte-identical to the one the API's [auth] list requires.
+func TestChartTrimsAttestationApiKey(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "attestationApi.service.nodePort=31040",
+		"--set-string", "attestationApi.auth.apiKey= test-key ",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	sec := renderedSecret(t, out, "c8s-attestation-api")
+	if got := sec.StringData["auth-key"]; got != "test-key" {
+		t.Fatalf("Secret auth-key = %q, want the trimmed key", got)
+	}
+	if cfg := sec.StringData["config.toml"]; !strings.Contains(cfg, `api_keys = ["test-key"]`) {
+		t.Fatalf("config must carry the trimmed key; got:\n%s", cfg)
 	}
 }
 
@@ -1878,6 +1990,14 @@ func hasHostIPEnv(c corev1.Container) bool {
 // the tenant get-cert sidecars it injects, so the placeholder must stay
 // UNEXPANDED there — the operator container deliberately omits HOST_IP so each
 // tenant pod expands it against its own node.
+// KNOWN-GAP (ATTEST-ORACLE, node mode): the http://$(HOST_IP):8400 wiring
+// this test pins reaches the node image's baked attestation-api, which still
+// binds 0.0.0.0:8400 with no auth — the oracle shape this branch removes
+// everywhere the chart controls. Closing node mode needs the
+// confidential-os-builder companion (loopback bind + baked attest-proxy
+// systemd unit + image-policy socket URL), tracked cross-repo; when it
+// lands, the chart's node-mode branch and this test flip to the socket shape
+// together.
 func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
 	const hostIPURL = "--attestation-api-url=http://$(HOST_IP):8400"
 	// The exact shape `c8s install --cvm-mode=node` produces: the node image
@@ -1891,6 +2011,12 @@ func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
 	)
 	if err != nil {
 		t.Fatalf("helm template (cvmMode=node): %v\n%s", err, out)
+	}
+
+	// No chart-managed evidence source renders in this shape at all.
+	if renderedManifestHasNamedKind(t, out, "Service", "c8s-attestation-api") ||
+		renderedManifestHasNamedKind(t, out, "DaemonSet", "c8s-attestation-api") {
+		t.Fatalf("cvmMode=node install shape renders no attestation-api Service or DaemonSet\n%s", out)
 	}
 
 	// cds: pod-netns, dials the host attestation-api via $(HOST_IP).
@@ -1953,6 +2079,17 @@ func TestChartNonNodeModeUsesAttestationSocket(t *testing.T) {
 			out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode="+mode, "--set", "tlsLb.attest.enabled=true")
 			if err != nil {
 				t.Fatalf("helm template (cvmMode=%s): %v\n%s", mode, err, out)
+			}
+			// The acceptance criteria are per-mode: no routable path to
+			// evidence generation, and the default-deny NetworkPolicy on the
+			// DaemonSet.
+			if renderedManifestHasNamedKind(t, out, "Service", "c8s-attestation-api") {
+				t.Fatalf("cvmMode=%s renders no attestation-api Service (evidence generation is node-local only)\n%s", mode, out)
+			}
+			assertNoLegacyAttestationStrings(t, out)
+			var np networkingv1.NetworkPolicy
+			if !findDoc(t, out, "NetworkPolicy", "c8s-attestation-api", &np) || len(np.Spec.Ingress) != 0 {
+				t.Fatalf("cvmMode=%s renders the attestation-api default-deny NetworkPolicy; got %+v", mode, np.Spec.Ingress)
 			}
 			cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
 			assertContainerArgs(t, cds, socketURL)
@@ -5354,6 +5491,15 @@ func renderedConfigMap(t *testing.T, manifest, name string) corev1.ConfigMap {
 	return cm
 }
 
+func renderedSecret(t *testing.T, manifest, name string) corev1.Secret {
+	t.Helper()
+	var sec corev1.Secret
+	if !findDoc(t, manifest, "Secret", name, &sec) {
+		t.Fatalf("rendered manifest missing Secret %q\n%s", name, manifest)
+	}
+	return sec
+}
+
 func renderedService(t *testing.T, manifest, name string) corev1.Service {
 	t.Helper()
 	var svc corev1.Service
@@ -6235,8 +6381,8 @@ func TestChartImagePullSecretReachesEveryPodSpecWithoutCreatingASecret(t *testin
 	}
 	const secretName = "ghcr-secret"
 
-	if kinds := renderedKinds(t, out); kinds["Secret"] > 0 {
-		t.Errorf("imagePullSecret mode rendered %d Secret(s), want 0 (the Secret pre-exists)", kinds["Secret"])
+	if renderedManifestHasNamedKind(t, out, "Secret", secretName) {
+		t.Errorf("imagePullSecret mode rendered Secret %q — it pre-exists; the chart must not create it", secretName)
 	}
 
 	sasWithSecret := map[string]bool{}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1367,6 +1367,9 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 	if strings.Contains(cfg, "[auth]") {
 		t.Fatalf("default config must not render [auth] (nothing routable to protect); got:\n%s", cfg)
 	}
+	if k, ok := sec.StringData["auth-key"]; ok {
+		t.Fatalf("default render must not carry proxy key material; auth-key = %q", k)
+	}
 
 	ds := renderedDaemonSet(t, out, "c8s-attestation-api")
 	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
@@ -1375,6 +1378,9 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 		"--socket=/var/run/nri-image-policy/attestation-api.sock",
 		"--upstream=http://127.0.0.1:8400",
 	)
+	// A stray --api-key-file against the keyless Secret crash-loops the proxy
+	// on every node.
+	assertContainerNoArgPrefix(t, "attest-proxy", proxy.Args, "--api-key-file")
 	// The proxy publishes into the socket-dir hostPath, and both it and the
 	// API read their config from the Secret — dropping either renders fine
 	// and only fails at runtime.
@@ -1395,6 +1401,18 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 	// internal budget.
 	if proxy.ReadinessProbe.TimeoutSeconds != 5 || proxy.LivenessProbe.TimeoutSeconds != 5 {
 		t.Fatalf("exec probes must set timeoutSeconds=5; got readiness %d / liveness %d", proxy.ReadinessProbe.TimeoutSeconds, proxy.LivenessProbe.TimeoutSeconds)
+	}
+	// uid 0 owns the socket (clients reject a foreign owner) and gid 65532 is
+	// the socket's group — the chgrp works by membership, all caps dropped.
+	sc := proxy.SecurityContext
+	if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 0 || sc.RunAsGroup == nil || *sc.RunAsGroup != 65532 {
+		t.Fatalf("attest-proxy must run as uid 0 / gid 65532 (socket owner and group); got %+v", sc)
+	}
+	if sc.Capabilities == nil || !slices.Contains(sc.Capabilities.Drop, corev1.Capability("ALL")) {
+		t.Fatalf("attest-proxy must drop all capabilities; got %+v", sc.Capabilities)
+	}
+	if sc.ReadOnlyRootFilesystem == nil || !*sc.ReadOnlyRootFilesystem {
+		t.Fatalf("attest-proxy must mount its root filesystem read-only; got %+v", sc.ReadOnlyRootFilesystem)
 	}
 	// An httpGet probe would never pass against the loopback bind, so the
 	// proxy's exec probe is the only health signal.
@@ -1581,6 +1599,10 @@ func TestChartRejectsExposedAttestationApiNullOrBlankKey(t *testing.T) {
 	if err := os.WriteFile(nullValues, []byte("attestationApi:\n  service:\n    nodePort: 30840\n  auth:\n    apiKey: null\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	nullAuthValues := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(nullAuthValues, []byte("attestationApi:\n  service:\n    nodePort: 30840\n  auth: null\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	for _, tc := range []struct {
 		name string
 		args []string
@@ -1588,6 +1610,12 @@ func TestChartRejectsExposedAttestationApiNullOrBlankKey(t *testing.T) {
 		{"null key via values file", []string{"-f", nullValues}},
 		{"null key via --set-json", []string{"--set", "attestationApi.service.nodePort=30840", "--set-json", "attestationApi.auth.apiKey=null"}},
 		{"whitespace-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=  "}},
+		// The guard's trim set is the proxy's strings.TrimSpace: a key that is
+		// blank under it must fail here, not render a proxy that rejects its
+		// own key file at runtime.
+		{"newline-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=\n"}},
+		{"unicode-whitespace-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=\u00a0"}},
+		{"null auth block", []string{"-f", nullAuthValues}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := helmTemplate(t, tc.args...)
@@ -1604,22 +1632,68 @@ func TestChartRejectsExposedAttestationApiNullOrBlankKey(t *testing.T) {
 	}
 }
 
-// The key is normalized (trimmed) before render, so the key the proxy
-// injects is byte-identical to the one the API's [auth] list requires.
+// The key is normalized (trimmed) before render with the proxy's
+// strings.TrimSpace set, so the key the proxy injects is byte-identical to
+// the one the API's [auth] list requires.
 func TestChartTrimsAttestationApiKey(t *testing.T) {
-	out, err := helmTemplate(t,
-		"--set", "attestationApi.service.nodePort=31040",
-		"--set-string", "attestationApi.auth.apiKey= test-key ",
-	)
-	if err != nil {
-		t.Fatalf("helm template: %v\n%s", err, out)
+	for _, tc := range []struct {
+		name   string
+		padded string
+		want   string
+	}{
+		{"space-padded", " test-key ", "test-key"},
+		{"newline-padded", "\ntest-key\n", "test-key"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := helmTemplate(t,
+				"--set", "attestationApi.service.nodePort=31040",
+				"--set-string", "attestationApi.auth.apiKey="+tc.padded,
+			)
+			if err != nil {
+				t.Fatalf("helm template: %v\n%s", err, out)
+			}
+			sec := renderedSecret(t, out, "c8s-attestation-api")
+			if got := sec.StringData["auth-key"]; got != tc.want {
+				t.Fatalf("Secret auth-key = %q, want the trimmed key %q", got, tc.want)
+			}
+			if cfg := sec.StringData["config.toml"]; !strings.Contains(cfg, `api_keys = ["`+tc.want+`"]`) {
+				t.Fatalf("config must carry the trimmed key; got:\n%s", cfg)
+			}
+		})
 	}
-	sec := renderedSecret(t, out, "c8s-attestation-api")
-	if got := sec.StringData["auth-key"]; got != "test-key" {
-		t.Fatalf("Secret auth-key = %q, want the trimmed key", got)
+}
+
+// A blank key without a nodePort renders the plain keyless shape — no
+// [auth], no key material in the Secret, no --api-key-file on the proxy (a
+// stray one crash-loops it on an empty key file at runtime).
+func TestChartBlankKeyWithoutNodePortRendersKeyless(t *testing.T) {
+	nullAuthValues := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(nullAuthValues, []byte("attestationApi:\n  auth: null\n"), 0o600); err != nil {
+		t.Fatal(err)
 	}
-	if cfg := sec.StringData["config.toml"]; !strings.Contains(cfg, `api_keys = ["test-key"]`) {
-		t.Fatalf("config must carry the trimmed key; got:\n%s", cfg)
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"whitespace-only key", []string{"--set-string", "attestationApi.auth.apiKey=  "}},
+		{"newline-only key", []string{"--set-string", "attestationApi.auth.apiKey=\n"}},
+		{"null auth block", []string{"-f", nullAuthValues}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := helmTemplate(t, tc.args...)
+			if err != nil {
+				t.Fatalf("helm template: %v\n%s", err, out)
+			}
+			sec := renderedSecret(t, out, "c8s-attestation-api")
+			if cfg := sec.StringData["config.toml"]; strings.Contains(cfg, "[auth]") {
+				t.Fatalf("keyless config must not render [auth]; got:\n%s", cfg)
+			}
+			if k, ok := sec.StringData["auth-key"]; ok {
+				t.Fatalf("keyless render must not carry proxy key material; auth-key = %q", k)
+			}
+			proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
+			assertContainerNoArgPrefix(t, "attest-proxy", proxy.Args, "--api-key-file")
+		})
 	}
 }
 

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -26,7 +26,6 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
@@ -1354,21 +1353,15 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 		t.Fatalf("NetworkPolicy policyTypes = %v, want Ingress", np.Spec.PolicyTypes)
 	}
 
-	// The config is a Secret, not a ConfigMap: with the nodePort opt-in it
-	// carries the [auth] Bearer key (TestChartAttestationApiNodePortWithAuthRenders).
-	if renderedManifestHasNamedKind(t, out, "ConfigMap", "c8s-attestation-api") {
-		t.Fatalf("attestation-api config must render as a Secret, not a ConfigMap\n%s", out)
+	if renderedManifestHasNamedKind(t, out, "Secret", "c8s-attestation-api") {
+		t.Fatalf("attestation-api config must render as a ConfigMap, not a Secret\n%s", out)
 	}
-	sec := renderedSecret(t, out, "c8s-attestation-api")
-	cfg := sec.StringData["config.toml"]
+	cfg := renderedConfigMap(t, out, "c8s-attestation-api").Data["config.toml"]
 	if !strings.Contains(cfg, `bind = "127.0.0.1:8400"`) {
 		t.Fatalf("default config must bind pod loopback; got:\n%s", cfg)
 	}
 	if strings.Contains(cfg, "[auth]") {
-		t.Fatalf("default config must not render [auth] (nothing routable to protect); got:\n%s", cfg)
-	}
-	if k, ok := sec.StringData["auth-key"]; ok {
-		t.Fatalf("default render must not carry proxy key material; auth-key = %q", k)
+		t.Fatalf("config must not render [auth] (nothing routable to protect); got:\n%s", cfg)
 	}
 
 	ds := renderedDaemonSet(t, out, "c8s-attestation-api")
@@ -1378,17 +1371,15 @@ func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 		"--socket=/var/run/nri-image-policy/attestation-api.sock",
 		"--upstream=http://127.0.0.1:8400",
 	)
-	// A stray --api-key-file against the keyless Secret crash-loops the proxy
-	// on every node.
 	assertContainerNoArgPrefix(t, "attest-proxy", proxy.Args, "--api-key-file")
 	// The proxy publishes into the socket-dir hostPath, and both it and the
-	// API read their config from the Secret — dropping either renders fine
-	// and only fails at runtime.
+	// API read their config from the ConfigMap — dropping either renders
+	// fine and only fails at runtime.
 	assertPodVolume(t, &ds.Spec.Template.Spec, "socket-dir", func(v corev1.Volume) bool {
 		return v.HostPath != nil && v.HostPath.Path == "/var/run/nri-image-policy"
 	})
 	assertPodVolume(t, &ds.Spec.Template.Spec, "config", func(v corev1.Volume) bool {
-		return v.Secret != nil && v.Secret.SecretName == "c8s-attestation-api"
+		return v.ConfigMap != nil && v.ConfigMap.Name == "c8s-attestation-api"
 	})
 	assertContainerMount(t, proxy, "socket-dir", "/var/run/nri-image-policy")
 	if proxy.ReadinessProbe == nil || proxy.ReadinessProbe.Exec == nil {
@@ -1470,52 +1461,6 @@ func TestChartAttestationApiSocketWiresNRI(t *testing.T) {
 	}
 }
 
-// Deliberate re-exposure: nodePort set WITH an API key renders the
-// authenticated routable shape — NodePort Service, 0.0.0.0 bind, [auth] in the
-// rendered config, the key file the proxy injects for on-node callers, and a
-// NetworkPolicy opening exactly the API port.
-func TestChartAttestationApiNodePortWithAuthRenders(t *testing.T) {
-	out, err := helmTemplate(t,
-		"--set", "attestationApi.service.nodePort=31040",
-		"--set-string", "attestationApi.auth.apiKey=test-key",
-	)
-	if err != nil {
-		t.Fatalf("helm template: %v\n%s", err, out)
-	}
-	svc := renderedService(t, out, "c8s-attestation-api")
-	if svc.Spec.Type != corev1.ServiceTypeNodePort {
-		t.Fatalf("attestation-api Service type = %q, want NodePort", svc.Spec.Type)
-	}
-	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
-		t.Fatalf("attestation-api externalTrafficPolicy = %q, want Local", svc.Spec.ExternalTrafficPolicy)
-	}
-	if got := svc.Spec.Ports[0].NodePort; got != 31040 {
-		t.Fatalf("attestation-api nodePort = %d, want 31040", got)
-	}
-
-	sec := renderedSecret(t, out, "c8s-attestation-api")
-	cfg := sec.StringData["config.toml"]
-	if !strings.Contains(cfg, `bind = "0.0.0.0:8400"`) {
-		t.Fatalf("exposed config must bind 0.0.0.0 for the NodePort to forward to; got:\n%s", cfg)
-	}
-	if !strings.Contains(cfg, `api_keys = ["test-key"]`) {
-		t.Fatalf("exposed config must carry the API key; got:\n%s", cfg)
-	}
-	if got := sec.StringData["auth-key"]; got != "test-key" {
-		t.Fatalf("Secret auth-key = %q, want the injected key for the proxy", got)
-	}
-	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
-	assertContainerArgs(t, proxy, "--api-key-file=/etc/attestation-api/auth-key")
-
-	var np networkingv1.NetworkPolicy
-	if !findDoc(t, out, "NetworkPolicy", "c8s-attestation-api", &np) {
-		t.Fatalf("exposed render missing the attestation-api NetworkPolicy\n%s", out)
-	}
-	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port == nil || *np.Spec.Ingress[0].Ports[0].Port != intstr.FromInt32(8400) {
-		t.Fatalf("exposed NetworkPolicy must allow exactly TCP 8400; got %+v", np.Spec.Ingress)
-	}
-}
-
 // On a cluster that is neither kata nor node-baked, host nri-image-policy is the
 // only image-admission enforcement, so disabling it must be rejected — otherwise
 // confidential workloads run with no attested allowlist gate. cvmMode=gke is the
@@ -1558,143 +1503,6 @@ func TestChartRejectsPlaintextNRIAllowlist(t *testing.T) {
 		t.Fatalf("helm template succeeded, want plaintext NRI allowlist failure\n%s", out)
 	}
 	assertHelmFailMessage(t, out, `nriImagePolicy.cds.url must start with https:// when nriImagePolicy.enabled=true (got "http://c8s-cds.c8s-system.svc:8443"): the host plugin must fetch the allowlist over RA-TLS`)
-}
-
-func TestChartRejectsInvalidAttestationApiNodePort(t *testing.T) {
-	out, err := helmTemplate(t,
-		"--set", "attestationApi.service.nodePort=29999",
-		"--set-string", "attestationApi.auth.apiKey=test-key",
-	)
-	if err == nil {
-		t.Fatalf("helm template succeeded, want invalid attestation-api nodePort failure\n%s", out)
-	}
-	assertHelmFailMessage(t, out, "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 (got 29999)")
-}
-
-// The render guard the whole hardening rests on: a routable evidence
-// listener without authentication must be impossible to render, and the
-// failure must name the value that fixes it.
-func TestChartRejectsExposedUnauthenticatedAttestationApi(t *testing.T) {
-	out, err := helmTemplate(t,
-		"--set", "attestationApi.service.nodePort=30840",
-	)
-	if err == nil {
-		t.Fatalf("helm template succeeded with a routable unauthenticated attestation-api, want failure\n%s", out)
-	}
-	if kind := parseValidationErrorKind(out); kind != "attestation_api_exposed_unauthenticated" {
-		t.Fatalf("validation error kind = %q, want attestation_api_exposed_unauthenticated\n%s", kind, out)
-	}
-	if msg := helmFailMessage(t, out); !strings.Contains(msg, "attestationApi.auth.apiKey") {
-		t.Fatalf("fail message must name the value to fix (attestationApi.auth.apiKey); got %q", msg)
-	}
-}
-
-// The guard must also catch the empty-key shapes a plain `eq … ""` check
-// misses: a YAML null (values file, or --set-json) coalesces to "key
-// absent", and a whitespace-only key is unusable. Each must fail the render
-// naming the value to fix — nodePort + null key is byte-for-byte the
-// unauthenticated routable shape otherwise.
-func TestChartRejectsExposedAttestationApiNullOrBlankKey(t *testing.T) {
-	nullValues := filepath.Join(t.TempDir(), "values.yaml")
-	if err := os.WriteFile(nullValues, []byte("attestationApi:\n  service:\n    nodePort: 30840\n  auth:\n    apiKey: null\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	nullAuthValues := filepath.Join(t.TempDir(), "values.yaml")
-	if err := os.WriteFile(nullAuthValues, []byte("attestationApi:\n  service:\n    nodePort: 30840\n  auth: null\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for _, tc := range []struct {
-		name string
-		args []string
-	}{
-		{"null key via values file", []string{"-f", nullValues}},
-		{"null key via --set-json", []string{"--set", "attestationApi.service.nodePort=30840", "--set-json", "attestationApi.auth.apiKey=null"}},
-		{"whitespace-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=  "}},
-		// The guard's trim set is the proxy's strings.TrimSpace: a key that is
-		// blank under it must fail here, not render a proxy that rejects its
-		// own key file at runtime.
-		{"newline-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=\n"}},
-		{"unicode-whitespace-only key", []string{"--set", "attestationApi.service.nodePort=30840", "--set-string", "attestationApi.auth.apiKey=\u00a0"}},
-		{"null auth block", []string{"-f", nullAuthValues}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			out, err := helmTemplate(t, tc.args...)
-			if err == nil {
-				t.Fatalf("helm template succeeded with a routable unauthenticated attestation-api, want failure\n%s", out)
-			}
-			if kind := parseValidationErrorKind(out); kind != "attestation_api_exposed_unauthenticated" {
-				t.Fatalf("validation error kind = %q, want attestation_api_exposed_unauthenticated\n%s", kind, out)
-			}
-			if msg := helmFailMessage(t, out); !strings.Contains(msg, "attestationApi.auth.apiKey") {
-				t.Fatalf("fail message must name the value to fix (attestationApi.auth.apiKey); got %q", msg)
-			}
-		})
-	}
-}
-
-// The key is normalized (trimmed) before render with the proxy's
-// strings.TrimSpace set, so the key the proxy injects is byte-identical to
-// the one the API's [auth] list requires.
-func TestChartTrimsAttestationApiKey(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		padded string
-		want   string
-	}{
-		{"space-padded", " test-key ", "test-key"},
-		{"newline-padded", "\ntest-key\n", "test-key"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			out, err := helmTemplate(t,
-				"--set", "attestationApi.service.nodePort=31040",
-				"--set-string", "attestationApi.auth.apiKey="+tc.padded,
-			)
-			if err != nil {
-				t.Fatalf("helm template: %v\n%s", err, out)
-			}
-			sec := renderedSecret(t, out, "c8s-attestation-api")
-			if got := sec.StringData["auth-key"]; got != tc.want {
-				t.Fatalf("Secret auth-key = %q, want the trimmed key %q", got, tc.want)
-			}
-			if cfg := sec.StringData["config.toml"]; !strings.Contains(cfg, `api_keys = ["`+tc.want+`"]`) {
-				t.Fatalf("config must carry the trimmed key; got:\n%s", cfg)
-			}
-		})
-	}
-}
-
-// A blank key without a nodePort renders the plain keyless shape — no
-// [auth], no key material in the Secret, no --api-key-file on the proxy (a
-// stray one crash-loops it on an empty key file at runtime).
-func TestChartBlankKeyWithoutNodePortRendersKeyless(t *testing.T) {
-	nullAuthValues := filepath.Join(t.TempDir(), "values.yaml")
-	if err := os.WriteFile(nullAuthValues, []byte("attestationApi:\n  auth: null\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for _, tc := range []struct {
-		name string
-		args []string
-	}{
-		{"whitespace-only key", []string{"--set-string", "attestationApi.auth.apiKey=  "}},
-		{"newline-only key", []string{"--set-string", "attestationApi.auth.apiKey=\n"}},
-		{"null auth block", []string{"-f", nullAuthValues}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			out, err := helmTemplate(t, tc.args...)
-			if err != nil {
-				t.Fatalf("helm template: %v\n%s", err, out)
-			}
-			sec := renderedSecret(t, out, "c8s-attestation-api")
-			if cfg := sec.StringData["config.toml"]; strings.Contains(cfg, "[auth]") {
-				t.Fatalf("keyless config must not render [auth]; got:\n%s", cfg)
-			}
-			if k, ok := sec.StringData["auth-key"]; ok {
-				t.Fatalf("keyless render must not carry proxy key material; auth-key = %q", k)
-			}
-			proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
-			assertContainerNoArgPrefix(t, "attest-proxy", proxy.Args, "--api-key-file")
-		})
-	}
 }
 
 // Off kata and node mode the host DaemonSet is the only evidence source, so
@@ -5565,15 +5373,6 @@ func renderedConfigMap(t *testing.T, manifest, name string) corev1.ConfigMap {
 	return cm
 }
 
-func renderedSecret(t *testing.T, manifest, name string) corev1.Secret {
-	t.Helper()
-	var sec corev1.Secret
-	if !findDoc(t, manifest, "Secret", name, &sec) {
-		t.Fatalf("rendered manifest missing Secret %q\n%s", name, manifest)
-	}
-	return sec
-}
-
 func renderedService(t *testing.T, manifest, name string) corev1.Service {
 	t.Helper()
 	var svc corev1.Service
@@ -6455,8 +6254,8 @@ func TestChartImagePullSecretReachesEveryPodSpecWithoutCreatingASecret(t *testin
 	}
 	const secretName = "ghcr-secret"
 
-	if renderedManifestHasNamedKind(t, out, "Secret", secretName) {
-		t.Errorf("imagePullSecret mode rendered Secret %q — it pre-exists; the chart must not create it", secretName)
+	if kinds := renderedKinds(t, out); kinds["Secret"] > 0 {
+		t.Errorf("imagePullSecret mode rendered %d Secret(s), want 0 (the Secret pre-exists)", kinds["Secret"])
 	}
 
 	sasWithSecret := map[string]bool{}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -22,9 +22,11 @@ import (
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
@@ -156,9 +158,9 @@ func containerArgValue(args []string, flag string) (string, bool) {
 }
 
 func TestChartDefaultRendersReplacementStack(t *testing.T) {
-	// gke keeps the host-side attestation-api enabled and reachable at its
-	// in-cluster Service DNS (node disables it and points components at the
-	// baked host attestation-api via HOST_IP; that path is covered separately).
+	// gke keeps the host-side attestation-api enabled, reachable only via the
+	// on-node Unix socket (node disables it and points components at the baked
+	// host attestation-api via HOST_IP; that path is covered separately).
 	out, err := helmTemplate(t, "--set", "attestationApi.cvmMode=gke")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
@@ -181,7 +183,7 @@ func TestChartDefaultRendersReplacementStack(t *testing.T) {
 	assertContainerArgs(t, cert,
 		"get-cert",
 		"--cds-url=https://c8s-cds.c8s-system.svc:8443",
-		"--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400",
+		"--attestation-api-url=unix:///var/run/nri-image-policy/attestation-api.sock",
 		"--san=c8s-tls-lb.c8s-system.svc",
 		"--out=/tls/cert.pem",
 		"--key-out=/tls/key.pem",
@@ -286,8 +288,10 @@ func TestChartRendersRATLSHostRoutingDefaults(t *testing.T) {
 		}
 	}
 
-	if kinds := renderedKinds(t, out); kinds["NetworkPolicy"] > 0 {
-		t.Errorf("ratls host routing must not render NetworkPolicy for hostNetwork pods; got %d", kinds["NetworkPolicy"])
+	// The only NetworkPolicy in a default render is the attestation-api
+	// default-deny; nothing may select the hostNetwork mesh pods.
+	if kinds := renderedKinds(t, out); kinds["NetworkPolicy"] != 1 || !renderedManifestHasNamedKind(t, out, "NetworkPolicy", "c8s-attestation-api") {
+		t.Errorf("default render must carry exactly the attestation-api default-deny NetworkPolicy (none may select the hostNetwork mesh pods); got %d", kinds["NetworkPolicy"])
 	}
 }
 
@@ -1313,7 +1317,7 @@ func TestChartNRIImagePolicyUsesPullMode(t *testing.T) {
 	if got, want := workerCfg.Allowlist.Pull.Interval, "5s"; got != want {
 		t.Fatalf("worker pull interval = %q, want %q", got, want)
 	}
-	if got, want := workerCfg.Allowlist.Pull.AttestationApiURL, "http://localhost:30840"; got != want {
+	if got, want := workerCfg.Allowlist.Pull.AttestationApiURL, "unix:///var/run/nri-image-policy/attestation-api.sock"; got != want {
 		t.Fatalf("runtime attestation-api URL = %q, want %q", got, want)
 	}
 	if want := []string{measurement}; !slices.Equal(workerCfg.Allowlist.Pull.CDSMeasurements, want) {
@@ -1325,26 +1329,77 @@ func TestChartNRIImagePolicyUsesPullMode(t *testing.T) {
 	}
 }
 
-func TestChartAttestationApiNodePortEnabledWithNRI(t *testing.T) {
+// The default attestation-api shape publishes nothing routable: no Service at
+// all, the API bound to pod loopback, a default-deny NetworkPolicy on the
+// DaemonSet pods, and the attest-proxy sidecar serving the on-node Unix
+// socket every consumer dials.
+func TestChartAttestationApiDefaultsToNodeLocalSocket(t *testing.T) {
 	out, err := helmTemplate(t)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
-	svc := renderedService(t, out, "c8s-attestation-api")
-	if svc.Spec.Type != corev1.ServiceTypeNodePort {
-		t.Fatalf("attestation-api Service type = %q by default, want NodePort", svc.Spec.Type)
+	if renderedManifestHasNamedKind(t, out, "Service", "c8s-attestation-api") {
+		t.Fatalf("default render must not create an attestation-api Service (evidence generation is node-local only)\n%s", out)
 	}
-	if svc.Spec.ExternalTrafficPolicy != corev1.ServiceExternalTrafficPolicyLocal {
-		t.Fatalf("attestation-api externalTrafficPolicy = %q, want Local", svc.Spec.ExternalTrafficPolicy)
+
+	var np networkingv1.NetworkPolicy
+	if !findDoc(t, out, "NetworkPolicy", "c8s-attestation-api", &np) {
+		t.Fatalf("default render missing the attestation-api default-deny NetworkPolicy\n%s", out)
 	}
-	if got := svc.Spec.Ports[0].NodePort; got != 30840 {
-		t.Fatalf("attestation-api nodePort = %d by default, want 30840", got)
+	if len(np.Spec.Ingress) != 0 {
+		t.Fatalf("default NetworkPolicy must deny all ingress; got rules %+v", np.Spec.Ingress)
+	}
+	if !slices.Contains(np.Spec.PolicyTypes, networkingv1.PolicyTypeIngress) {
+		t.Fatalf("NetworkPolicy policyTypes = %v, want Ingress", np.Spec.PolicyTypes)
+	}
+
+	cm := renderedConfigMap(t, out, "c8s-attestation-api")
+	cfg := cm.Data["config.toml"]
+	if !strings.Contains(cfg, `bind = "127.0.0.1:8400"`) {
+		t.Fatalf("default config must bind pod loopback; got:\n%s", cfg)
+	}
+	if strings.Contains(cfg, "[auth]") {
+		t.Fatalf("default config must not render [auth] (nothing routable to protect); got:\n%s", cfg)
+	}
+
+	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
+	assertContainerArgs(t, proxy,
+		"attest-proxy",
+		"--socket=/var/run/nri-image-policy/attestation-api.sock",
+		"--upstream=http://127.0.0.1:8400",
+	)
+	if proxy.ReadinessProbe == nil || proxy.ReadinessProbe.Exec == nil {
+		t.Fatalf("attest-proxy must carry an exec readiness probe (the API's loopback bind is not kubelet-dialable); got %+v", proxy.ReadinessProbe)
+	}
+	// The API container's old httpGet probes would never pass against a
+	// loopback bind, so the proxy's exec probe is the only health signal.
+	api := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attestation-api")
+	if api.ReadinessProbe != nil || api.LivenessProbe != nil {
+		t.Fatalf("attestation-api container must not carry kubelet probes against its loopback bind; got %+v / %+v", api.ReadinessProbe, api.LivenessProbe)
 	}
 }
 
-func TestChartAttestationApiNodePortWiresNRI(t *testing.T) {
+// The host NRI plugin is a host process: it reaches the attestation-api over
+// the node-local Unix socket, never the pod network.
+func TestChartAttestationApiSocketWiresNRI(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedNRIBootConfig(t, out, "c8s-nri-image-policy-worker")
+	if got, want := cfg.Allowlist.Pull.AttestationApiURL, "unix:///var/run/nri-image-policy/attestation-api.sock"; got != want {
+		t.Fatalf("runtime attestation-api URL = %q, want %q", got, want)
+	}
+}
+
+// Deliberate re-exposure: nodePort set WITH an API key renders the
+// authenticated routable shape — NodePort Service, 0.0.0.0 bind, [auth] in the
+// rendered config, the key file the proxy injects for on-node callers, and a
+// NetworkPolicy opening exactly the API port.
+func TestChartAttestationApiNodePortWithAuthRenders(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set", "attestationApi.service.nodePort=31040",
+		"--set-string", "attestationApi.auth.apiKey=test-key",
 	)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
@@ -1360,9 +1415,26 @@ func TestChartAttestationApiNodePortWiresNRI(t *testing.T) {
 		t.Fatalf("attestation-api nodePort = %d, want 31040", got)
 	}
 
-	cfg := renderedNRIBootConfig(t, out, "c8s-nri-image-policy-worker")
-	if got, want := cfg.Allowlist.Pull.AttestationApiURL, "http://localhost:31040"; got != want {
-		t.Fatalf("runtime attestation-api URL = %q, want %q", got, want)
+	cm := renderedConfigMap(t, out, "c8s-attestation-api")
+	cfg := cm.Data["config.toml"]
+	if !strings.Contains(cfg, `bind = "0.0.0.0:8400"`) {
+		t.Fatalf("exposed config must bind 0.0.0.0 for the NodePort to forward to; got:\n%s", cfg)
+	}
+	if !strings.Contains(cfg, `api_keys = ["test-key"]`) {
+		t.Fatalf("exposed config must carry the API key; got:\n%s", cfg)
+	}
+	if got := cm.Data["auth-key"]; got != "test-key" {
+		t.Fatalf("ConfigMap auth-key = %q, want the injected key for the proxy", got)
+	}
+	proxy := renderedDaemonSetContainer(t, out, "c8s-attestation-api", "attest-proxy")
+	assertContainerArgs(t, proxy, "--api-key-file=/etc/attestation-api/auth-key")
+
+	var np networkingv1.NetworkPolicy
+	if !findDoc(t, out, "NetworkPolicy", "c8s-attestation-api", &np) {
+		t.Fatalf("exposed render missing the attestation-api NetworkPolicy\n%s", out)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port == nil || *np.Spec.Ingress[0].Ports[0].Port != intstr.FromInt32(8400) {
+		t.Fatalf("exposed NetworkPolicy must allow exactly TCP 8400; got %+v", np.Spec.Ingress)
 	}
 }
 
@@ -1410,14 +1482,48 @@ func TestChartRejectsPlaintextNRIAllowlist(t *testing.T) {
 	assertHelmFailMessage(t, out, `nriImagePolicy.cds.url must start with https:// when nriImagePolicy.enabled=true (got "http://c8s-cds.c8s-system.svc:8443"): the host plugin must fetch the allowlist over RA-TLS`)
 }
 
-func TestChartRejectsInvalidAttestationApiNodePortWithNRI(t *testing.T) {
+func TestChartRejectsInvalidAttestationApiNodePort(t *testing.T) {
 	out, err := helmTemplate(t,
-		"--set", "attestationApi.service.nodePort=0",
+		"--set", "attestationApi.service.nodePort=29999",
+		"--set-string", "attestationApi.auth.apiKey=test-key",
 	)
 	if err == nil {
-		t.Fatalf("helm template succeeded, want invalid attestation-api host nodePort failure\n%s", out)
+		t.Fatalf("helm template succeeded, want invalid attestation-api nodePort failure\n%s", out)
 	}
-	assertHelmFailMessage(t, out, "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 when nriImagePolicy.enabled=true (got 0)")
+	assertHelmFailMessage(t, out, "attestationApi.service.nodePort must be within the Kubernetes NodePort range 30000-32767 (got 29999)")
+}
+
+// The render guard the whole hardening rests on: a routable evidence
+// listener without authentication must be impossible to render, and the
+// failure must name the value that fixes it.
+func TestChartRejectsExposedUnauthenticatedAttestationApi(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "attestationApi.service.nodePort=30840",
+	)
+	if err == nil {
+		t.Fatalf("helm template succeeded with a routable unauthenticated attestation-api, want failure\n%s", out)
+	}
+	if kind := parseValidationErrorKind(out); kind != "attestation_api_exposed_unauthenticated" {
+		t.Fatalf("validation error kind = %q, want attestation_api_exposed_unauthenticated\n%s", kind, out)
+	}
+	if msg := helmFailMessage(t, out); !strings.Contains(msg, "attestationApi.auth.apiKey") {
+		t.Fatalf("fail message must name the value to fix (attestationApi.auth.apiKey); got %q", msg)
+	}
+}
+
+// Off kata and node mode the host DaemonSet is the only evidence source, so
+// disabling it must fail like disabling the image policy does.
+func TestChartRejectsAttestationApiOffOnNonKata(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=gke",
+		"--set", "attestationApi.enabled=false",
+	)
+	if err == nil {
+		t.Fatalf("helm template succeeded with attestationApi disabled on a non-kata, non-node cluster, want failure\n%s", out)
+	}
+	if kind := parseValidationErrorKind(out); kind != "require_attestation_api" {
+		t.Fatalf("validation error kind = %q, want require_attestation_api\n%s", kind, out)
+	}
 }
 
 // parseValidationErrorKind extracts kind=<id> from helm's stderr when the
@@ -1774,7 +1880,15 @@ func hasHostIPEnv(c corev1.Container) bool {
 // tenant pod expands it against its own node.
 func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
 	const hostIPURL = "--attestation-api-url=http://$(HOST_IP):8400"
-	out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode=node", "--set", "tlsLb.attest.enabled=true")
+	// The exact shape `c8s install --cvm-mode=node` produces: the node image
+	// bakes attestation-api and nri-image-policy, so both chart components
+	// are off and consumers dial the baked host service via $(HOST_IP).
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=node",
+		"--set", "attestationApi.enabled=false",
+		"--set", "nriImagePolicy.enabled=false",
+		"--set", "tlsLb.attest.enabled=true",
+	)
 	if err != nil {
 		t.Fatalf("helm template (cvmMode=node): %v\n%s", err, out)
 	}
@@ -1828,10 +1942,12 @@ func TestChartNodeModeAttestationApiURLUsesHostIP(t *testing.T) {
 	}
 }
 
-// TestChartNonNodeModeKeepsServiceDNS proves the node-mode wiring does not leak
-// into the other cvmModes: pod/gke/aks still dial the in-cluster host
-// Service DNS and render no HOST_IP env anywhere.
-func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
+// TestChartNonNodeModeUsesAttestationSocket proves the node-mode wiring does
+// not leak into the other cvmModes: pod/gke/aks dial the on-node Unix socket
+// and render no HOST_IP env anywhere. The consumers that must carry both the
+// socket URL and the socket-directory mount are asserted per shape.
+func TestChartNonNodeModeUsesAttestationSocket(t *testing.T) {
+	const socketURL = "--attestation-api-url=unix:///var/run/nri-image-policy/attestation-api.sock"
 	for _, mode := range []string{"pod", "gke", "aks"} {
 		t.Run(mode, func(t *testing.T) {
 			out, err := helmTemplate(t, "--set-string", "attestationApi.cvmMode="+mode, "--set", "tlsLb.attest.enabled=true")
@@ -1839,7 +1955,30 @@ func TestChartNonNodeModeKeepsServiceDNS(t *testing.T) {
 				t.Fatalf("helm template (cvmMode=%s): %v\n%s", mode, err, out)
 			}
 			cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
-			assertContainerArgs(t, cds, "--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400")
+			assertContainerArgs(t, cds, socketURL)
+			// Every consumer of the socket URL must also mount the socket
+			// directory (read-only), at the host path so the URL is verbatim.
+			assertHasSocketMount := func(c corev1.Container) {
+				t.Helper()
+				for _, m := range c.VolumeMounts {
+					if m.Name == "attestation-api-socket" && m.MountPath == "/var/run/nri-image-policy" && m.ReadOnly {
+						return
+					}
+				}
+				t.Errorf("container %s carries the socket URL but no attestation-api-socket mount; mounts %+v", c.Name, c.VolumeMounts)
+			}
+			assertHasSocketMount(cds)
+			mesh := renderedDaemonSetContainer(t, out, "c8s-ratls-mesh", "ratls-mesh")
+			if !slices.Contains(mesh.Args, "unix:///var/run/nri-image-policy/attestation-api.sock") {
+				t.Errorf("ratls-mesh missing the socket URL arg; have %v", mesh.Args)
+			}
+			assertHasSocketMount(mesh)
+			if sc := renderedDaemonSet(t, out, "c8s-ratls-mesh").Spec.Template.Spec.SecurityContext; sc == nil || !slices.Contains(sc.SupplementalGroups, int64(65532)) {
+				t.Errorf("ratls-mesh pod must carry supplementalGroups [65532] to connect to the socket; got %+v", sc)
+			}
+			assertHasSocketMount(tlsLBGetCertContainer(t, out, "c8s-cert"))
+			assertHasSocketMount(renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest"))
+			assertHasSocketMount(renderedDeploymentContainer(t, out, "c8s-tls-lb", "allowlist-proxy"))
 			for _, w := range renderedPodSpecs(t, out) {
 				for _, c := range append(append([]corev1.Container{}, w.spec.InitContainers...), w.spec.Containers...) {
 					for _, e := range c.Env {
@@ -2237,7 +2376,7 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 		// the mTLS args render only for an https upstream.
 		"--upstream=http://c8s-infer.c8s-system.svc.cluster.local:8000",
 	)
-	assertContainerHasArgPrefix(t, "cds-attest", sidecar.Args, "--attestation-api-url=http://")
+	assertContainerHasArgPrefix(t, "cds-attest", sidecar.Args, "--attestation-api-url=unix:///var/run/nri-image-policy/attestation-api.sock")
 	for _, banned := range []string{"--upstream-ca", "--upstream-cert", "--upstream-key", "--upstream-server-name"} {
 		assertContainerNoArgPrefix(t, "cds-attest", sidecar.Args, banned)
 	}
@@ -2627,15 +2766,16 @@ func TestTLSLBExposesAllowlistThroughCDSByDefault(t *testing.T) {
 		"--host=127.0.0.1",
 		"--port=8801",
 		"--cds-url=https://c8s-cds.c8s-system.svc:8443",
-		"--attestation-api-url=http://$(HOST_IP):8400",
+		"--attestation-api-url=unix:///var/run/nri-image-policy/attestation-api.sock",
 	} {
 		assertContainerHasArg(t, "allowlist-proxy", proxy.Args, want)
 	}
-	if len(proxy.VolumeMounts) != 0 {
-		t.Fatalf("allowlist-proxy must not receive TLS or operator private keys: mounts=%v", proxy.VolumeMounts)
-	}
-	if !hasHostIPEnv(proxy) {
-		t.Fatalf("allowlist-proxy missing HOST_IP downward-API env: env=%v", proxy.Env)
+	// No TLS or operator key material: the only mount is the read-only
+	// attestation socket directory.
+	for _, m := range proxy.VolumeMounts {
+		if m.Name != "attestation-api-socket" || !m.ReadOnly {
+			t.Fatalf("allowlist-proxy must not receive TLS or operator private keys: mounts=%v", proxy.VolumeMounts)
+		}
 	}
 }
 
@@ -4616,16 +4756,16 @@ func TestChartPointsClientsAtCDS(t *testing.T) {
 // (no Secret/ca-cert flag), the allowlist DB, and the in-process JWKS (no
 // --jwks-url, since signing happens in the same binary).
 func TestChartCDSWiresInProcessTrustRoot(t *testing.T) {
-	// gke: host-side attestation-api at its Service DNS. node points CDS at the
-	// baked host attestation-api via HOST_IP (covered separately), so pin the
-	// Service-URL mode here.
+	// gke: host-side attestation-api over the on-node Unix socket. node points
+	// CDS at the baked host attestation-api via HOST_IP (covered separately),
+	// so pin the socket mode here.
 	out, err := helmTemplate(t, "--set", "attestationApi.cvmMode=gke")
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
 	args := renderedDeploymentContainer(t, out, "c8s-cds", "cds").Args
 	for _, want := range []string{
-		"--attestation-api-url=http://c8s-attestation-api.c8s-system.svc:8400",
+		"--attestation-api-url=unix:///var/run/nri-image-policy/attestation-api.sock",
 		"--allowlist-db=/data/allowlist.db",
 		"--ca-common-name=c8s Mesh CA",
 		"--ca-cert-validity=8760h",

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -1072,7 +1072,7 @@ func certContainer(inj *injection, cfg Config) corev1.Container {
 	args := []string{
 		"get-cert",
 		"--cds-url=" + cfg.CDSURL,
-		"--attestation-api-url=" + cfg.AttestationApiURL,
+		"--attestation-api-url=" + cfg.sidecarAttestationApiURL(),
 		"--san=" + inj.SAN,
 		"--out=" + certPath(inj.Cert.Dir, inj.Cert.CertFile),
 		"--key-out=" + certPath(inj.Cert.Dir, inj.Cert.KeyFile),
@@ -1501,7 +1501,7 @@ func volumeContainer(inj *injection, cfg Config) corev1.Container {
 	args := []string{
 		"get-volume",
 		"--cds-url=" + cfg.CDSURL,
-		"--attestation-api-url=" + cfg.AttestationApiURL,
+		"--attestation-api-url=" + cfg.sidecarAttestationApiURL(),
 		"--cert=" + certPath(inj.Cert.Dir, inj.Cert.CertFile),
 		"--key=" + certPath(inj.Cert.Dir, inj.Cert.KeyFile),
 	}
@@ -1543,7 +1543,7 @@ func secretContainer(inj *injection, cfg Config) corev1.Container {
 	args := []string{
 		"get-secret",
 		"--cds-url=" + cfg.CDSURL,
-		"--attestation-api-url=" + cfg.AttestationApiURL,
+		"--attestation-api-url=" + cfg.sidecarAttestationApiURL(),
 		"--cert=" + certPath(inj.Cert.Dir, inj.Cert.CertFile),
 		"--key=" + certPath(inj.Cert.Dir, inj.Cert.KeyFile),
 		"--out-dir=" + inj.Secrets.Dir,
@@ -1609,6 +1609,17 @@ func workloadClaimsVolume(cfg Config) (corev1.Volume, bool) {
 			HostPath: &corev1.HostPathVolumeSource{Path: cfg.WorkloadClaimsHostDir, Type: &hpType},
 		},
 	}, true
+}
+
+// sidecarAttestationApiURL rebases a unix:// attestation-api endpoint under
+// the inventory's host directory onto the sidecar's mount of that directory
+// (workloadClaimsMounts); every other shape passes through verbatim.
+func (cfg Config) sidecarAttestationApiURL() string {
+	hostPrefix := "unix://" + cfg.WorkloadClaimsHostDir + "/"
+	if cfg.WorkloadClaimsHostDir == "" || !strings.HasPrefix(cfg.AttestationApiURL, hostPrefix) {
+		return cfg.AttestationApiURL
+	}
+	return "unix://" + workloadclaims.SidecarSocketDir + "/" + strings.TrimPrefix(cfg.AttestationApiURL, hostPrefix)
 }
 
 // workloadClaimsMounts returns the sidecar mount for the inventory socket

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -1207,11 +1207,12 @@ func getCertEnv(inj *injection) []corev1.EnvVar {
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.uid"},
 		}},
 		// cvmMode=node: the chart passes the operator a verbatim
-		// --attestation-api-url=http://$(HOST_IP):8400, forwarded unexpanded into
-		// this arg (certContainer). The kubelet expands $(HOST_IP) against THIS
-		// tenant pod's node, so the sidecar reaches the node-baked host
-		// attestation-api on whichever node it lands. Unused (harmless) in modes
-		// whose URL has no $(HOST_IP).
+		// --attestation-api-url=http://$(HOST_IP):8400, which reaches this arg
+		// (certContainer) through sidecarAttestationApiURL — its pass-through of
+		// non-unix URLs is what keeps $(HOST_IP) unexpanded. The kubelet expands
+		// $(HOST_IP) against THIS tenant pod's node, so the sidecar reaches the
+		// node-baked host attestation-api on whichever node it lands. Unused
+		// (harmless) in modes whose URL has no $(HOST_IP).
 		{Name: "HOST_IP", ValueFrom: &corev1.EnvVarSource{
 			FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.hostIP"},
 		}},

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1568,5 +1569,38 @@ func TestCertContainerGetsRebasedAttestationURL(t *testing.T) {
 	want := "--attestation-api-url=unix://" + workloadclaims.SidecarSocketDir + "/attestation-api.sock"
 	if args := containerNamed(pod, reservedCertContainerName).Args; !hasArg(args, want) {
 		t.Fatalf("c8s-cert args %v missing %q", args, want)
+	}
+}
+
+// Every injected fetcher (cert, secret, volume) must carry the rebased
+// socket URL AND the mount that makes it reachable in the same container —
+// a rebased URL without the c8s-workload-claims mount dials a path nothing
+// serves.
+func TestFetchersCarryRebasedURLWithItsMount(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsHostDir = "/var/run/nri-image-policy"
+	cfg.AttestationApiURL = "unix:///var/run/nri-image-policy/attestation-api.sock"
+	pod := podWithApp()
+	mutatePod(pod, &injection{
+		WorkloadID: "api",
+		Secrets:    secretsSpec{Specs: []string{"DB=/api/db"}},
+		Volumes:    volumesSpec{Specs: []string{"weights=/tenant-a/volumes/weights"}},
+	}, cfg)
+
+	want := "--attestation-api-url=unix://" + workloadclaims.SidecarSocketDir + "/attestation-api.sock"
+	for _, name := range []string{reservedCertContainerName, reservedSecretContainerName, reservedVolumeContainerName} {
+		c := containerNamed(pod, name)
+		if c == nil {
+			t.Fatalf("injected pod missing container %q", name)
+		}
+		if !hasArg(c.Args, want) {
+			t.Errorf("%s args %v missing rebased %q", name, c.Args, want)
+		}
+		hasMount := slices.ContainsFunc(c.VolumeMounts, func(m corev1.VolumeMount) bool {
+			return m.Name == workloadClaimsVolumeName && m.MountPath == workloadclaims.SidecarSocketDir
+		})
+		if !hasMount {
+			t.Errorf("%s carries the rebased socket URL but no %s mount at %s; mounts %+v", name, workloadClaimsVolumeName, workloadclaims.SidecarSocketDir, c.VolumeMounts)
+		}
 	}
 }

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -1517,5 +1518,55 @@ func TestCertContainerOmitsEmptyCDSMeasurements(t *testing.T) {
 		if strings.HasPrefix(arg, "--cds-measurements") {
 			t.Fatalf("c8s-cert carries %q with no measurements configured", arg)
 		}
+	}
+}
+
+// The chart points the operator at the attestation proxy's Unix socket inside
+// the inventory's host directory; an injected sidecar sees that directory at
+// workloadclaims.SidecarSocketDir, so the endpoint must be rebased onto the
+// mount — and only there (every other shape passes through untouched).
+func TestSidecarAttestationApiURLRebase(t *testing.T) {
+	const hostDir = "/var/run/nri-image-policy"
+	for _, tc := range []struct {
+		name    string
+		hostDir string
+		url     string
+		want    string
+	}{
+		{"socket rebased onto the sidecar mount", hostDir,
+			"unix://" + hostDir + "/attestation-api.sock",
+			"unix://" + workloadclaims.SidecarSocketDir + "/attestation-api.sock"},
+		{"no inventory mount leaves the URL alone", "",
+			"unix://" + hostDir + "/attestation-api.sock",
+			"unix://" + hostDir + "/attestation-api.sock"},
+		{"http endpoint passes through", hostDir,
+			"http://attestation-api.c8s-system.svc:8400",
+			"http://attestation-api.c8s-system.svc:8400"},
+		{"socket outside the inventory dir passes through", hostDir,
+			"unix:///elsewhere/attest.sock",
+			"unix:///elsewhere/attest.sock"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := secretsConfig()
+			cfg.WorkloadClaimsHostDir = tc.hostDir
+			cfg.AttestationApiURL = tc.url
+			if got := cfg.sidecarAttestationApiURL(); got != tc.want {
+				t.Fatalf("sidecarAttestationApiURL() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The rebased endpoint must be what the injected containers actually receive.
+func TestCertContainerGetsRebasedAttestationURL(t *testing.T) {
+	cfg := secretsConfig()
+	cfg.WorkloadClaimsHostDir = "/var/run/nri-image-policy"
+	cfg.AttestationApiURL = "unix:///var/run/nri-image-policy/attestation-api.sock"
+	pod := podWithApp()
+	mutatePod(pod, &injection{WorkloadID: "api"}, cfg)
+
+	want := "--attestation-api-url=unix://" + workloadclaims.SidecarSocketDir + "/attestation-api.sock"
+	if args := containerNamed(pod, reservedCertContainerName).Args; !hasArg(args, want) {
+		t.Fatalf("c8s-cert args %v missing %q", args, want)
 	}
 }

--- a/node-guest-image/c8s/image-policy.yaml.in
+++ b/node-guest-image/c8s/image-policy.yaml.in
@@ -75,8 +75,8 @@ allowlist:
     interval: "30s"
     timeout: "30s"
     # The BAKED attestation-api (attest/attest-gpu profile, host service on
-    # :8400) — not the c8s chart's NodePort. The plugin runs in the host
-    # netns as a containerd child, so loopback reaches it.
+    # :8400). The plugin runs in the host netns as a containerd child, so
+    # loopback reaches it.
     attestation_api_url: "http://127.0.0.1:8400"
     # Deploy-time values; the installer's post-install config refresh pins
     # them. Empty = accept any RA-TLS-attested CDS measurement (logged).

--- a/pkg/attestationclient/client.go
+++ b/pkg/attestationclient/client.go
@@ -88,8 +88,13 @@ func validateVerifierSocket(socketPath string) error {
 	return nil
 }
 
-// NewClientWithHTTP creates a new client with a custom HTTP client.
+// NewClientWithHTTP creates a new client with a custom HTTP client. A
+// "unix://" baseURL always gets the socket transport from NewClient: a custom
+// TCP-dialing client cannot reach a Unix socket, so it is ignored there.
 func NewClientWithHTTP(baseURL string, httpClient *http.Client) Client {
+	if strings.HasPrefix(baseURL, "unix://") {
+		return NewClient(baseURL)
+	}
 	return Client{
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: httpClient,

--- a/pkg/attestationclient/client.go
+++ b/pkg/attestationclient/client.go
@@ -81,19 +81,31 @@ func validateVerifierSocket(socketPath string) error {
 		return fmt.Errorf("attestationclient: verifier socket %q is world-writable (mode %#o)", socketPath, fi.Mode().Perm())
 	}
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
-		if st.Uid != 0 && int(st.Uid) != os.Getuid() {
+		if !socketOwnerAllowed(st.Uid) {
 			return fmt.Errorf("attestationclient: verifier socket %q is owned by uid %d (want root or the verifier's own uid)", socketPath, st.Uid)
 		}
 	}
 	return nil
 }
 
+// socketOwnerAllowed reports whether a socket owned by uid may be dialed:
+// root-owned, or owned by the calling process.
+func socketOwnerAllowed(uid uint32) bool {
+	return uid == 0 || int(uid) == os.Getuid()
+}
+
 // NewClientWithHTTP creates a new client with a custom HTTP client. A
-// "unix://" baseURL always gets the socket transport from NewClient: a custom
-// TCP-dialing client cannot reach a Unix socket, so it is ignored there.
+// "unix://" baseURL keeps the caller's client — its Timeout still bounds each
+// request — with only the transport swapped for the socket dialer: a custom
+// TCP transport cannot reach a Unix socket.
 func NewClientWithHTTP(baseURL string, httpClient *http.Client) Client {
-	if strings.HasPrefix(baseURL, "unix://") {
-		return NewClient(baseURL)
+	if socket, ok := strings.CutPrefix(baseURL, "unix://"); ok {
+		c := *httpClient
+		c.Transport = unixSocketTransport(socket)
+		return Client{
+			baseURL:    "http://unix",
+			httpClient: &c,
+		}
 	}
 	return Client{
 		baseURL:    strings.TrimRight(baseURL, "/"),

--- a/pkg/attestationclient/client_socket_test.go
+++ b/pkg/attestationclient/client_socket_test.go
@@ -84,3 +84,33 @@ func TestValidateVerifierSocket(t *testing.T) {
 		t.Error("symlink accepted; want rejection")
 	}
 }
+
+// A unix:// URL must use the socket transport even when the caller supplies a
+// custom (TCP-dialing) HTTP client — e.g. attestclient passes its CDS client
+// through, which could never reach a Unix socket.
+func TestNewClientWithHTTPUnixSocketTransport(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "attest.sock")
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/attest", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	defer srv.Close()
+
+	// The custom client dials nothing: if it were used, every request would
+	// fail, so a successful call proves the socket transport took over.
+	c := NewClientWithHTTP("unix://"+sock, &http.Client{})
+	if _, err := c.Attest(context.Background(), types.AttestRequest{}); err != nil {
+		t.Fatalf("Attest over unix socket with custom client failed: %v", err)
+	}
+}

--- a/pkg/attestationclient/client_socket_test.go
+++ b/pkg/attestationclient/client_socket_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -107,10 +108,89 @@ func TestNewClientWithHTTPUnixSocketTransport(t *testing.T) {
 	go func() { _ = srv.Serve(ln) }()
 	defer srv.Close()
 
-	// The custom client dials nothing: if it were used, every request would
-	// fail, so a successful call proves the socket transport took over.
+	// The custom client's own transport dials TCP: if it survived, every
+	// request would fail, so a successful call proves the socket transport
+	// took over.
 	c := NewClientWithHTTP("unix://"+sock, &http.Client{})
 	if _, err := c.Attest(context.Background(), types.AttestRequest{}); err != nil {
 		t.Fatalf("Attest over unix socket with custom client failed: %v", err)
+	}
+}
+
+// The unix rewrite swaps the transport, not the client: the caller's Timeout
+// must still bound a wedged peer (accepts, never replies) — ratls-mesh's cert
+// rotation leg relies on it.
+func TestNewClientWithHTTPUnixKeepsCallerTimeout(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "attest.sock")
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close() // never answer
+		}
+	}()
+
+	c := NewClientWithHTTP("unix://"+sock, &http.Client{Timeout: 150 * time.Millisecond})
+	start := time.Now()
+	if _, err := c.Health(context.Background()); err == nil {
+		t.Fatal("Health succeeded against a wedged socket")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("caller timeout dropped on the unix path: Health returned after %s, want ~150ms", elapsed)
+	}
+}
+
+func TestSocketOwnerAllowed(t *testing.T) {
+	self := uint32(os.Getuid())
+	for _, tc := range []struct {
+		name string
+		uid  uint32
+		want bool
+	}{
+		{"root-owned", 0, true},
+		{"self-owned", self, true},
+		{"owned by another service account", self + 1, false},
+	} {
+		if got := socketOwnerAllowed(tc.uid); got != tc.want {
+			t.Errorf("%s: socketOwnerAllowed(%d) = %v, want %v", tc.name, tc.uid, got, tc.want)
+		}
+	}
+}
+
+// End-to-end owner rejection: a swapped socket owned by a non-root,
+// non-self uid must fail the dial-time validation.
+func TestValidateVerifierSocketRejectsForeignOwner(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("chown to a foreign uid requires root")
+	}
+	sock := filepath.Join(t.TempDir(), "attest.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	if err := os.Chmod(sock, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chown(sock, 1, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(sock); err == nil {
+		t.Error("socket owned by a foreign uid accepted; want rejection")
+	}
+	if err := os.Chown(sock, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateVerifierSocket(sock); err != nil {
+		t.Errorf("root-owned socket rejected: %v", err)
 	}
 }

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -75,9 +75,9 @@ type VerifyPolicy struct {
 	//
 	// SECURITY: the /verify response is currently not signed; the verifier
 	// trusts whatever this URL returns. Operators MUST point this at an
-	// attestation-api inside the same TCB (e.g. a same-node DaemonSet
-	// fronted by a Service with internalTrafficPolicy=Local, or a loopback
-	// sidecar). A response-signing scheme would lift this constraint.
+	// attestation-api inside the same TCB (e.g. the node-local Unix socket
+	// the DaemonSet's attest-proxy serves, or an in-guest loopback service).
+	// A response-signing scheme would lift this constraint.
 	AttestationApiURL string
 
 	// AttestationVerifyTimeout bounds online attestation-api verification.

--- a/test/e2e/ca-handoff.sh
+++ b/test/e2e/ca-handoff.sh
@@ -80,6 +80,25 @@ read -r cds_svc cds_svc_port < <(kget get svc -n "$cds_ns" -l "$cds_selector" \
 [ -n "${cds_svc_port:-}" ] || fail "cds Service $cds_ns/$cds_svc has no port named http"
 peer_url="https://${cds_svc}.${cds_ns}.svc:${cds_svc_port}"
 
+# When cds reaches the attestation-api over its node-local Unix socket, the
+# probe can only follow it with the socket directory mounted at the host path.
+socket_mount=""
+socket_volume=""
+case "$attest_url" in
+  unix://*/*)
+    socket_dir=$(dirname "${attest_url#unix://}")
+    socket_mount="
+        - name: attestation-api-socket
+          mountPath: $socket_dir
+          readOnly: true"
+    socket_volume="
+    - name: attestation-api-socket
+      hostPath:
+        path: $socket_dir
+        type: Directory"
+    ;;
+esac
+
 # --- probe pod: deployed cds image, pinned to the cds node -------------------
 
 # kubectl-only (no jq dependency, matching the sibling e2e scripts). Each
@@ -157,12 +176,12 @@ spec:
       volumeMounts:
         - name: operator-keys
           mountPath: /etc/cds-operator-keys
-          readOnly: true
+          readOnly: true$socket_mount
       securityContext: $ctr_sec_ctx
   volumes:
     - name: operator-keys
       configMap:
-        name: $operator_keys_cm
+        name: $operator_keys_cm$socket_volume
 EOF
 
 # --- await verdict ------------------------------------------------------------

--- a/test/e2e/ca-handoff.sh
+++ b/test/e2e/ca-handoff.sh
@@ -6,9 +6,12 @@
 # evidence, a real EAR minted by the live CDS, the real measurement gate,
 # and the transfer over the cluster network.
 #
-# Needs: kubectl pointed at a node-as-CVM (non-kata) cluster with the c8s
-# chart installed, cds.handoff.enabled=true, and a deployed cds image that
-# includes the request-handoff subcommand.
+# Needs: kubectl pointed at a node-as-CVM cluster running the chart's
+# attestation-api DaemonSet (gke/aks-style installs) with
+# cds.handoff.enabled=true, and a deployed cds image that includes the
+# request-handoff subcommand. Kata (in-guest endpoint) and cvmMode=node
+# (CDS's URL carries an unexpanded $(HOST_IP) the probe pod cannot resolve)
+# are unsupported.
 #
 # Env:
 #   CDS_NS                 namespace of the cds deployment (default: discover)


### PR DESCRIPTION
## Summary

Evidence generation is no longer published on a routable address. Full stop.

- The attestation-api binds loopback and is fronted by a node-local unix-socket proxy (`attest-proxy`, 0660 `root:65532`); every in-chart consumer (ratls-mesh, tls-lb, nri-image-policy, webhook-rendered mounts) uses the `unix://` client path, which enforces socket owner and mode. The Service is gone entirely.
- A default-deny NetworkPolicy ships for the attestation DaemonSet in all modes.
- The chart fails to render if the attestation-api is required but disabled (`require_attestation_api` guard).
- The snp-metal/confidential e2e lanes are moved to the socket shape.

There is no opt-in re-exposure: no NodePort, no auth-key machinery, no conditional bind. If a routable attestation API is ever needed, it comes back deliberately, with client auth support designed in at the same time.

Out of scope here (tracked separately): the node-mode image configuration, and requiring in-TCB proof of origin at the CDS before leaf issuance.

## Tests

- `chart_test.go`: default render has no attestation Service/NodePort in every `--cvm-mode`, has the NetworkPolicy, and render fails closed on the remaining guard shapes.
- Unit: `unix://` client enforces socket owner/mode; proxy healthcheck, securityContext, and header-handling pins; caller timeout preserved on the unix path.
- Regression: the finding's request shape fails at the evidence request on a default render.
- Full `go test -race ./...` (64 packages), chart verify, and render-mutant suite green.

## Upgrade note

The attestation-api Service (NodePort 30840) is removed. Known in-house consumers are in c8s-fleet: the attestation-core-health flux Job (curls the Service DNS from the pod network) and two scripts that `kubectl port-forward svc/c8s-attestation-api`; fleet-side fixes land before this is promoted. Note that `kubectl port-forward` to a DaemonSet pod keeps working against the loopback bind — forwarded connections originate from localhost inside the pod netns — so that is the migration path for anything that was port-forwarding the Service.

One acceptance item needs real hardware: off-node/cross-namespace unreachability + on-node success on a live cluster (the snp-metal lane exercises the socket shape).