### PR TITLE
ci(c8s-image): complete the kernel cache keys; cache cargo workspaces

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -161,6 +161,11 @@ jobs:
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
+        with:
+          # Both cargo workspaces this job compiles; the default "." caches neither.
+          cache-workspaces: |
+            attestation-rs
+            confidential-os-builder
 
       - name: Setup uv
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
@@ -171,16 +176,18 @@ jobs:
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
         # base ovmf is for the SNP path.
+        # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y systemd-container ovmf cpio acpica-tools
+          sudo apt-get install -y systemd-container ovmf cpio acpica-tools \
+            libclang-dev clang libtss2-dev
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache kernel tools
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf') }}
+          key: ${{ runner.os }}-tools-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
 
       - name: Cache kernel
         # Every input of confos's kernel fingerprint, or the cache is rejected
@@ -188,7 +195,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/output/kernel
-          key: ${{ runner.os }}-kernel-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
+          key: ${{ runner.os }}-kernel-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
       - name: Cache base image tools
         uses: actions/cache@v5
@@ -249,9 +256,6 @@ jobs:
           NVAT_USE_SYSTEM_LIB: "1"
         working-directory: attestation-rs
         run: |
-          # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
-          sudo apt-get update
-          sudo apt-get install -y libclang-dev clang libtss2-dev
           cargo build -p attestation-api --release \
             --features nvidia-gpu-attest --bin attestation-api
           # Must actually link libnvat (not a silent fallback).


### PR DESCRIPTION
## Problem

Every c8s-image build takes 23-29 min, and ~16 min of that is a kernel + NVIDIA module rebuild that should be a cache hit. The kernel cache key omits two of confos's fingerprint inputs (`kernel/randstruct.seed` and the `mkosi/kernel-builder/mkosi.sandbox/` tree), so a stale entry keeps restoring under a stable key, fails the fingerprint check inside `confos kernel`, and the run rebuilds from scratch; the primary-key hit then skips the save, so the stale entry is never replaced. The same run's second confos invocation prints `kernel cache HIT` against the freshly built kernel, confirming only the cached manifest is at fault. Separately, the rust cache stores no workspace (the default "." matches none), so attestation-api recompiles all deps (~2.5 min) and confos itself (~45 s) every run.

## Fix

- Hash every fingerprint input into the kernel cache key (add `randstruct.seed` + `mkosi.sandbox/**`), and the sandbox tree into the kernel-tools key, mirroring confos's `tools_tree_inputs_digest`.
- `cache-workspaces: attestation-rs, confidential-os-builder` on setup-rust-toolchain.
- Fold the attestation build's apt packages into the existing install step (drops a second `apt-get update`).

Expected steady state: gate legs and unchanged-rootfs main runs ~7-8 min, publishing main runs ~10-11 min. First run per new key still pays the full build once to seed the cache.