### PR TITLE
ci: automate the image reproducibility gate

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -35,6 +35,30 @@ on:
         required: false
         type: boolean
         default: false
+  # Reusable form for image-repro-gate.yml: two gate legs in one caller run.
+  workflow_call:
+    inputs:
+      dev:
+        required: false
+        type: boolean
+        default: false
+      c8s_ref:
+        required: false
+        type: string
+        default: ""
+      confos_ref:
+        required: false
+        type: string
+        default: ""
+      gate:
+        required: false
+        type: boolean
+        default: false
+      leg:
+        description: "Distinguishes gate artifacts when one caller runs several legs."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -54,9 +78,9 @@ concurrency:
   # path, so the auto path groups exactly as before.
   group: >-
     ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha
-    }}-${{ github.event.inputs.c8s_ref }}-${{ github.event.inputs.dev
-    }}-${{ github.event.inputs.confos_ref }}-${{ github.event.inputs.gate
-    }}-${{ github.event.inputs.gate_intree }}
+    }}-${{ inputs.c8s_ref }}-${{ inputs.dev
+    }}-${{ inputs.confos_ref }}-${{ inputs.gate
+    }}-${{ inputs.gate_intree }}-${{ inputs.leg }}
   cancel-in-progress: false
 
 env:
@@ -67,13 +91,15 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  CONFOS_REF: ${{ github.event.inputs.confos_ref || '14e770f26f912d360f1a60a464145c3ee5615124' }} # pin: v0.4.2 — every apt pocket snapshot-pinned by URI, mirror-guarded builds (confos#96)
+  CONFOS_REF: ${{ inputs.confos_ref || '14e770f26f912d360f1a60a464145c3ee5615124' }} # pin: v0.4.2 — every apt pocket snapshot-pinned by URI, mirror-guarded builds (confos#96)
 
 jobs:
   build-and-push:
     name: Build c8s node image (${{ matrix.platform }})
     # Auto path: Docker succeeded on main (its PR runs don't publish components).
+    # Gate legs arrive via workflow_call, where event_name is the caller's.
     if: |
+      inputs.gate == true ||
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_repository.full_name == github.repository &&
@@ -116,7 +142,7 @@ jobs:
         # VARIANT drives C8S_NAME (-> output/$VARIANT/) and the push tags.
         run: |
           echo "IMAGE=${REGISTRY}/confidential-dot-ai/node-guest-base" >> "$GITHUB_ENV"
-          if [ "${{ github.event.inputs.dev }}" = "true" ]; then
+          if [ "${{ inputs.dev }}" = "true" ]; then
             echo "VARIANT=rke2-${{ matrix.platform }}-dev" >> "$GITHUB_ENV"
             echo "KERNEL_FLAVOR=rke2-dev" >> "$GITHUB_ENV"
             echo "C8S_DEV=1" >> "$GITHUB_ENV"
@@ -237,7 +263,7 @@ jobs:
           ATTEST_GPU_BIN: ${{ github.workspace }}/attestation-rs/target/release/attestation-api
           LIBNVAT: /usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          C8S_REF_INPUT: ${{ github.event.inputs.c8s_ref }}
+          C8S_REF_INPUT: ${{ inputs.c8s_ref }}
           # Private half of the module signing certificate (org secret) — the
           # fetch script signs the NVIDIA modules with it and fails closed
           # without it. Signatures are deterministic (sign-file uses no
@@ -258,22 +284,22 @@ jobs:
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.
-        if: github.event.inputs.gate == 'true'
+        if: inputs.gate == true
         uses: actions/upload-artifact@v4
         with:
-          name: gate-${{ env.VARIANT }}-${{ github.run_id }}
+          name: gate-${{ env.VARIANT }}-${{ github.run_id }}${{ inputs.leg && format('-{0}', inputs.leg) || '' }}
           path: |
             confidential-os-builder/output/${{ env.VARIANT }}/manifest.json
             confidential-os-builder/output/${{ env.VARIANT }}/roothash
           if-no-files-found: error
 
       - name: Check whether the rootfs changed
-        if: github.event.inputs.gate != 'true'
+        if: inputs.gate != true
         # Skip the multi-GB push when the roothash matches what's published.
         id: changed
         working-directory: confidential-os-builder
         env:
-          C8S_REF_INPUT: ${{ github.event.inputs.c8s_ref }}
+          C8S_REF_INPUT: ${{ inputs.c8s_ref }}
         run: |
           set -uo pipefail
           # A c8s_ref rebuild compares against that release's own tag, not the
@@ -296,11 +322,11 @@ jobs:
           fi
 
       - name: Push to GHCR
-        if: github.event.inputs.gate != 'true' && steps.changed.outputs.skip != 'true'
+        if: inputs.gate != true && steps.changed.outputs.skip != 'true'
         working-directory: confidential-os-builder
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          C8S_REF_INPUT: ${{ github.event.inputs.c8s_ref }}
+          C8S_REF_INPUT: ${{ inputs.c8s_ref }}
         run: |
           set -eux
           SHORT_SHA="${C8S_REF_INPUT:-${HEAD_SHA::7}}"
@@ -323,7 +349,7 @@ jobs:
 
       - name: Summary
         env:
-          C8S_REF_INPUT: ${{ github.event.inputs.c8s_ref }}
+          C8S_REF_INPUT: ${{ inputs.c8s_ref }}
         run: |
           {
             echo "### ${VARIANT} confidential node image"

--- a/.github/workflows/image-repro-gate.yml
+++ b/.github/workflows/image-repro-gate.yml
@@ -1,0 +1,94 @@
+# Reproducibility gate for the node image: any PR that touches the image
+# definition or its pins builds the image TWICE (parallel legs, separate
+# runners) and fails unless every measured value matches — mrtd, RTMRs, UKI,
+# vmlinuz, roothash, the whole manifest minus the build timestamp. This is
+# the automated form of the manual idempotence runbook (c8s#264): the check
+# is the verdict, per platform.
+name: image repro gate
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/c8s-image.yml"
+      - ".github/workflows/image-repro-gate.yml"
+      - "node-guest-image/**"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: image-repro-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ref:
+    # Bake the same published components both legs and production use: the
+    # C8S_REF default straight out of mkosi.sync, the single source of truth.
+    runs-on: ubuntu-latest
+    outputs:
+      c8s_ref: ${{ steps.pick.outputs.c8s_ref }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - id: pick
+        run: |
+          set -euo pipefail
+          ref=$(sed -n 's/^C8S_REF="\${C8S_REF:-\(.*\)}"$/\1/p' node-guest-image/c8s/mkosi.sync)
+          test -n "$ref"
+          echo "c8s_ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "baking published components at \`$ref\`" >> "$GITHUB_STEP_SUMMARY"
+
+  build-a:
+    needs: ref
+    uses: ./.github/workflows/c8s-image.yml
+    secrets: inherit
+    with:
+      gate: true
+      leg: a
+      c8s_ref: ${{ needs.ref.outputs.c8s_ref }}
+
+  build-b:
+    needs: ref
+    uses: ./.github/workflows/c8s-image.yml
+    secrets: inherit
+    with:
+      gate: true
+      leg: b
+      c8s_ref: ${{ needs.ref.outputs.c8s_ref }}
+
+  compare:
+    needs: [build-a, build-b]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: gate-*-${{ github.run_id }}-*
+          path: evidence
+      - name: Every measured value must match
+        run: |
+          set -euo pipefail
+          python3 - <<'EOF'
+          import json, os, sys
+          run_id = os.environ["GITHUB_RUN_ID"]
+          fail = False
+          lines = ["### image repro gate", "", "| platform | field | verdict |", "|---|---|---|"]
+          for plat in ("tdx", "snp"):
+              legs = {}
+              for leg in ("a", "b"):
+                  d = f"evidence/gate-rke2-{plat}-{run_id}-{leg}"
+                  m = json.load(open(f"{d}/manifest.json"))
+                  # The report timestamp is metadata, not a baked byte.
+                  m.get("build", {}).pop("timestamp", None)
+                  legs[leg] = (m, open(f"{d}/roothash").read().strip())
+              (ma, ra), (mb, rb) = legs["a"], legs["b"]
+              fail = fail or ma != mb or ra != rb
+              lines.append(f"| {plat} | manifest (sans timestamp) | {'identical' if ma == mb else '**DIFFERS**'} |")
+              lines.append(f"| {plat} | roothash `{ra[:12]}…` | {'identical' if ra == rb else '**DIFFERS**'} |")
+              if ma != mb:
+                  a_flat = json.dumps(ma, sort_keys=True, indent=0).splitlines()
+                  b_flat = json.dumps(mb, sort_keys=True, indent=0).splitlines()
+                  for line in sorted(set(a_flat) ^ set(b_flat)):
+                      print(f"{plat} manifest delta: {line.strip()}", file=sys.stderr)
+          open(os.environ["GITHUB_STEP_SUMMARY"], "a").write("\n".join(lines) + "\n")
+          sys.exit(1 if fail else 0)
+          EOF


### PR DESCRIPTION
Automates the idempotence verification that has so far been a manual runbook (two sequential dispatches, artifact downloads, raw-value comparison, a verdict comment — c8s#264): any PR touching the image definition or its pins now gets a **required-check-shaped verdict** instead.

## How
- **`image-repro-gate.yml`** (new): on PRs touching `c8s-image.yml`, `image-repro-gate.yml`, or `node-guest-image/**` (+ manual dispatch) — resolves the published components ref from `mkosi.sync`'s own `C8S_REF` default at runtime (one source of truth), runs **two gate builds in parallel** on separate runners via reusable-workflow calls, then a compare job diffs each platform's pair: full `manifest.json` (minus the report timestamp) **and** `roothash`. Any delta fails the check and names the differing field with both values; the step summary carries the per-platform verdict table.
- **`c8s-image.yml`**: gains a `workflow_call` form with a `leg` input (names gate artifacts per leg so two legs in one caller run don't collide); input references move to the unified `inputs` context (identical semantics for dispatch, empty on `workflow_run`, populated for calls); boolean input comparisons drop the `== 'true'` string form a typed boolean never equals.

## Verified
The compare script was dry-run against the real v0.4.1 gate artifacts: identical pair → green with the summary table; a mutated `vmlinuz_sha256` → exit 1 naming the field and both values. Both workflows parse.

Costs two ~40-minute builds per image-touching PR — those are rare (pin bumps), and each one previously cost the same compute *plus* a human driving it.

Suggested follow-up once this lands: mark `compare` as a required status for `main` so image PRs can't merge ahead of their verdict (as #325 did, benignly, today).
