### PR TITLE
ci(c8s-image): chown the base tools tree too, so its cache save succeeds

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -296,12 +296,14 @@ jobs:
           # demand until M3 adds it to CI.
           C8S_PLATFORM="${{ matrix.platform }}" C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
 
-      - name: Make the tools tree cache-safe
-        # The post-job cache tar runs unprivileged; mkosi builds the tree as
-        # root, so the save fails on it without this. Runs after all use.
+      - name: Make the tools trees cache-safe
+        # The post-job cache tar runs unprivileged; mkosi builds these trees as
+        # root, so their saves fail without this. Runs after all use.
         run: |
           sudo chown -R "$(id -u):$(id -g)" \
-            confidential-os-builder/mkosi/kernel-builder/mkosi.output || true
+            confidential-os-builder/mkosi/kernel-builder/mkosi.output \
+            confidential-os-builder/mkosi/base/mkosi.tools \
+            confidential-os-builder/mkosi/base/mkosi.tools.manifest || true
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.


### PR DESCRIPTION
## Problem

The `Cache base image tools` save has never succeeded: mkosi builds `mkosi/base/mkosi.tools` as root and the unprivileged post-job tar fails on it, the same failure #342 fixed for the kernel-builder tree. Every build therefore spends ~2.5 min on "Building tools image" that a working cache would skip — the largest remaining chunk in the 10m20s cached build.

## Fix

Extend #342's chown step to `mkosi/base/mkosi.tools` (+ its manifest). No key bump needed: no entry has ever existed under the key, so the next run misses, saves a good entry, and subsequent runs restore it (mkosi reuses a present tools tree). Expected: ~10m20s to ~8m.