### PR TITLE
build(node-guest-image): pin CONFOS_REF to confos v0.4.2 — pocket-pinned, mirror-guarded builds

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -67,7 +67,7 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  CONFOS_REF: ${{ github.event.inputs.confos_ref || 'f7d03b74c1d6a740d0dc2478ee127245da567249' }} # pin: v0.4.1 — MODULE_SIG_KEY="" (no per-build GENKEY cert), fragment kernels bit-reproducible
+  CONFOS_REF: ${{ github.event.inputs.confos_ref || '14e770f26f912d360f1a60a464145c3ee5615124' }} # pin: v0.4.2 — every apt pocket snapshot-pinned by URI, mirror-guarded builds (confos#96)
 
 jobs:
   build-and-push:


### PR DESCRIPTION
Bumps `CONFOS_REF` to **confos v0.4.2** (`14e770f2`) — the confidential-dot-ai/confidential-os-builder#96 closure (#98): every apt pocket pinned to snapshot.ubuntu.com **by URI** (the security pocket was live and could drift cross-time), with a fail-closed mirror guard scanning every mkosi run's apt log.

No c8s-side config changes needed: the image build rides confos's own `mkosi/base` configs (fully pinned at v0.4.2), and `node-guest-image/c8s/` adds no apt sources (`[Content] Packages=` only — verified). The guard now validates every image build here automatically.

**Rolls measurements once**: security-pocket packages move to the snapshot timestamps (the kernel moves to the `9ed733d5…` lineage). The idempotence gate re-runs on this branch before merge — verdict to follow as a comment.

Tracked on #264's security-pocket epilogue.
