### PR TITLE
test(overenc): pin the canonical key schedule; hostile-record and fresh-IV tests

### DIFF
--- a/pkg/overenc/identity_test.go
+++ b/pkg/overenc/identity_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -102,16 +103,18 @@ func TestLBTranscriptHashValidatesShape(t *testing.T) {
 	for _, tc := range []struct {
 		name                     string
 		nonce, serving, leaf, ca []byte
+		wantErr                  string
 	}{
-		{name: "nonce short", nonce: make([]byte, 16), serving: []byte{1}, leaf: []byte{2}, ca: []byte{3}},
-		{name: "nonce long", nonce: make([]byte, 33), serving: []byte{1}, leaf: []byte{2}, ca: []byte{3}},
-		{name: "serving leaf empty", nonce: nonce, leaf: []byte{2}, ca: []byte{3}},
-		{name: "mesh leaf empty", nonce: nonce, serving: []byte{1}, ca: []byte{3}},
-		{name: "ca empty", nonce: nonce, serving: []byte{1}, leaf: []byte{2}},
+		{name: "nonce short", nonce: make([]byte, 16), serving: []byte{1}, leaf: []byte{2}, ca: []byte{3}, wantErr: "lb transcript nonce must be 32 bytes, got 16"},
+		{name: "nonce long", nonce: make([]byte, 33), serving: []byte{1}, leaf: []byte{2}, ca: []byte{3}, wantErr: "lb transcript nonce must be 32 bytes, got 33"},
+		{name: "serving leaf empty", nonce: nonce, leaf: []byte{2}, ca: []byte{3}, wantErr: "lb transcript requires serving leaf, mesh leaf, and CA certificates"},
+		{name: "mesh leaf empty", nonce: nonce, serving: []byte{1}, ca: []byte{3}, wantErr: "lb transcript requires serving leaf, mesh leaf, and CA certificates"},
+		{name: "ca empty", nonce: nonce, serving: []byte{1}, leaf: []byte{2}, wantErr: "lb transcript requires serving leaf, mesh leaf, and CA certificates"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := LBTranscriptHash(tc.nonce, tc.serving, tc.leaf, tc.ca); err == nil {
-				t.Fatal("invalid transcript input accepted")
+			_, err := LBTranscriptHash(tc.nonce, tc.serving, tc.leaf, tc.ca)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
 			}
 		})
 	}
@@ -162,21 +165,23 @@ func TestLBTranscriptGoldenVectors(t *testing.T) {
 func TestIdentityTranscriptHashValidatesShape(t *testing.T) {
 	valid := PublicKey{X25519: make([]byte, X25519PubBytes), MLKEM768: make([]byte, MLKEM768EKBytes)}
 	for _, tc := range []struct {
-		name  string
-		pub   PublicKey
-		nonce []byte
-		leaf  []byte
-		ca    []byte
+		name    string
+		pub     PublicKey
+		nonce   []byte
+		leaf    []byte
+		ca      []byte
+		wantErr string
 	}{
-		{name: "x25519", pub: PublicKey{X25519: make([]byte, 1), MLKEM768: valid.MLKEM768}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}},
-		{name: "mlkem", pub: PublicKey{X25519: valid.X25519, MLKEM768: make([]byte, 1)}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}},
-		{name: "nonce", pub: valid, nonce: make([]byte, 16), leaf: []byte{1}, ca: []byte{2}},
-		{name: "leaf", pub: valid, nonce: make([]byte, identityNonceBytes), ca: []byte{2}},
-		{name: "ca", pub: valid, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}},
+		{name: "x25519", pub: PublicKey{X25519: make([]byte, 1), MLKEM768: valid.MLKEM768}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}, wantErr: "identity transcript X25519 key must be 32 bytes, got 1"},
+		{name: "mlkem", pub: PublicKey{X25519: valid.X25519, MLKEM768: make([]byte, 1)}, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, ca: []byte{2}, wantErr: "identity transcript ML-KEM key must be 1184 bytes, got 1"},
+		{name: "nonce", pub: valid, nonce: make([]byte, 16), leaf: []byte{1}, ca: []byte{2}, wantErr: "identity transcript nonce must be 32 bytes, got 16"},
+		{name: "leaf", pub: valid, nonce: make([]byte, identityNonceBytes), ca: []byte{2}, wantErr: "identity transcript requires leaf and CA certificates"},
+		{name: "ca", pub: valid, nonce: make([]byte, identityNonceBytes), leaf: []byte{1}, wantErr: "identity transcript requires leaf and CA certificates"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := IdentityTranscriptHash(tc.pub, tc.nonce, tc.leaf, tc.ca); err == nil {
-				t.Fatal("invalid transcript input accepted")
+			_, err := IdentityTranscriptHash(tc.pub, tc.nonce, tc.leaf, tc.ca)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tc.wantErr)
 			}
 		})
 	}

--- a/pkg/overenc/overenc.go
+++ b/pkg/overenc/overenc.go
@@ -1,7 +1,7 @@
 // Package overenc implements the c8s-verify post-quantum over-encryption channel
-// that terminates inside the Load Balancer's TEE. It is the Go counterpart of the
-// browser library's keyagreement.js + channel.js and is wire-compatible with it
-// (see c8s-verify-js/PROTOCOL.md).
+// that terminates inside the Load Balancer's TEE. This package's key schedule is
+// the canonical contract (pinned by TestChannelKeyGoldenVector); the c8s-verify-js
+// client and its PROTOCOL.md follow it.
 //
 // Hybrid KEM = X25519 (crypto/ecdh) + ML-KEM-768 (crypto/mlkem), combined per the
 // TLS X25519MLKEM768 convention, run through HKDF-SHA256 to an AES-256-GCM key.

--- a/pkg/overenc/overenc.go
+++ b/pkg/overenc/overenc.go
@@ -18,6 +18,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/sha512"
+	"errors"
 	"fmt"
 	"sync"
 )
@@ -32,6 +33,19 @@ const (
 	MLKEM768EKBytes = 1184
 	// MLKEM768CTBytes is the ML-KEM-768 ciphertext length.
 	MLKEM768CTBytes = 1088
+)
+
+// Sentinel errors for Channel.Open's rejection paths, matchable via [errors.Is].
+var (
+	// ErrInvalidIV: the record's IV is not the AES-GCM nonce size.
+	ErrInvalidIV = fmt.Errorf("overenc: IV must be %d bytes", ivBytes)
+	// ErrAuthenticationFailed: the record failed AEAD authentication (wrong
+	// key, tampered ciphertext, or wrong AAD).
+	ErrAuthenticationFailed = errors.New("overenc: authentication failed")
+	// ErrReplayedRecord: this channel already opened a record with this IV.
+	ErrReplayedRecord = errors.New("overenc: replayed record rejected")
+	// ErrRecordLimit: the anti-replay set is full; re-establish the session.
+	ErrRecordLimit = errors.New("overenc: channel record limit reached; re-establish the session")
 )
 
 // PublicKey is the LB's per-session hybrid public key, published in the
@@ -153,11 +167,17 @@ func clientAgree(pub PublicKey, salt []byte) (*Channel, Handshake, error) {
 	return ch, Handshake{ClientX25519: clientPriv.PublicKey().Bytes(), MLKEMCiphertext: ct}, nil
 }
 
-func deriveChannel(mlkemSS, x25519SS, salt []byte) (*Channel, error) {
+// deriveKey is the canonical key schedule pinned by TestChannelKeyGoldenVector:
+// HKDF-SHA256, ikm = mlkemSS || x25519SS, salt = identity transcript hash.
+func deriveKey(mlkemSS, x25519SS, salt []byte) ([]byte, error) {
 	ikm := make([]byte, 0, len(mlkemSS)+len(x25519SS))
 	ikm = append(ikm, mlkemSS...)
 	ikm = append(ikm, x25519SS...)
-	key, err := hkdf.Key(sha256.New, ikm, salt, hkdfInfo, 32)
+	return hkdf.Key(sha256.New, ikm, salt, hkdfInfo, 32)
+}
+
+func deriveChannel(mlkemSS, x25519SS, salt []byte) (*Channel, error) {
+	key, err := deriveKey(mlkemSS, x25519SS, salt)
 	if err != nil {
 		return nil, fmt.Errorf("overenc: HKDF: %w", err)
 	}
@@ -221,11 +241,11 @@ func (c *Channel) Seal(plaintext, aad []byte) (Record, error) {
 // channel has already opened (exact-record replay).
 func (c *Channel) Open(rec Record, aad []byte) ([]byte, error) {
 	if len(rec.IV) != ivBytes {
-		return nil, fmt.Errorf("overenc: IV must be %d bytes", ivBytes)
+		return nil, fmt.Errorf("%w, got %d", ErrInvalidIV, len(rec.IV))
 	}
 	pt, err := c.aead.Open(nil, rec.IV, rec.CT, aad)
 	if err != nil {
-		return nil, fmt.Errorf("overenc: authentication failed: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrAuthenticationFailed, err)
 	}
 	// Only authenticated records reach here, so a forged record cannot poison
 	// the set, and a genuine record's IV is unique per Seal — a repeat means the
@@ -237,10 +257,10 @@ func (c *Channel) Open(rec Record, aad []byte) ([]byte, error) {
 		c.seen = make(map[string]struct{})
 	}
 	if _, dup := c.seen[key]; dup {
-		return nil, fmt.Errorf("overenc: replayed record rejected")
+		return nil, ErrReplayedRecord
 	}
 	if len(c.seen) >= maxTrackedNonces {
-		return nil, fmt.Errorf("overenc: channel record limit reached; re-establish the session")
+		return nil, ErrRecordLimit
 	}
 	c.seen[key] = struct{}{}
 	return pt, nil

--- a/pkg/overenc/overenc_test.go
+++ b/pkg/overenc/overenc_test.go
@@ -2,6 +2,8 @@ package overenc
 
 import (
 	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/sha512"
 	"encoding/hex"
 	"errors"
@@ -243,6 +245,7 @@ func TestChannelKeyGoldenVector(t *testing.T) {
 	mlkemSS := mustHex(t, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
 	x25519SS := mustHex(t, "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f")
 	salt := mustHex(t, "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f")
+	const wantKey = "f631405a5e117f1ff53e36c527782a3a1b97186007f277bd494db5d825dc08ab"
 
 	t.Run("info string", func(t *testing.T) {
 		if hkdfInfo != "c8s-verify/v1/over-encryption" {
@@ -250,7 +253,7 @@ func TestChannelKeyGoldenVector(t *testing.T) {
 		}
 	})
 
-	t.Run("salt is the identity transcript hash", func(t *testing.T) {
+	t.Run("salt is transcript-hash-shaped and load-bearing", func(t *testing.T) {
 		if len(salt) != sha512.Size384 {
 			t.Fatalf("vector salt = %d bytes, want the %d-byte identity transcript hash", len(salt), sha512.Size384)
 		}
@@ -273,9 +276,32 @@ func TestChannelKeyGoldenVector(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		const want = "f631405a5e117f1ff53e36c527782a3a1b97186007f277bd494db5d825dc08ab"
-		if got := hex.EncodeToString(key); got != want {
-			t.Fatalf("channel key = %s, want %s", got, want)
+		if got := hex.EncodeToString(key); got != wantKey {
+			t.Fatalf("channel key = %s, want %s", got, wantKey)
+		}
+	})
+
+	// The vector must hold through the production funnel, not only deriveKey.
+	t.Run("key through deriveChannel", func(t *testing.T) {
+		ch, err := deriveChannel(mlkemSS, x25519SS, salt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		aad := RequestAAD()
+		rec, err := ch.Seal([]byte("m"), aad)
+		if err != nil {
+			t.Fatal(err)
+		}
+		block, err := aes.NewCipher(mustHex(t, wantKey))
+		if err != nil {
+			t.Fatal(err)
+		}
+		aead, err := cipher.NewGCM(block)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := aead.Open(nil, rec.IV, rec.CT, aad); err != nil {
+			t.Fatalf("golden key cannot open a record sealed through deriveChannel: %v", err)
 		}
 	})
 }
@@ -319,23 +345,45 @@ func TestOpenRejectsMalformedRecord(t *testing.T) {
 			}
 		})
 	}
+
+	// A forgery reusing the genuine record's IV must not poison the anti-replay
+	// set: the genuine record still opens.
+	forged := Record{IV: valid.IV, CT: bytes.Clone(valid.CT)}
+	forged.CT[0] ^= 0xff
+	if _, err := server.Open(forged, aad); !errors.Is(err, ErrAuthenticationFailed) {
+		t.Fatalf("Open(forged) = %v, want %v", err, ErrAuthenticationFailed)
+	}
+	if _, err := server.Open(valid, aad); err != nil {
+		t.Fatalf("genuine record rejected after a forgery reused its IV: %v", err)
+	}
 }
 
 func TestSealUsesAFreshIV(t *testing.T) {
-	server, _ := channelPair(t)
+	server, client := channelPair(t)
+	// Both ends share one key, so IVs must be unique across the union of both
+	// ends' records.
+	ends := []struct {
+		name string
+		ch   *Channel
+	}{
+		{"server", server},
+		{"client", client},
+	}
 	const seals = 1024
-	seen := make(map[string]struct{}, seals)
+	seen := make(map[string]struct{}, 2*seals)
 	for i := 0; i < seals; i++ {
-		rec, err := server.Seal([]byte("m"), RequestAAD())
-		if err != nil {
-			t.Fatalf("seal %d: %v", i, err)
+		for _, end := range ends {
+			rec, err := end.ch.Seal([]byte("m"), RequestAAD())
+			if err != nil {
+				t.Fatalf("%s seal %d: %v", end.name, i, err)
+			}
+			if len(rec.IV) != ivBytes {
+				t.Fatalf("%s seal %d: IV = %d bytes, want %d", end.name, i, len(rec.IV), ivBytes)
+			}
+			if _, dup := seen[string(rec.IV)]; dup {
+				t.Fatalf("%s seal %d reused an IV", end.name, i)
+			}
+			seen[string(rec.IV)] = struct{}{}
 		}
-		if len(rec.IV) != ivBytes {
-			t.Fatalf("seal %d: IV = %d bytes, want %d", i, len(rec.IV), ivBytes)
-		}
-		if _, dup := seen[string(rec.IV)]; dup {
-			t.Fatalf("seal %d reused an IV", i)
-		}
-		seen[string(rec.IV)] = struct{}{}
 	}
 }

--- a/pkg/overenc/overenc_test.go
+++ b/pkg/overenc/overenc_test.go
@@ -3,6 +3,9 @@ package overenc
 import (
 	"bytes"
 	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -90,8 +93,8 @@ func TestChannelRejectsMismatchedTranscript(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := serverCh.Open(rec, RequestAAD()); err == nil {
-		t.Fatal("mismatched identity transcript derived the same channel")
+	if _, err := serverCh.Open(rec, RequestAAD()); !errors.Is(err, ErrAuthenticationFailed) {
+		t.Fatalf("Open with mismatched transcript = %v, want %v", err, ErrAuthenticationFailed)
 	}
 }
 
@@ -107,8 +110,8 @@ func TestOpenRejectsReplayedRecord(t *testing.T) {
 	}
 	// Resubmitting the exact same authenticated record must not decrypt to a
 	// second backend action.
-	if _, err := serverCh.Open(rec, RequestAAD()); err == nil {
-		t.Fatal("replayed record accepted; want rejection")
+	if _, err := serverCh.Open(rec, RequestAAD()); !errors.Is(err, ErrReplayedRecord) {
+		t.Fatalf("replayed record: Open = %v, want %v", err, ErrReplayedRecord)
 	}
 	// A fresh, distinct record from the same channel still opens.
 	rec2, err := clientCh.Seal([]byte("transfer $200"), RequestAAD())
@@ -127,25 +130,75 @@ func TestOpenRejectsTamperedAAD(t *testing.T) {
 		t.Fatal(err)
 	}
 	rec, _ := clientCh.Seal([]byte("x"), RequestAAD())
-	if _, err := clientCh.Open(rec, ResponseAAD()); err == nil {
-		t.Fatal("expected AAD mismatch to fail authentication")
+	if _, err := clientCh.Open(rec, ResponseAAD()); !errors.Is(err, ErrAuthenticationFailed) {
+		t.Fatalf("AAD mismatch: Open = %v, want %v", err, ErrAuthenticationFailed)
 	}
 }
 
 func TestAgreeRejectsWrongSizes(t *testing.T) {
 	srv, _ := GenerateServerKey()
 	transcriptHash := testTranscriptHash(0xA5)
-	if _, err := srv.Agree(Handshake{ClientX25519: make([]byte, 32), MLKEMCiphertext: make([]byte, 10)}, transcriptHash); err == nil {
-		t.Fatal("expected error for short ciphertext")
+	tests := []struct {
+		name    string
+		agree   func() error
+		wantErr string
+	}{
+		{
+			name: "server ML-KEM ciphertext short",
+			agree: func() error {
+				_, err := srv.Agree(Handshake{ClientX25519: make([]byte, 32), MLKEMCiphertext: make([]byte, 10)}, transcriptHash)
+				return err
+			},
+			wantErr: "ML-KEM ciphertext must be 1088 bytes, got 10",
+		},
+		{
+			name: "server client X25519 key short",
+			agree: func() error {
+				_, err := srv.Agree(Handshake{ClientX25519: make([]byte, 10), MLKEMCiphertext: make([]byte, MLKEM768CTBytes)}, transcriptHash)
+				return err
+			},
+			wantErr: "client X25519 key must be 32 bytes, got 10",
+		},
+		{
+			name: "client ML-KEM key short",
+			agree: func() error {
+				_, _, err := ClientAgree(PublicKey{X25519: make([]byte, 32), MLKEM768: make([]byte, 10)}, transcriptHash)
+				return err
+			},
+			wantErr: "ML-KEM key must be 1184 bytes, got 10",
+		},
+		{
+			name: "client X25519 key short",
+			agree: func() error {
+				_, _, err := ClientAgree(PublicKey{X25519: make([]byte, 10), MLKEM768: make([]byte, MLKEM768EKBytes)}, transcriptHash)
+				return err
+			},
+			wantErr: "X25519 key must be 32 bytes, got 10",
+		},
+		{
+			name: "server transcript hash missing",
+			agree: func() error {
+				_, err := srv.Agree(Handshake{ClientX25519: make([]byte, 32), MLKEMCiphertext: make([]byte, MLKEM768CTBytes)}, nil)
+				return err
+			},
+			wantErr: "identity transcript hash must be 48 bytes, got 0",
+		},
+		{
+			name: "client transcript hash short",
+			agree: func() error {
+				_, _, err := ClientAgree(srv.Public(), make([]byte, 32))
+				return err
+			},
+			wantErr: "identity transcript hash must be 48 bytes, got 32",
+		},
 	}
-	if _, _, err := ClientAgree(PublicKey{X25519: make([]byte, 32), MLKEM768: make([]byte, 10)}, transcriptHash); err == nil {
-		t.Fatal("expected error for short ML-KEM key")
-	}
-	if _, err := srv.Agree(Handshake{ClientX25519: make([]byte, 32), MLKEMCiphertext: make([]byte, MLKEM768CTBytes)}, nil); err == nil {
-		t.Fatal("expected error for missing transcript hash")
-	}
-	if _, _, err := ClientAgree(srv.Public(), make([]byte, 32)); err == nil {
-		t.Fatal("expected error for short transcript hash")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.agree()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("err = %v, want %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 
@@ -168,7 +221,121 @@ func TestOpenFailsClosedAtRecordLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := server.Open(rec, aad); err == nil || !strings.Contains(err.Error(), "record limit") {
-		t.Fatalf("Open after %d records = %v, want the fail-closed limit error", maxTrackedNonces, err)
+	if _, err := server.Open(rec, aad); !errors.Is(err, ErrRecordLimit) {
+		t.Fatalf("Open after %d records = %v, want %v", maxTrackedNonces, err, ErrRecordLimit)
+	}
+}
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+// TestChannelKeyGoldenVector pins the canonical key schedule against fixed
+// shared secrets and a fixed salt so the Go derivation cannot drift.
+// Cross-language contract: c8s-verify-js/test/keyagreement.test.ts must
+// reproduce this vector.
+func TestChannelKeyGoldenVector(t *testing.T) {
+	mlkemSS := mustHex(t, "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+	x25519SS := mustHex(t, "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f")
+	salt := mustHex(t, "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f")
+
+	t.Run("info string", func(t *testing.T) {
+		if hkdfInfo != "c8s-verify/v1/over-encryption" {
+			t.Fatalf("hkdfInfo = %q, want %q", hkdfInfo, "c8s-verify/v1/over-encryption")
+		}
+	})
+
+	t.Run("salt is the identity transcript hash", func(t *testing.T) {
+		if len(salt) != sha512.Size384 {
+			t.Fatalf("vector salt = %d bytes, want the %d-byte identity transcript hash", len(salt), sha512.Size384)
+		}
+		// A nonce-shaped salt derives a different key: the salt is load-bearing.
+		withTranscript, err := deriveKey(mlkemSS, x25519SS, salt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		withNonce, err := deriveKey(mlkemSS, x25519SS, bytes.Repeat([]byte{0x42}, identityNonceBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if bytes.Equal(withTranscript, withNonce) {
+			t.Fatal("derived key ignored the salt")
+		}
+	})
+
+	t.Run("key", func(t *testing.T) {
+		key, err := deriveKey(mlkemSS, x25519SS, salt)
+		if err != nil {
+			t.Fatal(err)
+		}
+		const want = "f631405a5e117f1ff53e36c527782a3a1b97186007f277bd494db5d825dc08ab"
+		if got := hex.EncodeToString(key); got != want {
+			t.Fatalf("channel key = %s, want %s", got, want)
+		}
+	})
+}
+
+// openNoPanic converts an Open panic into an error so a missing IV guard fails the subtest.
+func openNoPanic(ch *Channel, rec Record, aad []byte) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("overenc test: Open panicked: %v", r)
+		}
+	}()
+	_, err = ch.Open(rec, aad)
+	return err
+}
+
+func TestOpenRejectsMalformedRecord(t *testing.T) {
+	server, client := channelPair(t)
+	aad := RequestAAD()
+	valid, err := client.Seal([]byte("payload"), aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		rec  Record
+		want error
+	}{
+		{name: "IV length 0", rec: Record{IV: []byte{}, CT: valid.CT}, want: ErrInvalidIV},
+		{name: "IV length 11", rec: Record{IV: make([]byte, 11), CT: valid.CT}, want: ErrInvalidIV},
+		{name: "IV length 13", rec: Record{IV: make([]byte, 13), CT: valid.CT}, want: ErrInvalidIV},
+		{name: "IV length 16", rec: Record{IV: make([]byte, 16), CT: valid.CT}, want: ErrInvalidIV},
+		{name: "ciphertext nil", rec: Record{IV: valid.IV, CT: nil}, want: ErrAuthenticationFailed},
+		{name: "ciphertext 1 byte", rec: Record{IV: valid.IV, CT: []byte{0x00}}, want: ErrAuthenticationFailed},
+		{name: "ciphertext truncated", rec: Record{IV: valid.IV, CT: valid.CT[:len(valid.CT)-1]}, want: ErrAuthenticationFailed},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := openNoPanic(server, tt.rec, aad); !errors.Is(err, tt.want) {
+				t.Fatalf("Open = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestSealUsesAFreshIV(t *testing.T) {
+	server, _ := channelPair(t)
+	const seals = 1024
+	seen := make(map[string]struct{}, seals)
+	for i := 0; i < seals; i++ {
+		rec, err := server.Seal([]byte("m"), RequestAAD())
+		if err != nil {
+			t.Fatalf("seal %d: %v", i, err)
+		}
+		if len(rec.IV) != ivBytes {
+			t.Fatalf("seal %d: IV = %d bytes, want %d", i, len(rec.IV), ivBytes)
+		}
+		if _, dup := seen[string(rec.IV)]; dup {
+			t.Fatalf("seal %d reused an IV", i)
+		}
+		seen[string(rec.IV)] = struct{}{}
 	}
 }


### PR DESCRIPTION
## Summary

Pins the Go over-encryption key schedule as canonical and hardens the record path.

- A golden vector pins the full HKDF/AES-GCM key schedule byte-for-byte (independently recomputed via Python/OpenSSL/Go during review — it matches `c8s-verify-js` main and PROTOCOL.md).
- `Open` now returns typed sentinel errors instead of panicking on hostile records (short nonce, truncated tag, bad AAD); the sole caller collapses all of them to a uniform 400, so no decryption oracle is introduced.
- Hostile-record tests cover truncation/tampering/forgery classes; the fresh-IV test seals at both ends and asserts union uniqueness (a counter-IV mutation dies by name).
- Package doc now states the canonical-source relationship (Go is canonical; the vector enforces byte-parity).

## Mutation evidence

Full 10-mutant matrix re-run by multiple reviewers — all die at named assertions, including: counter-IV reuse, salt truncation, insert-before-auth forgery, and each typed-sentinel removal.

## Notes

- `c8s-verify-js` main already matches the Go schedule; the remaining client-side work is adding this golden vector to its test suite (tracked separately).
- `make test` green (64 packages, `-race`); lint clean.
