### PR TITLE
fix(cds): meter the unauthenticated endpoints and bound their state

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -687,9 +687,20 @@ allowlist fetches — stays bounded; CORS preflights are exempt. If a flood
 saturates the front-door buckets, signed writes still work over a direct CDS
 URL or port-forward, which CDS accounts under the caller's own source IP.
 LoadBalancer and NodePort Services default to `externalTrafficPolicy: Local`
-while this route renders so nginx receives the public source address the
-per-client keys need; `tlsLb.service.externalTrafficPolicy` overrides (Local
-delivers traffic only through nodes that run the tls-lb pod).
+while this route or the attestation sidecar (`tlsLb.attest.enabled`) renders,
+so nginx receives the public source address their per-client keys need;
+`tlsLb.service.externalTrafficPolicy` overrides (Local delivers traffic only
+through nodes that run the tls-lb pod).
+
+The attestation sidecar bounds what one client may hold as well as how fast it
+may ask: 512 concurrent sessions and 512 handshakes in flight per client
+address (an IPv6 client is one /64), inside pools of 8192 each. A pool that is
+full gives up an entry only from a client above the share the pool divides
+between its holders and the caller, and never below 8 entries, so a client
+holding a handful is not drained by one holding thousands. Once every holder is
+down to that floor — which takes 1024 client addresses holding sessions — a new
+session is refused with 503 until one expires; established sessions are never
+taken to admit a new one.
 
 The proxy preserves the request method, original URI and query, body, and
 `Authorization` header. Reads remain unauthenticated at CDS. Writes still

--- a/internal/attestation/challenge.go
+++ b/internal/attestation/challenge.go
@@ -11,9 +11,13 @@ import (
 //
 // NOTE: challenges are stored in-memory and lost on restart. This is acceptable
 // for single-instance deployments but must be addressed for HA configurations.
+// One TTL governs every challenge, so insertion order is expiry order: issued
+// holds the keys oldest-first, and a consumed key stays there until it reaches
+// the front.
 type ChallengeStore struct {
 	mu         sync.Mutex
 	challenges map[[32]byte]time.Time
+	issued     [][32]byte
 	ttl        time.Duration
 }
 
@@ -24,6 +28,12 @@ func NewChallengeStore(ttl time.Duration) ChallengeStore {
 		ttl:        ttl,
 	}
 }
+
+// maxChallenges bounds the challenges a store holds at roughly 15 MiB. The
+// queue that orders them is compacted at twice that, since a key Consume
+// removed is only reclaimed when it reaches the front or a compaction passes
+// it.
+const maxChallenges = 1 << 17
 
 // Create generates a new 32-byte random challenge and stores it.
 func (s *ChallengeStore) Create() [32]byte {
@@ -36,16 +46,59 @@ func (s *ChallengeStore) Create() [32]byte {
 	defer s.mu.Unlock()
 
 	now := time.Now()
-
-	// Evict expired challenges while holding the lock
-	for k, created := range s.challenges {
-		if now.Sub(created) >= s.ttl {
-			delete(s.challenges, k)
-		}
+	s.dropExpired(now)
+	if len(s.issued) >= 2*maxChallenges {
+		s.compact(now)
+	}
+	if len(s.challenges) >= maxChallenges {
+		s.dropOldest()
 	}
 
 	s.challenges[challenge] = now
+	s.issued = append(s.issued, challenge)
 	return challenge
+}
+
+// dropExpired removes challenges from the front of issued until it reaches one
+// that is both live and unconsumed.
+func (s *ChallengeStore) dropExpired(now time.Time) {
+	for len(s.issued) > 0 {
+		front := s.issued[0]
+		created, live := s.challenges[front]
+		if live && now.Sub(created) < s.ttl {
+			return
+		}
+		delete(s.challenges, front)
+		s.issued = s.issued[1:]
+	}
+}
+
+// compact rebuilds issued from the challenges still live, in order, so the
+// keys Consume removed from the middle stop occupying it. It runs once per
+// maxChallenges mints at most, since it leaves issued no longer than the map.
+func (s *ChallengeStore) compact(now time.Time) {
+	kept := s.issued[:0]
+	for _, key := range s.issued {
+		created, live := s.challenges[key]
+		if !live {
+			continue
+		}
+		if now.Sub(created) >= s.ttl {
+			delete(s.challenges, key)
+			continue
+		}
+		kept = append(kept, key)
+	}
+	s.issued = kept
+}
+
+// dropOldest makes room for one challenge by removing the oldest live one.
+func (s *ChallengeStore) dropOldest() {
+	if len(s.issued) == 0 {
+		return
+	}
+	delete(s.challenges, s.issued[0])
+	s.issued = s.issued[1:]
 }
 
 // Consume removes and validates a challenge, returning true if it was valid

--- a/internal/attestation/challenge_test.go
+++ b/internal/attestation/challenge_test.go
@@ -1,9 +1,22 @@
 package attestation
 
 import (
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 )
+
+// raceRounds: two goroutines can only be inside a check-then-act window at
+// once when they truly run at once, so this test's power comes from the
+// parallelism of the runner. TestCreateReclaimsBeforeEvicting covers the same
+// ordering deterministically.
+func raceRounds() int {
+	if runtime.GOMAXPROCS(0) >= 8 {
+		return 500
+	}
+	return 200
+}
 
 func TestCreateReturns32Bytes(t *testing.T) {
 	store := NewChallengeStore(5 * time.Minute)
@@ -68,6 +81,293 @@ func TestCreateEvictsExpiredChallenges(t *testing.T) {
 	}
 	if n != 1 {
 		t.Errorf("store holds %d challenges, want 1", n)
+	}
+}
+
+// entitledChallenges is the number of challenges a fleet may have outstanding
+// inside one TTL, stated here rather than derived from the bound so that
+// shrinking the bound fails this test. Every pod that starts, renews a
+// certificate or fetches a secret takes one.
+const entitledChallenges = 100000
+
+// challengeEntryBytes is a key, a timestamp and the queue slot behind it;
+// challengeBudget is what the store may cost CDS, which holds the mesh CA in
+// the same process.
+const (
+	challengeEntryBytes = 112
+	challengeBudget     = 32 << 20
+)
+
+// TestChallengeStoreStaysInsideItsBudget pins the bound from above: it exists
+// to stop unauthenticated traffic becoming memory, so it has to stay small
+// enough to do that.
+func TestChallengeStoreStaysInsideItsBudget(t *testing.T) {
+	// The queue may carry twice the map between compactions.
+	if cost := 2 * maxChallenges * challengeEntryBytes; cost > challengeBudget {
+		t.Fatalf("the challenge store may cost %d bytes, over its budget of %d", cost, challengeBudget)
+	}
+}
+
+// TestAStoreHoldsAFleetsWorthOfChallenges pins the bound against that number:
+// below it, a cluster-wide restart would have callers' challenges dropped
+// before they could redeem them.
+func TestAStoreHoldsAFleetsWorthOfChallenges(t *testing.T) {
+	store := NewChallengeStore(time.Minute)
+	first := store.Create()
+	for i := 1; i < entitledChallenges; i++ {
+		store.Create()
+	}
+
+	store.mu.Lock()
+	held := len(store.challenges)
+	store.mu.Unlock()
+	if held != entitledChallenges {
+		t.Fatalf("store holds %d challenges of %d issued, want all of them", held, entitledChallenges)
+	}
+	if !store.Consume(first[:]) {
+		t.Fatal("the first challenge of the fleet was dropped before it could be redeemed")
+	}
+}
+
+// TestCreateEvictsTheOldestAtCapacity fills the store to its bound and checks
+// minting keeps working there, that the store stays at the bound, and that the
+// challenge dropped is the oldest.
+func TestCreateEvictsTheOldestAtCapacity(t *testing.T) {
+	store := NewChallengeStore(time.Hour)
+	oldest := store.Create()
+	second := store.Create()
+	for i := 2; i < maxChallenges; i++ {
+		store.Create()
+	}
+
+	store.mu.Lock()
+	atCap := len(store.challenges)
+	store.mu.Unlock()
+	if atCap != maxChallenges {
+		t.Fatalf("store holds %d challenges after filling, want %d", atCap, maxChallenges)
+	}
+
+	newest := store.Create()
+
+	store.mu.Lock()
+	held, queued := len(store.challenges), len(store.issued)
+	_, oldestKept := store.challenges[oldest]
+	_, newestKept := store.challenges[newest]
+	store.mu.Unlock()
+
+	if held != maxChallenges {
+		t.Fatalf("store holds %d challenges past the bound, want %d", held, maxChallenges)
+	}
+	if queued > maxChallenges {
+		t.Fatalf("issued holds %d keys, want at most %d", queued, maxChallenges)
+	}
+	if oldestKept {
+		t.Fatal("the oldest challenge survived a mint at the bound")
+	}
+	if !newestKept {
+		t.Fatal("the challenge minted at the bound was not stored")
+	}
+	if !store.Consume(second[:]) {
+		t.Fatal("the second-oldest challenge was dropped as well")
+	}
+}
+
+// TestCreateHoldsTheBoundUnderConcurrency releases a crowd of minters at a
+// store one under its bound, round after round: the bound check and the insert
+// must be one critical section, or a round where two of them read the same
+// free slot leaves the store over its bound for good.
+func TestCreateHoldsTheBoundUnderConcurrency(t *testing.T) {
+	const minters = 256
+	store := NewChallengeStore(time.Hour)
+	for i := 0; i < maxChallenges; i++ {
+		store.Create()
+	}
+
+	for round := 0; round < raceRounds(); round++ {
+		store.mu.Lock()
+		for len(store.issued) >= maxChallenges {
+			store.dropOldest()
+		}
+		store.mu.Unlock()
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := 0; i < minters; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				store.Create()
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		store.mu.Lock()
+		held, queued := len(store.challenges), len(store.issued)
+		store.mu.Unlock()
+		if held != maxChallenges {
+			t.Fatalf("round %d: store holds %d challenges, want %d", round, held, maxChallenges)
+		}
+		if queued != maxChallenges {
+			t.Fatalf("round %d: issued holds %d keys, want %d", round, queued, maxChallenges)
+		}
+	}
+}
+
+// TestCreateReclaimsBeforeEvicting pins the order inside Create: expired
+// challenges are reclaimed first, and only a store still at its bound gives up
+// a live one. Deciding that on a count read before the reclaim costs a caller
+// a challenge that the expiry had already made room for.
+func TestCreateReclaimsBeforeEvicting(t *testing.T) {
+	store := NewChallengeStore(time.Hour)
+	expiring := store.Create()
+	survivor := store.Create()
+	for i := 2; i < maxChallenges; i++ {
+		store.Create()
+	}
+
+	store.mu.Lock()
+	store.challenges[expiring] = time.Now().Add(-2 * time.Hour)
+	store.mu.Unlock()
+
+	store.Create()
+
+	store.mu.Lock()
+	held := len(store.challenges)
+	store.mu.Unlock()
+	if held != maxChallenges {
+		t.Fatalf("store holds %d challenges, want %d", held, maxChallenges)
+	}
+	if !store.Consume(survivor[:]) {
+		t.Fatal("a live challenge was evicted although an expired one had freed room")
+	}
+}
+
+// TestCompactionKeepsLiveChallengesInOrder drives the queue past the length
+// that compacts it, with live challenges interleaved among consumed ones.
+// Compaction's job is to keep exactly the live keys and their order: dropping
+// one costs a caller a challenge it holds, and reordering makes the oldest no
+// longer the one at the front.
+func TestCompactionKeepsLiveChallengesInOrder(t *testing.T) {
+	store := NewChallengeStore(time.Hour)
+
+	// A live challenge often enough that a compaction retains thousands of
+	// them, the rest consumed straight away, for well past the 2*maxChallenges
+	// the queue compacts at.
+	const liveEvery = 100
+	var live [][32]byte
+	for i := 0; i < 3*maxChallenges; i++ {
+		challenge := store.Create()
+		if i%liveEvery == 0 {
+			live = append(live, challenge)
+			continue
+		}
+		if !store.Consume(challenge[:]) {
+			t.Fatalf("challenge %d did not consume", i)
+		}
+	}
+
+	store.mu.Lock()
+	held, queued := len(store.challenges), len(store.issued)
+	order := append([][32]byte(nil), store.issued...)
+	store.mu.Unlock()
+
+	// Counted from what was minted and not consumed, so a compaction that
+	// drops a live key from both the map and the queue is still caught.
+	if held != len(live) {
+		t.Fatalf("store holds %d challenges, want the %d minted and never consumed", held, len(live))
+	}
+	if queued > 2*maxChallenges {
+		t.Fatalf("the queue holds %d keys, over its bound of %d", queued, 2*maxChallenges)
+	}
+	// Between compactions the queue also carries keys Consume removed; the
+	// live ones inside it must still be all of them, in the order they were
+	// minted, since that is what makes the front of the queue the oldest.
+	var survived [][32]byte
+	store.mu.Lock()
+	for _, key := range order {
+		if _, ok := store.challenges[key]; ok {
+			survived = append(survived, key)
+		}
+	}
+	store.mu.Unlock()
+	if len(survived) != len(live) {
+		t.Fatalf("the queue names %d live challenges, want %d", len(survived), len(live))
+	}
+	for i := range survived {
+		if survived[i] != live[i] {
+			t.Fatalf("live position %d in the queue is a different challenge than the %d-th minted", i, i)
+		}
+	}
+	for i, challenge := range live {
+		if !store.Consume(challenge[:]) {
+			t.Fatalf("live challenge %d of %d was dropped by a compaction", i, len(live))
+		}
+	}
+}
+
+// TestConsumedChallengesDoNotOccupyCapacity mints and consumes far more
+// challenges than the bound while holding one back. A consumed challenge that
+// keeps its slot would fill the store with nothing, and the one live challenge
+// would be evicted to make room for a mint.
+func TestConsumedChallengesDoNotOccupyCapacity(t *testing.T) {
+	store := NewChallengeStore(time.Hour)
+	kept := store.Create()
+
+	for i := 0; i < 3*maxChallenges; i++ {
+		challenge := store.Create()
+		if !store.Consume(challenge[:]) {
+			t.Fatalf("challenge %d did not consume", i)
+		}
+		// Checked as it goes: a queue that keeps consumed keys grows until the
+		// eviction scan makes the run quadratic, and this test would look
+		// wedged for minutes instead of failing here.
+		if i%4096 == 0 {
+			store.mu.Lock()
+			queued := len(store.issued)
+			store.mu.Unlock()
+			if queued > 2*maxChallenges {
+				t.Fatalf("after %d mints the queue holds %d keys, over its bound of %d", i, queued, 2*maxChallenges)
+			}
+		}
+	}
+
+	store.mu.Lock()
+	held, queued := len(store.challenges), len(store.issued)
+	store.mu.Unlock()
+	if held != 1 {
+		t.Fatalf("store holds %d challenges, want the one never consumed", held)
+	}
+	if queued > 2*maxChallenges {
+		t.Fatalf("issued holds %d keys, over its bound of %d", queued, 2*maxChallenges)
+	}
+	if !store.Consume(kept[:]) {
+		t.Fatal("the challenge held back was evicted by mints that were consumed straight away")
+	}
+}
+
+// TestConsumedChallengesLeaveNoResidue pins the same reclaim from the other
+// side: consuming everything leaves neither the map nor the queue holding it.
+func TestConsumedChallengesLeaveNoResidue(t *testing.T) {
+	store := NewChallengeStore(time.Hour)
+	for i := 0; i < 3*maxChallenges; i++ {
+		challenge := store.Create()
+		if !store.Consume(challenge[:]) {
+			t.Fatalf("challenge %d did not consume", i)
+		}
+	}
+
+	store.mu.Lock()
+	held, queued := len(store.challenges), len(store.issued)
+	store.mu.Unlock()
+	if held != 0 {
+		t.Fatalf("store holds %d challenges after consuming every one", held)
+	}
+	// The last key is still queued, since nothing has minted after it; every
+	// other consumed key must have been shed.
+	if queued > 1 {
+		t.Fatalf("issued holds %d keys after consuming every one, want at most 1", queued)
 	}
 }
 

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -27,6 +27,7 @@ type dependencies struct {
 	CACertPEM         []byte
 	OperatorKeysPEM   []byte                // pinned operator public keys; empty = /operator-keys 404s
 	RateLimiter       *issuer.IPRateLimiter // per-source-IP limiter for attestation endpoints
+	ChallengeLimiter  *issuer.IPRateLimiter // /authenticate's own, so it cannot spend the map above
 	MaxRequestSize    int64                 // applied to write endpoints; must be > 0
 	SecretsHandler    *secrets.Handler      // nil leaves /secrets unrouted (--secrets off)
 	SecretsChallenges *attestation.ChallengeStore
@@ -41,6 +42,12 @@ func newRouter(deps dependencies) http.Handler {
 	if deps.RateLimiter == nil {
 		panic("cds: dependencies.RateLimiter must be set")
 	}
+	if deps.ChallengeLimiter == nil {
+		panic("cds: dependencies.ChallengeLimiter must be set")
+	}
+	if deps.ChallengeLimiter == deps.RateLimiter {
+		panic("cds: dependencies.ChallengeLimiter must be a limiter of its own, not the attestation one")
+	}
 	r := chi.NewRouter()
 	r.Use(server.RequestLogger)
 
@@ -51,7 +58,7 @@ func newRouter(deps dependencies) http.Handler {
 	r.Get("/.well-known/jwks.json", server.HandleJWKS(deps.EarIssuer, deps.JWKSFunc))
 	r.Method(http.MethodGet, "/metrics", promhttp.Handler())
 
-	r.Post("/authenticate", attestation.HandleAuthenticate(deps.AttestHandler.Challenges))
+	r.Method(http.MethodPost, "/authenticate", deps.challengeProtected(attestation.HandleAuthenticate(deps.AttestHandler.Challenges)))
 	r.Method(http.MethodPost, "/attest", deps.protected(http.HandlerFunc(deps.AttestHandler.HandleAttest)))
 	r.Method(http.MethodPost, "/attest-key", deps.protected(http.HandlerFunc(deps.AttestKeyHandler.HandleAttestKey)))
 	r.Method(http.MethodPost, "/sign-csr", deps.protected(http.HandlerFunc(deps.SignCSRHandler.HandleSignCSR)))
@@ -97,11 +104,22 @@ func newRouter(deps dependencies) http.Handler {
 const allowlistWriteBodyCap int64 = 1 << 20
 
 // protected wraps a write handler with per-source-IP rate limiting and the
-// request-body cap. Used for the endpoints an unauthenticated caller can hit
-// before any signature check: attestation issuance (each junk write costs up to
-// one ECDSA verify per pinned key).
+// request-body cap. Its routes verify evidence or a token before they answer,
+// so a junk write costs up to one ECDSA verify per pinned key.
 func (deps dependencies) protected(next http.Handler) http.Handler {
 	return issuer.RateLimitMiddleware(deps.RateLimiter, capBody(deps.MaxRequestSize, next))
+}
+
+// challengeProtected meters /authenticate in a limiter of its own, so a
+// challenge and the /attest that redeems it are charged separately and the
+// challenge keys do not spend the map the other routes are metered in.
+//
+// Its key is the source address, which for a pod is the node's: pods reach
+// CDS through a NodePort and the host-network mesh proxy. One pod can spend
+// the budget its co-tenants share — as it already can on /attest, which the
+// challenge is only useful with — and pods on a node share a trust domain.
+func (deps dependencies) challengeProtected(next http.Handler) http.Handler {
+	return issuer.RateLimitMiddleware(deps.ChallengeLimiter, capBody(deps.MaxRequestSize, next))
 }
 
 // allowlistWrite is protected with the larger allowlist body cap. Its callers

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -32,10 +32,11 @@ func secretsRouter(t *testing.T, enabled bool) http.Handler {
 	cs := attestation.NewChallengeStore(time.Minute)
 	secretsCS := attestation.NewChallengeStore(time.Minute)
 	deps := dependencies{
-		AttestHandler:  AttestHandler{Challenges: &cs},
-		ReadyFn:        func() bool { return true },
-		RateLimiter:    limiter,
-		MaxRequestSize: 65536,
+		AttestHandler:    AttestHandler{Challenges: &cs},
+		ReadyFn:          func() bool { return true },
+		RateLimiter:      limiter,
+		ChallengeLimiter: newTestRateLimiter(t),
+		MaxRequestSize:   65536,
 	}
 	if enabled {
 		// A bare handler: routing is what is under test, so every request that
@@ -103,6 +104,7 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 		AttestHandler:     AttestHandler{Challenges: &cs},
 		ReadyFn:           func() bool { return true },
 		RateLimiter:       limiter,
+		ChallengeLimiter:  newTestRateLimiter(t),
 		MaxRequestSize:    65536,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
@@ -145,6 +147,7 @@ func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
 		AttestHandler:     AttestHandler{Challenges: &cs},
 		ReadyFn:           func() bool { return true },
 		RateLimiter:       limiter,
+		ChallengeLimiter:  newTestRateLimiter(t),
 		MaxRequestSize:    8,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
@@ -233,6 +236,7 @@ func TestRouter_SecretRoutesRateLimitPerSandbox(t *testing.T) {
 		AttestHandler:     AttestHandler{Challenges: &cs},
 		ReadyFn:           func() bool { return true },
 		RateLimiter:       limiter,
+		ChallengeLimiter:  newTestRateLimiter(t),
 		MaxRequestSize:    65536,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,

--- a/internal/cmds/cds/routes_test.go
+++ b/internal/cmds/cds/routes_test.go
@@ -3,6 +3,8 @@ package cds
 import (
 	"bytes"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +17,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/earsigner"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"golang.org/x/time/rate"
 )
 
@@ -45,6 +48,7 @@ func newStubRouter(t *testing.T) http.Handler {
 		EarIssuer:        earIss,
 		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		RateLimiter:      newTestRateLimiter(t),
+		ChallengeLimiter: newTestRateLimiter(t),
 		MaxRequestSize:   65536,
 	}
 	return newRouter(deps)
@@ -69,6 +73,7 @@ func TestRouter_RateLimitsAttestationEndpoints(t *testing.T) {
 		EarIssuer:        earIss,
 		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		RateLimiter:      rl,
+		ChallengeLimiter: newTestRateLimiter(t),
 		MaxRequestSize:   65536,
 	}
 	r := newRouter(deps)
@@ -107,6 +112,7 @@ func TestRouter_RateLimitsAllowlistWrites(t *testing.T) {
 		EarIssuer:        earIss,
 		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		RateLimiter:      rl,
+		ChallengeLimiter: newTestRateLimiter(t),
 		MaxRequestSize:   65536,
 	}
 	r := newRouter(deps)
@@ -123,6 +129,80 @@ func TestRouter_RateLimitsAllowlistWrites(t *testing.T) {
 	}
 	if got := do(); got != http.StatusTooManyRequests {
 		t.Fatalf("second request: got %d, want 429", got)
+	}
+}
+
+// TestRouter_RateLimitsAuthenticate pins the challenge endpoint behind the
+// per-source limiter: minting a challenge costs a stored nonce, and no caller
+// is authenticated at that point. Its budget is its own, so spending it leaves
+// the /attest that redeems the challenge servable.
+func TestRouter_RateLimitsAuthenticate(t *testing.T) {
+	keyPEM, _ := earsigner.Generate()
+	earIss, _ := ear.NewIssuer(keyPEM, "cds", time.Hour)
+	store, _ := allowlist.OpenInMemory()
+	t.Cleanup(func() { _ = store.Close() })
+	ca, _ := issuer.NewCA("test ca", time.Hour)
+	cs := attestation.NewChallengeStore(time.Minute)
+	// Burst of 1 with a refill too slow to reach, so the assertion is on the
+	// budget rather than on how fast the test runs. The challenge route has a
+	// limiter of its own, as it does in the shipped wiring.
+	rl, err := issuer.NewIPRateLimiter(rate.Limit(0.001), 1, 100)
+	if err != nil {
+		t.Fatalf("rate limiter: %v", err)
+	}
+	// A single-entry map, so a second source churns the first out of it — and
+	// the routes on the other limiter must not notice.
+	challengeRL, err := issuer.NewIPRateLimiter(rate.Limit(0.001), 1, 1)
+	if err != nil {
+		t.Fatalf("challenge rate limiter: %v", err)
+	}
+	deps := dependencies{
+		AttestHandler:    AttestHandler{Challenges: &cs, CA: ca, CertTTL: time.Hour},
+		AllowlistHandler: allowlist.Handler{Store: &store, WriteAuthorizer: func(*http.Request, []byte) error { return nil }},
+		ReadyFn:          func() bool { return true },
+		EarIssuer:        earIss,
+		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
+		RateLimiter:      rl,
+		ChallengeLimiter: challengeRL,
+		MaxRequestSize:   65536,
+	}
+	r := newRouter(deps)
+
+	post := func(path, addr string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewReader([]byte(`{}`)))
+		req.RemoteAddr = addr
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+	first := post("/authenticate", "10.0.0.3:1234")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first /authenticate: got %d, want 200", first.Code)
+	}
+	var issued types.ChallengeResponse
+	if err := json.Unmarshal(first.Body.Bytes(), &issued); err != nil {
+		t.Fatalf("decode challenge: %v", err)
+	}
+	if raw, err := base64.StdEncoding.DecodeString(issued.Challenge); err != nil || len(raw) != 32 {
+		t.Fatalf("challenge %q decodes to %d bytes (err %v), want 32", issued.Challenge, len(raw), err)
+	}
+	if got := post("/authenticate", "10.0.0.3:1234").Code; got != http.StatusTooManyRequests {
+		t.Fatalf("second /authenticate from the same source: got %d, want 429", got)
+	}
+	// The same source's attestation budget is untouched by that flood: a
+	// challenge is only worth anything to a caller that can still redeem it.
+	if got := post("/attest", "10.0.0.3:1234").Code; got == http.StatusTooManyRequests {
+		t.Fatal("/attest was spent by the same source's challenge requests")
+	}
+	// A second source churns the one-entry challenge map, taking the first
+	// source's bucket with it. What must not follow is that source getting a
+	// fresh attestation bucket: the two maps are separate, so its spent
+	// /attest budget is still spent.
+	if got := post("/authenticate", "10.0.0.4:1234").Code; got != http.StatusOK {
+		t.Fatalf("/authenticate from a second source: got %d, want 200", got)
+	}
+	if got := post("/attest", "10.0.0.3:1234").Code; got != http.StatusTooManyRequests {
+		t.Fatalf("/attest after the challenge map churned: got %d, want the source's spent budget", got)
 	}
 }
 
@@ -201,6 +281,7 @@ func TestRouter_AttestRejectsOversizedBody(t *testing.T) {
 		EarIssuer:        earIss,
 		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		RateLimiter:      newTestRateLimiter(t),
+		ChallengeLimiter: newTestRateLimiter(t),
 		MaxRequestSize:   16,
 	}
 	r := newRouter(deps)
@@ -435,7 +516,7 @@ func TestNewRouter_PanicsOnZeroMaxRequestSize(t *testing.T) {
 			t.Fatal("expected panic for zero MaxRequestSize")
 		}
 	}()
-	newRouter(dependencies{RateLimiter: newTestRateLimiter(t), MaxRequestSize: 0})
+	newRouter(dependencies{RateLimiter: newTestRateLimiter(t), ChallengeLimiter: newTestRateLimiter(t), MaxRequestSize: 0})
 }
 
 func TestNewRouter_PanicsOnNilRateLimiter(t *testing.T) {
@@ -445,6 +526,30 @@ func TestNewRouter_PanicsOnNilRateLimiter(t *testing.T) {
 		}
 	}()
 	newRouter(dependencies{RateLimiter: nil, MaxRequestSize: 1})
+}
+
+// The challenge route meters in a map of its own, so a wiring that forgets it
+// must not fall back to sharing another route's.
+func TestNewRouter_PanicsOnNilChallengeLimiter(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for nil ChallengeLimiter")
+		}
+	}()
+	newRouter(dependencies{RateLimiter: newTestRateLimiter(t), ChallengeLimiter: nil, MaxRequestSize: 1})
+}
+
+// Sharing one limiter between the two routes is the regression the challenge
+// map exists to prevent, and it is a wiring mistake no route-level test would
+// notice, so the router refuses to be built that way.
+func TestNewRouter_PanicsOnASharedChallengeLimiter(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for a ChallengeLimiter shared with the attestation limiter")
+		}
+	}()
+	shared := newTestRateLimiter(t)
+	newRouter(dependencies{RateLimiter: shared, ChallengeLimiter: shared, MaxRequestSize: 1})
 }
 
 // When a HandoffHandler is wired, /handoff is mounted and reachable (a malformed
@@ -516,6 +621,7 @@ func newStubRouterWithHandoff(t *testing.T) http.Handler {
 		EarIssuer:        earIss,
 		CACertPEM:        certutil.EncodeCertPEM(ca.Cert.Raw),
 		RateLimiter:      newTestRateLimiter(t),
+		ChallengeLimiter: newTestRateLimiter(t),
 		MaxRequestSize:   65536,
 	}
 	return newRouter(deps)

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -59,6 +59,10 @@ func run(cfg config) error {
 	// var; set it before any /sign-csr request can be served.
 	issuer.JWTClockSkew = time.Duration(cfg.jwtClockSkew) * time.Second
 
+	challengeLimiter, err := issuer.NewIPRateLimiter(rate.Limit(cfg.rateLimit), cfg.rateBurst, cfg.rateLimiterMax)
+	if err != nil {
+		return fmt.Errorf("challenge rate limiter: %w", err)
+	}
 	rateLimiter, err := issuer.NewIPRateLimiter(rate.Limit(cfg.rateLimit), cfg.rateBurst, cfg.rateLimiterMax)
 	if err != nil {
 		return fmt.Errorf("init rate limiter: %w", err)
@@ -344,6 +348,7 @@ func run(cfg config) error {
 		CACertPEM:         caChainPEM,
 		OperatorKeysPEM:   operatorKeysPEM,
 		RateLimiter:       rateLimiter,
+		ChallengeLimiter:  challengeLimiter,
 		MaxRequestSize:    cfg.maxRequestSize,
 		SecretsHandler:    secretsHandler,
 		SecretsChallenges: &secretsChallenges,
@@ -354,6 +359,7 @@ func run(cfg config) error {
 		go rotator.Run(ctx)
 	}
 	go rateLimiter.EvictionLoop(ctx, cfg.rateLimiterEvictInterval, cfg.rateLimiterIdleTimeout)
+	go challengeLimiter.EvictionLoop(ctx, cfg.rateLimiterEvictInterval, cfg.rateLimiterIdleTimeout)
 
 	router := newRouter(deps)
 

--- a/internal/cmds/cdsattest/cmd.go
+++ b/internal/cmds/cdsattest/cmd.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -149,13 +148,9 @@ func run(cfg config) error {
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
-	go cmdsutil.ShutdownOnDone(ctx, httpSrv, 5*time.Second)
 
 	logger.Info("LB browser-facing endpoints listening", "addr", addr)
-	if err := httpSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return err
-	}
-	return nil
+	return srv.Serve(ctx, httpSrv)
 }
 
 func newLogger(level string) *slog.Logger {

--- a/internal/cmds/cdsattest/holders.go
+++ b/internal/cmds/cdsattest/holders.go
@@ -1,0 +1,106 @@
+package cdsattest
+
+// holders indexes the keys each client holds in one store, and the clients by
+// how many they hold, so the fullest client is found without scanning either.
+type holders struct {
+	byClient map[string]map[string]struct{} // client -> its keys
+	bySize   []map[string]struct{}          // count -> clients holding exactly that many
+	max      int
+}
+
+func newHolders() *holders {
+	return &holders{byClient: make(map[string]map[string]struct{})}
+}
+
+func (h *holders) keys(client string) map[string]struct{} { return h.byClient[client] }
+
+func (h *holders) count(client string) int { return len(h.byClient[client]) }
+
+func (h *holders) clients() int { return len(h.byClient) }
+
+func (h *holders) add(client, key string) {
+	held, ok := h.byClient[client]
+	if !ok {
+		held = make(map[string]struct{})
+		h.byClient[client] = held
+	}
+	if _, dup := held[key]; dup {
+		return
+	}
+	was := len(held)
+	held[key] = struct{}{}
+	h.resize(client, was, was+1)
+}
+
+func (h *holders) remove(client, key string) {
+	held, ok := h.byClient[client]
+	if !ok {
+		return
+	}
+	if _, has := held[key]; !has {
+		return
+	}
+	was := len(held)
+	delete(held, key)
+	if len(held) == 0 {
+		delete(h.byClient, client)
+	}
+	h.resize(client, was, was-1)
+}
+
+func (h *holders) resize(client string, was, now int) {
+	if was > 0 {
+		delete(h.bySize[was], client)
+	}
+	if now > 0 {
+		for len(h.bySize) <= now {
+			h.bySize = append(h.bySize, nil)
+		}
+		if h.bySize[now] == nil {
+			h.bySize[now] = make(map[string]struct{})
+		}
+		h.bySize[now][client] = struct{}{}
+		if now > h.max {
+			h.max = now
+		}
+	}
+	for h.max > 0 && len(h.bySize[h.max]) == 0 {
+		h.max--
+	}
+}
+
+// admit names the client a full store takes an entry from so that want may
+// have one, and reports whether such a client exists.
+//
+// The share every holder is entitled to is the capacity divided between the
+// holders and want, floored at minShare. Both halves of that matter:
+//
+//   - Counting want in the denominator means a client holding nothing is
+//     always admitted. If no holder were above capacity/(holders+1) the total
+//     would be under capacity, so the store would not be full.
+//   - The floor is what an attacker cannot buy down. Without it the share is
+//     capacity divided by a number of clients the attacker creates, so paying
+//     for addresses drives every honest client's floor toward one entry.
+//
+// A holder at or below its share is never taken from, so the request that
+// found the store full is refused instead once every holder is at the floor.
+func (h *holders) admit(capacity int, want string) (string, bool) {
+	if h.max == 0 {
+		return "", false
+	}
+	entitled := h.clients()
+	if h.count(want) == 0 {
+		entitled++
+	}
+	share := capacity / entitled
+	if share < minShare {
+		share = minShare
+	}
+	if h.max <= share {
+		return "", false
+	}
+	for client := range h.bySize[h.max] {
+		return client, true
+	}
+	return "", false
+}

--- a/internal/cmds/cdsattest/holders_test.go
+++ b/internal/cmds/cdsattest/holders_test.go
@@ -1,0 +1,146 @@
+package cdsattest
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestHoldersTracksCounts(t *testing.T) {
+	h := newHolders()
+	h.add("a", "k1")
+	h.add("a", "k2")
+	h.add("a", "k2") // the same key twice is one entry
+	h.add("b", "k3")
+
+	if got := h.count("a"); got != 2 {
+		t.Fatalf("count(a) = %d, want 2", got)
+	}
+	if got := h.clients(); got != 2 {
+		t.Fatalf("clients = %d, want 2", got)
+	}
+
+	h.remove("a", "k1")
+	h.remove("a", "k2")
+	if got := h.count("a"); got != 0 {
+		t.Fatalf("count(a) after removing both = %d, want 0", got)
+	}
+	if got := h.clients(); got != 1 {
+		t.Fatalf("clients after a let go = %d, want 1", got)
+	}
+	h.remove("a", "gone") // removing what nobody holds changes nothing
+	h.remove("nobody", "k3")
+	if got := h.count("b"); got != 1 {
+		t.Fatalf("count(b) = %d, want 1", got)
+	}
+}
+
+// TestHoldersFollowsTheFullestClient pins the running maximum, which is what
+// makes the admission decision O(1) instead of a scan: it has to fall when the
+// client holding the most gives entries up.
+func TestHoldersFollowsTheFullestClient(t *testing.T) {
+	h := newHolders()
+	for i := 0; i < 5*minShare; i++ {
+		h.add("big", fmt.Sprintf("k%d", i))
+	}
+	h.add("small", "s1")
+
+	// Capacity 6*minShare over three entitled clients: the share is 2*minShare
+	// and big is over it.
+	if client, ok := h.admit(6*minShare, "newcomer"); !ok || client != "big" {
+		t.Fatalf("admit = %q, %v; want big, true", client, ok)
+	}
+	// Capacity 30*minShare: the share is 10*minShare and nobody reaches it.
+	if client, ok := h.admit(30*minShare, "newcomer"); ok {
+		t.Fatalf("admit = %q, %v; want no client over its share", client, ok)
+	}
+
+	for i := 0; i < 5*minShare-1; i++ {
+		h.remove("big", fmt.Sprintf("k%d", i))
+	}
+	// Both hold one now, well under the floor, so nothing is taken from them.
+	if client, ok := h.admit(2, "newcomer"); ok {
+		t.Fatalf("admit after big gave up its lead = %q, %v; want none", client, ok)
+	}
+	if h.max != 1 {
+		t.Fatalf("running maximum is %d, want 1", h.max)
+	}
+}
+
+// TestHoldersFloorTheShare pins the quantity an attacker cannot buy down. The
+// share is capacity over a client count the attacker adds to, so without a
+// floor its addresses decide how far an honest client is drained.
+func TestHoldersFloorTheShare(t *testing.T) {
+	const capacity = 8192
+	h := newHolders()
+	for i := 0; i < minShare; i++ {
+		h.add("client:honest", fmt.Sprintf("honest-%d", i))
+	}
+	// Far more clients than capacity/minShare, each holding one: the unfloored
+	// share here would be 1.
+	for i := 0; i < 4000; i++ {
+		h.add(fmt.Sprintf("client:flooder-%d", i), "k")
+	}
+
+	if client, ok := h.admit(capacity, "client:newcomer"); ok {
+		t.Fatalf("admit = %q; want nothing taken with every client at or under the floor of %d", client, minShare)
+	}
+}
+
+// TestHoldersAdmitAClientHoldingNothing pins the other half: a full store
+// counts the caller in the share it divides, so a client holding nothing is
+// never the one refused while a holder is above that share.
+func TestHoldersAdmitAClientHoldingNothing(t *testing.T) {
+	const (
+		capacity  = 8192
+		perClient = 512
+	)
+	h := newHolders()
+	// Sixteen clients at the per-client bound fill the store exactly, so every
+	// holder is at capacity/16 and nobody is above it.
+	for c := 0; c < capacity/perClient; c++ {
+		client := fmt.Sprintf("client:holder-%d", c)
+		for i := 0; i < perClient; i++ {
+			h.add(client, fmt.Sprintf("%s-%d", client, i))
+		}
+	}
+	if client, ok := h.admit(capacity, "client:newcomer"); !ok {
+		t.Fatal("a client holding nothing was refused by a store whose holders are all at the per-client bound")
+	} else if h.count(client) != perClient {
+		t.Fatalf("admit chose %q holding %d, want one of the clients at %d", client, h.count(client), perClient)
+	}
+	// A client already holding its share is not entitled to more: it does not
+	// add to the denominator, so nothing is above the share it asks against.
+	if client, ok := h.admit(capacity, "client:holder-0"); ok {
+		t.Fatalf("admit = %q for a client already at its share; want it refused", client)
+	}
+}
+
+// TestHoldersLeaveNothingBehind pins that a client that has let everything go
+// leaves no entry in either index. A per-client map that outlives its keys is
+// the growth this bounding exists to stop, and the key is caller-chosen.
+func TestHoldersLeaveNothingBehind(t *testing.T) {
+	h := newHolders()
+	for i := 0; i < 1000; i++ {
+		client := fmt.Sprintf("client:%d", i)
+		h.add(client, "k")
+		h.remove(client, "k")
+	}
+	if got := h.clients(); got != 0 {
+		t.Fatalf("index holds %d clients after every one let go, want 0", got)
+	}
+	for size, clients := range h.bySize {
+		if len(clients) != 0 {
+			t.Fatalf("the size index still holds %d clients at size %d", len(clients), size)
+		}
+	}
+	if h.max != 0 {
+		t.Fatalf("the running maximum is %d, want 0", h.max)
+	}
+}
+
+func TestHoldersOverShareOnAnEmptyIndex(t *testing.T) {
+	h := newHolders()
+	if client, ok := h.admit(10, "client:newcomer"); ok {
+		t.Fatalf("admit on an empty index = %q, %v; want none", client, ok)
+	}
+}

--- a/internal/cmds/cdsattest/server.go
+++ b/internal/cmds/cdsattest/server.go
@@ -20,9 +20,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"sync"
@@ -30,7 +32,10 @@ import (
 
 	"github.com/fxamacker/cbor/v2"
 	"github.com/go-chi/chi/v5"
+	"golang.org/x/time/rate"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/internal/issuer"
 	"github.com/confidential-dot-ai/c8s/internal/server"
 	"github.com/confidential-dot-ai/c8s/pkg/overenc"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -43,6 +48,68 @@ const wellKnownPrefix = "/.well-known/c8s"
 // require: the transcripts frame a 32-byte nonce and anything else is refused
 // rather than truncated or padded.
 const nonceBytes = 32
+
+// sessionHeader names the session a tunnel request rides.
+const sessionHeader = "X-C8s-Session"
+
+// Bounds on the unauthenticated endpoints: what one client may hold, and what
+// the process holds across all of them.
+const (
+	// Session establishment: one attestation report and one ML-KEM keypair per
+	// request, and a client needs two requests to open a session.
+	establishRateLimit = 10 // requests per second per client
+	establishRateBurst = 20
+	// One established session's application traffic, charged to the session.
+	sessionRateLimit = 200
+	sessionRateBurst = 400
+	// Tunnel traffic across all of a client's sessions, charged to the client
+	// on top of its per-session budget.
+	clientRateLimit = 400
+	clientRateBurst = 800
+
+	// A limiter refuses a key it has no bucket for once its map is full, so
+	// the map size is the ceiling on how many callers it can meter at once.
+	// clientBuckets covers the distinct clients a front door sees inside one
+	// idle timeout; the session limiter also carries one bucket per live
+	// session, so its map holds the whole session store on top of them.
+	clientBuckets        = 1 << 16
+	sessionBuckets       = maxSessions + clientBuckets
+	limiterEvictInterval = time.Minute
+	limiterIdleTimeout   = 5 * time.Minute
+
+	// One client may hold a sixteenth of each store: a public address fronts
+	// a whole CGNAT or corporate egress, so the per-client tier is sized for
+	// the crowd behind one address. The global tier is the memory ceiling.
+	maxPendingPerClient  = 512
+	maxPendingSessions   = 8192
+	maxSessionsPerClient = 512
+	maxSessions          = 8192
+	// minShare is the floor under a client's fair share of either store. It is
+	// what stops an attacker setting the share by the number of addresses it
+	// buys: below this many entries a client is never taken from, however many
+	// clients hold the rest.
+	minShare = 8
+
+	// sweepInterval paces the background eviction of expired pending
+	// handshakes and idle sessions. Both are also checked on use.
+	sweepInterval = 10 * time.Second
+	// shutdownGrace bounds the wait for in-flight requests at shutdown.
+	shutdownGrace = 5 * time.Second
+	// defaultNonceTTL bounds the wait between attest-pq and the handshake: a
+	// client verifies the report in between, and nothing else.
+	defaultNonceTTL = 30 * time.Second
+	// readyzCacheTTL bounds how stale a readiness answer may be. The check
+	// reads and parses the whole mesh identity, and the conditions it reports
+	// change on the scale of a certificate renewal.
+	readyzCacheTTL = time.Second
+)
+
+var (
+	errNonceInUse   = errors.New("a handshake is already pending for this nonce")
+	errSessionInUse = errors.New("a session already holds this id")
+	errSessionsFull = errors.New("too many sessions are open for this client")
+	errStoreFull    = errors.New("the server is at capacity; retry shortly")
+)
 
 // Front-door modes: which credential terminates the public TLS in front of
 // this sidecar. attest-lb transport trust rests on the serving key being
@@ -91,7 +158,8 @@ type Config struct {
 	Backend          Backend // over-encrypted application backend (nil => EchoBackend)
 	SessionTTL       time.Duration
 	// NonceTTL bounds how long a pending handshake nonce stays valid between
-	// the attestation fetch and the handshake POST. Defaults to SessionTTL.
+	// the attestation fetch and the handshake POST. Defaults to
+	// defaultNonceTTL.
 	NonceTTL time.Duration
 }
 
@@ -99,11 +167,13 @@ type pendingSession struct {
 	key        *overenc.ServerKey
 	transcript []byte // identity transcript hash, the channel's HKDF salt
 	createdAt  time.Time
+	client     string // rate-limit bucket the entry is accounted to
 }
 
 type establishedSession struct {
 	channel  *overenc.Channel
 	lastUsed time.Time
+	client   string
 }
 
 // Server serves the c8s-verify endpoints.
@@ -111,10 +181,28 @@ type Server struct {
 	cfg     Config
 	log     *slog.Logger
 	backend Backend
+	// establishLimiter meters attest-pq, attest-lb and the handshake per
+	// client; sessionLimiter meters one session's tunnel traffic; and
+	// clientLimiter is the per-client aggregate over every session a client
+	// holds, plus readiness.
+	establishLimiter *issuer.IPRateLimiter
+	sessionLimiter   *issuer.IPRateLimiter
+	clientLimiter    *issuer.IPRateLimiter
 
-	mu       sync.Mutex
-	pending  map[string]pendingSession     // nonce(b64url) -> server key
-	sessions map[string]establishedSession // session id -> channel
+	mu         sync.Mutex
+	pending    map[string]pendingSession     // nonce(b64url) -> server key
+	pendingBy  *holders                      // client -> its nonces
+	sessions   map[string]establishedSession // session id -> channel
+	sessionsBy *holders                      // client -> its session ids
+
+	sweepEvery time.Duration
+	evictEvery time.Duration
+	idleAfter  time.Duration
+
+	readyzMu     sync.Mutex
+	readyzAt     time.Time
+	readyzCode   int
+	readyzReason string
 }
 
 // NewServer constructs a Server.
@@ -126,18 +214,63 @@ func NewServer(cfg Config) *Server {
 		cfg.SessionTTL = 5 * time.Minute
 	}
 	if cfg.NonceTTL <= 0 {
-		cfg.NonceTTL = cfg.SessionTTL
+		cfg.NonceTTL = defaultNonceTTL
 	}
 	backend := cfg.Backend
 	if backend == nil {
 		backend = EchoBackend{}
 	}
 	return &Server{
-		cfg:      cfg,
-		log:      cfg.Logger,
-		backend:  backend,
-		pending:  make(map[string]pendingSession),
-		sessions: make(map[string]establishedSession),
+		cfg:              cfg,
+		log:              cfg.Logger,
+		backend:          backend,
+		establishLimiter: newLimiter(establishRateLimit, establishRateBurst, clientBuckets),
+		sessionLimiter:   newLimiter(sessionRateLimit, sessionRateBurst, sessionBuckets),
+		clientLimiter:    newLimiter(clientRateLimit, clientRateBurst, clientBuckets),
+		sweepEvery:       sweepInterval,
+		evictEvery:       limiterEvictInterval,
+		idleAfter:        limiterIdleTimeout,
+		pending:          make(map[string]pendingSession),
+		pendingBy:        newHolders(),
+		sessions:         make(map[string]establishedSession),
+		sessionsBy:       newHolders(),
+	}
+}
+
+func newLimiter(limit rate.Limit, burst, buckets int) *issuer.IPRateLimiter {
+	limiter, err := issuer.NewIPRateLimiter(limit, burst, buckets)
+	if err != nil {
+		panic("cdsattest: " + err.Error())
+	}
+	return limiter
+}
+
+// Serve runs the sidecar until ctx is cancelled: the listener, its graceful
+// shutdown, and the maintenance its stores need.
+func (s *Server) Serve(ctx context.Context, httpSrv *http.Server) error {
+	go cmdsutil.ShutdownOnDone(ctx, httpSrv, shutdownGrace)
+	go s.maintain(ctx)
+	if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}
+
+// maintain evicts expired pending handshakes, idle sessions and quiet
+// rate-limiter entries. It blocks until ctx is cancelled.
+func (s *Server) maintain(ctx context.Context) {
+	for _, limiter := range []*issuer.IPRateLimiter{s.establishLimiter, s.sessionLimiter, s.clientLimiter} {
+		go limiter.EvictionLoop(ctx, s.evictEvery, s.idleAfter)
+	}
+	ticker := time.NewTicker(s.sweepEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sweep()
+		}
 	}
 }
 
@@ -147,9 +280,13 @@ func (s *Server) Handler() http.Handler {
 	r.Use(server.RequestLogger)
 
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	// Unmetered: the kubelet probes it through the same front door as the
+	// public, so a per-client limit keyed on the address nginx records would
+	// throttle the probe under externalTrafficPolicy: Cluster, which SNATs
+	// every client onto the node. The cache below is what bounds a flood.
 	r.Get("/readyz", s.handleReadyz)
-	r.Get(wellKnownPrefix+"/attest-pq", s.handleAttestPQ)
-	r.Get(wellKnownPrefix+"/attest-lb", s.handleAttestLB)
+	r.Method(http.MethodGet, wellKnownPrefix+"/attest-pq", s.establishing(http.HandlerFunc(s.handleAttestPQ)))
+	r.Method(http.MethodGet, wellKnownPrefix+"/attest-lb", s.establishing(http.HandlerFunc(s.handleAttestLB)))
 	// The pre-split endpoint. Kept registered so a stale client gets the
 	// explicit versioned 400 — never a 404 it might treat as transient, and
 	// never an alias or downgrade.
@@ -157,12 +294,69 @@ func (s *Server) Handler() http.Handler {
 		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest,
 			"the /.well-known/c8s/attestation endpoint is gone: use attest-pq (encrypted session) or attest-lb (ordinary TLS)")
 	})
-	r.Post(wellKnownPrefix+"/handshake", s.handleHandshake)
+	r.Method(http.MethodPost, wellKnownPrefix+"/handshake", s.establishing(http.HandlerFunc(s.handleHandshake)))
 	// Over-encrypted application traffic: a single tunnel endpoint. The real
 	// method/path/headers/body are sealed inside the request envelope, so nginx
 	// only needs to route this one fixed path to the sidecar.
-	r.Post(wellKnownPrefix+"/tunnel", s.handleTunnel)
+	r.Method(http.MethodPost, wellKnownPrefix+"/tunnel",
+		s.perClient(issuer.RateLimitBy(s.sessionLimiter, s.tunnelKey, http.HandlerFunc(s.handleTunnel))))
 	return r
+}
+
+// establishing rate-limits the session-establishment endpoints per client.
+func (s *Server) establishing(next http.Handler) http.Handler {
+	return issuer.RateLimitBy(s.establishLimiter, clientKey, next)
+}
+
+// perClient rate-limits on the client alone. It wraps the session limiter on
+// the tunnel, so a request the client aggregate refuses never reaches the
+// store lock that keying on a session needs.
+func (s *Server) perClient(next http.Handler) http.Handler {
+	return issuer.RateLimitBy(s.clientLimiter, clientKey, next)
+}
+
+// tunnelKey charges tunnel traffic to the session the sidecar issued. A
+// request naming no live session is charged to its client, so a caller cannot
+// name a bucket by inventing a session id.
+func (s *Server) tunnelKey(r *http.Request) string {
+	id := r.Header.Get(sessionHeader)
+	if id == "" {
+		return clientKey(r)
+	}
+	s.mu.Lock()
+	_, live := s.sessions[id]
+	s.mu.Unlock()
+	if !live {
+		return clientKey(r)
+	}
+	return "session:" + id
+}
+
+// clientKey charges a request to the address nginx recorded in X-Real-IP on
+// the loopback hop. A request whose peer is not loopback did not come through
+// the front door and is charged to its own address.
+func clientKey(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	if peer := net.ParseIP(host); peer == nil || !peer.IsLoopback() {
+		return ""
+	}
+	client := net.ParseIP(r.Header.Get("X-Real-IP"))
+	if client == nil {
+		return ""
+	}
+	return "client:" + issuer.ClientPrefix(client.String())
+}
+
+// clientBucket names the bucket a request's per-client state is counted in,
+// falling back the same way the limiter does when there is no front door.
+func clientBucket(r *http.Request) string {
+	if key := clientKey(r); key != "" {
+		return key
+	}
+	return issuer.SourceAddrKey(r)
 }
 
 // attestNonce validates the shared request shape of both attestation
@@ -210,6 +404,13 @@ func (s *Server) handleAttestPQ(w http.ResponseWriter, r *http.Request) {
 	if nonce == nil {
 		return
 	}
+	// Ahead of the report this request would mint: a request the store will
+	// not take costs no attestation.
+	client := clientBucket(r)
+	if err := s.pendingRoom(client, nonceB64); err != nil {
+		s.refusePending(w, err)
+		return
+	}
 	if s.cfg.MeshIdentityCertFile == "" || s.cfg.MeshIdentityKeyFile == "" || s.cfg.MeshIdentityCAFile == "" {
 		writeErr(w, http.StatusNotImplemented, types.ErrorCodeBindingUnavailable, "identity-bound PQ is not configured on this LB")
 		return
@@ -243,14 +444,14 @@ func (s *Server) handleAttestPQ(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.sweep()
-	s.mu.Lock()
-	s.pending[nonceB64] = pendingSession{
+	if err := s.addPending(client, nonceB64, pendingSession{
 		key:        key,
 		transcript: append([]byte(nil), reportData...),
 		createdAt:  time.Now(),
+	}); err != nil {
+		s.refusePending(w, err)
+		return
 	}
-	s.mu.Unlock()
 
 	writeJSON(w, http.StatusOK, types.AttestationBundle{
 		Version:    types.BindingAttestPQ,
@@ -366,14 +567,34 @@ func (s *Server) servingLeafDER() ([]byte, error) {
 // so the 503 body carries a reason that is not configuration and the specifics
 // go to the log.
 func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
-	if s.cfg.ExpectedWorkload == "" {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	notReady := func(reason string, detail ...any) {
-		s.log.Warn("readiness gate withholding traffic", append([]any{"reason", reason}, detail...)...)
-		w.WriteHeader(http.StatusServiceUnavailable)
+	code, reason := s.readiness()
+	w.WriteHeader(code)
+	if reason != "" {
 		fmt.Fprintln(w, reason)
+	}
+}
+
+// readiness answers from a result no older than readyzCacheTTL. Concurrent
+// probes collapse onto one computation of it, so the cost of a flood is the
+// cost of one check per TTL.
+func (s *Server) readiness() (int, string) {
+	s.readyzMu.Lock()
+	defer s.readyzMu.Unlock()
+	if !s.readyzAt.IsZero() && time.Since(s.readyzAt) < readyzCacheTTL {
+		return s.readyzCode, s.readyzReason
+	}
+	s.readyzCode, s.readyzReason = s.computeReadiness()
+	s.readyzAt = time.Now()
+	return s.readyzCode, s.readyzReason
+}
+
+func (s *Server) computeReadiness() (int, string) {
+	if s.cfg.ExpectedWorkload == "" {
+		return http.StatusOK, ""
+	}
+	notReady := func(reason string, detail ...any) (int, string) {
+		s.log.Warn("readiness gate withholding traffic", append([]any{"reason", reason}, detail...)...)
+		return http.StatusServiceUnavailable, reason
 	}
 	// Exactly the load attest-pq/attest-lb do: reading and parsing the leaf
 	// alone would report ready on a credential those endpoints refuse — an
@@ -381,23 +602,21 @@ func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
 	// stamped leaves carry a short TTL (issuer.MaxNamedLeafTTL).
 	identity, err := loadMeshIdentity(s.cfg.MeshIdentityCertFile, s.cfg.MeshIdentityKeyFile, s.cfg.MeshIdentityCAFile)
 	if err != nil {
-		notReady("mesh identity credentials unusable", "error", err)
-		return
+		return notReady("mesh identity credentials unusable", "error", err)
 	}
 	workload, err := ratls.MatchedWorkloadFromCert(identity.leaf)
 	switch {
 	case err != nil:
-		notReady("matched-workload stamp malformed", "error", err)
+		return notReady("matched-workload stamp malformed", "error", err)
 	case workload == nil:
-		notReady("mesh identity leaf carries no matched-workload stamp")
+		return notReady("mesh identity leaf carries no matched-workload stamp")
 	case workload.Name != s.cfg.ExpectedWorkload:
 		// Both names are this front door's configuration and this body is
 		// reachable from the public internet; name them only in the log.
-		notReady("mesh identity leaf is stamped for a different workload",
+		return notReady("mesh identity leaf is stamped for a different workload",
 			"stamped", workload.Name, "expected", s.cfg.ExpectedWorkload)
-	default:
-		w.WriteHeader(http.StatusOK)
 	}
+	return http.StatusOK, ""
 }
 
 func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
@@ -407,14 +626,8 @@ func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.sweep()
 	now := time.Now()
-	s.mu.Lock()
-	entry, ok := s.pending[req.Nonce]
-	if ok {
-		delete(s.pending, req.Nonce)
-	}
-	s.mu.Unlock()
+	entry, ok := s.takePending(req.Nonce)
 	if !ok || now.Sub(entry.createdAt) > s.cfg.NonceTTL {
 		writeErr(w, http.StatusBadRequest, types.ErrorCodeInvalidRequest, "unknown or expired nonce")
 		return
@@ -442,36 +655,44 @@ func (s *Server) handleHandshake(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	id := base64.RawURLEncoding.EncodeToString(idRaw)
-	s.mu.Lock()
-	s.sessions[id] = establishedSession{channel: channel, lastUsed: time.Now()}
-	s.mu.Unlock()
+	if err := s.addSession(clientBucket(r), id, establishedSession{channel: channel, lastUsed: time.Now()}); err != nil {
+		s.refuseSession(w, err)
+		return
+	}
 
 	writeJSON(w, http.StatusOK, types.HandshakeResponse{SessionID: id})
+}
+
+// refusePending maps a refused handshake onto the wire: a nonce collision is
+// the client's to fix, a full store is one to retry.
+func (s *Server) refusePending(w http.ResponseWriter, err error) {
+	if errors.Is(err, errStoreFull) {
+		writeErr(w, http.StatusServiceUnavailable, types.ErrorCodeAttestationUnavailable, err.Error())
+		return
+	}
+	writeErr(w, http.StatusConflict, types.ErrorCodeInvalidRequest, err.Error())
+}
+
+// refuseSession maps a refused session onto the wire. A colliding id is a
+// 128-bit random collision, so it is this server's fault, not the caller's.
+func (s *Server) refuseSession(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errSessionInUse):
+		s.log.Error("session id collision", "error", err)
+		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "session id generation failed")
+	case errors.Is(err, errStoreFull):
+		writeErr(w, http.StatusServiceUnavailable, types.ErrorCodeAttestationUnavailable, err.Error())
+	default:
+		writeErr(w, http.StatusTooManyRequests, types.ErrorCodeTooManyRequests, err.Error())
+	}
 }
 
 // handleTunnel terminates the over-encryption: it opens the sealed request
 // envelope, forwards the reconstructed request to the backend (plaintext; the
 // cluster raTLS mesh wraps that hop), and seals the response back to the client.
 func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
-	id := r.Header.Get("X-C8s-Session")
-	s.sweep()
-
-	s.mu.Lock()
-	now := time.Now()
-	session, ok := s.sessions[id]
-	switch {
-	case ok && now.Sub(session.lastUsed) > s.cfg.SessionTTL:
-		delete(s.sessions, id)
-		session = establishedSession{} // expired => treat as no session
-	case ok:
-		session.lastUsed = now
-		s.sessions[id] = session
-	default: // case !ok
-		session = establishedSession{}
-	}
-	s.mu.Unlock()
-
-	if session.channel == nil {
+	channel := s.useSession(r.Header.Get(sessionHeader))
+	if channel == nil {
 		writeErr(w, http.StatusUnauthorized, types.ErrorCodeChannelError, "no over-encryption session")
 		return
 	}
@@ -486,7 +707,7 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "invalid record")
 		return
 	}
-	plaintext, err := session.channel.Open(rec, overenc.RequestAAD())
+	plaintext, err := channel.Open(rec, overenc.RequestAAD())
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, types.ErrorCodeChannelError, "decrypt failed")
 		return
@@ -509,7 +730,7 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "marshal response envelope")
 		return
 	}
-	out, err := session.channel.Seal(respCBOR, overenc.ResponseAAD())
+	out, err := channel.Seal(respCBOR, overenc.ResponseAAD())
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, types.ErrorCodeInternal, "seal failed")
 		return
@@ -521,17 +742,171 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 func (s *Server) sweep() {
 	now := time.Now()
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	for k, v := range s.pending {
 		if now.Sub(v.createdAt) > s.cfg.NonceTTL {
-			delete(s.pending, k)
+			s.dropPending(k)
 		}
 	}
 	for k, v := range s.sessions {
 		if now.Sub(v.lastUsed) > s.cfg.SessionTTL {
-			delete(s.sessions, k)
+			s.dropSession(k)
 		}
 	}
-	s.mu.Unlock()
+}
+
+// pendingRoom reports why a handshake for client may not be parked under
+// nonce. handleAttestPQ asks before it mints anything, and addPending asks
+// again under the lock that inserts.
+func (s *Server) pendingRoom(client, nonce string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pendingRoomLocked(client, nonce)
+}
+
+func (s *Server) pendingRoomLocked(client, nonce string) error {
+	if _, taken := s.pending[nonce]; taken {
+		return errNonceInUse
+	}
+	// A client at its own bound makes room from its own entries, so the store
+	// cannot grow and the global bound does not apply.
+	if s.pendingBy.count(client) >= maxPendingPerClient {
+		return nil
+	}
+	if len(s.pending) >= maxPendingSessions {
+		if _, ok := s.pendingBy.admit(maxPendingSessions, client); !ok {
+			return errStoreFull
+		}
+	}
+	return nil
+}
+
+// addPending parks entry under nonce. A client past its own bound drops its
+// oldest pending handshake; a full store drops from a client over its share
+// (holders.admit).
+func (s *Server) addPending(client, nonce string, entry pendingSession) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.pendingRoomLocked(client, nonce); err != nil {
+		return err
+	}
+	switch {
+	case s.pendingBy.count(client) >= maxPendingPerClient:
+		s.dropPending(oldestPendingOf(s.pending, s.pendingBy.keys(client)))
+	case len(s.pending) >= maxPendingSessions:
+		over, ok := s.pendingBy.admit(maxPendingSessions, client)
+		if !ok {
+			return errStoreFull
+		}
+		s.dropPending(oldestPendingOf(s.pending, s.pendingBy.keys(over)))
+	}
+	entry.client = client
+	s.pending[nonce] = entry
+	s.pendingBy.add(client, nonce)
+	return nil
+}
+
+// takePending removes and returns the handshake parked under nonce.
+func (s *Server) takePending(nonce string) (pendingSession, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.pending[nonce]
+	if !ok {
+		return pendingSession{}, false
+	}
+	s.dropPending(nonce)
+	return entry, true
+}
+
+func (s *Server) dropPending(nonce string) {
+	entry, ok := s.pending[nonce]
+	if !ok {
+		return
+	}
+	delete(s.pending, nonce)
+	s.pendingBy.remove(entry.client, nonce)
+}
+
+// addSession stores an established channel under id. An established session is
+// never evicted for a new one; a client at its own bound is refused.
+func (s *Server) addSession(client, id string, entry establishedSession) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, taken := s.sessions[id]; taken {
+		return errSessionInUse
+	}
+	if s.sessionsBy.count(client) >= maxSessionsPerClient {
+		return errSessionsFull
+	}
+	if len(s.sessions) >= maxSessions {
+		over, ok := s.sessionsBy.admit(maxSessions, client)
+		if !ok {
+			return errStoreFull
+		}
+		s.dropSession(idlestSessionOf(s.sessions, s.sessionsBy.keys(over)))
+	}
+	entry.client = client
+	s.sessions[id] = entry
+	s.sessionsBy.add(client, id)
+	return nil
+}
+
+// useSession returns the channel id names, refreshing its idle deadline. An
+// expired session is dropped and reported as absent.
+func (s *Server) useSession(id string) *overenc.Channel {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.sessions[id]
+	if !ok {
+		return nil
+	}
+	now := time.Now()
+	if now.Sub(entry.lastUsed) > s.cfg.SessionTTL {
+		s.dropSession(id)
+		return nil
+	}
+	entry.lastUsed = now
+	s.sessions[id] = entry
+	return entry.channel
+}
+
+func (s *Server) dropSession(id string) {
+	entry, ok := s.sessions[id]
+	if !ok {
+		return
+	}
+	delete(s.sessions, id)
+	s.sessionsBy.remove(entry.client, id)
+}
+
+func oldestPendingOf(pending map[string]pendingSession, held map[string]struct{}) string {
+	var chosen string
+	var at time.Time
+	for nonce := range held {
+		entry, ok := pending[nonce]
+		if !ok {
+			continue
+		}
+		if at.IsZero() || entry.createdAt.Before(at) {
+			chosen, at = nonce, entry.createdAt
+		}
+	}
+	return chosen
+}
+
+func idlestSessionOf(sessions map[string]establishedSession, held map[string]struct{}) string {
+	var chosen string
+	var at time.Time
+	for id := range held {
+		entry, ok := sessions[id]
+		if !ok {
+			continue
+		}
+		if at.IsZero() || entry.lastUsed.Before(at) {
+			chosen, at = id, entry.lastUsed
+		}
+	}
+	return chosen
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/cmds/cdsattest/server_limits_test.go
+++ b/internal/cmds/cdsattest/server_limits_test.go
@@ -1,0 +1,1688 @@
+package cdsattest
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/overenc"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// countingEvidence reports how many attestation reports the endpoints minted.
+type countingEvidence struct {
+	inner FixtureEvidenceProvider
+	calls atomic.Int64
+}
+
+func (c *countingEvidence) Evidence(ctx context.Context, reportData []byte) (json.RawMessage, string, string, error) {
+	c.calls.Add(1)
+	return c.inner.Evidence(ctx, reportData)
+}
+
+func testFixture() FixtureEvidenceProvider {
+	return FixtureEvidenceProvider{
+		Raw:        json.RawMessage(`{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`),
+		Platform:   "snp",
+		Generation: "genoa",
+	}
+}
+
+// newMeteredTestServer returns the sidecar, the httptest server in front of it
+// and its evidence counter, so a test can inspect the state the endpoints fill.
+// It runs the shipped limits.
+func newMeteredTestServer(t *testing.T) (*Server, *httptest.Server, *countingEvidence) {
+	t.Helper()
+	return newBurstTestServer(t, 0)
+}
+
+// newBurstTestServer gives every limiter a refill too slow to matter, so a
+// test asserts on the burst alone and never on wall-clock time. A burst of 0
+// keeps the shipped limits.
+func newBurstTestServer(t *testing.T, burst int) (*Server, *httptest.Server, *countingEvidence) {
+	t.Helper()
+	return newTestServerWith(t, func(srv *Server) {
+		if burst > 0 {
+			srv.establishLimiter = newLimiter(0.001, burst, clientBuckets)
+			srv.sessionLimiter = newLimiter(0.001, burst, clientBuckets)
+			srv.clientLimiter = newLimiter(0.001, burst, clientBuckets)
+		}
+	})
+}
+
+// newTestServerWith applies tune before the router is built, since the router
+// binds the limiters it meters with.
+func newTestServerWith(t *testing.T, tune func(*Server)) (*Server, *httptest.Server, *countingEvidence) {
+	t.Helper()
+	identity := writeTestMeshIdentity(t)
+	evidence := &countingEvidence{inner: testFixture()}
+	srv := NewServer(Config{
+		Evidence:             evidence,
+		MeshIdentityCertFile: identity.certFile,
+		MeshIdentityKeyFile:  identity.keyFile,
+		MeshIdentityCAFile:   identity.caFile,
+	})
+	tune(srv)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+	return srv, ts, evidence
+}
+
+func testNonce(t *testing.T) []byte {
+	t.Helper()
+	nonce := make([]byte, nonceBytes)
+	if _, err := rand.Read(nonce); err != nil {
+		t.Fatal(err)
+	}
+	return nonce
+}
+
+// get issues a GET as the client X-Real-IP names and returns the status. An
+// empty clientIP sends no header, as a caller that never passed the front door
+// would.
+func get(t *testing.T, url, clientIP string, headers ...string) int {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if clientIP != "" {
+		req.Header.Set("X-Real-IP", clientIP)
+	}
+	for i := 0; i+1 < len(headers); i += 2 {
+		req.Header.Set(headers[i], headers[i+1])
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode
+}
+
+func getAttestPQ(t *testing.T, base, clientIP string, nonce []byte) int {
+	t.Helper()
+	return get(t, base+"/.well-known/c8s/attest-pq?nonce="+b64url(nonce), clientIP)
+}
+
+// TestAttestPQMetersEachClientSeparately spends one client's whole burst and
+// checks every request past it is refused and that the count is exactly the
+// burst, then that a second client still has its own.
+func TestAttestPQMetersEachClientSeparately(t *testing.T) {
+	const burst = 5
+	_, ts, _ := newBurstTestServer(t, burst)
+
+	var served, limited int
+	for i := 0; i < 3*burst; i++ {
+		switch code := getAttestPQ(t, ts.URL, "203.0.113.7", testNonce(t)); code {
+		case http.StatusOK:
+			served++
+		case http.StatusTooManyRequests:
+			limited++
+		default:
+			t.Fatalf("attest-pq: unexpected status %d", code)
+		}
+	}
+	if served != burst {
+		t.Fatalf("one client was served %d attest-pq, want its burst of %d", served, burst)
+	}
+	if limited != 2*burst {
+		t.Fatalf("%d requests were limited, want %d", limited, 2*burst)
+	}
+	if code := getAttestPQ(t, ts.URL, "198.51.100.9", testNonce(t)); code != http.StatusOK {
+		t.Fatalf("attest-pq from a second client: got %d, want 200", code)
+	}
+}
+
+// TestAttestLBAndHandshakeAreMetered pins the other two unauthenticated
+// session-establishment routes onto the same budget.
+func TestAttestLBAndHandshakeAreMetered(t *testing.T) {
+	identity := writeTestMeshIdentity(t)
+	srv := NewServer(Config{
+		Evidence:             testFixture(),
+		FrontDoorMode:        FrontDoorModeCDS,
+		ServingCertFile:      identity.certFile,
+		MeshIdentityCertFile: identity.certFile,
+		MeshIdentityKeyFile:  identity.keyFile,
+		MeshIdentityCAFile:   identity.caFile,
+	})
+	srv.establishLimiter = newLimiter(0.001, 1, clientBuckets)
+	ts := httptest.NewServer(srv.Handler())
+	t.Cleanup(ts.Close)
+
+	if code := get(t, ts.URL+"/.well-known/c8s/attest-lb?nonce="+b64url(testNonce(t)), "203.0.113.7"); code != http.StatusOK {
+		t.Fatalf("first attest-lb: got %d, want 200", code)
+	}
+	if code := get(t, ts.URL+"/.well-known/c8s/attest-lb?nonce="+b64url(testNonce(t)), "203.0.113.7"); code != http.StatusTooManyRequests {
+		t.Fatalf("second attest-lb: got %d, want 429", code)
+	}
+
+	post := func(clientIP string) int {
+		t.Helper()
+		body, err := json.Marshal(types.HandshakeRequest{Nonce: b64url(testNonce(t))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/.well-known/c8s/handshake", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Real-IP", clientIP)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+	// A second client's burst is untouched by the first's; its own second
+	// handshake is refused.
+	if code := post("198.51.100.9"); code == http.StatusTooManyRequests {
+		t.Fatal("first handshake from a fresh client was rate limited")
+	}
+	if code := post("198.51.100.9"); code != http.StatusTooManyRequests {
+		t.Fatalf("second handshake from the same client: got %d, want 429", code)
+	}
+}
+
+// TestShippedBurstCoversASessionFleet drives whole sessions through the
+// shipped constants. The load is stated here rather than derived from the
+// constants, so tightening a limit past it fails this test: one client
+// opening ten sessions back to back, which is a browser reloading a page.
+func TestShippedBurstCoversASessionFleet(t *testing.T) {
+	const legitimateSessions = 10
+
+	_, ts, _ := newMeteredTestServer(t)
+
+	// Each session costs one attest-pq and one handshake, and every request
+	// here lands in the one bucket the client is charged.
+	for i := 0; i < legitimateSessions; i++ {
+		if _, id := establishSession(t, ts.URL, testNonce(t)); id == "" {
+			t.Fatalf("session %d was not established", i)
+		}
+	}
+}
+
+// TestTunnelTrafficIsNotChargedToTheAttestationBudget runs an established
+// session past the attestation burst: application traffic rides its own
+// limiter, keyed on the session.
+func TestTunnelTrafficIsNotChargedToTheAttestationBudget(t *testing.T) {
+	_, ts, _ := newMeteredTestServer(t)
+
+	const applicationRequests = 100
+
+	nonce := testNonce(t)
+	channel, sessionID := establishSession(t, ts.URL, nonce)
+	for i := 0; i < applicationRequests; i++ {
+		if code := tunnelStatus(t, ts.URL, sessionID, channel, i); code != http.StatusOK {
+			t.Fatalf("tunnel request %d: got %d, want 200", i, code)
+		}
+	}
+}
+
+// TestSessionlessTunnelIsMetered pins the unauthenticated tunnel path, which
+// costs a session lookup and nothing else, to the caller's own bucket.
+func TestSessionlessTunnelIsMetered(t *testing.T) {
+	_, ts, _ := newBurstTestServer(t, 2)
+
+	post := func() int {
+		t.Helper()
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/.well-known/c8s/tunnel", bytes.NewReader([]byte("junk")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Real-IP", "203.0.113.7")
+		req.Header.Set(sessionHeader, "not-a-session-"+strconv.Itoa(int(time.Now().UnixNano())))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+	if code := post(); code != http.StatusUnauthorized {
+		t.Fatalf("first sessionless tunnel: got %d, want 401", code)
+	}
+	if code := post(); code != http.StatusUnauthorized {
+		t.Fatalf("second sessionless tunnel: got %d, want 401", code)
+	}
+	if code := post(); code != http.StatusTooManyRequests {
+		t.Fatalf("third sessionless tunnel past the burst: got %d, want 429", code)
+	}
+}
+
+// entitledClients is how many distinct clients a front door must be able to
+// meter at once, stated here rather than read from the constant. A limiter
+// refuses a client it has no bucket for, so this is an availability floor, and
+// the ceiling below is a memory budget: three maps of this size at roughly a
+// couple of hundred bytes a bucket.
+const (
+	entitledClients   = 50000
+	affordableBuckets = 1 << 17
+)
+
+// TestLimiterMapsMeterAFleetOfClients pins the map size against that load
+// rather than against itself.
+func TestLimiterMapsMeterAFleetOfClients(t *testing.T) {
+	if clientBuckets < entitledClients {
+		t.Fatalf("a limiter meters %d clients at once, fewer than the %d a front door must serve", clientBuckets, entitledClients)
+	}
+	if clientBuckets > affordableBuckets {
+		t.Fatalf("a limiter holds %d buckets, past the %d the sidecar budgets for", clientBuckets, affordableBuckets)
+	}
+}
+
+// TestMaintenanceReclaimsQuietLimiterBuckets pins the loop that keeps the
+// limiter maps off their ceiling. A map at capacity meters a smaller share of
+// its traffic with every new client, since each one takes a bucket from the
+// quietest, so the buckets of clients that have gone quiet have to come back.
+func TestMaintenanceReclaimsQuietLimiterBuckets(t *testing.T) {
+	const clients = 4
+	srv, ts, _ := newTestServerWith(t, func(srv *Server) {
+		srv.evictEvery = 5 * time.Millisecond
+		srv.idleAfter = 20 * time.Millisecond
+		srv.sweepEvery = time.Hour // not what this test is about
+	})
+
+	for i := 0; i < clients; i++ {
+		if code := getAttestPQ(t, ts.URL, fmt.Sprintf("203.0.113.%d", i), testNonce(t)); code != http.StatusOK {
+			t.Fatalf("client %d claiming a bucket: got %d, want 200", i, code)
+		}
+	}
+	if got := srv.establishLimiter.Len(); got != clients {
+		t.Fatalf("the limiter meters %d clients, want %d", got, clients)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go srv.maintain(ctx)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for srv.establishLimiter.Len() > 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the limiter still meters %d clients that have gone quiet", srv.establishLimiter.Len())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestTimingsMeetTheirStatedRequirements pins the durations against what each
+// one is for. Every bound here is a literal: a constant that only ever appears
+// next to itself is not pinned by anything.
+func TestTimingsMeetTheirStatedRequirements(t *testing.T) {
+	for _, tc := range []struct {
+		what     string
+		got      time.Duration
+		min, max time.Duration
+		why      string
+	}{
+		{"nonce TTL", defaultNonceTTL, 10 * time.Second, time.Minute,
+			"a client verifies a hardware report in between, on a phone; and a parked ML-KEM key is held for exactly this long"},
+		{"sweep interval", sweepInterval, time.Second, 30 * time.Second,
+			"expired entries hold their store's capacity until a sweep passes"},
+		{"readiness cache", readyzCacheTTL, 200 * time.Millisecond, time.Second,
+			"how stale an answer the kubelet may act on"},
+		{"shutdown grace", shutdownGrace, time.Second, 30 * time.Second,
+			"in-flight requests finish inside it, and a rollout waits on it"},
+		{"limiter eviction interval", limiterEvictInterval, time.Second, 5 * time.Minute,
+			"a client refused by a full map waits this long for a bucket"},
+		{"limiter idle timeout", limiterIdleTimeout, time.Minute, 30 * time.Minute,
+			"a bucket is held against a client that has gone quiet for this long"},
+	} {
+		t.Run(tc.what, func(t *testing.T) {
+			if tc.got < tc.min || tc.got > tc.max {
+				t.Fatalf("%s is %v, want between %v and %v: %s", tc.what, tc.got, tc.min, tc.max, tc.why)
+			}
+		})
+	}
+
+	// A client opening sessions steadily, not in a burst, must still get
+	// through: five a second is a browser reloading a page.
+	const steadySessionsPerSecond = 5
+	if establishRateLimit < 2*steadySessionsPerSecond {
+		t.Fatalf("establishment is limited to %v/s, under the %d requests %d sessions a second cost",
+			establishRateLimit, 2*steadySessionsPerSecond, steadySessionsPerSecond)
+	}
+}
+
+// The memory each store may cost, stated as a budget rather than as the
+// constants themselves. A ceiling exists to bound memory, so raising it is the
+// dangerous direction and the one these bounds catch.
+const (
+	// A pending handshake holds an ML-KEM-768 decapsulation key and its public
+	// key, about 4 KiB.
+	pendingEntryBytes = 4 << 10
+	pendingBudget     = 48 << 20
+	// An established session holds a channel: two AEAD keys, a transcript and
+	// a bounded replay set, about 1 KiB.
+	sessionEntryBytes = 1 << 10
+	sessionBudget     = 16 << 20
+)
+
+// TestStoresStayInsideTheirMemoryBudget pins the ceilings from above. A store
+// bound is what stops an attacker turning traffic into memory, so it has to be
+// small enough to matter, not only large enough to serve a fleet.
+func TestStoresStayInsideTheirMemoryBudget(t *testing.T) {
+	if cost := maxPendingSessions * pendingEntryBytes; cost > pendingBudget {
+		t.Fatalf("the pending store may cost %d bytes, over its budget of %d", cost, pendingBudget)
+	}
+	if cost := maxSessions * sessionEntryBytes; cost > sessionBudget {
+		t.Fatalf("the session pool may cost %d bytes, over its budget of %d", cost, sessionBudget)
+	}
+	// And no single client may hold more than an eighth of either store,
+	// however generous the per-client tier is to a crowd behind one address.
+	if maxSessionsPerClient > maxSessions/8 {
+		t.Fatalf("one client may hold %d of %d sessions, more than an eighth of the pool", maxSessionsPerClient, maxSessions)
+	}
+	if maxPendingPerClient > maxPendingSessions/8 {
+		t.Fatalf("one client may hold %d of %d handshakes, more than an eighth of the store", maxPendingPerClient, maxPendingSessions)
+	}
+}
+
+// TestLimiterMapsHoldTheirWholeKeySpace pins the relationship between the
+// stores and the maps that meter them. A limiter refuses a key it has no
+// bucket for, and the session limiter is keyed by session as well as by
+// client, so a map smaller than the session store turns a full store into a
+// denial on live sessions.
+func TestLimiterMapsHoldTheirWholeKeySpace(t *testing.T) {
+	if sessionBuckets <= maxSessions {
+		t.Fatalf("the session limiter holds %d buckets for a store of %d sessions", sessionBuckets, maxSessions)
+	}
+	if sessionBuckets < maxSessions+clientBuckets {
+		t.Fatalf("the session limiter holds %d buckets, want room for %d sessions and %d clients", sessionBuckets, maxSessions, clientBuckets)
+	}
+	if clientBuckets <= maxSessions/maxSessionsPerClient {
+		t.Fatalf("the client limiter holds %d buckets, fewer than the %d clients that can fill the session store", clientBuckets, maxSessions/maxSessionsPerClient)
+	}
+}
+
+// TestSessionlessFloodCannotDenyALiveSession is that relationship from the
+// outside: sessionless tunnel posts from many distinct prefixes each claim a
+// bucket in the same limiter the live sessions are keyed in, and a client
+// holding a live session must keep being served through it.
+func TestSessionlessFloodCannotDenyALiveSession(t *testing.T) {
+	// Enough churn to move buckets around the map the live session is keyed
+	// in. What pins the map's size is TestLimiterMapsHoldTheirWholeKeySpace;
+	// this pins the symptom that sizing was wrong for — a live session
+	// refused — which no amount of churn may cause.
+	const floodPrefixes = 2000
+
+	_, ts, _ := newMeteredTestServer(t)
+	channel, sessionID := establishSession(t, ts.URL, testNonce(t))
+
+	client := &http.Client{}
+	for i := 0; i < floodPrefixes; i++ {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/.well-known/c8s/tunnel", bytes.NewReader([]byte("junk")))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Real-IP", fmt.Sprintf("2001:db8:%x:%x::1", i/65536, i%65536))
+		req.Header.Set(sessionHeader, fmt.Sprintf("no-such-session-%d", i))
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	if code := tunnelStatus(t, ts.URL, sessionID, channel, 0); code != http.StatusOK {
+		t.Fatalf("a live session got %d after %d sessionless prefixes flooded the tunnel, want 200", code, floodPrefixes)
+	}
+}
+
+// TestTunnelKeyChargesOnlyLiveSessions pins that an invented session id cannot
+// name a bucket of its own.
+func TestTunnelKeyChargesOnlyLiveSessions(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	srv.sessions["live"] = establishedSession{lastUsed: time.Now()}
+
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.RemoteAddr = "127.0.0.1:5555"
+	req.Header.Set("X-Real-IP", "203.0.113.7")
+
+	req.Header.Set(sessionHeader, "live")
+	if got := srv.tunnelKey(req); got != "session:live" {
+		t.Fatalf("tunnelKey for a live session = %q", got)
+	}
+	req.Header.Set(sessionHeader, "invented")
+	if got := srv.tunnelKey(req); got != "client:203.0.113.7" {
+		t.Fatalf("tunnelKey for an invented session = %q, want the client bucket", got)
+	}
+	req.Header.Del(sessionHeader)
+	if got := srv.tunnelKey(req); got != "client:203.0.113.7" {
+		t.Fatalf("tunnelKey without a session = %q, want the client bucket", got)
+	}
+}
+
+// TestClientKeyOnlyTrustsTheFrontDoor pins where the bucket comes from: nginx
+// sets X-Real-IP on the loopback hop, nothing else is consulted, and an IPv6
+// client is charged to the /64 its provider assigned it rather than to an
+// address it can pick 2^64 of.
+func TestClientKeyOnlyTrustsTheFrontDoor(t *testing.T) {
+	cases := []struct {
+		name, remoteAddr, want string
+		headers                []string
+	}{
+		{name: "front door names the client", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "203.0.113.7"}, want: "client:203.0.113.7"},
+		{name: "IPv6 loopback front door", remoteAddr: "[::1]:5555", headers: []string{"X-Real-IP", "203.0.113.7"}, want: "client:203.0.113.7"},
+		{name: "IPv6 client is charged to its /64", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "2001:db8:1:2::1"}, want: "client:2001:db8:1:2::/64"},
+		{name: "another address in that /64 is the same bucket", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "2001:db8:1:2:ffff:ffff:ffff:ffff"}, want: "client:2001:db8:1:2::/64"},
+		{name: "the neighbouring /64 is a different bucket", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "2001:db8:1:3::1"}, want: "client:2001:db8:1:3::/64"},
+		{name: "direct caller cannot name a bucket", remoteAddr: "203.0.113.7:5555", headers: []string{"X-Real-IP", "198.51.100.9"}, want: ""},
+		{name: "direct caller cannot name a bucket with X-Forwarded-For", remoteAddr: "203.0.113.7:5555", headers: []string{"X-Forwarded-For", "198.51.100.9"}, want: ""},
+		{name: "direct caller cannot name a bucket with either header", remoteAddr: "203.0.113.7:5555", headers: []string{"X-Real-IP", "198.51.100.9", "X-Forwarded-For", "192.0.2.1"}, want: ""},
+		{name: "front door without the header", remoteAddr: "127.0.0.1:5555", want: ""},
+		{name: "unparseable header", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "not-an-ip"}, want: ""},
+		{name: "X-Forwarded-For is never consulted", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Forwarded-For", "198.51.100.9"}, want: ""},
+		{name: "X-Forwarded-For does not override X-Real-IP", remoteAddr: "127.0.0.1:5555", headers: []string{"X-Real-IP", "203.0.113.7", "X-Forwarded-For", "198.51.100.9"}, want: "client:203.0.113.7"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.remoteAddr
+			for i := 0; i+1 < len(tc.headers); i += 2 {
+				r.Header.Set(tc.headers[i], tc.headers[i+1])
+			}
+			if got := clientKey(r); got != tc.want {
+				t.Fatalf("clientKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIPv6ClientsShareTheirPrefixBucket asserts on the bucket the limiter
+// actually charged: one /64 is one budget, and the next /64 is its own.
+func TestIPv6ClientsShareTheirPrefixBucket(t *testing.T) {
+	_, ts, _ := newBurstTestServer(t, 1)
+
+	first := ts.URL + "/.well-known/c8s/attest-pq?nonce=" + b64url(testNonce(t))
+	if code := get(t, first, "2001:db8:1:2::1"); code != http.StatusOK {
+		t.Fatalf("first request from the /64: got %d, want 200", code)
+	}
+	second := ts.URL + "/.well-known/c8s/attest-pq?nonce=" + b64url(testNonce(t))
+	if code := get(t, second, "2001:db8:1:2:aaaa::9"); code != http.StatusTooManyRequests {
+		t.Fatalf("second address in the same /64: got %d, want 429", code)
+	}
+	third := ts.URL + "/.well-known/c8s/attest-pq?nonce=" + b64url(testNonce(t))
+	if code := get(t, third, "2001:db8:1:3::1"); code != http.StatusOK {
+		t.Fatalf("first request from a neighbouring /64: got %d, want 200", code)
+	}
+}
+
+// TestForwardedForCannotSplitTheBucket spends a burst under one X-Real-IP
+// while varying X-Forwarded-For, so the assertion is on the bucket the
+// limiter actually charged rather than on a key function's return value.
+func TestForwardedForCannotSplitTheBucket(t *testing.T) {
+	_, ts, _ := newBurstTestServer(t, 1)
+
+	url := ts.URL + "/.well-known/c8s/attest-pq?nonce=" + b64url(testNonce(t))
+	if code := get(t, url, "203.0.113.7", "X-Forwarded-For", "10.0.0.1"); code != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", code)
+	}
+	url = ts.URL + "/.well-known/c8s/attest-pq?nonce=" + b64url(testNonce(t))
+	if code := get(t, url, "203.0.113.7", "X-Forwarded-For", "10.0.0.2"); code != http.StatusTooManyRequests {
+		t.Fatalf("second request behind a different X-Forwarded-For: got %d, want 429", code)
+	}
+}
+
+// TestPendingEvictsTheClientsOwnOldest pins what a client past its bound
+// loses: its own oldest handshake, not the request it just made and not
+// another client's entry.
+func TestPendingEvictsTheClientsOwnOldest(t *testing.T) {
+	// The per-client bound, not the rate, is what this test drives.
+	srv, ts, _ := newBurstTestServer(t, 4*maxPendingPerClient)
+
+	firstNonce := testNonce(t)
+	if code := getAttestPQ(t, ts.URL, "203.0.113.7", firstNonce); code != http.StatusOK {
+		t.Fatalf("first attest-pq: got %d, want 200", code)
+	}
+	// The rest of the client's bound is filled directly: the requests this
+	// test is about are the first, which must survive, and the two at the
+	// boundary. Minting five hundred ML-KEM keys over HTTP adds nothing.
+	for i := 1; i < maxPendingPerClient-1; i++ {
+		if err := srv.addPending("client:203.0.113.7", fmt.Sprintf("filler-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("filling to one under the bound: %v", err)
+		}
+	}
+	if code := getAttestPQ(t, ts.URL, "203.0.113.7", testNonce(t)); code != http.StatusOK {
+		t.Fatalf("attest-pq at the bound: got %d, want 200", code)
+	}
+	// A neighbour's entry, parked before the bound is crossed.
+	neighbourNonce := testNonce(t)
+	if code := getAttestPQ(t, ts.URL, "198.51.100.9", neighbourNonce); code != http.StatusOK {
+		t.Fatalf("attest-pq from a second client: got %d, want 200", code)
+	}
+
+	if code := getAttestPQ(t, ts.URL, "203.0.113.7", testNonce(t)); code != http.StatusOK {
+		t.Fatalf("attest-pq past the bound: got %d, want 200", code)
+	}
+
+	srv.mu.Lock()
+	held := srv.pendingBy.count("client:203.0.113.7")
+	_, firstKept := srv.pending[b64url(firstNonce)]
+	_, neighbourKept := srv.pending[b64url(neighbourNonce)]
+	srv.mu.Unlock()
+	if held != maxPendingPerClient {
+		t.Fatalf("client holds %d pending handshakes, want %d", held, maxPendingPerClient)
+	}
+	if firstKept {
+		t.Fatal("the client's oldest handshake survived its own overflow")
+	}
+	if !neighbourKept {
+		t.Fatal("a second client's handshake was evicted by the first's overflow")
+	}
+}
+
+// TestRefusedAttestPQMintsNoEvidence pins that the one attest-pq refusal — a
+// nonce already pending — is decided before the hardware report is pulled.
+func TestRefusedAttestPQMintsNoEvidence(t *testing.T) {
+	_, ts, evidence := newMeteredTestServer(t)
+
+	nonce := testNonce(t)
+	if code := getAttestPQ(t, ts.URL, "203.0.113.7", nonce); code != http.StatusOK {
+		t.Fatalf("first attest-pq: got %d, want 200", code)
+	}
+	minted := evidence.calls.Load()
+
+	for i := 0; i < 5; i++ {
+		if code := getAttestPQ(t, ts.URL, "198.51.100.9", nonce); code != http.StatusConflict {
+			t.Fatalf("attest-pq reusing a pending nonce: got %d, want 409", code)
+		}
+	}
+	if got := evidence.calls.Load(); got != minted {
+		t.Fatalf("refused requests minted %d reports, want 0", got-minted)
+	}
+}
+
+// TestAddPendingRefusesADuplicateNonce asserts the collision check where it
+// has to live — inside the insert — rather than through the endpoint, whose
+// earlier check would answer for it.
+func TestAddPendingRefusesADuplicateNonce(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	first := pendingSession{createdAt: time.Now()}
+	if err := srv.addPending("client:first", "shared-nonce", first); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.addPending("client:second", "shared-nonce", pendingSession{createdAt: time.Now()}); err == nil {
+		t.Fatal("a second client parked a handshake under a nonce already pending")
+	}
+
+	srv.mu.Lock()
+	held := len(srv.pending)
+	kept := srv.pending["shared-nonce"]
+	second := srv.pendingBy.count("client:second")
+	srv.mu.Unlock()
+	if held != 1 {
+		t.Fatalf("store holds %d entries, want 1", held)
+	}
+	if kept.client != "client:first" {
+		t.Fatalf("the entry is charged to %q, want the client that took the nonce", kept.client)
+	}
+	if second != 0 {
+		t.Fatalf("the refused client is charged %d entries, want 0", second)
+	}
+}
+
+// TestPendingNonceIsNeverOverwritten pins that a second attest-pq under a
+// nonce already pending cannot replace the first client's handshake key.
+func TestPendingNonceIsNeverOverwritten(t *testing.T) {
+	srv, ts, _ := newMeteredTestServer(t)
+
+	nonce := testNonce(t)
+	if code := getAttestPQ(t, ts.URL, "203.0.113.7", nonce); code != http.StatusOK {
+		t.Fatalf("first attest-pq: got %d, want 200", code)
+	}
+	srv.mu.Lock()
+	first := srv.pending[b64url(nonce)].key
+	srv.mu.Unlock()
+
+	if code := getAttestPQ(t, ts.URL, "198.51.100.9", nonce); code != http.StatusConflict {
+		t.Fatalf("attest-pq reusing a pending nonce: got %d, want 409", code)
+	}
+	srv.mu.Lock()
+	after := srv.pending[b64url(nonce)].key
+	held := srv.pendingBy.count("client:198.51.100.9")
+	srv.mu.Unlock()
+	if after != first {
+		t.Fatal("a second client's attest-pq replaced the pending handshake key")
+	}
+	if held != 0 {
+		t.Fatalf("the refused client is accounted %d pending handshakes, want 0", held)
+	}
+}
+
+// raceRounds: two goroutines can only be inside a check-then-act window at
+// once when they truly run at once, so these rounds buy little on a runner
+// with few processors. The invariants they cover are also asserted directly,
+// without a race, by TestAddPendingRefusesADuplicateNonce and
+// TestPendingEvictsTheClientsOwnOldest.
+// noteRaceCoverage says out loud when a barrier test cannot do its job: with
+// one processor two goroutines never sit inside the window it guards, so it
+// passes without covering anything.
+func noteRaceCoverage(t *testing.T) {
+	t.Helper()
+	if runtime.GOMAXPROCS(0) == 1 {
+		t.Log("GOMAXPROCS=1: this test cannot interleave two goroutines, so it covers nothing here")
+	}
+}
+
+func raceRounds() int {
+	if runtime.GOMAXPROCS(0) >= 8 {
+		return 200
+	}
+	return 500
+}
+
+// TestPendingHoldsTheBoundUnderConcurrency releases a crowd of inserts at a
+// client already at its bound, round after round: the bound check, the
+// eviction and the insert must be one critical section, or a round leaves the
+// client holding more than its bound. Every insert past the bound costs the
+// client one of its own, so the store stays at the bound across rounds.
+func TestPendingHoldsTheBoundUnderConcurrency(t *testing.T) {
+	const (
+		client = "client:203.0.113.7"
+		racers = 64
+	)
+	noteRaceCoverage(t)
+	srv, _, _ := newMeteredTestServer(t)
+
+	for i := 0; i < maxPendingPerClient; i++ {
+		if err := srv.addPending(client, fmt.Sprintf("held-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("filling to the bound: %v", err)
+		}
+	}
+
+	for round := 0; round < raceRounds(); round++ {
+		// One under the bound, so the racers contend for the last free slot
+		// rather than all reading a full store.
+		srv.mu.Lock()
+		for _, nonce := range sortedKeys(srv.pendingBy.keys(client))[:1] {
+			srv.dropPending(nonce)
+		}
+		srv.mu.Unlock()
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				_ = srv.addPending(client, fmt.Sprintf("racer-%d-%d", round, i), pendingSession{createdAt: time.Now()})
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		srv.mu.Lock()
+		held, counted := len(srv.pending), srv.pendingBy.count(client)
+		srv.mu.Unlock()
+		if held != maxPendingPerClient || counted != maxPendingPerClient {
+			t.Fatalf("round %d: store holds %d entries and counts %d, want %d of each", round, held, counted, maxPendingPerClient)
+		}
+	}
+}
+
+// sortedKeys is a deterministic order over a holder's keys.
+func sortedKeys(held map[string]struct{}) []string {
+	keys := make([]string, 0, len(held))
+	for key := range held {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestSessionBoundHoldsUnderConcurrency races inserts at a client one under
+// its session bound. Refusing there is a plain count-then-insert, so the two
+// have to be one critical section or a client ends up holding more sessions
+// than its bound allows.
+func TestSessionBoundHoldsUnderConcurrency(t *testing.T) {
+	const (
+		client = "client:203.0.113.7"
+		racers = 256
+	)
+	noteRaceCoverage(t)
+	srv, _, _ := newMeteredTestServer(t)
+
+	for i := 0; i < maxSessionsPerClient-1; i++ {
+		if err := srv.addSession(client, fmt.Sprintf("held-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("filling to one under the bound: %v", err)
+		}
+	}
+
+	for round := 0; round < raceRounds(); round++ {
+		var wg sync.WaitGroup
+		var accepted atomic.Int64
+		start := make(chan struct{})
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				if err := srv.addSession(client, fmt.Sprintf("racer-%d-%d", round, i), establishedSession{lastUsed: time.Now()}); err == nil {
+					accepted.Add(1)
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		srv.mu.Lock()
+		held := srv.sessionsBy.count(client)
+		srv.mu.Unlock()
+		if got := accepted.Load(); got != 1 {
+			t.Fatalf("round %d: %d racing inserts took the one free slot, want 1", round, got)
+		}
+		if held != maxSessionsPerClient {
+			t.Fatalf("round %d: client holds %d sessions, want %d", round, held, maxSessionsPerClient)
+		}
+		// Back to one under the bound for the next round.
+		srv.mu.Lock()
+		srv.dropSession(sortedKeys(srv.sessionsBy.keys(client))[0])
+		srv.mu.Unlock()
+	}
+}
+
+// TestPendingNonceCollidesUnderConcurrency races two clients onto one nonce:
+// the collision check must sit inside the lock that inserts, or both are
+// charged for an entry only one of them holds.
+func TestPendingNonceCollidesUnderConcurrency(t *testing.T) {
+	const racers = 256
+	srv, _, _ := newMeteredTestServer(t)
+
+	for round := 0; round < raceRounds(); round++ {
+		srv.mu.Lock()
+		srv.pending = make(map[string]pendingSession)
+		srv.pendingBy = newHolders()
+		srv.mu.Unlock()
+
+		nonce := fmt.Sprintf("contested-%d", round)
+		var wg sync.WaitGroup
+		var accepted atomic.Int64
+		start := make(chan struct{})
+		for i := 0; i < racers; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				<-start
+				if err := srv.addPending(fmt.Sprintf("client:%d", i), nonce, pendingSession{createdAt: time.Now()}); err == nil {
+					accepted.Add(1)
+				}
+			}(i)
+		}
+		close(start)
+		wg.Wait()
+
+		srv.mu.Lock()
+		held, clients := len(srv.pending), srv.pendingBy.clients()
+		srv.mu.Unlock()
+		if got := accepted.Load(); got != 1 {
+			t.Fatalf("round %d: %d clients were accepted onto one nonce, want 1", round, got)
+		}
+		if held != 1 || clients != 1 {
+			t.Fatalf("round %d: store holds %d entries charged to %d clients, want 1 and 1", round, held, clients)
+		}
+	}
+}
+
+// TestPendingGlobalBoundDropsFromTheLargestHolder pins the memory ceiling on
+// pending handshakes: past it the entry dropped belongs to whoever holds the
+// most, so a client holding one keeps it.
+func TestPendingGlobalBoundDropsFromTheLargestHolder(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	// A victim that arrived first and holds a single, therefore oldest, entry.
+	if err := srv.addPending("client:victim", "victim-nonce", pendingSession{createdAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().Add(time.Second)
+	for i := 1; i < maxPendingSessions; i++ {
+		client := fmt.Sprintf("client:flooder-%d", i/maxPendingPerClient)
+		if err := srv.addPending(client, fmt.Sprintf("nonce-%d", i), pendingSession{createdAt: now.Add(time.Duration(i) * time.Millisecond)}); err != nil {
+			t.Fatalf("filling the store at %d: %v", i, err)
+		}
+	}
+
+	if err := srv.addPending("client:newcomer", "newcomer", pendingSession{createdAt: time.Now()}); err != nil {
+		t.Fatalf("insert into a full store: %v", err)
+	}
+
+	srv.mu.Lock()
+	held := len(srv.pending)
+	_, victimKept := srv.pending["victim-nonce"]
+	_, newcomerKept := srv.pending["newcomer"]
+	flooders := 0
+	for client := range srv.pendingBy.byClient {
+		if strings.HasPrefix(client, "client:flooder-") {
+			flooders += srv.pendingBy.count(client)
+		}
+	}
+	srv.mu.Unlock()
+
+	if held != maxPendingSessions {
+		t.Fatalf("store holds %d entries, want %d", held, maxPendingSessions)
+	}
+	if !victimKept {
+		t.Fatal("the oldest entry was dropped although its client held only one")
+	}
+	if !newcomerKept {
+		t.Fatal("the new pending handshake was not stored")
+	}
+	// The victim and the newcomer hold one each; every other entry, and the
+	// one dropped to make room, belongs to a flooder.
+	if want := maxPendingSessions - 2; flooders != want {
+		t.Fatalf("the flooders hold %d entries, want %d", flooders, want)
+	}
+}
+
+// TestPendingFullStoreAdmitsAClientHoldingNothing mirrors the session rule on
+// the handshake store.
+func TestPendingFullStoreAdmitsAClientHoldingNothing(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	for i := 0; i < maxPendingSessions; i++ {
+		client := fmt.Sprintf("client:holder-%d", i/maxPendingPerClient)
+		if err := srv.addPending(client, fmt.Sprintf("nonce-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("filling the store at %d: %v", i, err)
+		}
+	}
+	if err := srv.addPending("client:newcomer", "newcomer", pendingSession{createdAt: time.Now()}); err != nil {
+		t.Fatalf("a client holding nothing was refused by a full store: %v", err)
+	}
+}
+
+// TestPendingRefusesOnceEveryHolderIsAtTheFloor pins the endpoint's answer
+// when the store has nothing to give up: a 503 the client can retry, and no
+// attestation minted for it.
+func TestPendingRefusesOnceEveryHolderIsAtTheFloor(t *testing.T) {
+	srv, ts, evidence := newMeteredTestServer(t)
+
+	for i := 0; i < maxPendingSessions; i++ {
+		client := fmt.Sprintf("client:holder-%d", i/minShare)
+		if err := srv.addPending(client, fmt.Sprintf("nonce-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("filling the store at %d: %v", i, err)
+		}
+	}
+	if err := srv.addPending("client:newcomer", "newcomer", pendingSession{createdAt: time.Now()}); !errors.Is(err, errStoreFull) {
+		t.Fatalf("insert into a store level at the floor: %v, want it refused", err)
+	}
+
+	minted := evidence.calls.Load()
+	for i := 0; i < 5; i++ {
+		if code := getAttestPQ(t, ts.URL, "203.0.113.7", testNonce(t)); code != http.StatusServiceUnavailable {
+			t.Fatalf("attest-pq against a store with nothing to give up: got %d, want 503", code)
+		}
+	}
+	if got := evidence.calls.Load(); got != minted {
+		t.Fatalf("refused attest-pq minted %d reports, want 0", got-minted)
+	}
+
+	srv.mu.Lock()
+	held := len(srv.pending)
+	srv.mu.Unlock()
+	if held != maxPendingSessions {
+		t.Fatalf("store holds %d entries, want %d", held, maxPendingSessions)
+	}
+}
+
+// TestRefuseSessionSeparatesACollisionFromALimit pins that a 128-bit id
+// collision is reported as this server's fault, not as the caller's rate.
+func TestRefuseSessionSeparatesACollisionFromALimit(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{"id collision", errSessionInUse, http.StatusInternalServerError},
+		{"store full", errStoreFull, http.StatusServiceUnavailable},
+		{"client at its bound", errSessionsFull, http.StatusTooManyRequests},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			srv.refuseSession(w, tc.err)
+			if w.Code != tc.want {
+				t.Fatalf("refuseSession(%v) = %d, want %d", tc.err, w.Code, tc.want)
+			}
+		})
+	}
+}
+
+// TestSessionsAreBoundedPerClient pins that established sessions are counted
+// per client too: pending is a flow, and only this bounds the stock.
+func TestSessionsAreBoundedPerClient(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	const client = "client:203.0.113.7"
+
+	for i := 0; i < maxSessionsPerClient; i++ {
+		if err := srv.addSession(client, "session-"+strconv.Itoa(i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("session %d under the bound: %v", i, err)
+		}
+	}
+	if err := srv.addSession(client, "one-too-many", establishedSession{lastUsed: time.Now()}); err == nil {
+		t.Fatal("a client opened more sessions than its bound")
+	}
+	if err := srv.addSession("client:198.51.100.9", "other-client", establishedSession{lastUsed: time.Now()}); err != nil {
+		t.Fatalf("session for a client holding none: %v", err)
+	}
+}
+
+// The concurrency one address is entitled to, stated here rather than derived
+// from the bounds, so shrinking a bound fails this test. One public address
+// fronts a CGNAT or a corporate egress, so it stands for a crowd: 500
+// simultaneous sessions and 500 handshakes in flight behind one address.
+const (
+	entitledSessions = 500
+	entitledPending  = 500
+	// And the store as a whole holds a fleet of those crowds.
+	entitledStore = 8000
+)
+
+// TestOneAddressMayHoldACrowdsWorthOfSessions pins the per-client session
+// bound against a number a NAT actually reaches.
+func TestOneAddressMayHoldACrowdsWorthOfSessions(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	for i := 0; i < entitledSessions; i++ {
+		if err := srv.addSession("client:203.0.113.7", fmt.Sprintf("session-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("session %d of one address: %v", i, err)
+		}
+	}
+}
+
+// TestOneAddressMayHoldACrowdsWorthOfHandshakes pins the same for handshakes
+// in flight: past the bound the oldest is dropped, so the assertion is that
+// the crowd's own entries are all still there.
+func TestOneAddressMayHoldACrowdsWorthOfHandshakes(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	for i := 0; i < entitledPending; i++ {
+		if err := srv.addPending("client:203.0.113.7", fmt.Sprintf("nonce-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("handshake %d of one address: %v", i, err)
+		}
+	}
+	srv.mu.Lock()
+	held := srv.pendingBy.count("client:203.0.113.7")
+	srv.mu.Unlock()
+	if held != entitledPending {
+		t.Fatalf("one address holds %d handshakes of %d it started, want all of them", held, entitledPending)
+	}
+}
+
+// TestTheStoresHoldAFleet pins the global bounds against a number of clients
+// rather than against themselves.
+func TestTheStoresHoldAFleet(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	for i := 0; i < entitledStore; i++ {
+		client := fmt.Sprintf("client:%d", i%64)
+		if err := srv.addSession(client, fmt.Sprintf("session-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("session %d of a fleet: %v", i, err)
+		}
+		if err := srv.addPending(client, fmt.Sprintf("nonce-%d", i), pendingSession{createdAt: time.Now()}); err != nil {
+			t.Fatalf("handshake %d of a fleet: %v", i, err)
+		}
+	}
+	srv.mu.Lock()
+	sessions, pending := len(srv.sessions), len(srv.pending)
+	srv.mu.Unlock()
+	if sessions != entitledStore || pending != entitledStore {
+		t.Fatalf("the stores hold %d sessions and %d handshakes, want %d of each", sessions, pending, entitledStore)
+	}
+}
+
+// TestEvictionPicksTheIdlestWithinAHolder pins the choice inside the client a
+// full store takes from: the entry closest to being given up anyway, not the
+// one in use.
+func TestEvictionPicksTheIdlestWithinAHolder(t *testing.T) {
+	now := time.Now()
+	sessions := map[string]establishedSession{
+		"busy":   {lastUsed: now},
+		"idle":   {lastUsed: now.Add(-time.Hour)},
+		"middle": {lastUsed: now.Add(-time.Minute)},
+	}
+	held := map[string]struct{}{"busy": {}, "idle": {}, "middle": {}}
+	if got := idlestSessionOf(sessions, held); got != "idle" {
+		t.Fatalf("idlestSessionOf = %q, want idle", got)
+	}
+
+	pending := map[string]pendingSession{
+		"new":    {createdAt: now},
+		"oldest": {createdAt: now.Add(-time.Hour)},
+		"middle": {createdAt: now.Add(-time.Minute)},
+	}
+	heldNonces := map[string]struct{}{"new": {}, "oldest": {}, "middle": {}}
+	if got := oldestPendingOf(pending, heldNonces); got != "oldest" {
+		t.Fatalf("oldestPendingOf = %q, want oldest", got)
+	}
+}
+
+// TestFloodCannotEvictAnHonestSession is the guarantee the global session
+// bound has to make: an attacker saturating the pool from many addresses, and
+// keeping what it holds warm, still cannot take a session away from a client
+// holding one. Eviction by idleness would hand it over — a client waiting on a
+// long completion is the idlest thing in the pool.
+func TestFloodCannotEvictAnHonestSession(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	honest := establishedSession{lastUsed: time.Now()}
+	if err := srv.addSession("client:honest", "honest-session", honest); err != nil {
+		t.Fatal(err)
+	}
+
+	// The attacker fills the pool: every address at its per-client bound.
+	warm := time.Now().Add(time.Minute)
+	for i := 1; i < maxSessions; i++ {
+		client := fmt.Sprintf("client:flooder-%d", i/maxSessionsPerClient)
+		if err := srv.addSession(client, fmt.Sprintf("session-%d", i), establishedSession{lastUsed: warm}); err != nil {
+			t.Fatalf("filling the pool at %d: %v", i, err)
+		}
+	}
+
+	// It then keeps churning: every insert past the bound must cost it one of
+	// its own, however idle the honest session looks next to its warm ones.
+	for i := 0; i < 4*maxSessionsPerClient; i++ {
+		client := fmt.Sprintf("client:churn-%d", i/maxSessionsPerClient)
+		if err := srv.addSession(client, fmt.Sprintf("churn-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("attacker insert %d into a full pool: %v", i, err)
+		}
+		srv.mu.Lock()
+		_, kept := srv.sessions["honest-session"]
+		srv.mu.Unlock()
+		if !kept {
+			t.Fatalf("the honest session was evicted after %d attacker inserts", i+1)
+		}
+	}
+
+	srv.mu.Lock()
+	held := len(srv.sessions)
+	honestHeld := srv.sessionsBy.count("client:honest")
+	srv.mu.Unlock()
+	if held != maxSessions {
+		t.Fatalf("pool holds %d sessions, want %d", held, maxSessions)
+	}
+	if honestHeld != 1 {
+		t.Fatalf("the honest client is accounted %d sessions, want 1", honestHeld)
+	}
+}
+
+// fillSessions puts one session under each of clients[i], cycling, until the
+// pool holds want entries.
+func fillSessions(t *testing.T, srv *Server, want int, clients func(i int) string) {
+	t.Helper()
+	for i := 0; srv.sessionCount() < want; i++ {
+		if err := srv.addSession(clients(i), fmt.Sprintf("session-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("filling the pool at %d: %v", i, err)
+		}
+	}
+}
+
+func (s *Server) sessionCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sessions)
+}
+
+// TestFullStoreAdmitsAClientHoldingNothing pins the admission rule from the
+// side that matters to a first-time caller: a pool held entirely by clients at
+// the per-client bound still has room for one holding nothing, because the
+// share is divided between the holders and the caller.
+func TestFullStoreAdmitsAClientHoldingNothing(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	fillSessions(t, srv, maxSessions, func(i int) string {
+		return fmt.Sprintf("client:holder-%d", i/maxSessionsPerClient)
+	})
+
+	if err := srv.addSession("client:newcomer", "newcomer", establishedSession{lastUsed: time.Now()}); err != nil {
+		t.Fatalf("a client holding nothing was refused by a full pool: %v", err)
+	}
+
+	srv.mu.Lock()
+	held := len(srv.sessions)
+	_, kept := srv.sessions["newcomer"]
+	newcomer := srv.sessionsBy.count("client:newcomer")
+	srv.mu.Unlock()
+	if held != maxSessions {
+		t.Fatalf("pool holds %d sessions, want %d", held, maxSessions)
+	}
+	if !kept || newcomer != 1 {
+		t.Fatalf("the newcomer holds %d sessions and is stored: %v", newcomer, kept)
+	}
+}
+
+// TestFullStoreRefusesOnceEveryHolderIsAtTheFloor pins where admission stops.
+// The floor is a constant, so the number of clients it takes to reach this is
+// ours to set — capacity/minShare — not something an attacker can lower.
+func TestFullStoreRefusesOnceEveryHolderIsAtTheFloor(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	fillSessions(t, srv, maxSessions, func(i int) string {
+		return fmt.Sprintf("client:holder-%d", i/minShare)
+	})
+
+	srv.mu.Lock()
+	holders := srv.sessionsBy.clients()
+	srv.mu.Unlock()
+	if holders != maxSessions/minShare {
+		t.Fatalf("pool is held by %d clients, want %d", holders, maxSessions/minShare)
+	}
+
+	if err := srv.addSession("client:newcomer", "newcomer", establishedSession{lastUsed: time.Now()}); !errors.Is(err, errStoreFull) {
+		t.Fatalf("insert into a pool level at the floor: %v, want it refused", err)
+	}
+
+	srv.mu.Lock()
+	held := len(srv.sessions)
+	first := srv.sessionsBy.count("client:holder-0")
+	srv.mu.Unlock()
+	if held != maxSessions {
+		t.Fatalf("pool holds %d sessions, want %d", held, maxSessions)
+	}
+	if first != minShare {
+		t.Fatalf("a holder at the floor holds %d sessions, want %d", first, minShare)
+	}
+}
+
+// TestFullStoreGivesUpAnEntryOnlyFromAClientOverItsShare pins the other half:
+// a client above the share is what a full pool takes from, and its accounting
+// is released with the entry.
+func TestFullStoreGivesUpAnEntryOnlyFromAClientOverItsShare(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	// One client at its bound alongside many holding a single session: the
+	// share is small, so the big holder is well above it.
+	const hogs = 4
+	fillSessions(t, srv, maxSessions, func(i int) string {
+		if i < hogs*maxSessionsPerClient {
+			return fmt.Sprintf("client:hog-%d", i/maxSessionsPerClient)
+		}
+		return fmt.Sprintf("client:small-%d", i)
+	})
+
+	before := srv.sessionsBy.count("client:hog-0") + srv.sessionsBy.count("client:hog-1") +
+		srv.sessionsBy.count("client:hog-2") + srv.sessionsBy.count("client:hog-3")
+	if err := srv.addSession("client:newcomer", "newcomer", establishedSession{lastUsed: time.Now()}); err != nil {
+		t.Fatalf("insert into a pool with a client over its share: %v", err)
+	}
+
+	srv.mu.Lock()
+	held := len(srv.sessions)
+	after := srv.sessionsBy.count("client:hog-0") + srv.sessionsBy.count("client:hog-1") +
+		srv.sessionsBy.count("client:hog-2") + srv.sessionsBy.count("client:hog-3")
+	_, newcomerKept := srv.sessions["newcomer"]
+	counted := 0
+	for client := range srv.sessionsBy.byClient {
+		counted += srv.sessionsBy.count(client)
+	}
+	srv.mu.Unlock()
+
+	if held != maxSessions {
+		t.Fatalf("pool holds %d sessions, want %d", held, maxSessions)
+	}
+	if !newcomerKept {
+		t.Fatal("the newcomer was not stored")
+	}
+	if after != before-1 {
+		t.Fatalf("the clients over their share hold %d sessions, want %d", after, before-1)
+	}
+	if counted != held {
+		t.Fatalf("clients are charged for %d sessions but the pool holds %d", counted, held)
+	}
+}
+
+// entitledFloor is what a client keeps whatever an attacker spends on
+// addresses, stated here rather than read from minShare so that lowering the
+// floor fails this test. Eight concurrent sessions is a browser with a handful
+// of tabs open.
+const entitledFloor = 8
+
+// TestDrainStopsAtTheFloor is the property that ends the drain: an attacker
+// adding addresses divides the share further, so it decides how much a victim
+// gives up — but not past a floor this code sets, and never below what a
+// client is entitled to keep.
+func TestDrainStopsAtTheFloor(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	const victim = "client:victim"
+	for i := 0; i < maxSessionsPerClient; i++ {
+		if err := srv.addSession(victim, fmt.Sprintf("victim-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("victim session %d: %v", i, err)
+		}
+	}
+	fillSessions(t, srv, maxSessions, func(i int) string { return fmt.Sprintf("client:flooder-%d", i/maxSessionsPerClient) })
+
+	// Every address the attacker adds divides the share further; none of them
+	// may push the victim below the floor. The store settles well inside this,
+	// and every insert past that is a refusal re-asserting the same state.
+	for i := 0; i < 2*maxSessions; i++ {
+		_ = srv.addSession(fmt.Sprintf("client:churn-%d", i), fmt.Sprintf("churn-%d", i), establishedSession{lastUsed: time.Now()})
+
+		srv.mu.Lock()
+		held := srv.sessionsBy.count(victim)
+		srv.mu.Unlock()
+		if held < entitledFloor {
+			t.Fatalf("insert %d drained the victim to %d sessions, below the %d it is entitled to keep", i, held, entitledFloor)
+		}
+	}
+
+	srv.mu.Lock()
+	held, holders := srv.sessionsBy.count(victim), srv.sessionsBy.clients()
+	srv.mu.Unlock()
+	// Equality, not a lower bound: a store that evicts nothing at all would
+	// leave the victim untouched at its per-client bound and pass a test that
+	// only asked for the floor.
+	if held != entitledFloor {
+		t.Fatalf("the victim settled at %d sessions across %d holders, want exactly the %d it is entitled to keep", held, holders, entitledFloor)
+	}
+}
+
+// TestSessionIdIsNeverOverwritten pins the same invariant addPending carries:
+// an id already in the pool cannot be taken again, which would charge one
+// client for a session another holds.
+func TestSessionIdIsNeverOverwritten(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+
+	if err := srv.addSession("client:first", "shared-id", establishedSession{lastUsed: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.addSession("client:second", "shared-id", establishedSession{lastUsed: time.Now()}); err == nil {
+		t.Fatal("a second client took a session id already in the pool")
+	}
+
+	srv.mu.Lock()
+	held := len(srv.sessions)
+	second := srv.sessionsBy.count("client:second")
+	srv.mu.Unlock()
+	if held != 1 {
+		t.Fatalf("pool holds %d sessions, want 1", held)
+	}
+	if second != 0 {
+		t.Fatalf("the refused client is charged %d sessions, want 0", second)
+	}
+}
+
+// TestReadyzIsCached pins what bounds a flood on the readiness gate: the
+// answer is computed at most once per TTL, however many callers ask. The gate
+// stays unmetered because the kubelet probe shares the front door with them.
+func TestReadyzIsCached(t *testing.T) {
+	identity := writeTestMeshIdentity(t)
+	srv := NewServer(Config{
+		Evidence:             testFixture(),
+		ExpectedWorkload:     "some-workload",
+		MeshIdentityCertFile: identity.certFile,
+		MeshIdentityKeyFile:  identity.keyFile,
+		MeshIdentityCAFile:   identity.caFile,
+	})
+	handler := srv.Handler()
+
+	probe := func(remoteAddr, clientIP string) (int, string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		req.RemoteAddr = remoteAddr
+		if clientIP != "" {
+			req.Header.Set("X-Real-IP", clientIP)
+		}
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Code, strings.TrimSpace(w.Body.String())
+	}
+
+	// The leaf carries no matched-workload stamp, so the gate withholds.
+	code, reason := probe("127.0.0.1:5555", "203.0.113.7")
+	if code != http.StatusServiceUnavailable || reason == "" {
+		t.Fatalf("readiness with an unstamped leaf: got %d %q, want 503 with a reason", code, reason)
+	}
+
+	// Break the credential the check reads. Inside the TTL the cached answer
+	// stands, which is what makes a flood cost one identity load per second.
+	if err := os.WriteFile(identity.certFile, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 1000; i++ {
+		if _, cached := probe("127.0.0.1:5555", "198.51.100.9"); cached != reason {
+			t.Fatalf("readiness recomputed inside its TTL on request %d: reason %q became %q", i, reason, cached)
+		}
+	}
+	// A literal: readiness that a caller must wait longer than this for is
+	// stale enough to act on wrongly, whatever the constant says.
+	const staleAfter = 1500 * time.Millisecond
+	time.Sleep(staleAfter)
+	if _, fresh := probe("127.0.0.1:5555", "198.51.100.9"); fresh == reason {
+		t.Fatalf("readiness was not recomputed within %v: still %q", staleAfter, reason)
+	}
+
+	// However hard the public path is driven, the probe still answers: the
+	// gate is not metered, so a flood cannot deschedule the pod.
+	for i := 0; i < 1000; i++ {
+		probe("127.0.0.1:5555", "192.0.2.50")
+	}
+	if code, _ := probe("127.0.0.1:5555", "10.42.0.1"); code == http.StatusTooManyRequests {
+		t.Fatal("the kubelet probe was refused after a flood on the public path")
+	}
+}
+
+// TestTunnelIsCappedPerClientAcrossSessions pins the aggregate: a client
+// holding many sessions cannot multiply its way past the client budget.
+func TestTunnelIsCappedPerClientAcrossSessions(t *testing.T) {
+	// Generous per session, tight per client: the aggregate must bind.
+	_, ts, _ := newTestServerWith(t, func(srv *Server) {
+		srv.sessionLimiter = newLimiter(0.001, 1000, clientBuckets)
+		srv.clientLimiter = newLimiter(0.001, 4, clientBuckets)
+	})
+
+	channel, sessionID := establishSession(t, ts.URL, testNonce(t))
+	var limited int
+	for i := 0; i < 12; i++ {
+		if tunnelStatus(t, ts.URL, sessionID, channel, i) == http.StatusTooManyRequests {
+			limited++
+		}
+	}
+	if limited != 8 {
+		t.Fatalf("%d of 12 tunnel requests were limited, want 8 past a client burst of 4", limited)
+	}
+}
+
+// TestHandshakeRefusesWhenTheClientIsAtItsBound drives the session bound
+// through the endpoint: a handshake whose session cannot be stored must not
+// answer 200 with an id for a session the server does not hold.
+func TestHandshakeRefusesWhenTheClientIsAtItsBound(t *testing.T) {
+	srv, ts, _ := newMeteredTestServer(t)
+
+	// The bucket a request through the front door is charged to.
+	const client = "client:203.0.113.7"
+	for i := 0; i < maxSessionsPerClient; i++ {
+		if err := srv.addSession(client, fmt.Sprintf("held-%d", i), establishedSession{lastUsed: time.Now()}); err != nil {
+			t.Fatalf("filling the client to its bound: %v", err)
+		}
+	}
+
+	nonce := testNonce(t)
+	bundle := fetchBundleAs(t, ts.URL, "203.0.113.7", nonce)
+	_, handshake := clientChannelFromBundle(t, bundle, nonce)
+	body, err := json.Marshal(types.HandshakeRequest{
+		Nonce:        b64url(nonce),
+		ClientX25519: b64url(handshake.ClientX25519),
+		MLKEMCt:      b64url(handshake.MLKEMCiphertext),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/.well-known/c8s/handshake", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Real-IP", "203.0.113.7")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("handshake at the client's session bound: got %d, want 429", resp.StatusCode)
+	}
+	var refusal types.ErrorResponse
+	if err := json.NewDecoder(resp.Body).Decode(&refusal); err != nil {
+		t.Fatalf("decode refusal: %v", err)
+	}
+	if refusal.Error != types.ErrorCodeTooManyRequests {
+		t.Fatalf("refusal code = %q, want %q", refusal.Error, types.ErrorCodeTooManyRequests)
+	}
+
+	srv.mu.Lock()
+	held := srv.sessionsBy.count(client)
+	srv.mu.Unlock()
+	if held != maxSessionsPerClient {
+		t.Fatalf("client holds %d sessions after the refusal, want %d", held, maxSessionsPerClient)
+	}
+}
+
+// fetchBundleAs fetches attest-pq as a named client.
+func fetchBundleAs(t *testing.T, base, clientIP string, nonce []byte) types.AttestationBundle {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, base+"/.well-known/c8s/attest-pq?nonce="+b64url(nonce), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-Real-IP", clientIP)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("attest-pq status %d", resp.StatusCode)
+	}
+	var bundle types.AttestationBundle
+	if err := json.NewDecoder(resp.Body).Decode(&bundle); err != nil {
+		t.Fatal(err)
+	}
+	return bundle
+}
+
+// TestClientBucketFallsBackToTheAddress pins that per-client state is charged
+// to something even when no front door named the client: without the fallback
+// every direct caller shares one bound under the empty key.
+func TestClientBucketFallsBackToTheAddress(t *testing.T) {
+	direct := httptest.NewRequest(http.MethodGet, "/", nil)
+	direct.RemoteAddr = "203.0.113.7:5555"
+	if got := clientBucket(direct); got != "addr:203.0.113.7" {
+		t.Fatalf("clientBucket for a direct caller = %q, want its address", got)
+	}
+	other := httptest.NewRequest(http.MethodGet, "/", nil)
+	other.RemoteAddr = "198.51.100.9:5555"
+	if got := clientBucket(other); got == clientBucket(direct) {
+		t.Fatalf("two direct callers share the bucket %q", got)
+	}
+	front := httptest.NewRequest(http.MethodGet, "/", nil)
+	front.RemoteAddr = "127.0.0.1:5555"
+	front.Header.Set("X-Real-IP", "203.0.113.7")
+	if got := clientBucket(front); got != "client:203.0.113.7" {
+		t.Fatalf("clientBucket behind the front door = %q", got)
+	}
+}
+
+// TestTunnelClientAggregateIsCheckedFirst pins the order of the two limiters
+// on the tunnel: the per-client one carries no store lookup, so a request it
+// refuses must never reach the lock that keying on a session takes.
+func TestTunnelClientAggregateIsCheckedFirst(t *testing.T) {
+	srv, ts, _ := newTestServerWith(t, func(srv *Server) {
+		srv.clientLimiter = newLimiter(0.001, 0, clientBuckets) // refuses everything
+	})
+
+	// Hold the store lock: a request that reaches it will block until the
+	// test releases it, and the refusal must not.
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+
+	refused := make(chan int, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/.well-known/c8s/tunnel", bytes.NewReader([]byte("junk")))
+		if err != nil {
+			refused <- 0
+			return
+		}
+		req.Header.Set("X-Real-IP", "203.0.113.7")
+		req.Header.Set(sessionHeader, "any-session")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			refused <- 0
+			return
+		}
+		defer resp.Body.Close()
+		refused <- resp.StatusCode
+	}()
+
+	select {
+	case code := <-refused:
+		if code != http.StatusTooManyRequests {
+			t.Fatalf("tunnel refused by the client aggregate: got %d, want 429", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a tunnel request refused by the client aggregate blocked on the store lock")
+	}
+}
+
+// TestNonceTTLDefaultsShorterThanTheSession pins the wait a client is given
+// between attest-pq and its handshake, which is the window a parked ML-KEM key
+// is held for.
+func TestNonceTTLDefaultsShorterThanTheSession(t *testing.T) {
+	srv := NewServer(Config{Evidence: testFixture(), SessionTTL: time.Hour})
+	if srv.cfg.NonceTTL != defaultNonceTTL {
+		t.Fatalf("NonceTTL = %v, want %v", srv.cfg.NonceTTL, defaultNonceTTL)
+	}
+	if srv.cfg.NonceTTL >= srv.cfg.SessionTTL {
+		t.Fatalf("NonceTTL %v is not shorter than SessionTTL %v", srv.cfg.NonceTTL, srv.cfg.SessionTTL)
+	}
+	// A handshake later than that window is refused even though the session
+	// TTL has not passed.
+	if err := srv.addPending("client:x", "aged", pendingSession{createdAt: time.Now().Add(-defaultNonceTTL - time.Second)}); err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := srv.takePending("aged")
+	if !ok {
+		t.Fatal("the parked handshake vanished")
+	}
+	if time.Since(entry.createdAt) <= srv.cfg.NonceTTL {
+		t.Fatal("the parked handshake is still inside its TTL")
+	}
+}
+
+// TestSweepReleasesExpiredEntries pins that the background sweep, which is the
+// only sweep now, frees both the entry and the client's accounting.
+func TestSweepReleasesExpiredEntries(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	const client = "client:203.0.113.7"
+
+	stale := time.Now().Add(-2 * srv.cfg.SessionTTL)
+	if err := srv.addPending(client, "expired", pendingSession{createdAt: stale}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.addSession(client, "idle", establishedSession{lastUsed: stale}); err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.addPending(client, "fresh", pendingSession{createdAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv.sweep()
+
+	srv.mu.Lock()
+	pending, sessions := len(srv.pending), len(srv.sessions)
+	pendingHeld, sessionsHeld := srv.pendingBy.count(client), srv.sessionsBy.count(client)
+	srv.mu.Unlock()
+	if pending != 1 || pendingHeld != 1 {
+		t.Fatalf("sweep left %d pending entries counted %d, want 1 of each", pending, pendingHeld)
+	}
+	if sessions != 0 || sessionsHeld != 0 {
+		t.Fatalf("sweep left %d sessions counted %d, want none", sessions, sessionsHeld)
+	}
+}
+
+// TestMaintainSweepsAndStopsWithItsContext pins the background loop: it is the
+// only thing that reclaims expired entries now that no request sweeps, and it
+// has to stop with its context.
+func TestMaintainSweepsAndStopsWithItsContext(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	srv.sweepEvery = 5 * time.Millisecond
+
+	if err := srv.addPending("client:x", "stale", pendingSession{createdAt: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		srv.maintain(ctx)
+		close(done)
+	}()
+
+	waitFor(t, "the expired handshake to be swept", func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		return len(srv.pending) == 0
+	})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("maintain did not return when its context was cancelled")
+	}
+}
+
+// TestServeRunsMaintenance pins the wiring rather than the method: a sidecar
+// that serves must also be sweeping, or expired entries sit until their store
+// fills.
+func TestServeRunsMaintenance(t *testing.T) {
+	srv, _, _ := newMeteredTestServer(t)
+	srv.sweepEvery = 5 * time.Millisecond
+
+	if err := srv.addPending("client:x", "stale", pendingSession{createdAt: time.Now().Add(-time.Hour)}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	served := make(chan error, 1)
+	go func() { served <- srv.Serve(ctx, &http.Server{Addr: "127.0.0.1:0", Handler: srv.Handler()}) }()
+
+	waitFor(t, "the expired handshake to be swept while serving", func() bool {
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		return len(srv.pending) == 0
+	})
+
+	cancel()
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("Serve returned %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Serve did not return when its context was cancelled")
+	}
+}
+
+func waitFor(t *testing.T, what string, done func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if done() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// tunnelStatus sends one sealed request over an established session.
+func tunnelStatus(t *testing.T, base, sessionID string, ch *overenc.Channel, seq int) int {
+	t.Helper()
+	resp := postSealedTunnel(t, base, ch, sessionID, types.TunnelRequest{
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("/echo/%d", seq),
+	})
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode
+}

--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -258,6 +258,10 @@ data:
             location = /readyz {
                 access_log off;
                 proxy_pass http://127.0.0.1:{{ .Values.tlsLb.attest.port }};
+                proxy_set_header Host $host;
+                proxy_set_header X-Real-IP $remote_addr;
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $scheme;
             }
 
             # c8s-verify attestation + over-encryption sidecar (loopback).
@@ -267,6 +271,7 @@ data:
             # in-pod `cds-attest` sidecar. The prefix also covers the retired
             # /attestation path so the sidecar serves its explicit versioned
             # 400 (no alias or downgrade) instead of nginx 404ing it.
+            # X-Real-IP is the address the sidecar meters each client by.
             location /.well-known/c8s/ {
                 {{- if default false .Values.tlsLb.cors.enabled }}
                 {{- include "tls-lb.corsLocationDirectives" .Values.tlsLb.cors | nindent 16 }}

--- a/internal/helmchart/c8s/templates/tls-lb-service.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-service.yaml
@@ -14,12 +14,14 @@ spec:
   type: {{ $svc.type }}
   {{- if or (eq $svc.type "LoadBalancer") (eq $svc.type "NodePort") }}
   {{- $renderAllowlistRoute := eq (include "tls-lb.renderAllowlistRoute" .) "true" }}
-  {{- $policy := default (ternary "Local" "Cluster" $renderAllowlistRoute) $svc.externalTrafficPolicy }}
+  {{- $perClientLimits := or $renderAllowlistRoute .Values.tlsLb.attest.enabled }}
+  {{- $policy := default (ternary "Local" "Cluster" $perClientLimits) $svc.externalTrafficPolicy }}
   {{- if not (or (eq $policy "Local") (eq $policy "Cluster")) }}
   {{- fail (printf "tlsLb.service.externalTrafficPolicy must be Local or Cluster, got: %s" $policy) }}
   {{- end }}
-  # Local (the default while the built-in /allowlist route renders) preserves
-  # the public source IP its per-client limiters key on; see values.yaml.
+  # Local (the default while the /allowlist route or the attestation sidecar
+  # renders) preserves the public source IP their per-client limiters key on;
+  # see values.yaml.
   externalTrafficPolicy: {{ $policy }}
   {{- end }}
   ports:

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1381,11 +1381,14 @@ tlsLb:
     type: ClusterIP
     port: 443
     # -- externalTrafficPolicy for LoadBalancer/NodePort Services. Empty picks
-    # Local while the built-in /allowlist route renders (its limiters key on
-    # nginx's public peer address, which Cluster would SNAT away) and Cluster
-    # otherwise. Local delivers traffic only through nodes running the tls-lb
-    # pod; set Cluster explicitly if your LB cannot health-check nodes, at the
-    # cost of per-client limiting collapsing onto node IPs.
+    # Local while the built-in /allowlist route or the attestation sidecar
+    # renders (their limiters key on nginx's public peer address, which Cluster
+    # would SNAT away) and Cluster otherwise. Local delivers traffic only
+    # through nodes running the tls-lb pod; set Cluster explicitly if your LB
+    # cannot health-check nodes, and every client behind a node then shares one
+    # budget and one per-client bound: 512 concurrent attestation sessions for
+    # that whole node, past which any one client's traffic refuses new sessions
+    # for every other client behind it.
     externalTrafficPolicy: ""
     # -- Optional annotations on the Service. Use the provider's LB annotation to
     # pin a static IP (e.g. networking.gke.io/load-balancer-ip-addresses on GKE,

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2315,10 +2315,13 @@ func TestChartTLSLBServiceType(t *testing.T) {
 		{name: "default is ClusterIP", wantType: corev1.ServiceTypeClusterIP},
 		{name: "explicit LoadBalancer", args: []string{"--set", "tlsLb.service.type=LoadBalancer"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
 		{name: "explicit NodePort", args: []string{"--set", "tlsLb.service.type=NodePort"}, wantType: corev1.ServiceTypeNodePort, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
-		// Without the built-in allowlist route there is no source-IP-keyed
-		// limiter, so the default policy must not regress reachability
-		// through nodes that do not run the tls-lb pod.
-		{name: "LoadBalancer without allowlist route", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
+		// The attestation sidecar keys its limiter on the same public peer
+		// address, so it holds the policy on its own.
+		{name: "LoadBalancer without allowlist route", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyLocal},
+		// With neither, nothing keys on the source address, so the default
+		// must not regress reachability through nodes that do not run the
+		// tls-lb pod.
+		{name: "LoadBalancer with neither limiter", args: []string{"--set", "tlsLb.service.type=LoadBalancer", "--set", "tlsLb.allowlist.enabled=false", "--set", "tlsLb.attest.enabled=false"}, wantType: corev1.ServiceTypeLoadBalancer, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
 		{name: "explicit policy override wins", args: []string{"--set", "tlsLb.service.type=NodePort", "--set", "tlsLb.service.externalTrafficPolicy=Cluster"}, wantType: corev1.ServiceTypeNodePort, wantPolicy: corev1.ServiceExternalTrafficPolicyCluster},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2411,6 +2414,12 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	renderedTLSLBNginxConfig(t, out).
 		location(t, "prefix", "/.well-known/c8s/").
 		assertDirective(t, "proxy_pass", "http://127.0.0.1:8800")
+	renderedTLSLBNginxConfig(t, out).
+		location(t, "prefix", "/.well-known/c8s/").
+		assertDirective(t, "proxy_set_header", "X-Real-IP", "$remote_addr")
+	renderedTLSLBNginxConfig(t, out).
+		location(t, "exact", "/readyz").
+		assertDirective(t, "proxy_set_header", "X-Real-IP", "$remote_addr")
 
 	// An https upstream: the sidecar presents the CDS client cert and
 	// verifies the upstream against the CA chain get-cert writes to

--- a/internal/issuer/ratelimit.go
+++ b/internal/issuer/ratelimit.go
@@ -30,10 +30,16 @@ type ipLimiterEntry struct {
 	lastSeen time.Time
 }
 
-// IPRateLimiter implements keyed rate limiting with bounded memory. Entries
-// beyond MaxEntries are evicted LRU in O(n); idle entries are evicted by
-// EvictionLoop at IdleTimeout. RateLimitMiddleware keys on the source address;
-// RateLimitBy keys on whatever identifies the caller.
+// IPRateLimiter implements keyed rate limiting with bounded memory. It holds
+// at most MaxEntries buckets, evicting the least recently used to make room,
+// and EvictionLoop reclaims buckets idle longer than IdleTimeout.
+// RateLimitMiddleware keys on the source address; RateLimitBy keys on whatever
+// identifies the caller.
+//
+// MaxEntries is how many callers are metered at once. Past it a caller is
+// still served, on a bucket taken from the quietest one — so a caller that
+// varies its key faster than the map holds keys meters itself out of the map.
+// Issue #105 owns that, and a saturation policy for it.
 type IPRateLimiter struct {
 	mu         sync.Mutex
 	limiters   map[string]*ipLimiterEntry
@@ -85,6 +91,13 @@ func (rl *IPRateLimiter) getLimiter(ip string) *rate.Limiter {
 	return lim
 }
 
+// Len reports how many callers the limiter is metering, for metrics and tests.
+func (rl *IPRateLimiter) Len() int {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	return len(rl.limiters)
+}
+
 // EvictionLoop removes rate limiter entries idle longer than idleTimeout.
 // It blocks until ctx is cancelled.
 func (rl *IPRateLimiter) EvictionLoop(ctx context.Context, interval, idleTimeout time.Duration) {
@@ -125,13 +138,11 @@ func RateLimitMiddleware(rl *IPRateLimiter, next http.Handler) http.Handler {
 	return RateLimitBy(rl, nil, next)
 }
 
-// RateLimitBy wraps next, charging each request to the bucket key names.
-//
-// Use it where the source address is not the caller: pods reach CDS through a
-// NodePort and the host-network mesh proxy, so every pod on a node presents the
-// same address and one of them could exhaust the bucket every other one shares.
-// A request with no identity to key on still falls back to the address, so
-// nothing escapes limiting by declining to identify itself.
+// RateLimitBy wraps next, charging each request to the bucket key names. Use
+// it where the source address is not the caller — an attested identity, a
+// session, or the address a front door recorded. A request with no identity to
+// key on falls back to the source address, so nothing escapes limiting by
+// declining to identify itself.
 func RateLimitBy(rl *IPRateLimiter, key KeyFunc, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bucket := ""
@@ -150,11 +161,34 @@ func RateLimitBy(rl *IPRateLimiter, key KeyFunc, next http.Handler) http.Handler
 	})
 }
 
-// SourceAddrKey charges a request to the address it arrived from.
+// SourceAddrKey charges a request to the exact address it arrived from. Its
+// callers are reached by nodes, pods and operators, whose addresses are
+// assigned rather than chosen, and which sit densely inside one subnet: a
+// bucket per address is what keeps one node's traffic off another's.
 func SourceAddrKey(r *http.Request) string {
 	ip, _, _ := net.SplitHostPort(r.RemoteAddr)
 	if ip == "" {
 		ip = r.RemoteAddr
 	}
 	return "addr:" + ip
+}
+
+// clientPrefixBitsV6 is the IPv6 prefix a public client is charged to. An
+// ordinary subscriber is delegated a /64, so charging a full address would let
+// one of them name 2^64 buckets.
+const clientPrefixBitsV6 = 64
+
+// ClientPrefix names the address block a limit on a public client is charged
+// to: one IPv4 address, or one IPv6 /64. Use it where the caller is on the
+// internet and picks its own address within a prefix. An address it cannot
+// parse is charged verbatim, so nothing escapes a limit by being unparseable.
+func ClientPrefix(addr string) string {
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return addr
+	}
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return fmt.Sprintf("%s/%d", ip.Mask(net.CIDRMask(clientPrefixBitsV6, 8*net.IPv6len)), clientPrefixBitsV6)
 }

--- a/internal/issuer/ratelimit_test.go
+++ b/internal/issuer/ratelimit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -89,18 +90,14 @@ func TestRateLimiterMaxEntries(t *testing.T) {
 	rl.getLimiter("10.0.0.2")
 	rl.getLimiter("10.0.0.3")
 
-	rl.mu.Lock()
-	if len(rl.limiters) != 3 {
-		t.Fatalf("expected 3 entries, got %d", len(rl.limiters))
+	if got := rl.Len(); got != 3 {
+		t.Fatalf("expected 3 entries, got %d", got)
 	}
-	rl.mu.Unlock()
 
 	rl.getLimiter("10.0.0.4")
 
-	rl.mu.Lock()
-	defer rl.mu.Unlock()
-	if len(rl.limiters) != 3 {
-		t.Errorf("expected 3 entries after cap, got %d", len(rl.limiters))
+	if got := rl.Len(); got != 3 {
+		t.Errorf("expected 3 entries after cap, got %d", got)
 	}
 }
 
@@ -263,5 +260,120 @@ func TestRateLimitKeyNamespacesDoNotCollide(t *testing.T) {
 	// A sandbox whose ID is that same address string is a different bucket.
 	if code := send("sandbox:10.0.0.7"); code != http.StatusOK {
 		t.Fatalf("an address-shaped sandbox ID shares the address bucket: %d", code)
+	}
+}
+
+// TestClientPrefixChargesAnIPv6PrefixOnce pins the unit a public client is
+// charged to. A client delegated a /64 would otherwise hold 2^64 budgets.
+func TestClientPrefixChargesAnIPv6PrefixOnce(t *testing.T) {
+	for _, tc := range []struct {
+		name, addr, want string
+	}{
+		{"IPv4 address", "203.0.113.7", "203.0.113.7"},
+		{"IPv6 address", "2001:db8:1:2::1", "2001:db8:1:2::/64"},
+		{"another address in that /64", "2001:db8:1:2:aaaa:bbbb:cccc:dddd", "2001:db8:1:2::/64"},
+		{"the neighbouring /64", "2001:db8:1:3::1", "2001:db8:1:3::/64"},
+		{"IPv4 mapped into IPv6", "::ffff:203.0.113.7", "203.0.113.7"},
+		{"not an address", "/run/cds.sock", "/run/cds.sock"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClientPrefix(tc.addr); got != tc.want {
+				t.Fatalf("ClientPrefix(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSourceAddrKeyKeepsAddressesApart pins the other half of that split: CDS
+// is reached by nodes and pods, which sit densely inside one subnet, so two of
+// them must not land in one bucket.
+func TestSourceAddrKeyKeepsAddressesApart(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(0.001), 1, 10)
+	if err != nil {
+		t.Fatalf("NewIPRateLimiter: %v", err)
+	}
+	h := RateLimitMiddleware(rl, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	code := func(remoteAddr string) int {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = remoteAddr
+		h.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	if got := code("[2001:db8:1:2::1]:1111"); got != http.StatusOK {
+		t.Fatalf("first node: got %d, want 200", got)
+	}
+	if got := code("[2001:db8:1:2::2]:2222"); got != http.StatusOK {
+		t.Fatalf("a second node in the same /64: got %d, want its own budget", got)
+	}
+	if got := code("[2001:db8:1:2::1]:3333"); got != http.StatusTooManyRequests {
+		t.Fatalf("the first node past its burst: got %d, want 429", got)
+	}
+}
+
+// meterableClients is how many distinct callers one limiter must meter at
+// once, stated here rather than derived from any caller's constant. Past the
+// map a caller is still served, so this is what the limiter's accuracy costs,
+// not what its availability costs.
+const meterableClients = 50000
+
+// TestALimiterMetersItsWholeCapacity pins that relationship: capacity is the
+// number of distinct callers metered, not an approximation of it.
+func TestALimiterMetersItsWholeCapacity(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(0.001), 1, meterableClients)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < meterableClients; i++ {
+		rl.getLimiter("client-" + strconv.Itoa(i))
+	}
+	if got := rl.Len(); got != meterableClients {
+		t.Fatalf("the limiter meters %d callers, want %d", got, meterableClients)
+	}
+
+	// The first caller is the quietest, so it is the bucket the next one takes.
+	rl.getLimiter("one-too-many")
+	if got := rl.Len(); got != meterableClients {
+		t.Fatalf("the limiter holds %d buckets past its capacity, want %d", got, meterableClients)
+	}
+	rl.mu.Lock()
+	_, quietestKept := rl.limiters["client-0"]
+	_, newcomerKept := rl.limiters["one-too-many"]
+	rl.mu.Unlock()
+	if quietestKept {
+		t.Fatal("a full map kept the quietest caller instead of making room")
+	}
+	if !newcomerKept {
+		t.Fatal("a full map did not meter a new caller")
+	}
+}
+
+// TestEvictionLoopReclaimsQuietCallers pins the loop that keeps the map from
+// sitting at capacity: without it every new caller costs another its bucket,
+// so the limiter meters a smaller and smaller share of its traffic.
+func TestEvictionLoopReclaimsQuietCallers(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(0.001), 1, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 8; i++ {
+		rl.getLimiter("client-" + strconv.Itoa(i))
+	}
+	if got := rl.Len(); got != 8 {
+		t.Fatalf("the limiter meters %d callers, want 8", got)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go rl.EvictionLoop(ctx, time.Millisecond, 10*time.Millisecond)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for rl.Len() > 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("the limiter still meters %d callers that have gone quiet", rl.Len())
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/pkg/types/error_codes.go
+++ b/pkg/types/error_codes.go
@@ -18,6 +18,9 @@ const (
 	ErrorCodeInternal                  = "internal"
 	ErrorCodeAttestationUnavailable    = "attestation_unavailable"
 	ErrorCodeBindingUnavailable        = "binding_unavailable"
+	// ErrorCodeTooManyRequests: the caller holds as many sessions as one
+	// client may. Retrying once the sessions it holds expire succeeds.
+	ErrorCodeTooManyRequests = "too_many_requests"
 	// ErrorCodeUnsupportedFrontDoor: attest-lb was requested on a WebPKI-secret
 	// front door, whose host-visible serving key cannot support transport
 	// binding; that deployment shape is attest-pq-only.


### PR DESCRIPTION
/authenticate was a bare route while /attest, /sign-csr and the secrets challenge twin sat behind the per-source limiter and the body cap, and its challenge map had no ceiling. attest-pq on the tls-lb sidecar minted a hardware report and parked an ML-KEM key under a nonce the client chose, /tunnel was served with no session at all and swept both maps under the sidecar's only mutex on the way, and /readyz re-read and parsed the whole mesh identity on every call while being both publicly reachable and the kubelet's readiness gate.

A client is now one IPv4 address or one IPv6 /64 — the block a provider delegates, so a caller cannot hold 2^64 budgets — but only at the front door, where the caller is on the internet and picks its own address within a prefix. SourceAddrKey keeps the exact address, because CDS is reached by nodes, pods and operators whose addresses are assigned rather than chosen and which sit densely inside one subnet: collapsing them would put a whole cluster in one bucket. The sidecar reads the address nginx records in X-Real-IP on the loopback hop and only when the peer is loopback, so a caller reaching it any other way is charged to its own address and cannot name its bucket.

One client may hold 512 pending handshakes and 512 sessions inside pools of 8192 each, sized for the crowd behind a CGNAT or a corporate egress rather than for one browser. A full pool gives up an entry only from a client above the share it divides between its holders and the caller, which admits a client holding nothing while a holder is above that share, and never below a floor of eight. The floor is what an attacker cannot buy down: without it the share is capacity over a client count it creates, so paying for addresses drives every other client's floor toward one entry.

An established session is never taken to admit a new one. A client blocked on a long completion is the idlest thing in the pool by every measure the server has, so any rule that evicts on idleness hands its inference to whoever asked next, and this platform exists to run that inference. A client at its own session bound is refused instead; a pending handshake, which is a thirty-second promise rather than live state, gives up its own oldest.

Readiness answers come from a one-second cache, so a flood costs one identity load rather than one per request, and the gate stays unmetered because the kubelet probes it through the same front door as the public and a per-client limit would deschedule the pod under externalTrafficPolicy: Cluster. Expiry sweeps moved to a ticker, off the lock every endpoint needs. Whether a handshake can be parked is decided before the report that would bind it is minted, so a refusal costs no attestation. The challenge store keeps its keys in issue order, so expiry and eviction are O(1) and no request scans the map, and the queue behind it is compacted so a consumed challenge stops holding capacity.

Two properties are bounded rather than solved. Once every holder is at the floor, which takes 1024 client addresses, a new session is refused until one expires; that saturation policy is #106. The limiter holds a bucket per client up to its map size and takes the quietest one to make room past it, so a caller varying its key faster than the map holds keys meters itself out of the map — degrading metering rather than denying service, which is #105. They have to be solved together, because refusing at saturation closes the second and opens the first.