### PR TITLE
fix(node-guest-image): node-ip 0.0.0.0 means autodetect — omit it from the fragment

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -95,14 +95,21 @@ stage_addresses() {
     is_ipv4 "$node_ip" || fail "node-ip: not IPv4"
     # 0.0.0.0 = autodetect: omit the field so rke2 resolves the address
     # itself. Passing the literal through registers InternalIP 0.0.0.0 and
-    # breaks apiserver->kubelet traffic.
-    [[ "$node_ip" == 0.0.0.0 ]] && node_ip=""
+    # breaks apiserver->kubelet traffic. `if`, not `&&` — see
+    # emit_node_addr_lines for why under set -e.
+    if [[ "$node_ip" == 0.0.0.0 ]]; then
+        node_ip=""
+    fi
     NODE_IP="$node_ip"
     NODE_EXT=""
     # -L: a dangling symlink must be rejected in read_field, not read as absent.
     if [[ -e "$MNT/node-external-ip" || -L "$MNT/node-external-ip" ]]; then
         node_ext=$(read_field node-external-ip)
         is_ipv4 "$node_ext" || fail "node-external-ip: not IPv4"
+        # No autodetect for external addresses: the sentinel is a config error.
+        if [[ "$node_ext" == 0.0.0.0 ]]; then
+            fail "node-external-ip: 0.0.0.0 is not a routable address"
+        fi
         NODE_EXT="$node_ext"
     fi
 }

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -93,6 +93,10 @@ stage_addresses() {
     local node_ip node_ext
     node_ip=$(read_field node-ip)
     is_ipv4 "$node_ip" || fail "node-ip: not IPv4"
+    # 0.0.0.0 = autodetect: omit the field so rke2 resolves the address
+    # itself. Passing the literal through registers InternalIP 0.0.0.0 and
+    # breaks apiserver->kubelet traffic.
+    [[ "$node_ip" == 0.0.0.0 ]] && node_ip=""
     NODE_IP="$node_ip"
     NODE_EXT=""
     # -L: a dangling symlink must be rejected in read_field, not read as absent.
@@ -106,7 +110,9 @@ stage_addresses() {
 # Infallible: runs inside the fragment pipe, where a failure would stage a
 # truncated fragment. Everything fallible (stage_addresses) runs before it.
 emit_node_addr_lines() {
-    printf 'node-ip: %s\n' "$NODE_IP"
+    if [[ -n "$NODE_IP" ]]; then
+        printf 'node-ip: %s\n' "$NODE_IP"
+    fi
     # `if`, not `&&`: a bare `[[…]] && printf` as last statement returns 1
     # when NODE_EXT is empty, aborting the pipe under set -e for every node
     # without an external IP.

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -136,6 +136,16 @@ reset_state; agent_dir "$WORK/d" with_ext; make_iso "$WORK/d"; run_script
 ok "exit 0" test "$RC" -eq 0
 ok "fragment has external ip" grep -qx 'node-external-ip: 203.0.113.11' "$FRAG"
 
+# 0.0.0.0 is the autodetect sentinel: the fragment must omit node-ip so
+# rke2 resolves the address itself (a literal 0.0.0.0 registers as the
+# node's InternalIP and breaks apiserver->kubelet traffic).
+CASE="server-disk+autodetect-ip"
+reset_state; server_dir "$WORK/d"; write_f "$WORK/d" node-ip 0.0.0.0
+make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment omits node-ip" bash -c '! grep -q "node-ip" "'"$FRAG"'"'
+ok "role-server verdict" test -f "$RUN/role-server"
+
 # ---------------------------------------------------------------- happy: no disk
 CASE="no-disk-legacy-server"
 reset_state

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -138,13 +138,21 @@ ok "fragment has external ip" grep -qx 'node-external-ip: 203.0.113.11' "$FRAG"
 
 # 0.0.0.0 is the autodetect sentinel: the fragment must omit node-ip so
 # rke2 resolves the address itself (a literal 0.0.0.0 registers as the
-# node's InternalIP and breaks apiserver->kubelet traffic).
+# node's InternalIP and breaks apiserver->kubelet traffic). The agent
+# role shares stage_addresses, so this covers both roles.
 CASE="server-disk+autodetect-ip"
 reset_state; server_dir "$WORK/d"; write_f "$WORK/d" node-ip 0.0.0.0
 make_iso "$WORK/d"; run_script
 ok "exit 0" test "$RC" -eq 0
-ok "fragment omits node-ip" bash -c '! grep -q "node-ip" "'"$FRAG"'"'
+ok "fragment omits node-ip" bash -c '! grep -q "^node-ip:" "'"$FRAG"'"'
 ok "role-server verdict" test -f "$RUN/role-server"
+
+# No autodetect for external addresses: the sentinel there is a config
+# error and must reject, not pass through as ExternalIP 0.0.0.0.
+CASE="server-disk+zero-external-ip"
+reset_state; server_dir "$WORK/d" with_ext; write_f "$WORK/d" node-external-ip 0.0.0.0
+make_iso "$WORK/d"; run_script
+assert_rejected
 
 # ---------------------------------------------------------------- happy: no disk
 CASE="no-disk-legacy-server"


### PR DESCRIPTION
## Problem

Live two-CVM validation: launch tooling passes `node-ip: 0.0.0.0` (kubelet's autodetect sentinel — the only workable value on dynamically addressed fabrics), but rke2 registers the literal as the node's InternalIP, breaking apiserver→kubelet traffic (`kubectl exec`/`logs` dial 0.0.0.0). Both nodes showed `INTERNAL-IP 0.0.0.0`.

## Fix

Dispatch treats `0.0.0.0` as omit-the-field: the fragment carries no `node-ip`, so rke2 autodetects exactly like the single-node default. Validation still requires well-formed IPv4. Harness asserts the omission.
