### PR TITLE
fix(policymonitor): read HOST_DATA only from a verified self-report

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,9 +554,9 @@ than let you discover them:
   In-guest `policy-monitor` refuses to refresh from CDS unless
   `C8S_CDS_MEASUREMENTS` pins the CDS launch digest. On SEV-SNP the webhook
   delivers that pin in the pod's launch-committed init-data document and
-  running guests pick up writes within one refresh interval; on TDX the
-  digest lands in a register the guest does not read back, so refresh stays
-  disabled and each guest enforces only the seed baked into its measured
+  running guests pick up writes within one refresh interval; on TDX the guest
+  does not accept the pin, so refresh stays disabled and each guest enforces
+  only the seed baked into its measured
   image — admitting a new workload image inside a TDX confidential pod means
   rebuilding the guest image. Installs with no pinned measurements, and the
   chart-managed pods in the release namespace (which get no init-data),

--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -295,17 +295,19 @@ fake CDS.
 **Delivery: SEV-SNP init-data.** The host writes an init-data document
 the guest reads at `initdata.GuestDocumentPath`, and the shim commits
 `sha256(document)` into `HOST_DATA` at launch. policy-monitor attests
-itself against the in-guest attestation-service, reads `HOST_DATA` out
-of its own SNP report, and compares. The host still chooses the
-document, but it cannot choose one and commit another — the value is
-sealed into the measurement the operator already verifies, so a
-substituted pin changes an attested field rather than passing silently.
+itself against the in-guest attestation-service, has that report
+verified through the same attestation-api `/verify` endpoint the RA-TLS
+refresh uses, and compares the document against the `HOST_DATA` the
+verifier reports. The host still chooses the document, but it cannot choose one
+and commit another — the value is sealed into the measurement the
+operator already verifies, so a substituted pin changes an attested
+field rather than passing silently.
 On a mismatch, or with no document, the guest falls back to the baked
 seed.
 
-**TDX has no equivalent path yet:** the digest goes to `MRCONFIGID`
-rather than `HOST_DATA`, which this code does not read, so a TDX guest
-enforces the baked seed alone. Empty `cds.measurements` (the chart
+**TDX has no equivalent path yet:** the digest goes to `MRCONFIGID`,
+which is 48 bytes where the anchor is 32, so the guest refuses the
+claim and enforces the baked seed alone. Empty `cds.measurements` (the chart
 default) also leaves the refresh disabled on every platform — operator
 additions then reach the host-side enforcer but not running guests.
 

--- a/docs/kata-launch-measurement.md
+++ b/docs/kata-launch-measurement.md
@@ -260,9 +260,11 @@ already pinned.
 - **TDVF metadata must be present.** The tool refuses a firmware image without
   a TDX metadata GUID block, a TD HOB section, or whose firmware volumes do not
   tile the image.
-- **`MRCONFIGID` / `MROWNER` / `MROWNERCONFIG` are assumed zero**, which is what
-  kata's QEMU launches with today (the `tdx-guest` object sets none of them).
-  They are not part of MRTD, but a policy that pinned them would need capturing
+- **`MRCONFIGID` / `MROWNER` / `MROWNERCONFIG` are assumed zero.** kata sets
+  `mrconfigid` from the init-data digest when the pod carries an init-data
+  annotation, so the assumption holds only for pods without one; `MROWNER` and
+  `MROWNERCONFIG` are never set. None are part of MRTD, so `measure` is
+  unaffected either way, but a policy that pinned them would need capturing
   separately.
 
 ## Limitations

--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -2,30 +2,36 @@ package policymonitor
 
 import (
 	"context"
+	"crypto/sha512"
 	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
-	"github.com/google/go-sev-guest/abi"
-
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // Distinct from a document that fails verification: this is an older control
 // plane, that is a host that tampered.
 var errNoInitData = errors.New("policy-monitor: no init-data document")
 
-// The in-guest attestation service has not answered yet. Like errNoInitData
-// this is a "too early" condition rather than a verdict.
-//
-// applyInitDataMeasurements reads once and treats every other error as a
-// verdict. awaitInitDataMeasurements re-reads a few times first, because a
-// document still being written presents as one (initDataSettleReads).
+// The attester or the verifier did not answer; a later read may.
 var errAttestUnavailable = errors.New("policy-monitor: attestation service unavailable")
+
+// The verifier refused this guest's report, which every retry reproduces.
+var errAttestVerdict = errors.New("policy-monitor: self-report refused")
+
+// The verified report carries no 32-byte anchor to compare the document
+// against. TDX reports the digest padded into a 48-byte MRCONFIGID, so this is
+// what an ordinary TDX boot reaches, not a hostile one.
+var errNoHostDataAnchor = errors.New("policy-monitor: HOST_DATA claim is not a 32-byte anchor")
 
 // Bounds the self-attestation; on expiry the caller falls back to the seed.
 const initDataTimeout = 15 * time.Second
@@ -48,9 +54,9 @@ func resolveInitDataMeasurements(ctx context.Context, cfg *Config) (string, erro
 		return "", fmt.Errorf("read init-data: %w", err)
 	}
 
-	hostData, err := selfHostData(ctx, cfg)
+	hostData, err := verifiedSelfHostData(ctx, cfg)
 	if err != nil {
-		return "", fmt.Errorf("%w: %w", errAttestUnavailable, err)
+		return "", err
 	}
 	want := initdata.Digest(raw)
 	if subtle.ConstantTimeCompare(hostData, want[:]) != 1 {
@@ -81,7 +87,7 @@ func applyInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 			"path", initdata.GuestDocumentPath)
 		return
 	case err != nil:
-		// Host tampering or a broken attester; both leave the guest on the seed.
+		// One read, so every failure is final here — including one a retry would clear.
 		logger.Error("init-data rejected; enforcing the baked seed alone", "error", err)
 		return
 	case measurements == "":
@@ -144,6 +150,12 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 			logger.Warn("init-data carries no CDS measurements; allowlist refresh will stay disabled",
 				"key", initdata.KeyCDSMeasurements)
 			return
+		case errors.Is(err, errAttestVerdict):
+			logger.Error("self-report refused by the verifier", "error", err)
+			return
+		case errors.Is(err, errNoHostDataAnchor):
+			logger.Warn("verified report carries no 32-byte init-data anchor", "error", err)
+			return
 		}
 		lastErr = err
 
@@ -174,30 +186,67 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 		"path", initdata.GuestDocumentPath, "waited", initDataWaitBudget, "error", lastErr)
 }
 
-// selfHostData reads HOST_DATA from a fresh report for this guest. Report data
-// is unused here, hence the zero value.
-//
-// SEV-SNP only: TDX commits the digest to MRCONFIGID, so a TDX guest fails to
-// parse here and falls back to the baked seed — safe, but not yet wired.
-func selfHostData(ctx context.Context, cfg *Config) ([]byte, error) {
+// verifiedSelfHostData returns this guest's HOST_DATA as the attestation-api
+// reports it, from the claims of a report that api verified.
+func verifiedSelfHostData(ctx context.Context, cfg *Config) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, initDataTimeout)
 	defer cancel()
 
-	resp, err := attestclient.NewClient("").GenerateEvidenceContext(ctx, cfg.AttestationServiceURL, make([]byte, 48))
+	// One anchor, both legs: the attester is asked for the 48-byte prefix and
+	// zero-extends it into the 64-byte REPORTDATA the verifier must find.
+	var reportData [64]byte
+	resp, err := attestclient.NewClient("").GenerateEvidenceContext(ctx, cfg.AttestationServiceURL, reportData[:sha512.Size384])
 	if err != nil {
-		return nil, fmt.Errorf("attest self: %w", err)
+		return nil, fmt.Errorf("%w: attest self: %w", errAttestUnavailable, err)
 	}
-	report, err := attestclient.ExtractSNPReport(resp)
+	// Measurements stay unpinned.
+	verified, err := attestationclient.NewClient(cfg.AttestationServiceURL).VerifyEvidence(ctx,
+		types.AttestationEvidence(resp), attestationclient.EvidencePolicy{ExpectedReportData: reportData})
 	if err != nil {
-		return nil, fmt.Errorf("extract snp report: %w", err)
+		return nil, fmt.Errorf("%w: %w", classifyVerifyError(err), err)
 	}
-	parsed, err := abi.ReportToProto([]byte(report))
+
+	hostData, err := hex.DecodeString(verified.Result.Claims.InitData)
 	if err != nil {
-		return nil, fmt.Errorf("parse snp report: %w", err)
+		return nil, fmt.Errorf("%w: not hex: %w", errNoHostDataAnchor, err)
 	}
-	hostData := parsed.GetHostData()
 	if len(hostData) != initdata.DigestSize {
-		return nil, fmt.Errorf("policy-monitor: HOST_DATA is %d bytes, want %d", len(hostData), initdata.DigestSize)
+		return nil, fmt.Errorf("%w: %d bytes, want %d", errNoHostDataAnchor, len(hostData), initdata.DigestSize)
 	}
 	return hostData, nil
+}
+
+// classifyVerifyError splits a refusal of the report from a failure to reach
+// the verifier, which is what decides whether the caller retries. The
+// attestation-api refuses with a 4xx status rather than with a false verdict,
+// so the status arm is the one a conforming verifier takes. That arm is shared
+// with cds.classifyVerifyError; the sentinel arms are not.
+func classifyVerifyError(err error) error {
+	switch {
+	case errors.Is(err, attestationclient.ErrSignatureInvalid),
+		errors.Is(err, attestationclient.ErrReportDataMismatch),
+		errors.Is(err, attestationclient.ErrMeasurementNotAllowed),
+		errors.Is(err, attestationclient.ErrInvalidLaunchDigest),
+		errors.Is(err, attestationclient.ErrRTMRNotAllowed),
+		errors.Is(err, attestationclient.ErrUnsupportedPlatform):
+		return errAttestVerdict
+	}
+	// A refusal whose body is not the api's JSON error shape arrives as
+	// UnexpectedError, carrying the same status.
+	var apiErr *attestationclient.APIError
+	if errors.As(err, &apiErr) && refusesEvidence(apiErr.Status) {
+		return errAttestVerdict
+	}
+	var unexpected *attestationclient.UnexpectedError
+	if errors.As(err, &unexpected) && refusesEvidence(unexpected.Status) {
+		return errAttestVerdict
+	}
+	return errAttestUnavailable
+}
+
+// refusesEvidence reports whether a status names the evidence rather than the
+// service; 408 and 429 are availability.
+func refusesEvidence(status int) bool {
+	return status >= 400 && status < 500 &&
+		status != http.StatusRequestTimeout && status != http.StatusTooManyRequests
 }

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -1,61 +1,135 @@
 package policymonitor
 
 import (
+	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// snpHostDataOffset is HOST_DATA's byte offset in an SEV-SNP ATTESTATION_REPORT
-// (AMD SEV-SNP ABI table: VERSION..PLATFORM_INFO, REPORT_DATA at 0x50,
-// MEASUREMENT at 0x90, HOST_DATA at 0xC0).
-const snpHostDataOffset = 0xC0
+// hostDataVerdict passes verification and reports hostData as the HOST_DATA claim.
+func hostDataVerdict(hostData []byte) testattest.Verdict {
+	v := testattest.PassingVerdict("")
+	v.Claims.InitData = hex.EncodeToString(hostData)
+	return v
+}
 
-const snpReportLen = 1184
+// testHostData is an arbitrary well-formed anchor.
+func testHostData() []byte { return bytes.Repeat([]byte{0xa5}, initdata.DigestSize) }
 
-// snpPolicyOffset is POLICY's offset. go-sev-guest rejects a report whose
-// bit 17 is clear, so the field cannot be left zero. 0x30000 is what a kata
-// SNP guest actually reports (bit 16 SMT, bit 17 reserved-must-be-1).
-const (
-	snpPolicyOffset = 0x08
-	snpTestPolicy   = 0x30000
-)
-
-// attesterServing returns the URL of a fake in-guest attester whose report
-// carries hostData in HOST_DATA.
+// attesterServing returns the URL of a stub in-guest attestation-api that
+// verifies this guest's report and reports hostData as its HOST_DATA.
 func attesterServing(t *testing.T, hostData []byte) string {
 	t.Helper()
-	report := make([]byte, snpReportLen)
-	report[0] = 0x02 // VERSION 2
-	binary.LittleEndian.PutUint64(report[snpPolicyOffset:], snpTestPolicy)
-	copy(report[snpHostDataOffset:], hostData)
+	return attesterWithVerdict(t, hostDataVerdict(hostData))
+}
 
-	evidence, err := json.Marshal(map[string]string{
-		"attestation_report": base64.StdEncoding.EncodeToString(report),
-	})
+func attesterWithVerdict(t *testing.T, v testattest.Verdict) string {
+	t.Helper()
+	stub := testattest.New(t)
+	stub.SetVerdict(v)
+	return stub.URL
+}
+
+// scriptedVerifier is an in-guest attestation-api whose /attest comes from the
+// shared stub and whose /verify answers status for its first `failures` calls
+// before proxying to the stub; failures < 0 fails every call. Verify calls are
+// counted here because a refused one never reaches the stub.
+type scriptedVerifier struct {
+	url      string
+	attester *testattest.Stub
+
+	mu    sync.Mutex
+	calls int
+}
+
+func newScriptedVerifier(t *testing.T, status, failures int) *scriptedVerifier {
+	t.Helper()
+	v := &scriptedVerifier{attester: testattest.New(t)}
+	v.attester.SetVerdict(hostDataVerdict(testHostData()))
+
+	target, err := url.Parse(v.attester.URL)
 	if err != nil {
-		t.Fatalf("marshal evidence: %v", err)
+		t.Fatalf("parse stub URL: %v", err)
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	mux := http.NewServeMux()
+	mux.Handle("POST /attest", proxy)
+	mux.HandleFunc("POST /verify", func(w http.ResponseWriter, r *http.Request) {
+		v.mu.Lock()
+		v.calls++
+		n := v.calls
+		v.mu.Unlock()
+		if failures >= 0 && n > failures {
+			proxy.ServeHTTP(w, r)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: "snp", Evidence: evidence})
-	}))
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "verification_failed", Message: "evidence rejected"})
+	})
+
+	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv.URL
+	v.url = srv.URL
+	return v
+}
+
+func (v *scriptedVerifier) verifyCalls() int {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return v.calls
+}
+
+// levelRecorder captures each record's level so a test can pin the operator
+// signal, not only the outcome.
+type levelRecorder struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (l *levelRecorder) Enabled(context.Context, slog.Level) bool { return true }
+func (l *levelRecorder) WithAttrs([]slog.Attr) slog.Handler       { return l }
+func (l *levelRecorder) WithGroup(string) slog.Handler            { return l }
+
+func (l *levelRecorder) Handle(_ context.Context, r slog.Record) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.records = append(l.records, r)
+	return nil
+}
+
+// levelOf is the level of the first record whose message contains substr.
+func (l *levelRecorder) levelOf(t *testing.T, substr string) slog.Level {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, r := range l.records {
+		if strings.Contains(r.Message, substr) {
+			return r.Level
+		}
+	}
+	t.Fatalf("no log record mentioning %q", substr)
+	return 0
 }
 
 // writeInitData points initDataDocumentPath at a tempdir holding raw.
@@ -116,6 +190,21 @@ func TestResolveInitDataMeasurementsRejectsUncommittedDocument(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HOST_DATA") {
 		t.Fatalf("error = %v, want it to name HOST_DATA", err)
+	}
+}
+
+// HOST_DATA agreeing with the digest on every byte but one is still not the
+// commitment.
+func TestResolveInitDataMeasurementsRejectsNearCollision(t *testing.T) {
+	raw := testDocument(t, "aabb")
+	writeInitData(t, raw)
+
+	near := initdata.Digest(raw)
+	near[len(near)-1] ^= 0xff
+	cfg := &Config{AttestationServiceURL: attesterServing(t, near[:])}
+
+	if _, err := resolveInitDataMeasurements(context.Background(), cfg); err == nil {
+		t.Fatal("accepted a HOST_DATA that matches the digest only on its prefix")
 	}
 }
 
@@ -232,37 +321,216 @@ func TestApplyInitDataMeasurementsFailuresLeaveConfigEmpty(t *testing.T) {
 	}
 }
 
-func TestSelfHostDataReadsHostDataField(t *testing.T) {
-	want := make([]byte, initdata.DigestSize)
-	for i := range want {
-		want[i] = byte(i + 1)
-	}
+// The stub's report bytes carry an all-zero HOST_DATA, so a non-zero result can
+// only have come from the verified claim.
+func TestVerifiedSelfHostDataReadsTheVerifiedClaim(t *testing.T) {
+	want := testHostData()
 	cfg := &Config{AttestationServiceURL: attesterServing(t, want)}
 
-	got, err := selfHostData(context.Background(), cfg)
+	got, err := verifiedSelfHostData(context.Background(), cfg)
 	if err != nil {
-		t.Fatalf("selfHostData: %v", err)
+		t.Fatalf("verifiedSelfHostData: %v", err)
 	}
-	if string(got) != string(want) {
+	if !bytes.Equal(got, want) {
 		t.Fatalf("HOST_DATA = %x, want %x", got, want)
 	}
 }
 
-func TestSelfHostDataRejectsUnparseableReport(t *testing.T) {
-	evidence, err := json.Marshal(map[string]string{
-		"attestation_report": base64.StdEncoding.EncodeToString([]byte("too short")),
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+// Each way a report can be refused on a 200 response: no HOST_DATA reaches the
+// caller, and the refusal carries both the verifier's sentinel and the terminal
+// classification.
+func TestVerifiedSelfHostDataRejectsUnverifiedReport(t *testing.T) {
+	no := false
+	for _, tc := range []struct {
+		name  string
+		setup func(*testing.T) string
+		want  error
+	}{
+		{"signature invalid", refusing(func(v *testattest.Verdict) { v.SignatureValid = false }), attestationclient.ErrSignatureInvalid},
+		{"report data unchecked", refusing(func(v *testattest.Verdict) { v.ReportDataMatch = nil }), attestationclient.ErrReportDataMismatch},
+		{"report data mismatch", refusing(func(v *testattest.Verdict) { v.ReportDataMatch = &no }), attestationclient.ErrReportDataMismatch},
+		{"launch digest malformed", refusing(func(v *testattest.Verdict) { v.Claims.LaunchDigest = "not-hex" }), attestationclient.ErrInvalidLaunchDigest},
+		{"platform with no verification rules", unsupportedPlatformAttester, attestationclient.ErrUnsupportedPlatform},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: tc.setup(t)})
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("err = %v, want %v", err, tc.want)
+			}
+			if !errors.Is(err, errAttestVerdict) {
+				t.Fatalf("err = %v, want it classified as a terminal verdict", err)
+			}
+			if got != nil {
+				t.Fatalf("returned HOST_DATA %x alongside an error", got)
+			}
+		})
 	}
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: "snp", Evidence: evidence})
-	}))
-	defer srv.Close()
+}
 
-	if _, err := selfHostData(context.Background(), &Config{AttestationServiceURL: srv.URL}); err == nil {
-		t.Fatal("accepted a report that does not parse")
+// refusing builds an attester whose /verify answers a passing verdict with
+// reject applied.
+func refusing(reject func(*testattest.Verdict)) func(*testing.T) string {
+	return func(t *testing.T) string {
+		v := hostDataVerdict(testHostData())
+		reject(&v)
+		return attesterWithVerdict(t, v)
+	}
+}
+
+// unsupportedPlatformAttester labels its evidence with a platform VerifyEvidence
+// has no rules for, which is refused before any claim is read.
+func unsupportedPlatformAttester(t *testing.T) string {
+	t.Helper()
+	stub := testattest.New(t)
+	stub.SetVerdict(hostDataVerdict(testHostData()))
+	stub.SetPlatform(types.Platform("gcp-tdx"))
+	return stub.URL
+}
+
+// A 422 refusal is terminal, not an outage.
+func TestVerifiedSelfHostDataRejectsAStatusRefusal(t *testing.T) {
+	v := newScriptedVerifier(t, http.StatusUnprocessableEntity, -1)
+
+	got, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: v.url})
+	if !errors.Is(err, errAttestVerdict) {
+		t.Fatalf("err = %v, want a terminal verdict", err)
+	}
+	if got != nil {
+		t.Fatalf("returned HOST_DATA %x alongside an error", got)
+	}
+}
+
+// A verifier that cannot answer is retryable, and the attest-leg assertion is
+// what makes this the verify leg's classification.
+func TestVerifiedSelfHostDataTreatsAVerifierOutageAsRetryable(t *testing.T) {
+	v := newScriptedVerifier(t, http.StatusServiceUnavailable, -1)
+
+	got, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: v.url})
+	if !errors.Is(err, errAttestUnavailable) {
+		t.Fatalf("err = %v, want errAttestUnavailable", err)
+	}
+	if got != nil {
+		t.Fatalf("returned HOST_DATA %x alongside an error", got)
+	}
+	if n := len(v.attester.AttestRequests()); n != 1 {
+		t.Fatalf("attest requests = %d, want 1: the attest leg must have succeeded", n)
+	}
+	if n := v.verifyCalls(); n != 1 {
+		t.Fatalf("verify calls = %d, want 1", n)
+	}
+}
+
+// classifyVerifyError is what decides retry-versus-give-up, and most of its
+// inputs cannot be produced end to end from this call site (no measurement or
+// RTMR pin is sent), so the mapping is pinned directly.
+func TestClassifyVerifyError(t *testing.T) {
+	apiErr := func(status int) error {
+		return &attestationclient.APIError{Status: status, Response: types.ErrorResponse{Error: "verification_failed"}}
+	}
+	for _, tc := range []struct {
+		name string
+		err  error
+		want error
+	}{
+		{"signature invalid", attestationclient.ErrSignatureInvalid, errAttestVerdict},
+		{"report data mismatch", attestationclient.ErrReportDataMismatch, errAttestVerdict},
+		{"measurement not allowed", attestationclient.ErrMeasurementNotAllowed, errAttestVerdict},
+		{"launch digest malformed", attestationclient.ErrInvalidLaunchDigest, errAttestVerdict},
+		{"rtmr not allowed", attestationclient.ErrRTMRNotAllowed, errAttestVerdict},
+		{"unsupported platform", attestationclient.ErrUnsupportedPlatform, errAttestVerdict},
+		{"api 422", apiErr(http.StatusUnprocessableEntity), errAttestVerdict},
+		{"api 400", apiErr(http.StatusBadRequest), errAttestVerdict},
+		{"non-json 422", &attestationclient.UnexpectedError{Status: http.StatusUnprocessableEntity, Text: "Expected request with `Content-Type: application/json`"}, errAttestVerdict},
+		{"non-json 408", &attestationclient.UnexpectedError{Status: http.StatusRequestTimeout}, errAttestUnavailable},
+		{"non-json 429", &attestationclient.UnexpectedError{Status: http.StatusTooManyRequests}, errAttestUnavailable},
+		{"non-json 503", &attestationclient.UnexpectedError{Status: http.StatusServiceUnavailable, Text: "<html>502 Bad Gateway</html>"}, errAttestUnavailable},
+		{"api 408", apiErr(http.StatusRequestTimeout), errAttestUnavailable},
+		{"api 429", apiErr(http.StatusTooManyRequests), errAttestUnavailable},
+		{"api 500", apiErr(http.StatusInternalServerError), errAttestUnavailable},
+		{"transport", &attestationclient.RequestError{Err: errors.New("connection refused")}, errAttestUnavailable},
+		{"deadline", context.DeadlineExceeded, errAttestUnavailable},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Wrapped, because the call site never sees a bare sentinel.
+			if got := classifyVerifyError(fmt.Errorf("verify self report: %w", tc.err)); got != tc.want {
+				t.Fatalf("classifyVerifyError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// The attester is asked for the 48-byte anchor and the verifier is told to
+// expect its 64-byte zero-extension. Both are zero, so this pins the widths and
+// the value, not that one leg is derived from the other: when the anchor stops
+// being zero, this test must start asserting derivation.
+func TestVerifiedSelfHostDataBindsTheAnchorItRequested(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetVerdict(hostDataVerdict(testHostData()))
+
+	if _, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: stub.URL}); err != nil {
+		t.Fatalf("verifiedSelfHostData: %v", err)
+	}
+
+	attested, verified := stub.AttestRequests(), stub.VerifyRequests()
+	if len(attested) != 1 || len(verified) != 1 {
+		t.Fatalf("attest requests = %d, verify requests = %d, want 1 each", len(attested), len(verified))
+	}
+	if verified[0].Params == nil || verified[0].Params.ExpectedReportData == nil {
+		t.Fatal("the verifier was not asked to check any REPORTDATA binding")
+	}
+
+	if n := len(attested[0].ReportData.Bytes()); n != 48 {
+		t.Fatalf("attested report data = %d bytes, want the 48-byte anchor", n)
+	}
+	got := verified[0].Params.ExpectedReportData.Bytes()
+	if !bytes.Equal(got, make([]byte, 64)) {
+		t.Fatalf("expected_report_data = %x, want 64 zero bytes", got)
+	}
+}
+
+// A claim that is not a 32-byte anchor is refused rather than padded or
+// truncated, and is not a verifier refusal.
+func TestVerifiedSelfHostDataRejectsIllShapedClaim(t *testing.T) {
+	for _, tc := range []struct{ name, claim string }{
+		{"absent", ""},
+		{"tdx mrconfigid", strings.Repeat("00", 48)},
+		{"not hex", "not-hex"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := testattest.PassingVerdict("")
+			v.Claims.InitData = tc.claim
+
+			got, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: attesterWithVerdict(t, v)})
+			if !errors.Is(err, errNoHostDataAnchor) {
+				t.Fatalf("err = %v for claim %q, want errNoHostDataAnchor", err, tc.claim)
+			}
+			if errors.Is(err, errAttestVerdict) {
+				t.Fatalf("err = %v for claim %q, must not read as a verifier refusal", err, tc.claim)
+			}
+			if got != nil {
+				t.Fatalf("returned HOST_DATA %x alongside an error", got)
+			}
+		})
+	}
+}
+
+// A forged report committing the document on disk still fails, because the
+// forgery is what the verifier rejects.
+func TestResolveInitDataMeasurementsRejectsUnverifiedReport(t *testing.T) {
+	raw := testDocument(t, "aabb")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+
+	v := hostDataVerdict(digest[:])
+	v.SignatureValid = false
+	cfg := &Config{AttestationServiceURL: attesterWithVerdict(t, v)}
+
+	measurements, err := resolveInitDataMeasurements(context.Background(), cfg)
+	if !errors.Is(err, attestationclient.ErrSignatureInvalid) {
+		t.Fatalf("err = %v, want the verifier's signature verdict", err)
+	}
+	if measurements != "" {
+		t.Fatalf("measurements = %q, want none from an unverified report", measurements)
 	}
 }
 
@@ -362,13 +630,85 @@ func TestAwaitInitDataMeasurementsStopsOnUncommittedDocument(t *testing.T) {
 	}
 }
 
+// A refused report is terminal and reaches the operator at Error: the wait
+// stops at the first refusal rather than spending the budget on retries that
+// reproduce it.
+func TestAwaitInitDataMeasurementsStopsOnRefusedReport(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+	// A budget that would dominate the test if the refusal were retried.
+	shortInitDataWait(t, time.Minute, 10*time.Second)
+
+	v := newScriptedVerifier(t, http.StatusUnprocessableEntity, -1)
+	cfg := &Config{AttestationServiceURL: v.url}
+	rec := &levelRecorder{}
+	start := time.Now()
+	awaitInitDataMeasurements(context.Background(), slog.New(rec), cfg)
+
+	if cfg.CDSMeasurements != "" {
+		t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed onto the baked seed", cfg.CDSMeasurements)
+	}
+	if n := v.verifyCalls(); n != 1 {
+		t.Fatalf("verify attempts = %d, want 1: a refusal must not be retried", n)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("refusal took %s; it must not consume the wait budget", elapsed)
+	}
+	if got := rec.levelOf(t, "refused"); got != slog.LevelError {
+		t.Fatalf("refusal logged at %v, want Error", got)
+	}
+}
+
+// A missing anchor is terminal like a refusal, but not at a refusal's level.
+func TestAwaitInitDataMeasurementsStopsOnMissingAnchor(t *testing.T) {
+	writeInitData(t, testDocument(t, "aabb"))
+	shortInitDataWait(t, time.Minute, 10*time.Second)
+
+	// MRCONFIGID's width.
+	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, 48))}
+	rec := &levelRecorder{}
+	start := time.Now()
+	awaitInitDataMeasurements(context.Background(), slog.New(rec), cfg)
+
+	if cfg.CDSMeasurements != "" {
+		t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed onto the baked seed", cfg.CDSMeasurements)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Fatalf("missing anchor took %s; it must not consume the wait budget", elapsed)
+	}
+	if got := rec.levelOf(t, "anchor"); got != slog.LevelWarn {
+		t.Fatalf("missing anchor logged at %v, want Warn", got)
+	}
+}
+
+// The other half of the split: a verifier still coming up is retried, so a slow
+// attestation-service does not cost the guest its pin.
+func TestAwaitInitDataMeasurementsRetriesAnUnavailableVerifier(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
+
+	v := newScriptedVerifier(t, http.StatusServiceUnavailable, 2)
+	v.attester.SetVerdict(hostDataVerdict(digest[:]))
+
+	cfg := &Config{AttestationServiceURL: v.url}
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "aabb,ccdd" {
+		t.Fatalf("CDSMeasurements = %q, want the wait to outlast a verifier still coming up", cfg.CDSMeasurements)
+	}
+	if n := v.verifyCalls(); n != 3 {
+		t.Fatalf("verify calls = %d, want 3: two outages then the answer", n)
+	}
+}
+
 // A host that delivers no document at all leaves the guest exactly where it
 // was before: seed-only enforcement, no measurements.
 func TestAwaitInitDataMeasurementsBudgetExhausted(t *testing.T) {
 	pointInitDataAt(t)
 	shortInitDataWait(t, 100*time.Millisecond, 10*time.Millisecond)
 
-	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, 48))}
+	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, initdata.DigestSize))}
 	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
 
 	if cfg.CDSMeasurements != "" {

--- a/internal/cmds/policymonitor/run.go
+++ b/internal/cmds/policymonitor/run.go
@@ -152,7 +152,7 @@ rather than a transient runtime problem.`,
 	fs.StringVar(&cfg.LogLevel, "log-level", "info", "log level: debug, info, warn, error")
 	fs.StringVar(&cfg.CDSURL, "cds-url", "", "CDS base URL to refresh the allowlist from over RA-TLS (default $C8S_CDS_URL; empty = baked seed only, no network)")
 	fs.StringVar(&cfg.CDSMeasurements, "cds-measurements", "", "comma-separated SHA-384 hex launch digests CDS's RA-TLS serving cert must match (default $C8S_CDS_MEASUREMENTS)")
-	fs.StringVar(&cfg.AttestationServiceURL, "attestation-service-url", "", "local attestation-service URL for in-guest RA-TLS evidence (default $C8S_ATTESTATION_SERVICE_URL or http://127.0.0.1:8400)")
+	fs.StringVar(&cfg.AttestationServiceURL, "attestation-service-url", "", "local attestation-api URL: builds in-guest RA-TLS evidence and verifies this guest's own report (default $C8S_ATTESTATION_SERVICE_URL or http://127.0.0.1:8400)")
 	fs.DurationVar(&cfg.RefreshInterval, "allowlist-refresh-interval", defaultRefreshInterval, "interval to poll CDS for allowlist updates (only when --cds-url is set)")
 	return cmd
 }
@@ -189,8 +189,9 @@ type Config struct {
 	// $C8S_CDS_MEASUREMENTS. Empty = accept any (unsafe; warned).
 	CDSMeasurements string
 
-	// AttestationServiceURL is the local attester used to build the
-	// in-guest RA-TLS evidence for the CDS handshake. Defaults from
+	// AttestationServiceURL is the local attestation-api: it builds the
+	// in-guest RA-TLS evidence for the CDS handshake and verifies the
+	// self-report the init-data anchor is read from. Defaults from
 	// $C8S_ATTESTATION_SERVICE_URL, else http://127.0.0.1:8400.
 	AttestationServiceURL string
 

--- a/internal/webhook/initdata.go
+++ b/internal/webhook/initdata.go
@@ -21,7 +21,9 @@ var confidentialKataClasses = map[string]struct{}{
 // stampInitData carries the CDS measurements to the guest's policy-monitor.
 // Writing the annotation is not what makes it trustworthy — the shim hashes the
 // document into HOST_DATA and the guest re-derives the digest before trusting
-// it (docs/kata-image-policy.md).
+// it. On the TDX classes the digest lands padded in MRCONFIGID instead, which
+// the guest refuses, so those pods enforce the baked seed
+// (docs/kata-image-policy.md).
 //
 // An author-supplied value would name the CDS their own guest pins, and the
 // HOST_DATA check cannot tell it from ours, so it is rejected. Comparing

--- a/pkg/initdata/initdata.go
+++ b/pkg/initdata/initdata.go
@@ -9,9 +9,10 @@
 // HOST_DATA makes the document tamper-EVIDENT, not trusted. The host still
 // chooses the content, and kata's guest agent never compares what it wrote to
 // the guest against what the shim committed. A consumer must therefore
-// re-derive sha256(raw) and compare it against HOST_DATA in its own attestation
-// report before acting on anything inside. See docs/kata-image-policy.md —
-// "Init-data trust anchor".
+// re-derive sha256(raw) and compare it against the HOST_DATA of an attestation
+// report a verifier has accepted — HOST_DATA read out of an unverified report
+// is host-chosen on both sides. See docs/kata-image-policy.md — "Allowlist
+// sourcing: baked seed + CDS refresh".
 package initdata
 
 import (
@@ -201,8 +202,8 @@ func (d Document) Render() ([]byte, error) {
 // and a parser that accepts more than it needs to is surface a caller does not
 // want on host-supplied bytes.
 //
-// Parse does not authenticate. Callers must compare Digest(raw) against
-// HOST_DATA first.
+// Parse does not authenticate. Callers must compare Digest(raw) against the
+// HOST_DATA of a verified report first.
 func Parse(raw []byte) (Document, error) {
 	if !utf8.Valid(raw) {
 		return Document{}, fmt.Errorf("%w: not valid UTF-8", ErrMalformed)

--- a/pkg/initdata/initdata_test.go
+++ b/pkg/initdata/initdata_test.go
@@ -9,7 +9,7 @@ import (
 
 // The spike vector: this exact byte sequence was delivered to a live SEV-SNP
 // guest and its sha256 read back out of the AMD-signed report's HOST_DATA
-// (docs/kata-image-policy.md — "Init-data trust anchor"). Any change to Render
+// (docs/kata-image-policy.md — "Allowlist sourcing"). Any change to Render
 // that breaks it breaks the binding on hardware.
 const (
 	spikeRaw = "version = \"0.1.0\"\n" +


### PR DESCRIPTION
The init-data anchor was taken from a raw attestation blob: the guest asked its in-guest attester for a report, parsed it with abi.ReportToProto and read GetHostData off the result. Nothing checked the signature chain or the REPORTDATA binding first, so the value the guest compares its init-data document against came from an unauthenticated field.

Route the self-report through attestationclient.VerifyEvidence and read HOST_DATA from the verified claims. The verifier is :8400, which the guest already trusts to generate this evidence and to verify every RA-TLS peer, and which ships inside the same dm-verity-measured image the launch digest covers.

Split the failure classes while here, because the caller retries. The attestation-api reports a refusal as a 4xx status rather than a false verdict, so a status refusal and the client-side verdict sentinels are terminal and logged at Error; an unreachable attester or verifier, 408 and 429 stay retryable. A verified report carrying no 32-byte anchor is terminal too but is what a TDX guest's MRCONFIGID looks like, so it gets its own condition and a Warn rather than the level reserved for a forgery.

A refusal whose body is not the api's JSON error shape arrives as UnexpectedError rather than APIError, so both are matched on the status. cds.classifyVerifyError has the same gap and is being fixed separately; this is not a deliberate divergence from that pattern.

Relying-party pinning (ExpectedInitDataHash / InitDataMatch) is unchanged.