### PR TITLE
ci: arm the TDX MRTD tripwire on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,45 @@ jobs:
               gh api -X DELETE "repos/$REPO/actions/caches/$id" || true
             done
 
+  tdx-measure:
+    name: TDX MRTD tripwire
+    runs-on: ubuntu-latest
+    env:
+      # The TDVF the nodes boot, from the kata-static payload kata-deploy installs
+      # (values.yaml kata.digest). Bump with that pin and with wantTDVFSHA/wantMRTD.
+      TDVF_URL: https://github.com/kata-containers/kata-containers/releases/download/3.30.0/kata-static-3.30.0-amd64.tar.zst
+      TDVF_SHA256: 2af9e5e974c0dc201163d1fd419f234cc4b6e64e99425ce6619e9a077fb0c0b6
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-go-c8s
+
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+
+      # tar stops after the one member, early in the stream; curl's SIGPIPE is
+      # expected and the sha256 check is the gate on the untrusted fetch.
+      - name: Fetch the pinned TDVF
+        run: |
+          curl -fsSL "$TDVF_URL" | zstd -d | tar -xO --occurrence=1 ./opt/kata/share/ovmf/OVMF.inteltdx.fd > tdvf.fd || true
+          echo "$TDVF_SHA256  tdvf.fd" | sha256sum -c -
+
+      # With C8S_TDVF present nothing in this package may skip: a skip means
+      # the tripwire did not run, so it fails the job rather than reading green.
+      - name: Test pkg/tdxmeasure, failing on any skip
+        env:
+          C8S_TDVF: ${{ github.workspace }}/tdvf.fd
+        run: |
+          go test -count=1 -json ./pkg/tdxmeasure/... | tee tdxmeasure.json
+          if grep '"Action":"skip"' tdxmeasure.json; then
+            echo "::error::pkg/tdxmeasure test skipped — the MRTD tripwire must run (TDVF missing or sha mismatch)" >&2
+            exit 1
+          fi
+          if ! grep -q '"Action":"pass".*"Test":"TestMRTDMatchesHardware"' tdxmeasure.json; then
+            echo "::error::TestMRTDMatchesHardware did not run green — the tripwire is disarmed" >&2
+            exit 1
+          fi
+
   coverage:
     name: Coverage gate
     runs-on: ubuntu-latest

--- a/docs/kata-launch-measurement.md
+++ b/docs/kata-launch-measurement.md
@@ -227,10 +227,14 @@ moves the value fails the build rather than shipping a wrong pin.
 
 ### Re-validating against hardware
 
-The 4 MiB TDVF is not committed, so the hardware check runs only where the
-firmware exists (a TDX node, or `C8S_TDVF=/path/to/OVMF.inteltdx.fd`); it skips
-in CI, and also skips if the TDVF is not the sha256 the expected digest was
-captured from. The CLI wiring is covered in CI with a synthetic TDVF.
+The 4 MiB TDVF is not committed. CI's TDX MRTD tripwire job fetches the
+pinned TDVF out of the kata-static release the nodes' kata-deploy installs,
+sha256-checks it against the pin next to its URL in `.github/workflows/ci.yml`,
+and runs the `pkg/tdxmeasure` tests with `C8S_TDVF` set, failing if any test
+skips. Elsewhere the hardware check runs only where the firmware exists (a TDX
+node, or `C8S_TDVF=/path/to/OVMF.inteltdx.fd`), skipping if the TDVF is not
+the sha256 the expected digest was captured from. The CLI wiring is covered in
+CI with a synthetic TDVF.
 
 To re-capture the expected MRTD after a kata-static bump, read it from a live
 pod's own attestation report. The in-guest attestation-service listens on

--- a/pkg/tdxmeasure/tdxmeasure_test.go
+++ b/pkg/tdxmeasure/tdxmeasure_test.go
@@ -24,8 +24,10 @@ const (
 )
 
 // loadTDVF returns the validated TDVF build, or skips. The 4 MiB image is not
-// committed, so this runs on a TDX node (or with C8S_TDVF set) and is skipped
-// in CI. See docs/kata-launch-measurement.md to re-capture the expected value.
+// committed: CI's tripwire job fetches the pinned TDVF and sets C8S_TDVF;
+// elsewhere this runs on a TDX node (or with C8S_TDVF set) and skips
+// otherwise. See docs/kata-launch-measurement.md to re-capture the expected
+// value.
 func loadTDVF(t *testing.T) []byte {
 	t.Helper()
 	p := tdvfPath


### PR DESCRIPTION
TestMRTDMatchesHardware compares a computed MRTD against a value read back from TDX silicon, with the TDVF pinned by sha256 — but C8S_TDVF was set nowhere in the repo, so 3 of 4 pkg/tdxmeasure tests skipped on every lane, while docs/kata-launch-measurement.md told readers the tripwire fired in CI.

A new tdx-measure PR job fetches the TDVF out of the kata-static release the nodes boot (sha256-pinned next to its URL; the sha check gates the untrusted fetch), runs the package with C8S_TDVF set, and fails if any test skips or if TestMRTDMatchesHardware does not run green. A skip no longer reads as a pass.

loadTDVF needs only the firmware blob, not TDX hardware, so this runs as an ordinary PR job rather than in the hardware-gated tdx-metal-e2e lane.

docs/kata-launch-measurement.md and the loadTDVF comment now describe what actually runs.