### PR TITLE
fix(policymonitor): report every container that ran, fail closed on unresolved digests
 (#94)

### DIFF
--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -35,6 +35,7 @@ type admissionInventory struct {
 	mu         sync.RWMutex
 	containers map[string]string                          // live container id -> image digest
 	admitted   map[string]workloadclaims.SandboxContainer // key -> everything ever admitted
+	unresolved map[string]struct{}                        // container ids with no digest; cleared only by a later resolved record
 	sandboxID  string                                     // the guest's single pod sandbox
 	// refresh renders the allowlist-refresh posture. Set by runMonitor; nil
 	// leaves the field off the wire rather than reporting a false "disabled".
@@ -45,25 +46,35 @@ func newAdmissionInventory() *admissionInventory {
 	return &admissionInventory{
 		containers: map[string]string{},
 		admitted:   map[string]workloadclaims.SandboxContainer{},
+		unresolved: map[string]struct{}{},
 	}
 }
 
-// record notes an admitted container — injected sidecars included, so the
-// sandbox inventory is what actually ran in the guest. argv is the effective
-// OCI process.args the allowlist was evaluated against.
+// record notes every container that ran in the guest — injected sidecars
+// included, and denied containers too, so the sandbox inventory is what
+// actually ran, not what passed the checks. A container with no resolved
+// digest is tracked as unresolved and closes the sandbox's answer. argv is
+// the effective OCI process.args the allowlist was evaluated against.
 func (b *admissionInventory) record(cid, digest string, argv []string) {
-	if digest == "" {
+	if cid == "" {
 		return
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if digest == "" {
+		b.unresolved[cid] = struct{}{}
+		return
+	}
+	delete(b.unresolved, cid)
 	b.containers[cid] = digest
 	c := workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
 	b.admitted[c.Key()] = c
 }
 
 // remove evicts a container whose bundle kata-agent has torn down. The
-// admission record keeps it — it still ran in this guest. See docs/secrets.md,
+// admission record keeps it — it still ran in this guest — including an
+// unresolved digest, so a container that stops before one resolves closes the
+// sandbox's answer for the sandbox's life. See docs/secrets.md,
 // "The report is a high-water mark".
 func (b *admissionInventory) remove(cid string) {
 	b.mu.Lock()
@@ -101,11 +112,17 @@ func (b *admissionInventory) SandboxForPeer(_ workloadclaims.Peer) (string, erro
 // sandbox: every container ever admitted there, injected sidecars included, as
 // a sorted deduplicated digest set plus per-container (digest, argv) detail.
 // Any other sandbox ID is unknown.
+//
+// An unresolved digest fails the whole answer rather than commit a subset as
+// if it were the whole inventory.
 func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []workloadclaims.SandboxContainer, bool, error) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 	if b.sandboxID == "" || sandboxID != b.sandboxID {
 		return nil, nil, false, nil
+	}
+	if len(b.unresolved) > 0 {
+		return nil, nil, true, fmt.Errorf("sandbox %s admitted a container with no resolved image digest", sandboxID)
 	}
 	digests := []string{}
 	containers := make([]workloadclaims.SandboxContainer, 0, len(b.admitted))

--- a/internal/cmds/policymonitor/inventory_test.go
+++ b/internal/cmds/policymonitor/inventory_test.go
@@ -105,6 +105,72 @@ func TestKataInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 	}
 }
 
+// An unresolved digest fails the whole answer: serving the siblings that did
+// resolve would pass a subset off as the sandbox's whole image set.
+func TestKataInventoryRefusesUnresolvedDigest(t *testing.T) {
+	b := newAdmissionInventory()
+	b.recordSandboxID(pmSandboxID)
+	b.record(testCID("resolved"), pmDigestApp, nil)
+	b.record(testCID("unresolved"), "", nil)
+
+	if _, _, _, err := b.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("served a subset of the sandbox's images as if it were the whole set")
+	}
+}
+
+// A container recorded without a digest closes the sandbox's answer; a later
+// record that resolves that same container ID reopens it.
+func TestKataInventoryUnresolvedClearsWhenResolved(t *testing.T) {
+	b := newAdmissionInventory()
+	b.recordSandboxID(pmSandboxID)
+	b.record(testCID("ctr"), "", nil)
+
+	if _, _, _, err := b.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("an unresolved container must fail the whole answer")
+	}
+
+	b.record(testCID("ctr"), pmDigestApp, nil)
+	digests, _, known, err := b.DigestsForSandbox(pmSandboxID)
+	if err != nil || !known {
+		t.Fatalf("resolving the container must reopen the answer: known=%v err=%v", known, err)
+	}
+	if !slices.Contains(digests, pmDigestApp) {
+		t.Fatalf("digests = %v, want the newly-resolved digest present", digests)
+	}
+}
+
+// unresolved is keyed on the container ID: one container resolving must not
+// clear another container's unresolved marker.
+func TestKataInventoryUnresolvedIsKeyedOnContainerID(t *testing.T) {
+	b := newAdmissionInventory()
+	b.recordSandboxID(pmSandboxID)
+	b.record(testCID("who"), "", nil)
+	b.record(testCID("other"), pmDigestApp, nil)
+
+	if _, _, _, err := b.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("a resolved namesake cleared another container's unresolved marker")
+	}
+
+	b.record(testCID("who"), pmDigestSidecar, nil)
+	if _, _, _, err := b.DigestsForSandbox(pmSandboxID); err != nil {
+		t.Fatalf("resolving the container itself must reopen the answer: %v", err)
+	}
+}
+
+// A removed container with an unresolved digest stays unresolved: it still ran,
+// so the sandbox's answer stays closed even if its bundle goes away.
+func TestKataInventoryRemoveKeepsUnresolved(t *testing.T) {
+	b := newAdmissionInventory()
+	b.recordSandboxID(pmSandboxID)
+	b.record(testCID("gone"), "", nil)
+
+	b.remove(testCID("gone"))
+
+	if _, _, _, err := b.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("a removed unresolved container must keep the sandbox's answer closed")
+	}
+}
+
 // The advertise host CDS dials back: explicit config wins, and a host it could
 // never reach is rejected where it is configured rather than at issuance.
 func TestSandboxDigestsHost(t *testing.T) {

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -350,10 +350,10 @@ func (m *monitor) watch(ctx context.Context) (done bool, err error) {
 			if evt.Op.Has(fsnotify.Remove|fsnotify.Rename) && filepath.Clean(evt.Name) == filepath.Clean(m.cfg.WatchDir) {
 				return watchDirGone("inotify " + evt.Op.String())
 			}
-			// A bundle disappearing means its container is gone; drop it
-			// from the inventory so /digests answers what the sandbox is
-			// running rather than everything it ever ran. The watch dir's
-			// own removal was handled above, so this is a child path.
+			// A bundle disappearing means its container is gone; drop it from
+			// caller resolution only — the sandbox's record keeps what it ran
+			// (remove's doc). The watch dir's own removal was handled above, so
+			// this is a child path.
 			if evt.Op.Has(fsnotify.Remove|fsnotify.Rename) && m.pathLooksLikeContainer(evt.Name) {
 				if m.inventory != nil {
 					m.inventory.remove(filepath.Base(filepath.Clean(evt.Name)))
@@ -498,6 +498,9 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		// itself went away, or we are shutting down — nothing to decide.
 		if _, statErr := os.Lstat(configPath); statErr == nil {
 			m.logger.Warn("deny container: config.json present but unreadable/malformed", "cid", cid, "path", configPath, "error", err)
+			if m.inventory != nil {
+				m.inventory.record(cid, "", nil)
+			}
 			m.deny(ctx, dir)
 			return
 		}
@@ -542,6 +545,9 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 		m.logger.Warn("deny container: image reference is absent or not digest-pinned",
 			"cid", cid, "reference", spec.Annotations[kataspec.PullReferenceKey],
 			"annotation_keys", slices.Sorted(maps.Keys(spec.Annotations)))
+		if m.inventory != nil {
+			m.inventory.record(cid, "", nil)
+		}
 		m.deny(ctx, dir)
 		return
 	}
@@ -566,11 +572,11 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 	if !m.admits(rc) {
 		m.refresh.awaitSettled(ctx, refreshSettleBudget)
 	}
+	if m.inventory != nil {
+		m.inventory.record(cid, digest, rc.Argv)
+	}
 	if m.admits(rc) {
 		m.logger.Info("allow container", "cid", cid, "digest", digest)
-		if m.inventory != nil {
-			m.inventory.record(cid, digest, rc.Argv)
-		}
 		m.recordVerdict(dir, verdictAllow)
 		return
 	}

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -214,6 +215,38 @@ func TestHandleNewContainer_WorkloadArgvMismatchKills(t *testing.T) {
 	}
 }
 
+// A container denied on its argv is likewise recorded: it ran (briefly)
+// before the kill landed, so /digests must list it too.
+func TestHandleNewContainer_ArgvDeniedRecordedInInventory(t *testing.T) {
+	floor := strings.Repeat("a", 64)
+	wl := strings.Repeat("b", 64)
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + floor})
+	m.overlay.apply(exactEntrypointOverlay(t, "sha256:"+wl, []string{"/bin/app"}), 1)
+	m.inventory = newAdmissionInventory()
+	m.inventory.recordSandboxID(pmSandboxID)
+
+	cid := testCID("argv-denied-recorded")
+	writeConfigJSONArgs(t, watchDir, cid, map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/tenant/app@sha256:" + wl,
+	}, []string{"/bin/evil"})
+
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	calls := killer.snapshot()
+	if len(calls) != 1 || calls[0] != cid {
+		t.Fatalf("non-matching argv should kill workload container, got: %+v", calls)
+	}
+
+	digests, _, known, err := m.inventory.DigestsForSandbox(pmSandboxID)
+	if err != nil || !known {
+		t.Fatalf("known=%v err=%v", known, err)
+	}
+	if !slices.Contains(digests, "sha256:"+wl) {
+		t.Fatalf("digests = %v, want the argv-denied container recorded", digests)
+	}
+}
+
 // The overlay honors epoch anti-rollback: a lower version is ignored, so the
 // argv policy applied at the higher version still governs.
 func TestPolicyOverlayAntiRollback(t *testing.T) {
@@ -274,12 +307,16 @@ func TestPolicyOverlayTrustsFirstVersionAfterRestart(t *testing.T) {
 	}
 }
 
-func TestHandleNewContainer_DeniedDigest(t *testing.T) {
+// A denied container is still recorded in the inventory — it ran (briefly)
+// before the kill landed, and under-reporting is the attack.
+func TestHandleNewContainer_DeniedDigestRecorded(t *testing.T) {
 	allowed := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	denied := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + allowed})
+	m.inventory = newAdmissionInventory()
+	m.inventory.recordSandboxID(pmSandboxID)
 
-	cid := testCID("denied-digest")
+	cid := testCID("denied-digest-recorded")
 	writeConfigJSON(t, watchDir, cid, map[string]string{
 		"io.kubernetes.cri.container-type": "container",
 		"io.kubernetes.cri.image-name":     "ghcr.io/evil/badimage@sha256:" + denied,
@@ -293,6 +330,92 @@ func TestHandleNewContainer_DeniedDigest(t *testing.T) {
 	}
 	if calls[0] != cid {
 		t.Errorf("container ID = %q, want %q", calls[0], cid)
+	}
+
+	digests, _, known, err := m.inventory.DigestsForSandbox(pmSandboxID)
+	if err != nil || !known {
+		t.Fatalf("known=%v err=%v", known, err)
+	}
+	if !slices.Contains(digests, "sha256:"+denied) {
+		t.Fatalf("denied container's digest = %v, want the denied container recorded", digests)
+	}
+}
+
+// A passing (allowed) container is reported: the inventory records what ran,
+// and an admitted container's digest must land in /digests.
+func TestHandleNewContainer_AllowedContainerRecordedInInventory(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:" + digest})
+	m.inventory = newAdmissionInventory()
+	m.inventory.recordSandboxID(pmSandboxID)
+
+	cid := testCID("allowed-recorded")
+	writeConfigJSON(t, watchDir, cid, map[string]string{
+		"io.kubernetes.cri.container-type": "container",
+		"io.kubernetes.cri.image-name":     "ghcr.io/confidential-dot-ai/assam@sha256:" + digest,
+	})
+
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	if calls := killer.snapshot(); len(calls) != 0 {
+		t.Fatalf("unexpected kill calls: %+v", calls)
+	}
+
+	digests, _, known, err := m.inventory.DigestsForSandbox(pmSandboxID)
+	if err != nil || !known {
+		t.Fatalf("known=%v err=%v", known, err)
+	}
+	if !slices.Contains(digests, "sha256:"+digest) {
+		t.Fatalf("digests = %v, want the allowed container recorded", digests)
+	}
+}
+
+// A container denied for having a reference that is not digest-pinned is
+// recorded as unresolved, closing the sandbox's answer (the container ran, but
+// we cannot say what image it was).
+func TestHandleNewContainer_NoDigestReferenceRecordedUnresolved(t *testing.T) {
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m.inventory = newAdmissionInventory()
+	m.inventory.recordSandboxID(pmSandboxID)
+
+	cid := testCID("no-ref-recorded")
+	// Annotations carry an unrelated key only: the spec is complete input
+	// (non-partial), is not a sandbox, and carries no way to pull a digest.
+	writeConfigJSON(t, watchDir, cid, map[string]string{"unrelated": "x"})
+
+	m.handleNewContainer(context.Background(), filepath.Join(watchDir, cid))
+
+	if calls := killer.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected deny+kill on missing digest-pinned reference, got %d calls: %+v", len(calls), calls)
+	}
+
+	if _, _, _, err := m.inventory.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("a container with no resolved digest must fail the whole answer")
+	}
+}
+
+// A container whose config.json is unreadable is recorded as unresolved: the
+// bundle exists, kata will run it, and we cannot determine its image.
+func TestHandleNewContainer_UnreadableConfigRecordedUnresolved(t *testing.T) {
+	m, killer, watchDir := newTestMonitor(t, []string{"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"})
+	m.inventory = newAdmissionInventory()
+	m.inventory.recordSandboxID(pmSandboxID)
+	m.configReadDeadline = 50 * time.Millisecond
+
+	cid := testCID("unreadable-recorded")
+	dir := filepath.Join(watchDir, cid)
+	if err := os.MkdirAll(filepath.Join(dir, "config.json"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m.handleNewContainer(context.Background(), dir)
+
+	if calls := killer.snapshot(); len(calls) != 1 {
+		t.Fatalf("expected deny+kill on present-but-unreadable config.json, got %d calls: %+v", len(calls), calls)
+	}
+
+	if _, _, _, err := m.inventory.DigestsForSandbox(pmSandboxID); err == nil {
+		t.Fatal("a container with no resolved digest must fail the whole answer")
 	}
 }
 


### PR DESCRIPTION
DigestsForSandbox was documented as 'admitted means the container was let
run, not that it passed a check', but the kata-guest policymonitor only
recorded containers inside if m.admits(rc) and dropped empty digests
entirely. A sandbox that omits a container it ran still matches a
workload, so CDS releases that workload's secrets to a pod running
something else — under-reporting is the attack, and over-reporting fails
closed because CDS re-checks every reported digest.

Record every container that reached the digest-evaluation stage
(including denied ones that briefly ran in the guest's watch-and-kill
model), track containers with unresolved digests, and make
DigestsForSandbox return an error when any exist so the sandbox's answer
fails closed on both issuance and secret release. This matches the
established nri-image-policy (node-CVM) behavior and the interface
contract that the node side already satisfied. Also corrects a stale
comment on the inotify removal branch that misdescribed the high-water
mark as 'what is running now'.