### PR TITLE
feat(node-guest-image): skip the warm-path NVIDIA module rebuild; build on the 16-core runner

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -155,8 +155,8 @@ jobs:
       - name: Free up disk space
         # kernel + NVIDIA userspace + rke2 airgap + ~6G disk.raw on a 14G runner.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
-          # Backgrounded: frees its space minutes before the big writes start.
+          # Backgrounded: the space is free minutes before the big writes start.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL &
           sudo docker image prune --all --force >/dev/null 2>&1 &
           df -h
 
@@ -231,6 +231,28 @@ jobs:
           path: confidential-os-builder/output/gpu/cache
           key: ${{ runner.os }}-gpu-artifacts-${{ hashFiles('confidential-os-builder/bin/confos-fetch-gpu') }}
 
+      - name: Cache staged GPU tree
+        # Signed modules + userspace staged by confos-fetch-gpu; the build
+        # script's stamp check skips the module rebuild when this restores.
+        uses: actions/cache@v5
+        with:
+          path: |
+            confidential-os-builder/mkosi/base/mkosi.local/mkosi.extra
+            confidential-os-builder/output/gpu/stage.stamp
+          key: ${{ runner.os }}-gpu-staged-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt','confidential-os-builder/bin/confos-fetch-gpu') }}
+
+      - name: Attestation binary key
+        id: attest-sha
+        run: echo "sha=$(git -C attestation-rs rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache attestation-api binary
+        # Keyed on the attestation-rs commit plus this workflow (libnvat pin).
+        id: attest-bin
+        uses: actions/cache@v5
+        with:
+          path: attestation-rs/target/release/attestation-api
+          key: ${{ runner.os }}-attest-bin-${{ steps.attest-sha.outputs.sha }}-${{ hashFiles('c8s/.github/workflows/c8s-image.yml') }}
+
       # attest-gpu: the build runs confos-fetch-attest-gpu, which needs a
       # prebuilt ATTEST_GPU_BIN + LIBNVAT. Vendor libnvat (Apache-2.0, digest-
       # pinned) and build the binary with NVAT_USE_SYSTEM_LIB=1.
@@ -266,8 +288,10 @@ jobs:
           NVAT_USE_SYSTEM_LIB: "1"
         working-directory: attestation-rs
         run: |
-          cargo build -p attestation-api --release \
-            --features nvidia-gpu-attest --bin attestation-api
+          if [ "${{ steps.attest-bin.outputs.cache-hit }}" != "true" ]; then
+            cargo build -p attestation-api --release \
+              --features nvidia-gpu-attest --bin attestation-api
+          fi
           # Must actually link libnvat (not a silent fallback).
           ldd target/release/attestation-api | grep -q libnvat
 

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -106,7 +106,9 @@ jobs:
        (github.event.workflow_run.event == 'push' ||
         github.event.workflow_run.event == 'workflow_dispatch') &&
        github.event.workflow_run.head_branch == 'main')
-    runs-on: ubuntu-latest
+    # 16-core hosted larger runner (same as kernel-snapshot/kata-guest-base);
+    # scales to 100 concurrent jobs, 600G disk.
+    runs-on: the-machine
     timeout-minutes: 180
     strategy:
       # One image per TEE. fail-fast off: a platform-specific failure must not
@@ -152,14 +154,6 @@ jobs:
             echo "C8S_DEV=0" >> "$GITHUB_ENV"
           fi
 
-      - name: Free up disk space
-        # kernel + NVIDIA userspace + rke2 airgap + ~6G disk.raw on a 14G runner.
-        run: |
-          # Backgrounded: the space is free minutes before the big writes start.
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL &
-          sudo docker image prune --all --force >/dev/null 2>&1 &
-          df -h
-
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
         with:
@@ -184,10 +178,25 @@ jobs:
             libclang-dev clang libtss2-dev
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
+      - name: Cache staged GPU tree
+        # Signed modules + userspace staged by confos-fetch-gpu; the build
+        # script's stamp check skips the module rebuild when this restores.
+        # First of the confos caches: a hit makes the kernel-builder tools
+        # tree and the driver downloads unnecessary, so those restores gate
+        # on it.
+        id: gpu-staged
+        uses: actions/cache@v5
+        with:
+          path: |
+            confidential-os-builder/mkosi/base/mkosi.local/mkosi.extra
+            confidential-os-builder/output/gpu/stage.stamp
+          key: ${{ runner.os }}-gpu-staged-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt','confidential-os-builder/bin/confos-fetch-gpu') }}
+
       - name: Cache kernel-builder tools tree
         # mkosi.output (image + stamp) is what the kernel short-circuit path
         # still needs: confos-fetch-gpu compiles modules inside it. mkosi.tools
         # is only an intermediate for building it, so it isn't cached.
+        if: steps.gpu-staged.outputs.cache-hit != 'true'
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
@@ -226,20 +235,11 @@ jobs:
 
       - name: Cache NVIDIA driver downloads
         # ~500MB, sha-verified; keyed on the script that carries the pins.
+        if: steps.gpu-staged.outputs.cache-hit != 'true'
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/output/gpu/cache
           key: ${{ runner.os }}-gpu-artifacts-${{ hashFiles('confidential-os-builder/bin/confos-fetch-gpu') }}
-
-      - name: Cache staged GPU tree
-        # Signed modules + userspace staged by confos-fetch-gpu; the build
-        # script's stamp check skips the module rebuild when this restores.
-        uses: actions/cache@v5
-        with:
-          path: |
-            confidential-os-builder/mkosi/base/mkosi.local/mkosi.extra
-            confidential-os-builder/output/gpu/stage.stamp
-          key: ${{ runner.os }}-gpu-staged-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt','confidential-os-builder/bin/confos-fetch-gpu') }}
 
       - name: Attestation binary key
         id: attest-sha

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -83,7 +83,19 @@ bin/confos kernel \
     --module-signing-cert "$NGI_DIR/module-signing.crt" \
     --kernel-builder-package "$KB_PKGS"
 PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
-MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
+# Fingerprint-gated: the module build must rerun iff the kernel, the fetch
+# script (NVIDIA pins), or the signing cert changed. The kernel manifest
+# covers the kernel side; signatures are deterministic, so a staged tree
+# with a matching stamp is byte-identical to a fresh one.
+GPU_STAMP="output/gpu/stage.stamp"
+GPU_FPR=$(cat output/kernel/manifest.json bin/confos-fetch-gpu "$NGI_DIR/module-signing.crt" | sha256sum | cut -d' ' -f1)
+if [ -d mkosi/base/mkosi.local/mkosi.extra ] && [ "$(cat "$GPU_STAMP" 2>/dev/null)" = "$GPU_FPR" ]; then
+    echo "staged GPU tree matches $GPU_FPR — skipping confos-fetch-gpu"
+else
+    MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
+    mkdir -p "$(dirname "$GPU_STAMP")"
+    echo "$GPU_FPR" > "$GPU_STAMP"
+fi
 bin/confos-fetch-attest-gpu
 exec bin/confos build "${C8S_NAME:-c8s}" \
     "${PROFILES[@]}" \


### PR DESCRIPTION
## Problem

On a warm-cache build the remaining time is `confos-fetch-gpu` (~2m35s of module recompile+re-sign even when kernel, NVIDIA pins, and signing cert are unchanged), the attestation-api cargo build (~45s for a binary whose inputs rarely change), ~1.5m of sequential cache restores and setup, and ~2m of mkosi assembly that is CPU-bound on ubuntu-latest's 4 vCPUs. Current warm legs: 8m10s-9m17s.

## Fix

- `node-guest-image/build` gates `confos-fetch-gpu` on a fingerprint stamp: sha256 over the kernel manifest, the fetch script (carries the NVIDIA pins), and the signing cert. Any change reruns the full fetch; module signatures are deterministic, so a stamped staged tree is byte-identical to a fresh one. The staged tree (`mkosi/base/mkosi.local/mkosi.extra`) + stamp ride a new cache entry keyed on the kernel-key inputs plus the fetch script.
- The attestation-api binary is cached per attestation-rs commit (and this workflow file, which carries the libnvat pin); the ldd libnvat link check still runs on every path.
- The job moves to `the-machine`, the 16-core hosted runner kernel-snapshot and kata-guest-base already use (100 concurrent jobs, 600G disk): ~4x faster assembly and seed compiles, and the free-disk step is retired.
- Restores that are dead on the warm path (kernel-builder tools tree, NVIDIA driver downloads) gate on the staged-GPU-tree cache hitting, since a hit means `confos-fetch-gpu` never runs.

Measurement equivalence is provable from the gate: the seed run stages fresh, the rerun consumes the cache, and both upload manifest+roothash for comparison.

Editing `node-guest-image/build` rotates the kernel cache key (it is hashed into it), so the first run per platform seeds again (fast on 16 cores); warm legs after that project to ~3m.