### PR TITLE
fix(cds): make only the store ceiling terminal, and put the census on the Store

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -116,7 +116,8 @@ one caller and cannot be replayed.
 ```
 POST /secrets                      → {"challenge": "<base64>"}
 GET  /secrets/<store path>         → 200 {"value": "<base64>"} | 404 | 403
-POST /secrets/<store path>         → 201 {"value": "<base64>"} | 409 | 403 | 507
+POST /secrets/<store path>         → 201 {"value": "<base64>"} | 409 | 403
+                                   → 507 {"error": "secret_holder_quota"|"secret_store_full"}
 ```
 
 `PUT` on the same paths is the operator's, authorized by the operator key
@@ -181,7 +182,7 @@ PUT /secrets/<store path>   {"value": "<base64>", "overwrite": <bool>}
                             → 201 {"created": true}
                             → 409 {"existing": "workload"|"operator"}
                             → 200 {"existing": "workload"|"operator"}
-                            → 507 {"error": "secret_store_full"} a bound refused it
+                            → 507 {"error": "secret_store_full"} the ceiling refused it
 ```
 
 Authorization is the operator key that CDS already pins for allowlist writes

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -515,6 +515,9 @@ func normalizeHTTPServerConfig(cfg config) config {
 	return cfg
 }
 
+// newSecretsStore builds the store from sizing flags validateSecretsConfig has
+// already checked: NewMemoryStore panics on a pair validateSecretsConfig
+// refuses.
 func newSecretsStore(cfg config) *secrets.MemoryStore {
 	return secrets.NewMemoryStore(cfg.secretsMaxPaths, cfg.secretsMaxPathsPerWorkload, cfg.secretsMaxValueBytes)
 }
@@ -522,8 +525,8 @@ func newSecretsStore(cfg config) *secrets.MemoryStore {
 // validateSecretsConfig checks the bounds on secret storage. What secrets are
 // released to is policy, not configuration — see secretsEnabled.
 func validateSecretsConfig(cfg config) error {
-	if cfg.secretsMaxPaths <= 0 || cfg.secretsMaxPathsPerWorkload <= 0 || cfg.secretsMaxValueBytes <= 0 || cfg.sandboxLedgerMax <= 0 {
-		return fmt.Errorf("--secrets-max-paths, --secrets-max-paths-per-workload, --secrets-max-value-bytes and --sandbox-ledger-max-entries must be positive")
+	if cfg.secretsMaxPaths <= 0 || cfg.secretsMaxPathsPerWorkload <= 0 || cfg.sandboxLedgerMax <= 0 {
+		return fmt.Errorf("--secrets-max-paths, --secrets-max-paths-per-workload and --sandbox-ledger-max-entries must be positive")
 	}
 	if cfg.secretsMaxPathsPerWorkload >= cfg.secretsMaxPaths {
 		return fmt.Errorf("--secrets-max-paths-per-workload (%d) must be below --secrets-max-paths (%d), or one workload can fill the store", cfg.secretsMaxPathsPerWorkload, cfg.secretsMaxPaths)

--- a/internal/cmds/cds/secrets_config_test.go
+++ b/internal/cmds/cds/secrets_config_test.go
@@ -3,6 +3,7 @@ package cds
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -175,8 +176,12 @@ func TestSecretsSizingMustBePositive(t *testing.T) {
 		t.Run(tc.flag, func(t *testing.T) {
 			cfg := secretsReadyConfig()
 			tc.brk(&cfg)
-			if err := validateSecretsConfig(cfg); err == nil {
+			err := validateSecretsConfig(cfg)
+			if err == nil {
 				t.Fatalf("%s was accepted at zero", tc.flag)
+			}
+			if !strings.Contains(err.Error(), tc.flag) {
+				t.Fatalf("%s at zero reported %q, want the flag named", tc.flag, err)
 			}
 		})
 	}
@@ -196,8 +201,12 @@ func TestSecretsQuotaMustStayBelowTheCeiling(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := secretsReadyConfig()
 			cfg.secretsMaxPathsPerWorkload = tc.quota(cfg.secretsMaxPaths)
-			if err := validateSecretsConfig(cfg); err == nil {
+			err := validateSecretsConfig(cfg)
+			if err == nil {
 				t.Fatalf("--secrets-max-paths-per-workload=%d was accepted against --secrets-max-paths=%d", cfg.secretsMaxPathsPerWorkload, cfg.secretsMaxPaths)
+			}
+			if want := "--secrets-max-paths-per-workload (%d) must be below --secrets-max-paths"; !strings.Contains(err.Error(), fmt.Sprintf(want, cfg.secretsMaxPathsPerWorkload)) {
+				t.Fatalf("err = %q, want the quota/ceiling check", err)
 			}
 		})
 	}
@@ -213,8 +222,12 @@ func TestSecretsQuotaMustStayBelowTheCeiling(t *testing.T) {
 func TestSecretsValueBoundHoldsAGeneratedValue(t *testing.T) {
 	cfg := secretsReadyConfig()
 	cfg.secretsMaxValueBytes = secrets.GeneratedValueBytes - 1
-	if err := validateSecretsConfig(cfg); err == nil {
+	err := validateSecretsConfig(cfg)
+	if err == nil {
 		t.Fatalf("--secrets-max-value-bytes=%d was accepted below a generated value", cfg.secretsMaxValueBytes)
+	}
+	if !strings.Contains(err.Error(), "--secrets-max-value-bytes") {
+		t.Fatalf("err = %q, want the value-bytes check", err)
 	}
 	cfg.secretsMaxValueBytes = secrets.GeneratedValueBytes
 	if err := validateSecretsConfig(cfg); err != nil {

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -68,6 +68,7 @@ type fakeCDS struct {
 type reply struct {
 	status int
 	value  string // raw value; encoded as base64 in the response
+	code   string // c8s error-envelope code, for a non-2xx body
 }
 
 func newFakeCDS(t *testing.T, replies map[string][]reply) (*fakeCDS, string) {
@@ -107,6 +108,9 @@ func (f *fakeCDS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	f.replies[key] = queue[1:]
 	if next.status != http.StatusOK && next.status != http.StatusCreated {
 		w.WriteHeader(next.status)
+		if next.code != "" {
+			json.NewEncoder(w).Encode(types.ErrorResponse{Error: next.code, Message: "secret storage limit reached"})
+		}
 		return
 	}
 	w.WriteHeader(next.status)
@@ -189,14 +193,13 @@ func TestFetchOneRereadsAfterLosingCreateRace(t *testing.T) {
 	}
 }
 
-// The store evicts nothing, so a 507 does not clear without a CDS restart.
-// Retrying it spends the whole budget and then hands the pod to the kubelet,
-// which restarts the sidecar for the pod's life; fail on the first pass instead.
+// The ceiling clears only on a CDS restart, which empties the store, so
+// retrying it cannot succeed.
 func TestFetchStopsRetryingWhenTheStoreIsFull(t *testing.T) {
 	endpoint := startInventory(t)
 	cds, url := newFakeCDS(t, map[string][]reply{
 		"GET /secrets/api/db":  {{status: http.StatusNotFound}},
-		"POST /secrets/api/db": {{status: http.StatusInsufficientStorage}},
+		"POST /secrets/api/db": {{status: http.StatusInsufficientStorage, code: types.ErrorCodeSecretStoreFull}},
 	})
 	cfg := flowConfig(t, url)
 	pub := testKey(t)
@@ -213,6 +216,51 @@ func TestFetchStopsRetryingWhenTheStoreIsFull(t *testing.T) {
 	want := []string{"GET /secrets/api/db", "POST /secrets/api/db"}
 	if !equal(cds.requests, want) {
 		t.Fatalf("requests = %v, want the single pass %v", cds.requests, want)
+	}
+}
+
+// Every other create failure keeps retrying: an operator overwrite frees holder
+// quota with no restart, and a 500 is not a bound at all. Both share the branch
+// the ceiling is terminal on.
+func TestFetchRetriesCreateFailuresThatCanClear(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		refusal reply
+	}{
+		{"holder quota", reply{status: http.StatusInsufficientStorage, code: types.ErrorCodeSecretHolderQuota}},
+		{"507 with no envelope", reply{status: http.StatusInsufficientStorage}},
+		{"server failure", reply{status: http.StatusInternalServerError}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint := startInventory(t)
+			cds, url := newFakeCDS(t, map[string][]reply{
+				"GET /secrets/api/db":  {{status: http.StatusNotFound}, {status: http.StatusNotFound}},
+				"POST /secrets/api/db": {tc.refusal, {status: http.StatusCreated, value: "minted"}},
+			})
+			cfg := flowConfig(t, url)
+			cfg.RetryInterval = time.Millisecond
+			cfg.Attempts = 2
+			pub := testKey(t)
+			var values map[string][]byte
+			err := sidecar.Retry(context.Background(), cfg.Config, "secret", func(ctx context.Context) error {
+				var err error
+				values, err = fetchAllWith(ctx, cfg, http.DefaultClient, pub, endpoint)
+				return err
+			})
+			if err != nil {
+				t.Fatalf("a refusal that can clear was treated as terminal: %v", err)
+			}
+			if string(values["DB"]) != "minted" {
+				t.Fatalf("value = %q, want the second pass's", values["DB"])
+			}
+			want := []string{
+				"GET /secrets/api/db", "POST /secrets/api/db",
+				"GET /secrets/api/db", "POST /secrets/api/db",
+			}
+			if !equal(cds.requests, want) {
+				t.Fatalf("requests = %v, want two passes %v", cds.requests, want)
+			}
+		})
 	}
 }
 

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -12,6 +12,7 @@ package getsecret
 import (
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -24,6 +25,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/cmds/sidecar"
 	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // config is everything the sidecar needs. The webhook renders all of it.
@@ -139,9 +141,13 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 	case status == http.StatusCreated:
 		return value, nil
 	case status == http.StatusInsufficientStorage:
-		// The store evicts nothing, so a bound it has reached is still reached
-		// on every later attempt.
-		return nil, sidecar.Terminal(err)
+		// The ceiling clears only on a CDS restart; the holder quota clears
+		// whenever an operator moves a charge off this entry.
+		var refusal *sidecar.StatusError
+		if errors.As(err, &refusal) && refusal.Code == types.ErrorCodeSecretStoreFull {
+			return nil, sidecar.Terminal(err)
+		}
+		return nil, err
 	case status != http.StatusConflict:
 		return nil, err
 	}

--- a/internal/cmds/sidecar/client.go
+++ b/internal/cmds/sidecar/client.go
@@ -105,8 +105,29 @@ func Do(ctx context.Context, cfg Config, client *http.Client, pub crypto.PublicK
 	default:
 		// The body is deliberately opaque; the reason is in the CDS log.
 		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return nil, resp.StatusCode, fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(detail)))
+		return nil, resp.StatusCode, &StatusError{
+			Code: envelopeCode(detail),
+			Err:  fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, strings.TrimSpace(string(detail))),
+		}
 	}
+}
+
+// StatusError is a non-2xx answer from CDS. Code is the c8s error-envelope code
+// its body named, and is empty for a body that is not an envelope.
+type StatusError struct {
+	Code string
+	Err  error
+}
+
+func (e *StatusError) Error() string { return e.Err.Error() }
+func (e *StatusError) Unwrap() error { return e.Err }
+
+func envelopeCode(body []byte) string {
+	var env types.ErrorResponse
+	if json.Unmarshal(body, &env) != nil {
+		return ""
+	}
+	return env.Error
 }
 
 func fetchChallenge(ctx context.Context, cfg Config, client *http.Client) ([]byte, error) {

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -111,8 +111,8 @@ func (c *Config) ParseMeasurements() ([][]byte, error) {
 	return measurements, nil
 }
 
-// Terminal marks an error no later attempt can clear, so Retry stops on it
-// rather than spending its whole budget.
+// Terminal marks a non-nil error no later attempt can clear, so Retry stops on
+// it.
 func Terminal(err error) error { return terminal{err} }
 
 type terminal struct{ err error }

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -162,15 +162,12 @@
 {{- end -}}
 {{- /*
   CDS refuses to start unless the per-workload secret quota is strictly below
-  the store ceiling, and its Deployment rolls with strategy: Recreate — the
-  serving pod is deleted before the replacement CrashLoops, and CDS is the mesh
-  CA and the only /sign-csr. Catching the pair here turns a cluster-wide
-  certificate-issuance outage into a failed `helm template`.
+  the store ceiling, so the pair is refused here instead.
 */ -}}
 {{- $secretsCeiling := int (include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPaths "label" "cds.secretsMaxPaths")) -}}
 {{- $secretsQuota := int (include "c8s.positiveInt" (dict "value" .Values.cds.secretsMaxPathsPerWorkload "label" "cds.secretsMaxPathsPerWorkload")) -}}
 {{- if ge $secretsQuota $secretsCeiling -}}
-{{- fail (printf "VALIDATION_ERROR kind=cds_secrets_path_budget: cds.secretsMaxPathsPerWorkload must be below cds.secretsMaxPaths (%d), got: %d. Raise cds.secretsMaxPaths alongside it — CDS refuses to start on this pair, and its Recreate rollout deletes the serving pod first, so the cluster loses certificate issuance until the values are fixed." $secretsCeiling $secretsQuota) -}}
+{{- fail (printf "VALIDATION_ERROR kind=cds_secrets_path_budget: cds.secretsMaxPathsPerWorkload must be below cds.secretsMaxPaths (%d), got: %d" $secretsCeiling $secretsQuota) -}}
 {{- end -}}
 {{- /*
   Per-container `paths` was replaced by an entry-level `secrets` grant. CDS

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -234,8 +234,7 @@ cds:
   # cds.secretsMaxPaths; the chart refuses to render otherwise.
   secretsMaxPathsPerWorkload: 64
   # -- Max secret paths CDS holds in memory across every workload. Raise this
-  # alongside secretsMaxPathsPerWorkload; the store is process memory in the pod
-  # that also holds the mesh CA.
+  # alongside secretsMaxPathsPerWorkload.
   secretsMaxPaths: 1024
   readinessInterval: 10s
   ## /sign-csr CSRs arrive without a matching TCP source IP under chart routing,

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -1253,8 +1253,8 @@ func TestChartCDSPinnedToCDSNode(t *testing.T) {
 	}
 }
 
-// Both secret path bounds are chart-settable: sizing the quota without the
-// ceiling it must stay below renders a CDS that will not start.
+// Both secret path bounds are chart-settable, up to a quota one below the
+// ceiling — the largest the guard admits.
 func TestChartCDSSecretsPathQuotaFlagsThrough(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -1266,6 +1266,11 @@ func TestChartCDSSecretsPathQuotaFlagsThrough(t *testing.T) {
 			"sized",
 			[]string{"--set", "cds.secretsMaxPaths=256", "--set", "cds.secretsMaxPathsPerWorkload=8"},
 			[]string{"--secrets-max-paths=256", "--secrets-max-paths-per-workload=8"},
+		},
+		{
+			"quota one below the ceiling",
+			[]string{"--set", "cds.secretsMaxPaths=256", "--set", "cds.secretsMaxPathsPerWorkload=255"},
+			[]string{"--secrets-max-paths=256", "--secrets-max-paths-per-workload=255"},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1281,24 +1286,25 @@ func TestChartCDSSecretsPathQuotaFlagsThrough(t *testing.T) {
 	}
 }
 
-// The pair CDS refuses to start on is refused at template time instead: its
-// Recreate rollout deletes the serving pod before the replacement CrashLoops.
+// The pair CDS refuses to start on is refused at template time instead.
 func TestChartCDSSecretsQuotaAboveTheCeilingFailsRendering(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		set  []string
+		want string
 	}{
-		{"at the ceiling", []string{"--set", "cds.secretsMaxPaths=64"}},
-		{"above the ceiling", []string{"--set", "cds.secretsMaxPaths=32"}},
-		{"raised quota, default ceiling", []string{"--set", "cds.secretsMaxPathsPerWorkload=1024"}},
+		{"at the ceiling", []string{"--set", "cds.secretsMaxPaths=64"}, "kind=cds_secrets_path_budget"},
+		{"above the ceiling", []string{"--set", "cds.secretsMaxPaths=32"}, "kind=cds_secrets_path_budget"},
+		{"raised quota, default ceiling", []string{"--set", "cds.secretsMaxPathsPerWorkload=1024"}, "kind=cds_secrets_path_budget"},
+		{"zero ceiling", []string{"--set", "cds.secretsMaxPaths=0"}, "cds.secretsMaxPaths must be a positive integer"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := helmTemplate(t, tc.set...)
 			if err == nil {
 				t.Fatalf("a quota at or above the ceiling rendered:\n%s", out)
 			}
-			if !strings.Contains(out, "kind=cds_secrets_path_budget") {
-				t.Fatalf("render failed without naming the guard: %v\n%s", err, out)
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("render failed without %q: %v\n%s", tc.want, err, out)
 			}
 		})
 	}

--- a/internal/httputil/error.go
+++ b/internal/httputil/error.go
@@ -1,0 +1,16 @@
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// WriteError answers in the c8s error-envelope shape: code is one of
+// pkg/types' stable wire identifiers, message is prose for a human.
+func WriteError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: code, Message: message})
+}

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/confidential-dot-ai/c8s/internal/httputil"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -224,10 +225,12 @@ func (h Handler) servePost(ctx context.Context, w http.ResponseWriter, g grant, 
 		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretHolderQuota, "secret storage limit reached")
 		return
 	case errors.Is(err, ErrStoreFull):
-		// The census names the holders, and never the wire: it is other
-		// tenants' occupancy.
-		h.logger().Warn("secret create refused", "path", path, "workload", g.workload, "error", err,
-			"holders", census(h.Store, censusHolders))
+		// Enabled gates the census: slog evaluates attributes before it filters
+		// on level.
+		if log := h.logger(); log.Enabled(ctx, slog.LevelWarn) {
+			log.Warn("secret create refused", "path", path, "workload", g.workload, "error", err,
+				"holders", h.Store.TopHolders(censusHolders))
+		}
 		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretStoreFull, "secret storage limit reached")
 		return
 	}
@@ -259,35 +262,15 @@ func writeValue(w http.ResponseWriter, value []byte, status int) {
 	_ = json.NewEncoder(w).Encode(valueResponse{Value: base64.StdEncoding.EncodeToString(value)})
 }
 
-// writeError answers in the c8s error-envelope shape, so a caller reads which
-// bound refused it from code rather than from the message.
+// writeError is httputil.WriteError with the no-store every secrets response
+// carries.
 func writeError(w http.ResponseWriter, status int, code, message string) {
-	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: code, Message: message})
+	httputil.WriteError(w, status, code, message)
 }
 
 // censusHolders is how many holders the full-store log line names.
 const censusHolders = 5
-
-// storeCensus is the holder breakdown a store offers.
-type storeCensus interface {
-	TopHolders(n int) []HolderPaths
-}
-
-// census renders the largest holders for a log line.
-func census(s Store, n int) string {
-	c, ok := s.(storeCensus)
-	if !ok {
-		return ""
-	}
-	parts := make([]string, 0, n)
-	for _, hp := range c.TopHolders(n) {
-		parts = append(parts, fmt.Sprintf("%s=%d", hp.Holder, hp.Paths))
-	}
-	return strings.Join(parts, " ")
-}
 
 // requestPath returns the canonical store path a request names.
 //

--- a/internal/secrets/handler_errors_test.go
+++ b/internal/secrets/handler_errors_test.go
@@ -22,9 +22,10 @@ func (f failingStore) Get(context.Context, string) ([]byte, error) { return nil,
 func (f failingStore) PutIfAbsent(context.Context, string, []byte, Holder) ([]byte, Held, error) {
 	return nil, Held{}, f.err
 }
-func (f failingStore) Put(context.Context, string, []byte, Holder) (Held, error) {
+func (f failingStore) Put(context.Context, string, []byte) (Held, error) {
 	return Held{}, f.err
 }
+func (f failingStore) TopHolders(int) []HolderPaths { return nil }
 
 // A store failure is not a policy denial: the caller is told the secret is
 // unavailable, and the reason stays in the CDS log.

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -17,6 +17,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -308,9 +309,39 @@ func mintToken(t *testing.T, signer *workloadclaims.SandboxTokenSigner, sandboxI
 // seed plants a value directly, bypassing the release path under test.
 func (hn *harness) seed(t *testing.T, path string, value []byte) {
 	t.Helper()
-	if _, err := hn.store.Put(context.Background(), path, value, OperatorHolder()); err != nil {
+	if _, err := hn.store.Put(context.Background(), path, value); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// seedAs is seed charged to holder rather than to the operator.
+func (hn *harness) seedAs(t *testing.T, path string, holder Holder) {
+	t.Helper()
+	if _, _, err := hn.store.PutIfAbsent(context.Background(), path, []byte("neighbour-value"), holder); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// loggedHolder is one census entry as it lands in CDS's JSON log.
+type loggedHolder struct {
+	Holder string `json:"holder"`
+	Paths  int    `json:"paths"`
+}
+
+// logCensus collects the holders attribute from every captured log line.
+func logCensus(t *testing.T, out string) []loggedHolder {
+	t.Helper()
+	var found []loggedHolder
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		var rec struct {
+			Holders []loggedHolder `json:"holders"`
+		}
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("log line is not JSON: %q", line)
+		}
+		found = append(found, rec.Holders...)
+	}
+	return found
 }
 
 // assertNoRelease fails if a refused response carries value, raw or base64.
@@ -720,15 +751,21 @@ func TestQuotaIsPerWorkloadNotPerSandbox(t *testing.T) {
 
 // A workload that has spent none of its quota is still refused by the ceiling
 // when other holders have filled the store, and the refusal names the ceiling
-// rather than the quota — the two are one status apart and only the code tells
-// the workload whether shrinking its own footprint would help.
+// rather than the quota. Who holds the paths reaches the CDS log; the body
+// carries the code and nothing else.
 func TestCeilingRefusesAWorkloadUnderItsQuota(t *testing.T) {
 	hn := newHarness(t)
-	hn.setStore(t, NewMemoryStore(2, 1, 64))
-	// Operator values are exempt from the quota, so the store fills without
-	// anything being charged to the workload.
-	hn.seed(t, "/op/1", []byte("operator-value"))
-	hn.seed(t, "/op/2", []byte("operator-value"))
+	hn.setStore(t, NewMemoryStore(7, 3, 64))
+	var log bytes.Buffer
+	hn.h.Logger = slog.New(slog.NewJSONHandler(&log, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Six neighbours fill the store, the first holding two paths: enough for
+	// the census to have a largest holder and one holder it must leave out.
+	hn.seedAs(t, "/n1/a", WorkloadHolder("neighbour-1"))
+	hn.seedAs(t, "/n1/b", WorkloadHolder("neighbour-1"))
+	for i := 2; i <= 6; i++ {
+		hn.seedAs(t, fmt.Sprintf("/n%d/a", i), WorkloadHolder(fmt.Sprintf("neighbour-%d", i)))
+	}
 
 	w := do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
 	if w.Code != http.StatusInsufficientStorage {
@@ -737,15 +774,34 @@ func TestCeilingRefusesAWorkloadUnderItsQuota(t *testing.T) {
 	if code := errorCode(t, w); code != types.ErrorCodeSecretStoreFull {
 		t.Fatalf("error code = %q, want %q", code, types.ErrorCodeSecretStoreFull)
 	}
-	if hn.store.Len() != 2 {
-		t.Fatalf("store holds %d paths after a refusal, want the 2 it started with", hn.store.Len())
+	if hn.store.Len() != 7 {
+		t.Fatalf("store holds %d paths after a refusal, want the 7 it started with", hn.store.Len())
+	}
+
+	want := []loggedHolder{
+		{`workload "neighbour-1"`, 2},
+		{`workload "neighbour-2"`, 1},
+		{`workload "neighbour-3"`, 1},
+		{`workload "neighbour-4"`, 1},
+		{`workload "neighbour-5"`, 1},
+	}
+	if got := logCensus(t, log.String()); !slices.Equal(got, want) {
+		t.Fatalf("logged census = %+v, want the %d largest holders %+v:\n%s", got, censusHolders, want, log.String())
+	}
+	for _, leak := range []string{"neighbour", "holders", "paths"} {
+		if strings.Contains(w.Body.String(), leak) {
+			t.Fatalf("the refusal body carried the census (%q): %s", leak, w.Body)
+		}
 	}
 }
 
-// A workload at its own quota is told so, below a store that has room.
+// A workload at its own quota is told so, below a store that has room. The
+// census belongs to the ceiling, so this refusal does not carry one.
 func TestQuotaRefusalNamesTheQuota(t *testing.T) {
 	hn := newHarness(t)
 	hn.setStore(t, NewMemoryStore(16, 1, 64))
+	var log bytes.Buffer
+	hn.h.Logger = slog.New(slog.NewJSONHandler(&log, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	if w := do(hn.h, hn.request(t, http.MethodPost, "/api/db")); w.Code != http.StatusCreated {
 		t.Fatalf("first POST = %d (%s), want 201", w.Code, w.Body)
@@ -756,6 +812,18 @@ func TestQuotaRefusalNamesTheQuota(t *testing.T) {
 	}
 	if code := errorCode(t, w); code != types.ErrorCodeSecretHolderQuota {
 		t.Fatalf("error code = %q, want %q", code, types.ErrorCodeSecretHolderQuota)
+	}
+	if got := logCensus(t, log.String()); len(got) != 0 {
+		t.Fatalf("a quota refusal logged a census: %+v\n%s", got, log.String())
+	}
+}
+
+// The two codes are a published wire contract: docs/secrets.md and every
+// deployed client switch on these exact strings.
+func TestSecretErrorCodeWireValues(t *testing.T) {
+	if types.ErrorCodeSecretHolderQuota != "secret_holder_quota" || types.ErrorCodeSecretStoreFull != "secret_store_full" {
+		t.Fatalf("error codes = %q, %q; want %q, %q",
+			types.ErrorCodeSecretHolderQuota, types.ErrorCodeSecretStoreFull, "secret_holder_quota", "secret_store_full")
 	}
 }
 

--- a/internal/secrets/operator.go
+++ b/internal/secrets/operator.go
@@ -114,7 +114,7 @@ func (h OperatorHandler) create(w http.ResponseWriter, r *http.Request, path str
 }
 
 func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path string, value []byte) {
-	held, err := h.Store.Put(r.Context(), path, value, OperatorHolder())
+	held, err := h.Store.Put(r.Context(), path, value)
 	if h.writeFailed(w, path, err) {
 		return
 	}
@@ -127,15 +127,13 @@ func (h OperatorHandler) replace(w http.ResponseWriter, r *http.Request, path st
 	writeResult(w, http.StatusOK, PutResponse{Path: path, Existing: held.Origin})
 }
 
-// writeFailed answers a store error and reports whether it did. Both bounds
-// answer 507, distinguished by error code.
+// writeFailed answers a store error and reports whether it did. Both write
+// paths hold as the operator, which is quota-exempt, so the ceiling is the only
+// bound that can refuse them.
 func (h OperatorHandler) writeFailed(w http.ResponseWriter, path string, err error) bool {
 	switch {
 	case err == nil:
 		return false
-	case errors.Is(err, ErrHolderQuota):
-		h.logger().Warn("operator secret write refused", "path", path, "error", err)
-		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretHolderQuota, "secret storage limit reached")
 	case errors.Is(err, ErrStoreFull):
 		h.logger().Warn("operator secret write refused", "path", path, "error", err)
 		writeError(w, http.StatusInsufficientStorage, types.ErrorCodeSecretStoreFull, "secret storage limit reached")

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -33,7 +33,8 @@ const (
 )
 
 // Holder is the party a stored path is charged to. Origin and name together are
-// the key.
+// the key, so an allowlist entry named "operator" is a different holder from
+// the operator.
 type Holder struct {
 	origin Origin
 	name   string
@@ -46,6 +47,10 @@ func (h Holder) String() string {
 	}
 	return fmt.Sprintf("%s %q", h.origin, h.name)
 }
+
+// MarshalText renders the holder as its String form, so a structured log
+// carries the name.
+func (h Holder) MarshalText() ([]byte, error) { return []byte(h.String()), nil }
 
 // WorkloadHolder charges a path to the allowlist entry whose grant authorized
 // the write.
@@ -80,9 +85,11 @@ type Store interface {
 	// the write did not happen.
 	PutIfAbsent(ctx context.Context, path string, value []byte, by Holder) (current []byte, held Held, err error)
 	// Put stores value at path, replacing anything already there, and reports
-	// what it displaced. Replacing another holder's path moves the charge to by
-	// without a quota check, so only a quota-exempt holder may call it.
-	Put(ctx context.Context, path string, value []byte, by Holder) (Held, error)
+	// what it displaced. The path is charged to OperatorHolder, whose only
+	// bound is the ceiling.
+	Put(ctx context.Context, path string, value []byte) (Held, error)
+	// TopHolders returns the n holders with the most paths, largest first.
+	TopHolders(n int) []HolderPaths
 }
 
 // GeneratedValueBytes is the size of a value CDS mints for a workload that
@@ -167,7 +174,7 @@ func (s *MemoryStore) PutIfAbsent(_ context.Context, path string, value []byte, 
 	return append([]byte(nil), value...), Held{}, nil
 }
 
-func (s *MemoryStore) Put(_ context.Context, path string, value []byte, by Holder) (Held, error) {
+func (s *MemoryStore) Put(_ context.Context, path string, value []byte) (Held, error) {
 	if err := s.checkValue(value); err != nil {
 		return Held{}, err
 	}
@@ -175,11 +182,11 @@ func (s *MemoryStore) Put(_ context.Context, path string, value []byte, by Holde
 	defer s.mu.Unlock()
 	prior, existed := s.values[path]
 	if !existed {
-		if err := s.checkRoomLocked(by); err != nil {
+		if err := s.checkRoomLocked(OperatorHolder()); err != nil {
 			return Held{}, err
 		}
 	}
-	s.storeLocked(path, value, by)
+	s.storeLocked(path, value, OperatorHolder())
 	return Held{Exists: existed, Origin: prior.holder.origin}, nil
 }
 
@@ -228,8 +235,8 @@ func (s *MemoryStore) Len() int {
 
 // HolderPaths is one holder's share of the store.
 type HolderPaths struct {
-	Holder Holder
-	Paths  int
+	Holder Holder `json:"holder"`
+	Paths  int    `json:"paths"`
 }
 
 // TopHolders returns the n holders with the most paths, largest first, ties
@@ -247,5 +254,5 @@ func (s *MemoryStore) TopHolders(n int) []HolderPaths {
 		}
 		return cmp.Or(cmp.Compare(a.Holder.origin, b.Holder.origin), cmp.Compare(a.Holder.name, b.Holder.name))
 	})
-	return out[:min(n, len(out))]
+	return slices.Clip(out[:min(n, len(out))])
 }

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -60,7 +61,7 @@ func TestMemoryStorePut(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(10, 9, 64)
 
-	held, err := s.Put(ctx, "/a", []byte("operator"), OperatorHolder())
+	held, err := s.Put(ctx, "/a", []byte("operator"))
 	if err != nil || held.Exists {
 		t.Fatalf("put onto an empty path: %+v %v", held, err)
 	}
@@ -68,7 +69,7 @@ func TestMemoryStorePut(t *testing.T) {
 	if _, _, err := s.PutIfAbsent(ctx, "/b", []byte("generated"), WorkloadHolder("api")); err != nil {
 		t.Fatal(err)
 	}
-	held, err = s.Put(ctx, "/b", []byte("operator"), OperatorHolder())
+	held, err = s.Put(ctx, "/b", []byte("operator"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,59 +82,34 @@ func TestMemoryStorePut(t *testing.T) {
 	}
 
 	// The replacement carries its own origin forward.
-	held, err = s.Put(ctx, "/b", []byte("again"), OperatorHolder())
+	held, err = s.Put(ctx, "/b", []byte("again"))
 	if err != nil || held.Origin != OriginOperator {
 		t.Fatalf("held = %+v %v, want the operator value it replaced", held, err)
 	}
 }
 
-// Put is bounded by the ceiling and the value cap — its one caller writes as
-// the quota-exempt operator — and replacing a path consumes no room.
+// Put is bounded by the ceiling and the value cap, and replacing a path
+// consumes no room.
 func TestMemoryStorePutBounds(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(2, 1, 4)
 
-	if _, err := s.Put(ctx, "/a", []byte("toolong"), OperatorHolder()); err == nil {
+	if _, err := s.Put(ctx, "/a", []byte("toolong")); err == nil {
 		t.Fatal("an oversized value was stored")
 	}
 	for _, p := range []string{"/a", "/b"} {
-		if _, err := s.Put(ctx, p, []byte("ok"), OperatorHolder()); err != nil {
+		if _, err := s.Put(ctx, p, []byte("ok")); err != nil {
 			t.Fatalf("put %s: %v", p, err)
 		}
 	}
-	if _, err := s.Put(ctx, "/c", []byte("ok"), OperatorHolder()); !errors.Is(err, ErrStoreFull) {
+	if _, err := s.Put(ctx, "/c", []byte("ok")); !errors.Is(err, ErrStoreFull) {
 		t.Fatalf("put at the ceiling = %v, want ErrStoreFull", err)
 	}
-	if _, err := s.Put(ctx, "/a", []byte("new"), OperatorHolder()); err != nil {
+	if _, err := s.Put(ctx, "/a", []byte("new")); err != nil {
 		t.Fatalf("replacing an existing path at the ceiling: %v", err)
 	}
 	if s.Len() != 2 {
 		t.Fatalf("Len = %d, want 2", s.Len())
-	}
-}
-
-// Put moves a path's charge to the new holder without a quota check, so the
-// interface's one restriction — a quota-exempt caller — is pinned rather than
-// stated only in a comment.
-func TestPutMovesAChargePastTheQuota(t *testing.T) {
-	ctx := context.Background()
-	s := NewMemoryStore(4, 1, 8)
-	api, web := WorkloadHolder("api"), WorkloadHolder("web")
-
-	if _, _, err := s.PutIfAbsent(ctx, "/api/1", []byte("ok"), api); err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := s.PutIfAbsent(ctx, "/web/1", []byte("ok"), web); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := s.Put(ctx, "/api/1", []byte("taken"), web); err != nil {
-		t.Fatalf("Put onto another holder's path = %v, want the charge moved", err)
-	}
-	if got := s.TopHolders(1); len(got) != 1 || got[0].Holder != web || got[0].Paths != 2 {
-		t.Fatalf("top holder = %+v, want web holding 2 paths past a quota of 1", got)
-	}
-	if total, paths := holderTotal(s); total != paths || paths != 2 {
-		t.Fatalf("holder counts sum to %d over %d paths, want both 2", total, paths)
 	}
 }
 
@@ -283,8 +259,13 @@ func TestNewMemoryStoreRejectsAQuotaAboveTheCeiling(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			defer func() {
-				if recovered := recover() != nil; recovered != tc.wantPanic {
+				r := recover()
+				if recovered := r != nil; recovered != tc.wantPanic {
 					t.Fatalf("NewMemoryStore(%d, %d, 8) panicked=%v, want %v", tc.maxPaths, tc.quota, recovered, tc.wantPanic)
+				}
+				if want := fmt.Sprintf("maxPerHolder %d must be below maxPaths %d", tc.quota, tc.maxPaths); tc.wantPanic &&
+					!strings.Contains(fmt.Sprint(r), want) {
+					t.Fatalf("panic = %v, want it to name both bounds: %s", r, want)
 				}
 			}()
 			NewMemoryStore(tc.maxPaths, tc.quota, 8)
@@ -370,7 +351,6 @@ func TestMemoryStoreCeilingRefusesWithoutEvicting(t *testing.T) {
 
 // The quota bounds one holder, not the store: enough holders one path apiece
 // still reach the ceiling, and the holder that arrives after them is refused.
-// What the quota buys is the size of the blast radius, not its absence.
 func TestManyHoldersStillReachTheCeiling(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(8, 2, 8)
@@ -416,7 +396,7 @@ func TestReplacingAValueMovesItsCharge(t *testing.T) {
 	if _, _, err := s.PutIfAbsent(ctx, "/api/hf", []byte("generated"), api); !errors.Is(err, ErrHolderQuota) {
 		t.Fatalf("second path at a quota of 1 = %v, want ErrHolderQuota", err)
 	}
-	if _, err := s.Put(ctx, "/api/db", []byte("operator"), OperatorHolder()); err != nil {
+	if _, err := s.Put(ctx, "/api/db", []byte("operator")); err != nil {
 		t.Fatal(err)
 	}
 	if _, _, err := s.PutIfAbsent(ctx, "/api/hf", []byte("generated"), api); err != nil {
@@ -448,6 +428,15 @@ func TestMemoryStoreQuotaUnderConcurrentWrites(t *testing.T) {
 			}()
 		}
 	}
+	// The census is taken under the same lock the writers hold, so -race sees
+	// both sides.
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.TopHolders(censusHolders)
+		}()
+	}
 	wg.Wait()
 
 	for h, name := range names {
@@ -460,41 +449,49 @@ func TestMemoryStoreQuotaUnderConcurrentWrites(t *testing.T) {
 	}
 }
 
-// The census names the holders and their counts, largest first, and never a
-// value.
+// The census names the holders and their counts, largest first. Four holders
+// tied at one path pin the tie-break: without it the order is the map's.
 func TestTopHolders(t *testing.T) {
 	ctx := context.Background()
 	s := NewMemoryStore(16, 4, 16)
 
-	for i := range 3 {
+	for i := range 2 {
 		if _, _, err := s.PutIfAbsent(ctx, fmt.Sprintf("/api/%d", i), []byte("api-value"), WorkloadHolder("api")); err != nil {
 			t.Fatal(err)
 		}
 	}
-	if _, _, err := s.PutIfAbsent(ctx, "/web/1", []byte("web-value"), WorkloadHolder("web")); err != nil {
-		t.Fatal(err)
+	for _, name := range []string{"b", "c", "d"} {
+		if _, _, err := s.PutIfAbsent(ctx, "/"+name+"/1", []byte("value"), WorkloadHolder(name)); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if _, err := s.Put(ctx, "/op/1", []byte("op-value"), OperatorHolder()); err != nil {
+	if _, err := s.Put(ctx, "/op/1", []byte("op-value")); err != nil {
 		t.Fatal(err)
 	}
 
-	got := s.TopHolders(2)
-	if len(got) != 2 {
-		t.Fatalf("TopHolders(2) returned %d holders", len(got))
+	want := []HolderPaths{
+		{Holder: WorkloadHolder("api"), Paths: 2},
+		{Holder: OperatorHolder(), Paths: 1},
+		{Holder: WorkloadHolder("b"), Paths: 1},
+		{Holder: WorkloadHolder("c"), Paths: 1},
+		{Holder: WorkloadHolder("d"), Paths: 1},
 	}
-	if got[0].Holder != WorkloadHolder("api") || got[0].Paths != 3 {
-		t.Fatalf("largest holder = %+v, want api holding 3", got[0])
+	if got := s.TopHolders(10); !slices.Equal(got, want) {
+		t.Fatalf("TopHolders(10) = %+v, want %+v", got, want)
 	}
-	if got[1].Paths != 1 {
-		t.Fatalf("second holder = %+v, want a single path", got[1])
+	if got := s.TopHolders(2); !slices.Equal(got, want[:2]) {
+		t.Fatalf("TopHolders(2) = %+v, want the first two of %+v", got, want)
 	}
-	if n := len(s.TopHolders(10)); n != 3 {
-		t.Fatalf("TopHolders(10) returned %d holders, want every one of the 3", n)
+}
+
+// Holder.String is what the census prints, and the operator has no name to
+// print.
+func TestHolderString(t *testing.T) {
+	if got := OperatorHolder().String(); got != "operator" {
+		t.Fatalf("operator holder = %q, want %q", got, "operator")
 	}
-	for _, hp := range s.TopHolders(10) {
-		if strings.Contains(hp.Holder.String(), "value") {
-			t.Fatalf("a holder rendered a stored value: %s", hp.Holder)
-		}
+	if got := WorkloadHolder("api").String(); got != `workload "api"` {
+		t.Fatalf("workload holder = %q, want %q", got, `workload "api"`)
 	}
 }
 


### PR DESCRIPTION
get-secret treated every 507 as terminal, so a workload refused by secret_holder_quota failed on its first pass. The holder key is the allowlist entry, and every pod matching one entry shares its 64-path quota across namespaces and tenants: one tenant filling a shared entry fast-failed co-tenant pods into CrashLoopBackOff for up to five minutes, exactly while an operator was landing the overwrite that frees the quota. Only secret_store_full never clears without a restart. sidecar.Do already reads the refusal body to build its error; it now decodes the c8s error envelope out of those same bytes and returns a *StatusError carrying the code, and fetchOne marks a 507 terminal only when the code is secret_store_full. A 507 with no envelope, a holder quota, and a 500 all keep retrying.

The operator can never meet ErrHolderQuota: both entry points write as OperatorHolder and checkRoomLocked exempts OriginOperator, so writeFailed's quota arm was unreachable. It is gone, and docs/secrets.md now annotates the workload POST — the only endpoint that can return either code — with both, and the operator PUT with the one bound that can refuse it.

Put's quota bypass is now structural rather than documented: its only non-test caller wrote OperatorHolder(), so the by parameter is dropped and the implementation charges OperatorHolder() itself. The bypass cannot be expressed, so TestPutMovesAChargePastTheQuota no longer pins anything and goes.

TopHolders moves onto the Store interface. census type-asserted Store to an unexported one-implementation interface and returned "" when the assertion failed, so the diagnostic this change exists for would have vanished silently for any future backend, on a path no test drove. With the assertion gone the handler logs slog's structured form directly: HolderPaths carries json tags and Holder a MarshalText, so CDS's JSON log gets {"holder":"workload \"web\"","paths":3} rather than space-separated %s=%d pairs inside one field. slog evaluates attributes before it filters on level, so the census — which sorts up to maxPaths entries under RLock, in the state an attacker creates, inside the process that also serves /sign-csr — is now guarded by Logger.Enabled. TopHolders clips its result.

writeError was a third copy of the c8s error-envelope writer (after internal/attestation and internal/cmds/cdsattest), and the import-graph reason given for cloning it does not hold: internal/attestation is already in the single binary's deps. It moves to internal/httputil, which is dependency-neutral and already holds ReadCappedBody; internal/secrets keeps a two-line wrapper for the Cache-Control: no-store its responses carry. The other two copies are pre-existing and are left alone.

The chart guard's fail message asserted CDS "rolls with strategy: Recreate". cds.yaml makes that conditional: with cds.handoff.peerUrl set it renders RollingUpdate/maxSurge:1/maxUnavailable:0, which is also the shape in which CDS does not serve /secrets at all. The message is reduced to the invariant, matching its tlslb_allowlist_rate_budget siblings, and the same claim comes out of the template, chart-test and values comments. --secrets-max-value-bytes drops out of the grouped positivity check, which the GeneratedValueBytes floor already subsumes.

Tests. The census had no assertion at its only point of use: deleting "holders" from the log line left the suite green, and nothing checked that the 507 body carries no holder name. TestCeilingRefusesAWorkload- UnderItsQuota now fills the store from six neighbours under a captured JSON logger and asserts the logged census is exactly the five largest, in tie-broken order, while the body names none of them — which pins the wiring, censusHolders, the ordering and the wire silence together. TestQuotaRefusalNamesTheQuota asserts the mirror: a quota refusal carries no census. The two error-code literals are pinned once, since every other assertion compares against the constant and a changed value would leave the suite green while docs and deployed clients went stale. TopHolders gets four holders tied at one path so the tie-break comparator cannot be replaced by a constant, and Holder.String's two branches are asserted directly instead of through a check no implementation could fail. The concurrent-writes test takes the census while the writers run, so -race covers the snapshot; the NewMemoryStore panic message is asserted; validateSecretsConfig's tests name which check fired; and the chart guard gains a quota == ceiling-1 passing case and a zero-ceiling failing one.