### PR TITLE
test(ratlsmesh,getcert): assert outcomes, not log lines

### DIFF
--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -198,6 +198,9 @@ func cdsHTTPClient(cfg config) (*http.Client, error) {
 	return client, nil
 }
 
+// obtainCertFn is a var so renewal-loop tests can observe attempts.
+var obtainCertFn = obtainCert
+
 func run(cfg config) error {
 	slog.Info("starting get-cert", "san", cfg.SAN)
 
@@ -263,7 +266,7 @@ func run(cfg config) error {
 			slog.Info("shutting down cert renewer")
 			return nil
 		case <-renewTimer.C:
-			renewed, err := obtainCert(ctx, cfg, client)
+			renewed, err := obtainCertFn(ctx, cfg, client)
 			if err != nil {
 				// A short backoff, not a full interval: the timer is paced so
 				// it fires around half the installed leaf's remaining
@@ -313,10 +316,6 @@ const (
 	// never raises a delay above --renew-interval, which the operator chose.
 	minRenewalDelay = 5 * time.Second
 
-	// renewalRetryBase is the first delay after a failed renewal; consecutive
-	// failures double it up to the ordinary pacing.
-	renewalRetryBase = 15 * time.Second
-
 	// unnamedBackoffAfter is how many consecutive unnamed renewals run at the
 	// fast poll before it doubles toward --renew-interval. A pod can be
 	// permanently unnamed — a foreign admission, an inventory with no
@@ -325,6 +324,11 @@ const (
 	// for its whole lifetime.
 	unnamedBackoffAfter = 10
 )
+
+// renewalRetryBase is the first delay after a failed renewal; consecutive
+// failures double it up to the ordinary pacing. It is a var the renewal-loop
+// test shrinks and TestRenewalRetryInterval reads; keep the package non-parallel.
+var renewalRetryBase = 15 * time.Second
 
 // renewalInterval picks the next renewal delay.
 //
@@ -415,11 +419,11 @@ func isNamedLeaf(leaf *x509.Certificate) bool {
 // start without a real mesh cert.
 func obtainCertWithRetry(ctx context.Context, cfg config, client attestclient.Client) (*x509.Certificate, error) {
 	if cfg.InitialRetryTimeout <= 0 {
-		return obtainCert(ctx, cfg, client)
+		return obtainCertFn(ctx, cfg, client)
 	}
 	bo := backoff.NewConstantBackOff(cfg.InitialRetryInterval)
 	return backoff.Retry(ctx, func() (*x509.Certificate, error) {
-		return obtainCert(ctx, cfg, client)
+		return obtainCertFn(ctx, cfg, client)
 	},
 		backoff.WithBackOff(bo),
 		backoff.WithMaxElapsedTime(cfg.InitialRetryTimeout),

--- a/internal/cmds/getcert/run_loop_test.go
+++ b/internal/cmds/getcert/run_loop_test.go
@@ -2,6 +2,9 @@ package getcert
 
 import (
 	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -23,16 +26,10 @@ type capturedRecord struct {
 	attrs map[string]slog.Value
 }
 
-// logCapture is a slog.Handler that stores records and wakes waiters, so tests
-// can wait for a specific message without polling or sleeping.
+// logCapture is a slog.Handler that stores records for later inspection.
 type logCapture struct {
 	mu      sync.Mutex
 	records []capturedRecord
-	arrived chan struct{}
-}
-
-func newLogCapture() *logCapture {
-	return &logCapture{arrived: make(chan struct{}, 1)}
 }
 
 func (c *logCapture) Enabled(context.Context, slog.Level) bool { return true }
@@ -46,10 +43,6 @@ func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
 	c.mu.Lock()
 	c.records = append(c.records, rec)
 	c.mu.Unlock()
-	select {
-	case c.arrived <- struct{}{}:
-	default:
-	}
 	return nil
 }
 
@@ -67,26 +60,11 @@ func (c *logCapture) find(msg string) (capturedRecord, bool) {
 	return capturedRecord{}, false
 }
 
-func (c *logCapture) waitFor(t *testing.T, msg string) capturedRecord {
-	t.Helper()
-	deadline := time.After(15 * time.Second)
-	for {
-		if rec, ok := c.find(msg); ok {
-			return rec
-		}
-		select {
-		case <-c.arrived:
-		case <-deadline:
-			t.Fatalf("log message %q never appeared", msg)
-		}
-	}
-}
-
 // captureDefaultLogger swaps the process default logger for a capture handler
 // and restores it on cleanup.
 func captureDefaultLogger(t *testing.T) *logCapture {
 	t.Helper()
-	c := newLogCapture()
+	c := &logCapture{}
 	old := slog.Default()
 	slog.SetDefault(slog.New(c))
 	t.Cleanup(func() { slog.SetDefault(old) })
@@ -128,6 +106,74 @@ func terminateRun(t *testing.T, done <-chan error) {
 		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("run did not shut down after SIGTERM")
+	}
+}
+
+// stubObtainCert makes every certificate request return outcome(n), where n is
+// the 1-based attempt number, and returns a reader for the attempts' timestamps.
+func stubObtainCert(t *testing.T, outcome func(n int) (*x509.Certificate, error)) func() []time.Time {
+	t.Helper()
+	var mu sync.Mutex
+	var at []time.Time
+	old := obtainCertFn
+	obtainCertFn = func(context.Context, config, attestclient.Client) (*x509.Certificate, error) {
+		mu.Lock()
+		at = append(at, time.Now())
+		n := len(at)
+		mu.Unlock()
+		return outcome(n)
+	}
+	t.Cleanup(func() { obtainCertFn = old })
+	return func() []time.Time {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]time.Time(nil), at...)
+	}
+}
+
+// stubObtainCertFailing makes every certificate request fail.
+func stubObtainCertFailing(t *testing.T) func() []time.Time {
+	return stubObtainCert(t, func(int) (*x509.Certificate, error) {
+		return nil, errors.New("stubbed certificate request failure")
+	})
+}
+
+// waitForAttempts polls until at least n certificate attempts were made.
+func waitForAttempts(t *testing.T, attempts func() []time.Time, n int) []time.Time {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if at := attempts(); len(at) >= n {
+			return at
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("got %d certificate attempts, want at least %d", len(attempts()), n)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// catchSIGHUP subscribes for the reload signal reloadNginx sends the master.
+func catchSIGHUP(t *testing.T) <-chan os.Signal {
+	t.Helper()
+	hup := make(chan os.Signal, 1)
+	signal.Notify(hup, syscall.SIGHUP)
+	t.Cleanup(func() { signal.Stop(hup) })
+	return hup
+}
+
+// presentAsNginxMaster makes reloadNginx find this test process under root.
+func presentAsNginxMaster(t *testing.T, root string) {
+	t.Helper()
+	pidDir := filepath.Join(root, strconv.Itoa(os.Getpid()))
+	if err := os.MkdirAll(pidDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "comm"), []byte("nginx\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("nginx: master process\x00"), 0644); err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -188,31 +234,92 @@ func TestObtainCertLogsTokenFreeRequest(t *testing.T) {
 	}
 }
 
-// A failing renewal tick logs and retries instead of being treated as success.
-func TestRunRenewalLoopLogsFailedRenewal(t *testing.T) {
+// A failed renewal is retried off the renewalRetryBase backoff, not a whole
+// --renew-interval later: by the time a renewal fails the installed leaf is
+// already close to expiry.
+func TestRunRenewalLoopRetriesFailedRenewal(t *testing.T) {
 	holdSIGTERM(t)
-	c := captureDefaultLogger(t)
+
+	oldBase := renewalRetryBase
+	renewalRetryBase = 40 * time.Millisecond
+	t.Cleanup(func() { renewalRetryBase = oldBase })
+
+	attempts := stubObtainCertFailing(t)
 
 	cfg := unreachableRenewalConfig()
-	cfg.RenewInterval = 25 * time.Millisecond
+	cfg.RenewInterval = 200 * time.Millisecond
 	cfg.ReloadNginx = false
 
 	done := make(chan error, 1)
 	go func() { done <- run(cfg) }()
 
-	// A failed renewal no longer sleeps a whole interval: it backs off from
-	// renewalRetryBase, so the pod re-attempts long before the leaf it is
-	// still serving expires.
-	c.waitFor(t, "certificate renewal failed, retrying")
+	at := waitForAttempts(t, attempts, 4)
 	terminateRun(t, done)
+
+	// at[0] is the initial request, at[1] the first renewal tick. After each
+	// failure the loop must wait ~renewalRetryBase, then ~2x — never a whole
+	// --renew-interval.
+	if gap := at[2].Sub(at[1]); gap < renewalRetryBase || gap >= cfg.RenewInterval {
+		t.Errorf("first retry came %v after the failed renewal, want [%v, %v)", gap, renewalRetryBase, cfg.RenewInterval)
+	}
+	if gap := at[3].Sub(at[2]); gap < 2*renewalRetryBase || gap >= cfg.RenewInterval {
+		t.Errorf("second retry came %v after the failed renewal, want [%v, %v)", gap, 2*renewalRetryBase, cfg.RenewInterval)
+	}
 }
 
-// A changed watch file triggers the reload path, and a failed reload is
-// surfaced as a warning rather than swallowed.
-func TestRunRenewalLoopReloadsOnWatchChange(t *testing.T) {
-	overrideProcRoot(t, t.TempDir()) // no nginx master: reloads fail softly
+// A renewal that succeeds after failures resets the backoff: the loop keeps
+// running, paces the next renewal a full --renew-interval out, and a later
+// failure retries from renewalRetryBase again — not the pre-recovery climbed
+// delay.
+func TestRunRenewalLoopRecoversAfterFailedRenewals(t *testing.T) {
 	holdSIGTERM(t)
-	c := captureDefaultLogger(t)
+
+	oldBase := renewalRetryBase
+	renewalRetryBase = 40 * time.Millisecond
+	t.Cleanup(func() { renewalRetryBase = oldBase })
+
+	// The stub fails the initial request and three renewals — climbing the
+	// backoff to its ceiling — then returns a long-lived leaf on attempt 5, so
+	// post-recovery pacing is a full --renew-interval.
+	leaf := &x509.Certificate{NotAfter: time.Now().Add(time.Hour)}
+	attempts := stubObtainCert(t, func(n int) (*x509.Certificate, error) {
+		if n == 5 {
+			return leaf, nil
+		}
+		return nil, errors.New("stubbed certificate request failure")
+	})
+
+	cfg := unreachableRenewalConfig()
+	cfg.RenewInterval = 200 * time.Millisecond
+	cfg.ReloadNginx = false
+
+	done := make(chan error, 1)
+	go func() { done <- run(cfg) }()
+
+	at := waitForAttempts(t, attempts, 7)
+	terminateRun(t, done)
+
+	// at[4] is the recovered renewal, at[5] the next tick a full interval out,
+	// at[6] the retry after at[5] fails — back at renewalRetryBase, proving the
+	// failures counter reset.
+	if gap := at[5].Sub(at[4]); gap < cfg.RenewInterval {
+		t.Errorf("post-recovery renewal came %v after the success, want a full interval >= %v", gap, cfg.RenewInterval)
+	}
+	if gap := at[6].Sub(at[5]); gap < renewalRetryBase || gap >= cfg.RenewInterval {
+		t.Errorf("retry after the post-recovery failure came %v, want [%v, %v) — failures did not reset", gap, renewalRetryBase, cfg.RenewInterval)
+	}
+}
+
+// A changed watch file triggers an nginx reload, and a failed reload does
+// not stop the watcher: later changes still reload.
+func TestRunRenewalLoopReloadsOnWatchChange(t *testing.T) {
+	holdSIGTERM(t)
+	hup := catchSIGHUP(t)
+
+	// No nginx master yet, so the first reloads fail; the watcher proving
+	// live afterwards means those failures were tolerated.
+	root := t.TempDir()
+	overrideProcRoot(t, root)
 
 	watched := filepath.Join(t.TempDir(), "tls.crt")
 	if err := os.WriteFile(watched, []byte("v1"), 0644); err != nil {
@@ -227,13 +334,25 @@ func TestRunRenewalLoopReloadsOnWatchChange(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- run(cfg) }()
 
-	// The snapshot is taken before this record, so a change written now is seen.
-	c.waitFor(t, "watching files for nginx reload")
-	if err := os.WriteFile(watched, []byte("v2"), 0644); err != nil {
+	// A change written before the loop's initial snapshot is invisible to the
+	// watcher, so keep changing the file: every post-snapshot change is a
+	// failed reload while the master is absent.
+	for i := 2; i <= 4; i++ {
+		if err := os.WriteFile(watched, []byte(fmt.Sprintf("v%d", i)), 0644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	presentAsNginxMaster(t, root)
+	if err := os.WriteFile(watched, []byte("v5"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	c.waitFor(t, "watched file changed, reloading nginx")
-	c.waitFor(t, "watched file changed but nginx reload failed")
+	select {
+	case <-hup:
+	case <-time.After(5 * time.Second):
+		t.Fatal("no nginx reload after the watched file changed")
+	}
 	terminateRun(t, done)
 }
 
@@ -242,9 +361,10 @@ func TestRunRenewalLoopReloadsOnWatchChange(t *testing.T) {
 // come up and shut down cleanly.
 func TestRunRenewalLoopWithoutWatchPathsIgnoresWatchInterval(t *testing.T) {
 	holdSIGTERM(t)
-	c := captureDefaultLogger(t)
+	attempts := stubObtainCertFailing(t)
 
 	cfg := unreachableRenewalConfig()
+	cfg.RenewInterval = 25 * time.Millisecond
 	cfg.ReloadNginx = true
 	cfg.ReloadWatchPaths = nil
 	cfg.ReloadWatchInterval = 0
@@ -252,7 +372,9 @@ func TestRunRenewalLoopWithoutWatchPathsIgnoresWatchInterval(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- run(cfg) }()
 
-	c.waitFor(t, "entering renewal loop")
+	// A second attempt means the tolerated initial failure carried run into
+	// the renewal loop.
+	waitForAttempts(t, attempts, 2)
 	terminateRun(t, done)
 }
 
@@ -380,23 +502,9 @@ func TestFindNginxMasterPID(t *testing.T) {
 
 func TestReloadNginx(t *testing.T) {
 	t.Run("signals the master", func(t *testing.T) {
-		// Present this test process as the nginx master and swallow the SIGHUP
-		// reloadNginx sends it.
-		hup := make(chan os.Signal, 1)
-		signal.Notify(hup, syscall.SIGHUP)
-		defer signal.Stop(hup)
-
+		hup := catchSIGHUP(t)
 		root := t.TempDir()
-		pidDir := filepath.Join(root, strconv.Itoa(os.Getpid()))
-		if err := os.MkdirAll(pidDir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(pidDir, "comm"), []byte("nginx\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(pidDir, "cmdline"), []byte("nginx: master process\x00"), 0644); err != nil {
-			t.Fatal(err)
-		}
+		presentAsNginxMaster(t, root)
 		overrideProcRoot(t, root)
 
 		if err := reloadNginx(); err != nil {

--- a/internal/cmds/ratlsmesh/conntrack_linux.go
+++ b/internal/cmds/ratlsmesh/conntrack_linux.go
@@ -3,6 +3,8 @@
 package ratlsmesh
 
 import (
+	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 
@@ -26,12 +28,15 @@ import (
 // and as the reply-tuple destination of a direct pod-IP dial, so a single
 // ConntrackReplyAnyIP filter per IP catches both. Deleting a live flow's
 // entry forces the next packet to re-establish through the guard, where the
-// DROP now runs. Best-effort: a delete failure is logged, not fatal — the
-// guard still blocks all subsequent NEW flows.
-func flushCWConntrack(logger *slog.Logger, ips []string) {
+// DROP now runs. Best-effort: a failure is logged, not fatal — the guard
+// still blocks all subsequent NEW flows. Returns the entries deleted across
+// both families and any failures joined.
+func flushCWConntrack(logger *slog.Logger, ips []string) (int, error) {
 	if len(ips) == 0 {
-		return
+		return 0, nil
 	}
+	var errs []error
+	var deleted int
 	v4, v6 := splitIPsByFamily(ips)
 	for _, fam := range []struct {
 		family netlink.InetFamily
@@ -43,11 +48,13 @@ func flushCWConntrack(logger *slog.Logger, ips []string) {
 		if len(fam.ips) == 0 {
 			continue
 		}
+		label := inetFamilyLabel(fam.family)
 		var filters []netlink.CustomConntrackFilter
 		for _, ip := range fam.ips {
 			f := &netlink.ConntrackFilter{}
 			if err := f.AddIP(netlink.ConntrackReplyAnyIP, ip); err != nil {
 				logger.Warn("build cw conntrack filter failed", "ip", ip.String(), "error", err)
+				errs = append(errs, fmt.Errorf("%s: %w", label, err))
 				continue
 			}
 			filters = append(filters, f)
@@ -55,16 +62,25 @@ func flushCWConntrack(logger *slog.Logger, ips []string) {
 		if len(filters) == 0 {
 			continue
 		}
-		n, err := netlink.ConntrackDeleteFilters(netlink.ConntrackTable, fam.family, filters...)
+		n, err := conntrackDeleteFilters(netlink.ConntrackTable, fam.family, filters...)
+		deleted += int(n)
 		if err != nil {
-			logger.Warn("cw conntrack flush failed", "family", inetFamilyLabel(fam.family), "deleted", n, "error", err)
+			logger.Warn("cw conntrack flush failed", "family", label, "deleted", n, "error", err)
+			errs = append(errs, fmt.Errorf("%s: %w", label, err))
 			continue
 		}
 		if n > 0 {
-			logger.Info("flushed cw conntrack entries so the guard fails closed", "family", inetFamilyLabel(fam.family), "deleted", n)
+			logger.Info("flushed cw conntrack entries so the guard fails closed", "family", label, "deleted", n)
+		} else {
+			logger.Debug("cw conntrack flush matched no entries", "family", label)
 		}
 	}
+	return deleted, errors.Join(errs...)
 }
+
+// conntrackDeleteFilters is a var so tests can observe the flush without
+// CAP_NET_ADMIN.
+var conntrackDeleteFilters = netlink.ConntrackDeleteFilters
 
 // splitIPsByFamily parses and partitions IP strings into IPv4 and IPv6,
 // dropping unparseable entries. Extracted so the family split is unit-testable

--- a/internal/cmds/ratlsmesh/in_guest_linux_test.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -227,6 +228,53 @@ func TestBuildInGuestIptablesRules(t *testing.T) {
 	}
 	if !sawOutputRedirect {
 		t.Error("no OUTPUT REDIRECT rule to 15001")
+	}
+
+	// The UID-0 exemption is a documented plaintext bypass for in-guest
+	// infrastructure (attestation-service's KDS fetch); pin its exact args,
+	// its place ahead of the catch-all redirect, and its absence from
+	// PREROUTING.
+	wantExemption := []string{"-p", "tcp", "-m", "owner", "--uid-owner", "0", "-j", "RETURN"}
+	exemptionIdx, outputRedirectIdx := -1, -1
+	for i, r := range rules {
+		if r.chain == preroutingChainName && containsArg(r.args, "--uid-owner") {
+			t.Errorf("PREROUTING rule %d carries --uid-owner: %v", i, r.args)
+		}
+		if r.chain != chainName {
+			continue
+		}
+		if containsArgPair(r.args, "--uid-owner", "0") {
+			if exemptionIdx >= 0 {
+				t.Errorf("second UID-0 exemption rule at index %d", i)
+			}
+			exemptionIdx = i
+			if !slices.Equal(r.args, wantExemption) {
+				t.Errorf("UID-0 exemption args = %v, want exactly %v", r.args, wantExemption)
+			}
+		}
+		if containsArgPair(r.args, "-j", "REDIRECT") && containsArgPair(r.args, "--to-port", "15001") {
+			outputRedirectIdx = i
+		}
+	}
+	if exemptionIdx < 0 {
+		t.Error("no UID-0 exemption rule on OUTPUT chain")
+	} else if outputRedirectIdx >= 0 && exemptionIdx > outputRedirectIdx {
+		t.Error("UID-0 exemption follows the catch-all redirect — it would never match")
+	}
+
+	// Bound the exemption SET: the only --uid-owner values on any chain are
+	// the proxy UID and infra UID 0 — a stray one egresses in plaintext.
+	var ownerUIDs []string
+	for _, r := range rules {
+		for i := 0; i+1 < len(r.args); i++ {
+			if r.args[i] == "--uid-owner" {
+				ownerUIDs = append(ownerUIDs, r.args[i+1])
+			}
+		}
+	}
+	slices.Sort(ownerUIDs)
+	if got := slices.Compact(ownerUIDs); !slices.Equal(got, []string{"0", "1337"}) {
+		t.Errorf("uid-owner exemptions = %v, want exactly [0 1337]", got)
 	}
 
 	// The PREROUTING chain must end at a REDIRECT to 15006.

--- a/internal/cmds/ratlsmesh/origdst_conntrack_test.go
+++ b/internal/cmds/ratlsmesh/origdst_conntrack_test.go
@@ -4,10 +4,16 @@ package ratlsmesh
 
 import (
 	"encoding/binary"
+	"errors"
+	"io"
 	"log/slog"
 	"net"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 // A connection that never went through iptables REDIRECT must be rejected.
@@ -59,32 +65,126 @@ func TestDefaultOrigDstFuncRejectsNonTCP(t *testing.T) {
 	}
 }
 
-// Without CAP_NET_ADMIN the conntrack delete fails, which must surface as the
-// flush-failed warning; the filter-build step must stay silent for valid IPs.
+// conntrackDeleteStub records flushCWConntrack's delete calls and returns a
+// scripted outcome.
+type conntrackDeleteStub struct {
+	calls   []netlink.InetFamily
+	filters []int
+	deleted uint
+	err     error
+	// byFamily, when set, overrides the scalar outcome per address family.
+	byFamily func(netlink.InetFamily) (uint, error)
+}
+
+func (s *conntrackDeleteStub) delete(_ netlink.ConntrackTableType, family netlink.InetFamily, filters ...netlink.CustomConntrackFilter) (uint, error) {
+	s.calls = append(s.calls, family)
+	s.filters = append(s.filters, len(filters))
+	if s.byFamily != nil {
+		return s.byFamily(family)
+	}
+	return s.deleted, s.err
+}
+
+// The flush must reach the conntrack delete for valid IPs and report the
+// outcome — entries deleted, failures — through its return, and garbage IPs
+// must never reach netlink. The delete is stubbed, so this holds with and
+// without CAP_NET_ADMIN.
 func TestFlushCWConntrackReachesDeleteForValidIPs(t *testing.T) {
-	logsFor := func(ips []string) string {
-		var buf syncBuffer
-		flushCWConntrack(slog.New(slog.NewJSONHandler(&buf, nil)), ips)
-		return buf.String()
+	stub := &conntrackDeleteStub{}
+	orig := conntrackDeleteFilters
+	conntrackDeleteFilters = stub.delete
+	t.Cleanup(func() { conntrackDeleteFilters = orig })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	errDelete := errors.New("delete failed")
+	tests := []struct {
+		name        string
+		ips         []string
+		stubDeleted uint
+		stubErr     error
+		wantCalls   []netlink.InetFamily
+		wantFilters []int
+		wantDeleted int
+		wantErr     error
+	}{
+		{"valid IPv4 reaches the delete", []string{"10.99.88.7"}, 0, nil, []netlink.InetFamily{unix.AF_INET}, []int{1}, 0, nil},
+		{"delete failure is returned", []string{"10.99.88.7"}, 0, errDelete, []netlink.InetFamily{unix.AF_INET}, []int{1}, 0, errDelete},
+		{"partial delete with failure", []string{"10.99.88.7"}, 1, errDelete, []netlink.InetFamily{unix.AF_INET}, []int{1}, 1, errDelete},
+		{"deleted count is returned", []string{"10.99.88.7", "10.99.88.9"}, 2, nil, []netlink.InetFamily{unix.AF_INET}, []int{2}, 2, nil},
+		{"dual stack flushes both families", []string{"10.99.88.7", "fd00::5"}, 1, nil, []netlink.InetFamily{unix.AF_INET, unix.AF_INET6}, []int{1, 1}, 2, nil},
+		{"unparseable IP never reaches netlink", []string{"not-an-ip"}, 0, nil, nil, nil, 0, nil},
+		{"empty list never reaches netlink", nil, 0, nil, nil, nil, 0, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			stub.calls, stub.filters = nil, nil
+			stub.deleted, stub.err = tc.stubDeleted, tc.stubErr
+			deleted, err := flushCWConntrack(logger, tc.ips)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("err = %v, want %v", err, tc.wantErr)
+			}
+			if deleted != tc.wantDeleted {
+				t.Errorf("deleted = %d, want %d", deleted, tc.wantDeleted)
+			}
+			if !slices.Equal(stub.calls, tc.wantCalls) {
+				t.Errorf("delete calls = %v, want %v", stub.calls, tc.wantCalls)
+			}
+			if !slices.Equal(stub.filters, tc.wantFilters) {
+				t.Errorf("filters per call = %v, want %v", stub.filters, tc.wantFilters)
+			}
+		})
+	}
+}
+
+// A successful flush that matched no entries must stay observable at debug —
+// and silent above it — so this fail-closed cleanup is not silent on its normal
+// success path. Pinned by level, not text, to avoid a log oracle.
+func TestFlushCWConntrackLogsDebugOnEmptyFlush(t *testing.T) {
+	stub := &conntrackDeleteStub{} // deleted 0, err nil: the empty-flush success path
+	orig := conntrackDeleteFilters
+	conntrackDeleteFilters = stub.delete
+	t.Cleanup(func() { conntrackDeleteFilters = orig })
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	if _, err := flushCWConntrack(logger, []string{"10.99.88.7"}); err != nil {
+		t.Fatalf("flushCWConntrack: %v", err)
 	}
 
-	out := logsFor([]string{"10.99.88.7"})
-	records := decodeLogRecords(out)
-	if hasMsg(records, "build cw conntrack filter failed") {
-		t.Errorf("filter build warned for a valid IP: %s", out)
+	var sawDebug bool
+	for _, r := range decodeLogRecords(buf.String()) {
+		if r.Level == "DEBUG" {
+			sawDebug = true
+		} else {
+			t.Errorf("empty-flush success logged at %s, want DEBUG only", r.Level)
+		}
 	}
-	flushed := hasMsg(records, "flushed cw conntrack entries so the guard fails closed")
-	failed := hasMsg(records, "cw conntrack flush failed")
-	if !flushed && !failed {
-		t.Errorf("no evidence the conntrack delete ran; logs: %s", out)
+	if !sawDebug {
+		t.Error("empty-flush success emitted no debug log — the cleanup is silent on success")
 	}
+}
 
-	// Unparseable IPs are dropped by the family split: no netlink call, no log.
-	if out := logsFor([]string{"not-an-ip"}); strings.TrimSpace(out) != "" {
-		t.Errorf("unexpected logs for unparseable IP: %s", out)
+// A dual-stack flush must keep the entries a family already deleted even when a
+// later family's delete fails, and surface that failure.
+func TestFlushCWConntrackKeepsEarlierFamilyCountOnLaterFailure(t *testing.T) {
+	errV6 := errors.New("v6 delete failed")
+	stub := &conntrackDeleteStub{byFamily: func(f netlink.InetFamily) (uint, error) {
+		if f == unix.AF_INET6 {
+			return 0, errV6
+		}
+		return 2, nil
+	}}
+	orig := conntrackDeleteFilters
+	conntrackDeleteFilters = stub.delete
+	t.Cleanup(func() { conntrackDeleteFilters = orig })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	deleted, err := flushCWConntrack(logger, []string{"10.99.88.7", "fd00::5"})
+	if !errors.Is(err, errV6) {
+		t.Errorf("err = %v, want %v", err, errV6)
 	}
-	if out := logsFor(nil); strings.TrimSpace(out) != "" {
-		t.Errorf("unexpected logs for empty IP list: %s", out)
+	if deleted != 2 {
+		t.Errorf("deleted = %d, want 2 — the IPv4 count must survive the IPv6 failure", deleted)
 	}
 }
 

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -165,7 +165,7 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 	// any that raced the chain-flush-then-append window in installIptablesRules)
 	// must re-establish through the DROP instead of being grandfathered by the
 	// ESTABLISHED,RELATED RETURN rule.
-	flushCWConntrack(logger, cwIPs)
+	_, _ = flushCWConntrack(logger, cwIPs)
 	publishIptablesMetrics(logger)
 	if cfg.readyFile != "" {
 		if err := os.WriteFile(cfg.readyFile, []byte("ready\n"), 0o600); err != nil {
@@ -212,7 +212,7 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 			continue
 		}
 		curr := stringSet(cwIPs)
-		flushCWConntrack(logger, newMembers(prevCWIPs, curr))
+		_, _ = flushCWConntrack(logger, newMembers(prevCWIPs, curr))
 		prevCWIPs = curr
 		// Guard counters change only on packet hits, not pod events, so
 		// refresh on the resync tick rather than every event-driven sync


### PR DESCRIPTION
## What

Replace log-string oracles with outcome oracles in the ratlsmesh conntrack
flush test and the getcert renewal-loop tests, and pin the in-guest UID-0
egress exemption.

**`flushCWConntrack` gains an outcome contract.** It now returns the number of
conntrack entries deleted and any failures joined (`errors.Join`, family-tagged),
and the previously silent success path — `err == nil`, zero matching entries —
now logs at debug. `TestFlushCWConntrackReachesDeleteForValidIPs` no longer
scrapes logs: it asserts the return values and the delete calls themselves
through a stubbed `conntrackDeleteFilters` seam, so it passes with and without
`CAP_NET_ADMIN`. Previously it was green only where the delete *failed*
(unprivileged CI runners) and red on any privileged dev host, because the
successful-flush path emitted no log at all. Two focused tests guard that
surface: `TestFlushCWConntrackLogsDebugOnEmptyFlush` pins the zero-delete
success by log *level* (debug, and silent above it) rather than message text —
so the observability fix can't regress into silence without reintroducing a log
oracle — and `TestFlushCWConntrackKeepsEarlierFamilyCountOnLaterFailure` scripts
a dual-stack flush where IPv4 deletes entries and IPv6 fails, asserting the IPv4
count survives the IPv6 error.

**The in-guest UID-0 exemption is pinned.** `TestBuildInGuestIptablesRules` now
asserts the exemption's args are exactly
`["-p","tcp","-m","owner","--uid-owner","0","-j","RETURN"]`, that it sits ahead
of the catch-all OUTPUT redirect, and that no PREROUTING rule carries
`--uid-owner`. It also bounds the exemption *set* — the only `--uid-owner`
values on any chain must be the proxy UID and `0` — so a second exemption (e.g.
the workload UID `65532`), the plaintext egress the pin exists to catch, fails
the test. This is the in-guest twin of the host-side exclusion pin in
`iptables_test.go`.

**The getcert renewal-loop tests assert behavior.**

- `TestRunRenewalLoopRetriesFailedRenewal` (was `...LogsFailedRenewal`):
  stubs `obtainCert` (new `obtainCertFn` var), records attempt timestamps, and
  asserts a retry happened and that the gap after the first failure comes from
  `renewalRetryBase` (then doubles) — never a whole `--renew-interval`.
  `renewalRetryBase` is now a var the loop test shrinks and
  `TestRenewalRetryInterval` reads, so the package stays non-parallel.
- `TestRunRenewalLoopRecoversAfterFailedRenewals`: a renewal that succeeds after
  several failures resets the backoff — the loop keeps running, paces the next
  renewal a full `--renew-interval` out, and a later failure retries from
  `renewalRetryBase` again rather than the climbed pre-recovery delay, pinning
  the `failures` reset.
- `TestRunRenewalLoopReloadsOnWatchChange`: drops the log waits; the test
  process poses as the nginx master (via the existing `procRoot` seam) and the
  assertion is real SIGHUP delivery after a watched-file change, including
  after earlier reloads failed (no master present) — proving a failed reload
  does not stop the watcher.
- `TestRunRenewalLoopWithoutWatchPathsIgnoresWatchInterval`: proves run
  reaches the renewal loop by observing certificate attempts instead of the
  "entering renewal loop" log line.

## Why

Log-string oracles make tests depend on wording, not behavior: they go red when
a message is reworded or redacted, and — as here — they can silently depend on
host capabilities. The conntrack test's log-oracle also masked a real
observability gap: a security-relevant fail-closed cleanup whose success path
emitted nothing at any level.

## Test plan

- `go test -race ./internal/cmds/ratlsmesh/ ./internal/cmds/getcert/ -count=1`
  — green **unprivileged** (this environment, no capabilities).
- Same command under `sudo` (host netns, `CAP_NET_ADMIN`, `nf_conntrack`
  loaded) — green **privileged**. On main, the conntrack test fails in this
  mode (`no evidence the conntrack delete ran; logs:`); on this branch it
  passes.
- Mutation checks: sleeping a whole `--renew-interval` after a failed renewal,
  deleting the UID-0 rule, moving it after the catch-all, and widening its
  UID match each turn the corresponding test red. The round-1 pins are
  mutation-verified too: a second OUTPUT `--uid-owner` exemption, removing (or
  demoting to info) the empty-flush debug branch, overwriting instead of
  accumulating a family's delete count, and dropping the `failures` reset on a
  successful renewal each turn the corresponding new test red.
- `go build ./...`, `go vet`, `gofmt` clean; `make lint` (fmt + vet) passes.

## Threat-model notes

- The cw guard fails closed only for NEW flows; the conntrack flush is what
  stops already-established plaintext flows from being grandfathered past it.
  The zero-delete success path (normal when enforcement is installed before any
  bypass flow exists) is now visible at debug instead of silent, and delete
  failures remain warn-level and non-fatal, unchanged.
- The UID-0 exemption is a documented plaintext bypass for in-guest
  infrastructure: removing it hangs `/attest` (KDS fetch redirected into the
  proxy), widening it lets unprivileged workload egress leave the guest in
  plaintext. The test now fails on either drift.
- No behavior of the retry pacing itself changes; the seam only makes the
  existing backoff observable to tests.
