### PR TITLE
ci: arm the cw-guard rule assertions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,14 @@ jobs:
             exit 1
           fi
 
+      # The cw-guard rule assertions resolve through iptables-translate;
+      # C8S_REQUIRE_IPTABLES_TRANSLATE fails the job if it is missing.
+      - name: Install iptables
+        run: sudo apt-get update && sudo apt-get install -y iptables
+
       - name: Test
+        env:
+          C8S_REQUIRE_IPTABLES_TRANSLATE: "1"
         run: make test
 
       # The advisory mutation job only exercises the 0-mutant path on


### PR DESCRIPTION
TestCWGuardExemptionsTranslateToExpectedNftMatches resolves its golden nft matches through iptables-translate and ip6tables-translate, and skips when either is absent. No job set C8S_REQUIRE_IPTABLES_TRANSLATE, so the matches behind the confidential-workload guard were asserted on no lane and a rule-generation regression passed CI green.

The test job installs iptables and sets the variable, so both binaries are present and their absence fails the job instead of skipping it.