### PR TITLE
fix(node-guest-image): accept KubeVirt secret-ISO transport entries

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -67,6 +67,9 @@ allow_only() {
         # Unmatched globs stay literal; -L keeps dangling symlinks rejectable.
         [[ -e "$f" || -L "$f" ]] || continue
         name=${f##*/}
+        # KubeVirt secret-ISO disks carry kubelet AtomicWriter transport
+        # entries (..data, ..<timestamp> payload dirs); they are not fields.
+        case "$name" in ..*) continue ;; esac
         allowed=no
         for a in "$@"; do
             if [[ "$name" == "$a" ]]; then allowed=yes; break; fi

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -104,6 +104,17 @@ ok "exit 0" test "$RC" -eq 0
 ok "fragment has external ip" grep -qx 'node-external-ip: 203.0.113.10' "$FRAG"
 ok "role-server verdict" test -f "$RUN/role-server"
 
+# KubeVirt renders secret disks with kubelet AtomicWriter transport entries
+# at the ISO root; dispatch must skip them, not reject the disk.
+CASE="server-disk+kubevirt-transport-dirs"
+reset_state; server_dir "$WORK/d"
+mkdir -p "$WORK/d/..2026_01_01_00_00_00.111" "$WORK/d/..data"
+cp "$WORK/d/role" "$WORK/d/..data/role"
+cp "$WORK/d/role" "$WORK/d/..2026_01_01_00_00_00.111/role"
+make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "role-server verdict" test -f "$RUN/role-server"
+
 # ---------------------------------------------------------------- happy: agent
 CASE="agent-disk"
 reset_state; agent_dir "$WORK/d"; make_iso "$WORK/d"; run_script


### PR DESCRIPTION
## Problem

KubeVirt renders secret disks by running xorrisofs over the kubelet secret mount, so the ISO root carries AtomicWriter transport entries (`..data`, `..<timestamp>` payload dirs) beside the field files. `allow_only` treats them as unexpected files and fails dispatch on every KubeVirt-launched joindata disk — the launcher path (confidential-metal#133) is dead on arrival without this.

## Fix

Skip `..*` entries in the allowlist walk — kubelet transport artifacts, structurally incapable of being contract fields (fields are regular files with plain names). The harness gains a case building the kubelet-shaped ISO layout and asserting dispatch accepts it.

Merge order: this must ship in the node image before confidential-metal#133 is usable; #133 carries the matching note.
