### PR TITLE
ci(c8s-image): make the kernel cache hit path actually work

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -156,7 +156,8 @@ jobs:
         # kernel + NVIDIA userspace + rke2 airgap + ~6G disk.raw on a 14G runner.
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          sudo docker image prune --all --force || true
+          # Backgrounded: frees its space minutes before the big writes start.
+          sudo docker image prune --all --force >/dev/null 2>&1 &
           df -h
 
       - name: Setup Rust
@@ -183,19 +184,28 @@ jobs:
             libclang-dev clang libtss2-dev
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
-      - name: Cache kernel tools
+      - name: Cache kernel-builder tools tree
+        # mkosi.output (image + stamp) is what the kernel short-circuit path
+        # still needs: confos-fetch-gpu compiles modules inside it. mkosi.tools
+        # is only an intermediate for building it, so it isn't cached.
         uses: actions/cache@v5
         with:
-          path: confidential-os-builder/mkosi/kernel-builder/mkosi.tools
-          key: ${{ runner.os }}-tools-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
+          path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
+          key: ${{ runner.os }}-tools-v2-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
 
       - name: Cache kernel
         # Every input of confos's kernel fingerprint, or the cache is rejected
-        # and rebuilt (hashFiles has no brace expansion).
+        # and rebuilt (hashFiles has no brace expansion). The snapshot lockfile
+        # rides the cache: the build rewrites it with the fragment-resolved
+        # config and fingerprints THAT, so restoring output/kernel without it
+        # can never match. The key hashes the committed snapshot (evaluated at
+        # restore, before the rewrite), which is stable per confos pin.
         uses: actions/cache@v5
         with:
-          path: confidential-os-builder/output/kernel
-          key: ${{ runner.os }}-kernel-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
+          path: |
+            confidential-os-builder/output/kernel
+            confidential-os-builder/kernel/config-x86_64.snapshot
+          key: ${{ runner.os }}-kernel-v2-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
       - name: Cache base image tools
         uses: actions/cache@v5


### PR DESCRIPTION
## Problem

#340 fixed the cache keys, but the seeded cache still never hits: `confos kernel` rewrites `kernel/config-x86_64.snapshot` with the fragment-resolved config and fingerprints **that**, while every fresh checkout presents confos's committed bare-baseline snapshot. The restored manifest therefore always mismatches the live fingerprint and the ~16 min kernel rebuild happens on every run (the timed post-#340 run confirmed it). Two further gaps on the would-be hit path: `confos-fetch-gpu` hard-requires the kernel-builder `mkosi.output` tools tree, which was never cached (the old step cached `mkosi.tools`, an intermediate only needed when the tools tree itself rebuilds), and the `docker image prune` in the disk step blocks ~70 s for space that isn't needed until minutes later.

## Fix

- Cache `kernel/config-x86_64.snapshot` alongside `output/kernel`, so a restore presents exactly the state the cached manifest fingerprints. The key hashes the committed snapshot and is evaluated at restore time, before the rewrite, so it stays stable per confos pin. Key bumped to `-v2`: the existing entry lacks the snapshot and a same-key entry is never re-saved.
- Cache `mkosi/kernel-builder/mkosi.output` (image + stamp) instead of `mkosi.tools`.
- Background the docker prune.

First run per key still pays the full build to seed; after that the kernel, module toolchain, and short-circuit all line up.