### PR TITLE
ci(c8s-image): vendor the mkosi setup as a local action

### DIFF
--- a/.github/actions/setup-mkosi/action.yml
+++ b/.github/actions/setup-mkosi/action.yml
@@ -1,0 +1,37 @@
+name: setup-mkosi
+description: >
+  Local replacement for the systemd/mkosi setup action: same load-bearing host
+  prep (userns sysctls, ca-certificates mountpoint, apparmor teardown) plus a
+  pinned shallow clone of mkosi, without the codeload tarball fetch, the
+  diagnostics, the apparmor package removal, or the dnf/pacman/zypper installs
+  confos's Ubuntu-only builds never use.
+
+inputs:
+  ref:
+    description: mkosi commit to install (full sha)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Host prep
+      shell: bash
+      run: |
+        sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+        sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+        # unix-chkpwd/swtpm apparmor profiles are broken on runner images
+        # (apparmor/apparmor#402); unload and keep them off.
+        sudo aa-teardown || true
+        sudo systemctl mask --now apparmor || true
+        sudo mkdir -p /var/lib/ca-certificates
+
+    - name: Install mkosi (pinned)
+      shell: bash
+      env:
+        MKOSI_REF: ${{ inputs.ref }}
+      run: |
+        git init -q /opt/mkosi
+        git -C /opt/mkosi fetch -q --depth 1 https://github.com/systemd/mkosi.git "$MKOSI_REF"
+        git -C /opt/mkosi checkout -q FETCH_HEAD
+        sudo ln -svf /opt/mkosi/bin/mkosi /usr/bin/mkosi
+        mkosi --version

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -166,7 +166,11 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
 
       - name: Setup mkosi
-        uses: systemd/mkosi@84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
+        # Local action (repo is checked out under c8s/): pinned mkosi without
+        # the upstream action's codeload fetch or foreign-distro installs.
+        uses: ./c8s/.github/actions/setup-mkosi
+        with:
+          ref: 84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);


### PR DESCRIPTION
## Problem

The `systemd/mkosi` setup action is fetched from codeload per job (today's 429/503 storm failed several legs on exactly that), takes ~25s, and spends most of it on work this pipeline doesn't need: removing the apparmor package and installing dnf/pacman/zypper for distros the Ubuntu-only build never touches.

## Fix

A local composite action with the same load-bearing prep (userns sysctls, ca-certificates mountpoint, apparmor teardown + mask) and a pinned shallow git clone of mkosi (git transport, which stayed healthy through the storm). ~7s instead of ~25s, one less remote action to fetch.