### PR TITLE
fix(issuer): fail closed when the rate limiter map is full

### DIFF
--- a/internal/cmds/cds/cmd.go
+++ b/internal/cmds/cds/cmd.go
@@ -80,7 +80,7 @@ func NewCmd() *cobra.Command {
 
 	flags.Float64Var(&cfg.rateLimit, "rate-limit", 10, "max requests per second per source IP on attestation endpoints")
 	flags.IntVar(&cfg.rateBurst, "rate-burst", 20, "max burst size per source IP")
-	flags.IntVar(&cfg.rateLimiterMax, "rate-limiter-max-entries", 10000, "max entries in the per-IP rate limiter")
+	flags.IntVar(&cfg.rateLimiterMax, "rate-limiter-max-entries", 10000, "max entries in the per-IP rate limiter; once full, a new source is refused until entries idle out")
 	flags.DurationVar(&cfg.rateLimiterEvictInterval, "rate-limiter-evict-interval", time.Minute, "interval for per-IP rate limiter eviction sweep")
 	flags.DurationVar(&cfg.rateLimiterIdleTimeout, "rate-limiter-idle-timeout", 5*time.Minute, "idle duration before a per-IP rate limiter entry is evicted")
 

--- a/internal/cmds/cds/routes_test.go
+++ b/internal/cmds/cds/routes_test.go
@@ -150,8 +150,8 @@ func TestRouter_RateLimitsAuthenticate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rate limiter: %v", err)
 	}
-	// A single-entry map, so a second source churns the first out of it — and
-	// the routes on the other limiter must not notice.
+	// A single-entry map, so a second source is refused at capacity — and the
+	// routes on the other limiter must not notice.
 	challengeRL, err := issuer.NewIPRateLimiter(rate.Limit(0.001), 1, 1)
 	if err != nil {
 		t.Fatalf("challenge rate limiter: %v", err)
@@ -194,15 +194,15 @@ func TestRouter_RateLimitsAuthenticate(t *testing.T) {
 	if got := post("/attest", "10.0.0.3:1234").Code; got == http.StatusTooManyRequests {
 		t.Fatal("/attest was spent by the same source's challenge requests")
 	}
-	// A second source churns the one-entry challenge map, taking the first
-	// source's bucket with it. What must not follow is that source getting a
-	// fresh attestation bucket: the two maps are separate, so its spent
-	// /attest budget is still spent.
-	if got := post("/authenticate", "10.0.0.4:1234").Code; got != http.StatusOK {
-		t.Fatalf("/authenticate from a second source: got %d, want 200", got)
+	// The one-entry challenge map is full, so a second source is refused and
+	// the first source's bucket is untouched. What must not follow either is
+	// that source getting a fresh attestation bucket: the two maps are
+	// separate, so its spent /attest budget is still spent.
+	if got := post("/authenticate", "10.0.0.4:1234").Code; got != http.StatusTooManyRequests {
+		t.Fatalf("/authenticate from a second source: got %d, want 429 (the map is full)", got)
 	}
 	if got := post("/attest", "10.0.0.3:1234").Code; got != http.StatusTooManyRequests {
-		t.Fatalf("/attest after the challenge map churned: got %d, want the source's spent budget", got)
+		t.Fatalf("/attest after the challenge refusal: got %d, want the source's spent budget", got)
 	}
 }
 

--- a/internal/issuer/ratelimit.go
+++ b/internal/issuer/ratelimit.go
@@ -19,6 +19,11 @@ var (
 		Help: "Total requests rejected by rate limiter.",
 	})
 
+	rateLimitSaturationTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cds_rate_limit_saturation_total",
+		Help: "Total requests refused because the rate limiter was full and the key held no bucket; a subset of cds_rate_limit_rejections_total.",
+	})
+
 	rateLimiterEntries = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "cds_rate_limiter_entries",
 		Help: "Current number of entries in the rate limiter.",
@@ -31,15 +36,12 @@ type ipLimiterEntry struct {
 }
 
 // IPRateLimiter implements keyed rate limiting with bounded memory. It holds
-// at most MaxEntries buckets, evicting the least recently used to make room,
-// and EvictionLoop reclaims buckets idle longer than IdleTimeout.
+// at most MaxEntries buckets; once it is full a key with no bucket is
+// refused, so churning through more keys than the map holds cannot reset a
+// caller's allowance. EvictionLoop reclaims buckets idle longer than
+// IdleTimeout, so a full map recovers as callers go quiet.
 // RateLimitMiddleware keys on the source address; RateLimitBy keys on whatever
 // identifies the caller.
-//
-// MaxEntries is how many callers are metered at once. Past it a caller is
-// still served, on a bucket taken from the quietest one — so a caller that
-// varies its key faster than the map holds keys meters itself out of the map.
-// Issue #105 owns that, and a saturation policy for it.
 type IPRateLimiter struct {
 	mu         sync.Mutex
 	limiters   map[string]*ipLimiterEntry
@@ -50,9 +52,8 @@ type IPRateLimiter struct {
 
 func NewIPRateLimiter(r rate.Limit, burst, maxEntries int) (*IPRateLimiter, error) {
 	if maxEntries <= 0 {
-		// A non-positive cap makes len(limiters) >= maxEntries always true, so
-		// every new source IP evicts an existing one — the limiter would track
-		// one IP globally and rate limiting would collapse across clients.
+		// A non-positive cap makes len(limiters) >= maxEntries always true:
+		// every request would be refused.
 		return nil, fmt.Errorf("rate limiter maxEntries must be positive, got %d", maxEntries)
 	}
 	return &IPRateLimiter{
@@ -63,32 +64,25 @@ func NewIPRateLimiter(r rate.Limit, burst, maxEntries int) (*IPRateLimiter, erro
 	}, nil
 }
 
-func (rl *IPRateLimiter) getLimiter(ip string) *rate.Limiter {
+// allow charges one request to key's bucket and reports whether it may
+// proceed. A key with no bucket gets one while the map holds fewer than
+// MaxEntries entries; past that it is refused, so a held bucket is never
+// taken by another key and the map is the ceiling on metered callers.
+func (rl *IPRateLimiter) allow(key string) bool {
 	rl.mu.Lock()
-	defer rl.mu.Unlock()
-	if entry, ok := rl.limiters[ip]; ok {
-		entry.lastSeen = time.Now()
-		return entry.limiter
-	}
-	if len(rl.limiters) >= rl.maxEntries {
-		var oldestIP string
-		var oldestTime time.Time
-		for ip, entry := range rl.limiters {
-			if oldestTime.IsZero() || entry.lastSeen.Before(oldestTime) {
-				oldestIP = ip
-				oldestTime = entry.lastSeen
-			}
+	entry, ok := rl.limiters[key]
+	if !ok {
+		if len(rl.limiters) >= rl.maxEntries {
+			rl.mu.Unlock()
+			rateLimitSaturationTotal.Inc()
+			return false
 		}
-		if oldestIP != "" {
-			delete(rl.limiters, oldestIP)
-		}
+		entry = &ipLimiterEntry{limiter: rate.NewLimiter(rl.rate, rl.burst)}
+		rl.limiters[key] = entry
 	}
-	lim := rate.NewLimiter(rl.rate, rl.burst)
-	rl.limiters[ip] = &ipLimiterEntry{
-		limiter:  lim,
-		lastSeen: time.Now(),
-	}
-	return lim
+	entry.lastSeen = time.Now()
+	rl.mu.Unlock()
+	return entry.limiter.Allow()
 }
 
 // Len reports how many callers the limiter is metering, for metrics and tests.
@@ -152,7 +146,7 @@ func RateLimitBy(rl *IPRateLimiter, key KeyFunc, next http.Handler) http.Handler
 		if bucket == "" {
 			bucket = SourceAddrKey(r)
 		}
-		if !rl.getLimiter(bucket).Allow() {
+		if !rl.allow(bucket) {
 			rateLimitRejectionsTotal.Inc()
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return

--- a/internal/issuer/ratelimit_test.go
+++ b/internal/issuer/ratelimit_test.go
@@ -5,9 +5,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"golang.org/x/time/rate"
 )
 
@@ -54,9 +56,9 @@ func TestRateLimiterEviction(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rl.getLimiter("10.0.0.1")
-	rl.getLimiter("10.0.0.2")
-	rl.getLimiter("10.0.0.3")
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+	rl.allow("10.0.0.3")
 
 	rl.mu.Lock()
 	if len(rl.limiters) != 3 {
@@ -80,24 +82,30 @@ func TestRateLimiterEviction(t *testing.T) {
 	}
 }
 
+// TestRateLimiterMaxEntries pins the fail-closed boundary: past the cap a
+// caller with no bucket is refused, and no held bucket is taken to serve it.
 func TestRateLimiterMaxEntries(t *testing.T) {
 	rl, err := NewIPRateLimiter(rate.Limit(10), 20, 3)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	rl.getLimiter("10.0.0.1")
-	rl.getLimiter("10.0.0.2")
-	rl.getLimiter("10.0.0.3")
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+	rl.allow("10.0.0.3")
 
 	if got := rl.Len(); got != 3 {
 		t.Fatalf("expected 3 entries, got %d", got)
 	}
 
-	rl.getLimiter("10.0.0.4")
-
+	if rl.allow("10.0.0.4") {
+		t.Error("a full limiter admitted a key with no bucket")
+	}
 	if got := rl.Len(); got != 3 {
-		t.Errorf("expected 3 entries after cap, got %d", got)
+		t.Errorf("expected 3 entries after a refused key, got %d", got)
+	}
+	if !rl.allow("10.0.0.1") {
+		t.Error("a held bucket stopped metering while the map was full")
 	}
 }
 
@@ -313,10 +321,8 @@ func TestSourceAddrKeyKeepsAddressesApart(t *testing.T) {
 	}
 }
 
-// meterableClients is how many distinct callers one limiter must meter at
-// once, stated here rather than derived from any caller's constant. Past the
-// map a caller is still served, so this is what the limiter's accuracy costs,
-// not what its availability costs.
+// meterableClients is how many distinct callers one limiter meters at once;
+// past it a caller with no bucket is refused, so it is the availability cost.
 const meterableClients = 50000
 
 // TestALimiterMetersItsWholeCapacity pins that relationship: capacity is the
@@ -327,14 +333,15 @@ func TestALimiterMetersItsWholeCapacity(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i := 0; i < meterableClients; i++ {
-		rl.getLimiter("client-" + strconv.Itoa(i))
+		rl.allow("client-" + strconv.Itoa(i))
 	}
 	if got := rl.Len(); got != meterableClients {
 		t.Fatalf("the limiter meters %d callers, want %d", got, meterableClients)
 	}
 
-	// The first caller is the quietest, so it is the bucket the next one takes.
-	rl.getLimiter("one-too-many")
+	if rl.allow("one-too-many") {
+		t.Fatal("a full limiter metered one caller too many")
+	}
 	if got := rl.Len(); got != meterableClients {
 		t.Fatalf("the limiter holds %d buckets past its capacity, want %d", got, meterableClients)
 	}
@@ -342,27 +349,30 @@ func TestALimiterMetersItsWholeCapacity(t *testing.T) {
 	_, quietestKept := rl.limiters["client-0"]
 	_, newcomerKept := rl.limiters["one-too-many"]
 	rl.mu.Unlock()
-	if quietestKept {
-		t.Fatal("a full map kept the quietest caller instead of making room")
+	if !quietestKept {
+		t.Fatal("a full limiter took a held bucket from its quietest caller")
 	}
-	if !newcomerKept {
-		t.Fatal("a full map did not meter a new caller")
+	if newcomerKept {
+		t.Fatal("a full limiter metered one caller too many")
 	}
 }
 
-// TestEvictionLoopReclaimsQuietCallers pins the loop that keeps the map from
-// sitting at capacity: without it every new caller costs another its bucket,
-// so the limiter meters a smaller and smaller share of its traffic.
+// TestEvictionLoopReclaimsQuietCallers pins the recovery valve: a full map
+// refuses a new caller, and the loop reclaims buckets gone quiet so the same
+// caller is admitted once the map drains.
 func TestEvictionLoopReclaimsQuietCallers(t *testing.T) {
 	rl, err := NewIPRateLimiter(rate.Limit(0.001), 1, 8)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for i := 0; i < 8; i++ {
-		rl.getLimiter("client-" + strconv.Itoa(i))
+		rl.allow("client-" + strconv.Itoa(i))
 	}
 	if got := rl.Len(); got != 8 {
 		t.Fatalf("the limiter meters %d callers, want 8", got)
+	}
+	if rl.allow("latecomer") {
+		t.Fatal("a full map admitted a new caller")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -375,5 +385,132 @@ func TestEvictionLoopReclaimsQuietCallers(t *testing.T) {
 			t.Fatalf("the limiter still meters %d callers that have gone quiet", rl.Len())
 		}
 		time.Sleep(time.Millisecond)
+	}
+	if !rl.allow("latecomer") {
+		t.Fatal("a drained map still refused a new caller")
+	}
+}
+
+// TestChurnPastCapacityStaysLimited pins the ceiling on key churn: only the
+// first capacity keys get a bucket, so cycling through far more keys than the
+// map holds admits exactly what those buckets allow, on every wave. rate 0 so
+// the count comes from burst alone, not from how long the test runs.
+func TestChurnPastCapacityStaysLimited(t *testing.T) {
+	const capacity, burst, keys, pollsPerKey, waves = 100, 20, 10000, 2, 2
+	rl, err := NewIPRateLimiter(rate.Limit(0), burst, capacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for w := 0; w < waves; w++ {
+		allowed := 0
+		for i := 0; i < keys; i++ {
+			key := "attacker-" + strconv.Itoa(i)
+			for j := 0; j < pollsPerKey; j++ {
+				if rl.allow(key) {
+					allowed++
+				}
+			}
+		}
+		// capacity buckets admit pollsPerKey each, so the exact ceiling is capacity*pollsPerKey.
+		if want := capacity * pollsPerKey; allowed != want {
+			t.Errorf("wave %d admitted %d of %d requests; want exactly %d (capacity x pollsPerKey)",
+				w, allowed, keys*pollsPerKey, want)
+		}
+	}
+}
+
+// TestSaturationRefusalsAreCounted pins that a refusal because the map is
+// full is counted separately from an ordinary over-limit refusal.
+func TestSaturationRefusalsAreCounted(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(0.001), 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := testutil.ToFloat64(rateLimitSaturationTotal)
+
+	rl.allow("10.0.0.1")
+	rl.allow("10.0.0.2")
+	if rl.allow("10.0.0.3") { // no bucket left: saturation
+		t.Fatal("a full map admitted a key with no bucket")
+	}
+	if rl.allow("10.0.0.1") { // held bucket, over its own burst
+		t.Fatal("a held bucket over its limit was admitted")
+	}
+
+	if got := testutil.ToFloat64(rateLimitSaturationTotal) - before; got != 1 {
+		t.Errorf("saturation refusals = %v, want 1", got)
+	}
+}
+
+// TestConcurrentAllowNeverExceedsCapacity stresses the admission path from many
+// goroutines with far more keys than the map holds: the map never grows past
+// MaxEntries. allow releases rl.mu before touching the bucket, so -race
+// exercises the guarded map insert and the unlocked bucket call.
+func TestConcurrentAllowNeverExceedsCapacity(t *testing.T) {
+	const capacity, keys, goroutines, iterations = 64, 256, 32, 5000
+	rl, err := NewIPRateLimiter(rate.Limit(1000), 1000, capacity)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				rl.allow("key-" + strconv.Itoa((g+i)%keys))
+				if n := rl.Len(); n > capacity {
+					t.Errorf("map holds %d entries, over capacity %d", n, capacity)
+					return
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	if got := rl.Len(); got > capacity {
+		t.Errorf("map holds %d entries after the run, over capacity %d", got, capacity)
+	}
+}
+
+// TestSaturationIsASubsetOfRejections pins the counter relationship the metric
+// help text states: at the HTTP layer a full-map refusal increments both the
+// saturation and rejection counters, an over-limit refusal only the rejection
+// counter.
+func TestSaturationIsASubsetOfRejections(t *testing.T) {
+	rl, err := NewIPRateLimiter(rate.Limit(0), 1, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := RateLimitMiddleware(rl, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	send := func(addr string) int {
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		r.RemoteAddr = addr
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		return w.Code
+	}
+	satBefore := testutil.ToFloat64(rateLimitSaturationTotal)
+	rejBefore := testutil.ToFloat64(rateLimitRejectionsTotal)
+
+	if got := send("10.0.0.1:1"); got != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", got)
+	}
+	if got := send("10.0.0.1:2"); got != http.StatusTooManyRequests { // held bucket, over its own burst
+		t.Fatalf("over-limit request: got %d, want 429", got)
+	}
+	if got := send("10.0.0.2:1"); got != http.StatusTooManyRequests { // map full, new source has no bucket
+		t.Fatalf("full-map request: got %d, want 429", got)
+	}
+
+	if got := testutil.ToFloat64(rateLimitSaturationTotal) - satBefore; got != 1 {
+		t.Errorf("saturation delta = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(rateLimitRejectionsTotal) - rejBefore; got != 2 {
+		t.Errorf("rejection delta = %v, want 2 (both refusals)", got)
 	}
 }


### PR DESCRIPTION
## What

`IPRateLimiter` now fails closed at capacity: once its map holds MaxEntries buckets, a key with no bucket is refused (429) instead of evicting the least-recently-used holder and getting a fresh full burst. Refusals at capacity are counted in a new `cds_rate_limit_saturation_total` metric (a subset of the existing `cds_rate_limit_rejections_total`); the idle-timeout eviction loop is unchanged, so a full map recovers as callers go quiet.

Closes https://github.com/confidential-dot-ai/c8s-workspace/issues/105

## Why

At map capacity the limiter was a no-op: every churned key evicted a holder and got a full burst, so a caller cycling through more keys than the map holds was never limited. #77 put this limiter on the internet-facing tls-lb endpoints, where the caller chooses its own address within a delegated prefix — key churn is attacker-controlled there.

Measured on the issue's benchmark (rate 10/s, burst 20, capacity 10 000, 200 000 requests):

| Distinct buckets | Allowed, before | Allowed, this branch |
|---|---|---|
| 100 | 2 000 (1.0 %) | 2 000 (1.0 %) |
| 5 000 | 100 000 (50 %) | 100 000 (50 %) |
| 10 000 | 200 000 (100 %) | 200 000 (100 %) |
| 65 536 | **200 000 (100 %)** | **33 392 (16.7 %)** |
| 65 536, 2nd 200k wave | 200 000 (100 %) — unbounded | 33 392 (16.7 %) — steady |

Rows at or under capacity are unchanged by design: those keys fit the map and each is metered at its own per-key budget. The defect regime — churn past capacity — now degrades toward refusing: aggregate admission is bounded by what fits in the map (capacity × per-key budget), and the bound holds on every wave. The change also removes the O(capacity) LRU scan per inserted key (46 ms vs 23.3 s on the 65 536-key run).

Fail-closed matches the semantics `cdsattest`'s bucket sizing already documents ("a limiter refuses a key it has no bucket for once its map is full"). #77 shipped that sizing rationale against a limiter that still failed open, so this closes a dependency-contract gap: `issuer` now provides the property `cdsattest` already assumes.

## Threat-model notes

- Held buckets are never taken by another key: an active caller's allowance cannot be reset by anyone, including an attacker churning the map. Total limiter state stays bounded at MaxEntries.
- #77's accepted behavior is otherwise preserved: per-prefix IPv6 /64 bucketing (`issuer.ClientPrefix`), per-address CDS bucketing, endpoint metering, and the two-map challenge/attest split are all unchanged.
- Residual risk (same family as #106, deliberately not decided here): an attacker that keeps MaxEntries junk keys warm — cost ≈ MaxEntries/IdleTimeout refused requests per second (≈220 rps against the sidecar's 65 536 buckets and 5 min idle timeout) — can hold the map full and deny service to *new* callers until its entries idle out. Held buckets keep working. Refusing is the safe direction for an unauthenticated endpoint (report minting and ML-KEM keygen stay behind the limiter), and the saturation counter makes the condition observable.
- The sidecar exposes no `/metrics` route today, so the new counter is only scraped on CDS until that lands — pre-existing gap called out in the issue.
- `--rate-limiter-max-entries` changes operational meaning under fail-closed: it was an accuracy floor (past it callers were under-metered but served), it is now a hard availability ceiling (past it a new source gets a 429 until buckets idle out). No value changed; an operator who sized 10 000 (CDS) / 65 536 (sidecar) under the old semantics should confirm those caps exceed the realistic concurrent distinct-caller count. Sizing is deferred to Patrick / #106.

## Test plan

- `TestChurnPastCapacityStaysLimited`: 10 000 distinct keys against a capacity-100 map admit **exactly** `capacity × pollsPerKey`, asserted per wave. The exact bound catches a capacity off-by-one (a `>`-vs-`>=` gate admits `capacity+1` keys → 202 ≠ 200); verified to fail on main (20 000/20 000 admitted).
- `TestConcurrentAllowNeverExceedsCapacity` (new): 32 goroutines × 5 000 iterations churn 256 keys through a capacity-64 map; `Len()` never exceeds capacity, `-race` clean. Pins the deliberate release of `rl.mu` before `entry.limiter.Allow()`.
- `TestSaturationIsASubsetOfRejections` (new): drives one at-capacity refusal and one over-limit refusal through `RateLimitMiddleware`; the saturation counter advances by 1 and rejections by 2, pinning the subset relationship the help text documents.
- `TestSaturationRefusalsAreCounted`: an at-capacity refusal increments the saturation counter; an over-limit refusal on a held bucket does not (both refusals now asserted, not discarded).
- `TestEvictionLoopReclaimsQuietCallers`: a full map refuses a new caller, then admits that same caller once the eviction loop drains the map (refuse → drain → re-admit).
- `TestRateLimiterMaxEntries`, `TestALimiterMetersItsWholeCapacity`, `TestRouter_RateLimitsAuthenticate` pin fail-closed semantics (unknown key refused, held buckets kept, challenge/attest maps still separate).
- `go build ./...`, `go test -race -count=2 ./internal/issuer/ ./internal/cmds/cds/... ./internal/cmds/cdsattest/...`, full `go test -count=1 ./...`, `go vet`, `make lint` all pass. No TEE- or cluster-dependent behavior. The end-to-end "sidecar front door refuses past 65 536 /64s" path is covered only transitively (unit `allow()` + `ClientPrefix` + cdsattest sizing test), not as one integration test.
