### PR TITLE
ci: pin attestation-rs to a full SHA in the measured image builds

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -92,6 +92,7 @@ env:
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
   CONFOS_REF: ${{ inputs.confos_ref || 'e56427984177a680f1ee66b13f9de0c8db504b1d' }} # pin: v0.4.2 + attest-gpu serves SNP (platforms + DeviceAllow, confos#102/#103); snapshot-pinned mirror-guarded builds (confos#96)
+  ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
 
 jobs:
   build-and-push:
@@ -129,7 +130,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: confidential-dot-ai/attestation-rs
-          ref: main
+          ref: ${{ env.ATTESTATION_RS_REF }}
           path: attestation-rs
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -87,6 +87,7 @@ env:
   # measurement, and the committed kernel/config-x86_64.snapshot lockfile must
   # be refreshed in the same PR (kernel-snapshot.yml produces it).
   CONFOS_REF: "14e770f26f912d360f1a60a464145c3ee5615124" # v0.4.2 — apt pockets snapshot-pinned by URI, mirror-guarded (confos#96); rolls the kata kernel measurement once
+  ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA; rolls the SNP launch measurement
 
 jobs:
   build:
@@ -147,6 +148,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: confidential-dot-ai/attestation-rs
+          ref: ${{ env.ATTESTATION_RS_REF }}
           path: attestation-rs
 
       - name: Checkout confidential-os-builder
@@ -204,7 +206,7 @@ jobs:
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: attestation-rs/target/release/attestation-api
-          key: ${{ runner.os }}-attestation-api-${{ hashFiles('attestation-rs/Cargo.lock', 'attestation-rs/Cargo.toml', 'attestation-rs/crates/**') }}
+          key: ${{ runner.os }}-attestation-api-${{ env.ATTESTATION_RS_REF }}-${{ hashFiles('attestation-rs/Cargo.lock', 'attestation-rs/Cargo.toml', 'attestation-rs/crates/**') }}
 
       # attestation-api links tss-esapi-sys, whose build.rs resolves the TPM2-TSS
       # system library via pkg-config (tss2-sys.pc, shipped by libtss2-dev) for

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -318,6 +318,7 @@ reviewed commit.
 | `UBUNTU_BASE_DIGEST` | `build.sh` | osbuilder's rootfs-builder toolchain image |
 | `UBUNTU_REPO_URL` (snapshot timestamp) | `build.sh` | guest apt packages |
 | `CONFOS_REF` | workflow env | guest kernel |
+| `ATTESTATION_RS_REF` | workflow env | baked `attestation-api` binary |
 | `REPRO_E2FSPROGS_VERSION` / `REPRO_CRYPTSETUP_VERSION` | workflow env | re-lay toolchain |
 | cds / get-cert / c8s-operator digests | resolved per build by `fetch.sh` | bootstrap allowlist |
 


### PR DESCRIPTION
The node image and the kata guest rootfs both bake attestation-rs's attestation-api binary into dm-verity/TDX-measured artifacts, checked out from a floating branch: c8s-image.yml used ref: main and kata-guest-base.yml defaulted to it, while CONFOS_REF beside them is a full SHA. A floating attester means the same c8s tag rebuilt later yields a different measured image, and an attestation-rs main-merge silently changes what the e2e fleet boots.

Declare ATTESTATION_RS_REF as a full-SHA env pin next to CONFOS_REF in both workflows and consume it in both checkouts, with the same bump note style. Fold the pin into the kata attestation-api cache key so a bump forces a rebuild even when the hashFiles set is unchanged, and add it to the Component pins table in docs/kata-guest-base.md, which claims to enumerate the measured-input pins in full.