### PR TITLE
feat(credrelease): SNP operator-key binding via launch-time HOSTDATA

### DIFF
--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -1,18 +1,26 @@
 // Package credrelease implements the in-guest credential-release service (B4
 // of the operator-key design). It issues an operator a short-lived kube client
 // certificate, but only to a caller who proves possession of the operator
-// private key whose public half was bound into the CVM's RTMR[3] at launch —
-// giving an external operator console-free, non-TOFU admin access with no
-// pre-shared cluster secret and no trust in the untrusted host.
+// private key whose public half was bound into the CVM's launch identity
+// (TDX RTMR[3] / SNP HOSTDATA) at launch — giving an external operator
+// console-free, non-TOFU admin access with no pre-shared cluster secret and
+// no trust in the untrusted host.
 package credrelease
 
 import (
 	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 // operatorPubkeyPath is where the measured initrd stages the operator public
@@ -87,16 +95,92 @@ func readOperatorPubkey() ([]byte, error) {
 	return pub, nil
 }
 
-// LoadMeasuredOperatorKey reads the operator pubkey off the opkeydata disk and
-// verifies it against RTMR[3]. The returned bytes are safe to trust as the
-// authorized operator key. This is called once at service start; the key is
-// fixed for the life of the TD.
-func LoadMeasuredOperatorKey() ([]byte, error) {
+// selfReportTimeout bounds the SNP self-attestation round trip against the
+// local attestation-api; on expiry the service fails start and systemd
+// retries, same as a failed RTMR read on TDX.
+const selfReportTimeout = 15 * time.Second
+
+// verifiedSelfHostData returns this guest's HOSTDATA as the attestation-api
+// reports it, from the claims of a report that api verified — reading it off
+// an unverified self-report would take the anchor from an unauthenticated
+// field. Mirrors policymonitor's verifiedSelfHostData, with a random anchor:
+// nothing here needs the zero-anchor convention, and a fresh nonce makes the
+// self-report non-replayable for free.
+func verifiedSelfHostData(ctx context.Context, attestationAPIURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, selfReportTimeout)
+	defer cancel()
+
+	// The attester is asked for the 48-byte prefix and zero-extends it into
+	// the 64-byte REPORTDATA the verifier must find.
+	var reportData [64]byte
+	if _, err := rand.Read(reportData[:sha512.Size384]); err != nil {
+		return nil, fmt.Errorf("self-report nonce: %w", err)
+	}
+	resp, err := attestclient.NewClient("").GenerateEvidenceContext(ctx, attestationAPIURL, reportData[:sha512.Size384])
+	if err != nil {
+		return nil, fmt.Errorf("attest self: %w", err)
+	}
+	verified, err := attestationclient.NewClient(attestationAPIURL).VerifyEvidence(ctx,
+		types.AttestationEvidence(resp), attestationclient.EvidencePolicy{ExpectedReportData: reportData})
+	if err != nil {
+		return nil, fmt.Errorf("verify self-report: %w", err)
+	}
+
+	hostData, err := hex.DecodeString(verified.Result.Claims.InitData)
+	if err != nil {
+		return nil, fmt.Errorf("HOSTDATA claim is not hex: %w", err)
+	}
+	// A TDX report leaking into this arm carries a 48-byte MRCONFIGID here
+	// and is refused by length, not silently truncated.
+	if len(hostData) != runtimemeasure.HostDataSize {
+		return nil, fmt.Errorf("HOSTDATA claim is %d bytes, want %d", len(hostData), runtimemeasure.HostDataSize)
+	}
+	return hostData, nil
+}
+
+// verifyKeyLaunchBound is the SNP analog of verifyKeyMeasured: before trusting
+// the on-disk key the service confirms sha256(file bytes) equals the HOSTDATA
+// the launcher committed at launch. HOSTDATA is immutable post-launch and
+// carried in every report, so a host that swapped the pubkey file post-boot
+// produces a mismatch here — it cannot alter HOSTDATA any more than it can
+// rewind RTMR[3]. A VM launched without an operator key carries all-zero
+// HOSTDATA, which no SHA-256 output equals, so that fails closed too.
+func verifyKeyLaunchBound(ctx context.Context, attestationAPIURL string, pubkey []byte) error {
+	hostData, err := verifiedSelfHostData(ctx, attestationAPIURL)
+	if err != nil {
+		return err
+	}
+	want := runtimemeasure.HostDataForOperatorKey(pubkey)
+	// Not secret (a public-key hash) — plain compare is fine.
+	if !bytes.Equal(hostData, want[:]) {
+		return fmt.Errorf(
+			"operator pubkey does not match the launch-committed HOSTDATA: got %s, key implies %s (was the pubkey file substituted after boot, or the VM launched for a different key?)",
+			hex.EncodeToString(hostData), hex.EncodeToString(want[:]))
+	}
+	return nil
+}
+
+// LoadMeasuredOperatorKey reads the operator pubkey the initrd staged off the
+// opkeydata disk and verifies it against the platform's launch binding: the
+// TDX RTMR[3] the initrd extended, or the SNP HOSTDATA the launcher committed.
+// The returned bytes are safe to trust as the authorized operator key. Called
+// once at service start; both bindings are fixed for the life of the guest.
+// platform is the ratls-normalized platform ("tdx" or "sev-snp").
+func LoadMeasuredOperatorKey(ctx context.Context, platform, attestationAPIURL string) ([]byte, error) {
 	pub, err := readOperatorPubkey()
 	if err != nil {
 		return nil, err
 	}
-	if err := verifyKeyMeasured(pub); err != nil {
+	switch platform {
+	case "tdx":
+		err = verifyKeyMeasured(pub)
+	case "sev-snp":
+		err = verifyKeyLaunchBound(ctx, attestationAPIURL, pub)
+	default:
+		// Fail closed: an unknown platform has no binding to check.
+		err = fmt.Errorf("no operator-key binding check for platform %q", platform)
+	}
+	if err != nil {
 		return nil, err
 	}
 	return pub, nil

--- a/internal/cmds/credrelease/binding_test.go
+++ b/internal/cmds/credrelease/binding_test.go
@@ -1,10 +1,14 @@
 package credrelease
 
 import (
+	"bytes"
+	"context"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
 
@@ -45,7 +49,7 @@ func TestLoadMeasuredOperatorKey(t *testing.T) {
 	writeFileT(t, pubPath, pub)
 	writeFileT(t, rtmrPath, expectedRTMR3ForKey(pub))
 
-	got, err := LoadMeasuredOperatorKey()
+	got, err := LoadMeasuredOperatorKey(context.Background(), "tdx", "")
 	if err != nil {
 		t.Fatalf("LoadMeasuredOperatorKey: %v", err)
 	}
@@ -97,7 +101,93 @@ func TestLoadMeasuredOperatorKeyFailsClosed(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pubPath, rtmrPath := overrideBindingPaths(t)
 			tc.stage(t, pubPath, rtmrPath)
-			if _, err := LoadMeasuredOperatorKey(); err == nil {
+			if _, err := LoadMeasuredOperatorKey(context.Background(), "tdx", ""); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}
+
+// snpAttester returns the URL of a stub attestation-api whose verified claims
+// report initData (hex-encoded verbatim) as this guest's HOSTDATA.
+func snpAttester(t *testing.T, initData string) string {
+	t.Helper()
+	stub := testattest.New(t)
+	v := testattest.PassingVerdict("")
+	v.Claims.InitData = initData
+	stub.SetVerdict(v)
+	return stub.URL
+}
+
+// TestLoadMeasuredOperatorKeySNP covers the SNP happy path: the verified
+// self-report's HOSTDATA equals sha256 of the staged pubkey bytes.
+func TestLoadMeasuredOperatorKeySNP(t *testing.T) {
+	pubPath, _ := overrideBindingPaths(t)
+	pub := []byte("operator public key bytes")
+	writeFileT(t, pubPath, pub)
+	want := runtimemeasure.HostDataForOperatorKey(pub)
+	url := snpAttester(t, hex.EncodeToString(want[:]))
+
+	got, err := LoadMeasuredOperatorKey(context.Background(), "sev-snp", url)
+	if err != nil {
+		t.Fatalf("LoadMeasuredOperatorKey: %v", err)
+	}
+	if string(got) != string(pub) {
+		t.Errorf("returned key = %q, want %q", got, pub)
+	}
+}
+
+// TestLoadMeasuredOperatorKeySNPFailsClosed enumerates the SNP refusals:
+// keyless launch (zero HOSTDATA), a different key's HOSTDATA, TDX-shaped and
+// malformed claims, an unreachable attestation-api, an unknown platform.
+func TestLoadMeasuredOperatorKeySNPFailsClosed(t *testing.T) {
+	pub := []byte("operator public key bytes")
+	otherKey := runtimemeasure.HostDataForOperatorKey([]byte("a different operator key"))
+	tests := []struct {
+		name     string
+		platform string
+		url      func(t *testing.T) string
+	}{
+		{
+			name:     "keyless launch: zero HOSTDATA",
+			platform: "sev-snp",
+			url: func(t *testing.T) string {
+				return snpAttester(t, hex.EncodeToString(bytes.Repeat([]byte{0}, runtimemeasure.HostDataSize)))
+			},
+		},
+		{
+			name:     "launched for a different key",
+			platform: "sev-snp",
+			url:      func(t *testing.T) string { return snpAttester(t, hex.EncodeToString(otherKey[:])) },
+		},
+		{
+			name:     "TDX-sized InitData (48-byte MRCONFIGID)",
+			platform: "sev-snp",
+			url: func(t *testing.T) string {
+				return snpAttester(t, hex.EncodeToString(bytes.Repeat([]byte{0xa5}, 48)))
+			},
+		},
+		{
+			name:     "InitData not hex",
+			platform: "sev-snp",
+			url:      func(t *testing.T) string { return snpAttester(t, "zz") },
+		},
+		{
+			name:     "attestation-api unreachable",
+			platform: "sev-snp",
+			url:      func(t *testing.T) string { return "http://127.0.0.1:1" },
+		},
+		{
+			name:     "unknown platform has no binding check",
+			platform: "no-such-platform",
+			url:      func(t *testing.T) string { return "" },
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pubPath, _ := overrideBindingPaths(t)
+			writeFileT(t, pubPath, pub)
+			if _, err := LoadMeasuredOperatorKey(context.Background(), tc.platform, tc.url(t)); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})

--- a/internal/cmds/credrelease/binding_test.go
+++ b/internal/cmds/credrelease/binding_test.go
@@ -173,6 +173,40 @@ func TestLoadMeasuredOperatorKeySNPFailsClosed(t *testing.T) {
 			url:      func(t *testing.T) string { return snpAttester(t, "zz") },
 		},
 		{
+			name:     "InitData claim empty",
+			platform: "sev-snp",
+			url:      func(t *testing.T) string { return snpAttester(t, "") },
+		},
+		// The two verdict cases carry a MATCHING InitData: refusal must come
+		// from verdict enforcement, not the claims compare, so a refactor
+		// that drops VerifyEvidence's enforcement fails here.
+		{
+			name:     "verifier refuses: signature invalid",
+			platform: "sev-snp",
+			url: func(t *testing.T) string {
+				want := runtimemeasure.HostDataForOperatorKey(pub)
+				stub := testattest.New(t)
+				v := testattest.PassingVerdict("")
+				v.SignatureValid = false
+				v.Claims.InitData = hex.EncodeToString(want[:])
+				stub.SetVerdict(v)
+				return stub.URL
+			},
+		},
+		{
+			name:     "verifier refuses: REPORTDATA not bound",
+			platform: "sev-snp",
+			url: func(t *testing.T) string {
+				want := runtimemeasure.HostDataForOperatorKey(pub)
+				stub := testattest.New(t)
+				v := testattest.PassingVerdict("")
+				v.ReportDataMatch = nil
+				v.Claims.InitData = hex.EncodeToString(want[:])
+				stub.SetVerdict(v)
+				return stub.URL
+			},
+		},
+		{
 			name:     "attestation-api unreachable",
 			platform: "sev-snp",
 			url:      func(t *testing.T) string { return "http://127.0.0.1:1" },

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -8,16 +8,18 @@ import (
 
 // NewCmd builds the `cred-release` subcommand: the in-guest service that
 // issues an operator a short-lived kube client cert, gated on possession of
-// the operator key measured into RTMR[3]. Baked as a systemd unit in the c8s
-// node image; not run by hand in normal operation.
+// the operator key bound into the launch identity (TDX RTMR[3] / SNP
+// HOSTDATA). Baked as a systemd unit in the c8s node image; not run by hand
+// in normal operation.
 func NewCmd() *cobra.Command {
 	var cfg Config
 	cmd := &cobra.Command{
 		Use:   "cred-release",
-		Short: "Release a kube operator credential to the attested holder of the RTMR[3]-bound key",
+		Short: "Release a kube operator credential to the attested holder of the launch-bound key",
 		Long: "cred-release serves an RA-TLS endpoint that issues a short-lived\n" +
 			"kube client certificate to a caller who proves possession of the\n" +
-			"operator key whose public half was bound into RTMR[3] at launch.\n" +
+			"operator key whose public half was bound into the launch identity\n" +
+			"(TDX: RTMR[3]; SNP: HOSTDATA) at launch.\n" +
 			"It gives an external operator console-free, non-TOFU cluster-admin\n" +
 			"access with no pre-shared secret and no trust in the host. The cert\n" +
 			"is signed by the cluster's client CA and the kubeconfig anchors to\n" +
@@ -30,8 +32,8 @@ func NewCmd() *cobra.Command {
 	}
 	f := cmd.Flags()
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
-	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (source of the RA-TLS serving cert's TDX quote)")
-	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required; operator-key binding is TDX-only)")
+	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (RA-TLS serving quote; on SNP also the HOSTDATA self-verify)")
+	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required)")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")

--- a/internal/cmds/credrelease/handler.go
+++ b/internal/cmds/credrelease/handler.go
@@ -51,7 +51,8 @@ type Handler struct {
 
 // NewHandler builds the release handler from the measured operator pubkey (PEM)
 // and the loaded cluster CA. The pubkey MUST already have been verified against
-// RTMR[3] by LoadMeasuredOperatorKey — NewHandler trusts it as authorized.
+// the launch binding by LoadMeasuredOperatorKey — NewHandler trusts it as
+// authorized.
 func NewHandler(operatorPubPEM []byte, ca *clusterCA, org, cn string, ttl time.Duration) (*Handler, error) {
 	keys, err := operatorauth.ParsePublicKeysPEM(operatorPubPEM)
 	if err != nil {

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -15,9 +15,10 @@ import (
 type Config struct {
 	// ListenAddr is the HTTPS bind address (e.g. ":8443").
 	ListenAddr string
-	// AttestationAPIURL is the local attestation-api base URL the RA-TLS
-	// serving cert's TDX quote is fetched from (the same :8400 service the
-	// rest of the stack uses).
+	// AttestationAPIURL is the local attestation-api base URL (the same
+	// :8400 service the rest of the stack uses). It provides the RA-TLS
+	// serving cert's quote and, on SNP, the verified self-report that
+	// anchors the operator key to the launch-committed HOSTDATA.
 	AttestationAPIURL string
 	// Platform is the TEE platform ("tdx" or "snp"; no default).
 	Platform string
@@ -41,7 +42,8 @@ type Config struct {
 //
 // Startup order matters for the trust story:
 //  1. LoadMeasuredOperatorKey — read the opkeydata pubkey and CONFIRM it
-//     matches RTMR[3]. Fails closed if the key was substituted after boot.
+//     matches the launch binding (TDX RTMR[3] / SNP HOSTDATA). Fails closed
+//     if the key was substituted after boot.
 //  2. loadClusterCA — the cluster client-CA that signs the operator's cert.
 //  3. serve over an RA-TLS config so the caller can attest this is the real
 //     guest before trusting the returned cert.
@@ -58,7 +60,7 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("--platform: %w", err)
 	}
 
-	operatorPub, err := LoadMeasuredOperatorKey()
+	operatorPub, err := LoadMeasuredOperatorKey(ctx, cfg.Platform, cfg.AttestationAPIURL)
 	if err != nil {
 		return fmt.Errorf("load measured operator key: %w", err)
 	}

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -24,10 +24,11 @@ ConditionPathExists=/run/confos/role-server
 
 [Service]
 Type=simple
-# The operator key is bound into the platform's runtime measurement at launch
-# (TDX RTMR[3] today — the binding is TDX-only, so on SNP this check fails
-# closed pending an SNP binding design); the service verifies the on-disk
-# pubkey against it and refuses (exits non-zero) if it was substituted.
+# The operator key is bound into the platform's launch identity (TDX: the
+# initrd extends its hash into RTMR[3]; SNP: the launcher commits its sha256
+# as HOSTDATA); the service verifies the on-disk pubkey against that binding
+# via the local attestation-api and refuses (exits non-zero) if it was
+# substituted.
 # Non-operator boots never reach here (ConditionPathExists skips the unit).
 # Waits bounded (10 min) rather than failing fast: on a slow first boot the
 # CA can take minutes to appear, and 5 quick ExecStartPre failures 10s apart

--- a/pkg/runtimemeasure/runtimemeasure.go
+++ b/pkg/runtimemeasure/runtimemeasure.go
@@ -23,15 +23,19 @@
 // FromDigestsSeeded(ForOperatorKey(pub), …) rather than FromDigests.
 //
 // This package is deliberately vendor-neutral: it is arithmetic over digests
-// and says nothing about where the register lives. Today the only backing
-// hardware is Intel TDX RTMR[3] — SEV-SNP has no equivalent runtime-extend
-// register — so the code that reads or writes the register is TDX-specific
-// (internal/cmds/rtmr3measurer, credrelease, the guest initrd) while the
-// convention it implements is not. See docs/kata-guest-base.md
-// "Per-workload RTMR[3] measurement".
+// and says nothing about where the register lives. The register-backed
+// convention above runs on Intel TDX RTMR[3]. SEV-SNP has no runtime-extend
+// register, so on SNP only the operator-key half of the convention exists:
+// the launcher commits the key digest into the report's immutable HOSTDATA
+// field at launch (HostDataForOperatorKey), and per-workload extends do not
+// exist — FromDigestsSeeded/Event remain TDX-only. The code that reads or
+// writes the TDX register is TDX-specific (internal/cmds/rtmr3measurer,
+// credrelease, the guest initrd) while the convention it implements is not.
+// See docs/kata-guest-base.md "Per-workload RTMR[3] measurement".
 package runtimemeasure
 
 import (
+	"crypto/sha256"
 	"crypto/sha512"
 	"fmt"
 	"strings"
@@ -101,6 +105,31 @@ func FromDigestsSeeded(seed [Size]byte, canonicalDigests []string) [Size]byte {
 // through unmodified rather than round-tripping through a PEM parser.
 func ForOperatorKey(pubkey []byte) [Size]byte {
 	return Extend(Zero, sha512.Sum384(pubkey))
+}
+
+// HostDataSize is the byte length of the SNP HOSTDATA field, and so of the
+// operator-key binding value on SNP (SHA-256).
+const HostDataSize = 32
+
+// HostDataForOperatorKey computes the SNP launch-time operator-key binding:
+// the value the launcher commits as HOSTDATA when launching a node CVM for
+// this key:
+//
+//	HOSTDATA = SHA256(pubkey)
+//
+// It is the SNP analog of ForOperatorKey. SEV-SNP has no runtime-extend
+// register, so instead of the measured initrd extending the key digest into
+// RTMR[3] after launch, the (untrusted) launcher commits it into the report's
+// immutable HOSTDATA field at launch. The trust argument is unchanged: the
+// host could set any value, but a verifier that checks HOSTDATA against the
+// key it expects rejects a wrong-key launch, exactly as it would reject a
+// wrong RTMR[3]. A VM launched without an operator key carries all-zero
+// HOSTDATA, which no SHA-256 output equals.
+//
+// pubkey is the EXACT bytes staged as the opkeydata disk's pubkey file (see
+// ForOperatorKey); any re-encoding yields a different digest.
+func HostDataForOperatorKey(pubkey []byte) [HostDataSize]byte {
+	return sha256.Sum256(pubkey)
 }
 
 // CanonicalDigest strictly canonicalizes an image reference to the

--- a/pkg/runtimemeasure/runtimemeasure_test.go
+++ b/pkg/runtimemeasure/runtimemeasure_test.go
@@ -165,3 +165,26 @@ func TestCanonicalDigest(t *testing.T) {
 		})
 	}
 }
+
+// TestHostDataForOperatorKeyGolden pins the SNP binding formula: a changed
+// vector here breaks the launcher, the guest initrd, and every verifier at
+// once, exactly like the RTMR[3] vectors above.
+func TestHostDataForOperatorKeyGolden(t *testing.T) {
+	pub := []byte("-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n")
+	const want = "f61b347fbb8e6469f294c1faa146d37688e5c1c8a6b1b25653ee85ad10b7447a"
+	if got := hex.EncodeToString(hostDataSlice(HostDataForOperatorKey(pub))); got != want {
+		t.Errorf("HostDataForOperatorKey = %s, want %s", got, want)
+	}
+}
+
+// Same exact-bytes rule as ForOperatorKey: a trailing newline changes the
+// binding.
+func TestHostDataForOperatorKeyIsByteExact(t *testing.T) {
+	withNewline := []byte("-----BEGIN PUBLIC KEY-----\nAAAA\n-----END PUBLIC KEY-----\n")
+	withoutNewline := withNewline[:len(withNewline)-1]
+	if HostDataForOperatorKey(withNewline) == HostDataForOperatorKey(withoutNewline) {
+		t.Error("HostDataForOperatorKey must not normalize its input; a trailing newline changes the binding")
+	}
+}
+
+func hostDataSlice(v [HostDataSize]byte) []byte { return v[:] }


### PR DESCRIPTION
## Problem

`cred-release` verifies the staged operator pubkey against TDX RTMR[3], which does not exist on SEV-SNP — so on SNP the check fails closed and sealed SNP node-CVMs have no operator access path (#331). The launcher-side leg commits `sha256(pubkey bytes)` into the report's immutable HOSTDATA at launch; nothing in c8s verifies it.

## Fix

- `runtimemeasure.HostDataForOperatorKey` — the SNP binding formula (`HOSTDATA = SHA256(exact pubkey file bytes)`), anchored next to `ForOperatorKey` so the two bindings share one source of truth and the exact-bytes rule. Golden vector + byte-exactness tests, and the package doc now states both mechanisms.
- `credrelease.LoadMeasuredOperatorKey` grows a platform switch: TDX keeps the RTMR[3] read; the SNP arm fetches a self-report and verifies it through the local attestation-api (the policymonitor pattern — HOSTDATA is only ever read from verified claims, never from a raw report), then compares against the key's digest. Unknown platforms fail closed.
- Fail-closed edges pinned by tests: keyless launch (all-zero HOSTDATA never equals a sha256 output), a different key's HOSTDATA, 48-byte TDX MRCONFIGID refused by length, non-hex claims, unreachable attestation-api, unknown platform.
- Help text, comments, and the `cred-release.service` header drop the "TDX-only" wording.

The `get-kubeconfig` operator-side SNP gate is deliberately not in this PR: its image-identity half needs a trustworthy `snp_launch_digest` in the published manifests, which they don't yet carry (the e2e pins a runtime-captured golden instead).