### PR TITLE
ci: extend the shipped-binary guard to test-helper packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,18 +95,20 @@ jobs:
       - name: Build macOS CLI
         run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o /tmp/c8s-darwin ./cmd/c8s
 
-      # testing must stay out of the measured binaries. CGO_ENABLED=0 matches the
-      # shipped builds; c8s_node changes the graph, so it is listed separately.
+      # testing and test-helper packages must stay out of the measured binaries.
+      # CGO_ENABLED=0 matches the shipped builds; c8s_node changes the graph, so
+      # it is listed separately.
       - name: Guard testing out of shipped binaries
         run: |
+          forbidden='^(testing|github.com/confidential-dot-ai/c8s/internal/testattest)$'
           deps=$(CGO_ENABLED=0 go list -deps ./cmd/...)
-          if grep -qx testing <<<"$deps"; then
-            echo "testing is in the dep graph of a shipped binary" >&2
+          if grep -qE "$forbidden" <<<"$deps"; then
+            echo "testing code is in the dep graph of a shipped binary" >&2
             exit 1
           fi
           node_deps=$(CGO_ENABLED=0 go list -tags c8s_node -deps ./cmd/c8s)
-          if grep -qx testing <<<"$node_deps"; then
-            echo "testing is in the dep graph of the c8s_node binary" >&2
+          if grep -qE "$forbidden" <<<"$node_deps"; then
+            echo "testing code is in the dep graph of the c8s_node binary" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to the shipped-binary guard: name the shared test-helper package explicitly.

- The guard fails the build if `testing` enters a shipped dep graph. `internal/testattest` (the shared attestation-api stub) is a non-`_test.go` package, so today it would only trip the guard transitively via its own `testing` import — a future production import of the stub should fail directly and by name.
- The check becomes a forbidden-set match (`testing`, `internal/testattest`) over both graphs (default `./cmd/...` and the `c8s_node` tag graph), `CGO_ENABLED=0` as before.
- Verified locally: clean graphs pass; a graph containing the stub trips the guard.