### PR TITLE
fix(verify): report debug/smt/report_data from the verified claims; pin the attest nonce

### DIFF
--- a/internal/cmds/getkubeconfig/cmd_test.go
+++ b/internal/cmds/getkubeconfig/cmd_test.go
@@ -62,7 +62,7 @@ func TestNewCmdValidation(t *testing.T) {
 // TestNewCmdEndToEnd runs the whole command against the fake node: flags,
 // attest gate, RA-TLS release, kubeconfig on disk.
 func TestNewCmdEndToEnd(t *testing.T) {
-	env := newTestEnv(t, http.StatusOK, http.StatusOK, goodRelease)
+	env := newTestEnv(t, newAttestStub(t).URL+"/attest", http.StatusOK, goodRelease)
 
 	err := execCmd(t,
 		"--attest-url", env.attestURL,

--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -1,6 +1,7 @@
 package getkubeconfig
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/ed25519"
@@ -23,8 +24,10 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/credrelease"
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // tdxEnvelope is a minimal self-describing evidence envelope; the actual
@@ -52,27 +55,25 @@ func newAttestedTLSServer(t *testing.T, handler http.Handler) *httptest.Server {
 	return srv
 }
 
-// attestHandler serves POST /attest with the given status; on 200 it returns
-// the TDX evidence envelope after checking the request shape.
-func attestHandler(t *testing.T, status int) http.Handler {
+// newAttestStub starts the shared fake attestation-api (internal/testattest)
+// reporting the TDX platform the trust gate requires; the recorded requests
+// let tests pin what production code sent.
+func newAttestStub(t *testing.T) *testattest.Stub {
 	t.Helper()
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("attest method = %s, want POST", r.Method)
-		}
-		var req map[string]string
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("attest body: %v", err)
-		}
-		if nonce, err := base64.StdEncoding.DecodeString(req["report_data"]); err != nil || len(nonce) != 32 {
-			t.Errorf("attest report_data = %q, want base64 32-byte nonce", req["report_data"])
-		}
-		if status != http.StatusOK {
-			http.Error(w, "attest boom", status)
-			return
-		}
-		fmt.Fprint(w, tdxEnvelope)
-	})
+	stub := testattest.New(t)
+	stub.SetPlatform(types.PlatformTdx)
+	return stub
+}
+
+// failingAttest serves POST /attest with the given status — the attest gate's
+// HTTP failure path.
+func failingAttest(t *testing.T, status int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "attest boom", status)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 // releaseHandler serves POST /release-credential with the given status; on 200
@@ -114,7 +115,7 @@ type testEnv struct {
 	exp          measuredPolicy
 }
 
-func newTestEnv(t *testing.T, attestStatus, releaseStatus int, releaseBody string) testEnv {
+func newTestEnv(t *testing.T, attestURL string, releaseStatus int, releaseBody string) testEnv {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
@@ -137,14 +138,12 @@ func newTestEnv(t *testing.T, attestStatus, releaseStatus int, releaseBody strin
 	}
 	stubVerify(t, verifiedResultFor(exp), nil)
 
-	attest := httptest.NewServer(attestHandler(t, attestStatus))
-	t.Cleanup(attest.Close)
 	release := newAttestedTLSServer(t, releaseHandler(t, releaseStatus, releaseBody))
 
 	return testEnv{
 		keyPath:      keyPath,
 		manifestPath: manifestPath,
-		attestURL:    attest.URL + "/attest",
+		attestURL:    attestURL,
 		releaseURL:   release.URL,
 		outPath:      filepath.Join(dir, "kubeconfig"),
 		exp:          exp,
@@ -171,7 +170,7 @@ func (e testEnv) config() Config {
 // gate, RA-TLS dial (verified via the stub), operator-signed CSR exchange, and
 // kubeconfig assembly on disk.
 func TestRunEndToEnd(t *testing.T) {
-	env := newTestEnv(t, http.StatusOK, http.StatusOK, goodRelease)
+	env := newTestEnv(t, newAttestStub(t).URL+"/attest", http.StatusOK, goodRelease)
 
 	if err := Run(context.Background(), env.config()); err != nil {
 		t.Fatalf("Run: %v", err)
@@ -193,9 +192,44 @@ func TestRunEndToEnd(t *testing.T) {
 	}
 }
 
+// TestAttestNonceIsFreshPerRun pins the attest gate's freshness: each run
+// sends a fresh random nonce to /attest and asks the verifier to bind exactly
+// those bytes. Replacing rand.Read(nonce) with a constant fails this — the
+// gate would accept one recorded genuine quote replayed forever.
+func TestAttestNonceIsFreshPerRun(t *testing.T) {
+	attest := newAttestStub(t)
+	exp := testPolicy(t, operatorPub(t))
+	rec := stubVerify(t, verifiedResultFor(exp), nil)
+
+	for i := 0; i < 2; i++ {
+		if err := attestAndVerify(context.Background(), attest.URL+"/attest", exp); err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+	}
+
+	reqs := attest.AttestRequests()
+	calls := rec.all()
+	if len(reqs) != 2 || len(calls) != 2 {
+		t.Fatalf("attest requests = %d, verifier calls = %d, want 2 each", len(reqs), len(calls))
+	}
+	for i := range reqs {
+		nonce := reqs[i].ReportData.Bytes()
+		if len(nonce) != 32 {
+			t.Errorf("run %d: /attest nonce is %d bytes, want 32", i, len(nonce))
+		}
+		if !bytes.Equal(calls[i].params.ExpectedReportData, nonce) {
+			t.Errorf("run %d: verifier asked to bind %x, but /attest was sent %x",
+				i, calls[i].params.ExpectedReportData, nonce)
+		}
+	}
+	if bytes.Equal(reqs[0].ReportData.Bytes(), reqs[1].ReportData.Bytes()) {
+		t.Error("the attest nonce is constant across runs — a recorded genuine quote replays forever")
+	}
+}
+
 func TestRunErrors(t *testing.T) {
 	t.Run("attest gate HTTP failure", func(t *testing.T) {
-		cfg := newTestEnv(t, http.StatusInternalServerError, http.StatusOK, goodRelease).config()
+		cfg := newTestEnv(t, failingAttest(t, http.StatusInternalServerError).URL+"/attest", http.StatusOK, goodRelease).config()
 		err := Run(context.Background(), cfg)
 		if err == nil || !strings.Contains(err.Error(), "attestation gate") ||
 			!strings.Contains(err.Error(), "attest HTTP 500") {
@@ -204,7 +238,7 @@ func TestRunErrors(t *testing.T) {
 	})
 
 	t.Run("release failure", func(t *testing.T) {
-		cfg := newTestEnv(t, http.StatusOK, http.StatusForbidden, goodRelease).config()
+		cfg := newTestEnv(t, newAttestStub(t).URL+"/attest", http.StatusForbidden, goodRelease).config()
 		err := Run(context.Background(), cfg)
 		if err == nil || !strings.Contains(err.Error(), "credential release") ||
 			!strings.Contains(err.Error(), "release HTTP 403") {
@@ -217,7 +251,7 @@ func TestRunErrors(t *testing.T) {
 // verifies but rtmr_3 doesn't match the operator-key chain, so Run must stop
 // before ever contacting cred-release.
 func TestRunRejectsWrongRTMR3(t *testing.T) {
-	env := newTestEnv(t, http.StatusOK, http.StatusOK, goodRelease)
+	env := newTestEnv(t, newAttestStub(t).URL+"/attest", http.StatusOK, goodRelease)
 	res := verifiedResultFor(env.exp)
 	res.Claims.PlatformData["rtmr_3"] = "00"
 	stubVerify(t, res, nil) // overrides the env's stub
@@ -245,7 +279,7 @@ func TestRunRejectsWrongRTMR3(t *testing.T) {
 // TestRATLSClientRejectsPlainCert confirms the RA-TLS dial fails closed
 // against a server whose cert carries no attestation envelope (a host MITM).
 func TestRATLSClientRejectsPlainCert(t *testing.T) {
-	env := newTestEnv(t, http.StatusOK, http.StatusOK, goodRelease)
+	env := newTestEnv(t, newAttestStub(t).URL+"/attest", http.StatusOK, goodRelease)
 	plain := httptest.NewTLSServer(releaseHandler(t, http.StatusOK, goodRelease))
 	t.Cleanup(plain.Close)
 

--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -104,8 +104,9 @@ func releaseHandler(t *testing.T, status int, respBody string) http.Handler {
 }
 
 // testEnv wires up a full fake node: operator key + image manifest on disk,
-// attest endpoint, RA-TLS cred-release endpoint, and a stubbed verifier that
-// accepts iff the claims satisfy the full measured-identity policy.
+// the caller's attest endpoint URL, RA-TLS cred-release endpoint, and a
+// stubbed verifier that accepts iff the claims satisfy the full
+// measured-identity policy.
 type testEnv struct {
 	keyPath      string
 	manifestPath string

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -1,6 +1,7 @@
 package getkubeconfig
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -13,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -98,16 +100,47 @@ func attestedCert(t *testing.T, envelope types.AttestationEvidence) *x509.Certif
 	return cert
 }
 
+// capturedVerify records one call to the stubbed verifier: the evidence
+// envelope and the params production code asked it to enforce.
+type capturedVerify struct {
+	envelope []byte
+	params   teetypes.VerifyParams
+}
+
+// verifyRecorder collects verifier calls; the RA-TLS dial can invoke the
+// verifier off the test goroutine, so reads and writes go through the mutex.
+type verifyRecorder struct {
+	mu    sync.Mutex
+	calls []capturedVerify
+}
+
+func (r *verifyRecorder) add(envelope []byte, params teetypes.VerifyParams) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, capturedVerify{envelope, params})
+}
+
+func (r *verifyRecorder) all() []capturedVerify {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]capturedVerify(nil), r.calls...)
+}
+
 // stubVerify replaces the in-process attestation-go verifier with one that
-// returns the given result/error. Lets the tests drive verifyServerCert's
-// post-verification logic deterministically without real hardware.
-func stubVerify(t *testing.T, res *teetypes.VerificationResult, err error) {
+// returns the given result/error and records what it was asked to check, so
+// tests can pin the request side (the report_data binding), not just the
+// verdict. Lets the tests drive verifyServerCert's post-verification logic
+// deterministically without real hardware.
+func stubVerify(t *testing.T, res *teetypes.VerificationResult, err error) *verifyRecorder {
 	t.Helper()
+	rec := &verifyRecorder{}
 	orig := verifyEnvelope
-	verifyEnvelope = func([]byte, teetypes.VerifyParams) (*teetypes.VerificationResult, error) {
+	verifyEnvelope = func(envelope []byte, params teetypes.VerifyParams) (*teetypes.VerificationResult, error) {
+		rec.add(envelope, params)
 		return res, err
 	}
 	t.Cleanup(func() { verifyEnvelope = orig })
+	return rec
 }
 
 // verifiedResultFor builds a passing VerificationResult whose claims satisfy
@@ -220,11 +253,24 @@ func TestVerifyServerCertRejectsEachMismatchedRegister(t *testing.T) {
 func TestVerifyServerCertAccepts(t *testing.T) {
 	// Genuine quote, bound to the cert key, full measured identity: accept.
 	exp := testPolicy(t, operatorPub(t))
-	stubVerify(t, verifiedResultFor(exp), nil)
+	rec := stubVerify(t, verifiedResultFor(exp), nil)
 	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx", Evidence: json.RawMessage(`{}`)})
 
 	if err := verifyServerCert(cert, exp); err != nil {
 		t.Fatalf("want accept, got %v", err)
+	}
+	// The verifier must be asked to bind the quote to THIS cert's public key —
+	// the check that ties the RA-TLS channel to the attested guest.
+	want, err := ratls.ReportDataForKey(cert.PublicKey, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := rec.all()
+	if len(calls) != 1 {
+		t.Fatalf("verifier calls = %d, want 1", len(calls))
+	}
+	if !bytes.Equal(calls[0].params.ExpectedReportData, want[:]) {
+		t.Errorf("report_data binding = %x, want SHA-384(cert key) %x", calls[0].params.ExpectedReportData, want[:])
 	}
 }
 

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -879,12 +879,13 @@ type Outcome struct {
 	Platform    string    `json:"platform,omitempty"`
 	Measurement string    `json:"measurement,omitempty"`
 	ReportData  string    `json:"report_data,omitempty"`
-	Debug       bool      `json:"debug,omitempty"`
-	SMT         bool      `json:"smt,omitempty"`
-	CurrentTCB  string    `json:"current_tcb,omitempty"`
-	CertSHA256  string    `json:"cert_sha256,omitempty"`
-	Pinned      bool      `json:"measurement_pinned"`
-	Error       string    `json:"error,omitempty"`
+	// Debug and SMT omit omitempty: an absent key reads as false to a CI gate.
+	Debug      bool   `json:"debug"`
+	SMT        bool   `json:"smt"`
+	CurrentTCB string `json:"current_tcb,omitempty"`
+	CertSHA256 string `json:"cert_sha256,omitempty"`
+	Pinned     bool   `json:"measurement_pinned"`
+	Error      string `json:"error,omitempty"`
 
 	// RTMRsPinned lists the TDX runtime measurement registers this verdict
 	// enforced, as "<index>:<hex>". On TDX the --measurements pin covers only
@@ -1113,6 +1114,8 @@ func newOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, v
 	}
 	oc.Measurement = result.Claims.LaunchDigest
 	oc.CurrentTCB = formatTCB(result.Claims.TCB)
+	oc.ReportData = hex.EncodeToString(result.Claims.ReportData)
+	oc.Debug, oc.SMT = reportFlags(oc.Platform, result.Claims.PlatformData)
 
 	// The TDX-only gate runs before any register is compared: on non-TDX
 	// evidence an MRTD/RTMR pin cannot be enforced at all, and reporting a
@@ -1330,6 +1333,21 @@ func minTCBFromCfg(cfg config) *teetypes.SnpTcb {
 		Snp:        byte(cfg.minTCBSNP),
 		Microcode:  byte(cfg.minTCBMicrocode),
 	}
+}
+
+// reportFlags reads the debug and SMT state the verifier extracted into the
+// platform-specific claims: SNP carries them under policy/platform_info, TDX
+// attests debug under td_attributes_parsed and carries no SMT state.
+func reportFlags(platform string, pd map[string]any) (debug, smt bool) {
+	nested := func(section, key string) bool {
+		m, _ := pd[section].(map[string]any)
+		v, _ := m[key].(bool)
+		return v
+	}
+	if isTDX(platform) {
+		return nested("td_attributes_parsed", "debug"), false
+	}
+	return nested("policy", "debug_allowed"), nested("platform_info", "smt_enabled")
 }
 
 // formatTCB renders the verified TCB for display: SNP shows its components, TDX

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -879,7 +879,7 @@ type Outcome struct {
 	Platform    string    `json:"platform,omitempty"`
 	Measurement string    `json:"measurement,omitempty"`
 	ReportData  string    `json:"report_data,omitempty"`
-	// Debug and SMT omit omitempty: an absent key reads as false to a CI gate.
+	// Debug and SMT always serialize, even when false: an absent key reads as false to a CI gate.
 	Debug      bool   `json:"debug"`
 	SMT        bool   `json:"smt"`
 	CurrentTCB string `json:"current_tcb,omitempty"`
@@ -1337,7 +1337,10 @@ func minTCBFromCfg(cfg config) *teetypes.SnpTcb {
 
 // reportFlags reads the debug and SMT state the verifier extracted into the
 // platform-specific claims: SNP carries them under policy/platform_info, TDX
-// attests debug under td_attributes_parsed and carries no SMT state.
+// attests debug under td_attributes_parsed and carries no SMT state (smt:false
+// means unattested, not off). attestation-go routes all six supported platforms
+// through one of these two claim layouts, so the non-TDX branch is SNP-shaped
+// by exhaustion.
 func reportFlags(platform string, pd map[string]any) (debug, smt bool) {
 	nested := func(section, key string) bool {
 		m, _ := pd[section].(map[string]any)

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -920,6 +920,60 @@ func TestRenderOutcome(t *testing.T) {
 		if !oc.Verified || oc.Measurement != measHex {
 			t.Errorf("unexpected outcome: %+v", oc)
 		}
+		// The security booleans must serialize even when false: a gate reading
+		// an absent key cannot tell "reported false" from "never checked".
+		var raw map[string]any
+		if err := json.Unmarshal(out.Bytes(), &raw); err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"debug", "smt"} {
+			v, present := raw[key]
+			if !present {
+				t.Errorf("json verdict omits %q — absent reads as false to a CI gate", key)
+			} else if v != false {
+				t.Errorf("json %q = %v, want false for these claims", key, v)
+			}
+		}
+	})
+
+	t.Run("debug/smt/report_data come from the verified claims", func(t *testing.T) {
+		snpResult := &teetypes.VerificationResult{
+			SignatureValid: true,
+			Platform:       teetypes.PlatformSNP,
+			Claims: teetypes.Claims{
+				LaunchDigest: measHex,
+				ReportData:   bytes.Repeat([]byte{0xAB}, 64),
+				PlatformData: map[string]any{
+					"policy":        map[string]any{"debug_allowed": true, "smt_allowed": true},
+					"platform_info": map[string]any{"smt_enabled": false},
+				},
+			},
+		}
+		oc := newOutcome(config{}, ev, snpResult, nil, emptyPlan())
+		if !oc.Debug {
+			t.Error("SNP policy.debug_allowed=true must surface as debug=true")
+		}
+		if oc.SMT {
+			t.Error("SMT must report platform_info.smt_enabled (false), not policy.smt_allowed")
+		}
+		if want := strings.Repeat("ab", 64); oc.ReportData != want {
+			t.Errorf("report_data = %q, want the claims' report_data %q", oc.ReportData, want)
+		}
+
+		tdxResult := &teetypes.VerificationResult{
+			SignatureValid: true,
+			Platform:       teetypes.PlatformTDX,
+			Claims: teetypes.Claims{
+				LaunchDigest: measHex,
+				PlatformData: map[string]any{
+					"td_attributes_parsed": map[string]any{"debug": true},
+				},
+			},
+		}
+		oc = newOutcome(config{}, ev, tdxResult, nil, emptyPlan())
+		if !oc.Debug || oc.SMT {
+			t.Errorf("TDX td_attributes debug=true must surface as debug=true (smt unattested), got %+v", oc)
+		}
 	})
 
 	t.Run("verdict error -> NOT VERIFIED", func(t *testing.T) {
@@ -1249,11 +1303,34 @@ func TestRenderTextSections(t *testing.T) {
 		}
 	})
 
-	t.Run("show-evidence prints the report data", func(t *testing.T) {
+	// The security section is only truthful if it comes from the verified
+	// claims: drive it through newOutcome with a debug=true SNP report.
+	t.Run("show-evidence prints the claims' security state", func(t *testing.T) {
+		ev := &evidence{platform: "snp", source: "test", bindingNote: "test binding", fresh: true}
+		result := &teetypes.VerificationResult{
+			SignatureValid: true,
+			Platform:       teetypes.PlatformSNP,
+			Claims: teetypes.Claims{
+				LaunchDigest: "ab" + strings.Repeat("00", 47),
+				ReportData:   bytes.Repeat([]byte{0xde, 0xad, 0xbe, 0xef}, 16),
+				PlatformData: map[string]any{
+					"policy":        map[string]any{"debug_allowed": true, "smt_allowed": true},
+					"platform_info": map[string]any{"smt_enabled": true},
+				},
+			},
+		}
+		oc := newOutcome(config{}, ev, result, nil, &verifyPlan{policy: &ratls.VerifyPolicy{}})
+		if !oc.Verified || !oc.Debug || !oc.SMT {
+			t.Fatalf("newOutcome = %+v, want verified with debug=true smt=true", oc)
+		}
 		var out bytes.Buffer
-		renderText(config{showEvidence: true}, Outcome{Verified: true, Fresh: true, Pinned: true, ReportData: "deadbeef"}, &out)
-		if !strings.Contains(out.String(), "report_data:  deadbeef") {
-			t.Errorf("missing report_data with --show-evidence:\n%s", out.String())
+		renderText(config{showEvidence: true}, oc, &out)
+		got := out.String()
+		if !strings.Contains(got, "report_data:  "+strings.Repeat("deadbeef", 16)) {
+			t.Errorf("missing the claims' report_data with --show-evidence:\n%s", got)
+		}
+		if !strings.Contains(got, "debug=true smt=true") {
+			t.Errorf("debug/smt state not rendered from the claims:\n%s", got)
 		}
 	})
 }

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -821,6 +821,38 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 	}
 }
 
+// TestNewOutcomeFromRealGenoaEvidence drives the vendored Genoa fixture
+// through verifyInProcess + newOutcome and asserts the verdict carries the
+// platform's real security state — the report's policy is debug-off and the
+// platform has SMT on, a value no hand-built PlatformData map can
+// accidentally supply. This pins reportFlags against the engine's real claim
+// keys: an attestation-go key rename fails here instead of silently
+// reporting false. No TDX fixture verifies offline, so the TDX mapping keeps
+// only the hand-built pin in TestRenderOutcome.
+func TestNewOutcomeFromRealGenoaEvidence(t *testing.T) {
+	fixture, err := os.ReadFile("testdata/snp-evidence-genoa.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := gatherFromFile(fixture, []byte("genoa-test-fixture"), "fixture", leafTrust{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil)
+	if err != nil {
+		t.Fatalf("the real fixture must verify: %v", err)
+	}
+	oc := newOutcome(config{}, ev, res, nil, &verifyPlan{policy: &ratls.VerifyPolicy{}})
+	if !oc.Verified || oc.Debug || !oc.SMT {
+		t.Errorf("outcome = verified:%v debug:%v smt:%v, want verified:true debug:false smt:true", oc.Verified, oc.Debug, oc.SMT)
+	}
+	// The fixture binds ASCII "genoa-test-fixture", zero-padded to 64 bytes.
+	wantRD := hex.EncodeToString([]byte("genoa-test-fixture")) + strings.Repeat("00", 64-len("genoa-test-fixture"))
+	if oc.ReportData != wantRD {
+		t.Errorf("report_data = %q, want the fixture's %q", oc.ReportData, wantRD)
+	}
+}
+
 func TestGatherFromEndpoint_Integration(t *testing.T) {
 	report := bytes.Repeat([]byte{0x01}, 64)
 	x := bytes.Repeat([]byte{0x02}, overenc.X25519PubBytes)

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -823,12 +823,14 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 
 // TestNewOutcomeFromRealGenoaEvidence drives the vendored Genoa fixture
 // through verifyInProcess + newOutcome and asserts the verdict carries the
-// platform's real security state — the report's policy is debug-off and the
-// platform has SMT on, a value no hand-built PlatformData map can
-// accidentally supply. This pins reportFlags against the engine's real claim
-// keys: an attestation-go key rename fails here instead of silently
-// reporting false. No TDX fixture verifies offline, so the TDX mapping keeps
-// only the hand-built pin in TestRenderOutcome.
+// platform's real security state — the platform has SMT on, a value no
+// hand-built PlatformData map can accidentally supply. The debug-off policy
+// is pinned by the key's presence in the real claims: the fixture's value is
+// the zero value, so value alone cannot catch a renamed key. Together these
+// pin reportFlags against the engine's real claim keys: an attestation-go
+// key rename fails here instead of silently reporting false. No TDX fixture
+// verifies offline, so the TDX mapping keeps only the hand-built pin in
+// TestRenderOutcome.
 func TestNewOutcomeFromRealGenoaEvidence(t *testing.T) {
 	fixture, err := os.ReadFile("testdata/snp-evidence-genoa.json")
 	if err != nil {
@@ -841,6 +843,13 @@ func TestNewOutcomeFromRealGenoaEvidence(t *testing.T) {
 	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil)
 	if err != nil {
 		t.Fatalf("the real fixture must verify: %v", err)
+	}
+	pol, ok := res.Claims.PlatformData["policy"].(map[string]any)
+	if !ok {
+		t.Fatalf("real claims carry no policy map, got %T", res.Claims.PlatformData["policy"])
+	}
+	if _, ok := pol["debug_allowed"].(bool); !ok {
+		t.Fatalf("real claims lack a bool policy.debug_allowed — reportFlags would read a renamed key as false; policy = %v", pol)
 	}
 	oc := newOutcome(config{}, ev, res, nil, &verifyPlan{policy: &ratls.VerifyPolicy{}})
 	if !oc.Verified || oc.Debug || !oc.SMT {

--- a/internal/localverify/localverify.go
+++ b/internal/localverify/localverify.go
@@ -89,24 +89,32 @@ func Verify(ctx context.Context, platform string, evidence json.RawMessage, p Pa
 		// reachable-but-rejected outcome, i.e. a security verdict.
 		return nil, err
 	}
-	// Defense in depth: a nil error already implies these, but never report a
-	// success the result contradicts.
-	if !res.SignatureValid {
-		return nil, fmt.Errorf("verifier returned signature_valid=false")
+	if err := enforceResult(res, p); err != nil {
+		return nil, err
 	}
-	if params.ExpectedReportData != nil && (res.ReportDataMatch == nil || !*res.ReportDataMatch) {
-		return nil, fmt.Errorf("REPORTDATA does not match the expected binding (report_data_match not true)")
+	return res, nil
+}
+
+// enforceResult re-checks the verdict against p on the verifier's own claims.
+// Defense in depth: a nil dispatch error already implies these, but never
+// report a success the result contradicts.
+func enforceResult(res *teetypes.VerificationResult, p Params) error {
+	if !res.SignatureValid {
+		return fmt.Errorf("verifier returned signature_valid=false")
+	}
+	if p.ExpectedReportData != nil && (res.ReportDataMatch == nil || !*res.ReportDataMatch) {
+		return fmt.Errorf("REPORTDATA does not match the expected binding (report_data_match not true)")
 	}
 	if len(p.Measurements) > 0 {
 		mb, err := hex.DecodeString(res.Claims.LaunchDigest)
 		if err != nil || len(mb) == 0 {
-			return nil, fmt.Errorf("cannot enforce the measurement pin: launch digest missing or malformed (%q)", res.Claims.LaunchDigest)
+			return fmt.Errorf("cannot enforce the measurement pin: launch digest missing or malformed (%q)", res.Claims.LaunchDigest)
 		}
 		if !attestationclient.MeasurementAllowed(mb, p.Measurements) {
-			return nil, fmt.Errorf("%w (launch digest %s)", ErrMeasurementNotAllowed, res.Claims.LaunchDigest)
+			return fmt.Errorf("%w (launch digest %s)", ErrMeasurementNotAllowed, res.Claims.LaunchDigest)
 		}
 	}
-	return res, nil
+	return nil
 }
 
 // dispatch routes evidence to attestation-go. The envelope path

--- a/internal/localverify/tamper_test.go
+++ b/internal/localverify/tamper_test.go
@@ -68,8 +68,8 @@ func (p *genoaParts) evidence(t *testing.T) json.RawMessage {
 	return out
 }
 
-// foreignVCEKDER mints a self-signed P-384 certificate: no AMD key material
-// exists offline, so a forged or out-of-window VCEK is necessarily self-signed.
+// foreignVCEKDER mints a self-signed P-384 certificate: the offline stand-in
+// for a forged or expired VCEK.
 func foreignVCEKDER(t *testing.T, notBefore, notAfter time.Time) []byte {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
@@ -93,7 +93,8 @@ func foreignVCEKDER(t *testing.T, notBefore, notAfter time.Time) []byte {
 // mutated one way per case and asserts each failure is a verdict (a plain
 // error, which the CLI maps to exit 2), never a CollateralError (exit 3, "no
 // verdict, retry") — a host tampering with evidence must not read as an
-// infrastructure hiccup.
+// infrastructure hiccup. wantErr pins the rejection cause, so fixture drift
+// that moves a case's failure off its named path fails here.
 func TestVerifyRejectsTamperedEvidence(t *testing.T) {
 	now := time.Now()
 
@@ -104,20 +105,31 @@ func TestVerifyRejectsTamperedEvidence(t *testing.T) {
 	})
 
 	for _, tc := range []struct {
-		name  string
-		wreck func(t *testing.T, p *genoaParts)
+		name    string
+		wantErr string
+		wreck   func(t *testing.T, p *genoaParts)
 	}{
-		{"wrong signature", func(t *testing.T, p *genoaParts) { p.report[snpSignatureOff] ^= 0x01 }},
-		{"foreign VCEK", func(t *testing.T, p *genoaParts) {
+		{"wrong signature", "report signature verification error", func(t *testing.T, p *genoaParts) {
+			p.report[snpSignatureOff] ^= 0x01
+		}},
+		{"foreign VCEK", "reading VCEK product extension", func(t *testing.T, p *genoaParts) {
 			p.vcek = foreignVCEKDER(t, now.Add(-time.Hour), now.Add(time.Hour))
 		}},
-		{"broken chain", func(t *testing.T, p *genoaParts) { p.vcek[len(p.vcek)-20] ^= 0x01 }},
-		{"expired VCEK", func(t *testing.T, p *genoaParts) {
+		{"broken chain", "certificate signed by unknown authority", func(t *testing.T, p *genoaParts) {
+			p.vcek[len(p.vcek)-20] ^= 0x01
+		}},
+		// The self-signed expired stand-in is rejected at VCEK extension parsing.
+		{"expired VCEK", "reading VCEK product extension", func(t *testing.T, p *genoaParts) {
 			p.vcek = foreignVCEKDER(t, now.Add(-2*time.Hour), now.Add(-time.Hour))
 		}},
-		{"truncated report", func(t *testing.T, p *genoaParts) { p.report = p.report[:len(p.report)/2] }},
-		{"zero-filled report", func(t *testing.T, p *genoaParts) { p.report = make([]byte, len(p.report)) }},
-		{"in-report TCB downgrade", func(t *testing.T, p *genoaParts) {
+		{"truncated report", "array size is 0x250", func(t *testing.T, p *genoaParts) {
+			p.report = p.report[:len(p.report)/2]
+		}},
+		{"zero-filled report", "malformed guest policy", func(t *testing.T, p *genoaParts) {
+			p.report = make([]byte, len(p.report))
+		}},
+		// Zeroing reported_tcb breaks the VCEK signature over the report.
+		{"in-report TCB downgrade", "report signature verification error", func(t *testing.T, p *genoaParts) {
 			copy(p.report[snpReportedTCBOff:snpReportedTCBOff+8], make([]byte, 8))
 		}},
 	} {
@@ -127,6 +139,9 @@ func TestVerifyRejectsTamperedEvidence(t *testing.T) {
 			_, err := Verify(context.Background(), "snp", p.evidence(t), Params{})
 			if err == nil {
 				t.Fatal("tampered evidence must be rejected")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("rejection = %q, want cause %q", err, tc.wantErr)
 			}
 			var ce *CollateralError
 			if errors.As(err, &ce) {

--- a/internal/localverify/tamper_test.go
+++ b/internal/localverify/tamper_test.go
@@ -1,0 +1,216 @@
+package localverify
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+// SNP report field offsets (AMD SEV-SNP ABI, attestation report structure).
+const (
+	snpReportedTCBOff = 0x180
+	snpSignatureOff   = 0x2A0
+)
+
+// genoaParts is the decoded real Genoa fixture — the SNP report and its VCEK
+// DER — so a tamper case can wreck either part and re-pack the evidence.
+type genoaParts struct {
+	report []byte
+	vcek   []byte
+}
+
+func loadGenoaParts(t *testing.T) *genoaParts {
+	t.Helper()
+	_, evidence := envelopeFixture(t, "snp-evidence-genoa.json")
+	var env struct {
+		AttestationReport string `json:"attestation_report"`
+		CertChain         struct {
+			VCEK string `json:"vcek"`
+		} `json:"cert_chain"`
+	}
+	if err := json.Unmarshal(evidence, &env); err != nil {
+		t.Fatal(err)
+	}
+	report, err := base64.StdEncoding.DecodeString(env.AttestationReport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vcek, err := base64.StdEncoding.DecodeString(env.CertChain.VCEK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &genoaParts{report: report, vcek: vcek}
+}
+
+func (p *genoaParts) evidence(t *testing.T) json.RawMessage {
+	t.Helper()
+	out, err := json.Marshal(map[string]any{
+		"attestation_report": base64.StdEncoding.EncodeToString(p.report),
+		"cert_chain":         map[string]string{"vcek": base64.StdEncoding.EncodeToString(p.vcek)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// foreignVCEKDER mints a self-signed P-384 certificate: no AMD key material
+// exists offline, so a forged or out-of-window VCEK is necessarily self-signed.
+func foreignVCEKDER(t *testing.T, notBefore, notAfter time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "foreign VCEK"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return der
+}
+
+// TestVerifyRejectsTamperedEvidence feeds the verifier the real Genoa evidence
+// mutated one way per case and asserts each failure is a verdict (a plain
+// error, which the CLI maps to exit 2), never a CollateralError (exit 3, "no
+// verdict, retry") — a host tampering with evidence must not read as an
+// infrastructure hiccup.
+func TestVerifyRejectsTamperedEvidence(t *testing.T) {
+	now := time.Now()
+
+	t.Run("control: the untampered fixture verifies", func(t *testing.T) {
+		if _, err := Verify(context.Background(), "snp", loadGenoaParts(t).evidence(t), Params{}); err != nil {
+			t.Fatalf("the unmutated fixture must verify: %v", err)
+		}
+	})
+
+	for _, tc := range []struct {
+		name  string
+		wreck func(t *testing.T, p *genoaParts)
+	}{
+		{"wrong signature", func(t *testing.T, p *genoaParts) { p.report[snpSignatureOff] ^= 0x01 }},
+		{"foreign VCEK", func(t *testing.T, p *genoaParts) {
+			p.vcek = foreignVCEKDER(t, now.Add(-time.Hour), now.Add(time.Hour))
+		}},
+		{"broken chain", func(t *testing.T, p *genoaParts) { p.vcek[len(p.vcek)-20] ^= 0x01 }},
+		{"expired VCEK", func(t *testing.T, p *genoaParts) {
+			p.vcek = foreignVCEKDER(t, now.Add(-2*time.Hour), now.Add(-time.Hour))
+		}},
+		{"truncated report", func(t *testing.T, p *genoaParts) { p.report = p.report[:len(p.report)/2] }},
+		{"zero-filled report", func(t *testing.T, p *genoaParts) { p.report = make([]byte, len(p.report)) }},
+		{"in-report TCB downgrade", func(t *testing.T, p *genoaParts) {
+			copy(p.report[snpReportedTCBOff:snpReportedTCBOff+8], make([]byte, 8))
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := loadGenoaParts(t)
+			tc.wreck(t, p)
+			_, err := Verify(context.Background(), "snp", p.evidence(t), Params{})
+			if err == nil {
+				t.Fatal("tampered evidence must be rejected")
+			}
+			var ce *CollateralError
+			if errors.As(err, &ce) {
+				t.Fatalf("tampered evidence classified as CollateralError (exit 3, no verdict): %v", err)
+			}
+		})
+	}
+}
+
+// TestEnforceResult drives the post-verification re-checks directly. Genuine
+// evidence can never reach them (the engine returns an error instead of a
+// self-contradicting verdict), so only a unit call covers the branches.
+func TestEnforceResult(t *testing.T) {
+	digest := strings.Repeat("ab", 48)
+	good := func() *teetypes.VerificationResult {
+		return &teetypes.VerificationResult{
+			SignatureValid:  true,
+			ReportDataMatch: teetypes.Ptr(true),
+			Claims:          teetypes.Claims{LaunchDigest: digest},
+		}
+	}
+	anchor := Params{ExpectedReportData: []byte("nonce")}
+
+	t.Run("passing verdict", func(t *testing.T) {
+		if err := enforceResult(good(), anchor); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+	})
+
+	t.Run("signature_valid false", func(t *testing.T) {
+		res := good()
+		res.SignatureValid = false
+		if err := enforceResult(res, anchor); err == nil || !strings.Contains(err.Error(), "signature_valid=false") {
+			t.Fatalf("want signature_valid rejection, got %v", err)
+		}
+	})
+
+	t.Run("report_data match unreported", func(t *testing.T) {
+		res := good()
+		res.ReportDataMatch = nil
+		if err := enforceResult(res, anchor); err == nil || !strings.Contains(err.Error(), "REPORTDATA") {
+			t.Fatalf("want REPORTDATA rejection, got %v", err)
+		}
+	})
+
+	t.Run("report_data mismatch", func(t *testing.T) {
+		res := good()
+		res.ReportDataMatch = teetypes.Ptr(false)
+		if err := enforceResult(res, anchor); err == nil || !strings.Contains(err.Error(), "REPORTDATA") {
+			t.Fatalf("want REPORTDATA rejection, got %v", err)
+		}
+	})
+
+	t.Run("no anchor skips the binding check", func(t *testing.T) {
+		res := good()
+		res.ReportDataMatch = nil
+		if err := enforceResult(res, Params{}); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+	})
+
+	t.Run("malformed launch digest fails the pin closed", func(t *testing.T) {
+		res := good()
+		res.Claims.LaunchDigest = "zz"
+		p := Params{Measurements: [][]byte{bytes.Repeat([]byte{0xAB}, 48)}}
+		if err := enforceResult(res, p); err == nil || !strings.Contains(err.Error(), "missing or malformed") {
+			t.Fatalf("want malformed-digest rejection, got %v", err)
+		}
+	})
+
+	t.Run("digest outside the allowlist", func(t *testing.T) {
+		p := Params{Measurements: [][]byte{bytes.Repeat([]byte{0x00}, 48)}}
+		if err := enforceResult(good(), p); !errors.Is(err, ErrMeasurementNotAllowed) {
+			t.Fatalf("want ErrMeasurementNotAllowed, got %v", err)
+		}
+	})
+
+	t.Run("pinned digest admitted", func(t *testing.T) {
+		m, err := hex.DecodeString(digest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := enforceResult(good(), Params{ExpectedReportData: []byte("nonce"), Measurements: [][]byte{m}}); err != nil {
+			t.Fatalf("want nil, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

`c8s verify` reported `debug=false smt=false` and an empty `report_data` unconditionally — the `Outcome` fields were declared but never populated. This makes the verdict say only what the evidence supports, and pins the attest nonce against replay.

- `newOutcome` populates `Debug`, `SMT` and `ReportData` from the verified claims; rendering tests drive `newOutcome` with real (Genoa) and claim-level inputs instead of hand-built literals, including a presence/type assertion on the real claims so a dependency claim-key rename fails loudly rather than silently reporting false.
- `omitempty` dropped from the two security booleans: `--json` always carries explicit `debug`/`smt` keys, so "unknown" can no longer masquerade as "false". **Caveat for consumers:** on a *failed* verdict (verification error, no claims) the keys serialize as `false` alongside `"verified": false` and a non-empty `error` — gates must key on `verified` first.
- get-kubeconfig's private verify fake is replaced by the shared `internal/testattest` stub; `stubVerify` records its calls, and tests assert the captured `ExpectedReportData` equals what the stub's `/attest` issued, with `TestAttestNonceIsFreshPerRun` killing any constant-nonce regression.
- `TestVerifyRejectsTamperedEvidence` mutates a real evidence file across seven classes (claim flips, binding breaks, measurement mismatch) and asserts each is a verdict refusal (exit 2), never a collateral error ("no verdict").
- `enforceResult` extracted so the enforcement branches are reachable and covered.

## `--json` sample from a DEBUG-set report

Render-level (produced by `newOutcome` from debug=true SNP claims; a live-capture sample from real SNP hardware follows separately):

```json
{
  "verified": true,
  "verified_at": "2026-08-14T11:10:06.490215846Z",
  "backend": "attestation-go",
  "source": "file debug-report.json",
  "fresh": true,
  "binding": "REPORTDATA bound to the caller nonce",
  "platform": "snp",
  "measurement": "d9912ba3…",
  "report_data": "1111…1111",
  "debug": true,
  "smt": true
}
```

## Tests

`make test` green (64 packages, `-race`); lint clean. Mutation evidence: constant-nonce, unbound-attest, unbound-RA-TLS, omitempty-restore, claim-key renames, and the original defect all die at named tests (independently reproduced in review).
