### PR TITLE
build(kata): bump CONFOS_REF to confos v0.4.2

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -86,7 +86,7 @@ env:
   # new pin means a new guest kernel and therefore a new SNP launch
   # measurement, and the committed kernel/config-x86_64.snapshot lockfile must
   # be refreshed in the same PR (kernel-snapshot.yml produces it).
-  CONFOS_REF: "f7d03b74c1d6a740d0dc2478ee127245da567249" # v0.4.1 — reproducible kernel (confos#85); rolls the kata kernel measurement once
+  CONFOS_REF: "14e770f26f912d360f1a60a464145c3ee5615124" # v0.4.2 — apt pockets snapshot-pinned by URI, mirror-guarded (confos#96); rolls the kata kernel measurement once
 
 jobs:
   build:


### PR DESCRIPTION
Kata guest kernel moves to confos v0.4.2: every apt pocket pinned to snapshot.ubuntu.com by URI, all mkosi runs mirror-guarded (confidential-dot-ai/confidential-os-builder#96). The [kernel-snapshot check at the new ref](https://github.com/confidential-dot-ai/c8s/actions/runs/31969956152) produced a byte-identical resolved config, so no lockfile refresh belongs in this PR; the kernel bytes change once via the security-pocket snapshot and the SNP launch measurement rolls with them. Closes the last build item on c8s#264's epilogue. The old host-apt ≥ 2.7.11 caveat is moot — URI pinning needs no apt snapshot support.