### PR TITLE
ci(c8s-image): conf-only globs in the pkgcache key

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -233,7 +233,9 @@ jobs:
           path: |
             confidential-os-builder/mkosi/base/mkosi.pkgcache
             !confidential-os-builder/mkosi/base/mkosi.pkgcache/c8s
-          key: ${{ runner.os }}-pkgcache-${{ hashFiles('confidential-os-builder/mkosi/base/mkosi.conf','confidential-os-builder/mkosi/base/mkosi.conf.d/**','confidential-os-builder/mkosi/base/mkosi.profiles/**','confidential-os-builder/mkosi/base/mkosi.sandbox/**','c8s/node-guest-image/c8s/mkosi.conf') }}
+          # conf-only globs: profile mkosi.extra trees carry dangling systemd
+          # enablement symlinks, which hashFiles refuses to hash.
+          key: ${{ runner.os }}-pkgcache-${{ hashFiles('confidential-os-builder/mkosi/base/mkosi.conf','confidential-os-builder/mkosi/base/mkosi.conf.d/*.conf','confidential-os-builder/mkosi/base/mkosi.profiles/*/mkosi.conf','confidential-os-builder/mkosi/base/mkosi.sandbox/**','c8s/node-guest-image/c8s/mkosi.conf') }}
           restore-keys: |
             ${{ runner.os }}-pkgcache-
 


### PR DESCRIPTION
## Problem

#345's pkgcache cache key globs `mkosi.profiles/**`, which matches the profiles' `mkosi.extra` trees — and those carry dangling systemd enablement symlinks that `hashFiles` refuses to hash. Every c8s-image job on main now fails at the cache step before building anything.

## Fix

Match only the conf files that define the package set (`mkosi.conf`, `mkosi.conf.d/*.conf`, `mkosi.profiles/*/mkosi.conf`), the same shape the base-tools key already uses.