### PR TITLE
fix(nri-image-policy): check the digest before the namespace exemption

### DIFF
--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -109,9 +109,9 @@ hijack. On node-CVM it is a unix socket, and there are two separate threats:
   into every `confidential.ai/cw` pod. Generates the leaf key, builds the CSR,
   redeems a sandbox token, drives the CDS attestation flow, writes the cert.
   (`internal/cmds/getcert`)
-- **The inventory** — the component that already makes the admit/deny decision,
-  so what it vouches for is exactly what was admitted. It serves two disjoint
-  surfaces (`pkg/workloadclaims`): `POST /sandbox` on a **local** endpoint
+- **The inventory** — fed by the component that makes the admit/deny decision,
+  so it reports what ran on the node whatever that decision was. It serves two
+  disjoint surfaces (`pkg/workloadclaims`): `POST /sandbox` on a **local** endpoint
   get-cert dials at one of two compiled addresses, and `GET /identity` +
   `GET /digests/{sandboxID}` on a **network endpoint over mutually-attested
   RA-TLS**, at the fixed privileged port `workloadclaims.DigestsPort` (1019),
@@ -262,11 +262,12 @@ skips it (it is measured via the rootfs, not allowlisted). Unknown sandbox ⇒
 - **Order-independent.** The same images in a different container order answer
   identically, so a reschedule that reorders containers does not churn the
   identity.
-- **All-or-nothing.** If the inventory cannot resolve a tracked container's
-  image digest it records an empty one (logged at error, see
-  `recordForInventory`), and rather than answer with the containers it *can*
-  describe — a subset passed off as the whole set — it fails the whole request,
-  which CDS treats as fail-closed.
+- **All-or-nothing.** If the inventory has no digest for a tracked container it
+  records an empty one — logged at error when a resolve failed
+  (`recordForInventory`), silently on the pre-allowlist hook that does not
+  resolve at all (`recordUncheckedForInventory`). Rather than answer with the
+  containers it *can* describe — a subset passed off as the whole set — it fails
+  the whole request, which CDS treats as fail-closed.
 - **CDS checks membership, not composition.** Every image the inventory reports
   must be allowlisted (floor or any workload container). Injected c8s containers
   are floor entries, so they pass by digest, not by name. CDS does not require
@@ -348,22 +349,27 @@ Two inventory behaviours that still matter here:
   containerd), a node reboot, or a crash. Running containers survive that
   restart, so their digests must be re-derived; NRI replays `Synchronize` with
   the full container list on every plugin start, and `checkExisting` records
-  what it admits. That recovery deliberately does **not** depend on
+  every container it sees. That recovery deliberately does **not** depend on
   `policy.enforce_existing` — that knob gates only the *kill* step, because
   "learn what is running" and "kill what shouldn't be" are separate concerns.
   Until the check completes, a callback landing in between gets a 404 (unknown
   sandbox) or a short set, and CDS refuses; get-cert retries at the next renewal
-  interval. The window is bounded by the plugin's initial pull (backoff plus
+  interval. That window is bounded by the plugin's initial pull (backoff plus
   fetch timeouts, tens of seconds), against a renewal interval measured in
-  hours.
-- **A partially repopulated check.** The `c8s-cert` image sits in the plugin's
-  `always_allow` floor, so the check always admits it; a tenant app image does
-  not, and a check running after the allowlist changed can deny one. The
-  sidecar is then tracked and the app container is not, so the callback answers
-  a floor-only set and the renewal is issued against it. With
-  `enforce_existing` on, the same check kills the offending container and the
-  state cannot persist; with it off, tolerating that container is the operator's
-  stated intent.
+  hours. One case outlives it: a container created in that window is recorded
+  from its image reference alone, so a reference carrying no digest records an
+  empty one and its sandbox answers closed until some later record resolves
+  that container — in practice the next `Synchronize` replay, not the deferred
+  check, which replays only what `Synchronize` listed.
+- **A check that denies one of the containers.** The `c8s-cert` image sits in
+  the plugin's `always_allow` floor, so the check always admits it; a tenant app
+  image does not, and a check running after the allowlist changed can deny one.
+  Recording is independent of that verdict, so both are tracked and the callback
+  answers the full set — including the denied image, which CDS then refuses. The
+  pod loses its certificate whether or not `enforce_existing` is on, because the
+  denied container ran in that sandbox either way; the knob decides only whether
+  it is also killed. `mode: audit` does not change this: it suppresses the kill,
+  not the record.
 
 **Enforcement is on both sides now.** Issuance refuses a sandbox running an
 image the allowlist does not admit; a relying party pinning

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -337,9 +337,9 @@ kept for operator-authored input, where an unknown field is a typo.
 | `digests` | deduplicated digest set | cert issuance (membership) |
 | `containers` | `[{digest, argv}]`, **not** deduplicated | secret release |
 
-`argv` is the effective OCI `process.args` that admission evaluated, so release
-can hold a sandbox to the same `(digest, argv)` pair the allowlist matched rather
-than to a digest set that says nothing about what those images were told to run.
+`argv` is the effective OCI `process.args` a container runs, so release can hold
+a sandbox to the `(digest, argv)` pairs that ran in it rather than to a digest
+set that says nothing about what those images were told to run.
 Without it, two entries differing only in argv are indistinguishable, and the
 argv admission enforces is a **union across every entry listing the digest** — so
 an entry that pins `command: exact` gives no guarantee at release time if another

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -8,6 +8,7 @@ type Event struct {
 	Action    string // allow, deny
 	Reason    string
 	Rule      string // label rule name, if any
+	Overrides string // the denial this allow overturned, if any
 	Namespace string
 	Pod       string
 	Container string
@@ -35,6 +36,9 @@ func (l *Logger) Log(event Event) {
 	}
 	if event.Rule != "" {
 		attrs = append(attrs, "rule", event.Rule)
+	}
+	if event.Overrides != "" {
+		attrs = append(attrs, "overrides", event.Overrides)
 	}
 	if event.Error != "" {
 		attrs = append(attrs, "error", event.Error)

--- a/internal/audit/logger_test.go
+++ b/internal/audit/logger_test.go
@@ -61,6 +61,9 @@ func TestLogOmitsRuleAndErrorWhenEmpty(t *testing.T) {
 	if _, ok := rec["rule"]; ok {
 		t.Error("rule should be omitted when empty")
 	}
+	if _, ok := rec["overrides"]; ok {
+		t.Error("overrides should be omitted when empty")
+	}
 	if _, ok := rec["error"]; ok {
 		t.Error("error should be omitted when empty")
 	}

--- a/internal/cmds/nri-image-policy/config.go
+++ b/internal/cmds/nri-image-policy/config.go
@@ -88,7 +88,7 @@ type policyConfig struct {
 	Mode                  string      `yaml:"mode"`                    // fail-closed, audit
 	EnforceExisting       bool        `yaml:"enforce_existing"`        // kill non-allowlisted containers on startup
 	DenyMissingAnnotation bool        `yaml:"deny_missing_annotation"` // deny containers without image annotation
-	ExemptNamespaces      []string    `yaml:"exempt_namespaces"`
+	ExemptNamespaces      []string    `yaml:"exempt_namespaces"`       // admit a denied container; applied after the checks
 	LabelRules            []labelRule `yaml:"label_rules"`
 }
 
@@ -238,10 +238,8 @@ func (c *config) Validate() error {
 	if c.Policy.Mode != ModeFailClosed && c.Policy.Mode != ModeAudit {
 		return fmt.Errorf("policy.mode must be '%s' or '%s'", ModeFailClosed, ModeAudit)
 	}
-	// Both inventory record sites sit under AllowlistEnabled, so without one the
-	// inventory answers every get-cert fetch empty-handed, forever.
 	if c.WorkloadClaims.SocketDir != "" && !c.AllowlistEnabled() {
-		return fmt.Errorf("workload_claims.socket_dir requires allowlist.always_allow or allowlist.pull: the inventory only records digest-checked containers")
+		return fmt.Errorf("workload_claims.socket_dir requires allowlist.always_allow or allowlist.pull: the inventory reports digests for CDS to match against the allowlist")
 	}
 	return validateLabelRules(c.Policy.LabelRules)
 }

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -12,9 +12,12 @@ import (
 // which sandbox a calling process belongs to, and which image digests a named
 // sandbox is running (docs/ratls.md, "Sandbox identity"). It is fed from the
 // same CreateContainer / Synchronize events that drive enforcement — and
-// pod-sandbox events for the sandbox set — so what it vouches for is exactly
-// what was admitted. Caller identity comes from the kernel (SO_PEERCRED →
-// cgroup → container), never from the request.
+// pod-sandbox events for the sandbox set. Caller identity comes from the kernel
+// (SO_PEERCRED → cgroup → container), never from the request.
+//
+// "Admitted" here and in every caller means the plugin let the container run,
+// not that it passed the checks: an exemption, audit mode or an undeliverable
+// kill each leave one running, and the inventory reports what runs.
 type admissionInventory struct {
 	mu         sync.RWMutex
 	containers map[string]ctrRec   // live containerID -> record (caller resolution)
@@ -25,7 +28,7 @@ type admissionInventory struct {
 
 type ctrRec struct {
 	sandboxID string
-	name      string
+	name      string // unread
 	digest    string // canonical sha256:<hex>; "" when unresolved
 	argv      []string
 }
@@ -35,7 +38,7 @@ type ctrRec struct {
 // See docs/secrets.md — "The report is a high-water mark".
 type sbxRec struct {
 	byKey      map[string]workloadclaims.SandboxContainer
-	unresolved bool // some admitted container never resolved a digest
+	unresolved map[string]struct{} // container IDs with no digest; cleared only by a later resolved record for the same ID
 }
 
 func newAdmissionInventory(procRoot string) *admissionInventory {
@@ -50,7 +53,7 @@ func newAdmissionInventory(procRoot string) *admissionInventory {
 // record notes an admitted container, injected sidecars included: /digests is
 // an inventory of what was admitted in the sandbox, and the injected images are
 // allowlist floor entries, so CDS drops them from workload matching itself.
-// argv is the effective OCI process.args the allowlist was evaluated against.
+// argv is the effective OCI process.args the container runs.
 func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string) {
 	if containerID == "" || sandboxID == "" {
 		return
@@ -61,11 +64,15 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 
 	rec, ok := b.admitted[sandboxID]
 	if !ok {
-		rec = sbxRec{byKey: map[string]workloadclaims.SandboxContainer{}}
+		rec = sbxRec{
+			byKey:      map[string]workloadclaims.SandboxContainer{},
+			unresolved: map[string]struct{}{},
+		}
 	}
 	if digest == "" {
-		rec.unresolved = true
+		rec.unresolved[containerID] = struct{}{}
 	} else {
+		delete(rec.unresolved, containerID)
 		c := workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
 		rec.byKey[c.Key()] = c
 	}
@@ -78,7 +85,9 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 
 // remove evicts a stopped container from caller resolution only. The sandbox's
 // admission record keeps it: a stopped container must not bind a caller, but it
-// still ran here (sbxRec).
+// still ran here (sbxRec). That includes an unresolved digest, so a container
+// that stops before one resolves closes its sandbox's answer for the sandbox's
+// life.
 func (b *admissionInventory) remove(containerID string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -175,7 +184,7 @@ func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []wo
 		return nil, nil, false, nil
 	}
 	rec := b.admitted[sandboxID]
-	if rec.unresolved {
+	if len(rec.unresolved) > 0 {
 		return nil, nil, true, fmt.Errorf("sandbox %s admitted a container with no resolved image digest", sandboxID)
 	}
 	digests := []string{}

--- a/internal/cmds/nri-image-policy/inventory_test.go
+++ b/internal/cmds/nri-image-policy/inventory_test.go
@@ -322,3 +322,49 @@ func TestInventoryArgvSeparatorDoesNotEraseAdmissions(t *testing.T) {
 		}
 	}
 }
+
+// A container recorded without a digest closes its sandbox's answer; a later
+// record that resolves that same container reopens it.
+func TestInventory_UnresolvedClearsWhenTheContainerResolves(t *testing.T) {
+	inv := newAdmissionInventory(t.TempDir())
+	inv.record("ctr-1", "sbx-1", "app", "", nil)
+	inv.record("ctr-2", "sbx-1", "side", pushDigestA, nil)
+
+	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
+		t.Fatal("an unresolved container must fail the whole answer")
+	}
+
+	inv.record("ctr-3", "sbx-1", "other", "", nil)
+	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil)
+	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
+		t.Fatal("a second unresolved container must keep the answer closed")
+	}
+
+	inv.record("ctr-3", "sbx-1", "other", pushDigestC, nil)
+	digests, _, _, err := inv.DigestsForSandbox("sbx-1")
+	if err != nil {
+		t.Fatalf("resolving every container must reopen the answer: %v", err)
+	}
+	for _, want := range []string{pushDigestA, pushDigestB, pushDigestC} {
+		if !slices.Contains(digests, want) {
+			t.Fatalf("digests %v missing %s", digests, want)
+		}
+	}
+}
+
+// unresolved is keyed on the runtime-assigned container ID: two containers in a
+// sandbox can share a name, and one resolving must not clear the other.
+func TestInventory_UnresolvedIsKeyedOnContainerID(t *testing.T) {
+	inv := newAdmissionInventory(t.TempDir())
+	inv.record("ctr-1", "sbx-1", "app", "", nil)
+	inv.record("ctr-2", "sbx-1", "app", pushDigestA, nil)
+
+	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
+		t.Fatal("a namesake container cleared another container's unresolved marker")
+	}
+
+	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil)
+	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err != nil {
+		t.Fatalf("resolving the container itself must reopen the answer: %v", err)
+	}
+}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -92,13 +92,17 @@ func (s *policyStore) apply(pulled *allowlist.Allowlist, version uint64) bool {
 
 // plugin implements the NRI plugin interface for image policy enforcement.
 type plugin struct {
-	stub     stub.Stub
-	cfg      *config
-	resolver *ctrdresolver.Resolver
-	policy   *policyStore
-	audit    *audit.Logger
-	logger   *slog.Logger
-	ready    atomic.Bool
+	stub   stub.Stub
+	cfg    *config
+	policy *policyStore
+	audit  *audit.Logger
+	logger *slog.Logger
+	ready  atomic.Bool
+
+	// The containerd operations, bound by newPlugin; func fields so tests reach
+	// the resolve and kill paths without a socket.
+	resolve       func(ctx context.Context, imageRef string) (string, error)
+	stopContainer func(ctx context.Context, containerID string) error
 
 	// inventory serves the sandbox-identity flow (docs/ratls.md). nil ⇔ the flow
 	// is disabled (no workload_claims.socket_dir) — configuration, not a
@@ -122,11 +126,12 @@ func newPlugin(
 	logger *slog.Logger,
 ) (*plugin, error) {
 	p := &plugin{
-		cfg:      cfg,
-		resolver: resolver,
-		policy:   store,
-		audit:    auditLogger,
-		logger:   logger,
+		cfg:           cfg,
+		policy:        store,
+		audit:         auditLogger,
+		logger:        logger,
+		resolve:       resolver.Resolve,
+		stopContainer: resolver.StopContainer,
 	}
 	if cfg.WorkloadClaims.SocketDir != "" {
 		procRoot := cfg.WorkloadClaims.ProcRoot
@@ -204,8 +209,9 @@ func (p *plugin) Configure(ctx context.Context, config, runtime, version string)
 	return mask, nil
 }
 
-// RemoveContainer evicts a stopped container from the admission inventory.
-// Only subscribed when the inventory is enabled (see Configure).
+// RemoveContainer evicts a stopped container from caller resolution; the
+// sandbox's record keeps it (inventory.remove). Only subscribed when the
+// inventory is enabled (see Configure).
 func (p *plugin) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
 	if p.inventory != nil {
 		p.inventory.remove(ctr.GetId())
@@ -231,27 +237,40 @@ func (p *plugin) RemovePodSandbox(ctx context.Context, pod *api.PodSandbox) erro
 	return nil
 }
 
-// recordForInventory resolves a container's admitted image digest and records it
-// for the admission inventory. A resolve failure records an empty digest,
-// which makes the inventory refuse the pod's whole answer rather than commit a
-// subset — fail-closed, and logged at error because it costs the pod its
-// claim. It never blocks the create path: admission already decided the
-// container.
+// recordForInventory resolves a container's image digest and records it for the
+// admission inventory. A resolve failure records an empty digest, which makes
+// the inventory refuse the pod's whole answer rather than commit a subset —
+// fail-closed, and logged at error because it costs the pod its claim.
+//
+// INVARIANT: callers record what runs, not what passed the checks.
 func (p *plugin) recordForInventory(ctx context.Context, ctr *api.Container, imageRef string) {
 	if p.inventory == nil {
 		return
 	}
 	digest := extractDigest(imageRef)
 	if digest == "" && imageRef != "" {
-		if resolved, err := p.resolver.Resolve(ctx, imageRef); err == nil {
+		if resolved, err := p.resolve(ctx, imageRef); err == nil {
 			digest = extractDigest(resolved)
 		} else {
-			p.logger.Error("cannot resolve admitted image digest; the sandbox inventory will refuse to answer for this pod", "image", imageRef, "error", err)
+			p.logger.Error("cannot resolve the image digest of a running container; the sandbox inventory will refuse to answer for this pod", "image", imageRef, "error", err)
 		}
 	}
-	// ctr.Args is the effective OCI process.args admission was evaluated
-	// against, so the inventory vouches for the same (digest, argv) pair the
-	// allowlist matched.
+	p.recordDigest(ctr, digest)
+}
+
+// recordUncheckedForInventory takes only a digest already inlined in the
+// reference: it runs on the hook that must answer inside NRI's
+// plugin_request_timeout for a required plugin, so it stays off containerd.
+func (p *plugin) recordUncheckedForInventory(ctr *api.Container, imageRef string) {
+	p.recordDigest(ctr, extractDigest(imageRef))
+}
+
+// recordDigest is the only inventory.record call site. ctr.Args is the
+// effective OCI process.args, the same value the checks read.
+func (p *plugin) recordDigest(ctr *api.Container, digest string) {
+	if p.inventory == nil {
+		return
+	}
 	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest, ctr.GetArgs())
 }
 
@@ -265,13 +284,8 @@ func evaluateRule(rule labelRule, podLabels map[string]string) bool {
 }
 
 // checkLabels evaluates all label rules against a pod's labels.
-// Returns verdictSkip for exempt namespaces, verdictDeny if any rule is violated,
-// or verdictAllow if all rules pass.
+// Returns verdictDeny if any rule is violated, or verdictAllow if all rules pass.
 func (p *plugin) checkLabels(cfg *config, namespace, podName, containerName string, podLabels map[string]string) (imageVerdict, string) {
-	if slices.Contains(cfg.Policy.ExemptNamespaces, namespace) {
-		return verdictSkip, ""
-	}
-
 	for _, rule := range cfg.Policy.LabelRules {
 		if !evaluateRule(rule, podLabels) {
 			reason := fmt.Sprintf("label rule %q denied workload", rule.Name)
@@ -307,20 +321,6 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 		"image", imageRef,
 	)
 
-	// Check if namespace is exempt
-	if slices.Contains(cfg.Policy.ExemptNamespaces, namespace) {
-		log.Info("namespace exempt from policy")
-		p.audit.Log(audit.Event{
-			Action:    "allow",
-			Reason:    "namespace_exempt",
-			Namespace: namespace,
-			Pod:       podName,
-			Container: containerName,
-			Image:     imageRef,
-		})
-		return verdictSkip, ""
-	}
-
 	// If no image ref found, deny by default (missing annotation means kubelet was bypassed)
 	if imageRef == "" {
 		if cfg.Policy.DenyMissingAnnotation {
@@ -349,7 +349,7 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	digest := extractDigest(imageRef)
 	if digest == "" {
 		// No digest in reference — resolve tag via containerd image store
-		resolved, err := p.resolver.Resolve(ctx, imageRef)
+		resolved, err := p.resolve(ctx, imageRef)
 		if err != nil {
 			log.Warn("cannot resolve image digest via containerd", "error", err)
 			p.audit.Log(audit.Event{
@@ -420,15 +420,59 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	return verdictAllow, ""
 }
 
+// checkContainer runs the label rules and the image allowlist over a container,
+// then applies the namespace exemption to their verdict.
+//
+// INVARIANT: the exemption runs last and only downgrades a denial, so an exempt
+// container is still checked and audited, and every downgrade emits
+// namespace_exempt.
+func (p *plugin) checkContainer(ctx context.Context, cfg *config, pod *api.PodSandbox, ctr *api.Container, imageRef string) (imageVerdict, string) {
+	namespace, podName, ctrName := pod.GetNamespace(), pod.GetName(), ctr.GetName()
+	exempt := slices.Contains(cfg.Policy.ExemptNamespaces, namespace)
+
+	verdict, reason := p.checkLabels(cfg, namespace, podName, ctrName, pod.GetLabels())
+	if verdict == verdictDeny && !exempt {
+		return verdict, reason
+	}
+
+	if cfg.AllowlistEnabled() {
+		imgVerdict, imgReason := p.checkImage(ctx, cfg, namespace, podName, ctrName, imageRef, ctr.GetArgs())
+		if verdict != verdictDeny {
+			verdict, reason = imgVerdict, imgReason
+		}
+	}
+
+	if verdict == verdictDeny && exempt {
+		p.logger.Info("namespace exempt from policy; admitting denied container",
+			"namespace", namespace,
+			"pod", podName,
+			"container", ctrName,
+			"denial", reason,
+		)
+		p.audit.Log(audit.Event{
+			Action:    "allow",
+			Reason:    "namespace_exempt",
+			Overrides: reason,
+			Namespace: namespace,
+			Pod:       podName,
+			Container: ctrName,
+			Image:     imageRef,
+		})
+		return verdictSkip, ""
+	}
+
+	return verdict, reason
+}
+
 // shouldCheckExisting reports whether the startup check has work — enforcement,
 // inventory recovery, or both. See docs/getcert-workload-binding.md, Corner 4.
 func (p *plugin) shouldCheckExisting() bool {
 	return p.cfg.Policy.EnforceExisting || p.inventory != nil
 }
 
-// Synchronize is called when the plugin connects to containerd. It checks all
-// existing containers against the allowlist, records the admitted ones for the
-// inventory, and kills violations when enforce_existing is set.
+// Synchronize is called when the plugin connects to containerd. It records every
+// existing container, checks what it can, and kills violations when
+// enforce_existing is set.
 func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, ctrs []*api.Container) ([]*api.ContainerUpdate, error) {
 	cfg := p.cfg
 
@@ -460,9 +504,8 @@ func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, ctrs [
 	return nil, nil
 }
 
-// checkExisting checks all existing containers against the allowlist, records
-// the admitted ones for the inventory, and kills violations when enforce_existing
-// is set.
+// checkExisting records every container it is handed, checks the ones whose pod
+// sandbox it was also handed, and kills violations when enforce_existing is set.
 func (p *plugin) checkExisting(ctx context.Context, cfg *config, pods []*api.PodSandbox, ctrs []*api.Container) {
 	p.logger.Info("checking existing containers",
 		"pods", len(pods), "containers", len(ctrs), "enforcing", cfg.Policy.EnforceExisting)
@@ -475,41 +518,23 @@ func (p *plugin) checkExisting(ctx context.Context, cfg *config, pods []*api.Pod
 
 	var killed, failed int
 	for _, ctr := range ctrs {
+		// Recorded ahead of the lookup that can skip it; the record needs no pod.
+		imageRef := ctr.GetAnnotations()[annotationImageName]
+		p.recordForInventory(ctx, ctr, imageRef)
+
 		pod := podByID[ctr.GetPodSandboxId()]
 		if pod == nil {
 			continue
 		}
-
-		denied := false
-
-		labelVerdict, _ := p.checkLabels(cfg, pod.GetNamespace(), pod.GetName(), ctr.GetName(), pod.GetLabels())
-		if labelVerdict == verdictSkip {
+		if verdict, _ := p.checkContainer(ctx, cfg, pod, ctr, imageRef); verdict != verdictDeny {
 			continue
 		}
-		if labelVerdict == verdictDeny {
-			denied = true
-		}
-
-		if !denied && cfg.AllowlistEnabled() {
-			imageRef := ctr.GetAnnotations()[annotationImageName]
-			imgVerdict, _ := p.checkImage(ctx, cfg, pod.GetNamespace(), pod.GetName(), ctr.GetName(), imageRef, ctr.GetArgs())
-			if imgVerdict == verdictDeny {
-				denied = true
-			} else {
-				p.recordForInventory(ctx, ctr, imageRef)
-			}
-		}
-
-		if !denied {
-			continue
-		}
-
 		// enforce_existing off: the check only feeds the inventory.
 		if cfg.Policy.Mode == ModeAudit || !cfg.Policy.EnforceExisting {
 			continue
 		}
 
-		if err := p.resolver.StopContainer(ctx, ctr.GetId()); err != nil {
+		if err := p.stopContainer(ctx, ctr.GetId()); err != nil {
 			p.logger.Error("sync: failed to kill container", "container", ctr.GetName(), "error", err)
 			failed++
 		} else {
@@ -546,72 +571,48 @@ func (p *plugin) RunDeferredCheck(ctx context.Context) {
 	p.checkExisting(ctx, cfg, pods, ctrs)
 }
 
+// admitWhileInitializing decides a container seen after NRI registration but
+// before the first allowlist fetch: exempt namespaces and audit mode pass,
+// everything else is denied.
+func (p *plugin) admitWhileInitializing(cfg *config, pod *api.PodSandbox, ctr *api.Container) error {
+	log := p.logger.With(
+		"namespace", pod.GetNamespace(),
+		"pod", pod.GetName(),
+		"container", ctr.GetName(),
+	)
+
+	if slices.Contains(cfg.Policy.ExemptNamespaces, pod.GetNamespace()) {
+		log.Info("plugin initializing: allowing container in exempt namespace")
+		return nil
+	}
+	if cfg.Policy.Mode == ModeAudit {
+		log.Warn("plugin initializing: would deny container creation (audit mode)")
+		return nil
+	}
+	log.Warn("plugin initializing: denying container creation")
+	return fmt.Errorf("image policy plugin initializing, container creation denied")
+}
+
 // CreateContainer is called when a container is being created.
 // Returning an error will reject the container creation.
 func (p *plugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	cfg := p.cfg
+	imageRef := ctr.GetAnnotations()[annotationImageName]
 
-	// Not-ready guard: plugin is registered with NRI but allowlist hasn't
-	// been fetched yet. Deny all non-exempt container creation to close
-	// the startup window.
 	if !p.Ready() {
-		// Exempt namespaces always pass (prevents deadlock when CDS itself
-		// runs in-cluster inside an exempt namespace).
-		if slices.Contains(cfg.Policy.ExemptNamespaces, pod.GetNamespace()) {
-			p.logger.Info("plugin initializing: allowing container in exempt namespace",
-				"namespace", pod.GetNamespace(),
-				"pod", pod.GetName(),
-				"container", ctr.GetName(),
-			)
-			return nil, nil, nil
+		if err := p.admitWhileInitializing(cfg, pod, ctr); err != nil {
+			return nil, nil, err
 		}
-
-		if cfg.Policy.Mode == ModeAudit {
-			p.logger.Warn("plugin initializing: would deny container creation (audit mode)",
-				"namespace", pod.GetNamespace(),
-				"pod", pod.GetName(),
-				"container", ctr.GetName(),
-			)
-			return nil, nil, nil
-		}
-
-		p.logger.Warn("plugin initializing: denying container creation",
-			"namespace", pod.GetNamespace(),
-			"pod", pod.GetName(),
-			"container", ctr.GetName(),
-		)
-		return nil, nil, fmt.Errorf("image policy plugin initializing, container creation denied")
-	}
-
-	// Label-based policy check (fast, no I/O — runs before image check)
-	labelVerdict, labelReason := p.checkLabels(cfg, pod.GetNamespace(), pod.GetName(), ctr.GetName(), pod.GetLabels())
-	if labelVerdict == verdictDeny {
-		if cfg.Policy.Mode == ModeAudit {
-			return nil, nil, nil
-		}
-		return nil, nil, fmt.Errorf("%s", labelReason)
-	}
-	if labelVerdict == verdictSkip {
+		p.recordUncheckedForInventory(ctr, imageRef)
 		return nil, nil, nil
 	}
 
-	// Image allowlist check (only when configured)
-	if cfg.AllowlistEnabled() {
-		imageRef := ctr.GetAnnotations()[annotationImageName]
-
-		// Effective argv (ctr.Args): NRI folds the OCI process.args here, so the
-		// full merged entrypoint+cmd the container runs is available at this hook.
-		verdict, reason := p.checkImage(ctx, cfg, pod.GetNamespace(), pod.GetName(), ctr.GetName(), imageRef, ctr.GetArgs())
-		if verdict == verdictDeny {
-			if cfg.Policy.Mode == ModeAudit {
-				return nil, nil, nil
-			}
-			return nil, nil, fmt.Errorf("%s", reason)
-		}
-		// Admitted: record for the admission inventory.
-		p.recordForInventory(ctx, ctr, imageRef)
+	verdict, reason := p.checkContainer(ctx, cfg, pod, ctr, imageRef)
+	if verdict == verdictDeny && cfg.Policy.Mode != ModeAudit {
+		return nil, nil, fmt.Errorf("%s", reason)
 	}
 
+	p.recordForInventory(ctx, ctr, imageRef)
 	return nil, nil, nil
 }
 

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/confidential-dot-ai/c8s/internal/audit"
-	ctrdresolver "github.com/confidential-dot-ai/c8s/internal/containerd"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -90,19 +89,22 @@ func (s *policyStore) apply(pulled *allowlist.Allowlist, version uint64) bool {
 	return true
 }
 
+// containerdOps is the containerd surface admission drives; internal/containerd's
+// *Resolver satisfies it.
+type containerdOps interface {
+	Resolve(ctx context.Context, imageRef string) (string, error)
+	StopContainer(ctx context.Context, containerID string) error
+}
+
 // plugin implements the NRI plugin interface for image policy enforcement.
 type plugin struct {
-	stub   stub.Stub
-	cfg    *config
-	policy *policyStore
-	audit  *audit.Logger
-	logger *slog.Logger
-	ready  atomic.Bool
-
-	// The containerd operations, bound by newPlugin; func fields so tests reach
-	// the resolve and kill paths without a socket.
-	resolve       func(ctx context.Context, imageRef string) (string, error)
-	stopContainer func(ctx context.Context, containerID string) error
+	stub       stub.Stub
+	cfg        *config
+	policy     *policyStore
+	audit      *audit.Logger
+	logger     *slog.Logger
+	ready      atomic.Bool
+	containerd containerdOps
 
 	// inventory serves the sandbox-identity flow (docs/ratls.md). nil ⇔ the flow
 	// is disabled (no workload_claims.socket_dir) — configuration, not a
@@ -120,18 +122,17 @@ type plugin struct {
 
 func newPlugin(
 	cfg *config,
-	resolver *ctrdresolver.Resolver,
+	ctrd containerdOps,
 	store *policyStore,
 	auditLogger *audit.Logger,
 	logger *slog.Logger,
 ) (*plugin, error) {
 	p := &plugin{
-		cfg:           cfg,
-		policy:        store,
-		audit:         auditLogger,
-		logger:        logger,
-		resolve:       resolver.Resolve,
-		stopContainer: resolver.StopContainer,
+		cfg:        cfg,
+		policy:     store,
+		audit:      auditLogger,
+		logger:     logger,
+		containerd: ctrd,
 	}
 	if cfg.WorkloadClaims.SocketDir != "" {
 		procRoot := cfg.WorkloadClaims.ProcRoot
@@ -249,7 +250,7 @@ func (p *plugin) recordForInventory(ctx context.Context, ctr *api.Container, ima
 	}
 	digest := extractDigest(imageRef)
 	if digest == "" && imageRef != "" {
-		if resolved, err := p.resolve(ctx, imageRef); err == nil {
+		if resolved, err := p.containerd.Resolve(ctx, imageRef); err == nil {
 			digest = extractDigest(resolved)
 		} else {
 			p.logger.Error("cannot resolve the image digest of a running container; the sandbox inventory will refuse to answer for this pod", "image", imageRef, "error", err)
@@ -349,7 +350,7 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	digest := extractDigest(imageRef)
 	if digest == "" {
 		// No digest in reference — resolve tag via containerd image store
-		resolved, err := p.resolve(ctx, imageRef)
+		resolved, err := p.containerd.Resolve(ctx, imageRef)
 		if err != nil {
 			log.Warn("cannot resolve image digest via containerd", "error", err)
 			p.audit.Log(audit.Event{
@@ -534,7 +535,7 @@ func (p *plugin) checkExisting(ctx context.Context, cfg *config, pods []*api.Pod
 			continue
 		}
 
-		if err := p.stopContainer(ctx, ctr.GetId()); err != nil {
+		if err := p.containerd.StopContainer(ctx, ctr.GetId()); err != nil {
 			p.logger.Error("sync: failed to kill container", "container", ctr.GetName(), "error", err)
 			failed++
 		} else {

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -1,14 +1,18 @@
 package nriimagepolicy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/confidential-dot-ai/c8s/internal/audit"
-	ctrdresolver "github.com/confidential-dot-ai/c8s/internal/containerd"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/containerd/nri/pkg/api"
@@ -18,12 +22,20 @@ func newTestPlugin(cfg *config) *plugin {
 	if err := validateLabelRules(cfg.Policy.LabelRules); err != nil {
 		panic(err)
 	}
-	return &plugin{
-		cfg:      cfg,
-		resolver: &ctrdresolver.Resolver{},
-		audit:    audit.NewLogger(),
-		logger:   slog.Default(),
+	p := &plugin{
+		cfg:    cfg,
+		audit:  audit.NewLogger(),
+		logger: slog.Default(),
 	}
+	noContainerd(p)
+	return p
+}
+
+// noContainerd makes any containerd call a named panic. Tests that need one
+// rebind the field; the rest must stay on digest-bearing references.
+func noContainerd(p *plugin) {
+	p.resolve = func(context.Context, string) (string, error) { panic("unexpected containerd resolve") }
+	p.stopContainer = func(context.Context, string) error { panic("unexpected container kill") }
 }
 
 func TestCheckImage_MissingAnnotation_DenyEnabled(t *testing.T) {
@@ -55,7 +67,7 @@ func TestCheckImage_MissingAnnotation_DenyDisabled(t *testing.T) {
 	}
 }
 
-func TestCheckImage_MissingAnnotation_ExemptNamespace(t *testing.T) {
+func TestCheckImage_MissingAnnotation_ExemptNamespaceStillDenied(t *testing.T) {
 	p := newTestPlugin(&config{
 		Policy: policyConfig{
 			DenyMissingAnnotation: true,
@@ -64,6 +76,23 @@ func TestCheckImage_MissingAnnotation_ExemptNamespace(t *testing.T) {
 	})
 
 	verdict, _ := p.checkImage(context.Background(), p.cfg, "kube-system", "pod", "ctr", "", nil)
+	if verdict != verdictDeny {
+		t.Fatalf("expected verdictDeny, got %d", verdict)
+	}
+}
+
+func TestCheckContainer_MissingAnnotation_ExemptNamespaceAdmitted(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy: policyConfig{
+			Mode:                  ModeFailClosed,
+			DenyMissingAnnotation: true,
+			ExemptNamespaces:      []string{"kube-system"},
+		},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+
+	pod := makePod("kube-system", "pod")
+	verdict, _ := p.checkContainer(context.Background(), p.cfg, pod, makeCtr(pod.Id, "ctr"), "")
 	if verdict != verdictSkip {
 		t.Fatalf("expected verdictSkip for exempt namespace, got %d", verdict)
 	}
@@ -282,11 +311,11 @@ func TestCreateContainer_Ready_PassesThrough(t *testing.T) {
 				ExemptNamespaces:      []string{"kube-system"},
 			},
 		},
-		resolver: &ctrdresolver.Resolver{},
-		audit:    audit.NewLogger(),
-		logger:   slog.Default(),
-		policy:   newPolicyStore(floorAllowlist(map[string]string{})),
+		audit:  audit.NewLogger(),
+		logger: slog.Default(),
+		policy: newPolicyStore(floorAllowlist(map[string]string{})),
 	}
+	noContainerd(p)
 	p.SetReady()
 
 	// Container with no image annotation and deny_missing_annotation=true
@@ -386,7 +415,7 @@ func TestEvaluateRule_UncompiledRuleFailsClosed(t *testing.T) {
 
 // --- checkLabels tests ---
 
-func TestCheckLabels_ExemptNamespace(t *testing.T) {
+func TestCheckLabels_ExemptNamespaceStillEvaluatesRules(t *testing.T) {
 	p := newTestPlugin(&config{
 		Policy: policyConfig{
 			ExemptNamespaces: []string{"kube-system"},
@@ -399,6 +428,25 @@ func TestCheckLabels_ExemptNamespace(t *testing.T) {
 	})
 
 	verdict, _ := p.checkLabels(p.cfg, "kube-system", "pod", "ctr", nil)
+	if verdict != verdictDeny {
+		t.Fatalf("expected verdictDeny, got %d", verdict)
+	}
+}
+
+func TestCheckContainer_ExemptNamespace_OverridesLabelDenial(t *testing.T) {
+	p := newTestPlugin(&config{
+		Policy: policyConfig{
+			ExemptNamespaces: []string{"kube-system"},
+			LabelRules: []labelRule{
+				{Name: "require-tenant", MatchExpressions: []labelExpression{
+					{Key: "tenant", Operator: "Exists"},
+				}},
+			},
+		},
+	})
+
+	pod := makePod("kube-system", "pod")
+	verdict, _ := p.checkContainer(context.Background(), p.cfg, pod, makeCtr(pod.Id, "ctr"), "")
 	if verdict != verdictSkip {
 		t.Fatalf("expected verdictSkip for exempt namespace, got %d", verdict)
 	}
@@ -556,22 +604,21 @@ func mustDigest(t *testing.T, s string) types.Digest {
 }
 
 // newCachedPlugin builds a plugin whose policy store admits wl (applied as a
-// version-1 pull over an empty floor). The resolver is a zero-value placeholder;
-// tests must only exercise digest-bearing image references so resolver.Resolve
-// is never reached (no real containerd socket).
+// version-1 pull over an empty floor).
 func newCachedPlugin(cfg *config, wl *allowlist.Allowlist) (*plugin, *policyStore) {
 	if err := validateLabelRules(cfg.Policy.LabelRules); err != nil {
 		panic(err)
 	}
 	store := newPolicyStore(floorAllowlist(map[string]string{}))
 	store.apply(wl, 1)
-	return &plugin{
-		cfg:      cfg,
-		resolver: &ctrdresolver.Resolver{},
-		policy:   store,
-		audit:    audit.NewLogger(),
-		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-	}, store
+	p := &plugin{
+		cfg:    cfg,
+		policy: store,
+		audit:  audit.NewLogger(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	noContainerd(p)
+	return p, store
 }
 
 // --- checkImage: digest-bearing references (no resolver needed) ---
@@ -619,16 +666,16 @@ func TestCheckImage_NoPolicyLoaded_Denies(t *testing.T) {
 	}
 }
 
-func TestCheckImage_ExemptNamespace_WithImage_Skips(t *testing.T) {
-	imageRef := "registry/repo@" + pushDigestB // not in allowlist; exemption wins
+func TestCheckImage_ExemptNamespace_StillCheckedAgainstAllowlist(t *testing.T) {
+	imageRef := "registry/repo@" + pushDigestB // not in allowlist
 	p, _ := newCachedPlugin(&config{Policy: policyConfig{
 		Mode:             ModeFailClosed,
 		ExemptNamespaces: []string{"kube-system"},
 	}}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
 
 	verdict, _ := p.checkImage(context.Background(), p.cfg, "kube-system", "pod", "ctr", imageRef, nil)
-	if verdict != verdictSkip {
-		t.Fatalf("expected verdictSkip for exempt namespace, got %d", verdict)
+	if verdict != verdictDeny {
+		t.Fatalf("expected verdictDeny, got %d", verdict)
 	}
 }
 
@@ -842,7 +889,7 @@ func TestRunDeferredCheck_AuditMode_NoKill(t *testing.T) {
 	p.deferredCtrs = []*api.Container{ctr}
 	p.deferredMu.Unlock()
 
-	// Should run the check without panicking or touching the (nil) resolver.
+	// Should run the check without reaching containerd (noContainerd panics).
 	p.RunDeferredCheck(context.Background())
 	assertDeferredCleared(t, p)
 }
@@ -861,30 +908,6 @@ func TestRunDeferredCheck_OrphanContainer_Skipped(t *testing.T) {
 	p.deferredCtrs = []*api.Container{ctr}
 	p.deferredMu.Unlock()
 
-	p.RunDeferredCheck(context.Background())
-	assertDeferredCleared(t, p)
-}
-
-func TestRunDeferredCheck_ExemptNamespace_Skipped(t *testing.T) {
-	p, _ := newCachedPlugin(&config{
-		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
-		Policy: policyConfig{
-			Mode:             ModeFailClosed,
-			EnforceExisting:  true,
-			ExemptNamespaces: []string{"kube-system"},
-		},
-	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
-	p.SetReady()
-
-	pod := makePod("kube-system", "pod1")
-	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
-	p.deferredMu.Lock()
-	p.deferredPods = []*api.PodSandbox{pod}
-	p.deferredCtrs = []*api.Container{ctr}
-	p.deferredMu.Unlock()
-
-	// Exempt namespace → checkLabels returns verdictSkip → check continues,
-	// fail-closed mode but no kill because the container is skipped entirely.
 	p.RunDeferredCheck(context.Background())
 	assertDeferredCleared(t, p)
 }
@@ -927,7 +950,7 @@ func TestSynchronize_EnforceExistingDisabled_BrokerRecordsWithoutKilling(t *test
 	denied := makeCtrWithImage(pod.Id, "ctr2", "registry/repo@"+pushDigestB)
 
 	// Fail-closed, but enforce_existing off: the denied container must not reach
-	// resolver.StopContainer (nil containerd client → panic).
+	// stopContainer (noContainerd panics).
 	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{allowed, denied}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -939,8 +962,17 @@ func TestSynchronize_EnforceExistingDisabled_BrokerRecordsWithoutKilling(t *test
 	if rec.digest != pushDigestA {
 		t.Fatalf("recorded digest = %q, want %q", rec.digest, pushDigestA)
 	}
-	if _, ok := p.inventory.containers[denied.Id]; ok {
-		t.Fatal("denied container must not be recorded in the inventory")
+	// The denial did not stop it, so /digests must report it: a sandbox whose
+	// answer omits a running container reads as a workload it is not.
+	if _, ok := p.inventory.containers[denied.Id]; !ok {
+		t.Fatalf("a denied container left running is invisible to the inventory: %v", p.inventory.containers)
+	}
+	digests, _, _, err := p.inventory.DigestsForSandbox(pod.Id)
+	if err != nil {
+		t.Fatalf("DigestsForSandbox: %v", err)
+	}
+	if !slices.Contains(digests, pushDigestB) {
+		t.Fatalf("/digests omits the denied container: %v", digests)
 	}
 }
 
@@ -984,7 +1016,7 @@ func TestSynchronize_Ready_AuditMode_ChecksWithoutEnforcing(t *testing.T) {
 	denied := makeCtrWithImage(pod.Id, "ctr2", "registry/repo@"+pushDigestB)
 
 	// Audit mode must run the check without enforcement: a denied container
-	// reaching resolver.StopContainer would panic on the nil containerd client.
+	// reaching stopContainer would panic (noContainerd).
 	updates, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{allowed, denied})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -994,6 +1026,439 @@ func TestSynchronize_Ready_AuditMode_ChecksWithoutEnforcing(t *testing.T) {
 	}
 	if _, ok := p.inventory.containers[allowed.Id]; !ok {
 		t.Fatalf("check did not record the allowed container in the inventory: %v", p.inventory.containers)
+	}
+	// Audit mode leaves the denied container running, so it belongs in /digests.
+	if _, ok := p.inventory.containers[denied.Id]; !ok {
+		t.Fatalf("audit mode left a container running and unrecorded: %v", p.inventory.containers)
+	}
+}
+
+// --- Namespace exemption: ordering and inventory ---
+
+// captureAudit collects the audit events fn emits on the default slog logger.
+// Swaps a process-global: not safe under t.Parallel.
+func captureAudit(t *testing.T, fn func()) []map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&buf, nil)))
+	defer slog.SetDefault(prev)
+
+	fn()
+
+	var events []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("parse log line %q: %v", line, err)
+		}
+		if rec["msg"] == "audit" {
+			events = append(events, rec)
+		}
+	}
+	return events
+}
+
+// exemptPlugin admits pushDigestA only, exempts kube-system, and carries an
+// inventory.
+func exemptPlugin(t *testing.T) *plugin {
+	t.Helper()
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy: policyConfig{
+			Mode:                  ModeFailClosed,
+			EnforceExisting:       true,
+			DenyMissingAnnotation: true,
+			ExemptNamespaces:      []string{"kube-system"},
+		},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	return p
+}
+
+func TestCheckContainer_ExemptNamespace_DigestCheckedBeforeExemption(t *testing.T) {
+	p := exemptPlugin(t)
+	pod := makePod("kube-system", "pod1")
+	imageRef := "registry/repo@" + pushDigestB // not in the allowlist
+	ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+	var verdict imageVerdict
+	events := captureAudit(t, func() {
+		verdict, _ = p.checkContainer(context.Background(), p.cfg, pod, ctr, imageRef)
+	})
+
+	if verdict != verdictSkip {
+		t.Fatalf("exempt namespace should still be admitted, got verdict %d", verdict)
+	}
+	if len(events) != 2 {
+		t.Fatalf("want the digest denial then the exemption, got %d events: %v", len(events), events)
+	}
+	if events[0]["action"] != "deny" || events[0]["reason"] != "not_in_allowlist" {
+		t.Fatalf("the digest check must run first, got %v", events[0])
+	}
+	if events[1]["reason"] != "namespace_exempt" {
+		t.Fatalf("the exemption must be applied after the digest check, got %v", events[1])
+	}
+}
+
+func TestCheckContainer_ExemptNamespace_LabelDenialDoesNotSkipDigestCheck(t *testing.T) {
+	p := exemptPlugin(t)
+	p.cfg.Policy.LabelRules = []labelRule{mustCompileRule(t, labelRule{
+		Name:             "require-tenant",
+		MatchExpressions: []labelExpression{{Key: "tenant", Operator: "Exists"}},
+	})}
+
+	pod := makePodWithLabels("kube-system", "pod1", nil) // violates require-tenant
+	imageRef := "registry/repo@" + pushDigestB
+	ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+	var verdict imageVerdict
+	events := captureAudit(t, func() {
+		verdict, _ = p.checkContainer(context.Background(), p.cfg, pod, ctr, imageRef)
+	})
+
+	if verdict != verdictSkip {
+		t.Fatalf("exempt namespace should still be admitted, got verdict %d", verdict)
+	}
+	var sawImageDenial bool
+	for _, e := range events {
+		if e["action"] == "deny" && e["reason"] == "not_in_allowlist" {
+			sawImageDenial = true
+		}
+	}
+	if !sawImageDenial {
+		t.Fatalf("a label denial suppressed the digest check: %v", events)
+	}
+}
+
+func TestExemptNamespaceContainerIsRecordedOnEveryPath(t *testing.T) {
+	pod := makePod("kube-system", "pod1")
+	imageRef := "registry/repo@" + pushDigestB // not in the allowlist
+	ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+	paths := []struct {
+		name string
+		run  func(*testing.T, *plugin)
+	}{
+		{"create hook", func(t *testing.T, p *plugin) {
+			p.SetReady()
+			if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+				t.Fatalf("exempt namespace should be admitted: %v", err)
+			}
+		}},
+		{"create hook while initializing", func(t *testing.T, p *plugin) {
+			if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+				t.Fatalf("exempt namespace should be admitted: %v", err)
+			}
+		}},
+		{"startup check", func(t *testing.T, p *plugin) {
+			p.SetReady()
+			if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{ctr}); err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"deferred check", func(t *testing.T, p *plugin) {
+			if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{ctr}); err != nil {
+				t.Fatal(err)
+			}
+			p.SetReady()
+			p.RunDeferredCheck(context.Background())
+		}},
+	}
+
+	for _, path := range paths {
+		t.Run(path.name, func(t *testing.T) {
+			p := exemptPlugin(t)
+			path.run(t, p)
+
+			rec, ok := p.inventory.containers[ctr.Id]
+			if !ok {
+				t.Fatalf("exempt container is invisible to the inventory: %v", p.inventory.containers)
+			}
+			if rec.digest != pushDigestB {
+				t.Fatalf("recorded digest = %q, want %q", rec.digest, pushDigestB)
+			}
+			digests, _, known, err := p.inventory.DigestsForSandbox(pod.Id)
+			if err != nil || !known {
+				t.Fatalf("DigestsForSandbox(%s) = known %v, err %v", pod.Id, known, err)
+			}
+			if !slices.Contains(digests, pushDigestB) {
+				t.Fatalf("/digests omits the exempt container: %v", digests)
+			}
+		})
+	}
+}
+
+// Platform components on a default install take the ordinary allow, not the
+// exemption: the exemption leaves no trace when nothing denied.
+func TestCheckContainer_ExemptNamespace_AllowlistedImageIsPlainAllow(t *testing.T) {
+	p := exemptPlugin(t)
+	pod := makePod("kube-system", "pod1")
+	imageRef := "registry/repo@" + pushDigestA // in the allowlist
+	ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+	var verdict imageVerdict
+	events := captureAudit(t, func() {
+		verdict, _ = p.checkContainer(context.Background(), p.cfg, pod, ctr, imageRef)
+	})
+
+	if verdict != verdictAllow {
+		t.Fatalf("an allowlisted image should be a plain allow, got verdict %d", verdict)
+	}
+	var sawVerified bool
+	for _, e := range events {
+		if e["reason"] == "namespace_exempt" {
+			t.Fatalf("the exemption fired with nothing to override: %v", events)
+		}
+		sawVerified = sawVerified || e["reason"] == "verified"
+	}
+	if !sawVerified {
+		t.Fatalf("the digest check did not run: %v", events)
+	}
+}
+
+// The overridden denial must stay visible: an exemption that admits a container
+// a rule denied is the event an operator needs to see.
+func TestCheckContainer_ExemptNamespace_LabelDenialIsAuditedAsOverridden(t *testing.T) {
+	p := exemptPlugin(t)
+	p.cfg.Policy.LabelRules = []labelRule{mustCompileRule(t, labelRule{
+		Name:             "require-tenant",
+		MatchExpressions: []labelExpression{{Key: "tenant", Operator: "Exists"}},
+	})}
+
+	pod := makePodWithLabels("kube-system", "pod1", nil) // violates require-tenant
+	imageRef := "registry/repo@" + pushDigestA           // but the image is allowlisted
+	ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+	var verdict imageVerdict
+	events := captureAudit(t, func() {
+		verdict, _ = p.checkContainer(context.Background(), p.cfg, pod, ctr, imageRef)
+	})
+
+	if verdict != verdictSkip {
+		t.Fatalf("a label denial the exemption overrode should be verdictSkip, got %d", verdict)
+	}
+	var exemptEvent map[string]any
+	for _, e := range events {
+		if e["reason"] == "namespace_exempt" {
+			exemptEvent = e
+		}
+	}
+	if exemptEvent == nil {
+		t.Fatalf("an allowlisted image erased the record of the overridden label rule: %v", events)
+	}
+	if got, _ := exemptEvent["overrides"].(string); !strings.Contains(got, "require-tenant") {
+		t.Fatalf("the exemption event does not name the denial it overturned: %q", got)
+	}
+}
+
+func TestCheckContainer_NamespaceNearMissesAreNotExempt(t *testing.T) {
+	imageRef := "registry/repo@" + pushDigestB // not in the allowlist
+	for _, tc := range []struct {
+		namespace string
+		want      imageVerdict
+	}{
+		{"kube-system", verdictSkip}, // positive control: the exemption does fire
+		{"", verdictDeny},
+		{"kube-system ", verdictDeny},
+		{" kube-system", verdictDeny},
+		{"KUBE-SYSTEM", verdictDeny},
+		{"Kube-System", verdictDeny},
+		{"kube-system.", verdictDeny},
+		{"kube-system\x00", verdictDeny},
+		{"kube-system\n", verdictDeny},
+		{"kube-systems", verdictDeny},
+		{"kube_system", verdictDeny},
+	} {
+		t.Run(fmt.Sprintf("%q", tc.namespace), func(t *testing.T) {
+			p := exemptPlugin(t)
+			pod := makePod(tc.namespace, "pod1")
+			ctr := makeCtrWithImage(pod.Id, "ctr1", imageRef)
+
+			verdict, _ := p.checkContainer(context.Background(), p.cfg, pod, ctr, imageRef)
+			if verdict != tc.want {
+				t.Fatalf("namespace %q: verdict %d, want %d", tc.namespace, verdict, tc.want)
+			}
+		})
+	}
+}
+
+// noContainerd panics if this path reaches the image store.
+func TestCreateContainer_NotReady_RecordsWithoutResolving(t *testing.T) {
+	p := exemptPlugin(t) // not ready
+	pod := makePod("kube-system", "pod1")
+	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo:latest") // no inline digest
+
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+		t.Fatalf("exempt namespace should be admitted: %v", err)
+	}
+	rec, ok := p.inventory.containers[ctr.Id]
+	if !ok {
+		t.Fatalf("bootstrap container not recorded: %v", p.inventory.containers)
+	}
+	if rec.digest != "" {
+		t.Fatalf("the bootstrap path resolved a digest, got %q", rec.digest)
+	}
+	if _, _, _, err := p.inventory.DigestsForSandbox(pod.Id); err == nil {
+		t.Fatal("an unresolved digest must fail the sandbox answer closed")
+	}
+}
+
+// Audit mode admits what it denies, so what it admits it must record.
+func TestCreateContainer_AuditModeDenial_IsRecorded(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy:    policyConfig{Mode: ModeAudit},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	p.SetReady()
+
+	pod := makePod("default", "pod1")
+	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
+
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+		t.Fatalf("audit mode should admit: %v", err)
+	}
+	rec, ok := p.inventory.containers[ctr.Id]
+	if !ok {
+		t.Fatalf("audit mode admitted a container it did not record: %v", p.inventory.containers)
+	}
+	if rec.digest != pushDigestB {
+		t.Fatalf("recorded digest = %q, want %q", rec.digest, pushDigestB)
+	}
+}
+
+func TestCheckExisting_RecordsBeforeAttemptingTheKill(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy:    policyConfig{Mode: ModeFailClosed, EnforceExisting: true},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	p.SetReady()
+
+	pod := makePod("default", "pod1")
+	denied := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
+
+	var killed []string
+	var recordedAtKill bool
+	p.stopContainer = func(_ context.Context, id string) error {
+		killed = append(killed, id)
+		_, recordedAtKill = p.inventory.containers[denied.Id]
+		return errors.New("kill not delivered")
+	}
+
+	p.checkExisting(context.Background(), p.cfg, []*api.PodSandbox{pod}, []*api.Container{denied})
+
+	if len(killed) != 1 || killed[0] != denied.Id {
+		t.Fatalf("the kill was not attempted: %v", killed)
+	}
+	if !recordedAtKill {
+		t.Fatal("the container was recorded only after the kill was attempted")
+	}
+	if _, ok := p.inventory.containers[denied.Id]; !ok {
+		t.Fatal("an undeliverable kill left the container unrecorded")
+	}
+}
+
+// A container whose sandbox is absent from the Synchronize list runs like any
+// other, so the sandbox's answer must carry it.
+func TestCheckExisting_OrphanContainerIsStillRecorded(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy:    policyConfig{Mode: ModeFailClosed, EnforceExisting: true},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	p.SetReady()
+
+	orphan := makeCtrWithImage("missing-pod-id", "orphan", "registry/repo@"+pushDigestB)
+	if _, err := p.Synchronize(context.Background(), nil, []*api.Container{orphan}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := p.inventory.containers[orphan.Id]; !ok {
+		t.Fatalf("a container with no pod in the list went unrecorded: %v", p.inventory.containers)
+	}
+	digests, _, known, err := p.inventory.DigestsForSandbox("missing-pod-id")
+	if err != nil || !known {
+		t.Fatalf("DigestsForSandbox = known %v, err %v", known, err)
+	}
+	if !slices.Contains(digests, pushDigestB) {
+		t.Fatalf("the sandbox answer launders the orphan: %v", digests)
+	}
+}
+
+// Only the pre-allowlist hook skips containerd; the startup path resolves.
+func TestCheckExisting_ResolvesTagOnlyReference(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy:    policyConfig{Mode: ModeFailClosed, EnforceExisting: false},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	var resolved []string
+	p.resolve = func(_ context.Context, ref string) (string, error) {
+		resolved = append(resolved, ref)
+		return "registry/repo@" + pushDigestA, nil
+	}
+	p.SetReady()
+
+	pod := makePod("default", "pod1")
+	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo:latest")
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{ctr}); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resolved) == 0 {
+		t.Fatal("the startup path recorded a tag-only reference without resolving it")
+	}
+	if rec := p.inventory.containers[ctr.Id]; rec.digest != pushDigestA {
+		t.Fatalf("recorded digest = %q, want the resolved %q", rec.digest, pushDigestA)
+	}
+}
+
+// argv reaches MatchWorkload, so the recorded value must be the container's.
+func TestCreateContainer_RecordsTheContainerArgv(t *testing.T) {
+	p, _ := newCachedPlugin(&config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
+		Policy:    policyConfig{Mode: ModeFailClosed},
+	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
+	p.inventory = newAdmissionInventory("/proc")
+	p.SetReady()
+
+	pod := makePod("default", "pod1")
+	argv := []string{"/bin/app", "--serve"}
+	ctr := makeCtrWithImageArgs(pod.Id, "ctr1", "registry/repo@"+pushDigestA, argv)
+
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+		t.Fatalf("allowlisted digest should be admitted: %v", err)
+	}
+	if rec := p.inventory.containers[ctr.Id]; !slices.Equal(rec.argv, argv) {
+		t.Fatalf("recorded argv = %v, want %v", rec.argv, argv)
+	}
+	_, containers, _, err := p.inventory.DigestsForSandbox(pod.Id)
+	if err != nil {
+		t.Fatalf("DigestsForSandbox: %v", err)
+	}
+	if len(containers) != 1 || !slices.Equal(containers[0].Argv, argv) {
+		t.Fatalf("the sandbox answer reports argv %v, want %v", containers, argv)
+	}
+}
+
+// A container the create hook rejected never ran.
+func TestCreateContainer_DeniedContainerIsNotRecorded(t *testing.T) {
+	p := exemptPlugin(t)
+	p.SetReady()
+
+	pod := makePod("default", "pod1")
+	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
+
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+		t.Fatal("expected denial for an image not in the allowlist")
+	}
+	if _, ok := p.inventory.containers[ctr.Id]; ok {
+		t.Fatal("a denied container must not be recorded in the inventory")
 	}
 }
 

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -22,20 +22,33 @@ func newTestPlugin(cfg *config) *plugin {
 	if err := validateLabelRules(cfg.Policy.LabelRules); err != nil {
 		panic(err)
 	}
-	p := &plugin{
-		cfg:    cfg,
-		audit:  audit.NewLogger(),
-		logger: slog.Default(),
+	return &plugin{
+		cfg:        cfg,
+		audit:      audit.NewLogger(),
+		logger:     slog.Default(),
+		containerd: &fakeContainerd{},
 	}
-	noContainerd(p)
-	return p
 }
 
-// noContainerd makes any containerd call a named panic. Tests that need one
-// rebind the field; the rest must stay on digest-bearing references.
-func noContainerd(p *plugin) {
-	p.resolve = func(context.Context, string) (string, error) { panic("unexpected containerd resolve") }
-	p.stopContainer = func(context.Context, string) error { panic("unexpected container kill") }
+// fakeContainerd is the containerdOps a test drives. An unset hook panics, so a
+// test that reaches containerd without arranging for it names the call it made.
+type fakeContainerd struct {
+	resolve func(ctx context.Context, imageRef string) (string, error)
+	stop    func(ctx context.Context, containerID string) error
+}
+
+func (f *fakeContainerd) Resolve(ctx context.Context, imageRef string) (string, error) {
+	if f.resolve == nil {
+		panic("unexpected containerd resolve")
+	}
+	return f.resolve(ctx, imageRef)
+}
+
+func (f *fakeContainerd) StopContainer(ctx context.Context, containerID string) error {
+	if f.stop == nil {
+		panic("unexpected container kill")
+	}
+	return f.stop(ctx, containerID)
 }
 
 func TestCheckImage_MissingAnnotation_DenyEnabled(t *testing.T) {
@@ -311,11 +324,11 @@ func TestCreateContainer_Ready_PassesThrough(t *testing.T) {
 				ExemptNamespaces:      []string{"kube-system"},
 			},
 		},
-		audit:  audit.NewLogger(),
-		logger: slog.Default(),
-		policy: newPolicyStore(floorAllowlist(map[string]string{})),
+		audit:      audit.NewLogger(),
+		logger:     slog.Default(),
+		policy:     newPolicyStore(floorAllowlist(map[string]string{})),
+		containerd: &fakeContainerd{},
 	}
-	noContainerd(p)
 	p.SetReady()
 
 	// Container with no image annotation and deny_missing_annotation=true
@@ -612,12 +625,12 @@ func newCachedPlugin(cfg *config, wl *allowlist.Allowlist) (*plugin, *policyStor
 	store := newPolicyStore(floorAllowlist(map[string]string{}))
 	store.apply(wl, 1)
 	p := &plugin{
-		cfg:    cfg,
-		policy: store,
-		audit:  audit.NewLogger(),
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:        cfg,
+		policy:     store,
+		audit:      audit.NewLogger(),
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		containerd: &fakeContainerd{},
 	}
-	noContainerd(p)
 	return p, store
 }
 
@@ -889,7 +902,7 @@ func TestRunDeferredCheck_AuditMode_NoKill(t *testing.T) {
 	p.deferredCtrs = []*api.Container{ctr}
 	p.deferredMu.Unlock()
 
-	// Should run the check without reaching containerd (noContainerd panics).
+	// Should run the check without reaching containerd (fakeContainerd panics).
 	p.RunDeferredCheck(context.Background())
 	assertDeferredCleared(t, p)
 }
@@ -950,7 +963,7 @@ func TestSynchronize_EnforceExistingDisabled_BrokerRecordsWithoutKilling(t *test
 	denied := makeCtrWithImage(pod.Id, "ctr2", "registry/repo@"+pushDigestB)
 
 	// Fail-closed, but enforce_existing off: the denied container must not reach
-	// stopContainer (noContainerd panics).
+	// StopContainer (fakeContainerd panics).
 	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{allowed, denied}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1016,7 +1029,7 @@ func TestSynchronize_Ready_AuditMode_ChecksWithoutEnforcing(t *testing.T) {
 	denied := makeCtrWithImage(pod.Id, "ctr2", "registry/repo@"+pushDigestB)
 
 	// Audit mode must run the check without enforcement: a denied container
-	// reaching stopContainer would panic (noContainerd).
+	// reaching StopContainer would panic (fakeContainerd).
 	updates, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{allowed, denied})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1286,7 +1299,7 @@ func TestCheckContainer_NamespaceNearMissesAreNotExempt(t *testing.T) {
 	}
 }
 
-// noContainerd panics if this path reaches the image store.
+// fakeContainerd panics if this path reaches the image store.
 func TestCreateContainer_NotReady_RecordsWithoutResolving(t *testing.T) {
 	p := exemptPlugin(t) // not ready
 	pod := makePod("kube-system", "pod1")
@@ -1344,11 +1357,11 @@ func TestCheckExisting_RecordsBeforeAttemptingTheKill(t *testing.T) {
 
 	var killed []string
 	var recordedAtKill bool
-	p.stopContainer = func(_ context.Context, id string) error {
+	p.containerd = &fakeContainerd{stop: func(_ context.Context, id string) error {
 		killed = append(killed, id)
 		_, recordedAtKill = p.inventory.containers[denied.Id]
 		return errors.New("kill not delivered")
-	}
+	}}
 
 	p.checkExisting(context.Background(), p.cfg, []*api.PodSandbox{pod}, []*api.Container{denied})
 
@@ -1398,10 +1411,10 @@ func TestCheckExisting_ResolvesTagOnlyReference(t *testing.T) {
 	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
 	p.inventory = newAdmissionInventory("/proc")
 	var resolved []string
-	p.resolve = func(_ context.Context, ref string) (string, error) {
+	p.containerd = &fakeContainerd{resolve: func(_ context.Context, ref string) (string, error) {
 		resolved = append(resolved, ref)
 		return "registry/repo@" + pushDigestA, nil
-	}
+	}}
 	p.SetReady()
 
 	pod := makePod("default", "pod1")

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -25,8 +25,9 @@ import (
 	"github.com/containerd/nri/pkg/stub"
 )
 
-// bindDeadResolver points the plugin's containerd operations at a socket nobody
-// listens on: construction is lazy, every RPC fails fast with a connection error.
+// bindDeadResolver points the plugin at a real *ctrdresolver.Resolver on a socket
+// nobody listens on: construction is lazy, every RPC fails fast with a connection
+// error.
 func bindDeadResolver(t *testing.T, p *plugin) {
 	t.Helper()
 	r, err := ctrdresolver.NewResolver(filepath.Join(t.TempDir(), "ctr.sock"), "k8s.io")
@@ -34,7 +35,7 @@ func bindDeadResolver(t *testing.T, p *plugin) {
 		t.Fatalf("NewResolver: %v", err)
 	}
 	t.Cleanup(func() { _ = r.Close() })
-	p.resolve, p.stopContainer = r.Resolve, r.StopContainer
+	p.containerd = r
 }
 
 // --- plugin.Run via a fake stub ---
@@ -417,7 +418,7 @@ func TestNewPlugin_WorkloadClaimsWiring(t *testing.T) {
 				Policy:         policyConfig{Mode: ModeFailClosed},
 				WorkloadClaims: workloadClaimsConfig{SocketDir: tc.socketDir, ProcRoot: tc.procRoot},
 			}
-			p, err := newPlugin(cfg, &ctrdresolver.Resolver{}, store, audit.NewLogger(), discardLogger())
+			p, err := newPlugin(cfg, &fakeContainerd{}, store, audit.NewLogger(), discardLogger())
 			if err != nil {
 				t.Fatalf("newPlugin: %v", err)
 			}

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -25,16 +25,16 @@ import (
 	"github.com/containerd/nri/pkg/stub"
 )
 
-// deadResolver returns a real containerd resolver whose socket nobody listens
-// on: construction is lazy, every RPC fails fast with a connection error.
-func deadResolver(t *testing.T) *ctrdresolver.Resolver {
+// bindDeadResolver points the plugin's containerd operations at a socket nobody
+// listens on: construction is lazy, every RPC fails fast with a connection error.
+func bindDeadResolver(t *testing.T, p *plugin) {
 	t.Helper()
 	r, err := ctrdresolver.NewResolver(filepath.Join(t.TempDir(), "ctr.sock"), "k8s.io")
 	if err != nil {
 		t.Fatalf("NewResolver: %v", err)
 	}
 	t.Cleanup(func() { _ = r.Close() })
-	return r
+	p.resolve, p.stopContainer = r.Resolve, r.StopContainer
 }
 
 // --- plugin.Run via a fake stub ---
@@ -115,7 +115,7 @@ func TestConfigure_InventoryAddsRemoveContainerMask(t *testing.T) {
 func TestCheckImage_ResolveFails_Denies(t *testing.T) {
 	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}},
 		&allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
-	p.resolver = deadResolver(t)
+	bindDeadResolver(t, p)
 
 	// The containerd RPC blocks until the dial deadline; bound it so the
 	// failure path is exercised without a multi-second wait.
@@ -133,7 +133,7 @@ func TestCheckImage_ResolveFails_Denies(t *testing.T) {
 func TestRecordForInventory_ResolveFails_RecordsEmptyDigest(t *testing.T) {
 	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}},
 		&allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
-	p.resolver = deadResolver(t)
+	bindDeadResolver(t, p)
 	p.inventory = newAdmissionInventory(t.TempDir())
 
 	ctr := &api.Container{Id: "ctr-id", PodSandboxId: "sandbox-1", Name: "app"}
@@ -440,7 +440,7 @@ func TestCheckExisting_CountsFailedKill(t *testing.T) {
 		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "image-a"}},
 		Policy:    policyConfig{Mode: ModeFailClosed, EnforceExisting: true},
 	}, &allowlist.Allowlist{Digests: map[string]string{pushDigestA: "image-a"}})
-	p.resolver = deadResolver(t)
+	bindDeadResolver(t, p)
 	var buf bytes.Buffer
 	p.logger = slog.New(slog.NewJSONHandler(&buf, nil))
 	p.SetReady()

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -84,7 +84,8 @@
   otherwise the NRI plugin would deny that component's pod on its own node.
   cds.image is exempt: it is always added to the floor via the seed self-entry,
   independent of derivation. This guard only applies in fail-closed mode (the
-  default); audit mode admits everything and never blocks.
+  default); audit mode creates every container, but with workloadClaims on a
+  would-be denial still reaches /digests and costs its sandbox a certificate.
 */ -}}
 {{- if and .Values.nriImagePolicy.enabled (eq .Values.nriImagePolicy.policy.mode "fail-closed") (not .Values.nriImagePolicy.bootstrapAllowlist.deriveComponents) -}}
 {{- $floor := .Values.nriImagePolicy.bootstrapAllowlist.digests -}}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -865,9 +865,8 @@ nriImagePolicy:
     # Secure by default: match the plugin binary's own default and reject images
     # not on the allowlist. Set to `audit` only for bring-up — it logs would-be
     # denials to journald and creates the container anyway, so you can populate
-    # the allowlist and review the audit log before enforcing. With
-    # workloadClaims on, the admitted image still lands in the node's /digests
-    # answer, so the pod it runs in gets no workload certificate.
+    # the allowlist and review the audit log before enforcing. Its effect on the
+    # pod's certificate: docs/getcert-workload-binding.md, Corner 4.
     # Don't ship `audit` to production: a permissive default that only docs tell
     # you to harden leaks.
     mode: fail-closed  # fail-closed | audit

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -864,9 +864,12 @@ nriImagePolicy:
   policy:
     # Secure by default: match the plugin binary's own default and reject images
     # not on the allowlist. Set to `audit` only for bring-up — it logs would-be
-    # denials to journald and admits everything, so you can populate the
-    # allowlist and review the audit log before enforcing. Don't ship `audit` to
-    # production: a permissive default that only docs tell you to harden leaks.
+    # denials to journald and creates the container anyway, so you can populate
+    # the allowlist and review the audit log before enforcing. With
+    # workloadClaims on, the admitted image still lands in the node's /digests
+    # answer, so the pod it runs in gets no workload certificate.
+    # Don't ship `audit` to production: a permissive default that only docs tell
+    # you to harden leaks.
     mode: fail-closed  # fail-closed | audit
     enforceExisting: true
     denyMissingAnnotation: true

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -151,7 +151,7 @@ type SandboxTokenRequest struct {
 // Digests is the deduplicated digest set cert issuance gates on. Containers
 // carries each container's effective argv, deduplicated by SandboxContainer.Key
 // (the whole (digest, argv) pair, not the digest alone), so a consumer can hold
-// a sandbox to the same pair admission evaluated.
+// a sandbox to the pair each container actually ran with.
 //
 // Digests is [] (never null) for a known sandbox with no containers. Containers
 // is absent on an inventory that predates it, which consumers must treat as
@@ -213,7 +213,8 @@ type SandboxResolver interface {
 	SandboxForPeer(peer Peer) (string, error)
 	// DigestsForSandbox returns every container ever admitted in the named
 	// sandbox — deduplicated digests for issuance, and the per-container
-	// (digest, argv) detail for secret release. known=false means no such
+	// (digest, argv) detail for secret release. Admitted means the container
+	// was let run, not that it passed a check. known=false means no such
 	// sandbox (a 404 on the wire); a known sandbox with no containers returns
 	// empty slices.
 	DigestsForSandbox(sandboxID string) (digests []string, containers []SandboxContainer, known bool, err error)


### PR DESCRIPTION
The exempt-namespace test was the first statement of every enforcement path, so a pod whose namespace name matched one was never measured against the allowlist and never reached the admission inventory. That name is control-plane metadata, so choosing it bought both a free pass and invisibility in the /digests answer CDS binds a sandbox identity to. A sandbox that under-reports what ran in it still matches a workload, so CDS releases its secrets to a pod that is not that workload.

Fold the label and image checks into a single checkContainer predicate shared by the create hook, the startup check and the deferred check, and apply the exemption at its end where it can only downgrade a denial. The container is still resolved, evaluated and audited: the exemption event now names the denial it overturned, and a tripped label rule can no longer suppress the image check.

Separate recording from enforcement entirely. Every path that lets a container run records it, whatever the verdict and whatever policy.mode or policy.enforce_existing say, and the startup check records before it attempts a kill it cannot confirm landed. The bootstrap hook records only a digest already inlined in the reference: it answers under NRI's plugin_request_timeout as a required plugin, and an unresolved digest fails that sandbox's answer closed.

checkContainer is now the only production site reading pod.GetNamespace() for policy, so keying the exemption on an identity the control plane cannot choose has exactly one insertion point.