### PR TITLE
chore(c8s-image): bump CONFOS_REF — attest-gpu serves SNP

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -91,7 +91,7 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  CONFOS_REF: ${{ inputs.confos_ref || '14e770f26f912d360f1a60a464145c3ee5615124' }} # pin: v0.4.2 — every apt pocket snapshot-pinned by URI, mirror-guarded builds (confos#96)
+  CONFOS_REF: ${{ inputs.confos_ref || 'e56427984177a680f1ee66b13f9de0c8db504b1d' }} # pin: v0.4.2 + attest-gpu serves SNP (platforms + DeviceAllow, confos#102/#103); snapshot-pinned mirror-guarded builds (confos#96)
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Problem

The pinned confos tree bakes an attestation-api that cannot serve SNP requests on attest-gpu-based images: `platforms = ["tdx"]` only, and the unit hardening lacks `DeviceAllow=/dev/sev-guest`. On SNP node-CVMs, CDS's self-attestation is refused (400 platform-not-allowed; after fixing that, 422 `Firmware::open: Operation not permitted`) and `c8s install` deadlocks — CDS crashloops while every other component sits in CreateContainerError waiting on the allowlist it serves. Found and fix-verified live on the two-CVM SNP multinode bring-up (with both fixes hand-applied, the full stack converges Running on both nodes).

## Fix

Bump `CONFOS_REF` to confos main (`e564279`), which carries confos #102 (platforms = ["snp", "tdx"]) and #103 (DeviceAllow /dev/sev-guest). Measurement note: this changes the baked rootfs, so MRTD/RTMRs move — the tdx refs CM and any pinned measurements need the usual refresh once the new build publishes.