### PR TITLE
ci: let CI use Go's test cache

### DIFF
--- a/.github/actions/setup-go-c8s/action.yml
+++ b/.github/actions/setup-go-c8s/action.yml
@@ -23,6 +23,12 @@ inputs:
   cache-dependency-path:
     description: Path to go.sum used to key the module cache.
     default: go.sum
+  cache:
+    description: >-
+      Use setup-go's built-in cache. Set "false" when the job manages its own
+      restore/save (setup-go only saves on a key miss, so a go.sum-keyed cache
+      goes stale between dependency bumps).
+    default: "true"
 
 runs:
   using: composite
@@ -62,5 +68,5 @@ runs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ steps.go-minor.outputs.version }}
-        cache: true
+        cache: ${{ inputs.cache }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,9 @@ jobs:
       - name: Test
         env:
           C8S_REQUIRE_IPTABLES_TRANSLATE: "1"
-        run: make test
+        # TEST_COUNT= : unchanged packages reuse cached results from the
+        # restored GOCACHE; Go invalidates by content, so edits still rerun.
+        run: make test TEST_COUNT=
 
       # The advisory mutation job only exercises the 0-mutant path on
       # script-only diffs; this guards the summary paths it skips.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,22 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-go-c8s
+        with:
+          cache: "false"
+
+      # Managed here instead of setup-go: restore the freshest main cache
+      # (build artifacts + test results), save a new one on every main push.
+      # setup-go's own go.sum-keyed cache never re-saves between dependency
+      # bumps, so its snapshot goes stale and tests re-run in full.
+      - name: Restore Go caches
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: &go-cache-paths |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-ci-${{ github.sha }}
+          restore-keys: |
+            go-ci-
 
       - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
@@ -128,6 +144,13 @@ jobs:
       # script-only diffs; this guards the summary paths it skips.
       - name: mutation-check selftest
         run: ./scripts/mutation-check.sh selftest
+
+      - name: Save Go caches
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: *go-cache-paths
+          key: go-ci-${{ github.sha }}
 
   coverage:
     name: Coverage gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
   test:
     name: Build & Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Cache pruning (the step after the save) deletes this job's own
+      # superseded go-ci-* entries so they cannot LRU-evict the image caches.
+      actions: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -87,16 +92,25 @@ jobs:
         with:
           cache: "false"
 
-      # Managed here instead of setup-go: restore the freshest main cache
-      # (build artifacts + test results), save a new one on every main push.
-      # setup-go's own go.sum-keyed cache never re-saves between dependency
-      # bumps, so its snapshot goes stale and tests re-run in full.
-      - name: Restore Go caches
+      # Module cache: immutable per go.sum, so save-on-miss keying is correct
+      # for it (what setup-go does; managed here because its cache cannot be
+      # split from the build cache below).
+      - name: Cache Go modules
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/go/pkg/mod
+          key: go-mod-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            go-mod-
+
+      # Build/test-result cache: NOT immutable per go.sum — every commit adds
+      # artifacts — so save-on-miss goes stale and cached test results never
+      # materialize. Restore the freshest entry; a new one is saved per main
+      # push and superseded entries are pruned.
+      - name: Restore Go build cache
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: &go-cache-paths |
-            ~/go/pkg/mod
-            ~/.cache/go-build
+          path: ~/.cache/go-build
           key: go-ci-${{ github.sha }}
           restore-keys: |
             go-ci-
@@ -136,21 +150,39 @@ jobs:
       - name: Test
         env:
           C8S_REQUIRE_IPTABLES_TRANSLATE: "1"
-        # TEST_COUNT= : unchanged packages reuse cached results from the
+        # C8S_TEST_COUNT= : unchanged packages reuse cached results from the
         # restored GOCACHE; Go invalidates by content, so edits still rerun.
-        run: make test TEST_COUNT=
+        # External binaries the tests exec (iptables-translate) are covered
+        # via the testlog's stat of the LookPath'd path: an apt bump changes
+        # its mtime and invalidates the cached pass.
+        run: make test C8S_TEST_COUNT=
 
       # The advisory mutation job only exercises the 0-mutant path on
       # script-only diffs; this guards the summary paths it skips.
       - name: mutation-check selftest
         run: ./scripts/mutation-check.sh selftest
 
-      - name: Save Go caches
+      - name: Save Go build cache
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          path: *go-cache-paths
+          path: ~/.cache/go-build
           key: go-ci-${{ github.sha }}
+
+      - name: Prune superseded go-ci caches
+        # Only go-ci-* entries this job created; never touches other caches.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CURRENT_KEY: go-ci-${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/actions/caches?per_page=100" \
+            --jq '.actions_caches[]|select(.key|startswith("go-ci-"))|"\(.id) \(.key)"' |
+            awk -v cur="$CURRENT_KEY" '$2 != cur {print $1}' |
+            while read -r id; do
+              gh api -X DELETE "repos/$REPO/actions/caches/$id" || true
+            done
 
   coverage:
     name: Coverage gate

--- a/Makefile
+++ b/Makefile
@@ -121,8 +121,11 @@ build-nri-image-policy:
 
 # --- Tests ---
 
+# TEST_COUNT=  lets CI use Go's content-addressed test cache; the local
+# default keeps forced reruns.
+TEST_COUNT ?= -count=1
 test:
-	go test -race -count=1 -timeout=120s ./...
+	go test -race $(TEST_COUNT) -timeout=120s ./...
 
 test-integration:
 	./test/integration/run.sh

--- a/Makefile
+++ b/Makefile
@@ -121,11 +121,11 @@ build-nri-image-policy:
 
 # --- Tests ---
 
-# TEST_COUNT=  lets CI use Go's content-addressed test cache; the local
+# C8S_TEST_COUNT= lets CI use Go's content-addressed test cache; the local
 # default keeps forced reruns.
-TEST_COUNT ?= -count=1
+C8S_TEST_COUNT ?= -count=1
 test:
-	go test -race $(TEST_COUNT) -timeout=120s ./...
+	go test -race $(C8S_TEST_COUNT) -timeout=120s ./...
 
 test-integration:
 	./test/integration/run.sh


### PR DESCRIPTION
## Problem

`make test` pins `-count=1`, which disables Go's content-addressed test cache: every PR re-runs the full race-enabled suite (~3m35s) even when most packages are untouched. And the cache setup-go restores can never fix this on its own: it saves only on a go.sum key miss, so its snapshot goes stale between dependency bumps — fresh build artifacts and test results are computed on every run and then discarded (confirmed on this PR's first CI run: Test stayed at 209s with the flag alone).

## Fix

- `C8S_TEST_COUNT ?= -count=1` in the Makefile (local behavior unchanged); the CI step passes `C8S_TEST_COUNT=` so unchanged packages reuse cached results. Go invalidates by content hash, so edited packages always rerun; only recorded passes under the same -race configuration replay. External binaries the tests exec (iptables-translate) are covered by the testlog's stat of the resolved path, so an apt bump invalidates cached passes.
- The Build & Test job splits the Go caches by mutability: modules ride their own immutable go.sum-keyed entry (save-on-miss is correct there), while `~/.cache/go-build` rides a `go-ci-<sha>` entry restored freshest-first and saved on every main push. A prune step then deletes superseded `go-ci-*` entries (job-scoped `actions: write`), so cache churn cannot LRU-evict the image-build caches sharing the 10GB quota.
- Lint/Coverage/Mutation stay on setup-go's built-in cache deliberately: their build flags (cover/mutant/plain) produce different GOCACHE artifacts than the race-test cache, so restoring `go-ci-*` there adds transfer cost for little reuse; their module caching is already correct.

First post-merge main push seeds `go-ci-*`; verification after that merge: the entry exists at plausible size, exactly one `go-ci-*` survives pruning, and the next PR's Test log shows `(cached)` package lines. Expected steady state: Build ~15s, macOS cross-build ~15s, Test at roughly the changed packages' runtime instead of 94s/81s/209s.