### PR TITLE
ci(c8s-image): bound the apt step

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -177,9 +177,13 @@ jobs:
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
         # base ovmf is for the SNP path.
         # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
+        # Bounded: a dead mirror connection otherwise hangs until the job's
+        # 3h limit.
+        timeout-minutes: 5
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y systemd-container ovmf cpio acpica-tools \
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
+            systemd-container ovmf cpio acpica-tools \
             libclang-dev clang libtss2-dev
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.


### PR DESCRIPTION
## Problem

The install-deps step has no timeout, so a dead mirror connection hangs a gate leg until the job's 3-hour limit (one leg sat in `apt-get install` for over an hour today before being cancelled).

## Fix

`timeout-minutes: 5` on the step plus `Acquire::http::Timeout=30` and `Acquire::Retries=3` on both apt calls: transient stalls retry, a genuinely dead mirror fails the leg in minutes instead of silently eating the runner.