### PR TITLE
test(e2e): stop cw-label-policy blaming the CEL for a PodSecurity denial

### DIFF
--- a/test/e2e/cw-label-policy.sh
+++ b/test/e2e/cw-label-policy.sh
@@ -36,12 +36,21 @@ expect_deny() {
 }
 
 kubectl create namespace "$ns" >/dev/null
+# The probes are bare pods, so a cluster enforcing the restricted PSA standard
+# denies them before the policy under test is ever consulted.
+kubectl label namespace "$ns" \
+  pod-security.kubernetes.io/enforce=privileged \
+  pod-security.kubernetes.io/warn=privileged \
+  pod-security.kubernetes.io/audit=privileged >/dev/null
 
 # Ordinary pod admission must be unaffected. This is also the canary for a
 # broken CEL expression: failurePolicy=Fail turns one into a deny-all.
-kubectl run "$pod" --namespace "$ns" --image=registry.k8s.io/pause:3.9 \
-  --restart=Never >/dev/null \
-  || fail "plain pod creation was denied; the policy is misfiring (broken CEL?)"
+# Report the admission error verbatim: this control cannot tell which admitter
+# refused, and guessing sent one investigation after a healthy CEL.
+if ! err=$(kubectl run "$pod" --namespace "$ns" --image=registry.k8s.io/pause:3.9 \
+  --restart=Never 2>&1); then
+  fail "plain pod creation was denied: ${err}"
+fi
 echo "ok: plain pod admitted"
 
 # Out-of-band writes on a running pod: the post-create mutation the


### PR DESCRIPTION
`cw-label-policy` has been red on the post-merge e2e since #317 turned it on at 2026-08-14 20:50, in c8s and in confidential-ci, and it reports a broken CEL. The CEL is fine.

The probe namespace is created with no PSA labels, so on a cluster enforcing `restricted` the bare probe pod is denied before the policy under test is ever consulted:

```
Error from server (Forbidden): pods "probe" is forbidden:
  violates PodSecurity "restricted:latest": allowPrivilegeEscalation != false
FAIL: plain pod creation was denied; the policy is misfiring (broken CEL?)
```

The policy could not have denied it. All three validations short-circuit on `variables.cwLabel == ''`, which is exactly what a plain pod has.

Two changes:

- Label the probe namespace `privileged`, matching what the snp-metal lane already does for `c8s-system`. This also protects the later `expect_deny` cases, which create pods too and would fail for the same reason once they are reached.
- Report the admission error verbatim. The control cannot tell which admitter refused, and asserting a cause it cannot know sent one investigation chasing a healthy CEL before the message was read.

Not covered: whether the lane should run against a `restricted` namespace at all and assert PSA-compliant probes instead. That is a bigger call about what this test is for, and this keeps it doing the job it was written for.

Verified `bash -n` only. The assertion needs a live cluster, which is the point of the lane.
