### PR TITLE
test(testattest): model the attestation-api's real refusal shape

### DIFF
--- a/internal/attestation/handler_test.go
+++ b/internal/attestation/handler_test.go
@@ -571,6 +571,8 @@ func attestKeyBody(t *testing.T, appURL string) string {
 	})
 }
 
+// Defense in depth: a self-contradicting 200 must still mint no EAR. The
+// production refusal shape is the 422 below (testattest.Verdict).
 func TestAttestKeySignatureInvalid(t *testing.T) {
 	stub := testattest.New(t)
 	verdict := testattest.PassingVerdict("")
@@ -587,6 +589,30 @@ func TestAttestKeySignatureInvalid(t *testing.T) {
 	}
 }
 
+// The attestation-api refuses a report it cannot verify with a 422; evidence
+// it rejected must mint no EAR.
+func TestAttestKeyVerifierRefusalMintsNoEAR(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetVerifyError(testattest.VerificationFailed("report signature does not verify"))
+
+	app := httptest.NewServer(testApp(stub.URL))
+	defer app.Close()
+
+	resp := postAttestKey(t, app.URL, attestKeyBody(t, app.URL))
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("status = 200 for evidence the verifier refused; body=%s", body)
+	}
+	var out types.AttestKeyResponseBody
+	if json.Unmarshal(body, &out) == nil && out.EAR != "" {
+		t.Fatalf("an EAR was minted for refused evidence; body=%s", body)
+	}
+}
+
+// Defensive: non-production shape (testattest.Verdict). Production refuses a
+// mismatch with the 422 of VerificationFailed; the 401 pins the handler's own
+// fail-closed gate.
 func TestAttestKeyReportDataMismatch(t *testing.T) {
 	stub := testattest.New(t)
 	verdict := testattest.PassingVerdict("")

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -327,7 +327,9 @@ func TestAttest_BindsReportDataToCSRKeyAndChallenge(t *testing.T) {
 }
 
 // A verifier reporting that the evidence binds different report data must
-// deny issuance: the report attests some other key or challenge.
+// deny issuance: the report attests some other key or challenge. Defensive:
+// non-production shape (testattest.Verdict) — production refuses a mismatch
+// with a 422; the 401 pins CDS's own fail-closed gate.
 func TestAttest_ReportDataMismatchReturns401(t *testing.T) {
 	stub := newStubAttestationApi(t, "deadbeef")
 	verdict := testattest.PassingVerdict("deadbeef")

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -346,9 +346,9 @@ func TestVerifiedSelfHostDataRejectsUnverifiedReport(t *testing.T) {
 		setup func(*testing.T) string
 		want  error
 	}{
-		{"signature invalid", refusing(func(v *testattest.Verdict) { v.SignatureValid = false }), attestationclient.ErrSignatureInvalid},
+		{"signature invalid on a 200 (defense in depth)", refusing(func(v *testattest.Verdict) { v.SignatureValid = false }), attestationclient.ErrSignatureInvalid},
 		{"report data unchecked", refusing(func(v *testattest.Verdict) { v.ReportDataMatch = nil }), attestationclient.ErrReportDataMismatch},
-		{"report data mismatch", refusing(func(v *testattest.Verdict) { v.ReportDataMatch = &no }), attestationclient.ErrReportDataMismatch},
+		{"report data mismatch on a 200 (defense in depth)", refusing(func(v *testattest.Verdict) { v.ReportDataMatch = &no }), attestationclient.ErrReportDataMismatch},
 		{"launch digest malformed", refusing(func(v *testattest.Verdict) { v.Claims.LaunchDigest = "not-hex" }), attestationclient.ErrInvalidLaunchDigest},
 		{"platform with no verification rules", unsupportedPlatformAttester, attestationclient.ErrUnsupportedPlatform},
 	} {
@@ -515,19 +515,16 @@ func TestVerifiedSelfHostDataRejectsIllShapedClaim(t *testing.T) {
 }
 
 // A forged report committing the document on disk still fails, because the
-// forgery is what the verifier rejects.
+// forgery is what the verifier rejects: a 422, terminal rather than retryable.
 func TestResolveInitDataMeasurementsRejectsUnverifiedReport(t *testing.T) {
-	raw := testDocument(t, "aabb")
-	writeInitData(t, raw)
-	digest := initdata.Digest(raw)
+	writeInitData(t, testDocument(t, "aabb"))
 
-	v := hostDataVerdict(digest[:])
-	v.SignatureValid = false
-	cfg := &Config{AttestationServiceURL: attesterWithVerdict(t, v)}
+	stub := testattest.New(t)
+	stub.SetVerifyError(testattest.VerificationFailed("report signature does not verify"))
 
-	measurements, err := resolveInitDataMeasurements(context.Background(), cfg)
-	if !errors.Is(err, attestationclient.ErrSignatureInvalid) {
-		t.Fatalf("err = %v, want the verifier's signature verdict", err)
+	measurements, err := resolveInitDataMeasurements(context.Background(), &Config{AttestationServiceURL: stub.URL})
+	if !errors.Is(err, errAttestVerdict) {
+		t.Fatalf("err = %v, want the refusal classified as a terminal verdict", err)
 	}
 	if measurements != "" {
 		t.Fatalf("measurements = %q, want none from an unverified report", measurements)

--- a/internal/testattest/testattest.go
+++ b/internal/testattest/testattest.go
@@ -10,14 +10,17 @@
 // detects — snp, unless SetPlatform says otherwise.
 //
 // POST /verify decodes the types.VerifyRequest, records it
-// (Params.ExpectedReportData included), and answers the configured Verdict.
-// Tests assert on the recorded requests, so the report-data binding
-// production code asks the verifier to check is pinned.
+// (Params.ExpectedReportData included), and answers the configured Verdict, or
+// the ErrorReply set by SetVerifyError. Tests assert on the recorded requests,
+// so the report-data binding production code asks the verifier to check is
+// pinned.
 package testattest
 
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -29,7 +32,11 @@ import (
 // Verdict is what the stub's /verify answers for every request; the response
 // platform echoes the request's, like the real api. The fields map onto
 // types.VerificationResult; ReportDataMatch is a pointer so the no-check wire
-// shape (the real api's explicit null) is expressible next to true and false.
+// shape (the real api's explicit null) is expressible. Every 200 the real api
+// sends reports success: a failed signature or report-data check is refused
+// with the 422 of VerificationFailed. A false in SignatureValid or
+// ReportDataMatch models a verifier contradicting itself — defense in depth
+// for caller tests, not a production refusal.
 type Verdict struct {
 	SignatureValid  bool
 	ReportDataMatch *bool
@@ -47,17 +54,39 @@ func PassingVerdict(launchDigest string) Verdict {
 	}
 }
 
+// ErrorReply is an error response from the attestation-api. A non-empty Code
+// sends the types.ErrorResponse JSON envelope, which callers see as
+// *attestationclient.APIError; an empty Code sends Message as text/plain — the
+// axum rejection shape — which callers see as *attestationclient.UnexpectedError.
+type ErrorReply struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+// VerificationFailed is what the attestation-api answers /verify with for
+// evidence that does not verify: HTTP 422, error code verification_failed
+// (attestation-api's ApiError::Verification).
+func VerificationFailed(message string) ErrorReply {
+	return ErrorReply{
+		Status:  http.StatusUnprocessableEntity,
+		Code:    types.ErrorCodeVerificationFailed,
+		Message: message,
+	}
+}
+
 // Stub is an httptest.Server speaking the attestation-api wire protocol. The
 // default verdict is PassingVerdict("") and the detected platform snp; change
 // them with SetVerdict and SetPlatform.
 type Stub struct {
 	*httptest.Server
 
-	mu       sync.Mutex
-	verdict  Verdict
-	platform types.Platform
-	attest   []types.AttestRequest
-	verify   []types.VerifyRequest
+	mu        sync.Mutex
+	verdict   Verdict
+	verifyErr ErrorReply
+	platform  types.Platform
+	attest    []types.AttestRequest
+	verify    []types.VerifyRequest
 }
 
 // New starts a stub attestation-api, closed at test cleanup.
@@ -77,6 +106,14 @@ func (s *Stub) SetVerdict(v Verdict) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.verdict = v
+}
+
+// SetVerifyError makes /verify answer reply instead of a verdict, still
+// recording the request. A zero Status answers the verdict.
+func (s *Stub) SetVerifyError(reply ErrorReply) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.verifyErr = reply
 }
 
 // SetPlatform sets the platform the stub reports detecting: what /attest
@@ -105,7 +142,7 @@ func (s *Stub) VerifyRequests() []types.VerifyRequest {
 func (s *Stub) handleAttest(w http.ResponseWriter, r *http.Request) {
 	var req types.AttestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, undecodableBody(err))
 		return
 	}
 	s.mu.Lock()
@@ -139,14 +176,18 @@ func fakeSNPEvidence(reportData []byte) json.RawMessage {
 func (s *Stub) handleVerify(w http.ResponseWriter, r *http.Request) {
 	var req types.VerifyRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		writeError(w, undecodableBody(err))
 		return
 	}
 	s.mu.Lock()
 	s.verify = append(s.verify, req)
-	verdict := s.verdict
+	verdict, verifyErr := s.verdict, s.verifyErr
 	s.mu.Unlock()
 
+	if verifyErr.Status != 0 {
+		writeError(w, verifyErr)
+		return
+	}
 	writeJSON(w, types.VerifyResponse{
 		Result: types.VerificationResult{
 			Platform:        req.Platform,
@@ -157,13 +198,36 @@ func (s *Stub) handleVerify(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// undecodableBody mirrors axum's Json rejection: 400 for a body that is not
+// valid JSON, 422 for one that does not fit the handler's type; both
+// text/plain.
+func undecodableBody(err error) ErrorReply {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return ErrorReply{
+			Status:  http.StatusUnprocessableEntity,
+			Message: "Failed to deserialize the JSON body into the target type: " + err.Error(),
+		}
+	}
+	return ErrorReply{
+		Status:  http.StatusBadRequest,
+		Message: "Failed to parse the request body as JSON: " + err.Error(),
+	}
+}
+
 func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func writeError(w http.ResponseWriter, status int, message string) {
+func writeError(w http.ResponseWriter, reply ErrorReply) {
+	if reply.Code == "" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(reply.Status)
+		_, _ = io.WriteString(w, reply.Message)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: "bad_request", Message: message})
+	w.WriteHeader(reply.Status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: reply.Code, Message: reply.Message})
 }

--- a/internal/testattest/testattest_test.go
+++ b/internal/testattest/testattest_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -143,6 +144,8 @@ func TestStubVerifyRecordsAndAnswersVerdict(t *testing.T) {
 	}
 }
 
+// Defense in depth: a mismatch verdict on a 200 is a non-production shape
+// (Verdict); enforcement must still fail closed on it.
 func TestStubVerifyMismatchFailsEnforcement(t *testing.T) {
 	stub := testattest.New(t)
 	verdict := testattest.PassingVerdict("")
@@ -159,6 +162,76 @@ func TestStubVerifyMismatchFailsEnforcement(t *testing.T) {
 	}
 }
 
+// The shape a refused report arrives in: HTTP 422 carrying the
+// attestation-api's verification_failed envelope, which reaches Go callers as
+// *attestationclient.APIError — a different branch from every verdict sentinel.
+func TestStubVerifyErrorAnswersTheRefusalShape(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetVerifyError(testattest.VerificationFailed("report signature does not verify"))
+	client := attestationclient.NewClient(stub.URL)
+
+	expected := types.NewBase64Bytes([]byte("expected-report-data"))
+	req := types.VerifyReportData(types.AttestationEvidence{Platform: "snp", Evidence: []byte(`{}`)}, expected)
+	_, err := client.VerifyEnforced(context.Background(), req)
+
+	var apiErr *attestationclient.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("err = %#v, want *attestationclient.APIError", err)
+	}
+	if apiErr.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", apiErr.Status)
+	}
+	if apiErr.Response.Error != "verification_failed" {
+		t.Fatalf("error code = %q, want verification_failed", apiErr.Response.Error)
+	}
+	if errors.Is(err, attestationclient.ErrSignatureInvalid) || errors.Is(err, attestationclient.ErrReportDataMismatch) {
+		t.Fatalf("a 422 refusal matched a verdict sentinel: %v", err)
+	}
+
+	// The refusal is decided after the body is parsed, so the request stays recorded.
+	reqs := stub.VerifyRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("/verify calls = %d, want 1", len(reqs))
+	}
+	if reqs[0].Params == nil || reqs[0].Params.ExpectedReportData == nil {
+		t.Fatal("recorded request carries no expected_report_data")
+	}
+
+	// A zero reply restores the verdict.
+	stub.SetVerifyError(testattest.ErrorReply{})
+	if _, err := client.VerifyEnforced(context.Background(), req); err != nil {
+		t.Fatalf("VerifyEnforced after a zero-Status reset: %v", err)
+	}
+}
+
+// A codeless ErrorReply is the axum rejection: a status with a text/plain
+// body, which the client cannot decode into the error envelope.
+func TestStubVerifyErrorPlainTextBody(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetVerifyError(testattest.ErrorReply{
+		Status:  http.StatusUnprocessableEntity,
+		Message: "Failed to deserialize the JSON body into the target type",
+	})
+	client := attestationclient.NewClient(stub.URL)
+
+	req := types.VerifyReportData(
+		types.AttestationEvidence{Platform: "snp", Evidence: []byte(`{}`)},
+		types.NewBase64Bytes([]byte("expected-report-data")),
+	)
+	_, err := client.VerifyEnforced(context.Background(), req)
+
+	var unexpected *attestationclient.UnexpectedError
+	if !errors.As(err, &unexpected) {
+		t.Fatalf("err = %#v, want *attestationclient.UnexpectedError", err)
+	}
+	if unexpected.Status != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", unexpected.Status)
+	}
+	if !strings.Contains(unexpected.Text, "Failed to deserialize") {
+		t.Fatalf("body = %q, want the plain-text rejection", unexpected.Text)
+	}
+}
+
 func TestStubRejectsUnknownPaths(t *testing.T) {
 	stub := testattest.New(t)
 	resp, err := http.Post(stub.URL+"/nope", "application/json", strings.NewReader(`{}`))
@@ -171,17 +244,38 @@ func TestStubRejectsUnknownPaths(t *testing.T) {
 	}
 }
 
+// axum splits the rejection: 400 for a body that is not valid JSON, 422 for
+// one that does not fit the request type.
 func TestStubRejectsUndecodableBody(t *testing.T) {
-	stub := testattest.New(t)
-	resp, err := http.Post(stub.URL+"/verify", "application/json", strings.NewReader(`not json`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusBadRequest {
-		t.Fatalf("status = %d, want 400", resp.StatusCode)
-	}
-	if got := len(stub.VerifyRequests()); got != 0 {
-		t.Fatalf("an undecodable body was recorded as %d request(s)", got)
+	for _, tc := range []struct {
+		name       string
+		body       string
+		wantStatus int
+		wantPrefix string
+	}{
+		{"not valid JSON", `not json`, http.StatusBadRequest, "Failed to parse the request body as JSON"},
+		{"wrong field type", `{"platform": 123}`, http.StatusUnprocessableEntity, "Failed to deserialize the JSON body into the target type"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := testattest.New(t)
+			resp, err := http.Post(stub.URL+"/verify", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body %q)", resp.StatusCode, tc.wantStatus, body)
+			}
+			if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/plain") {
+				t.Fatalf("content-type = %q, want the text/plain axum rejection", got)
+			}
+			if !strings.HasPrefix(string(body), tc.wantPrefix) {
+				t.Fatalf("body = %q, want the axum rejection prefix %q", body, tc.wantPrefix)
+			}
+			if got := len(stub.VerifyRequests()); got != 0 {
+				t.Fatalf("an undecodable body was recorded as %d request(s)", got)
+			}
+		})
 	}
 }

--- a/pkg/ratls/ratls_test.go
+++ b/pkg/ratls/ratls_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -758,6 +759,18 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 	measurement := bytes.Repeat([]byte{0x42}, SNPMeasurementSize)
 	allowedMeasurements := [][]byte{measurement}
 
+	t.Run("422 verification_failed is refused", func(t *testing.T) {
+		stub := testattest.New(t)
+		stub.SetVerifyError(testattest.VerificationFailed("report signature does not verify"))
+		_, err := VerifyCert(cert, &VerifyPolicy{AttestationApiURL: stub.URL, Measurements: allowedMeasurements}, nil)
+		var apiErr *attestationclient.APIError
+		if !errors.As(err, &apiErr) || apiErr.Status != http.StatusUnprocessableEntity {
+			t.Fatalf("got %v, want a 422 *attestationclient.APIError", err)
+		}
+	})
+
+	// Defense in depth: a self-contradicting 200 must still be refused. The
+	// production refusal shape is the 422 above (testattest.Verdict).
 	t.Run("signature_valid=false maps to ErrSignatureInvalid", func(t *testing.T) {
 		stub := testattest.New(t)
 		verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))
@@ -781,6 +794,8 @@ func TestVerifyCertEmbeddedAzureNegativePaths(t *testing.T) {
 		}
 	})
 
+	// Defense in depth: a self-contradicting 200 must still be refused. The
+	// production refusal shape is the 422 above (testattest.Verdict).
 	t.Run("report_data_match=false maps to ErrKeyBinding", func(t *testing.T) {
 		stub := testattest.New(t)
 		verdict := testattest.PassingVerdict(hex.EncodeToString(measurement))


### PR DESCRIPTION
The shared stub answered every /verify with a 200 carrying VerificationResult fields, so a refusal was only expressible as 200 + signature_valid:false — a shape the real service never sends: every platform hard-codes signature_valid:true on success, and a report-data mismatch returns Err, which the api maps to 422 verification_failed. Callers' refusal handling was being tested against a fiction.

Add SetVerifyError/ErrorReply: the stub now answers a coded reply in the api's JSON error envelope (surfacing as *attestationclient.APIError, as in production) or a codeless text/plain rejection mirroring axum 0.8.9's 400/422 decode split (surfacing as *UnexpectedError). SetVerdict stays for the 200 path, with both false-on-200 fields documented as defensive shapes and the consumer tests asserting on them labelled. Stub-level tests pin all four shapes; the consumer sweep re-points refusal tests at the 422.

No production code changes.