### PR TITLE
fix(cred-release)!: --platform is required, no tdx default

### DIFF
--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -31,12 +31,15 @@ func NewCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
 	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (source of the RA-TLS serving cert's TDX quote)")
-	f.StringVar(&cfg.Platform, "platform", "tdx", "TEE platform (RTMR is TDX-only)")
+	f.StringVar(&cfg.Platform, "platform", "", "TEE platform, tdx or snp — required; the operator-key binding is TDX-only today")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
 	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
 	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")
+	// No default: an image must never silently serve for the wrong TEE (the
+	// node image renders the value from its required C8S_PLATFORM).
+	_ = cmd.MarkFlagRequired("platform")
 	return cmd
 }

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -31,15 +31,14 @@ func NewCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
 	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (source of the RA-TLS serving cert's TDX quote)")
-	f.StringVar(&cfg.Platform, "platform", "", "TEE platform, tdx or snp — required; the operator-key binding is TDX-only today")
+	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required; operator-key binding is TDX-only)")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
 	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
 	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")
-	// No default: an image must never silently serve for the wrong TEE (the
-	// node image renders the value from its required C8S_PLATFORM).
+	// No default: the baked unit always passes the flag explicitly.
 	_ = cmd.MarkFlagRequired("platform")
 	return cmd
 }

--- a/internal/cmds/credrelease/cmd_test.go
+++ b/internal/cmds/credrelease/cmd_test.go
@@ -2,6 +2,8 @@ package credrelease
 
 import (
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestNewCmdDefaultsAndHelp(t *testing.T) {
@@ -36,10 +38,9 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 		}
 	}
 
-	// --platform is required: an image must never silently serve for the
-	// wrong TEE, so omission is a usage error, not a tdx default.
+	// Omitting --platform is a usage error, not a tdx default.
 	pf := flags.Lookup("platform")
-	if pf == nil || pf.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+	if pf == nil || pf.Annotations[cobra.BashCompOneRequiredFlag] == nil {
 		t.Errorf("--platform is not marked required")
 	}
 }

--- a/internal/cmds/credrelease/cmd_test.go
+++ b/internal/cmds/credrelease/cmd_test.go
@@ -16,7 +16,7 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 	}{
 		{"listen", ":8443"},
 		{"attestation-api-url", "http://127.0.0.1:8400"},
-		{"platform", "tdx"},
+		{"platform", ""},
 		{"client-ca-cert", defaultClientCACert},
 		{"client-ca-key", defaultClientCAKey},
 		{"server-ca-cert", defaultServerCACert},
@@ -34,5 +34,12 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 		if flag.DefValue != tt.want {
 			t.Errorf("flag %q default = %q, want %q", tt.name, flag.DefValue, tt.want)
 		}
+	}
+
+	// --platform is required: an image must never silently serve for the
+	// wrong TEE, so omission is a usage error, not a tdx default.
+	pf := flags.Lookup("platform")
+	if pf == nil || pf.Annotations["cobra_annotation_bash_completion_one_required_flag"] == nil {
+		t.Errorf("--platform is not marked required")
 	}
 }

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -19,7 +19,7 @@ type Config struct {
 	// serving cert's TDX quote is fetched from (the same :8400 service the
 	// rest of the stack uses).
 	AttestationAPIURL string
-	// Platform is the TEE platform ("tdx").
+	// Platform is the TEE platform ("tdx" or "snp"; no default).
 	Platform string
 	// ClientCACert / ClientCAKey locate the cluster's client-signing CA
 	// (defaults: the RKE2 paths; kubeadm works via /etc/kubernetes/pki/ca.{crt,key}).
@@ -52,6 +52,10 @@ func Run(ctx context.Context, cfg Config) error {
 	cfg.Platform = ratls.NormalizePlatform(cfg.Platform)
 	if cfg.Platform == "" {
 		return fmt.Errorf("--platform is required (RA-TLS is mandatory for credential release)")
+	}
+	// Fail on a bad value here, before the RTMR and cluster-CA reads below.
+	if err := ratls.ValidatePlatform(cfg.Platform); err != nil {
+		return fmt.Errorf("--platform: %w", err)
 	}
 
 	operatorPub, err := LoadMeasuredOperatorKey()

--- a/internal/cmds/credrelease/run_test.go
+++ b/internal/cmds/credrelease/run_test.go
@@ -98,6 +98,12 @@ func TestRunStartupErrors(t *testing.T) {
 			},
 		},
 		{
+			name: "platform value validated before privileged reads",
+			cfg: func(t *testing.T) Config {
+				return Config{Platform: "foo"}
+			},
+		},
+		{
 			name: "operator key not staged",
 			cfg: func(t *testing.T) Config {
 				overrideBindingPaths(t) // paths exist, files do not


### PR DESCRIPTION
Follow-up from the #296 review (its altitude finding): the image machinery guarantees no defaulted TEE — but the binary's own flag still declared `default "tdx"`, so any invocation omitting it silently served as TDX. The no-default principle now reaches the binary:

- `--platform` is **required** (`MarkFlagRequired`, default empty); omission is a usage error at parse time. `Run`'s empty-check stays as the cobra-bypass backstop.
- The **value** is validated up front too (`ratls.ValidatePlatform`, per its own "call at config creation time" doc): a bad value previously died three layers down inside `NewServerTLSConfig` — *after* the RTMR read and the cluster client-CA key load, burning a `StartLimitBurst` attempt on privileged I/O per retry.

Blast radius: the only production invoker is the baked systemd unit, which has passed `--platform tdx` explicitly since its introduction; the pinned `C8S_REF` binary accepts both directions of skew. Marked `!` for out-of-tree invokers.

**Deliberately scoped to cred-release** — the review's inventory found the same silent-TEE-default shape elsewhere, left for follow-up: `cds --ratls-platform` (default `sev-snp`, and empty explicitly disables TLS — the strongest candidate, same trust posture as this one), `cdsattest --platform`, and `install`/`render-values`/`operator --hardware-platform` (notably inconsistent with their sibling `--cvm-mode`, which is already required). Detection-style defaults (`ratlsmesh --platform auto`, `katameasure`) are fine as-is.