### PR TITLE
ci(e2e): run cw-label-policy and ca-handoff in the post-merge snp-metal lane

### DIFF
--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -52,8 +52,9 @@ jobs:
   # ── ONE JOB PER PLATFORM ─────────────────────────────────────────────────
   # Vendored from confidential-ci. c8s is PUBLIC and confidential-ci is PRIVATE,
   # so a public repo cannot `uses:` the private reusable workflows and must keep
-  # local copies. cvm-e2e.yml, snp-metal-e2e.yml and tdx-metal-e2e.yml here are
-  # byte-identical to their originals; edit the original, then copy across.
+  # local copies. cvm-e2e.yml and tdx-metal-e2e.yml here are byte-identical to
+  # their originals; edit the original, then copy across. snp-metal-e2e.yml is
+  # c8s-owned (the c8s payload lives in this copy); edit it here.
   #
   # NOT a `matrix:`. A reusable-workflow `uses:` takes no expressions, so a
   # matrix would need an if-gated dispatcher, and because every row instantiates

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -124,6 +124,10 @@ jobs:
           AATAG="${{ inputs.aa_ref || 'main' }}"
           echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
 
+          # Throwaway operator keypair for the ca-handoff e2e below (handoff requires cds.operatorKeys); the private half never leaves the runner.
+          openssl ecparam -name prime256v1 -genkey -noout -out /tmp/e2e-op.key
+          OPPUB=$(openssl ec -in /tmp/e2e-op.key -pubout 2>/dev/null | sed 's/^/    /')  # the 4 spaces are the operatorKeys block-scalar indent below; keep $OPPUB outdented
+
           # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:
           #  - cds.node.selector/tolerations null : the --single-node effect. The chart
           #    default pins role=cds, so CDS sits Pending forever on a single node.
@@ -148,6 +152,12 @@ jobs:
                                   # resurfaces -> CDS Pending (run 29536583462).
             ratlsPlatform: sev-snp
             measurements: ["RUNTIME_MEASUREMENT"]
+            # ca-handoff e2e in the payload: serve /handoff, gated on the pinned
+            # measurement; the chart requires an operator-key bundle with it.
+            operatorKeys: |-
+          $OPPUB
+            handoff:
+              enabled: true
             # NODE_CIDR placeholder: payload substitutes the node's InternalIP/32 (matching `c8s install`'s per-node host routes) — CDS fail-closes sandbox-token CSRs without it (#168; this lane writes raw values, so `c8s install` never fills it).
             sandboxInventoryCIDRs: ["NODE_CIDR"]
           attestationApi:
@@ -286,7 +296,16 @@ jobs:
             IC=\$(\$K -n default get pods -l app=demo-nginx -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null)
             echo "@@CWCONTAINERS \${IC:-none}@@"
             printf '%s' "\$IC" | grep -q 'c8s-cert' && { COK=1; say CERT_INJECTED; }
-            [ "\$WOK" = "1" ] && [ "\$COK" = "1" ] && say PAYLOAD_OK
+            if [ "\$WOK" = "1" ] && [ "\$COK" = "1" ]; then
+              # Live-cluster e2e suites from the merge-under-test's own source.
+              # A suite failure fails the lane (FAIL_ marker -> no PAYLOAD_OK).
+              export PATH="/var/lib/rancher/rke2/bin:\$PATH"
+              E2E=\$(echo /tmp/c8s-*/test/e2e)
+              FAILED=""
+              bash "\$E2E/cw-label-policy.sh" && say E2E_CW_LABEL_OK || FAILED="\$FAILED cw-label-policy"
+              bash "\$E2E/ca-handoff.sh" && say E2E_CA_HANDOFF_OK || FAILED="\$FAILED ca-handoff"
+              if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
+            fi
             if [ "\$WOK" != "1" ]; then
               \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
               \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'

--- a/Makefile
+++ b/Makefile
@@ -138,19 +138,24 @@ mutation-full:
 	./scripts/mutation-check.sh summary
 
 # Live-cluster check of the cw-label integrity admission policy. Needs
-# kubectl pointed at a cluster with the c8s chart installed.
+# kubectl pointed at a cluster with the c8s chart installed. Also runs
+# post-merge in the snp-metal-e2e lane's in-guest payload.
 test-e2e-cw-label-policy:
 	./test/e2e/cw-label-policy.sh
 
 # Live-cluster check that the workload path is mesh-wrapped and plaintext
 # bypasses to cw pods fail closed. Needs kubectl pointed at a cluster with
-# the c8s chart installed and a Running confidential workload.
+# the c8s chart installed and a Running confidential workload. Not CI-wired:
+# snp-metal's guest kernel lacks ratls-mesh's netfilter matches (the lane
+# installs ratlsMesh.enabled=false) and tdx-metal's vendored lane runs Cilium
+# kube-proxy-free, so VIP traffic never hits the FORWARD guard this asserts.
 test-e2e-mesh-cw-enforcement:
 	./test/e2e/mesh-cw-enforcement.sh
 
 # Live-cluster check that attested CA handoff works end to end: an attested
 # probe pulls the mesh CA over /handoff and proves it is the live trust root.
 # Needs kubectl pointed at a node-as-CVM cluster with cds.handoff.enabled=true.
+# Also runs post-merge in the snp-metal-e2e lane's in-guest payload.
 test-e2e-ca-handoff:
 	./test/e2e/ca-handoff.sh
 

--- a/test/e2e/ca-handoff.sh
+++ b/test/e2e/ca-handoff.sh
@@ -2,9 +2,11 @@
 # Live-cluster verification that attested mesh-CA handoff works end to end:
 # an attested probe pod (the deployed cds image running `request-handoff`)
 # pulls the CA over /handoff and proves the material is the live trust root
-# served on /ca. Proves on a real cluster what unit tests cannot: real TEE
-# evidence, a real EAR minted by the live CDS, the real measurement gate,
-# and the transfer over the cluster network.
+# served on /ca, and a second probe with a wrong --measurements pin proves a
+# mismatched peer is refused. Proves on a real cluster what unit tests
+# cannot: real TEE evidence, a real EAR minted by the live CDS, the real
+# measurement gate on the probe's own pin (accept and refuse), and the
+# transfer over the cluster network.
 #
 # Needs: kubectl pointed at a node-as-CVM (non-kata) cluster with the c8s
 # chart installed, cds.handoff.enabled=true, and a deployed cds image that
@@ -12,7 +14,8 @@
 #
 # Env:
 #   CDS_NS                 namespace of the cds deployment (default: discover)
-#   PROBE_TIMEOUT_SECONDS  wait for the probe pod to finish (default 180)
+#   PROBE_TIMEOUT_SECONDS  wait for the accept probe pod to finish (default
+#                          180); the wrong-pin probe gets a fixed 30s budget
 set -euo pipefail
 . "$(dirname "$0")/lib.sh"
 
@@ -21,15 +24,16 @@ cds_selector="app.kubernetes.io/name=c8s-operator,app.kubernetes.io/component=cd
 
 cds_ns=""
 pod=""
+bad_pod=""
 kget_err=$(mktemp)
 cleanup() {
   rm -f "$kget_err"
   if [ -n "$cds_ns" ] && [ -n "$pod" ]; then
-    kubectl delete pod "$pod" -n "$cds_ns" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+    kubectl delete pod "$pod" "$bad_pod" -n "$cds_ns" --ignore-not-found --wait=false >/dev/null 2>&1 || true
   fi
 }
-# INT/TERM as well as EXIT: a Ctrl-C during the up-to-3-minute wait must not
-# leave the probe pod (with the cds SA and pull rights) parked on the node.
+# INT/TERM as well as EXIT: a Ctrl-C during a probe wait must not leave a
+# probe pod (with the cds SA and pull rights) parked on the node.
 trap cleanup EXIT INT TERM
 
 # kget runs kubectl and, on failure, surfaces the real error instead of
@@ -119,22 +123,27 @@ ctr_sec_ctx=$(sed -n 6p <<<"$pod_fields"); [ -n "$ctr_sec_ctx" ] || ctr_sec_ctx=
 [ -n "$cds_image" ] || fail "cds pod $cds_ns/$cds_pod has no container named cds"
 
 pod="ca-handoff-probe-$$"
+bad_pod="$pod-bad"
 operator_keys_cm="${cds_deploy}-operator-keys"
 kubectl get configmap "$operator_keys_cm" -n "$cds_ns" >/dev/null 2>&1 ||
   fail "CDS handoff requires operator keys, but ConfigMap $cds_ns/$operator_keys_cm is missing"
 echo "cds: $cds_ns/$cds_deploy on $cds_node; peer $peer_url"
 
-# Release namespace + cds ServiceAccount: image pull secrets ride along and
-# the image digest is already in the allowlist floor. nodeName pins the probe
-# to cds's node so its launch measurement matches --handoff-measurements and
-# the node-local attestation-api attests the right node. The probe's --timeout
-# tracks PROBE_TIMEOUT_SECONDS so raising the env actually extends the in-pod
-# retry window (leave the pod-watch a little longer to observe the verdict).
-kubectl apply -f - >/dev/null <<EOF
+# run_probe <name> <measurements> [timeout-seconds]: launch the probe pod and
+# print its terminal phase on stdout. Release namespace + cds ServiceAccount:
+# image pull secrets ride along and the image digest is already in the
+# allowlist floor. nodeName pins the probe to cds's node so its launch
+# measurement matches --handoff-measurements and the node-local
+# attestation-api attests the right node. The in-pod --timeout defaults to
+# PROBE_TIMEOUT_SECONDS; the pod-watch runs 30s past it to observe the
+# verdict.
+run_probe() {
+  local name=$1 meas=$2 timeout=${3:-$probe_timeout}
+  kubectl apply -f - >/dev/null <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
-  name: $pod
+  name: $name
   namespace: $cds_ns
 spec:
   restartPolicy: Never
@@ -146,7 +155,7 @@ spec:
   containers:
     - name: probe
       image: $cds_image
-      # The copied --attestation-api-url keeps the chart's $(HOST_IP) form
+      # The copied --attestation-api-url keeps the chart's \$(HOST_IP) form
       # under cvmMode=node; kubelet expands it only if the pod defines the env.
       env:
         - name: HOST_IP
@@ -157,10 +166,10 @@ spec:
         - request-handoff
         - --peer-url=$peer_url
         - --attestation-api-url=$attest_url
-        - --measurements=$handoff_meas
+        - --measurements=$meas
         - --operator-keys=/etc/cds-operator-keys/keys.pem
         - --expected-issuer=$ear_issuer
-        - --timeout=${probe_timeout}s
+        - --timeout=${timeout}s
       volumeMounts:
         - name: operator-keys
           mountPath: /etc/cds-operator-keys
@@ -171,26 +180,43 @@ spec:
       configMap:
         name: $operator_keys_cm
 EOF
+  local deadline=$((SECONDS + timeout + 30)) phase=""
+  while :; do
+    phase=$(kubectl get pod "$name" -n "$cds_ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    case "$phase" in Succeeded|Failed) break ;; esac
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      kubectl describe pod "$name" -n "$cds_ns" >&2 || true
+      fail "probe $name did not reach a terminal phase in $((timeout + 30))s (phase=${phase:-unknown})"
+    fi
+    sleep 3
+  done
+  printf '%s\n' "$phase"
+}
 
-# --- await verdict ------------------------------------------------------------
+# --- accept: the pinned probe pulls the live trust root -----------------------
 
-# Watch a little past the probe's own --timeout so the pod reaches a terminal
-# phase before we give up.
-deadline=$((SECONDS + probe_timeout + 30))
-phase=""
-while :; do
-  phase=$(kubectl get pod "$pod" -n "$cds_ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)
-  case "$phase" in Succeeded|Failed) break ;; esac
-  if [ "$SECONDS" -ge "$deadline" ]; then
-    kubectl describe pod "$pod" -n "$cds_ns" >&2 || true
-    fail "probe did not reach a terminal phase in $((probe_timeout + 30))s (phase=${phase:-unknown})"
-  fi
-  sleep 3
-done
-
+phase=$(run_probe "$pod" "$handoff_meas")
 kubectl logs "$pod" -n "$cds_ns" || true
 
 # Pod phase is the verdict: Succeeded means the probe exited 0, which by
 # construction requires the pulled CA to match the served trust root.
 [ "$phase" = Succeeded ] || fail "handoff probe failed (see logs above)"
-echo "PASS: mesh CA handoff verified end-to-end (EAR-gated transfer, served-CA match)"
+echo "ok: pinned probe pulled the CA over /handoff and matched the served trust root"
+
+# --- negative: a wrong --measurements pin is refused --------------------------
+
+# 48 zero bytes: well-formed SHA-384 hex no launch produces. The refusal is
+# the probe's own RA-TLS client rejecting the peer cert, which surfaces as a
+# plain *url.Error, so ClassifyPullError calls it PullTransient: the probe
+# retries the settled verdict until --timeout and exits 3 — still Failed,
+# with the mismatch text logged on every attempt. Hence the short 30s budget.
+bad_meas=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+phase=$(run_probe "$bad_pod" "$bad_meas" 30)
+bad_logs=$(kubectl logs "$bad_pod" -n "$cds_ns" 2>/dev/null || true)
+printf '%s\n' "$bad_logs"
+[ "$phase" = Failed ] || fail "probe with a wrong --measurements pin was not refused (phase=${phase:-unknown}; logs above)"
+grep -q "launch measurement not in allowed set" <<<"$bad_logs" \
+  || fail "refused probe's log names no measurement mismatch (see above)"
+echo "ok: wrong --measurements pin refused (log names the measurement mismatch)"
+
+echo "PASS: mesh CA handoff verified end-to-end (EAR-gated transfer, served-CA match, wrong-pin refusal)"

--- a/test/e2e/ca-handoff.sh
+++ b/test/e2e/ca-handoff.sh
@@ -146,6 +146,13 @@ spec:
   containers:
     - name: probe
       image: $cds_image
+      # The copied --attestation-api-url keeps the chart's $(HOST_IP) form
+      # under cvmMode=node; kubelet expands it only if the pod defines the env.
+      env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
       args:
         - request-handoff
         - --peer-url=$peer_url

--- a/test/e2e/mesh-cw-enforcement.sh
+++ b/test/e2e/mesh-cw-enforcement.sh
@@ -19,9 +19,11 @@
 #   EXCLUDED_NS     mesh-excluded source namespace (default kube-system)
 #   MESH_HEALTH_PORT     ratls-mesh health/metrics port (chart
 #                        ratlsMesh.ports.health; default 15021)
-#   METRIC_WAIT_SECONDS  how long to wait for a counter to move (default 75;
-#                        raise it above ~2x ratlsMesh.iptablesSync.resyncPeriod
-#                        on clusters tuned to a longer resync)
+#   METRIC_WAIT_SECONDS  how long to wait for a counter to move; also the
+#                        abort budget for a baseline that never gets a
+#                        successful scrape (default 75; raise it above ~2x
+#                        ratlsMesh.iptablesSync.resyncPeriod on clusters tuned
+#                        to a longer resync)
 set -euo pipefail
 . "$(dirname "$0")/lib.sh"
 
@@ -78,35 +80,54 @@ client_curl() { kubectl exec -n "$ns" "$client" -- curl -s "$@"; }
 
 # Sum a mesh metric from a node's ratls-mesh /metrics (hostNetwork). The
 # health port is a node IP, never a pod IP, so this scrape is not itself
-# mesh-intercepted. A transient scrape failure prints 0 rather than aborting
-# the script under set -e/pipefail: callers poll, so a blip should retry, not
-# be a hard failure. awk always prints an integer, so the result is never
-# empty. The curl exit code is intentionally dropped ($? is not inspected).
+# mesh-intercepted. Exit 1 with no output marks a failed scrape, kept distinct
+# from a genuine 0 (curl -f fails on HTTP errors; kubectl exec propagates the
+# exit code): a blip must retry, never read as "counter is 0".
 mesh_metric() {
   local node_ip=$1 pattern=$2 body
-  body=$(client_curl --max-time 10 "http://${node_ip}:${health_port}/metrics" 2>/dev/null || true)
+  body=$(client_curl -f --max-time 10 "http://${node_ip}:${health_port}/metrics" 2>/dev/null) || return 1
   awk -v p="$pattern" '$0 ~ p {sum += $NF} END {printf "%d", sum+0}' <<<"$body"
 }
 
-# Poll until a metric exceeds a baseline, tolerating transient scrape failures
-# (mesh_metric returns 0 for those). The cw drop counter is published by the
-# iptables-sync sidecar on its resync tick, so the default deadline gives two
-# 30s ticks of headroom; raise METRIC_WAIT_SECONDS for a longer resyncPeriod.
-await_metric_above() {
-  local node_ip=$1 pattern=$2 baseline=$3 what=$4
-  local deadline=$((SECONDS + metric_wait)) v
-  while [ $SECONDS -lt $deadline ]; do
-    v=$(mesh_metric "$node_ip" "$pattern")
-    if [ "$v" -gt "$baseline" ]; then echo "ok: $what ($baseline -> $v)"; return 0; fi
+# Baselines gate every await_metric_above, so one must come from a genuine
+# scrape. Retry until one scrape succeeds; abort if none does inside the
+# budget.
+metric_baseline() {
+  local node_ip=$1 pattern=$2 what=$3 v
+  local deadline=$((SECONDS + metric_wait))
+  while :; do
+    if v=$(mesh_metric "$node_ip" "$pattern"); then
+      printf '%d\n' "$v"
+      return 0
+    fi
+    [ $SECONDS -lt $deadline ] || break
     sleep 5
   done
+  fail "$what: no successful metrics scrape of $node_ip:$health_port within ${metric_wait}s; cannot baseline"
+}
+
+# Poll until a metric exceeds a baseline, skipping failed scrapes rather than
+# reading them as 0. The cw drop counter is published by the iptables-sync
+# sidecar on its resync tick, so the default deadline gives two 30s ticks of
+# headroom; raise METRIC_WAIT_SECONDS for a longer resyncPeriod.
+await_metric_above() {
+  local node_ip=$1 pattern=$2 baseline=$3 what=$4
+  local deadline=$((SECONDS + metric_wait)) v scraped=""
+  while [ $SECONDS -lt $deadline ]; do
+    if v=$(mesh_metric "$node_ip" "$pattern"); then
+      scraped=1
+      [ "$v" -gt "$baseline" ] && { echo "ok: $what ($baseline -> $v)"; return 0; }
+    fi
+    sleep 5
+  done
+  [ -n "$scraped" ] || fail "$what: every metrics scrape of $node_ip:$health_port failed within ${metric_wait}s"
   fail "$what: no increase above $baseline within ${metric_wait}s"
 }
 
 # --- positive: a pod-IP dial is mesh-wrapped --------------------------------
 
 inbound='^ratls_mesh_connections_total.*direction="inbound"'
-base_inbound=$(mesh_metric "$cw_node_ip" "$inbound")
+base_inbound=$(metric_baseline "$cw_node_ip" "$inbound" "mesh inbound connections on $cw_node")
 
 client_curl -o /dev/null --max-time 10 "http://${cw_ip}:${cw_port}/" \
   || fail "direct pod-IP request to $cw_ip:$cw_port failed (exit $?); the mesh-wrapped path must work"
@@ -147,7 +168,7 @@ drops='^ratls_mesh_iptables_cw_inbound_drops_total'
 # cluster-wide). Under IPVS/nftables kube-proxy the VIP is rewritten off the
 # FORWARD path (see the README precondition), so this counter assertion, and
 # the guard itself, only hold in iptables mode.
-base_drops=$(mesh_metric "$client_node_ip" "$drops")
+base_drops=$(metric_baseline "$client_node_ip" "$drops" "cw inbound drops on $client_node")
 
 rc=0
 client_curl -o /dev/null --max-time 5 "http://${vip}:${cw_port}/" || rc=$?
@@ -174,7 +195,7 @@ kubectl wait --for=condition=Ready pod/"$excluded_pod" -n "$excluded_ns" --timeo
 excluded_node=$(kubectl get pod "$excluded_pod" -n "$excluded_ns" -o jsonpath='{.spec.nodeName}')
 excluded_node_ip=$(kubectl get node "$excluded_node" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
 [ -n "$excluded_node_ip" ] || fail "node $excluded_node reports no InternalIP; cannot read its drop counter"
-base_excluded_drops=$(mesh_metric "$excluded_node_ip" "$drops")
+base_excluded_drops=$(metric_baseline "$excluded_node_ip" "$drops" "cw inbound drops on $excluded_node")
 
 rc=0
 kubectl exec -n "$excluded_ns" "$excluded_pod" -- \


### PR DESCRIPTION
## Summary

Wires the strongest e2e suites into post-merge CI and closes the two false-green holes.

- `cw-label-policy.sh` and the hardened `ca-handoff.sh` now run in the post-merge `snp-metal-e2e` lane from the merge-under-test's source; a suite failure fails the lane (`FAIL_E2E` marker — no more `PAYLOAD_OK` regardless).
- `ca-handoff.sh` gains the negative leg: a probe with a deliberately wrong `--measurements` pin is asserted `Failed` *and* the log names the measurement mismatch (exit status alone doesn't prove the property — the leg asserts the real refusal path: policy error → transient → bounded retry → fail).
- `mesh-cw-enforcement.sh`: `mesh_metric` baselines distinguish "scrape failed" from "counter is 0" and retry (bounded) until a scrape genuinely succeeds; the script aborts if none does. The `$(HOST_IP)` expansion bug in the ca-handoff probe URL is fixed.
- `mesh-cw-enforcement.sh` itself is **not** wired into a lane: no current lane satisfies its preconditions (snp-metal lacks the netfilter/xt_set kernel matches; tdx is vendored + kube-proxy-free + baked-ref). Its Makefile target says so, so it fails loudly rather than sitting silently dark.
- The vendored-workflow byte-identical rule is respected: only the cvm/tdx copies are byte-identical (comment corrected); c8s-specific steps live in the c8s-owned snp lane.

## Tests

- Negative-leg refusal path, retry termination, and lane fail-red chain verified by simulation harness in review (16/16); render gate clean; `bash -n` + chart verify green.
- Owed post-merge (needs the real lane): break one assertion in each wired script and link the red runs — will be demonstrated on the first post-merge executions.

## Notes

- No production code changes; `.github/workflows` + `test/e2e` + Makefile only.