### PR TITLE
fix(cds): chart the secret path ceiling, and close the quota guard

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -22,19 +22,28 @@ hold, with no error anywhere. Refusing to serve is better than that divergence.
 
 Sizing: `--secrets-max-paths-per-workload` (default 64, chart
 `cds.secretsMaxPathsPerWorkload`) bounds the paths one allowlist entry may hold,
-and is the bound a workload meets first. `--secrets-max-paths` (default 1024) is
-the store's memory ceiling; size it above the number of entries carrying a grant
-times the per-workload quota, or entries that arrive late find the store full.
-The quota must stay below the ceiling — CDS refuses to start otherwise, since a
-quota that reaches the ceiling is one workload's room to fill the store.
+and is checked before the ceiling. A workload, for this bound, is one allowlist
+entry — which the store calls a holder. `--secrets-max-paths` (default 1024,
+chart `cds.secretsMaxPaths`) is the store's memory ceiling; size it above the
+number of entries carrying a grant times the per-workload quota, or entries that
+arrive late find the store full. The quota must stay below the ceiling: CDS
+refuses to start otherwise, and the chart refuses to render
+(`VALIDATION_ERROR kind=cds_secrets_path_budget`), so raise the two together.
 Operator values count against the ceiling only. Also `--secrets-max-value-bytes`
-and `--sandbox-ledger-max-entries`. CDS is a single in-memory process holding
-the mesh CA, so a workload able to grow the store without limit could OOM it and
+(at least 32, the size of every value CDS generates) and
+`--sandbox-ledger-max-entries`. CDS is a single in-memory process holding the
+mesh CA, so a workload able to grow the store without limit could OOM it and
 take every certificate in the cluster with it.
 
 **Both bounds refuse the write; nothing is ever evicted.** A path holds the only
 copy of its value, so a store at either bound answers `507` and keeps what it
-has. Raising a bound needs a restart, which empties the store; see "Restarts".
+has, carrying `secret_holder_quota` or `secret_store_full` as the error code so
+a caller can tell which bound refused it. Raising a bound needs a restart, which
+empties the store; see "Restarts".
+
+The quota bounds one entry, not the store: enough entries one path apiece still
+reach the ceiling. What it buys is that the refusal lands on the entry that
+caused it rather than on the next one to ask.
 
 **kata is supported, with two caveats.** The fetcher redeems its sandbox token
 from whichever inventory its shape has: the mounted nri-image-policy socket on
@@ -172,7 +181,7 @@ PUT /secrets/<store path>   {"value": "<base64>", "overwrite": <bool>}
                             → 201 {"created": true}
                             → 409 {"existing": "workload"|"operator"}
                             → 200 {"existing": "workload"|"operator"}
-                            → 507 the store is at --secrets-max-paths
+                            → 507 {"error": "secret_store_full"} a bound refused it
 ```
 
 Authorization is the operator key that CDS already pins for allowlist writes

--- a/internal/cmds/cds/cmd.go
+++ b/internal/cmds/cds/cmd.go
@@ -79,7 +79,7 @@ func NewCmd() *cobra.Command {
 	flags.DurationVar(&cfg.rateLimiterEvictInterval, "rate-limiter-evict-interval", time.Minute, "interval for per-IP rate limiter eviction sweep")
 	flags.DurationVar(&cfg.rateLimiterIdleTimeout, "rate-limiter-idle-timeout", 5*time.Minute, "idle duration before a per-IP rate limiter entry is evicted")
 
-	flags.IntVar(&cfg.secretsMaxPaths, "secrets-max-paths", 1024, "max distinct secret paths held in memory")
+	flags.IntVar(&cfg.secretsMaxPaths, "secrets-max-paths", 1024, "max distinct secret paths held in memory across every workload")
 	flags.IntVar(&cfg.secretsMaxPathsPerWorkload, "secrets-max-paths-per-workload", secrets.DefaultMaxPathsPerHolder, "max secret paths one allowlist entry may hold")
 	flags.IntVar(&cfg.secretsMaxValueBytes, "secrets-max-value-bytes", 4096, "max bytes in one secret value")
 	flags.IntVar(&cfg.sandboxLedgerMax, "sandbox-ledger-max-entries", 10000, "max sandbox-to-inventory bindings held in memory")

--- a/internal/cmds/cds/routes_secrets_test.go
+++ b/internal/cmds/cds/routes_secrets_test.go
@@ -43,7 +43,7 @@ func secretsRouter(t *testing.T, enabled bool) http.Handler {
 		// reaches it is refused for want of a client certificate.
 		deps.SecretsHandler = &secrets.Handler{}
 		deps.SecretsChallenges = &secretsCS
-		deps.SecretsOperator = &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 8, 64)}
+		deps.SecretsOperator = &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 7, 64)}
 		deps.SecretsExplain = &secrets.ExplainHandler{}
 	}
 	return newRouter(deps)
@@ -108,7 +108,7 @@ func TestRouter_SecretsChallengePoolIsSeparate(t *testing.T) {
 		MaxRequestSize:    65536,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
-		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 8, 64)},
+		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 7, 64)},
 		SecretsExplain:    &secrets.ExplainHandler{},
 	}
 	_ = newRouter(deps)
@@ -153,7 +153,7 @@ func TestRouter_SecretsPutUsesTheAllowlistWriteCap(t *testing.T) {
 		SecretsChallenges: &secretsCS,
 		SecretsExplain:    &secrets.ExplainHandler{},
 		SecretsOperator: &secrets.OperatorHandler{
-			Store:        secrets.NewMemoryStore(8, 8, 4096),
+			Store:        secrets.NewMemoryStore(8, 7, 4096),
 			MaxBodyBytes: allowlistWriteBodyCap,
 			Authorize:    func(_ *http.Request, body []byte) error { seen = len(body); return nil },
 		},
@@ -240,7 +240,7 @@ func TestRouter_SecretRoutesRateLimitPerSandbox(t *testing.T) {
 		MaxRequestSize:    65536,
 		SecretsHandler:    &secrets.Handler{},
 		SecretsChallenges: &secretsCS,
-		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 8, 64)},
+		SecretsOperator:   &secrets.OperatorHandler{Store: secrets.NewMemoryStore(8, 7, 64)},
 		SecretsExplain:    &secrets.ExplainHandler{},
 	})
 

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -515,8 +515,6 @@ func normalizeHTTPServerConfig(cfg config) config {
 	return cfg
 }
 
-// newSecretsStore builds the store the secret handlers share, from the sizing
-// flags validateSecretsConfig has already checked.
 func newSecretsStore(cfg config) *secrets.MemoryStore {
 	return secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxPathsPerWorkload, cfg.secretsMaxValueBytes)
 }
@@ -529,6 +527,9 @@ func validateSecretsConfig(cfg config) error {
 	}
 	if cfg.secretsMaxPathsPerWorkload >= cfg.secretsMaxPaths {
 		return fmt.Errorf("--secrets-max-paths-per-workload (%d) must be below --secrets-max-paths (%d), or one workload can fill the store", cfg.secretsMaxPathsPerWorkload, cfg.secretsMaxPaths)
+	}
+	if cfg.secretsMaxValueBytes < secrets.GeneratedValueBytes {
+		return fmt.Errorf("--secrets-max-value-bytes (%d) must be at least %d, the size of every value CDS generates", cfg.secretsMaxValueBytes, secrets.GeneratedValueBytes)
 	}
 	return nil
 }

--- a/internal/cmds/cds/secrets_config_test.go
+++ b/internal/cmds/cds/secrets_config_test.go
@@ -11,24 +11,25 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
-// An operator must be able to raise the quota without a rebuild, and the two
-// shipped defaults must satisfy the relation CDS starts on.
+// The shipped flag defaults must satisfy the relation CDS starts on.
 func TestSecretsPathQuotaFlagIsWired(t *testing.T) {
 	flags := NewCmd().Flags()
-	f := flags.Lookup("secrets-max-paths-per-workload")
-	if f == nil {
+	quota := flags.Lookup("secrets-max-paths-per-workload")
+	if quota == nil {
 		t.Fatal("missing --secrets-max-paths-per-workload flag")
-	}
-	if want := strconv.Itoa(secrets.DefaultMaxPathsPerHolder); f.DefValue != want {
-		t.Fatalf("default = %q, want %q", f.DefValue, want)
 	}
 	ceiling := flags.Lookup("secrets-max-paths")
 	if ceiling == nil {
 		t.Fatal("missing --secrets-max-paths flag")
 	}
+	value := flags.Lookup("secrets-max-value-bytes")
+	if value == nil {
+		t.Fatal("missing --secrets-max-value-bytes flag")
+	}
 	cfg := secretsReadyConfig()
 	cfg.secretsMaxPaths = mustAtoi(t, ceiling.DefValue)
-	cfg.secretsMaxPathsPerWorkload = mustAtoi(t, f.DefValue)
+	cfg.secretsMaxPathsPerWorkload = mustAtoi(t, quota.DefValue)
+	cfg.secretsMaxValueBytes = mustAtoi(t, value.DefValue)
 	if err := validateSecretsConfig(cfg); err != nil {
 		t.Fatalf("the shipped flag defaults refuse to start CDS: %v", err)
 	}
@@ -43,8 +44,7 @@ func mustAtoi(t *testing.T, s string) int {
 	return n
 }
 
-// The store the handlers share carries each flag to the bound it names. Three
-// distinct values, so dropping one or swapping two changes what the store does.
+// The store the handlers share carries each flag to the bound it names.
 func TestNewSecretsStoreCarriesEachBound(t *testing.T) {
 	ctx := context.Background()
 	s := newSecretsStore(config{
@@ -75,6 +75,11 @@ func TestNewSecretsStoreCarriesEachBound(t *testing.T) {
 	}
 	if _, _, err := s.PutIfAbsent(ctx, "/web/2", make([]byte, 8), web); !errors.Is(err, secrets.ErrStoreFull) {
 		t.Fatalf("fourth path across holders = %v, want ErrStoreFull", err)
+	}
+	// The store is now at its ceiling as well, and api is still the holder its
+	// own quota answers for.
+	if _, _, err := s.PutIfAbsent(ctx, "/api/4", make([]byte, 8), api); !errors.Is(err, secrets.ErrHolderQuota) {
+		t.Fatalf("a holder at its quota against a full store = %v, want ErrHolderQuota", err)
 	}
 }
 
@@ -180,8 +185,6 @@ func TestSecretsSizingMustBePositive(t *testing.T) {
 	}
 }
 
-// A quota at the ceiling is one workload's room to fill the store; above it the
-// ceiling answers first and the quota never fires.
 func TestSecretsQuotaMustStayBelowTheCeiling(t *testing.T) {
 	for _, tc := range []struct {
 		name  string
@@ -202,5 +205,19 @@ func TestSecretsQuotaMustStayBelowTheCeiling(t *testing.T) {
 	cfg.secretsMaxPathsPerWorkload = cfg.secretsMaxPaths - 1
 	if err := validateSecretsConfig(cfg); err != nil {
 		t.Fatalf("a quota one below the ceiling refused: %v", err)
+	}
+}
+
+// Generate always mints GeneratedValueBytes, so a smaller cap turns every
+// workload's first POST into a 500 rather than refusing at startup.
+func TestSecretsValueBoundHoldsAGeneratedValue(t *testing.T) {
+	cfg := secretsReadyConfig()
+	cfg.secretsMaxValueBytes = secrets.GeneratedValueBytes - 1
+	if err := validateSecretsConfig(cfg); err == nil {
+		t.Fatalf("--secrets-max-value-bytes=%d was accepted below a generated value", cfg.secretsMaxValueBytes)
+	}
+	cfg.secretsMaxValueBytes = secrets.GeneratedValueBytes
+	if err := validateSecretsConfig(cfg); err != nil {
+		t.Fatalf("a cap exactly fitting a generated value refused: %v", err)
 	}
 }

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -189,6 +189,33 @@ func TestFetchOneRereadsAfterLosingCreateRace(t *testing.T) {
 	}
 }
 
+// The store evicts nothing, so a 507 does not clear without a CDS restart.
+// Retrying it spends the whole budget and then hands the pod to the kubelet,
+// which restarts the sidecar for the pod's life; fail on the first pass instead.
+func TestFetchStopsRetryingWhenTheStoreIsFull(t *testing.T) {
+	endpoint := startInventory(t)
+	cds, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/api/db":  {{status: http.StatusNotFound}},
+		"POST /secrets/api/db": {{status: http.StatusInsufficientStorage}},
+	})
+	cfg := flowConfig(t, url)
+	pub := testKey(t)
+	err := sidecar.Retry(context.Background(), cfg.Config, "secret", func(ctx context.Context) error {
+		_, err := fetchAllWith(ctx, cfg, http.DefaultClient, pub, endpoint)
+		return err
+	})
+	if err == nil {
+		t.Fatal("a full store was treated as success")
+	}
+	if !strings.Contains(err.Error(), "/api/db") {
+		t.Fatalf("err = %v, want the refused path in the detail", err)
+	}
+	want := []string{"GET /secrets/api/db", "POST /secrets/api/db"}
+	if !equal(cds.requests, want) {
+		t.Fatalf("requests = %v, want the single pass %v", cds.requests, want)
+	}
+}
+
 // A denial is not a create: only 404 means the path is free.
 func TestFetchOneDoesNotCreateOnDenial(t *testing.T) {
 	endpoint := startInventory(t)

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -138,6 +138,10 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 	switch {
 	case status == http.StatusCreated:
 		return value, nil
+	case status == http.StatusInsufficientStorage:
+		// The store evicts nothing, so a bound it has reached is still reached
+		// on every later attempt.
+		return nil, sidecar.Terminal(err)
 	case status != http.StatusConflict:
 		return nil, err
 	}

--- a/internal/cmds/sidecar/retry_test.go
+++ b/internal/cmds/sidecar/retry_test.go
@@ -2,6 +2,8 @@ package sidecar
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"testing"
 )
 
@@ -34,6 +36,26 @@ func TestRetryGivesUp(t *testing.T) {
 	}
 	if calls != cfg.Attempts {
 		t.Fatalf("attempted %d times, want %d", calls, cfg.Attempts)
+	}
+}
+
+// A Terminal error stops the loop on its first attempt, and reaches the caller
+// intact through the wrapping an attempt does on the way out.
+func TestRetryStopsOnATerminalError(t *testing.T) {
+	cfg := testConfig("https://cds.example")
+	var calls int
+	err := Retry(context.Background(), cfg, "secret", func(context.Context) error {
+		calls++
+		return fmt.Errorf("secret /api/db: %w", Terminal(errNotYet))
+	})
+	if err == nil {
+		t.Fatal("a terminal error was treated as success")
+	}
+	if !errors.Is(err, errNotYet) {
+		t.Fatalf("err = %v, want the wrapped cause", err)
+	}
+	if calls != 1 {
+		t.Fatalf("attempted %d times, want to stop after the first", calls)
 	}
 }
 

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -8,6 +8,7 @@ package sidecar
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -110,7 +111,17 @@ func (c *Config) ParseMeasurements() ([][]byte, error) {
 	return measurements, nil
 }
 
-// Retry runs one whole release pass at a time, retrying the set.
+// Terminal marks an error no later attempt can clear, so Retry stops on it
+// rather than spending its whole budget.
+func Terminal(err error) error { return terminal{err} }
+
+type terminal struct{ err error }
+
+func (t terminal) Error() string { return t.err.Error() }
+func (t terminal) Unwrap() error { return t.err }
+
+// Retry runs one whole release pass at a time, retrying the set until an
+// attempt succeeds, one returns a Terminal error, or the budget runs out.
 //
 // Retrying is expected, not exceptional: until every main container is running
 // the sandbox does not match its workload entry, so early attempts are denied
@@ -125,6 +136,11 @@ func Retry(ctx context.Context, cfg Config, what string, attempt func(context.Co
 			return nil
 		}
 		lastErr = err
+		var t terminal
+		if errors.As(err, &t) {
+			slog.Error(what+" release cannot succeed", "attempt", n, "of", cfg.Attempts, "error", err)
+			return err
+		}
 		if n == cfg.Attempts {
 			// The last attempt's error is the one that matters: log it at
 			// ERROR so a stuck release shows its real cause in the sidecar's

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -203,7 +203,8 @@ spec:
             - --challenge-ttl={{ .Values.cds.challengeTTL }}
             - --request-timeout={{ .Values.cds.requestTimeout }}
             - --max-request-size={{ .Values.cds.maxRequestSize }}
-            - --secrets-max-paths-per-workload={{ .Values.cds.secretsMaxPathsPerWorkload }}
+            - --secrets-max-paths={{ include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPaths "label" "cds.secretsMaxPaths") }}
+            - --secrets-max-paths-per-workload={{ include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPathsPerWorkload "label" "cds.secretsMaxPathsPerWorkload") }}
             - --readiness-interval={{ .Values.cds.readinessInterval }}
             - --san-validation={{ .Values.cds.sanValidation }}
             {{- /* Always allow in-cluster Service SANs so the mesh's own

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -161,6 +161,18 @@
 {{- end -}}
 {{- end -}}
 {{- /*
+  CDS refuses to start unless the per-workload secret quota is strictly below
+  the store ceiling, and its Deployment rolls with strategy: Recreate — the
+  serving pod is deleted before the replacement CrashLoops, and CDS is the mesh
+  CA and the only /sign-csr. Catching the pair here turns a cluster-wide
+  certificate-issuance outage into a failed `helm template`.
+*/ -}}
+{{- $secretsCeiling := int (include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPaths "label" "cds.secretsMaxPaths")) -}}
+{{- $secretsQuota := int (include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPathsPerWorkload "label" "cds.secretsMaxPathsPerWorkload")) -}}
+{{- if ge $secretsQuota $secretsCeiling -}}
+{{- fail (printf "VALIDATION_ERROR kind=cds_secrets_path_budget: cds.secretsMaxPathsPerWorkload must be below cds.secretsMaxPaths (%d), got: %d. Raise cds.secretsMaxPaths alongside it — CDS refuses to start on this pair, and its Recreate rollout deletes the serving pod first, so the cluster loses certificate issuance until the values are fixed." $secretsCeiling $secretsQuota) -}}
+{{- end -}}
+{{- /*
   Per-container `paths` was replaced by an entry-level `secrets` grant. CDS
   parses its seed with unknown fields rejected and fails closed on a parse
   error, so a values file carried over from a release that used `paths` would

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -230,9 +230,13 @@ cds:
   # (evidence ~2 KiB) but rejects every TDX request with HTTP 422
   # `http: request body too large`.
   maxRequestSize: 262144
-  # -- Max secret paths one allowlist entry may hold. Must stay below the store
-  # ceiling (--secrets-max-paths, 1024) or CDS refuses to start.
+  # -- Max secret paths one allowlist entry may hold. Must stay below
+  # cds.secretsMaxPaths; the chart refuses to render otherwise.
   secretsMaxPathsPerWorkload: 64
+  # -- Max secret paths CDS holds in memory across every workload. Raise this
+  # alongside secretsMaxPathsPerWorkload; the store is process memory in the pod
+  # that also holds the mesh CA.
+  secretsMaxPaths: 1024
   readinessInterval: 10s
   ## /sign-csr CSRs arrive without a matching TCP source IP under chart routing,
   ## so leave sanValidation off and pin DNS SAN / CN patterns instead.

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1253,16 +1253,20 @@ func TestChartCDSPinnedToCDSNode(t *testing.T) {
 	}
 }
 
-// The per-workload secret quota is the bound a flooding workload meets first,
-// so a chart-deployed cluster must be able to size it.
+// Both secret path bounds are chart-settable: sizing the quota without the
+// ceiling it must stay below renders a CDS that will not start.
 func TestChartCDSSecretsPathQuotaFlagsThrough(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		set  []string
-		want string
+		want []string
 	}{
-		{"default", nil, "--secrets-max-paths-per-workload=64"},
-		{"sized", []string{"--set", "cds.secretsMaxPathsPerWorkload=8"}, "--secrets-max-paths-per-workload=8"},
+		{"default", nil, []string{"--secrets-max-paths=1024", "--secrets-max-paths-per-workload=64"}},
+		{
+			"sized",
+			[]string{"--set", "cds.secretsMaxPaths=256", "--set", "cds.secretsMaxPathsPerWorkload=8"},
+			[]string{"--secrets-max-paths=256", "--secrets-max-paths-per-workload=8"},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := helmTemplate(t, tc.set...)
@@ -1270,7 +1274,32 @@ func TestChartCDSSecretsPathQuotaFlagsThrough(t *testing.T) {
 				t.Fatalf("helm template: %v\n%s", err, out)
 			}
 			args := renderedDeploymentContainer(t, out, "c8s-cds", "cds").Args
-			assertContainerHasArg(t, "cds", args, tc.want)
+			for _, want := range tc.want {
+				assertContainerHasArg(t, "cds", args, want)
+			}
+		})
+	}
+}
+
+// The pair CDS refuses to start on is refused at template time instead: its
+// Recreate rollout deletes the serving pod before the replacement CrashLoops.
+func TestChartCDSSecretsQuotaAboveTheCeilingFailsRendering(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  []string
+	}{
+		{"at the ceiling", []string{"--set", "cds.secretsMaxPaths=64"}},
+		{"above the ceiling", []string{"--set", "cds.secretsMaxPaths=32"}},
+		{"raised quota, default ceiling", []string{"--set", "cds.secretsMaxPathsPerWorkload=1024"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := helmTemplate(t, tc.set...)
+			if err == nil {
+				t.Fatalf("a quota at or above the ceiling rendered:\n%s", out)
+			}
+			if !strings.Contains(out, "kind=cds_secrets_path_budget") {
+				t.Fatalf("render failed without naming the guard: %v\n%s", err, out)
+			}
 		})
 	}
 }

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -17,6 +17,7 @@ import (
 
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
@@ -113,8 +114,8 @@ type Handler struct {
 	Logger *slog.Logger
 }
 
-// grant is the allowlist entry authorization matched: workload is the store's
-// holder key, secrets is the policy the request is checked against.
+// grant is the allowlist entry authorization matched: workload keys the store's
+// holder, secrets gates the path.
 type grant struct {
 	workload string
 	secrets  *pkgallowlist.SecretsPolicy
@@ -217,9 +218,17 @@ func (h Handler) servePost(ctx context.Context, w http.ResponseWriter, g grant, 
 		return
 	}
 	_, held, err := h.Store.PutIfAbsent(ctx, path, candidate, WorkloadHolder(g.workload))
-	if bounded(err) {
+	switch {
+	case errors.Is(err, ErrHolderQuota):
 		h.logger().Warn("secret create refused", "path", path, "workload", g.workload, "error", err)
-		http.Error(w, "secret storage limit reached", http.StatusInsufficientStorage)
+		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretHolderQuota, "secret storage limit reached")
+		return
+	case errors.Is(err, ErrStoreFull):
+		// The census names the holders, and never the wire: it is other
+		// tenants' occupancy.
+		h.logger().Warn("secret create refused", "path", path, "workload", g.workload, "error", err,
+			"holders", census(h.Store, censusHolders))
+		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretStoreFull, "secret storage limit reached")
 		return
 	}
 	if err != nil {
@@ -248,6 +257,36 @@ func writeValue(w http.ResponseWriter, value []byte, status int) {
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(valueResponse{Value: base64.StdEncoding.EncodeToString(value)})
+}
+
+// writeError answers in the c8s error-envelope shape, so a caller reads which
+// bound refused it from code rather than from the message.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: code, Message: message})
+}
+
+// censusHolders is how many holders the full-store log line names.
+const censusHolders = 5
+
+// storeCensus is the holder breakdown a store offers.
+type storeCensus interface {
+	TopHolders(n int) []HolderPaths
+}
+
+// census renders the largest holders for a log line.
+func census(s Store, n int) string {
+	c, ok := s.(storeCensus)
+	if !ok {
+		return ""
+	}
+	parts := make([]string, 0, n)
+	for _, hp := range c.TopHolders(n) {
+		parts = append(parts, fmt.Sprintf("%s=%d", hp.Holder, hp.Paths))
+	}
+	return strings.Join(parts, " ")
 }
 
 // requestPath returns the canonical store path a request names.

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -38,7 +38,6 @@ const (
 	testAppImg      = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
 	// testAppImg2 is the entry's second main: release is gated on both running.
 	testAppImg2  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
-	testBulkImg  = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
 	testInjected = "sha256:9999999999999999999999999999999999999999999999999999999999999999"
 	testOther    = "sha256:8888888888888888888888888888888888888888888888888888888888888888"
 	// testInjectedOld is the previous release's injected image, still running in
@@ -47,6 +46,10 @@ const (
 	// testWorkerImg is the main of a second workload entry, declared only by
 	// tests that need one.
 	testWorkerImg = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+	// testBulkImg is the main of the "bulk" entry, likewise declared where it
+	// is needed. Its digest is its own: a digest two entries share matches both
+	// the moment either widens its argv, and MatchWorkload answers ambiguous.
+	testBulkImg = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
 )
 
 // --- fakes ---
@@ -199,18 +202,6 @@ func newHarness(t *testing.T) *harness {
 				Write:  []string{"/api/**"},
 			},
 		},
-		"bulk": {
-			Containers: []pkgallowlist.Container{{
-				Digest:  mustDigest(t, testBulkImg),
-				Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/bulk"}},
-				Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
-			}},
-			Secrets: &pkgallowlist.SecretsPolicy{
-				Policy: pkgallowlist.PolicyAllow,
-				Read:   []string{"/bulk/**"},
-				Write:  []string{"/bulk/**"},
-			},
-		},
 	}}
 	inv := &fakeInventory{
 		keys: map[string]*ecdsa.PublicKey{testHost: signer.PublicKey()},
@@ -221,7 +212,7 @@ func newHarness(t *testing.T) *harness {
 		},
 	}
 	challenges := &fakeChallenges{used: map[string]bool{}}
-	store := NewMemoryStore(16, 16, 64)
+	store := NewMemoryStore(16, 15, 64)
 	return &harness{
 		h: Handler{
 			Store:          store,
@@ -239,6 +230,37 @@ func newHarness(t *testing.T) *harness {
 func (hn *harness) setStore(t *testing.T, s *MemoryStore) {
 	t.Helper()
 	hn.store, hn.h.Store = s, s
+}
+
+// declareBulkEntry adds a second granted entry, running in testBulkSandbox, and
+// returns the leaf that sandbox presents.
+func (hn *harness) declareBulkEntry(t *testing.T) *x509.Certificate {
+	t.Helper()
+	al, err := hn.h.Policy.Allowlist()
+	if err != nil {
+		t.Fatal(err)
+	}
+	al.Workloads["bulk"] = pkgallowlist.Workload{
+		Containers: []pkgallowlist.Container{{
+			Digest:  mustDigest(t, testBulkImg),
+			Command: pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: []string{"/bulk"}},
+			Args:    pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny},
+		}},
+		Secrets: &pkgallowlist.SecretsPolicy{
+			Policy: pkgallowlist.PolicyAllow,
+			Read:   []string{"/bulk/**"},
+			Write:  []string{"/bulk/**"},
+		},
+	}
+	if hn.inv.bySandbox == nil {
+		hn.inv.bySandbox = map[string][]workloadclaims.SandboxContainer{}
+	}
+	hn.inv.bySandbox[testBulkSandbox] = []workloadclaims.SandboxContainer{
+		{Digest: testBulkImg, Argv: []string{"/bulk"}},
+		{Digest: testInjected, Argv: []string{"get-secret"}},
+	}
+	leaf, _ := leafFor(t, testBulkSandbox)
+	return leaf
 }
 
 // request builds a request as the fetcher would send it.
@@ -653,13 +675,7 @@ func TestInjectedImageFromPreviousReleaseIsDropped(t *testing.T) {
 func TestFloodingWorkloadDoesNotRefuseAnother(t *testing.T) {
 	hn := newHarness(t)
 	hn.setStore(t, NewMemoryStore(16, 2, 64))
-	hn.inv.bySandbox = map[string][]workloadclaims.SandboxContainer{
-		testBulkSandbox: {
-			{Digest: testBulkImg, Argv: []string{"/bulk"}},
-			{Digest: testInjected, Argv: []string{"get-secret"}},
-		},
-	}
-	bulkLeaf, _ := leafFor(t, testBulkSandbox)
+	bulkLeaf := hn.declareBulkEntry(t)
 
 	created, refused := 0, 0
 	for i := range 10 {
@@ -699,6 +715,47 @@ func TestQuotaIsPerWorkloadNotPerSandbox(t *testing.T) {
 	}
 	if hn.store.Len() != 1 {
 		t.Fatalf("store holds %d paths, want 1", hn.store.Len())
+	}
+}
+
+// A workload that has spent none of its quota is still refused by the ceiling
+// when other holders have filled the store, and the refusal names the ceiling
+// rather than the quota — the two are one status apart and only the code tells
+// the workload whether shrinking its own footprint would help.
+func TestCeilingRefusesAWorkloadUnderItsQuota(t *testing.T) {
+	hn := newHarness(t)
+	hn.setStore(t, NewMemoryStore(2, 1, 64))
+	// Operator values are exempt from the quota, so the store fills without
+	// anything being charged to the workload.
+	hn.seed(t, "/op/1", []byte("operator-value"))
+	hn.seed(t, "/op/2", []byte("operator-value"))
+
+	w := do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
+	if w.Code != http.StatusInsufficientStorage {
+		t.Fatalf("first POST against a full store = %d (%s), want 507", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != types.ErrorCodeSecretStoreFull {
+		t.Fatalf("error code = %q, want %q", code, types.ErrorCodeSecretStoreFull)
+	}
+	if hn.store.Len() != 2 {
+		t.Fatalf("store holds %d paths after a refusal, want the 2 it started with", hn.store.Len())
+	}
+}
+
+// A workload at its own quota is told so, below a store that has room.
+func TestQuotaRefusalNamesTheQuota(t *testing.T) {
+	hn := newHarness(t)
+	hn.setStore(t, NewMemoryStore(16, 1, 64))
+
+	if w := do(hn.h, hn.request(t, http.MethodPost, "/api/db")); w.Code != http.StatusCreated {
+		t.Fatalf("first POST = %d (%s), want 201", w.Code, w.Body)
+	}
+	w := do(hn.h, hn.request(t, http.MethodPost, "/api/hf"))
+	if w.Code != http.StatusInsufficientStorage {
+		t.Fatalf("POST past the quota = %d (%s), want 507", w.Code, w.Body)
+	}
+	if code := errorCode(t, w); code != types.ErrorCodeSecretHolderQuota {
+		t.Fatalf("error code = %q, want %q", code, types.ErrorCodeSecretHolderQuota)
 	}
 }
 

--- a/internal/secrets/operator.go
+++ b/internal/secrets/operator.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/confidential-dot-ai/c8s/internal/httputil"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // DefaultMaxOperatorBodyBytes caps a PUT body when OperatorHandler.MaxBodyBytes
@@ -125,15 +127,18 @@ func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path st
 	writeResult(w, http.StatusOK, PutResponse{Path: path, Existing: held.Origin})
 }
 
-// writeFailed answers a store error and reports whether it did. A bound is the
-// operator's own sizing, so it answers 507.
+// writeFailed answers a store error and reports whether it did. Both bounds
+// answer 507, distinguished by error code.
 func (h OperatorHandler) writeFailed(w http.ResponseWriter, path string, err error) bool {
 	switch {
 	case err == nil:
 		return false
-	case bounded(err):
+	case errors.Is(err, ErrHolderQuota):
 		h.logger().Warn("operator secret write refused", "path", path, "error", err)
-		http.Error(w, "secret storage limit reached", http.StatusInsufficientStorage)
+		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretHolderQuota, "secret storage limit reached")
+	case errors.Is(err, ErrStoreFull):
+		h.logger().Warn("operator secret write refused", "path", path, "error", err)
+		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretStoreFull, "secret storage limit reached")
 	default:
 		h.logger().Error("operator secret write failed", "path", path, "error", err)
 		http.Error(w, "secret write failed", http.StatusInternalServerError)

--- a/internal/secrets/operator_test.go
+++ b/internal/secrets/operator_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // operatorHarness wires the handler to a real store and a recording authorizer,
@@ -31,7 +32,7 @@ type operatorHarness struct {
 
 func newOperatorHarness(t *testing.T) *operatorHarness {
 	t.Helper()
-	oh := &operatorHarness{store: NewMemoryStore(8, 8, 64)}
+	oh := &operatorHarness{store: NewMemoryStore(8, 7, 64)}
 	oh.h = OperatorHandler{
 		Store: oh.store,
 		Authorize: func(_ *http.Request, body []byte) error {
@@ -40,6 +41,22 @@ func newOperatorHarness(t *testing.T) *operatorHarness {
 		},
 	}
 	return oh
+}
+
+// setStore swaps in a store bounded for the test at hand, keeping the
+// harness's own view and the handler's the same one.
+func (oh *operatorHarness) setStore(s *MemoryStore) {
+	oh.store, oh.h.Store = s, s
+}
+
+// errorCode reads the machine-readable code out of a refusal envelope.
+func errorCode(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+	var resp types.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error envelope %q: %v", w.Body.String(), err)
+	}
+	return resp.Error
 }
 
 func putRequest(t *testing.T, path string, value []byte, overwrite bool) *http.Request {
@@ -170,7 +187,7 @@ func TestOperatorPutRejectsUnauthorized(t *testing.T) {
 
 // Nil means no operator keys are pinned, which must reject rather than admit.
 func TestOperatorPutWithoutAuthorizerRejects(t *testing.T) {
-	h := OperatorHandler{Store: NewMemoryStore(8, 8, 64)}
+	h := OperatorHandler{Store: NewMemoryStore(8, 7, 64)}
 	w, _ := doPut(h, putRequest(t, "/a", []byte("v"), false))
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("status = %d, want 401", w.Code)
@@ -245,17 +262,26 @@ func TestOperatorPutRespectsTheStoreValueBound(t *testing.T) {
 	}
 }
 
-// A full store is the operator's own sizing, so it answers 507; an existing
-// path can still be replaced.
+// A full store is the operator's own sizing, so it answers 507 naming the
+// ceiling; an existing path can still be replaced.
 func TestOperatorPutAtTheCeilingIsInsufficientStorage(t *testing.T) {
 	oh := newOperatorHarness(t)
-	oh.h.Store = NewMemoryStore(1, 1, 64)
+	oh.setStore(NewMemoryStore(2, 1, 64))
 
-	if w, _ := doPut(oh.h, putRequest(t, "/a", []byte("first"), false)); w.Code != http.StatusCreated {
-		t.Fatalf("first put = %d, want 201", w.Code)
+	for _, p := range []string{"/a", "/b"} {
+		if w, _ := doPut(oh.h, putRequest(t, p, []byte("first"), false)); w.Code != http.StatusCreated {
+			t.Fatalf("put %s = %d, want 201", p, w.Code)
+		}
 	}
-	if w, _ := doPut(oh.h, putRequest(t, "/b", []byte("second"), false)); w.Code != http.StatusInsufficientStorage {
+	w, _ := doPut(oh.h, putRequest(t, "/c", []byte("second"), false))
+	if w.Code != http.StatusInsufficientStorage {
 		t.Fatalf("put at the ceiling = %d, want 507", w.Code)
+	}
+	if code := errorCode(t, w); code != types.ErrorCodeSecretStoreFull {
+		t.Fatalf("error code = %q, want %q", code, types.ErrorCodeSecretStoreFull)
+	}
+	if oh.store.Len() != 2 {
+		t.Fatalf("store holds %d paths after a refusal, want 2", oh.store.Len())
 	}
 	if w, _ := doPut(oh.h, putRequest(t, "/a", []byte("replaced"), true)); w.Code != http.StatusOK {
 		t.Fatalf("replacing an existing path at the ceiling = %d, want 200", w.Code)
@@ -293,7 +319,7 @@ func TestOperatorPutAgainstRealOperatorAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	store := NewMemoryStore(8, 8, 64)
+	store := NewMemoryStore(8, 7, 64)
 	h := OperatorHandler{
 		Store:     store,
 		Authorize: operatorauth.Verifier{Keys: []*ecdsa.PublicKey{&key.PublicKey}}.Authorize,

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -3,10 +3,12 @@
 package secrets
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 )
 
@@ -18,11 +20,6 @@ var (
 	ErrHolderQuota = errors.New("secrets: holder path quota")
 	ErrStoreFull   = errors.New("secrets: store path ceiling")
 )
-
-// bounded reports whether err is a bound refusing a write.
-func bounded(err error) bool {
-	return errors.Is(err, ErrHolderQuota) || errors.Is(err, ErrStoreFull)
-}
 
 // Origin records what put a value at a path.
 type Origin string
@@ -36,11 +33,18 @@ const (
 )
 
 // Holder is the party a stored path is charged to. Origin and name together are
-// the key, so an allowlist entry named "operator" is a different holder from
-// the operator.
+// the key.
 type Holder struct {
 	origin Origin
 	name   string
+}
+
+// String names the holder for a log line. It never carries a value.
+func (h Holder) String() string {
+	if h.origin == OriginOperator {
+		return string(OriginOperator)
+	}
+	return fmt.Sprintf("%s %q", h.origin, h.name)
 }
 
 // WorkloadHolder charges a path to the allowlist entry whose grant authorized
@@ -49,7 +53,7 @@ func WorkloadHolder(workload string) Holder {
 	return Holder{origin: OriginWorkload, name: workload}
 }
 
-// OperatorHolder charges a path to the operator key, which holds one bucket.
+// OperatorHolder charges a path to the operator; the ceiling is its only bound.
 func OperatorHolder() Holder {
 	return Holder{origin: OriginOperator}
 }
@@ -76,7 +80,8 @@ type Store interface {
 	// the write did not happen.
 	PutIfAbsent(ctx context.Context, path string, value []byte, by Holder) (current []byte, held Held, err error)
 	// Put stores value at path, replacing anything already there, and reports
-	// what it displaced.
+	// what it displaced. Replacing another holder's path moves the charge to by
+	// without a quota check, so only a quota-exempt holder may call it.
 	Put(ctx context.Context, path string, value []byte, by Holder) (Held, error)
 }
 
@@ -119,11 +124,11 @@ type entry struct {
 
 // NewMemoryStore builds the store. maxPaths bounds distinct paths across every
 // holder, maxPerHolder bounds one holder's, and maxValue bounds one value.
-// Operator writes count against maxPaths only. A quota above the ceiling is
-// inert — the ceiling answers first — so it is a wiring error.
+// Operator writes count against maxPaths only. maxPerHolder must be below
+// maxPaths.
 func NewMemoryStore(maxPaths, maxPerHolder, maxValue int) *MemoryStore {
-	if maxPerHolder > maxPaths {
-		panic(fmt.Sprintf("secrets: maxPerHolder %d exceeds maxPaths %d", maxPerHolder, maxPaths))
+	if maxPerHolder >= maxPaths {
+		panic(fmt.Sprintf("secrets: maxPerHolder %d must be below maxPaths %d", maxPerHolder, maxPaths))
 	}
 	return &MemoryStore{
 		values:       make(map[string]entry),
@@ -199,10 +204,9 @@ func (s *MemoryStore) storeLocked(path string, value []byte, by Holder) {
 	s.holders[by]++
 }
 
-// checkRoomLocked guards the path bounds. Callers hold the lock and have
-// established the path is absent, so this is only ever asked about a write that
-// grows the map. The holder's quota answers first, so a flood meets the bound
-// on its own writer.
+// checkRoomLocked guards the path bounds for a write that grows the map:
+// callers hold the lock and have established the path is absent. The holder's
+// quota answers before the ceiling.
 func (s *MemoryStore) checkRoomLocked(by Holder) error {
 	if by.origin != OriginOperator {
 		if held := s.holders[by]; held >= s.maxPerHolder {
@@ -220,4 +224,28 @@ func (s *MemoryStore) Len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.values)
+}
+
+// HolderPaths is one holder's share of the store.
+type HolderPaths struct {
+	Holder Holder
+	Paths  int
+}
+
+// TopHolders returns the n holders with the most paths, largest first, ties
+// broken by holder so the order is stable.
+func (s *MemoryStore) TopHolders(n int) []HolderPaths {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]HolderPaths, 0, len(s.holders))
+	for h, paths := range s.holders {
+		out = append(out, HolderPaths{Holder: h, Paths: paths})
+	}
+	slices.SortFunc(out, func(a, b HolderPaths) int {
+		if c := cmp.Compare(b.Paths, a.Paths); c != 0 {
+			return c
+		}
+		return cmp.Or(cmp.Compare(a.Holder.origin, b.Holder.origin), cmp.Compare(a.Holder.name, b.Holder.name))
+	})
+	return out[:min(n, len(out))]
 }

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -22,7 +23,7 @@ func holderTotal(s *MemoryStore) (total, paths int) {
 }
 
 func TestMemoryStoreGetMissing(t *testing.T) {
-	s := NewMemoryStore(10, 10, 64)
+	s := NewMemoryStore(10, 9, 64)
 	if _, err := s.Get(context.Background(), "/nope"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("err = %v, want ErrNotFound", err)
 	}
@@ -32,7 +33,7 @@ func TestMemoryStoreGetMissing(t *testing.T) {
 // that it did not create it — which is how a losing replica recovers.
 func TestMemoryStorePutIfAbsent(t *testing.T) {
 	ctx := context.Background()
-	s := NewMemoryStore(10, 10, 64)
+	s := NewMemoryStore(10, 9, 64)
 
 	got, held, err := s.PutIfAbsent(ctx, "/a", []byte("first"), WorkloadHolder("api"))
 	if err != nil || held.Exists || !bytes.Equal(got, []byte("first")) {
@@ -57,7 +58,7 @@ func TestMemoryStorePutIfAbsent(t *testing.T) {
 // thing the operator write path learns about a value it did not write.
 func TestMemoryStorePut(t *testing.T) {
 	ctx := context.Background()
-	s := NewMemoryStore(10, 10, 64)
+	s := NewMemoryStore(10, 9, 64)
 
 	held, err := s.Put(ctx, "/a", []byte("operator"), OperatorHolder())
 	if err != nil || held.Exists {
@@ -86,26 +87,53 @@ func TestMemoryStorePut(t *testing.T) {
 	}
 }
 
-// Put is bounded by the same caps as PutIfAbsent, and replacing a path does not
-// consume room the store does not have.
+// Put is bounded by the ceiling and the value cap — its one caller writes as
+// the quota-exempt operator — and replacing a path consumes no room.
 func TestMemoryStorePutBounds(t *testing.T) {
 	ctx := context.Background()
-	s := NewMemoryStore(1, 1, 4)
+	s := NewMemoryStore(2, 1, 4)
 
 	if _, err := s.Put(ctx, "/a", []byte("toolong"), OperatorHolder()); err == nil {
 		t.Fatal("an oversized value was stored")
 	}
-	if _, err := s.Put(ctx, "/a", []byte("ok"), OperatorHolder()); err != nil {
-		t.Fatal(err)
+	for _, p := range []string{"/a", "/b"} {
+		if _, err := s.Put(ctx, p, []byte("ok"), OperatorHolder()); err != nil {
+			t.Fatalf("put %s: %v", p, err)
+		}
 	}
-	if _, err := s.Put(ctx, "/b", []byte("ok"), OperatorHolder()); err == nil {
-		t.Fatal("the path cap did not bound Put")
+	if _, err := s.Put(ctx, "/c", []byte("ok"), OperatorHolder()); !errors.Is(err, ErrStoreFull) {
+		t.Fatalf("put at the ceiling = %v, want ErrStoreFull", err)
 	}
 	if _, err := s.Put(ctx, "/a", []byte("new"), OperatorHolder()); err != nil {
-		t.Fatalf("replacing an existing path at the cap: %v", err)
+		t.Fatalf("replacing an existing path at the ceiling: %v", err)
 	}
-	if s.Len() != 1 {
-		t.Fatalf("Len = %d, want 1", s.Len())
+	if s.Len() != 2 {
+		t.Fatalf("Len = %d, want 2", s.Len())
+	}
+}
+
+// Put moves a path's charge to the new holder without a quota check, so the
+// interface's one restriction — a quota-exempt caller — is pinned rather than
+// stated only in a comment.
+func TestPutMovesAChargePastTheQuota(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(4, 1, 8)
+	api, web := WorkloadHolder("api"), WorkloadHolder("web")
+
+	if _, _, err := s.PutIfAbsent(ctx, "/api/1", []byte("ok"), api); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := s.PutIfAbsent(ctx, "/web/1", []byte("ok"), web); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(ctx, "/api/1", []byte("taken"), web); err != nil {
+		t.Fatalf("Put onto another holder's path = %v, want the charge moved", err)
+	}
+	if got := s.TopHolders(1); len(got) != 1 || got[0].Holder != web || got[0].Paths != 2 {
+		t.Fatalf("top holder = %+v, want web holding 2 paths past a quota of 1", got)
+	}
+	if total, paths := holderTotal(s); total != paths || paths != 2 {
+		t.Fatalf("holder counts sum to %d over %d paths, want both 2", total, paths)
 	}
 }
 
@@ -113,7 +141,7 @@ func TestMemoryStorePutBounds(t *testing.T) {
 // slice.
 func TestMemoryStoreCopiesValues(t *testing.T) {
 	ctx := context.Background()
-	s := NewMemoryStore(10, 10, 64)
+	s := NewMemoryStore(10, 9, 64)
 	original := []byte("secret")
 	if _, _, err := s.PutIfAbsent(ctx, "/a", original, WorkloadHolder("api")); err != nil {
 		t.Fatal(err)
@@ -142,16 +170,16 @@ func TestMemoryStoreBounds(t *testing.T) {
 	if _, _, err := s.PutIfAbsent(ctx, "/big", []byte("toolong"), WorkloadHolder("api")); err == nil {
 		t.Fatal("an oversized value was stored")
 	}
-	for _, p := range []string{"/a", "/b"} {
-		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok"), WorkloadHolder(p)); err != nil {
-			t.Fatalf("put %s: %v", p, err)
+	for _, w := range []struct{ holder, path string }{{"a", "/one"}, {"b", "/two"}} {
+		if _, _, err := s.PutIfAbsent(ctx, w.path, []byte("ok"), WorkloadHolder(w.holder)); err != nil {
+			t.Fatalf("put %s: %v", w.path, err)
 		}
 	}
-	if _, _, err := s.PutIfAbsent(ctx, "/c", []byte("ok"), WorkloadHolder("/c")); !errors.Is(err, ErrStoreFull) {
+	if _, _, err := s.PutIfAbsent(ctx, "/three", []byte("ok"), WorkloadHolder("c")); !errors.Is(err, ErrStoreFull) {
 		t.Fatalf("put at the path cap = %v, want ErrStoreFull", err)
 	}
 	// An existing path still resolves at the cap.
-	if _, held, err := s.PutIfAbsent(ctx, "/a", []byte("ok"), WorkloadHolder("/a")); err != nil || !held.Exists {
+	if _, held, err := s.PutIfAbsent(ctx, "/one", []byte("ok"), WorkloadHolder("a")); err != nil || !held.Exists {
 		t.Fatalf("existing path at the cap: held=%+v err=%v", held, err)
 	}
 	if s.Len() != 2 {
@@ -165,13 +193,25 @@ func TestMemoryStoreHolderQuota(t *testing.T) {
 	s := NewMemoryStore(64, 2, 8)
 
 	flooder := WorkloadHolder("flooder")
-	for _, p := range []string{"/f/1", "/f/2"} {
-		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok"), flooder); err != nil {
+	stored := map[string]string{"/f/1": "one", "/f/2": "two"}
+	for p, v := range stored {
+		if _, _, err := s.PutIfAbsent(ctx, p, []byte(v), flooder); err != nil {
 			t.Fatalf("put %s: %v", p, err)
 		}
 	}
 	if _, _, err := s.PutIfAbsent(ctx, "/f/3", []byte("ok"), flooder); !errors.Is(err, ErrHolderQuota) {
 		t.Fatalf("put past the quota = %v, want ErrHolderQuota", err)
+	}
+	// The quota refuses and keeps what it has, like the ceiling: a stored value
+	// is the only copy.
+	for p, v := range stored {
+		got, err := s.Get(ctx, p)
+		if err != nil || !bytes.Equal(got, []byte(v)) {
+			t.Fatalf("%s = %q %v, want %q still stored", p, got, err, v)
+		}
+	}
+	if s.Len() != len(stored) {
+		t.Fatalf("Len = %d, want %d unchanged by a refusal", s.Len(), len(stored))
 	}
 	// An existing path still resolves for a holder at its quota: it grows
 	// nothing.
@@ -180,8 +220,8 @@ func TestMemoryStoreHolderQuota(t *testing.T) {
 	}
 }
 
-// The guarantee the per-holder tier exists for: a holder that floods is refused
-// by the bound on itself, and every other holder keeps writing.
+// A holder that floods is refused by the bound on itself; every other holder
+// keeps writing.
 func TestFloodingHolderDoesNotRefuseAnother(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(8, 2, 8)
@@ -213,45 +253,63 @@ func TestFloodingHolderDoesNotRefuseAnother(t *testing.T) {
 	}
 }
 
-// The shipped quota, which every other test replaces with a small one.
 func TestDefaultMaxPathsPerHolder(t *testing.T) {
 	ctx := context.Background()
+	if DefaultMaxPathsPerHolder != 64 {
+		t.Fatalf("the shipped quota is %d, want 64", DefaultMaxPathsPerHolder)
+	}
 	s := NewMemoryStore(1024, DefaultMaxPathsPerHolder, 8)
 	api := WorkloadHolder("api")
 
-	for i := range 64 {
+	for i := range DefaultMaxPathsPerHolder {
 		if _, _, err := s.PutIfAbsent(ctx, fmt.Sprintf("/api/%d", i), []byte("ok"), api); err != nil {
 			t.Fatalf("write %d under the default quota: %v", i+1, err)
 		}
 	}
-	if _, _, err := s.PutIfAbsent(ctx, "/api/64", []byte("ok"), api); !errors.Is(err, ErrHolderQuota) {
-		t.Fatalf("write 65 under the default quota = %v, want ErrHolderQuota", err)
+	if _, _, err := s.PutIfAbsent(ctx, "/api/last", []byte("ok"), api); !errors.Is(err, ErrHolderQuota) {
+		t.Fatalf("write %d under the default quota = %v, want ErrHolderQuota", DefaultMaxPathsPerHolder+1, err)
 	}
 }
 
-// A quota above the ceiling never fires: the ceiling answers first.
 func TestNewMemoryStoreRejectsAQuotaAboveTheCeiling(t *testing.T) {
-	defer func() {
-		if recover() == nil {
-			t.Fatal("a store whose quota is above its ceiling was built")
-		}
-	}()
-	NewMemoryStore(2, 3, 8)
+	for _, tc := range []struct {
+		name            string
+		maxPaths, quota int
+		wantPanic       bool
+	}{
+		{"at the ceiling", 2, 2, true},
+		{"above the ceiling", 2, 3, true},
+		{"one below the ceiling", 2, 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if recovered := recover() != nil; recovered != tc.wantPanic {
+					t.Fatalf("NewMemoryStore(%d, %d, 8) panicked=%v, want %v", tc.maxPaths, tc.quota, recovered, tc.wantPanic)
+				}
+			}()
+			NewMemoryStore(tc.maxPaths, tc.quota, 8)
+		})
+	}
 }
 
 // With both bounds exceeded at once the holder's quota is the one that answers.
+// The collision needs a third holder: at a legal quota one holder cannot reach
+// the ceiling alone.
 func TestHolderQuotaAnswersBeforeTheCeiling(t *testing.T) {
 	ctx := context.Background()
-	s := NewMemoryStore(2, 2, 8)
-	api := WorkloadHolder("api")
+	s := NewMemoryStore(3, 2, 8)
+	api, web := WorkloadHolder("api"), WorkloadHolder("web")
 
 	for _, p := range []string{"/api/1", "/api/2"} {
 		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok"), api); err != nil {
 			t.Fatalf("put %s: %v", p, err)
 		}
 	}
-	if s.Len() != 2 {
-		t.Fatalf("Len = %d, want the ceiling reached as well as the quota", s.Len())
+	if _, _, err := s.PutIfAbsent(ctx, "/web/1", []byte("ok"), web); err != nil {
+		t.Fatal(err)
+	}
+	if s.Len() != 3 {
+		t.Fatalf("Len = %d, want the ceiling reached as well as api's quota", s.Len())
 	}
 	if _, _, err := s.PutIfAbsent(ctx, "/api/3", []byte("ok"), api); !errors.Is(err, ErrHolderQuota) {
 		t.Fatalf("both bounds exceeded = %v, want ErrHolderQuota", err)
@@ -293,13 +351,13 @@ func TestMemoryStoreCeilingRefusesWithoutEvicting(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(2, 1, 8)
 
-	stored := map[string]string{"/a/1": "a-value", "/b/1": "b-value"}
-	for p, v := range stored {
-		if _, _, err := s.PutIfAbsent(ctx, p, []byte(v), WorkloadHolder(p)); err != nil {
-			t.Fatalf("put %s: %v", p, err)
+	stored := map[string]string{"/one": "a-value", "/two": "b-value"}
+	for _, w := range []struct{ holder, path string }{{"a", "/one"}, {"b", "/two"}} {
+		if _, _, err := s.PutIfAbsent(ctx, w.path, []byte(stored[w.path]), WorkloadHolder(w.holder)); err != nil {
+			t.Fatalf("put %s: %v", w.path, err)
 		}
 	}
-	if _, _, err := s.PutIfAbsent(ctx, "/c/1", []byte("c-value"), WorkloadHolder("/c/1")); !errors.Is(err, ErrStoreFull) {
+	if _, _, err := s.PutIfAbsent(ctx, "/three", []byte("c-value"), WorkloadHolder("c")); !errors.Is(err, ErrStoreFull) {
 		t.Fatalf("put at the ceiling = %v, want ErrStoreFull", err)
 	}
 	for p, v := range stored {
@@ -307,6 +365,29 @@ func TestMemoryStoreCeilingRefusesWithoutEvicting(t *testing.T) {
 		if err != nil || !bytes.Equal(got, []byte(v)) {
 			t.Fatalf("%s = %q %v, want %q still stored", p, got, err, v)
 		}
+	}
+}
+
+// The quota bounds one holder, not the store: enough holders one path apiece
+// still reach the ceiling, and the holder that arrives after them is refused.
+// What the quota buys is the size of the blast radius, not its absence.
+func TestManyHoldersStillReachTheCeiling(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(8, 2, 8)
+
+	for i := range 8 {
+		p := fmt.Sprintf("/w%d/1", i)
+		if _, _, err := s.PutIfAbsent(ctx, p, []byte("ok"), WorkloadHolder(fmt.Sprintf("w%d", i))); err != nil {
+			t.Fatalf("holder %d's only path: %v", i, err)
+		}
+	}
+	late := WorkloadHolder("late")
+	if _, _, err := s.PutIfAbsent(ctx, "/late/1", []byte("ok"), late); !errors.Is(err, ErrStoreFull) {
+		t.Fatalf("a holder arriving at the full store = %v, want ErrStoreFull", err)
+	}
+	// It is the ceiling, not its own quota, that refuses it.
+	if total, paths := holderTotal(s); total != paths || paths != 8 {
+		t.Fatalf("holder counts sum to %d over %d paths, want both 8", total, paths)
 	}
 }
 
@@ -376,6 +457,44 @@ func TestMemoryStoreQuotaUnderConcurrentWrites(t *testing.T) {
 	}
 	if total, paths := holderTotal(s); total != paths || paths != 8 {
 		t.Fatalf("holder counts sum to %d over %d paths, want both 8", total, paths)
+	}
+}
+
+// The census names the holders and their counts, largest first, and never a
+// value.
+func TestTopHolders(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore(16, 4, 16)
+
+	for i := range 3 {
+		if _, _, err := s.PutIfAbsent(ctx, fmt.Sprintf("/api/%d", i), []byte("api-value"), WorkloadHolder("api")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, _, err := s.PutIfAbsent(ctx, "/web/1", []byte("web-value"), WorkloadHolder("web")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Put(ctx, "/op/1", []byte("op-value"), OperatorHolder()); err != nil {
+		t.Fatal(err)
+	}
+
+	got := s.TopHolders(2)
+	if len(got) != 2 {
+		t.Fatalf("TopHolders(2) returned %d holders", len(got))
+	}
+	if got[0].Holder != WorkloadHolder("api") || got[0].Paths != 3 {
+		t.Fatalf("largest holder = %+v, want api holding 3", got[0])
+	}
+	if got[1].Paths != 1 {
+		t.Fatalf("second holder = %+v, want a single path", got[1])
+	}
+	if n := len(s.TopHolders(10)); n != 3 {
+		t.Fatalf("TopHolders(10) returned %d holders, want every one of the 3", n)
+	}
+	for _, hp := range s.TopHolders(10) {
+		if strings.Contains(hp.Holder.String(), "value") {
+			t.Fatalf("a holder rendered a stored value: %s", hp.Holder)
+		}
 	}
 }
 

--- a/pkg/types/error_codes.go
+++ b/pkg/types/error_codes.go
@@ -25,4 +25,8 @@ const (
 	// front door, whose host-visible serving key cannot support transport
 	// binding; that deployment shape is attest-pq-only.
 	ErrorCodeUnsupportedFrontDoor = "unsupported_front_door"
+	// ErrorCodeSecretHolderQuota: the caller is at --secrets-max-paths-per-workload.
+	ErrorCodeSecretHolderQuota = "secret_holder_quota"
+	// ErrorCodeSecretStoreFull: the store is at --secrets-max-paths.
+	ErrorCodeSecretStoreFull = "secret_store_full"
 )


### PR DESCRIPTION
The chart renders --secrets-max-paths-per-workload but nothing renders --secrets-max-paths, so under Helm the ceiling is pinned to the binary default of 1024. values.yaml documents raising the per-workload quota as the remedy for a workload hitting it, and raising it to 1024 or above produces a CDS that refuses to start. The CDS Deployment rolls with strategy: Recreate, so the serving pod is deleted before the replacement CrashLoops, and CDS is the mesh CA and the only /sign-csr — an ordinary values edit takes certificate issuance down cluster-wide, and the fix docs/secrets.md prescribes is unreachable through the chart. cds.yaml now renders both flags through c8s.positiveInt from cds.secretsMaxPaths and cds.secretsMaxPathsPerWorkload, and validations.yaml fails the render on quota >= ceiling (VALIDATION_ERROR kind=cds_secrets_path_budget), so the pair is refused by `helm template` rather than by a CrashLoop.

NewMemoryStore panicked on maxPerHolder > maxPaths while validateSecretsConfig rejects >=, so the store admitted exactly the pair CDS will not start on. It is the pair that matters: at equality one holder can fill the store, which is the lockout the quota exists to remove. The guard is now >= and twelve fixtures move one below their ceiling, so the handler suite no longer runs on stores CDS would refuse — and no longer on stores in which the per-holder tier can never bind before the ceiling. TestNewMemoryStoreRejectsAQuotaAboveTheCeiling becomes a table over {2,2}, {2,3} and {2,1}, mirroring TestSecretsQuotaMustStayBelowTheCeiling.

The quota/ceiling relation, stated once: the quota is checked before the ceiling, so it must be reachable first to do anything. At the ceiling it never binds before the store is already full; above it, it can never fire at all. Below it, a flooding entry meets a bound charged to itself while every other entry keeps writing. That is why validateSecretsConfig, the chart guard and NewMemoryStore all enforce the same strict relation, and why the justification now lives here rather than at six code sites.

ErrHolderQuota and ErrStoreFull were collapsed into one 507 body, so a caller could not tell whether to shrink its own footprint or page an operator. Both keep 507 — a path quota is storage, not rate, and 429 would misdescribe the condition and change retry semantics — and are now distinguished by error code in the c8s error envelope, secret_holder_quota and secret_store_full. Distinguishing them tells a caller under its own quota that the aggregate is full, which is a near-worthless occupancy signal it can already infer from being refused; the operational ambiguity is real and costs an operator a debugging session. #77 separates the per-client bound from the store-full case and #95 says to follow that shape.

A ceiling refusal named only the workload that lost, not the ones holding the paths. It now logs a census of the largest holders, server-side only: on the wire it would hand one tenant a list of others.

get-secret treated a 507 as retryable, spending 60 attempts over 5 minutes before the kubelet restarts the sidecar for the pod's life. The store evicts nothing, so a bound it has reached is still reached on the next attempt: sidecar.Retry now stops on a Terminal error and fetchOne marks 507 as one.

Also: --secrets-max-value-bytes below 32 turned every workload's first POST into a 500, since Generate always mints GeneratedValueBytes and checkValue's error is not a bound; validateSecretsConfig now refuses it at startup. Put's replace branch moves a charge without a quota check — the invariant is stated on the interface and pinned by a test rather than guarded against a caller that does not exist, since only the quota-exempt operator calls it. testBulkImg was byte-identical to testAppImg2, so the two entries were separated only by argv and any future widening would have turned every test in handler_test.go and explain_test.go into an ambiguous denial; it gets its own digest and is declared in the test that needs it. Tests added for the ordering collision in a legal config, for a workload refused by the ceiling while under its own quota, for a quota refusal evicting nothing, and for many holders one path apiece still reaching the ceiling — the bound limits the blast radius, it does not eliminate lockout.

TestGenerate's assertion against the literal 32, added in the parent commit, is unrelated to quotas; it stays, because the form it replaced compared Generate's output against the constant Generate allocates from and could not fail. TestDefaultMaxPathsPerHolder is made consistent with it: the shipped 64 is pinned once, explicitly.

The shipped defaults admit sixteen entries at quota before the ceiling is exhausted; the seventeenth holder's first write is refused. Reserving floor capacity per holder and raising the shipped ceiling are both policy with memory and fairness consequences, and #106 is open on saturation for the sibling pools. Neither is done here.