### PR TITLE
test(ratlsmesh): prove the mesh accepts attested peers and rejects unpinned measurements

### DIFF
--- a/internal/cmds/ratlsmesh/attest_test.go
+++ b/internal/cmds/ratlsmesh/attest_test.go
@@ -5,16 +5,12 @@ package ratlsmesh
 import (
 	"context"
 	"crypto/sha512"
-	"encoding/base64"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
-	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 func TestMakeAttestFunc_ReportDataSize(t *testing.T) {
@@ -22,25 +18,8 @@ func TestMakeAttestFunc_ReportDataSize(t *testing.T) {
 	// (48-byte SHA-384 hash + 16 zero bytes). makeAttestFunc must send
 	// only the 48-byte hash to the attestation-api, NOT the full
 	// 64-byte padded array. Sending 64 bytes causes TPM_RC_SIZE on vTPMs.
-	var receivedSize int
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req types.AttestRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, err.Error(), 500)
-			return
-		}
-		receivedSize = len(req.ReportData.Bytes())
-		// Return minimal valid bare-metal SNP evidence.
-		fakeReport := make([]byte, 1184)
-		json.NewEncoder(w).Encode(map[string]any{
-			"platform": "snp",
-			"evidence": map[string]string{"attestation_report": base64.StdEncoding.EncodeToString(fakeReport)},
-		})
-	}))
-	defer srv.Close()
-
-	client := attestclient.NewClient("")
-	attestFunc := makeAttestFunc(client, srv.URL)
+	stub := testattest.New(t)
+	attestFunc := makeAttestFunc(attestclient.NewClient(""), stub.URL)
 
 	// Build a 64-byte hex string (like SelfSignedProvider.Provision does).
 	var reportData [64]byte
@@ -48,13 +27,16 @@ func TestMakeAttestFunc_ReportDataSize(t *testing.T) {
 	copy(reportData[:], hash[:])
 	customData := fmt.Sprintf("%x", reportData[:])
 
-	_, err := attestFunc(context.Background(), customData)
-	if err != nil {
+	if _, err := attestFunc(context.Background(), customData); err != nil {
 		t.Fatalf("attestFunc failed: %v", err)
 	}
 
-	if receivedSize != sha512.Size384 {
-		t.Errorf("attestation-api received %d bytes, want %d (SHA-384 hash only, no zero padding)", receivedSize, sha512.Size384)
+	reqs := stub.AttestRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/attest calls = %d, want 1", len(reqs))
+	}
+	if got := len(reqs[0].ReportData.Bytes()); got != sha512.Size384 {
+		t.Errorf("attestation-api received %d bytes, want %d (SHA-384 hash only, no zero padding)", got, sha512.Size384)
 	}
 }
 
@@ -62,23 +44,8 @@ func TestMakeAttestFunc_ReportDataNotZeroPadded(t *testing.T) {
 	// Regression test: even when the SHA-384 hash contains trailing bytes
 	// that happen to be non-zero, the sent data must be exactly sha512.Size384
 	// bytes, no more and no less.
-	var receivedBytes []byte
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req types.AttestRequest
-		json.NewDecoder(r.Body).Decode(&req)
-		receivedBytes = req.ReportData.Bytes()
-		fakeReport := make([]byte, 1184)
-		json.NewEncoder(w).Encode(map[string]any{
-			"platform": "snp",
-			"evidence": map[string]string{
-				"attestation_report": base64.StdEncoding.EncodeToString(fakeReport),
-			},
-		})
-	}))
-	defer srv.Close()
-
-	client := attestclient.NewClient("")
-	attestFunc := makeAttestFunc(client, srv.URL)
+	stub := testattest.New(t)
+	attestFunc := makeAttestFunc(attestclient.NewClient(""), stub.URL)
 
 	// Create report data where the hash fills all 48 bytes.
 	var reportData [64]byte
@@ -87,11 +54,15 @@ func TestMakeAttestFunc_ReportDataNotZeroPadded(t *testing.T) {
 	}
 	customData := hex.EncodeToString(reportData[:])
 
-	_, err := attestFunc(context.Background(), customData)
-	if err != nil {
+	if _, err := attestFunc(context.Background(), customData); err != nil {
 		t.Fatalf("attestFunc failed: %v", err)
 	}
 
+	reqs := stub.AttestRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/attest calls = %d, want 1", len(reqs))
+	}
+	receivedBytes := reqs[0].ReportData.Bytes()
 	if len(receivedBytes) != sha512.Size384 {
 		t.Fatalf("received %d bytes, want %d", len(receivedBytes), sha512.Size384)
 	}

--- a/internal/cmds/ratlsmesh/health_test.go
+++ b/internal/cmds/ratlsmesh/health_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -232,9 +234,10 @@ func TestHealthServerServe(t *testing.T) {
 }
 
 func TestHealthReadyCertProvisioningGates(t *testing.T) {
+	stub := testattest.New(t)
 	_, mgr, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
 		Platform:   "sev-snp",
-		AttestFunc: fakeAttestFunc,
+		AttestFunc: makeAttestFunc(attestclient.NewClient(""), stub.URL),
 		CertTTL:    time.Hour,
 	})
 	if err != nil {

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -201,20 +201,11 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 	})
 	attestFunc := makeAttestFunc(asClient, c.attestationApiURL)
 
-	meshPolicy := &ratls.VerifyPolicy{AttestationApiURL: c.attestationApiURL}
-	if c.measurements != "" {
-		for _, h := range strings.Split(c.measurements, ",") {
-			h = strings.TrimSpace(h)
-			b, err := hex.DecodeString(h)
-			if err != nil {
-				return fmt.Errorf("invalid measurement hex %q: %w", h, err)
-			}
-			if len(b) != ratls.SNPMeasurementSize {
-				return fmt.Errorf("invalid measurement length: %q is %d bytes, want %d (SHA-384 measurement must be %d hex characters)",
-					h, len(b), ratls.SNPMeasurementSize, ratls.SNPMeasurementSize*2)
-			}
-			meshPolicy.Measurements = append(meshPolicy.Measurements, b)
-		}
+	meshPolicy, err := meshVerifyPolicy(c.attestationApiURL, c.measurements)
+	if err != nil {
+		return err
+	}
+	if len(meshPolicy.Measurements) > 0 {
 		logger.Info("measurement pinning enabled", "count", len(meshPolicy.Measurements))
 	} else {
 		logger.Warn("no --measurements set: accepting any TEE attestation (unsafe for production)")
@@ -680,6 +671,30 @@ func makeAttestFunc(client attestclient.Client, attestationApiURL string) func(c
 
 		return attestclient.RATLSEvidence(resp)
 	}
+}
+
+// meshVerifyPolicy builds the mesh peer-verification policy: evidence checked
+// by the same-node attestation-api, launch measurements pinned to the
+// --measurements allowlist. Empty measurements leaves the policy unpinned
+// (accept any TEE — development only).
+func meshVerifyPolicy(attestationApiURL, measurements string) (*ratls.VerifyPolicy, error) {
+	policy := &ratls.VerifyPolicy{AttestationApiURL: attestationApiURL}
+	if measurements == "" {
+		return policy, nil
+	}
+	for _, h := range strings.Split(measurements, ",") {
+		h = strings.TrimSpace(h)
+		b, err := hex.DecodeString(h)
+		if err != nil {
+			return nil, fmt.Errorf("invalid measurement hex %q: %w", h, err)
+		}
+		if len(b) != ratls.SNPMeasurementSize {
+			return nil, fmt.Errorf("invalid measurement length: %q is %d bytes, want %d (SHA-384 measurement must be %d hex characters)",
+				h, len(b), ratls.SNPMeasurementSize, ratls.SNPMeasurementSize*2)
+		}
+		policy.Measurements = append(policy.Measurements, b)
+	}
+	return policy, nil
 }
 
 func effectiveCDSCAURL(certMode, cdsURL string) string {

--- a/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
+++ b/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
@@ -10,8 +10,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"net"
@@ -24,6 +22,9 @@ import (
 	"time"
 
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
 // stdoutCapture redirects os.Stdout into a drained pipe so tests can assert
@@ -75,21 +76,6 @@ func (c *stdoutCapture) String() string { return c.buf.String() }
 
 func (c *stdoutCapture) hasMsg(msg string) bool {
 	return hasMsg(decodeLogRecords(c.String()), msg)
-}
-
-// fakeAttestationServer serves minimal bare-metal SNP evidence so RA-TLS
-// certificate provisioning succeeds without hardware.
-func fakeAttestationServer(t *testing.T) *httptest.Server {
-	t.Helper()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		fakeReport := make([]byte, 1184)
-		json.NewEncoder(w).Encode(map[string]any{
-			"platform": "snp",
-			"evidence": map[string]string{"attestation_report": base64.StdEncoding.EncodeToString(fakeReport)},
-		})
-	}))
-	t.Cleanup(srv.Close)
-	return srv
 }
 
 // junkClientCert returns a self-signed cert with no RA-TLS extension: the
@@ -162,7 +148,7 @@ func TestRunProxySelfSignedReadiness(t *testing.T) {
 	nodeIP := "127.0.0.1"
 	stubKubeClientset(t, k8sfake.NewSimpleClientset(testPod("web", "default", "10.244.0.7", nodeIP, nil)), nil)
 	t.Setenv("NODE_IP", "")
-	attest := fakeAttestationServer(t)
+	attest := testattest.New(t)
 
 	cfg := defaultTestProxyConfig(t)
 	cfg.logLevel = "error"
@@ -226,12 +212,17 @@ func TestRunProxySelfSignedReadiness(t *testing.T) {
 		t.Errorf("cert_mode_configured{cds} = %v in self-signed mode, want 0", v)
 	}
 
-	// A client without RA-TLS evidence must fail peer verification.
-	conn, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.inboundPort), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-		Certificates:       []tls.Certificate{junkClientCert(t)},
+	// A client without RA-TLS evidence must fail peer verification. The
+	// dialer verifies the mesh server normally; its own junk cert is what
+	// the server must reject.
+	junkClientTLS, _, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
+		Policy:       &ratls.VerifyPolicy{AttestationApiURL: attest.URL},
+		CertProvider: staticCertProvider{junkClientCert(t)},
 	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conn, err := tls.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", cfg.inboundPort), junkClientTLS)
 	if err == nil {
 		// TLS 1.3 may surface the rejection on first read instead of dial.
 		conn.SetReadDeadline(time.Now().Add(5 * time.Second))

--- a/internal/cmds/ratlsmesh/main_run_test.go
+++ b/internal/cmds/ratlsmesh/main_run_test.go
@@ -312,6 +312,11 @@ func TestRunProxyFullLifecycle(t *testing.T) {
 		return resp.StatusCode == http.StatusOK
 	}, "health server never came up")
 
+	// --measurements is set: the pinning gauge must read 1.
+	if v := scrapedValue(t, cfg.healthPort, "ratls_mesh_measurement_pinning", nil); v != 1 {
+		t.Errorf("measurement_pinning = %v with --measurements configured, want 1", v)
+	}
+
 	// Let the metric ticker read the sidecar file at least once, then remove
 	// it so the read-after-success warning path runs too.
 	time.Sleep(50 * time.Millisecond)

--- a/internal/cmds/ratlsmesh/main_run_test.go
+++ b/internal/cmds/ratlsmesh/main_run_test.go
@@ -128,6 +128,11 @@ func TestRunProxyConfigErrors(t *testing.T) {
 			c.attestationApiURL = "http://127.0.0.1:1"
 			c.measurements = "abcd"
 		}, "invalid measurement length"},
+		{"blank measurement entry", func(c *proxyConfig) {
+			c.nodeIP = "127.0.0.1"
+			c.attestationApiURL = "http://127.0.0.1:1"
+			c.measurements = valid48 + ","
+		}, "invalid measurement length"},
 		{"missing CA cert file", func(c *proxyConfig) {
 			c.nodeIP = "127.0.0.1"
 			c.attestationApiURL = "http://127.0.0.1:1"
@@ -234,8 +239,9 @@ func TestNewKubeClientsetDefaultOutsideCluster(t *testing.T) {
 }
 
 // TestRunProxyFullLifecycle drives runProxy end to end with a fake
-// clientset and local fake CDS / probe / attestation endpoints, then
-// cancels the context and expects a clean shutdown.
+// clientset and local fake CDS / probe endpoints (the attestation-api
+// URL is a dead port), then cancels the context and expects a clean
+// shutdown.
 func TestRunProxyFullLifecycle(t *testing.T) {
 	nodeIP := "127.0.0.1"
 	pod := testPod("web", "default", "10.244.0.7", nodeIP, nil)

--- a/internal/cmds/ratlsmesh/mesh_handshake_test.go
+++ b/internal/cmds/ratlsmesh/mesh_handshake_test.go
@@ -1,0 +1,129 @@
+//go:build linux
+
+package ratlsmesh
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// attestedMeshTLSConfigs returns server and client TLS configs wired like
+// runProxy's: both sides mint self-signed RA-TLS certs from testattest
+// evidence and verify the peer through the production VerifyPeerCertificate
+// against the policy meshVerifyPolicy builds from the measurements string.
+func attestedMeshTLSConfigs(t *testing.T, stub *testattest.Stub, measurements string) (server, client *tls.Config) {
+	t.Helper()
+	attestFunc := makeAttestFunc(attestclient.NewClient(""), stub.URL)
+
+	policy, err := meshVerifyPolicy(stub.URL, measurements)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	server, _, err = ratls.NewServerTLSConfig(&ratls.ServerConfig{
+		Platform:     "sev-snp",
+		AttestFunc:   attestFunc,
+		ClientPolicy: policy,
+		CertTTL:      time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, _, err = ratls.NewClientTLSConfig(&ratls.ClientConfig{
+		Policy:     policy,
+		Platform:   "sev-snp",
+		AttestFunc: attestFunc,
+		CertTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server, client
+}
+
+// serveAttested drives handshakes on ln until it closes, answering every peer
+// that completes the mutual handshake with one "ok" byte.
+func serveAttested(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer conn.Close()
+			if _, err := conn.Write([]byte("ok")); err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, conn)
+		}()
+	}
+}
+
+// An attested peer completes the mesh handshake: the client accepts the
+// server's evidence, and the server's post-handshake byte proves it accepted
+// the client's. Both directions run the production VerifyPeerCertificate —
+// one /verify call each.
+func TestMeshHandshakeAcceptsAttestedPeer(t *testing.T) {
+	measurement := bytes.Repeat([]byte{0x42}, ratls.SNPMeasurementSize)
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(measurement)))
+
+	serverTLS, clientTLS := attestedMeshTLSConfigs(t, stub, hex.EncodeToString(measurement))
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go serveAttested(ln)
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err != nil {
+		t.Fatalf("attested peer handshake failed: %v", err)
+	}
+	defer conn.Close()
+	if _, err := io.ReadFull(conn, make([]byte, 2)); err != nil {
+		t.Fatalf("server rejected the attested client: %v", err)
+	}
+
+	if got := len(stub.VerifyRequests()); got != 2 {
+		t.Fatalf("/verify calls = %d, want 2 (one per direction)", got)
+	}
+}
+
+// The same handshake with the verifier reporting a launch_digest outside the
+// pinned set fails with a typed policy error, not a generic TLS alert.
+func TestMeshHandshakeRejectsUnpinnedMeasurement(t *testing.T) {
+	served := bytes.Repeat([]byte{0x42}, ratls.SNPMeasurementSize)
+	pinned := bytes.Repeat([]byte{0x99}, ratls.SNPMeasurementSize)
+	stub := testattest.New(t)
+	stub.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(served)))
+
+	serverTLS, clientTLS := attestedMeshTLSConfigs(t, stub, hex.EncodeToString(pinned))
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	go serveAttested(ln)
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err == nil {
+		conn.Close()
+		t.Fatal("handshake with an unpinned launch measurement succeeded")
+	}
+	if !errors.Is(err, ratls.ErrPolicyViolation) {
+		t.Fatalf("handshake error = %v, want ErrPolicyViolation", err)
+	}
+}

--- a/internal/cmds/ratlsmesh/mesh_handshake_test.go
+++ b/internal/cmds/ratlsmesh/mesh_handshake_test.go
@@ -4,7 +4,9 @@ package ratlsmesh
 
 import (
 	"bytes"
+	"crypto"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"io"
@@ -92,12 +94,41 @@ func TestMeshHandshakeAcceptsAttestedPeer(t *testing.T) {
 		t.Fatalf("attested peer handshake failed: %v", err)
 	}
 	defer conn.Close()
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := io.ReadFull(conn, make([]byte, 2)); err != nil {
 		t.Fatalf("server rejected the attested client: %v", err)
 	}
 
-	if got := len(stub.VerifyRequests()); got != 2 {
-		t.Fatalf("/verify calls = %d, want 2 (one per direction)", got)
+	// Each direction asks the verifier to bind the key its peer presented:
+	// the client pins the server's cert key, the server the client's (the
+	// TLS 1.3 server cert flight comes first, fixing the request order).
+	serverKey := conn.ConnectionState().PeerCertificates[0].PublicKey
+	clientCert, err := clientTLS.GetClientCertificate(&tls.CertificateRequestInfo{})
+	if err != nil {
+		t.Fatalf("GetClientCertificate: %v", err)
+	}
+	clientLeaf, err := x509.ParseCertificate(clientCert.Certificate[0])
+	if err != nil {
+		t.Fatalf("parse client cert: %v", err)
+	}
+
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 2 {
+		t.Fatalf("/verify calls = %d, want 2 (one per direction)", len(reqs))
+	}
+	for i, key := range []crypto.PublicKey{serverKey, clientLeaf.PublicKey} {
+		want, err := ratls.ReportDataForKey(key, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if reqs[i].Params == nil || reqs[i].Params.ExpectedReportData == nil {
+			t.Fatalf("/verify call %d: missing expected report data", i)
+		}
+		if got := reqs[i].Params.ExpectedReportData.Bytes(); !bytes.Equal(got, want[:]) {
+			t.Fatalf("/verify call %d: expected_report_data = %x, want %x (peer key binding)", i, got, want[:])
+		}
 	}
 }
 

--- a/internal/cmds/ratlsmesh/proxy_serve_test.go
+++ b/internal/cmds/ratlsmesh/proxy_serve_test.go
@@ -157,7 +157,7 @@ func TestReleaseSrcKeepsBudgetWhileHeld(t *testing.T) {
 // included) is within the limit and must be accepted.
 func TestInboundHeaderAtSizeLimitAccepted(t *testing.T) {
 	backend := startBackend(t, "edge")
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	header := backend + "\n"
 	p := &Proxy{
@@ -188,10 +188,7 @@ func TestInboundHeaderAtSizeLimitAccepted(t *testing.T) {
 		}
 	}()
 
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -221,10 +218,11 @@ func TestOutboundDialFailureClassifiedAsTLSError(t *testing.T) {
 	deadPort := freePort(t)
 	m := testMetrics()
 	var logBuf syncBuffer
+	_, clientTLS := testTLSConfigs(t)
 	p := &Proxy{
 		nodeIP:      "1.1.1.1",
 		inboundPort: deadPort,
-		clientTLS:   &tls.Config{MinVersion: tls.VersionTLS13, InsecureSkipVerify: true},
+		clientTLS:   clientTLS,
 		resolver:    &fixedRemoteResolver{nodeIP: "127.0.0.1"},
 		origDstFunc: func(net.Conn) (string, error) { return "10.244.1.5:8080", nil },
 		accessLog:   true,

--- a/internal/cmds/ratlsmesh/proxy_test.go
+++ b/internal/cmds/ratlsmesh/proxy_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -59,47 +61,51 @@ func (r *fixedRemoteResolver) Resolve(string) (string, bool)              { retu
 func (r *fixedRemoteResolver) ValidateOutboundDest(string) (bool, string) { return true, "" }
 func (r *fixedRemoteResolver) ValidateLocalDest(string) bool              { return true }
 
-// fakeAttestFunc builds a fake SNP report from the hex-encoded REPORTDATA.
-// Suitable for TLS plumbing tests without AMD hardware.
-func fakeAttestFunc(_ context.Context, customData string) (string, error) {
-	var rd [64]byte
-	fmt.Sscanf(customData, "%x", &rd)
-	return string(fakeSNPReport(rd)), nil
-}
-
-// fakeSNPReport creates a minimal fake SEV-SNP report (1184 bytes).
-func fakeSNPReport(reportData [64]byte) []byte {
-	report := make([]byte, ratls.SNPReportSize)
-	report[0] = 0x02
-	report[0x0A] = 0x03
-	copy(report[0x50:], reportData[:])
-	return report
-}
-
-// testTLSConfigs creates server+client TLS configs for testing. Uses
-// InsecureSkipVerify because fake reports lack valid AMD signatures.
+// testTLSConfigs creates mutually-attested server+client TLS configs: both
+// sides mint RA-TLS certs from testattest evidence and verify the peer
+// through the production VerifyPeerCertificate. These tests exercise L4 proxy
+// plumbing, not attestation policy, so the policy pins no measurements;
+// pinning is covered by the mesh handshake tests.
 func testTLSConfigs(t *testing.T) (server, client *tls.Config) {
 	t.Helper()
 
+	stub := testattest.New(t)
+	attestFunc := makeAttestFunc(attestclient.NewClient(""), stub.URL)
+	policy := &ratls.VerifyPolicy{AttestationApiURL: stub.URL}
+
 	serverCfg, _, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+		Platform:     "sev-snp",
+		AttestFunc:   attestFunc,
+		DNSNames:     []string{"localhost"},
+		CertTTL:      1 * time.Hour,
+		ClientPolicy: policy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	clientCfg, _, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
+		Policy:     policy,
 		Platform:   "sev-snp",
-		AttestFunc: fakeAttestFunc,
-		DNSNames:   []string{"localhost"},
+		AttestFunc: attestFunc,
 		CertTTL:    1 * time.Hour,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Don't require client certs in tests (fake reports can't pass verification).
-	serverCfg.ClientAuth = tls.NoClientCert
-	serverCfg.VerifyPeerCertificate = nil
-
-	clientCfg := &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	}
 
 	return serverCfg, clientCfg
+}
+
+// staticCertProvider serves one fixed certificate through the
+// ratls.CertProvider interface, for tests that need the handshake to present
+// a specific leaf.
+type staticCertProvider struct {
+	cert tls.Certificate
+}
+
+func (p staticCertProvider) Provision(context.Context) (*tls.Certificate, time.Duration, error) {
+	return &p.cert, 0, nil
 }
 
 func testLogger() *slog.Logger {
@@ -209,7 +215,7 @@ func TestPipe(t *testing.T) {
 
 func TestInboundHandler(t *testing.T) {
 	backend := startBackend(t, "backend")
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	p := &Proxy{
 		inboundAddr: "127.0.0.1:0",
@@ -241,10 +247,7 @@ func TestInboundHandler(t *testing.T) {
 	}()
 
 	// Connect as RA-TLS client, send destination header, then data.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -490,7 +493,7 @@ func TestConcurrentConnections(t *testing.T) {
 }
 
 func TestDestHeaderTimeout(t *testing.T) {
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	p := &Proxy{
 		inboundAddr:       "127.0.0.1:0",
@@ -522,10 +525,7 @@ func TestDestHeaderTimeout(t *testing.T) {
 	}()
 
 	// Connect but never send the destination header.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -541,7 +541,7 @@ func TestDestHeaderTimeout(t *testing.T) {
 }
 
 func TestInvalidDestination(t *testing.T) {
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	p := &Proxy{
 		inboundAddr:       "127.0.0.1:0",
@@ -573,10 +573,7 @@ func TestInvalidDestination(t *testing.T) {
 	}()
 
 	// Send an invalid destination header (no port).
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +591,7 @@ func TestInvalidDestination(t *testing.T) {
 
 func TestGracefulDrain(t *testing.T) {
 	backend := startBackend(t, "drain")
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	p := &Proxy{
 		inboundAddr:  "127.0.0.1:0",
@@ -629,10 +626,7 @@ func TestGracefulDrain(t *testing.T) {
 	}()
 
 	// Establish a connection that will be in-flight during shutdown.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -727,7 +721,7 @@ func TestIPv6RemoteAddr(t *testing.T) {
 
 func TestConnectionLimit(t *testing.T) {
 	backend := startBackend(t, "limited")
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	m := testMetrics()
 	p := &Proxy{
@@ -776,10 +770,7 @@ func TestConnectionLimit(t *testing.T) {
 	}()
 
 	// First connection: should succeed.
-	conn1, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn1, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -794,10 +785,7 @@ func TestConnectionLimit(t *testing.T) {
 	// Second connection: should be rejected (limit=1, one in-flight).
 	// Server closes the raw TCP connection before TLS handshake, so
 	// tls.Dial itself may fail — that's the expected rejection.
-	conn2, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn2, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err == nil {
 		// If TLS handshake somehow completed, the read should still fail.
 		conn2.SetReadDeadline(time.Now().Add(1 * time.Second))
@@ -945,7 +933,7 @@ func TestOutboundRejectsNonPodOriginalDestination(t *testing.T) {
 }
 
 func TestDestHeaderReadErrorMetrics(t *testing.T) {
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	m := testMetrics()
 	p := &Proxy{
@@ -977,10 +965,7 @@ func TestDestHeaderReadErrorMetrics(t *testing.T) {
 	}()
 
 	// Send an invalid destination header (no port).
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1027,7 +1012,7 @@ func TestReadinessOnShutdown(t *testing.T) {
 
 func TestMetricsAccounting(t *testing.T) {
 	backend := startBackend(t, "metrics")
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	m := testMetrics()
 	p := &Proxy{
@@ -1058,10 +1043,7 @@ func TestMetricsAccounting(t *testing.T) {
 	}()
 
 	// Send a request through the inbound handler.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1080,7 +1062,7 @@ func TestMetricsAccounting(t *testing.T) {
 }
 
 func TestInboundDialFailureMetrics(t *testing.T) {
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	m := testMetrics()
 	p := &Proxy{
@@ -1112,10 +1094,7 @@ func TestInboundDialFailureMetrics(t *testing.T) {
 	}()
 
 	// Trigger an inbound connection whose destination pod dial fails.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1231,7 +1210,7 @@ func (r *rejectResolver) ValidateOutboundDest(ip string) (bool, string) {
 func (r *rejectResolver) ValidateLocalDest(ip string) bool { return false }
 
 func TestInboundDestRejected(t *testing.T) {
-	serverTLS, _ := testTLSConfigs(t)
+	serverTLS, clientTLS := testTLSConfigs(t)
 
 	m := testMetrics()
 	p := &Proxy{
@@ -1263,10 +1242,7 @@ func TestInboundDestRejected(t *testing.T) {
 	}()
 
 	// Send a valid destination header that the resolver rejects.
-	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{
-		MinVersion:         tls.VersionTLS13,
-		InsecureSkipVerify: true,
-	})
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ratls/cdsclient/ratls_test.go
+++ b/pkg/ratls/cdsclient/ratls_test.go
@@ -1,6 +1,7 @@
 package cdsclient
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -8,14 +9,18 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
+	"errors"
 	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -51,11 +56,8 @@ func TestProviderRATLSRejectsUnattestedCDS(t *testing.T) {
 	if err == nil {
 		t.Fatal("Provision succeeded against unattested CDS")
 	}
-	// The exact error wording depends on which side of the handshake fails
-	// first, but it must be a TLS-layer failure (not e.g. a parse error from
-	// a successful HTTP exchange).
-	if !strings.Contains(err.Error(), "tls") && !strings.Contains(err.Error(), "ratls") && !strings.Contains(err.Error(), "x509") {
-		t.Fatalf("Provision error = %v, want TLS/RA-TLS handshake failure", err)
+	if !errors.Is(err, ratls.ErrNotAttested) {
+		t.Fatalf("Provision error = %v, want ErrNotAttested", err)
 	}
 }
 
@@ -112,5 +114,56 @@ func TestProviderRATLSRejectsCertWithoutAttestationExtension(t *testing.T) {
 	}
 	if _, _, err := p.Provision(context.Background()); err == nil {
 		t.Fatal("Provision accepted CDS cert without an RA-TLS attestation extension")
+	}
+}
+
+// TestProviderRATLSRejectsCDSWithUnpinnedMeasurement proves the measurement
+// pin closes the bootstrap-channel MITM gap: a real RA-TLS listener whose
+// evidence verifies but whose launch digest is not in CDSMeasurements must
+// fail the handshake with ErrPolicyViolation before any CDS request flows.
+func TestProviderRATLSRejectsCDSWithUnpinnedMeasurement(t *testing.T) {
+	as := testattest.New(t)
+	served := bytes.Repeat([]byte{0x42}, ratls.SNPMeasurementSize)
+	as.SetVerdict(testattest.PassingVerdict(hex.EncodeToString(served)))
+
+	serverTLS, _, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+		Platform:   "sev-snp",
+		AttestFunc: attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), as.URL),
+		CertTTL:    time.Hour,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var reached atomic.Int64
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go http.Serve(tls.NewListener(ln, serverTLS), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached.Add(1)
+	}))
+
+	pinned := bytes.Repeat([]byte{0x99}, ratls.SNPMeasurementSize)
+	p, err := NewProvider(&Config{
+		CDSURL:            "https://" + ln.Addr().String(),
+		AttestationApiURL: as.URL,
+		CDSCAURL:          "http://unused.invalid",
+		NodeIP:            "10.0.0.1",
+		TEEType:           ratls.TEETypeSEVSNP,
+		CDSMeasurements:   [][]byte{pinned},
+		// HTTPClient deliberately nil so NewClient builds the RA-TLS transport.
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = p.Provision(context.Background())
+	if !errors.Is(err, ratls.ErrPolicyViolation) {
+		t.Fatalf("Provision error = %v, want ErrPolicyViolation", err)
+	}
+	if got := reached.Load(); got != 0 {
+		t.Fatalf("CDS handler reached %d time(s); the measurement pin must fail the handshake first", got)
 	}
 }


### PR DESCRIPTION
## Summary

The mesh proxy suite previously disabled verification (`ClientAuth = NoClientCert`, `VerifyPeerCertificate = nil`) because the fakes couldn't produce consumable evidence. With the shared `internal/testattest` stub, the suite now runs a real attested mTLS handshake end-to-end.

- `TestMeshHandshakeAcceptsAttestedPeer` dials the real listener with `ratls.NewClientTLSConfig` and completes the handshake through the production `VerifyPeerCertificate`; the accept path also asserts the recorded `ExpectedReportData`, pinning key residency at the mesh layer.
- Its mirror with a wrong `launch_digest` fails with a typed `ErrPolicyViolation`, before any proxied bytes flow.
- `TestProviderRATLSRejectsCDSWithUnpinnedMeasurement`: real RA-TLS listener serving `launch_digest=X` against pin `[Y]` → `ErrPolicyViolation`; the `ratls_mesh_measurement_pinning` gauge reads 1 when pinned.
- `cdsclient` test swaps the `strings.Contains(err, ...)` crumb for `errors.Is(..., ErrNotAttested)`.
- The `InsecureSkipVerify`/`NoClientCert` crutches are gone; production change is one verbatim extraction (`meshVerifyPolicy`) to make the handshake testable.
- One config-row pin keeps the mesh's blank-entry measurement parsing distinct from `ratls.ParseHexMeasurements`, so a future parser convergence can't silently relax `--measurements`.

## Deletion mutations (both verified red, independently reproduced)

- Delete the measurement-plumbing line in the client handshake path → `TestMeshHandshakeAcceptsAttestedPeer` fails.
- Delete the policy comparison in `meshVerifyPolicy` → the wrong-digest mirror test fails.

## Tests

`make test` green (64 packages, `-race`); `golangci-lint` clean.
