### PR TITLE
docs: update QUICKSTART/DEMO/install-flows for required --cvm-mode and --operator-keys

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -11,11 +11,16 @@ it installs with tls-lb disabled. To also expose a workload through tls-lb, give
 it an upstream instead (see [tls-lb upstream](operator.md#tls-lb-upstream)).
 
 ```sh
-c8s install --namespace c8s-system -f - <<'EOF'
+c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem -f - <<'EOF'
 tlsLb:
   enabled: false
 EOF
 ```
+
+`--cvm-mode` is required (`pod`, `node`, `gke`, or `aks` — see
+[install-flows.md](install-flows.md)); `--operator-keys` points at a PEM bundle
+of EC public keys authorizing `c8s allowlist` writes (or pass `--force` to
+install with writes disabled).
 
 ## 2. Apply optional CRD object
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -24,7 +24,19 @@ This installs the supported chart-managed CVM shape: operator, RBAC, CRDs,
 webhook, attestation-api, and CDS.
 
 ```sh
-c8s install --namespace c8s-system --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
+  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+```
+
+`--cvm-mode` is required — one of `pod` (per-pod kata CVMs), `node`
+(node-as-CVM: the nodes themselves are TDX/SNP CVMs, shown here), `gke`, or
+`aks`. `--operator-keys` takes a PEM bundle of EC public keys that authorize
+`c8s allowlist` writes; without it the install refuses to proceed (pass
+`--force` to install with allowlist writes disabled):
+
+```sh
+openssl ecparam -genkey -name prime256v1 -noout -out operator.key
+openssl ec -in operator.key -pubout -out operator-pub.pem
 ```
 
 tls-lb ships no default upstream: `--upstream` (with the port on its
@@ -68,7 +80,7 @@ default image tag of its own, so the image tag above is supplied by
 To install without the advisory CRDs:
 
 ```sh
-c8s install --namespace c8s-system --install-crds=false \
+c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem --install-crds=false \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
 
@@ -90,7 +102,8 @@ kubectl create secret docker-registry ghcr-pull-secret \
   --docker-username=<user-or-x-access-token> \
   --docker-password="$GITHUB_TOKEN"
 
-c8s install --namespace c8s-system --image-pull-secret ghcr-pull-secret \
+c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
+  --image-pull-secret ghcr-pull-secret \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
 
@@ -99,7 +112,8 @@ idempotently (re-run it to rotate the credential in place):
 
 ```sh
 IMAGE_PULL_SECRET=<ghcr-token> NAMESPACE=c8s-system ./scripts/deploy-image-pull-secret.sh
-c8s install --namespace c8s-system --image-pull-secret ghcr-pull-secret \
+c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
+  --image-pull-secret ghcr-pull-secret \
   --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
 

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -26,18 +26,21 @@ resources, `internal/helmchart/c8s/templates/`.
 
 ## The two modes
 
-`c8s install` runs `helm upgrade --install` against the embedded chart. One
-flag selects a **mode**, which is a fixed set of `--set` choices.
+`c8s install` runs `helm upgrade --install` against the embedded chart. The
+required `--cvm-mode` flag selects a **mode**, which is a fixed set of `--set`
+choices. `pod` is the kata shape; `node`, `gke`, and `aks` are the
+node-as-CVM shapes ("base" below), differing only in how the node's TEE
+evidence is read (native device, GKE managed CVM, Azure vTPM).
 
 | Mode | Flag | One-liner |
 |---|---|---|
-| **base** | *(none)* | Normal Kubernetes. No kata, no per-pod confidentiality. Host-side mesh + attestation + image policy. The dev/baseline shape. |
+| **base** | `--cvm-mode=node` (or `gke`/`aks`) | Normal Kubernetes pods on CVM nodes. No kata, no per-pod confidentiality. Host-side mesh + attestation + image policy. The dev/baseline shape. |
 | **kata** | `--cvm-mode=pod` | Installs the kata runtime + RuntimeClasses **and enforces them**: the webhook *injects* a kata RuntimeClass into every in-scope workload pod, a ValidatingAdmissionPolicy *rejects* non-kata pods, and the host-side mesh/attestation/image-policy move into the guest image. The production "pod-as-CVM" shape — kata is enforcing, there is no kata-without-enforcement mode. |
 
 ```mermaid
 flowchart LR
-    A["c8s install"] --> B{flags}
-    B -->|none| BASE["base<br/>host-side everything<br/>no confidentiality"]
+    A["c8s install"] --> B{--cvm-mode}
+    B -->|"node / gke / aks"| BASE["base<br/>host-side everything<br/>no per-pod confidentiality"]
     B -->|"--cvm-mode=pod"| KATA["kata (enforcing)<br/>all workloads forced<br/>into kata VMs"]
 ```
 
@@ -338,8 +341,8 @@ already deleted. See [`kata.md`](kata.md#uninstalling).
 # workload's mesh-wrapped headless Service for every flow below
 # (see operator.md, "tls-lb upstream").
 
-# Base — normal cluster, host-side components, no confidentiality.
-c8s install --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+# Base — normal cluster, host-side components, no per-pod confidentiality.
+c8s install --cvm-mode=node --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 
 # Kata (enforcing): every workload pod becomes a kata VM, non-kata pods
 # rejected, host-side mesh/attestation/image-policy replaced by their


### PR DESCRIPTION
The in-repo install docs still showed `c8s install` invocations without `--cvm-mode` (now required, one of `pod|node|gke|aks` — the old implicit base mode is gone) and predate the `--operator-keys` guarded prompt. Updated the QUICKSTART/DEMO commands (using `--cvm-mode=node` as the base-shape example, with the EC keygen snippet) and reworked install-flows.md's mode table and quick reference accordingly.

Companion to the site-side refresh in confidential-dot-ai/c8s-docs#9.