### PR TITLE
ci(c8s-image): chown the tools tree before the cache save; kernel key to v3

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -205,7 +205,7 @@ jobs:
           path: |
             confidential-os-builder/output/kernel
             confidential-os-builder/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kernel-v2-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
+          key: ${{ runner.os }}-kernel-v3-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
       - name: Cache base image tools
         uses: actions/cache@v5
@@ -295,6 +295,13 @@ jobs:
           # workflow publishes the TDX image; the snp variant is built on
           # demand until M3 adds it to CI.
           C8S_PLATFORM="${{ matrix.platform }}" C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
+
+      - name: Make the tools tree cache-safe
+        # The post-job cache tar runs unprivileged; mkosi builds the tree as
+        # root, so the save fails on it without this. Runs after all use.
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" \
+            confidential-os-builder/mkosi/kernel-builder/mkosi.output || true
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.


### PR DESCRIPTION
## Problem

Follow-up to #341, which merged before this landed on its branch. The tools-tree cache save fails every run: the post-job cache tar runs unprivileged and mkosi builds `mkosi.output` as root, so tar errors on root-owned files and the entry is never written (the same reason the base-tools cache has never saved in this repo). With #341's kernel cache working but no tools tree, the second main image build from now will hit the kernel cache, skip the tools-tree build, and then die in `confos-fetch-gpu` ("kernel-builder tools tree missing"). This needs to merge before that run happens.

## Fix

- `chown` the tools tree to the runner user at job end, after all use, so the save succeeds.
- Bump the kernel key to v3, forcing one seed run that saves the kernel and tools entries together; a kernel hit can then never occur without the tools tree it needs.