### PR TITLE
test(secrets,credrelease): pin release-path negatives

### DIFF
--- a/internal/cmds/credrelease/handler_test.go
+++ b/internal/cmds/credrelease/handler_test.go
@@ -107,6 +107,60 @@ func TestHandlerReleasesServerCA(t *testing.T) {
 	}
 }
 
+// The token's pbh binds it to the exact body it was minted over: a token
+// captured from one release must not authorize a different CSR, on the
+// endpoint that issues cluster-admin credentials.
+func TestReleaseRefusesATokenBoundToAnotherCSR(t *testing.T) {
+	signer, pubPEM := newOperatorAuth(t)
+	h, err := NewHandler(pubPEM, testCA(t), "system:masters", "operator", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyA, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyB, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyA, err := json.Marshal(ReleaseRequest{CSRPEM: string(csrPEMFromKey(t, keyA))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	bodyB, err := json.Marshal(ReleaseRequest{CSRPEM: string(csrPEMFromKey(t, keyB))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authz, err := signer.Authorization(http.MethodPost, "/release-credential", bodyA)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The token signed over bodyA is replayed against bodyB.
+	req := httptest.NewRequest(http.MethodPost, "/release-credential", bytes.NewReader(bodyB))
+	req.Header.Set("Authorization", authz)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("token bound to another CSR = %d, body %q; want 401", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "BEGIN CERTIFICATE") {
+		t.Fatalf("a refused request issued a certificate: %s", rec.Body.String())
+	}
+
+	// The same token against the body it was minted over succeeds, so the
+	// refusal above is the body binding and nothing else.
+	req = httptest.NewRequest(http.MethodPost, "/release-credential", bytes.NewReader(bodyA))
+	req.Header.Set("Authorization", authz)
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("the unswapped body = %d, body %q; want 200", rec.Code, rec.Body.String())
+	}
+}
+
 // newOperatorAuth generates a fresh operator keypair, returning a token signer
 // (the operator side) and the PKIX public-key PEM (the measured side).
 func newOperatorAuth(t *testing.T) (*operatorauth.Signer, []byte) {

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -232,8 +232,8 @@ func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
 }
 
 // The sidecar's log leaves the TEE (docs/engineering-standards.md §8), so a
-// fetched value must never reach it — on a read, a create, or a refusal the
-// retry loop logs alike.
+// fetched value must never reach it: the read, create, write, and retry legs
+// are each driven with the log captured.
 func TestSecretValueNeverReachesTheLog(t *testing.T) {
 	endpoint := startInventory(t)
 	var log bytes.Buffer

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -1,12 +1,14 @@
 package getsecret
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -226,6 +228,63 @@ func TestEveryRequestTakesAFreshChallengeAndToken(t *testing.T) {
 			t.Fatal("a sandbox token was reused across requests")
 		}
 		seen[tok] = true
+	}
+}
+
+// The sidecar's log leaves the TEE (docs/engineering-standards.md §8), so a
+// fetched value must never reach it — on a read, a create, or a refusal the
+// retry loop logs alike.
+func TestSecretValueNeverReachesTheLog(t *testing.T) {
+	endpoint := startInventory(t)
+	var log bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	const existing = "sentinel-existing-value"
+	const minted = "sentinel-minted-value"
+	_, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db":   {{status: http.StatusOK, value: existing}},
+		"GET /secrets/api/new":  {{status: http.StatusNotFound}},
+		"POST /secrets/api/new": {{status: http.StatusCreated, value: minted}},
+	})
+	cfg := flowConfig(t, url)
+	cfg.Secrets = []secretRequest{{Name: "DB", Path: "/api/db"}, {Name: "NEW", Path: "/api/new"}}
+	pub := testKey(t)
+	values, err := fetchAllWith(context.Background(), cfg, http.DefaultClient, pub, endpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(values["DB"]) != existing || string(values["NEW"]) != minted {
+		t.Fatalf("values = %q, %q; want both sentinels", values["DB"], values["NEW"])
+	}
+	if err := writeAll(cfg, values); err != nil {
+		t.Fatal(err)
+	}
+
+	// A refusal and a server failure: each attempt's error is logged, the last
+	// at ERROR.
+	_, brokenURL := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db": {{status: http.StatusForbidden}, {status: http.StatusInternalServerError}},
+	})
+	cfg = flowConfig(t, brokenURL)
+	cfg.RetryInterval = time.Millisecond
+	cfg.Attempts = 2
+	if err := sidecar.Retry(context.Background(), cfg.Config, "secret", func(ctx context.Context) error {
+		_, err := fetchAllWith(ctx, cfg, http.DefaultClient, pub, endpoint)
+		return err
+	}); err == nil {
+		t.Fatal("a refused release reported success")
+	}
+
+	out := log.String()
+	if !strings.Contains(out, "not released yet") {
+		t.Fatalf("the retries never reached the captured log; capture is broken:\n%s", out)
+	}
+	for _, v := range []string{existing, minted} {
+		if strings.Contains(out, v) || strings.Contains(out, base64.StdEncoding.EncodeToString([]byte(v))) {
+			t.Fatalf("the secret reached the log as %q:\n%s", v, out)
+		}
 	}
 }
 

--- a/internal/secrets/explain_test.go
+++ b/internal/secrets/explain_test.go
@@ -71,8 +71,8 @@ func TestExplainMarksInjectedContainers(t *testing.T) {
 	eh := newExplainHarness(t)
 	_, resp := eh.serve(testSandbox)
 
-	if len(resp.Reported) != 2 || len(resp.Candidates) != 1 {
-		t.Fatalf("reported=%d candidates=%d, want 2 and 1", len(resp.Reported), len(resp.Candidates))
+	if len(resp.Reported) != 3 || len(resp.Candidates) != 2 {
+		t.Fatalf("reported=%d candidates=%d, want 3 and 2", len(resp.Reported), len(resp.Candidates))
 	}
 	var injected int
 	for _, c := range resp.Reported {
@@ -86,8 +86,8 @@ func TestExplainMarksInjectedContainers(t *testing.T) {
 	if injected != 1 {
 		t.Fatalf("injected = %d, want 1", injected)
 	}
-	if resp.Candidates[0].Digest != testAppImg {
-		t.Fatalf("candidate = %s, want the app image", resp.Candidates[0].Digest)
+	if resp.Candidates[0].Digest != testAppImg || resp.Candidates[1].Digest != testAppImg2 {
+		t.Fatalf("candidates = %+v, want the two app images", resp.Candidates)
 	}
 }
 
@@ -145,7 +145,7 @@ func TestExplainDoesNotDropAFloorImageRunningAShell(t *testing.T) {
 	}
 }
 
-// A declared main that is not running is the other half of the diff.
+// Declared mains that are not running are the other half of the diff.
 func TestExplainNamesAMissingMain(t *testing.T) {
 	eh := newExplainHarness(t)
 	eh.inv.containers = []workloadclaims.SandboxContainer{
@@ -158,8 +158,8 @@ func TestExplainNamesAMissingMain(t *testing.T) {
 		if e.Name != "api" {
 			continue
 		}
-		if len(e.MissingMains) != 1 || e.MissingMains[0].Digest != testAppImg {
-			t.Fatalf("missing mains = %+v, want the app image", e.MissingMains)
+		if len(e.MissingMains) != 2 || e.MissingMains[0].Digest != testAppImg || e.MissingMains[1].Digest != testAppImg2 {
+			t.Fatalf("missing mains = %+v, want both app images", e.MissingMains)
 		}
 	}
 }
@@ -287,6 +287,7 @@ func TestExplainAgreesWithTheMatcher(t *testing.T) {
 	}{
 		{"match", []workloadclaims.SandboxContainer{
 			{Digest: testAppImg, Argv: []string{"/serve"}},
+			{Digest: testAppImg2, Argv: []string{"/metrics"}},
 			{Digest: testInjected, Argv: []string{"get-cert"}},
 		}},
 		{"foreign image", []workloadclaims.SandboxContainer{

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -1,7 +1,9 @@
 package secrets
 
 import (
+	"bytes"
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -10,6 +12,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"math/big"
 	"net/http"
 	"net/http/httptest"
@@ -24,14 +28,19 @@ import (
 )
 
 const (
-	testSandbox  = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	testHost     = "10.0.0.7"
-	testAppImg   = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	testSandbox = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	testHost    = "10.0.0.7"
+	testAppImg  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	// testAppImg2 is the entry's second main: release is gated on both running.
+	testAppImg2  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 	testInjected = "sha256:9999999999999999999999999999999999999999999999999999999999999999"
 	testOther    = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
 	// testInjectedOld is the previous release's injected image, still running in
 	// pods created before an upgrade.
 	testInjectedOld = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+	// testWorkerImg is the main of a second workload entry, declared only by
+	// tests that need one.
+	testWorkerImg = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
 )
 
 // --- fakes ---
@@ -50,14 +59,21 @@ func (f *fakeChallenges) Consume(c []byte) bool {
 	return true
 }
 
+// keys is per host so a token signed under another inventory's key fails
+// verification the way it would against the real client, which resolves the
+// key by dialling the host.
 type fakeInventory struct {
-	key        *ecdsa.PublicKey
+	keys       map[string]*ecdsa.PublicKey
 	containers []workloadclaims.SandboxContainer
 	err        error
 }
 
-func (f *fakeInventory) InventoryKey(context.Context, string) (*ecdsa.PublicKey, error) {
-	return f.key, nil
+func (f *fakeInventory) InventoryKey(_ context.Context, host string) (*ecdsa.PublicKey, error) {
+	key, ok := f.keys[host]
+	if !ok {
+		return nil, fmt.Errorf("no inventory at %s", host)
+	}
+	return key, nil
 }
 func (f *fakeInventory) FetchSandbox(context.Context, string, string) (workloadclaims.SandboxDigestsResponse, error) {
 	if f.err != nil {
@@ -150,12 +166,21 @@ func newHarness(t *testing.T) *harness {
 		testInjectedOld: "ghcr.io/confidential-dot-ai/c8s@" + testInjectedOld,
 		testOther:       "docker.io/library/busybox@" + testOther,
 	}, Workloads: map[string]pkgallowlist.Workload{
+		// Two mains: release is gated on every main container running, so the
+		// gate is only exercisable with more than one.
 		"api": {
-			Containers: []pkgallowlist.Container{{
-				Digest:  mustDigest(t, testAppImg),
-				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/serve"}},
-				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			}},
+			Containers: []pkgallowlist.Container{
+				{
+					Digest:  mustDigest(t, testAppImg),
+					Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/serve"}},
+					Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+				},
+				{
+					Digest:  mustDigest(t, testAppImg2),
+					Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/metrics"}},
+					Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+				},
+			},
 			Secrets: &pkgallowlist.SecretsPolicy{
 				Policy: pkgallowlist.PolicyAllow,
 				Read:   []string{"/api/**"},
@@ -164,9 +189,10 @@ func newHarness(t *testing.T) *harness {
 		},
 	}}
 	inv := &fakeInventory{
-		key: signer.PublicKey(),
+		keys: map[string]*ecdsa.PublicKey{testHost: signer.PublicKey()},
 		containers: []workloadclaims.SandboxContainer{
 			{Digest: testAppImg, Argv: []string{"/serve"}},
+			{Digest: testAppImg2, Argv: []string{"/metrics"}},
 			{Digest: testInjected, Argv: []string{"get-cert", "--san=x"}},
 		},
 	}
@@ -193,16 +219,15 @@ func (hn *harness) request(t *testing.T, method, path string) *http.Request {
 
 func (hn *harness) requestWith(t *testing.T, method, path string, leaf *x509.Certificate, tokenSandbox string, nonce []byte) *http.Request {
 	t.Helper()
-	keyDigest, err := workloadclaims.RequesterKeyDigest(leaf.PublicKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	token, err := hn.signer.Sign(tokenSandbox, keyDigest, nonce)
-	if err != nil {
-		t.Fatal(err)
-	}
-	body, _ := json.Marshal(token)
+	token := mintToken(t, hn.signer, tokenSandbox, leaf.PublicKey, nonce)
+	return hn.requestWithToken(t, method, path, leaf, token, nonce)
+}
 
+// requestWithToken sends an explicitly minted token against nonce, so a test
+// controls what the token proves independently of what the request carries.
+func (hn *harness) requestWithToken(t *testing.T, method, path string, leaf *x509.Certificate, token *workloadclaims.SignedSandboxToken, nonce []byte) *http.Request {
+	t.Helper()
+	body, _ := json.Marshal(token)
 	r := httptest.NewRequest(method, "/secrets"+path, nil)
 	r.Header.Set("X-C8s-Challenge", base64.StdEncoding.EncodeToString(nonce))
 	r.Header.Set("Authorization", AuthScheme+base64.StdEncoding.EncodeToString(body))
@@ -211,6 +236,29 @@ func (hn *harness) requestWith(t *testing.T, method, path string, leaf *x509.Cer
 		VerifiedChains:   [][]*x509.Certificate{{leaf}},
 	}
 	return r
+}
+
+// mintToken signs with signer over the given requester key and nonce — the
+// three axes verifyToken checks, each bendable on its own.
+func mintToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner, sandboxID string, pub crypto.PublicKey, nonce []byte) *workloadclaims.SignedSandboxToken {
+	t.Helper()
+	keyDigest, err := workloadclaims.RequesterKeyDigest(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := signer.Sign(sandboxID, keyDigest, nonce)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return token
+}
+
+// seed plants a value directly, bypassing the release path under test.
+func (hn *harness) seed(t *testing.T, path string, value []byte) {
+	t.Helper()
+	if _, err := hn.store.Put(context.Background(), path, value, OriginOperator); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func do(h Handler, r *http.Request) *httptest.ResponseRecorder {
@@ -282,6 +330,21 @@ func TestChallengeIsSingleUse(t *testing.T) {
 	}
 }
 
+// A denied request spends its nonce: a nonce that survived a denial could be
+// replayed with a valid token against another method or path.
+func TestChallengeIsConsumedEvenOnDenial(t *testing.T) {
+	hn := newHarness(t)
+	nonce := []byte("spent-on-denial")
+	bad := mintToken(t, hn.signer, testSandbox, hn.leaf.PublicKey, []byte("another-challenge"))
+	if w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, bad, nonce)); w.Code != http.StatusForbidden {
+		t.Fatalf("denied request = %d, want 403", w.Code)
+	}
+	good := mintToken(t, hn.signer, testSandbox, hn.leaf.PublicKey, nonce)
+	if w := do(hn.h, hn.requestWithToken(t, http.MethodPost, "/api/db", hn.leaf, good, nonce)); w.Code != http.StatusBadRequest {
+		t.Fatalf("replayed nonce = %d, want 400", w.Code)
+	}
+}
+
 // An unverified chain must never be trusted for the sandbox ID: a self-signed
 // leaf's extension is whatever its minter chose.
 func TestUnverifiedChainRefused(t *testing.T) {
@@ -340,6 +403,58 @@ func TestTokenHostMustMatchBinding(t *testing.T) {
 	}
 }
 
+// The signature must verify under the key the bound inventory serves: an
+// impostor naming the right host still signs with the wrong key.
+func TestTokenSignedByAnotherInventoryRefused(t *testing.T) {
+	hn := newHarness(t)
+	impostor, err := workloadclaims.NewSandboxTokenSigner(testHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := []byte("impostor")
+	token := mintToken(t, impostor, testSandbox, hn.leaf.PublicKey, nonce)
+	hn.seed(t, "/api/db", []byte("stored-secret"))
+	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, nonce))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("impostor-signed token = %d, want 403", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "value") {
+		t.Fatalf("a refused token released a value: %s", w.Body)
+	}
+}
+
+// The token is bound to one requester key: a token minted for another key must
+// not be redeemable by this pod's leaf.
+func TestTokenBoundToAnotherKeyRefused(t *testing.T) {
+	hn := newHarness(t)
+	other, _ := leafFor(t, testSandbox)
+	nonce := []byte("bound-to-another-key")
+	token := mintToken(t, hn.signer, testSandbox, other.PublicKey, nonce)
+	hn.seed(t, "/api/db", []byte("stored-secret"))
+	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, nonce))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("token for another key = %d, want 403", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "value") {
+		t.Fatalf("a refused token released a value: %s", w.Body)
+	}
+}
+
+// The token carries this request's challenge: one minted against another
+// challenge is stale here even though its signature verifies.
+func TestTokenForAnotherChallengeRefused(t *testing.T) {
+	hn := newHarness(t)
+	token := mintToken(t, hn.signer, testSandbox, hn.leaf.PublicKey, []byte("another-challenge"))
+	hn.seed(t, "/api/db", []byte("stored-secret"))
+	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, []byte("this-request")))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("token for another challenge = %d, want 403", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "value") {
+		t.Fatalf("a refused token released a value: %s", w.Body)
+	}
+}
+
 // A floor image the entry does not declare is still foreign: floor membership
 // alone must not drop a container, or a pod could add busybox running a shell
 // and have it ignored.
@@ -394,6 +509,65 @@ func TestEntryWithoutGrantRefused(t *testing.T) {
 	}
 }
 
+// Release is gated on the whole container set: until every main the entry
+// declares is running, the sandbox matches nothing and is refused.
+func TestReleaseRefusedUntilEveryMainIsRunning(t *testing.T) {
+	hn := newHarness(t)
+	hn.inv.containers = []workloadclaims.SandboxContainer{
+		{Digest: testAppImg, Argv: []string{"/serve"}},
+		{Digest: testInjected, Argv: []string{"get-cert", "--san=x"}},
+	}
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("one main not yet running = %d, want 403", w.Code)
+	}
+}
+
+// Two entries the running set satisfies equally are a refusal, through the
+// release path itself rather than the diagnostic.
+func TestAmbiguousMatchRefused(t *testing.T) {
+	hn := newHarness(t)
+	al, err := hn.h.Policy.Allowlist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	al.Workloads["api-copy"] = al.Workloads["api"]
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+		t.Fatalf("ambiguous match = %d, want 403", w.Code)
+	}
+}
+
+// The grant honoured is the matched entry's own: a path only another entry
+// grants is as absent as an ungranted one.
+func TestGrantOfAnotherEntryIsNotHonoured(t *testing.T) {
+	hn := newHarness(t)
+	al, err := hn.h.Policy.Allowlist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	al.Workloads["worker"] = pkgallowlist.Workload{
+		Containers: []pkgallowlist.Container{{
+			Digest:  mustDigest(t, testWorkerImg),
+			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/work"}},
+			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+		}},
+		Secrets: &pkgallowlist.SecretsPolicy{
+			Policy: pkgallowlist.PolicyAllow,
+			Read:   []string{"/worker/**"},
+			Write:  []string{"/worker/**"},
+		},
+	}
+	// The store holds the other entry's secret, so honouring its grant would
+	// release it.
+	hn.seed(t, "/worker/db", []byte("worker-secret"))
+	w := do(hn.h, hn.request(t, http.MethodGet, "/worker/db"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("another entry's path = %d, want 404", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "worker-secret") {
+		t.Fatalf("another entry's grant released a value: %s", w.Body)
+	}
+}
+
 func TestNonCanonicalPathRejected(t *testing.T) {
 	hn := newHarness(t)
 	for _, p := range []string{"/api/../etc", "/api/db/", "/api%2Fdb", ""} {
@@ -421,6 +595,7 @@ func TestInjectedImageFromPreviousReleaseIsDropped(t *testing.T) {
 	hn := newHarness(t)
 	hn.inv.containers = []workloadclaims.SandboxContainer{
 		{Digest: testAppImg, Argv: []string{"/serve"}},
+		{Digest: testAppImg2, Argv: []string{"/metrics"}},
 		{Digest: testInjectedOld, Argv: []string{"get-cert", "--san=x"}},
 	}
 	if w := do(hn.h, hn.request(t, http.MethodPost, "/api/db")); w.Code != http.StatusCreated {
@@ -436,5 +611,69 @@ func TestEmptyFloorRefuses(t *testing.T) {
 	hn.h.Policy = fakePolicy{al: &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema}}
 	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
 		t.Fatalf("unconfigured drop set = %d, want 403", w.Code)
+	}
+}
+
+// Logs leave the TEE (docs/engineering-standards.md §8), so a secret value
+// must never reach one — on a served read, a denial, a miss, or a store
+// failure alike.
+func TestSecretValueNeverReachesTheLog(t *testing.T) {
+	hn := newHarness(t)
+	var log bytes.Buffer
+	hn.h.Logger = slog.New(slog.NewTextHandler(&log, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	value := []byte("sentinel-plaintext-value")
+	valueB64 := base64.StdEncoding.EncodeToString(value)
+	hn.seed(t, "/api/db", value)
+
+	// The read serves the value in its body by design; every other surface is
+	// asserted clean below.
+	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusOK ||
+		!strings.Contains(w.Body.String(), valueB64) {
+		t.Fatalf("read = %d (%s), want 200 carrying the value", w.Code, w.Body)
+	}
+
+	impostor, err := workloadclaims.NewSandboxTokenSigner(testHost)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := []byte("denied-read")
+	denied := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf,
+		mintToken(t, impostor, testSandbox, hn.leaf.PublicKey, nonce), nonce))
+	ungranted := do(hn.h, hn.request(t, http.MethodGet, "/other/db"))
+	missing := do(hn.h, hn.request(t, http.MethodGet, "/api/never-created"))
+
+	hn.h.Store = failingStore{err: fmt.Errorf("backend down")}
+	unavailable := do(hn.h, hn.requestWith(t, http.MethodGet, "/api/db", hn.leaf, testSandbox, []byte("store-down")))
+
+	drives := []struct {
+		name string
+		w    *httptest.ResponseRecorder
+		want int
+	}{
+		{"denied read", denied, http.StatusForbidden},
+		{"ungranted path", ungranted, http.StatusNotFound},
+		{"absent secret", missing, http.StatusNotFound},
+		{"store failure", unavailable, http.StatusInternalServerError},
+	}
+	for _, d := range drives {
+		if d.w.Code != d.want {
+			t.Fatalf("%s = %d (%s), want %d", d.name, d.w.Code, d.w.Body, d.want)
+		}
+		for _, leak := range []string{string(value), valueB64} {
+			if strings.Contains(d.w.Body.String(), leak) {
+				t.Fatalf("%s body carried the secret: %s", d.name, d.w.Body)
+			}
+		}
+	}
+
+	out := log.String()
+	if !strings.Contains(out, "secret request denied") {
+		t.Fatalf("the denial never reached the captured log; capture is broken:\n%s", out)
+	}
+	for _, leak := range []string{string(value), valueB64} {
+		if strings.Contains(out, leak) {
+			t.Fatalf("the secret reached the log as %q:\n%s", leak, out)
+		}
 	}
 }

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -229,7 +230,7 @@ func (hn *harness) requestWithToken(t *testing.T, method, path string, leaf *x50
 	t.Helper()
 	body, _ := json.Marshal(token)
 	r := httptest.NewRequest(method, "/secrets"+path, nil)
-	r.Header.Set("X-C8s-Challenge", base64.StdEncoding.EncodeToString(nonce))
+	r.Header.Set(ChallengeHeader, base64.StdEncoding.EncodeToString(nonce))
 	r.Header.Set("Authorization", AuthScheme+base64.StdEncoding.EncodeToString(body))
 	r.TLS = &tls.ConnectionState{
 		PeerCertificates: []*x509.Certificate{leaf},
@@ -238,8 +239,8 @@ func (hn *harness) requestWithToken(t *testing.T, method, path string, leaf *x50
 	return r
 }
 
-// mintToken signs with signer over the given requester key and nonce — the
-// three axes verifyToken checks, each bendable on its own.
+// mintToken signs with signer over the given sandbox, requester key, and
+// nonce — the axes verifyToken checks, each bendable on its own.
 func mintToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner, sandboxID string, pub crypto.PublicKey, nonce []byte) *workloadclaims.SignedSandboxToken {
 	t.Helper()
 	keyDigest, err := workloadclaims.RequesterKeyDigest(pub)
@@ -258,6 +259,16 @@ func (hn *harness) seed(t *testing.T, path string, value []byte) {
 	t.Helper()
 	if _, err := hn.store.Put(context.Background(), path, value, OriginOperator); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// assertNoRelease fails if a refused response carries value, raw or base64.
+func assertNoRelease(t *testing.T, w *httptest.ResponseRecorder, value []byte) {
+	t.Helper()
+	for _, leak := range []string{string(value), base64.StdEncoding.EncodeToString(value)} {
+		if strings.Contains(w.Body.String(), leak) {
+			t.Fatalf("a refused request leaked the secret: %s", w.Body)
+		}
 	}
 }
 
@@ -413,14 +424,13 @@ func TestTokenSignedByAnotherInventoryRefused(t *testing.T) {
 	}
 	nonce := []byte("impostor")
 	token := mintToken(t, impostor, testSandbox, hn.leaf.PublicKey, nonce)
-	hn.seed(t, "/api/db", []byte("stored-secret"))
+	stored := []byte("stored-secret")
+	hn.seed(t, "/api/db", stored)
 	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, nonce))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("impostor-signed token = %d, want 403", w.Code)
 	}
-	if strings.Contains(w.Body.String(), "value") {
-		t.Fatalf("a refused token released a value: %s", w.Body)
-	}
+	assertNoRelease(t, w, stored)
 }
 
 // The token is bound to one requester key: a token minted for another key must
@@ -430,14 +440,13 @@ func TestTokenBoundToAnotherKeyRefused(t *testing.T) {
 	other, _ := leafFor(t, testSandbox)
 	nonce := []byte("bound-to-another-key")
 	token := mintToken(t, hn.signer, testSandbox, other.PublicKey, nonce)
-	hn.seed(t, "/api/db", []byte("stored-secret"))
+	stored := []byte("stored-secret")
+	hn.seed(t, "/api/db", stored)
 	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, nonce))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("token for another key = %d, want 403", w.Code)
 	}
-	if strings.Contains(w.Body.String(), "value") {
-		t.Fatalf("a refused token released a value: %s", w.Body)
-	}
+	assertNoRelease(t, w, stored)
 }
 
 // The token carries this request's challenge: one minted against another
@@ -445,14 +454,13 @@ func TestTokenBoundToAnotherKeyRefused(t *testing.T) {
 func TestTokenForAnotherChallengeRefused(t *testing.T) {
 	hn := newHarness(t)
 	token := mintToken(t, hn.signer, testSandbox, hn.leaf.PublicKey, []byte("another-challenge"))
-	hn.seed(t, "/api/db", []byte("stored-secret"))
+	stored := []byte("stored-secret")
+	hn.seed(t, "/api/db", stored)
 	w := do(hn.h, hn.requestWithToken(t, http.MethodGet, "/api/db", hn.leaf, token, []byte("this-request")))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("token for another challenge = %d, want 403", w.Code)
 	}
-	if strings.Contains(w.Body.String(), "value") {
-		t.Fatalf("a refused token released a value: %s", w.Body)
-	}
+	assertNoRelease(t, w, stored)
 }
 
 // A floor image the entry does not declare is still foreign: floor membership
@@ -513,27 +521,35 @@ func TestEntryWithoutGrantRefused(t *testing.T) {
 // declares is running, the sandbox matches nothing and is refused.
 func TestReleaseRefusedUntilEveryMainIsRunning(t *testing.T) {
 	hn := newHarness(t)
+	stored := []byte("stored-secret")
+	hn.seed(t, "/api/db", stored)
 	hn.inv.containers = []workloadclaims.SandboxContainer{
 		{Digest: testAppImg, Argv: []string{"/serve"}},
 		{Digest: testInjected, Argv: []string{"get-cert", "--san=x"}},
 	}
-	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+	w := do(hn.h, hn.request(t, http.MethodGet, "/api/db"))
+	if w.Code != http.StatusForbidden {
 		t.Fatalf("one main not yet running = %d, want 403", w.Code)
 	}
+	assertNoRelease(t, w, stored)
 }
 
-// Two entries the running set satisfies equally are a refusal, through the
-// release path itself rather than the diagnostic.
+// Two entries the running set satisfies equally are a refusal, driven through
+// Handler.authorize.
 func TestAmbiguousMatchRefused(t *testing.T) {
 	hn := newHarness(t)
+	stored := []byte("stored-secret")
+	hn.seed(t, "/api/db", stored)
 	al, err := hn.h.Policy.Allowlist()
 	if err != nil {
 		t.Fatal(err)
 	}
 	al.Workloads["api-copy"] = al.Workloads["api"]
-	if w := do(hn.h, hn.request(t, http.MethodGet, "/api/db")); w.Code != http.StatusForbidden {
+	w := do(hn.h, hn.request(t, http.MethodGet, "/api/db"))
+	if w.Code != http.StatusForbidden {
 		t.Fatalf("ambiguous match = %d, want 403", w.Code)
 	}
+	assertNoRelease(t, w, stored)
 }
 
 // The grant honoured is the matched entry's own: a path only another entry
@@ -615,8 +631,8 @@ func TestEmptyFloorRefuses(t *testing.T) {
 }
 
 // Logs leave the TEE (docs/engineering-standards.md §8), so a secret value
-// must never reach one — on a served read, a denial, a miss, or a store
-// failure alike.
+// must never reach one — on a served read, a create that mints it, a denial,
+// a miss, or a store failure alike.
 func TestSecretValueNeverReachesTheLog(t *testing.T) {
 	hn := newHarness(t)
 	var log bytes.Buffer
@@ -633,6 +649,18 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 		t.Fatalf("read = %d (%s), want 200 carrying the value", w.Code, w.Body)
 	}
 
+	// The create's body carries the minted value by design; parse it out so
+	// the log can be checked against those exact bytes.
+	created := do(hn.h, hn.request(t, http.MethodPost, "/api/new"))
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create = %d (%s), want 201", created.Code, created.Body)
+	}
+	mintedB64 := decodeValue(t, created)
+	minted, err := base64.StdEncoding.DecodeString(mintedB64)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	impostor, err := workloadclaims.NewSandboxTokenSigner(testHost)
 	if err != nil {
 		t.Fatal(err)
@@ -642,10 +670,18 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 		mintToken(t, impostor, testSandbox, hn.leaf.PublicKey, nonce), nonce))
 	ungranted := do(hn.h, hn.request(t, http.MethodGet, "/other/db"))
 	missing := do(hn.h, hn.request(t, http.MethodGet, "/api/never-created"))
+	deniedCreate := do(hn.h, hn.request(t, http.MethodPost, "/other/db"))
 
 	hn.h.Store = failingStore{err: fmt.Errorf("backend down")}
 	unavailable := do(hn.h, hn.requestWith(t, http.MethodGet, "/api/db", hn.leaf, testSandbox, []byte("store-down")))
+	failedCreate := do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
 
+	// minted is binary: a text log would carry it quoted, as base64, or as a
+	// byte dump, so raw containment alone is not enough.
+	leaks := []string{
+		string(value), valueB64,
+		string(minted), mintedB64, strconv.Quote(string(minted)), fmt.Sprintf("%v", minted),
+	}
 	drives := []struct {
 		name string
 		w    *httptest.ResponseRecorder
@@ -654,13 +690,15 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 		{"denied read", denied, http.StatusForbidden},
 		{"ungranted path", ungranted, http.StatusNotFound},
 		{"absent secret", missing, http.StatusNotFound},
+		{"denied create", deniedCreate, http.StatusNotFound},
 		{"store failure", unavailable, http.StatusInternalServerError},
+		{"failed create", failedCreate, http.StatusInternalServerError},
 	}
 	for _, d := range drives {
 		if d.w.Code != d.want {
 			t.Fatalf("%s = %d (%s), want %d", d.name, d.w.Code, d.w.Body, d.want)
 		}
-		for _, leak := range []string{string(value), valueB64} {
+		for _, leak := range leaks {
 			if strings.Contains(d.w.Body.String(), leak) {
 				t.Fatalf("%s body carried the secret: %s", d.name, d.w.Body)
 			}
@@ -671,7 +709,7 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 	if !strings.Contains(out, "secret request denied") {
 		t.Fatalf("the denial never reached the captured log; capture is broken:\n%s", out)
 	}
-	for _, leak := range []string{string(value), valueB64} {
+	for _, leak := range leaks {
 		if strings.Contains(out, leak) {
 			t.Fatalf("the secret reached the log as %q:\n%s", leak, out)
 		}


### PR DESCRIPTION
## Summary

Release-path negatives for the secret store, credrelease, and getsecret — the lines binding a secret release to its token, its main containers, and its challenge are now asserted.

- `fakeInventory` widened to per-host keys; `TestTokenSignedByAnotherInventoryRefused`, `TestTokenBoundToAnotherKeyRefused`, `TestTokenForAnotherChallengeRefused` — each 403 with no secret in the body.
- Two-main harness: `TestReleaseRefusedUntilEveryMainIsRunning`, `TestAmbiguousMatchRefused` (through `Handler.authorize`), `TestGrantOfAnotherEntryIsNotHonoured`.
- `TestChallengeIsConsumedEvenOnDenial`: 403 first, then the same nonce with a valid token → 400.
- `TestReleaseRefusesATokenBoundToAnotherCSR` (credrelease): token over `bodyA`, POST `bodyB` → 401, no certificate issued.
- `TestSecretValueNeverReachesTheLog`: slog captured at Debug, driven 200/403/404/500, asserting the seeded sentinel and its base64 appear in neither log nor body (with non-vacuity controls); mirrored in getsecret.

## Mutation evidence (each verified against real code, then reverted; independently reproduced in review)

| Test | Mutation | Observed |
|---|---|---|
| TestTokenSignedByAnotherInventoryRefused | drop `ecdsa.VerifyASN1` check | 200 (released), want 403 |
| challenge-consumption tests | reorder consume-before-deny | second request mints 201 with a secret |
| TestReleaseRefusesATokenBoundToAnotherCSR | drop the `pbh` body binding | 200 with an O=system:masters cert |
| TestSecretValueNeverReachesTheLog | log the value / its base64 in servePost | test fails (both forms) |
| gate/ambiguity tests | bypass the main-running gate | 200 + release instead of refusal |

(Full table in the commit history / branch summary; 13/13 mutants killed.)

## Tests

`make test` green (64 packages, `-race`); lint clean. Test-only change; no production behaviour changes. The volumed/getvolume log mirror is out of scope (covered by #51's issue).
