### PR TITLE
ci: pin hygiene — dependabot for action shas, immutable-ref check for build pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,7 @@
 # Bump PRs for action sha-pins (c8s#264 pinning-review follow-up); component
-# and image pins are deliberate measurement changes and stay manual.
+# and image pins are deliberate measurement changes and stay manual. The image
+# repro gate gives every image-relevant PR a throwaway module-signing key; never
+# copy the production MODULE_SIG_KEY_PEM into Dependabot secrets.
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Bump PRs for action sha-pins (c8s#264 pinning-review follow-up); component
+# and image pins are deliberate measurement changes and stay manual.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/c8s-image-publish.yml
+++ b/.github/workflows/c8s-image-publish.yml
@@ -1,0 +1,50 @@
+# Trusted production entrypoint for the reusable c8s image builder. Keeping the
+# write grant and production secrets here lets pull-request callers use the same
+# builder with a read-only token and no inherited secrets.
+name: c8s-image
+
+on:
+  # build-c8s resolves cds:<sha> / nri-image-policy:<sha>, which Docker
+  # publishes first. Gate on it so those digests exist.
+  workflow_run:
+    workflows: ["Docker"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      dev:
+        description: "Build the rke2-dev variant (serial root autologin, different measurement). Never ship."
+        required: false
+        type: boolean
+        default: false
+      c8s_ref:
+        description: "Bake c8s components from this published commit (short SHA) instead of the triggering commit. Rebuilds a release against the current CONFOS_REF; pushes only the :<variant>[-cdi]-<ref> tags, leaving the floating tags alone."
+        required: false
+        type: string
+        default: ""
+      confos_ref:
+        description: "Build with this confos commit instead of the pinned CONFOS_REF. For A/B measurement checks (pair with gate=true); a different confos can mean a different measurement."
+        required: false
+        type: string
+        default: ""
+      gate:
+        description: "Build only — skip the publish and upload manifest.json + roothash as a run artifact, for measurement comparison against a published build."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-push:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/c8s-image.yml
+    with:
+      dev: ${{ inputs.dev || false }}
+      c8s_ref: ${{ inputs.c8s_ref || '' }}
+      confos_ref: ${{ inputs.confos_ref || '' }}
+      gate: ${{ inputs.gate || false }}
+    secrets:
+      MODULE_SIG_KEY_PEM: ${{ secrets.MODULE_SIG_KEY_PEM }}

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -1,6 +1,6 @@
 # Build + publish the c8s confidential node image (TDX-measured RKE2 + NRI +
 # attestation-api + NVIDIA stack in the verity rootfs). confos is the build
-# tree (pinned CONFOS_REF); the trigger, baked commit, and publish live here.
+# tree (pinned CONFOS_REF); callers select the baked commit and publish policy.
 # Output: ghcr.io/confidential-dot-ai/node-guest-base, one image per TEE:
 # tags :rke2-{tdx,snp}[-cdi] / :rke2-{tdx,snp}[-cdi]-<sha>. The pre-matrix
 # :rke2[-cdi]* tags are frozen (TDX builds up to the rename).
@@ -8,34 +8,6 @@
 # (CDI image) + :rke2 / :rke2-<sha> (oras artifact). dev=true -> :rke2-dev-*.
 
 on:
-  # After Docker: build-c8s resolves cds:<sha> / nri-image-policy:<sha>, which
-  # docker.yml publishes. Gate on it so those digests exist.
-  workflow_run:
-    workflows: ["Docker"]
-    types: [completed]
-  workflow_dispatch:
-    inputs:
-      dev:
-        description: "Build the rke2-dev variant (serial root autologin, different measurement). Never ship."
-        required: false
-        type: boolean
-        default: false
-      c8s_ref:
-        description: "Bake c8s components from this published commit (short SHA) instead of the triggering commit. Rebuilds a release against the current CONFOS_REF; pushes only the :<variant>[-cdi]-<ref> tags, leaving the floating tags alone."
-        required: false
-        type: string
-        default: ""
-      confos_ref:
-        description: "Build with this confos commit instead of the pinned CONFOS_REF. For A/B measurement checks (pair with gate=true); a different confos can mean a different measurement."
-        required: false
-        type: string
-        default: ""
-      gate:
-        description: "Build only — skip the publish and upload manifest.json + roothash as a run artifact, for measurement comparison against a published build."
-        required: false
-        type: boolean
-        default: false
-  # Reusable form for image-repro-gate.yml: two gate legs in one caller run.
   workflow_call:
     inputs:
       dev:
@@ -59,10 +31,18 @@ on:
         required: false
         type: string
         default: ""
+      gate_signing_artifact:
+        description: "Artifact containing the throwaway keypair shared by gate legs."
+        required: false
+        type: string
+        default: ""
+    secrets:
+      MODULE_SIG_KEY_PEM:
+        description: "Production module-signing key; omitted by repro-gate callers."
+        required: false
 
-permissions:
-  contents: read
-  packages: write
+# The caller owns token permissions: c8s-image-publish.yml grants package write
+# to trusted release builds; image-repro-gate.yml grants read only to PR code.
 
 concurrency:
   # Per triggering commit, not per ref (workflow_run's ref is always main).
@@ -80,7 +60,7 @@ concurrency:
     ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha
     }}-${{ inputs.c8s_ref }}-${{ inputs.dev
     }}-${{ inputs.confos_ref }}-${{ inputs.gate
-    }}-${{ inputs.gate_intree }}-${{ inputs.leg }}
+    }}-${{ inputs.leg }}
   cancel-in-progress: false
 
 env:
@@ -115,6 +95,12 @@ jobs:
       matrix:
         platform: [tdx, snp]
     steps:
+      - name: Keep gate-only signing material out of published images
+        if: inputs.gate_signing_artifact != '' && inputs.gate != true
+        run: |
+          echo "::error::gate_signing_artifact requires gate=true"
+          exit 1
+
       # Layout: ./c8s ./attestation-rs ./confidential-os-builder (sibling repos).
       - name: Checkout c8s
         # head_sha, not the default (workflow_run's ref is main).
@@ -122,6 +108,20 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           path: c8s
+
+      - name: Download gate-only module-signing key
+        if: inputs.gate_signing_artifact != ''
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: ${{ inputs.gate_signing_artifact }}
+          path: gate-signing
+
+      - name: Stage gate-only module-signing keypair
+        if: inputs.gate_signing_artifact != ''
+        run: |
+          chmod 0600 gate-signing/module-signing.key
+          install -m 0644 gate-signing/module-signing.crt \
+            c8s/node-guest-image/module-signing.crt
 
       - name: Checkout attestation-rs (for the gpu-attest binary)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -268,7 +268,10 @@ jobs:
           # fetch script signs the NVIDIA modules with it and fails closed
           # without it. Signatures are deterministic (sign-file uses no
           # authenticated attributes), so identical inputs sign identically.
-          MODULE_SIG_KEY_PEM: ${{ secrets.MODULE_SIG_KEY_PEM }}
+          # Repro-gate callers instead supply one throwaway keypair to both
+          # legs. It is never used by a published image.
+          MODULE_SIG_KEY_PEM: ${{ inputs.gate_signing_artifact == '' && secrets.MODULE_SIG_KEY_PEM || '' }}
+          MODULE_SIG_KEY: ${{ inputs.gate_signing_artifact != '' && format('{0}/gate-signing/module-signing.key', github.workspace) || '' }}
         run: |
           set -euo pipefail
           # Short SHA matches docker.yml's component tags. The build script

--- a/.github/workflows/image-repro-gate.yml
+++ b/.github/workflows/image-repro-gate.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: image-repro-gate-${{ github.ref }}
@@ -34,7 +33,7 @@ jobs:
             image=true  # manual dispatch: always run the full gate
           elif gh api "repos/${{ github.repository }}/pulls/$PR/files" --paginate \
                  --jq '.[].filename' \
-               | grep -qE '^(node-guest-image/|\.github/workflows/(c8s-image|image-repro-gate)\.yml)'; then
+               | grep -qE "^(node-guest-image/|\.github/workflows/(c8s-image(-publish)?|image-repro-gate)\.yml)"; then
             image=true
           else
             image=false
@@ -42,30 +41,62 @@ jobs:
           echo "image=$image" >> "$GITHUB_OUTPUT"
           # Bake the same published components production uses: mkosi.sync's
           # own C8S_REF default, the single source of truth.
-          ref=$(sed -n 's/^C8S_REF="\${C8S_REF:-\(.*\)}"$/\1/p' node-guest-image/c8s/mkosi.sync)
+          ref=$(sed -n "s/^C8S_REF=\"\\\${C8S_REF:-\(.*\)}\"$/\1/p" node-guest-image/c8s/mkosi.sync)
           test -n "$ref"
           echo "c8s_ref=$ref" >> "$GITHUB_OUTPUT"
           echo "image-relevant: $image (components at \`$ref\`)" >> "$GITHUB_STEP_SUMMARY"
 
+      # PR code must never run with the production module-signing key. This
+      # keypair is shared by both legs, used only in unpublished gate images,
+      # and has no authority after those images are discarded.
+      - name: Generate gate-only module-signing key
+        if: steps.diff.outputs.image == 'true'
+        run: |
+          set -euo pipefail
+          install -d -m 0700 gate-signing
+          openssl req -x509 -newkey rsa:4096 -sha256 -nodes \
+            -subj "/CN=c8s image reproducibility gate/" \
+            -days 1 -set_serial 1 \
+            -keyout gate-signing/module-signing.key \
+            -out gate-signing/module-signing.crt
+          chmod 0600 gate-signing/module-signing.key
+
+      - name: Share gate-only module-signing key
+        if: steps.diff.outputs.image == 'true'
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: module-signing-${{ github.run_id }}
+          path: gate-signing
+          if-no-files-found: error
+          retention-days: 1
+          # Full reruns replace it; failed-job reruns reuse the prior artifact.
+          overwrite: true
+
   build-a:
     needs: changes
     if: needs.changes.outputs.image == 'true'
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/c8s-image.yml
-    secrets: inherit
     with:
       gate: true
       leg: a
       c8s_ref: ${{ needs.changes.outputs.c8s_ref }}
+      gate_signing_artifact: module-signing-${{ github.run_id }}
 
   build-b:
     needs: changes
     if: needs.changes.outputs.image == 'true'
+    permissions:
+      contents: read
+      packages: read
     uses: ./.github/workflows/c8s-image.yml
-    secrets: inherit
     with:
       gate: true
       leg: b
       c8s_ref: ${{ needs.changes.outputs.c8s_ref }}
+      gate_signing_artifact: module-signing-${{ github.run_id }}
 
   compare:
     # The required check: green fast on image-irrelevant PRs, otherwise only

--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -22,12 +22,19 @@ jobs:
           set -euo pipefail
           fail=0
           for wf in .github/workflows/c8s-image.yml .github/workflows/kata-guest-base.yml; do
-            if ! grep -m1 'CONFOS_REF:' "$wf" | grep -qE '[0-9a-f]{40}'; then
-              echo "::error file=$wf::CONFOS_REF must pin a full 40-hex commit"; fail=1
+            value=$(yq -r '.env.CONFOS_REF // ""' "$wf")
+            if [[ "$value" =~ ^\$\{\{[[:space:]]*inputs\.confos_ref[[:space:]]*\|\|[[:space:]]*\'([0-9a-fA-F]{40})\'[[:space:]]*\}\}$ ]]; then
+              ref=${BASH_REMATCH[1]}
+            else
+              ref=$value
+            fi
+            if [[ ! "$ref" =~ ^[0-9a-fA-F]{40}$ ]]; then
+              echo "::error file=$wf::CONFOS_REF effective default must be a full 40-hex commit, got '$ref'"; fail=1
             fi
           done
-          ref=$(sed -n 's/^C8S_REF="\${C8S_REF:-\(.*\)}"$/\1/p' node-guest-image/c8s/mkosi.sync)
-          if ! echo "$ref" | grep -qE '^(v[0-9][0-9A-Za-z.+-]*|[0-9a-f]{7,40})$'; then
-            echo "::error file=node-guest-image/c8s/mkosi.sync::C8S_REF default must be a release tag or commit, got '$ref'"; fail=1
+          ref=$(sed -n "s/^C8S_REF=\"\\\${C8S_REF:-\(.*\)}\"$/\1/p" node-guest-image/c8s/mkosi.sync)
+          release_re="^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)[1-9][0-9]*)?$"
+          if [[ ! "$ref" =~ $release_re ]]; then
+            echo "::error file=node-guest-image/c8s/mkosi.sync::C8S_REF default must be a published vX.Y.Z[-alphaN|-betaN|-rcN] release tag, got '$ref'"; fail=1
           fi
           exit $fail

--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -1,0 +1,33 @@
+# Build pins must stay immutable refs (c8s#264): a branch name or short sha
+# here silently changes what a "pinned" build means.
+name: pin hygiene
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/c8s-image.yml"
+      - ".github/workflows/kata-guest-base.yml"
+      - ".github/workflows/pin-hygiene.yml"
+      - "node-guest-image/c8s/mkosi.sync"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pins:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - run: |
+          set -euo pipefail
+          fail=0
+          for wf in .github/workflows/c8s-image.yml .github/workflows/kata-guest-base.yml; do
+            if ! grep -m1 'CONFOS_REF:' "$wf" | grep -qE '[0-9a-f]{40}'; then
+              echo "::error file=$wf::CONFOS_REF must pin a full 40-hex commit"; fail=1
+            fi
+          done
+          ref=$(sed -n 's/^C8S_REF="\${C8S_REF:-\(.*\)}"$/\1/p' node-guest-image/c8s/mkosi.sync)
+          if ! echo "$ref" | grep -qE '^(v[0-9][0-9A-Za-z.+-]*|[0-9a-f]{7,40})$'; then
+            echo "::error file=node-guest-image/c8s/mkosi.sync::C8S_REF default must be a release tag or commit, got '$ref'"; fail=1
+          fi
+          exit $fail

--- a/node-guest-image/MODULE-SIGNING.md
+++ b/node-guest-image/MODULE-SIGNING.md
@@ -25,6 +25,15 @@ What is specific to this image:
 Owning the certificate here is the point: which key may sign modules that
 load in this image is an image decision, not a builder decision (#264).
 
+Pull-request reproducibility builds never receive that private key. The image
+repro gate generates one throwaway keypair per run and stages its certificate
+over the gate checkout's working copy before sharing the same pair with both
+comparison legs. The production wrapper is the only caller that passes
+`MODULE_SIG_KEY_PEM`; gate callers have read-only package access and pass no
+secrets. Those images are not published, so the throwaway certificate grants
+no authority over a released image. In particular, do not mirror the production
+key into a Dependabot secret just to make action-update PRs pass.
+
 ## Generating the keypair
 
 Run once; keep the private key in a password manager or KMS as well as the CI


### PR DESCRIPTION
Closes two parked items from the c8s#264 pinning reviews:

- **dependabot** (github-actions, weekly): proposes bump PRs for action sha-pins. Component and image pins are deliberate measurement changes and stay manual — dependabot only sees workflow actions.
- **pin-hygiene check**: on PRs touching the image workflows or `mkosi.sync`, asserts `CONFOS_REF` is a full 40-hex commit in both `c8s-image.yml` and `kata-guest-base.yml`, and that `mkosi.sync`'s `C8S_REF` default is a release tag or commit — a branch name or short sha silently changes what a pinned build means. Verified green against the current tree (`v0.1.0-rc2`, both 40-hex pins).

Still parked from that review list (needing kata-build/infra decisions, happy to pick up separately): recording kata's pins in its `manifest.json`, and pause-image OCI caching on the persistent runner.