### PR TITLE
fix(verify): never report VERIFIED for a WebPKI front door or a responder-chosen chain anchor

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -521,9 +521,11 @@ flags against SEV-SNP evidence is a policy error, not an ignored option: SNP
 has no runtime measurement registers.
 
 A TDX verdict pinned on MRTD alone is **rejected**, not warned about, when no
-CA anchor stands beside the measurements (no `--mesh-ca`, and no chain
-verified while gathering): the measurement pins are then the entire trust
-anchor, so an incomplete image policy leaves nothing behind the verdict.
+operator-pinned CA anchor (`--mesh-ca`) stands beside the measurements: the
+measurement pins are then the entire trust anchor, so an incomplete image
+policy leaves nothing behind the verdict. A chain checked against a CA the
+responder committed into its own transcript (attest-pq) does not downgrade
+this — that anchor is responder-chosen.
 
 Certificate-sourced evidence must also carry an authenticated certificate
 body. A self-signed leaf authenticates its own body under the attested key; a
@@ -537,7 +539,16 @@ CA-issued discovery certificate requires `--mesh-ca` (the document publishes
 
 Exit codes are a CI contract: `0` verified, `1` usage error, `2`
 verification/policy failed (e.g. wrong measurement), `3` evidence unavailable
-(unreachable/unparseable).
+(unreachable/unparseable), `4` partially verified — the evidence verified, but
+a property it presents is not proven. The two partial cases today: a
+discovery document declaring `public_tls.mode=webpki` (the front door's
+serving key is not attestation-bound — what is proven is the tls-lb pod's TEE
+residency and measurement, not the TLS endpoint clients reach), and attest-pq
+or saved-bundle evidence without `--mesh-ca` (the mesh chain anchors to a CA
+the responder committed into its own transcript, so which deployment the
+endpoint belongs to is not proven). JSON renders these as
+`verified: false, partial: true` with a `not_proven` list, so a gate checking
+`verified` fails closed while scripts can still tell partial from failure.
 
 Caveats the output surfaces:
 

--- a/internal/cmds/verify/certbody_test.go
+++ b/internal/cmds/verify/certbody_test.go
@@ -338,6 +338,18 @@ func TestDescribeCertBody(t *testing.T) {
 		!strings.Contains(got, "validity enforced") {
 		t.Errorf("chain-verified note = %q", got)
 	}
+	// The attest-pq transcript binds the exact body bytes, so validity is
+	// genuinely enforced — but the note must not claim a verified chain: the
+	// anchor is responder-chosen, which the chain-anchor / not-proven lines
+	// carry.
+	derived := &evidence{leafChainDerived: true}
+	dgot := describeCertBody(config{}, derived)
+	if !strings.Contains(dgot, "identity transcript") || !strings.Contains(dgot, "validity enforced") {
+		t.Errorf("derived-chain note = %q", dgot)
+	}
+	if strings.Contains(dgot, "verified issuing chain") {
+		t.Errorf("derived-chain note = %q: a responder-chosen anchor is not a verified chain", dgot)
+	}
 	// A live handshake proves possession of the attested key, which is what
 	// stands behind an un-chained body there — say that, not "validity
 	// enforced": NotAfter inside an unsigned body bounds nothing on its own.

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -81,10 +81,23 @@ func fetchDiscoveryDoc(ctx context.Context, base, path, serverName string, timeo
 // the document is authenticated only by a --mesh-ca chain check; without one
 // the document is rejected rather than verified against a body nothing signed
 // for (authorizeLeafBody).
+//
+// public_tls.mode travels with the evidence to the verdict: a "webpki" front
+// door terminates public TLS on a certificate this evidence says nothing
+// about, so the verdict is demoted to partial downstream
+// (applyFrontDoorPolicy). An unknown mode fails closed here — a
+// securityError, so auto mode cannot fall through to the serving cert past a
+// document it cannot classify.
 func evidenceFromDiscovery(data []byte, source string, trust leafTrust) (*evidence, error) {
 	var d types.DiscoveryDocument
 	if err := json.Unmarshal(data, &d); err != nil {
 		return nil, fmt.Errorf("parse discovery document: %w", err)
+	}
+	switch d.PublicTLS.Mode {
+	case "", "cds", "webpki":
+	default:
+		return nil, &securityError{err: fmt.Errorf(
+			"unknown public_tls.mode %q in discovery document (this build knows cds and webpki): the front door's serving-key binding cannot be established", d.PublicTLS.Mode)}
 	}
 	cert, rd, err := ratls.AttestedCertFromDiscovery(&d)
 	if err != nil {
@@ -112,6 +125,7 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust) (*eviden
 		leaf:              cert,
 		leafBody:          body,
 		leafChainVerified: chainVerified,
+		publicTLSMode:     d.PublicTLS.Mode,
 		sandboxID:         sandboxID,
 		sandboxErr:        sandboxErr,
 		workload:          workload,

--- a/internal/cmds/verify/evidence.go
+++ b/internal/cmds/verify/evidence.go
@@ -65,8 +65,9 @@ type evidence struct {
 	// leaf is the CDS-issued leaf the evidence speaks for: the serving cert in
 	// cert and discovery modes, the transcript-committed mesh leaf in
 	// attest-pq mode, nil otherwise. Kept so --mesh-ca can check what CDS
-	// actually signed. Every leaf set here has passed authenticateLeafBody
-	// AND one of the three body-authentication backstops below.
+	// actually signed. Every leaf set here has passed body authentication
+	// (authenticateLeafBody, or verifyCommittedChain on attest-pq) AND one of
+	// the body-authentication backstops below.
 	leaf *x509.Certificate
 	// leafBody is what authenticateLeafBody proved about the leaf's body
 	// fields: BodySelfSigned (authenticated by its own attested key) or
@@ -74,9 +75,20 @@ type evidence struct {
 	// leaf is nil.
 	leafBody certutil.BodyAuthentication
 	// leafChainVerified is true when the leaf's issuing chain was verified
-	// while gathering — the transcript-committed CA on attest-pq, or the
-	// --mesh-ca bundle elsewhere — so a CA-vouched body is authenticated.
+	// against the operator-pinned --mesh-ca bundle while gathering, so a
+	// CA-vouched body is authenticated by an anchor the operator chose.
 	leafChainVerified bool
+	// leafChainDerived is true when the leaf's issuing chain was checked
+	// against the CA the responder committed into its own attestation
+	// transcript (attest-pq). The transcript binds those CA bytes to the
+	// hardware evidence, but the anchor is responder-chosen: it is not a
+	// pinned trust anchor and the verdict must never treat it as one.
+	leafChainDerived bool
+	// publicTLSMode is the discovery document's declared front-door TLS mode
+	// ("" when not discovery-sourced): "cds" serves the attestation-bound
+	// CDS leaf, "webpki" an operator WebPKI certificate the evidence says
+	// nothing about.
+	publicTLSMode string
 	// leafKeyProven is true when a live TLS handshake with the leaf completed,
 	// which proves the presenter holds the attested private key. A forged body
 	// carrying someone else's attested SubjectPublicKeyInfo cannot complete
@@ -362,7 +374,9 @@ func evidenceFromEndpointJSON(data, expectNonce []byte, source string) (*evidenc
 	// come before anything from the leaf is surfaced. The hardware evidence
 	// itself is verified downstream against erd; a failure here means the
 	// responder does not hold the committed identity, whatever its evidence
-	// says.
+	// says. The chain check anchors to the CA the responder committed — a
+	// derived anchor, recorded as such: only --mesh-ca turns it into a
+	// verified chain (applyChainAnchorPolicy).
 	if err := verifyIdentityProof(r.IdentityProof, leaf, erd); err != nil {
 		return nil, &securityError{err: err}
 	}
@@ -375,18 +389,18 @@ func evidenceFromEndpointJSON(data, expectNonce []byte, source string) (*evidenc
 	sandboxID, sandboxErr := ratls.SandboxIDFromCert(leaf)
 	workload, workloadErr := ratls.MatchedWorkloadFromCert(leaf)
 	return &evidence{
-		platform:          platformOrDefault(r.Platform),
-		rawEvidence:       r.Evidence,
-		erd:               erd,
-		fresh:             fresh,
-		source:            source,
-		bindingNote:       "REPORTDATA binds the identity transcript: session keys + nonce + the exact mesh leaf and its transcript-committed issuing CA (leaf proof of possession verified)",
-		leaf:              leaf,
-		leafChainVerified: true,
-		sandboxID:         sandboxID,
-		sandboxErr:        sandboxErr,
-		workload:          workload,
-		workloadErr:       workloadErr,
+		platform:         platformOrDefault(r.Platform),
+		rawEvidence:      r.Evidence,
+		erd:              erd,
+		fresh:            fresh,
+		source:           source,
+		bindingNote:      "REPORTDATA binds the identity transcript: session keys + nonce + the exact mesh leaf and its transcript-committed issuing CA (leaf proof of possession verified)",
+		leaf:             leaf,
+		leafChainDerived: true,
+		sandboxID:        sandboxID,
+		sandboxErr:       sandboxErr,
+		workload:         workload,
+		workloadErr:      workloadErr,
 	}, nil
 }
 

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -1,0 +1,365 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+
+	"github.com/confidential-dot-ai/c8s/pkg/overenc"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// discoveryDocWithPublicTLS is discoveryDocWith plus the public_tls block
+// get-cert writes (empty mode omits the mode field, as a pre-mode document).
+func discoveryDocWithPublicTLS(t *testing.T, mode, certPEM string, challenge []byte, evidence string) []byte {
+	t.Helper()
+	var doc map[string]any
+	if err := json.Unmarshal(discoveryDocWith(t, certPEM, challenge, evidence), &doc); err != nil {
+		t.Fatal(err)
+	}
+	doc["public_tls"] = map[string]any{"hostname": "lb.example.com", "mode": mode}
+	data, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return data
+}
+
+// The discovery gather must read public_tls.mode: cds (and its pre-mode-field
+// empty spelling) and webpki are recorded for the verdict; anything else
+// fails closed as a security verdict — auto mode must not fall through past a
+// document it cannot classify.
+func TestDiscoveryPublicTLSModeParsing(t *testing.T) {
+	certPEM, _ := selfSignedCertPEM(t)
+	challenge := []byte("issuance-challenge")
+	evidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+
+	for _, mode := range []string{"", "cds", "webpki"} {
+		ev, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, mode, certPEM, challenge, evidence), "test", leafTrust{})
+		if err != nil {
+			t.Fatalf("mode %q: %v", mode, err)
+		}
+		if ev.publicTLSMode != mode {
+			t.Errorf("mode %q: publicTLSMode = %q", mode, ev.publicTLSMode)
+		}
+	}
+
+	_, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, "dns", certPEM, challenge, evidence), "test", leafTrust{})
+	if err == nil || !isSecurityError(err) {
+		t.Fatalf("an unknown public_tls.mode must fail closed as a security verdict, got %v", err)
+	}
+	if !strings.Contains(err.Error(), `public_tls.mode "dns"`) {
+		t.Errorf("error = %q, want it to name the unrecognized mode", err)
+	}
+}
+
+// snpVerifiedOutcome builds a passing SNP verdict for ev the way
+// verifyEvidence does: newOutcome plus the full ordered policy sequence.
+func snpVerifiedOutcome(t *testing.T, cfg config, ev *evidence) Outcome {
+	t.Helper()
+	launch := "ab" + strings.Repeat("00", 47)
+	if cfg.measurements == nil {
+		cfg.measurements = []string{launch}
+	}
+	plan := mustPlan(t, cfg)
+	result := &teetypes.VerificationResult{
+		SignatureValid: true,
+		Platform:       teetypes.PlatformSNP,
+		Claims:         teetypes.Claims{LaunchDigest: launch},
+	}
+	oc := newOutcome(cfg, ev, result, nil, plan)
+	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{})
+	return oc
+}
+
+// A WebPKI front door terminates public TLS on a certificate the evidence
+// says nothing about: the evidence verifies, but the verdict is partial —
+// never "✓ VERIFIED" — and the exit code tells scripts so.
+func TestWebPKIFrontDoorIsPartialNotVerified(t *testing.T) {
+	ev := &evidence{
+		platform:      "snp",
+		source:        "discovery document https://lb.example.com/v1/discovery",
+		bindingNote:   "REPORTDATA binds the CDS cert key + issuance challenge",
+		publicTLSMode: "webpki",
+	}
+	oc := snpVerifiedOutcome(t, config{}, ev)
+	if oc.Verified || !oc.Partial {
+		t.Fatalf("webpki front door: verified=%v partial=%v, want a partial verdict", oc.Verified, oc.Partial)
+	}
+	if got := verdictExitCode(oc); got != exitPartial {
+		t.Errorf("exit = %d, want %d", got, exitPartial)
+	}
+	if len(oc.NotProven) != 1 || !strings.Contains(oc.NotProven[0], "public_tls.mode=webpki") ||
+		!strings.Contains(oc.NotProven[0], "not attestation-bound") {
+		t.Errorf("NotProven = %v, want it to name the WebPKI serving key", oc.NotProven)
+	}
+
+	var out bytes.Buffer
+	renderText(config{}, oc, &out)
+	got := out.String()
+	for _, want := range []string{"~ PARTIALLY VERIFIED", "not proven:", "public_tls.mode=webpki", "measurement:", "binding:"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("partial render missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "✓ VERIFIED") {
+		t.Errorf("a WebPKI front door must never print ✓:\n%s", got)
+	}
+
+	// JSON carries the same honesty: verified stays false (CI fails closed),
+	// partial and the unproven property are machine-readable.
+	var jout bytes.Buffer
+	render(config{output: "json"}, oc, &jout)
+	var parsed map[string]any
+	if err := json.Unmarshal(jout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json render: %v", err)
+	}
+	if parsed["verified"] != false || parsed["partial"] != true {
+		t.Errorf("json verified=%v partial=%v", parsed["verified"], parsed["partial"])
+	}
+	if np, ok := parsed["not_proven"].([]any); !ok || len(np) != 1 {
+		t.Errorf("json not_proven = %v", parsed["not_proven"])
+	}
+
+	// A verification failure dominates the mode: exit 2, not partial.
+	verr := &securityError{err: errors.New("rejected")}
+	failed := newOutcome(config{}, ev, nil, verr, mustPlan(t, config{measurements: []string{"ab" + strings.Repeat("00", 47)}}))
+	applyVerdictPolicies(&failed, config{}, ev, nil, operatorKeysReport{})
+	if failed.Partial || verdictExitCode(failed) != exitFailed {
+		t.Errorf("failed evidence + webpki: partial=%v exit=%d, want a plain failure", failed.Partial, verdictExitCode(failed))
+	}
+}
+
+// genoaFileEvidence parses the vendored Genoa fixture (VCEK inline, verifies
+// offline) into evidence the way --from-file does.
+func genoaFileEvidence(t *testing.T) *evidence {
+	t.Helper()
+	fixture, err := os.ReadFile("testdata/snp-evidence-genoa.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := gatherFromFile(fixture, []byte("genoa-test-fixture"), "fixture", leafTrust{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+// The full verify path on real offline-verifiable evidence: a WebPKI-mode
+// discovery verdict exits 4, and the same evidence with an attestation-bound
+// front door still exits 0 — the regression pair.
+func TestVerifyEvidenceWebPKIExitCodes(t *testing.T) {
+	plan := &verifyPlan{policy: &ratls.VerifyPolicy{}}
+
+	t.Run("webpki front door exits partial", func(t *testing.T) {
+		ev := genoaFileEvidence(t)
+		ev.publicTLSMode = "webpki" // as a discovery gather would record it
+		var out, errOut bytes.Buffer
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		if code != exitPartial {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitPartial, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "~ PARTIALLY VERIFIED") {
+			t.Errorf("output:\n%s", out.String())
+		}
+	})
+
+	t.Run("pre-mode discovery document still verifies", func(t *testing.T) {
+		ev := genoaFileEvidence(t) // publicTLSMode "" — a pre-mode-field document
+		var out, errOut bytes.Buffer
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		if code != exitVerified {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
+		}
+	})
+
+	t.Run("attestation-bound front door still verifies", func(t *testing.T) {
+		ev := genoaFileEvidence(t)
+		ev.publicTLSMode = "cds"
+		var out, errOut bytes.Buffer
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		if code != exitVerified {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), "✓ VERIFIED") {
+			t.Errorf("output:\n%s", out.String())
+		}
+	})
+}
+
+// writeMeshCAPEM writes ca as the --mesh-ca bundle file.
+func writeMeshCAPEM(t *testing.T, ca *x509.Certificate) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mesh-ca.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// endpointEvidence is the shape attest-pq / saved-bundle gathering produces:
+// a transcript-committed mesh leaf whose chain anchor the responder chose.
+func endpointEvidence(id *endpointIdentity) *evidence {
+	return &evidence{
+		platform:         "snp",
+		source:           "attestation endpoint https://lb.example.com",
+		bindingNote:      "REPORTDATA binds the identity transcript",
+		fresh:            true,
+		leaf:             id.leaf,
+		leafChainDerived: true,
+	}
+}
+
+// A responder-chosen chain anchor is never reported as verified: without
+// --mesh-ca the verdict is partial (exit 4); pinning the CA the leaf actually
+// chains to is what earns the tick (exit 0); pinning a CA it does not chain
+// to is a failure (exit 2).
+func TestAttestPQChainAnchorHonesty(t *testing.T) {
+	id := mintEndpointIdentity(t)
+
+	t.Run("responder-chosen chain is partial", func(t *testing.T) {
+		cfg := config{}
+		oc := snpVerifiedOutcome(t, cfg, endpointEvidence(id))
+		if oc.Verified || !oc.Partial {
+			t.Fatalf("verified=%v partial=%v, want partial", oc.Verified, oc.Partial)
+		}
+		if got := verdictExitCode(oc); got != exitPartial {
+			t.Errorf("exit = %d, want %d", got, exitPartial)
+		}
+		if len(oc.NotProven) != 1 || !strings.Contains(oc.NotProven[0], "responder committed") ||
+			!strings.Contains(oc.NotProven[0], "--mesh-ca") {
+			t.Errorf("NotProven = %v, want it to name the responder-chosen anchor and the way out", oc.NotProven)
+		}
+		if oc.ChainAnchor != "" {
+			t.Errorf("ChainAnchor = %q: a responder-chosen anchor must never report as verified", oc.ChainAnchor)
+		}
+
+		var out bytes.Buffer
+		renderText(config{}, oc, &out)
+		got := out.String()
+		for _, want := range []string{"~ PARTIALLY VERIFIED", "not proven:", "responder-chosen", "binding:"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("partial render missing %q:\n%s", want, got)
+			}
+		}
+		if strings.Contains(got, "✓ VERIFIED") || strings.Contains(got, "\n  chain anchor: ") {
+			t.Errorf("a responder-chosen chain must not print a verified anchor:\n%s", got)
+		}
+	})
+
+	t.Run("pinned anchor verifies", func(t *testing.T) {
+		cfg := config{meshCA: writeMeshCAPEM(t, id.ca)}
+		oc := snpVerifiedOutcome(t, cfg, endpointEvidence(id))
+		if !oc.Verified || oc.Partial {
+			t.Fatalf("verified=%v partial=%v error=%q, want verified", oc.Verified, oc.Partial, oc.Error)
+		}
+		if got := verdictExitCode(oc); got != exitVerified {
+			t.Errorf("exit = %d, want %d", got, exitVerified)
+		}
+		if oc.ChainAnchor == "" || !strings.Contains(oc.ChainAnchor, "verified against the pinned --mesh-ca") {
+			t.Errorf("ChainAnchor = %q", oc.ChainAnchor)
+		}
+		var out bytes.Buffer
+		renderText(cfg, oc, &out)
+		got := out.String()
+		if !strings.Contains(got, "✓ VERIFIED") || !strings.Contains(got, "chain anchor: verified against the pinned --mesh-ca") {
+			t.Errorf("pinned-anchor render:\n%s", got)
+		}
+	})
+
+	t.Run("pinned anchor the leaf does not chain to fails", func(t *testing.T) {
+		other := mintEndpointIdentity(t)
+		cfg := config{meshCA: writeMeshCAPEM(t, other.ca)}
+		oc := snpVerifiedOutcome(t, cfg, endpointEvidence(id))
+		if oc.Verified || oc.Partial {
+			t.Fatalf("verified=%v partial=%v, want a failure", oc.Verified, oc.Partial)
+		}
+		if got := verdictExitCode(oc); got != exitFailed {
+			t.Errorf("exit = %d, want %d", got, exitFailed)
+		}
+		if !strings.Contains(oc.Error, "does not chain to the --mesh-ca bundle") {
+			t.Errorf("Error = %q", oc.Error)
+		}
+	})
+}
+
+// Both endpoint-evidence sources — a live attest-pq fetch and a saved bundle
+// via --from-file — must mark the chain derived, never verified.
+func TestEndpointEvidenceMarksChainDerived(t *testing.T) {
+	nonce := bytes.Repeat([]byte{0x07}, nonceSize)
+	report := bytes.Repeat([]byte{0x01}, 64)
+	x := bytes.Repeat([]byte{0x02}, overenc.X25519PubBytes)
+	m := bytes.Repeat([]byte{0x03}, overenc.MLKEM768EKBytes)
+	id := mintEndpointIdentity(t)
+	data := buildEndpointJSON(t, id, nonce, report, []byte("vcek"), x, m)
+
+	for _, tc := range []struct {
+		name string
+		get  func() (*evidence, error)
+	}{
+		{"live fetch", func() (*evidence, error) { return evidenceFromEndpointJSON(data, nonce, "test") }},
+		{"saved bundle", func() (*evidence, error) { return gatherFromFile(data, nil, "file", leafTrust{}) }},
+	} {
+		ev, err := tc.get()
+		if err != nil {
+			t.Fatalf("%s: %v", tc.name, err)
+		}
+		if !ev.leafChainDerived {
+			t.Errorf("%s: leafChainDerived must record the responder-chosen anchor", tc.name)
+		}
+		if ev.leafChainVerified {
+			t.Errorf("%s: a responder-chosen anchor is not a verified chain", tc.name)
+		}
+	}
+}
+
+// run() over a served discovery document: WebPKI mode with evidence that
+// itself fails verification is a failure (exit 2), not a partial — the mode
+// demotion only ever applies to a passing verdict. An unknown mode is a
+// security verdict, and auto mode must not fall through past it.
+func TestRunDiscoveryPublicTLSModeVerdicts(t *testing.T) {
+	certPEM, _ := selfSignedCertPEM(t)
+	challenge := []byte("issuance-challenge")
+	stubEvidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+
+	serve := func(t *testing.T, doc []byte) string {
+		t.Helper()
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(doc)
+		}))
+		t.Cleanup(srv.Close)
+		return srv.URL
+	}
+
+	t.Run("webpki + failing evidence is a failure, not partial", func(t *testing.T) {
+		url := serve(t, discoveryDocWithPublicTLS(t, "webpki", certPEM, challenge, stubEvidence))
+		var out, errOut bytes.Buffer
+		code := run(context.Background(), config{url: url, kind: "lb", output: "text"}, &out, &errOut)
+		if code != exitFailed {
+			t.Errorf("exit = %d, want %d; output:\n%s%s", code, exitFailed, out.String(), errOut.String())
+		}
+	})
+
+	t.Run("unknown mode is a verdict failure", func(t *testing.T) {
+		url := serve(t, discoveryDocWithPublicTLS(t, "dns", certPEM, challenge, stubEvidence))
+		var out, errOut bytes.Buffer
+		code := run(context.Background(), config{url: url, kind: "lb", output: "text"}, &out, &errOut)
+		if code != exitFailed {
+			t.Errorf("exit = %d, want %d; output:\n%s%s", code, exitFailed, out.String(), errOut.String())
+		}
+		if !strings.Contains(out.String(), `public_tls.mode "dns"`) {
+			t.Errorf("the verdict should name the unrecognized mode:\n%s", out.String())
+		}
+	})
+}

--- a/internal/cmds/verify/rtmrpin_test.go
+++ b/internal/cmds/verify/rtmrpin_test.go
@@ -309,12 +309,13 @@ func TestTDXPolicyDecisionsNormalizeThePlatformTag(t *testing.T) {
 
 // A passing TDX verdict pinned on MRTD alone must warn prominently: MRTD
 // covers only the TDVF firmware, and the guest kernel/rootfs stay unmeasured
-// by that policy. The warning is the degraded form — it requires a CA anchor
-// (see TestTDXMRTDOnlyRejectedWithoutCAAnchor).
+// by that policy. The warning is the degraded form — it requires an
+// operator-pinned CA anchor (see TestTDXMRTDOnlyRejectedWithoutCAAnchor).
 func TestTDXMRTDOnlyWarns(t *testing.T) {
 	cfg := config{measurements: []string{testMRTD}}
 	plan := mustPlan(t, cfg)
-	anchored := &evidence{platform: "tdx", leafChainVerified: true}
+	plan.meshCA = x509.NewCertPool()
+	anchored := &evidence{platform: "tdx"}
 
 	oc := newOutcome(cfg, anchored, tdxResult(testMRTD, matchingRTMRs()), nil, plan)
 	if !oc.Verified {
@@ -344,9 +345,10 @@ func TestTDXMRTDOnlyWarns(t *testing.T) {
 }
 
 // What decides between rejecting an MRTD-only TDX policy and warning about it
-// is whether a CA anchor stands beside the measurements — a property of the
-// evidence, not of the CLI mode string. Every mode, including the empty one
-// --from-file leaves behind, is rejected when there is no anchor at all.
+// is whether an operator-pinned CA anchor (--mesh-ca) stands beside the
+// measurements — a property of the policy, not of the CLI mode string. Every
+// mode, including the empty one --from-file leaves behind, is rejected when
+// there is no pinned anchor at all.
 func TestTDXMRTDOnlyRejectedWithoutCAAnchor(t *testing.T) {
 	for _, mode := range []string{"", "auto", "ratls-cert", "discovery", "attest-pq"} {
 		cfg := config{mode: mode, measurements: []string{testMRTD}}
@@ -359,34 +361,34 @@ func TestTDXMRTDOnlyRejectedWithoutCAAnchor(t *testing.T) {
 		}
 	}
 
-	// Either anchor downgrades the same condition to a warning: the operator's
-	// --mesh-ca pin, or a chain verified while gathering (attest-pq's
-	// transcript-committed CA).
-	for _, tc := range []struct {
-		name string
-		plan func(*testing.T) *verifyPlan
-		ev   *evidence
-	}{
-		{"--mesh-ca pinned", func(t *testing.T) *verifyPlan {
-			p := mustPlan(t, config{measurements: []string{testMRTD}})
-			p.meshCA = x509.NewCertPool()
-			return p
-		}, &evidence{platform: "tdx"}},
-		{"chain verified while gathering", func(t *testing.T) *verifyPlan {
-			return mustPlan(t, config{measurements: []string{testMRTD}})
-		}, &evidence{platform: "tdx", leafChainVerified: true}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg := config{mode: "attest-pq", measurements: []string{testMRTD}}
-			oc := newOutcome(cfg, tc.ev, tdxResult(testMRTD, matchingRTMRs()), nil, tc.plan(t))
-			if !oc.Verified {
-				t.Fatalf("an anchored verdict must pass with a warning: %s", oc.Error)
-			}
-			if len(oc.Warnings) != 1 || !strings.Contains(oc.Warnings[0], "UNMEASURED") {
-				t.Fatalf("Warnings = %v, want the MRTD-only warning", oc.Warnings)
-			}
-		})
-	}
+	// Only an operator-pinned anchor downgrades the same condition to a
+	// warning. A chain checked against the responder-committed CA (attest-pq's
+	// derived anchor) does NOT: the responder chose that CA, so it anchors
+	// nothing the operator asked about and the verdict stays deployment-class.
+	t.Run("--mesh-ca pinned", func(t *testing.T) {
+		plan := mustPlan(t, config{measurements: []string{testMRTD}})
+		plan.meshCA = x509.NewCertPool()
+		cfg := config{mode: "attest-pq", measurements: []string{testMRTD}}
+		oc := newOutcome(cfg, &evidence{platform: "tdx"}, tdxResult(testMRTD, matchingRTMRs()), nil, plan)
+		if !oc.Verified {
+			t.Fatalf("a pinned-anchor verdict must pass with a warning: %s", oc.Error)
+		}
+		if len(oc.Warnings) != 1 || !strings.Contains(oc.Warnings[0], "UNMEASURED") {
+			t.Fatalf("Warnings = %v, want the MRTD-only warning", oc.Warnings)
+		}
+	})
+
+	t.Run("responder-committed chain is not an anchor", func(t *testing.T) {
+		cfg := config{mode: "attest-pq", measurements: []string{testMRTD}}
+		ev := &evidence{platform: "tdx", leafChainDerived: true}
+		oc := newOutcome(cfg, ev, tdxResult(testMRTD, matchingRTMRs()), nil, mustPlan(t, cfg))
+		if oc.Verified {
+			t.Fatal("a responder-chosen chain anchor must not downgrade the MRTD-only rejection")
+		}
+		if !strings.Contains(oc.Error, "UNMEASURED") || !strings.Contains(oc.Error, "deployment-class") {
+			t.Errorf("Error = %q, want the MRTD-only rejection", oc.Error)
+		}
+	})
 }
 
 func TestRTMRPinFlagErrors(t *testing.T) {

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -34,13 +34,28 @@ import (
 )
 
 // Exit codes. These are a stable contract for CI: a wrong measurement (2) is
-// distinguishable from an unreachable endpoint (3).
+// distinguishable from an unreachable endpoint (3), and a partial verdict (4)
+// — evidence verified, but a property the evidence presents is not proven —
+// from both a full pass and a failure.
 const (
 	exitVerified   = 0
 	exitUsage      = 1
 	exitFailed     = 2 // evidence obtained, but verification/policy failed
 	exitNoEvidence = 3 // could not obtain evidence (connect/parse/file)
+	exitPartial    = 4 // evidence verified, but a presented property is not proven
 )
+
+// verdictExitCode maps a rendered verdict to the process exit code.
+func verdictExitCode(oc Outcome) int {
+	switch {
+	case oc.Verified:
+		return exitVerified
+	case oc.Partial:
+		return exitPartial
+	default:
+		return exitFailed
+	}
+}
 
 // connectError marks a failure to obtain evidence or verification collateral
 // (vs. a verification verdict), so the orchestration can map it to exit code 3.
@@ -157,7 +172,9 @@ Evidence sources:
   c8s verify https://lb.example.com:443 --kind lb --measurements <sha384-hex>
 
 Exit codes: 0 verified · 1 usage · 2 verification/policy failed · 3 evidence
-unavailable (unreachable / unparseable).`,
+unavailable (unreachable / unparseable) · 4 partially verified (the evidence
+verified, but a property it presents is not proven — a WebPKI front door whose
+serving key is not attestation-bound, or a chain anchor the responder chose).`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -189,7 +206,7 @@ unavailable (unreachable / unparseable).`,
 	f.StringVar(&cfg.sandboxID, "sandbox-id", "", "expected CRI pod sandbox ID on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the ID (docs/ratls.md)")
 	f.StringVar(&cfg.workload, "workload", "", "expected matched-workload name on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the stamp (docs/ratls.md)")
 	f.StringVar(&cfg.allowlistFile, "allowlist", "", "file holding the exact canonical allowlist bytes (as served by GET /allowlist); the leaf's stamped policy digest must equal SHA-256 of these bytes and the stamped name must resolve in the document. Requires --mesh-ca")
-	f.StringVar(&cfg.meshCA, "mesh-ca", "", "PEM bundle of the CDS mesh CA; when set, the target's leaf must chain to it, which is what authenticates the reported sandbox ID")
+	f.StringVar(&cfg.meshCA, "mesh-ca", "", "PEM bundle of the CDS mesh CA; when set, the target's leaf must chain to it, which is what authenticates the reported sandbox ID. On attest-pq it is also what upgrades the chain anchor from responder-chosen (partial verdict) to verified")
 	f.BoolVar(&cfg.allowDebug, "allow-debug", false, "accept debug-enabled guests")
 	const tcbSNPOnly = " (SEV-SNP evidence only — TDX carries no such component, so against TDX evidence this is a policy error rather than an ignored flag)"
 	f.UintVar(&cfg.minTCBBootloader, "min-tcb-bootloader", 0, "minimum bootloader TCB component"+tcbSNPOnly)
@@ -344,13 +361,64 @@ func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evide
 	oc := newOutcome(cfg, ev, result, verr, plan)
 	oc.OperatorKeys = opKeys.fingerprints
 	oc.OperatorKeysNote = opKeys.note
-	applySandboxPolicy(&oc, cfg, ev, opKeys)
-	applyWorkloadPolicy(&oc, cfg, ev, held)
+	applyVerdictPolicies(&oc, cfg, ev, held, opKeys)
 	render(cfg, oc, out)
+	return verdictExitCode(oc)
+}
+
+// applyVerdictPolicies runs every post-verification policy in verdict order:
+// the CA-vouched pins first (they authenticate the leaf's stamps and can fail
+// the verdict), then the honesty demotions, which only ever turn a passing
+// verdict partial. Ordering matters: applyChainAnchorPolicy reads the pinned
+// chain check's outcome from oc.Verified.
+func applyVerdictPolicies(oc *Outcome, cfg config, ev *evidence, held *heldAllowlist, opKeys operatorKeysReport) {
+	applySandboxPolicy(oc, cfg, ev, opKeys)
+	applyWorkloadPolicy(oc, cfg, ev, held)
+	applyFrontDoorPolicy(oc, ev)
+	applyChainAnchorPolicy(oc, cfg, ev)
+}
+
+// demoteToPartial turns a passing verdict into a partial one, naming the
+// presented property that is not proven. It never rescues a failed verdict:
+// a verification failure dominates and stays exit 2.
+func demoteToPartial(oc *Outcome, notProven string) {
 	if !oc.Verified {
-		return exitFailed
+		return
 	}
-	return exitVerified
+	oc.Verified = false
+	oc.Partial = true
+	oc.NotProven = append(oc.NotProven, notProven)
+}
+
+// applyFrontDoorPolicy enforces the discovery document's public_tls.mode: a
+// WebPKI front door terminates public TLS on an operator certificate, so the
+// serving key clients reach is not the attestation-bound CDS key the evidence
+// speaks for.
+func applyFrontDoorPolicy(oc *Outcome, ev *evidence) {
+	if ev.publicTLSMode != "webpki" {
+		return
+	}
+	demoteToPartial(oc, "the front-door serving key is not attestation-bound: public_tls.mode=webpki terminates public TLS on an operator WebPKI certificate, not the CDS-issued key this evidence attests — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not")
+}
+
+// applyChainAnchorPolicy settles what the verdict may claim about an
+// endpoint-presented mesh chain (attest-pq / saved bundle). At gather time
+// the chain was checked against the CA the responder committed into its own
+// transcript — an anchor the responder chose. Only --mesh-ca turns that into
+// a verified chain (applySandboxPolicy has already enforced the pinned check
+// when it is set); a responder-chosen anchor leaves the endpoint's deployment
+// identity unproven, so a passing verdict is partial.
+func applyChainAnchorPolicy(oc *Outcome, cfg config, ev *evidence) {
+	if !ev.leafChainDerived {
+		return
+	}
+	if cfg.meshCA != "" {
+		if oc.Verified {
+			oc.ChainAnchor = "verified against the pinned --mesh-ca bundle"
+		}
+		return
+	}
+	demoteToPartial(oc, "the mesh chain anchor: the leaf chains to a CA the responder committed into its own attestation transcript — the evidence binds those CA bytes, but the anchor is responder-chosen, so which deployment this endpoint belongs to is not proven (pass --mesh-ca to pin it)")
 }
 
 // verifyPlan is one run's parsed, validated policy: the verifier policy, the
@@ -898,12 +966,28 @@ type Outcome struct {
 	// true, but with named limits a relying party should read.
 	Warnings []string `json:"warnings,omitempty"`
 
+	// Partial is true when the hardware evidence verified but a property the
+	// evidence presents is not proven (a WebPKI front door's serving key, a
+	// responder-chosen chain anchor). Verified stays false, so a CI gate
+	// checking verified==true fails closed; the exit code distinguishes the
+	// case (4) from a failure (2). NotProven names each unproven property.
+	Partial   bool     `json:"partial,omitempty"`
+	NotProven []string `json:"not_proven,omitempty"`
+
+	// ChainAnchor states what an endpoint-presented mesh chain (attest-pq /
+	// saved bundle) was verified against: set only when the chain verified
+	// against the pinned --mesh-ca bundle. A responder-chosen anchor is never
+	// reported here — it lands in NotProven.
+	ChainAnchor string `json:"chain_anchor,omitempty"`
+
 	// CertBody says what authenticates the leaf certificate's body fields
 	// (subject/serial/validity): the leaf's own attested key when
-	// self-signed, a verified issuing chain, or — on a live RA-TLS dial —
-	// possession of the attested key. A leaf with none of the three is not
-	// accepted as evidence at all (authorizeLeafBody), because checking a
-	// validity window inside an unsigned body bounds nothing.
+	// self-signed, a verified issuing chain, possession of the attested key on
+	// a live RA-TLS dial, or — on attest-pq — the identity transcript the
+	// hardware evidence binds (whose chain anchor is responder-chosen; see
+	// ChainAnchor). A leaf with none of these is not accepted as evidence at
+	// all (authorizeLeafBody), because checking a validity window inside an
+	// unsigned body bounds nothing.
 	CertBody string `json:"cert_body,omitempty"`
 
 	// OperatorKeys are hex SHA-256 fingerprints (of the PKIX/SPKI DER) of the
@@ -1159,20 +1243,19 @@ func newOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, v
 	}
 	oc.Verified = true
 
-	// A passing TDX verdict with a launch-measurement pin but no image tuple
-	// says less than it looks like: MRTD covers only the TDVF firmware. What
-	// decides between rejecting that and warning about it is whether ANY CA
-	// anchor stands next to the measurements — not the CLI mode string, which
-	// says nothing about the evidence (--from-file leaves it empty, and
-	// ratls-cert without --mesh-ca has a self-signed leaf and no CA at all).
-	// With no anchor the verdict is deployment-class, the measurement pins are
-	// the entire trust anchor, and an incomplete image policy is a hard
-	// failure.
+	// What decides between rejecting an MRTD-only TDX verdict and warning
+	// about it is whether an operator-pinned CA anchor (--mesh-ca) stands next
+	// to the measurements. Without one the verdict is deployment-class — the
+	// measurement pins are the entire trust anchor — and an incomplete image
+	// policy is a hard failure. A responder-committed CA (attest-pq's derived
+	// anchor) does not downgrade this: chosen by the responder, it anchors
+	// nothing the operator asked about — the same rule the JS verifier applies
+	// to a deployment-class verdict.
 	if isTDX(oc.Platform) && pinned && plan.pins.image == nil {
 		const mrtdOnly = "TDX measurement pin covers MRTD only — MRTD measures the TDVF firmware, so the guest kernel and rootfs are UNMEASURED by this policy; pass --image-manifest to pin the full image tuple"
-		if plan.meshCA == nil && !ev.leafChainVerified {
+		if plan.meshCA == nil {
 			oc.Verified = false
-			oc.Error = mrtdOnly + " (with no CA anchor this verdict is deployment-class — the measurement pins are the entire trust anchor — so an incomplete measurement policy is rejected; pin --mesh-ca to downgrade this to a warning)"
+			oc.Error = mrtdOnly + " (with no pinned CA anchor this verdict is deployment-class — the measurement pins are the entire trust anchor — so an incomplete measurement policy is rejected; pin --mesh-ca to downgrade this to a warning)"
 			return oc
 		}
 		oc.Warnings = append(oc.Warnings, mrtdOnly)
@@ -1313,7 +1396,9 @@ func describeCertBody(_ config, ev *evidence) string {
 	case ev.leafBody == certutil.BodySelfSigned:
 		return "self-signed: body authenticated by the certificate's own attested key" + skew + certutil.LeafValiditySkew.String() + ")"
 	case ev.leafChainVerified:
-		return "CA-signed: body authenticated by a verified issuing chain (--mesh-ca, or the transcript-committed CA)" + skew + certutil.LeafValiditySkew.String() + ")"
+		return "CA-signed: body authenticated by a verified issuing chain (--mesh-ca)" + skew + certutil.LeafValiditySkew.String() + ")"
+	case ev.leafChainDerived:
+		return "CA-signed: body committed into the identity transcript — the hardware evidence binds these exact bytes" + skew + certutil.LeafValiditySkew.String() + ")"
 	case ev.leafKeyProven:
 		return "CA-signed: body not chain-checked, but the live RA-TLS handshake proves the peer holds the attested key, so this body could not have been minted around it — pass --mesh-ca to also check the issuing chain"
 	default:
@@ -1389,9 +1474,12 @@ func render(cfg config, oc Outcome, out io.Writer) {
 }
 
 func renderText(cfg config, oc Outcome, out io.Writer) {
-	if oc.Verified {
+	switch {
+	case oc.Verified:
 		fmt.Fprintf(out, "✓ VERIFIED  (%s backend)\n", oc.Backend)
-	} else {
+	case oc.Partial:
+		fmt.Fprintf(out, "~ PARTIALLY VERIFIED  (%s backend)\n", oc.Backend)
+	default:
 		fmt.Fprintf(out, "✗ NOT VERIFIED  (%s backend)\n", oc.Backend)
 	}
 	fmt.Fprintf(out, "  source:       %s\n", oc.Source)
@@ -1413,7 +1501,13 @@ func renderText(cfg config, oc Outcome, out io.Writer) {
 	if oc.CertBody != "" {
 		fmt.Fprintf(out, "  cert body:    %s\n", oc.CertBody)
 	}
+	if oc.ChainAnchor != "" {
+		fmt.Fprintf(out, "  chain anchor: %s\n", oc.ChainAnchor)
+	}
 	fmt.Fprintf(out, "  binding:      %s\n", oc.Binding)
+	for _, np := range oc.NotProven {
+		fmt.Fprintf(out, "  not proven:   %s\n", np)
+	}
 	for _, w := range oc.Warnings {
 		fmt.Fprintf(out, "  WARNING:      %s\n", w)
 	}


### PR DESCRIPTION
c8s verify printed a bare VERIFIED in two cases where the property a relying party reads into the tick was not proven:

- --kind lb ignored public_tls.mode, so a WebPKI front door — whose serving key is not attestation-bound — got the same tick as a CDS-served door.
- attest-pq / saved-bundle evidence marked the mesh chain verified against the CA the responder committed into its own transcript — an anchor the responder chose.

Add a partial verdict: hardware evidence verified, but a presented property is not proven. It renders verified:false (so CI gates fail closed), names each unproven property, and maps to a new documented exit code 4, distinct from a failure (2). An unknown public_tls.mode now fails closed at gather time instead of falling through to the serving cert.

On attest-pq, passing --mesh-ca upgrades the chain anchor from responder-chosen (partial) to verified against the pinned bundle; the verdict's chain_anchor field is set only in that case.

The exit-code contract belongs to a wider CLI rework tracked separately; code 4 is documented in help and docs/operator.md so scripts can rely on it now.