### PR TITLE
fix(node-guest-image): absent node-ip also means autodetect

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -11,7 +11,7 @@
 # joindata contract (v0), all files a single <=256-byte ASCII line (edge
 # whitespace tolerated and trimmed; interior whitespace rejected):
 #   role              server|agent            (both roles)
-#   node-ip           routable IPv4           (both roles)
+#   node-ip           IPv4, optional          (both roles; absent or 0.0.0.0 = autodetect)
 #   node-external-ip  routable IPv4, optional (both roles)
 #   server            IPv4, no scheme/port    (agent only; forbidden on server)
 #   server-token      64 lowercase hex        (server only; forbidden on agent)

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -91,16 +91,19 @@ write_atomic() {
 # Common address fields, validated the same way for both roles.
 stage_addresses() {
     local node_ip node_ext
-    node_ip=$(read_field node-ip)
-    is_ipv4 "$node_ip" || fail "node-ip: not IPv4"
-    # 0.0.0.0 = autodetect: omit the field so rke2 resolves the address
-    # itself. Passing the literal through registers InternalIP 0.0.0.0 and
+    # node-ip is optional: absent, like the kubelet sentinel 0.0.0.0, means
+    # rke2 resolves the address itself (Kubernetes ChooseHostInterface).
+    # Passing a literal 0.0.0.0 through registers InternalIP 0.0.0.0 and
     # breaks apiserver->kubelet traffic. `if`, not `&&` — see
     # emit_node_addr_lines for why under set -e.
-    if [[ "$node_ip" == 0.0.0.0 ]]; then
-        node_ip=""
+    NODE_IP=""
+    if [[ -e "$MNT/node-ip" || -L "$MNT/node-ip" ]]; then
+        node_ip=$(read_field node-ip)
+        is_ipv4 "$node_ip" || fail "node-ip: not IPv4"
+        if [[ "$node_ip" != 0.0.0.0 ]]; then
+            NODE_IP="$node_ip"
+        fi
     fi
-    NODE_IP="$node_ip"
     NODE_EXT=""
     # -L: a dangling symlink must be rejected in read_field, not read as absent.
     if [[ -e "$MNT/node-external-ip" || -L "$MNT/node-external-ip" ]]; then

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -144,14 +144,17 @@ CASE="server-disk+autodetect-ip"
 reset_state; server_dir "$WORK/d"; write_f "$WORK/d" node-ip 0.0.0.0
 make_iso "$WORK/d"; run_script
 ok "exit 0" test "$RC" -eq 0
-ok "fragment omits node-ip" bash -c '! grep -q "^node-ip:" "'"$FRAG"'"'
+ok "fragment exact (node-ip omitted)" \
+   test "$(cat "$FRAG")" = "token-file: $RUN/rke2-server-token"
 ok "role-server verdict" test -f "$RUN/role-server"
 
 # Absent node-ip is the same autodetect path as the sentinel.
 CASE="agent-disk+absent-node-ip"
 reset_state; agent_dir "$WORK/d"; rm "$WORK/d/node-ip"; make_iso "$WORK/d"; run_script
 ok "exit 0" test "$RC" -eq 0
-ok "fragment omits node-ip" bash -c '! grep -q "^node-ip:" "'"$FRAG"'"'
+ok "fragment exact (node-ip omitted)" \
+   test "$(cat "$FRAG")" = "token-file: $RUN/rke2-agent-token
+server: https://192.168.7.10:$JOIN_PORT"
 ok "role-agent verdict" test -f "$RUN/role-agent"
 
 # No autodetect for external addresses: the sentinel there is a config
@@ -229,6 +232,9 @@ m_oversize_line()     { server_dir "$1"; { head -c 257 /dev/zero | tr '\0' a; } 
 m_nul_byte()          { server_dir "$1"; printf 'ser\0ver' > "$1/role"; }
 m_symlink()           { server_dir "$1"; rm "$1/role"; ln -s /etc/hostname "$1/role"; }
 m_dangling_ext_ip()   { server_dir "$1"; ln -s /nonexistent-target "$1/node-external-ip"; }
+# Now that absent node-ip means autodetect, a dangling symlink must still
+# reject in read_field, never read as absent.
+m_dangling_node_ip()  { server_dir "$1"; rm "$1/node-ip"; ln -s /nonexistent-target "$1/node-ip"; }
 m_nonregular_dir()    { server_dir "$1"; rm "$1/role"; mkdir "$1/role"; }
 m_empty_ext_ip()      { server_dir "$1"; write_f "$1" node-external-ip ''; }
 m_agent_no_server()   { agent_dir "$1"; rm "$1/server"; }
@@ -238,8 +244,8 @@ for c in wrong_role role_missing forbid_server forbid_stok extra_file_server \
          extra_file_agent equal_tokens tok_63 tok_upper tok_nonhex ip_range \
          ip_short ip_leading_zero ip_octet_08 srv_scheme srv_port interior_ws \
          multiline oversize_file oversize_line nul_byte symlink \
-         dangling_ext_ip nonregular_dir empty_ext_ip agent_no_server \
-         server_no_atok; do
+         dangling_ext_ip dangling_node_ip nonregular_dir empty_ext_ip \
+         agent_no_server server_no_atok; do
     reject_case "reject-$c" "m_$c"
 done
 

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -147,6 +147,13 @@ ok "exit 0" test "$RC" -eq 0
 ok "fragment omits node-ip" bash -c '! grep -q "^node-ip:" "'"$FRAG"'"'
 ok "role-server verdict" test -f "$RUN/role-server"
 
+# Absent node-ip is the same autodetect path as the sentinel.
+CASE="agent-disk+absent-node-ip"
+reset_state; agent_dir "$WORK/d"; rm "$WORK/d/node-ip"; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment omits node-ip" bash -c '! grep -q "^node-ip:" "'"$FRAG"'"'
+ok "role-agent verdict" test -f "$RUN/role-agent"
+
 # No autodetect for external addresses: the sentinel there is a config
 # error and must reject, not pass through as ExternalIP 0.0.0.0.
 CASE="server-disk+zero-external-ip"


### PR DESCRIPTION
## Problem

`node-ip` is a required joindata field: an absent file fails dispatch, so the only way to ask for address autodetection is the `0.0.0.0` sentinel from #337. `node-external-ip` is already optional — the two address fields behave differently for no reason.

## Fix

Gate the `node-ip` read in `stage_addresses` on the file existing (same `-e || -L` shape as `node-external-ip`, so a dangling symlink still rejects in `read_field` instead of reading as absent). The sentinel check stays inside the branch; absent and `0.0.0.0` land on the same omit-the-field path and rke2 resolves the address itself.

New harness case `agent-disk+absent-node-ip` pins the behaviour: exit 0, fragment omits `node-ip`, agent role dispatches.