### PR TITLE
fix(node-guest-image): mirror the staged GPU tree; cache the apt package cache

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -179,16 +179,16 @@ jobs:
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache staged GPU tree
-        # Signed modules + userspace staged by confos-fetch-gpu; the build
-        # script's stamp check skips the module rebuild when this restores.
-        # First of the confos caches: a hit makes the kernel-builder tools
-        # tree and the driver downloads unnecessary, so those restores gate
-        # on it.
+        # Mirror + stamp written by the build script (confos build wipes the
+        # live mkosi.local staging, so only the mirror survives to save). A
+        # hit makes the driver downloads unnecessary, so that restore gates
+        # on it; the tools tree still restores unconditionally because the
+        # fallback path (stamp mismatch) needs it.
         id: gpu-staged
         uses: actions/cache@v5
         with:
           path: |
-            confidential-os-builder/mkosi/base/mkosi.local/mkosi.extra
+            confidential-os-builder/output/gpu/staged
             confidential-os-builder/output/gpu/stage.stamp
           key: ${{ runner.os }}-gpu-staged-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','confidential-os-builder/kernel/config-x86_64.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt','confidential-os-builder/bin/confos-fetch-gpu') }}
 
@@ -196,7 +196,6 @@ jobs:
         # mkosi.output (image + stamp) is what the kernel short-circuit path
         # still needs: confos-fetch-gpu compiles modules inside it. mkosi.tools
         # is only an intermediate for building it, so it isn't cached.
-        if: steps.gpu-staged.outputs.cache-hit != 'true'
         uses: actions/cache@v5
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
@@ -223,6 +222,20 @@ jobs:
             confidential-os-builder/mkosi/base/mkosi.tools
             confidential-os-builder/mkosi/base/mkosi.tools.manifest
           key: ${{ runner.os }}-c8s-tools-${{ hashFiles('confidential-os-builder/mkosi/base/mkosi.conf.d/tools.conf','confidential-os-builder/mkosi/base/mkosi.profiles/*/mkosi.conf','c8s/node-guest-image/c8s/mkosi.conf') }}
+
+      - name: Cache apt package cache
+        # mkosi's package cache for every subimage (initrd, base, main). Keeps
+        # assembly off snapshot.ubuntu.com, whose fetch latency varies by
+        # runner. restore-keys tolerates partial staleness: apt re-fetches
+        # only what's missing, and the mirror guard still polices the source.
+        uses: actions/cache@v5
+        with:
+          path: |
+            confidential-os-builder/mkosi/base/mkosi.pkgcache
+            !confidential-os-builder/mkosi/base/mkosi.pkgcache/c8s
+          key: ${{ runner.os }}-pkgcache-${{ hashFiles('confidential-os-builder/mkosi/base/mkosi.conf','confidential-os-builder/mkosi/base/mkosi.conf.d/**','confidential-os-builder/mkosi/base/mkosi.profiles/**','confidential-os-builder/mkosi/base/mkosi.sandbox/**','c8s/node-guest-image/c8s/mkosi.conf') }}
+          restore-keys: |
+            ${{ runner.os }}-pkgcache-
 
       - name: Cache c8s artifact downloads
         # ~3.5G rke2 tarball + airgap bundles, sha256-verified on reuse.
@@ -327,7 +340,8 @@ jobs:
           sudo chown -R "$(id -u):$(id -g)" \
             confidential-os-builder/mkosi/kernel-builder/mkosi.output \
             confidential-os-builder/mkosi/base/mkosi.tools \
-            confidential-os-builder/mkosi/base/mkosi.tools.manifest || true
+            confidential-os-builder/mkosi/base/mkosi.tools.manifest \
+            confidential-os-builder/mkosi/base/mkosi.pkgcache || true
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -86,14 +86,21 @@ PROFILES=(--profile gpu --profile attest-gpu --profile c8s)
 # Fingerprint-gated: the module build must rerun iff the kernel, the fetch
 # script (NVIDIA pins), or the signing cert changed. The kernel manifest
 # covers the kernel side; signatures are deterministic, so a staged tree
-# with a matching stamp is byte-identical to a fresh one.
+# with a matching stamp is byte-identical to a fresh one. The tree is
+# mirrored under output/ because confos build wipes mkosi.local on exit.
 GPU_STAMP="output/gpu/stage.stamp"
+GPU_MIRROR="output/gpu/staged"
 GPU_FPR=$(cat output/kernel/manifest.json bin/confos-fetch-gpu "$NGI_DIR/module-signing.crt" | sha256sum | cut -d' ' -f1)
-if [ -d mkosi/base/mkosi.local/mkosi.extra ] && [ "$(cat "$GPU_STAMP" 2>/dev/null)" = "$GPU_FPR" ]; then
-    echo "staged GPU tree matches $GPU_FPR — skipping confos-fetch-gpu"
+if [ -d "$GPU_MIRROR" ] && [ "$(cat "$GPU_STAMP" 2>/dev/null)" = "$GPU_FPR" ]; then
+    echo "staged GPU tree matches $GPU_FPR — restoring mirror, skipping confos-fetch-gpu"
+    rm -rf mkosi/base/mkosi.local/mkosi.extra
+    mkdir -p mkosi/base/mkosi.local
+    cp -a "$GPU_MIRROR" mkosi/base/mkosi.local/mkosi.extra
 else
     MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
-    mkdir -p "$(dirname "$GPU_STAMP")"
+    rm -rf "$GPU_MIRROR"
+    mkdir -p "$(dirname "$GPU_MIRROR")"
+    cp -a mkosi/base/mkosi.local/mkosi.extra "$GPU_MIRROR"
     echo "$GPU_FPR" > "$GPU_STAMP"
 fi
 bin/confos-fetch-attest-gpu


### PR DESCRIPTION
## Problem

Two defects surfaced by #344's first main seed. The staged-GPU-tree cache saved 0 MB: `confos build` wipes `mkosi.local` on exit (`RemoveDirOnDrop` in build.rs), so by post-job save time only the stamp existed — and since the tools-tree restore gated on that cache hitting, the next warm run would restore an empty "hit", fall back to `confos-fetch-gpu`, and die on the missing tools tree. Separately, assembly on `the-machine` re-fetches apt metadata and ~170 debs from snapshot.ubuntu.com every build, and that mirror is several times slower from the larger-runner network (initrd build 4m03s vs 45s on ubuntu-latest) — costing back most of what the 16 cores won.

## Fix

- The build script mirrors the staged tree to `output/gpu/staged` (which survives the build) right after `confos-fetch-gpu`, and on a stamp match copies the mirror back into `mkosi.local` instead of rerunning the fetch. The cache entry now stores the mirror.
- The kernel-builder tools-tree restore is unconditional again; only the driver-downloads restore stays gated on the staged cache (its absence degrades to a curl re-fetch, not a failure).
- `mkosi.pkgcache` (minus the separately-cached c8s artifacts) rides a new cache entry with prefix restore-keys, keeping every subimage's apt work local; the fail-closed mirror guard still polices sources when apt does go out.
- The chown step covers the root-owned pkgcache so its save succeeds.

Editing `node-guest-image/build` rotates the kernel + gpu-staged keys, so one more seed cycle; warm legs after that are the ~3 min measurement.