### PR TITLE
feat(kata): record build provenance in manifest.json

### DIFF
--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -149,6 +149,10 @@ jobs:
           repository: confidential-dot-ai/attestation-rs
           path: attestation-rs
 
+      - name: Record the resolved attestation-rs revision
+        # The checkout floats on main; the manifest records what it resolved to.
+        run: echo "ATTESTATION_RS_SHA=$(git -C attestation-rs rev-parse HEAD)" >> "$GITHUB_ENV"
+
       - name: Checkout confidential-os-builder
         # CONFOS_REF above is the single source of truth for the ref.
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -510,6 +514,10 @@ jobs:
           # Re-lay toolchain gate (values = published artifact's relay_toolchain): a runner upgrade fails preflight instead of silently shifting root_hash; re-pin on upgrade, expecting a new measurement.
           REPRO_E2FSPROGS_VERSION: "1.47.0"
           REPRO_CRYPTSETUP_VERSION: "2.7.0"
+          # Build provenance, recorded in manifest.json inputs (additive, v2).
+          PROV_C8S_REF: ${{ github.event.workflow_run.head_sha || github.sha }}
+          PROV_CONFOS_REF: ${{ env.CONFOS_REF }}
+          PROV_ATTESTATION_RS_REF: ${{ env.ATTESTATION_RS_SHA }}
           # GPU variants are mandatory in CI. build.sh Step 6 grafts the
           # NVIDIA payload from the staged kata-static artifacts
           # (KATA_NVIDIA_CONFIDENTIAL_IMG / KATA_NVIDIA_VMLINUZ, exported by

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -655,6 +655,10 @@ seal_and_assemble() {
         --arg built_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --arg e2fsprogs_ver "${MKE2FS_VERSION}" \
         --arg cryptsetup_ver "${VERITYSETUP_VERSION}" \
+        --arg c8s_ref "${PROV_C8S_REF:-}" \
+        --arg confos_ref "${PROV_CONFOS_REF:-}" \
+        --arg attestation_rs_ref "${PROV_ATTESTATION_RS_REF:-}" \
+        --arg snapshot_sha "$(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}')" \
         '{
            version: ($version|tonumber),
            boot_model: "kata-direct-kernel",
@@ -664,6 +668,12 @@ seal_and_assemble() {
            build_variant: $build_variant,
            kernel_verity_params: $kvp,
            relay_toolchain: { e2fsprogs: $e2fsprogs_ver, cryptsetup: $cryptsetup_ver },
+           inputs: {
+             c8s_ref: $c8s_ref,
+             confos_ref: $confos_ref,
+             attestation_rs_ref: $attestation_rs_ref,
+             kernel_config_snapshot_sha256: $snapshot_sha
+           },
            outputs: {
              kernel:        { path: "vmlinuz",         sha256: $vmlinuz_sha },
              rootfs_image:  { path: "kata-rootfs.img", sha256: $image_sha }


### PR DESCRIPTION
The parked c8s#264 item: kata-guest-base's manifest described its outputs (verity params, hashes, kata version, relay toolchain) but not what built them. This adds an **additive** `inputs` block — `c8s_ref`, `confos_ref`, the **resolved** `attestation_rs_ref` (that checkout floats on `main`; the manifest now records what each build actually used), and `kernel_config_snapshot_sha256`.

Schema stays **v2** deliberately: `katameasure` hard-rejects any other version and published artifacts must remain readable — Go readers ignore unknown fields, so additive is the compat-preserving move.

Flagging, not changing: the attestation-rs checkout floating on `main` means two identical-input kata builds can differ via that repo's head. Recording it makes the drift visible per artifact; pinning it (like `CONFOS_REF`) is a measurement-affecting policy change worth its own decision.

Verified: `bash -n`, workflow YAML parses, and the jq emission smoke-tested with the new args.