### PR TITLE
feat(verify): pin the guest init-data digest at the relying party

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -475,6 +475,14 @@ are enforced client-side against the report's launch measurement; with no
 `--measurements` the command still runs but prints an UNSAFE warning — any
 genuine TEE is accepted.
 
+`--init-data <sha256-hex>` pins the guest's init-data document: the kata shim
+commits `sha256(document)` at launch, and a verdict pinned this way fails
+unless the evidence commits exactly that digest. The document renders
+deterministically from the pod's role and CDS measurement set (`pkg/initdata`),
+so the digest comes from the same pipeline that chose those measurements. With
+no `--init-data` the committed digest is still shown on SNP/TDX, labelled as
+compared against nothing.
+
 On TDX, `--measurements` pins MRTD, which covers only the TDVF firmware: the
 guest kernel and rootfs live in RTMR[1] and RTMR[2], and a verdict pinned on
 MRTD alone warns that they are unmeasured by that policy. To pin the whole

--- a/internal/cmds/verify/initdata_test.go
+++ b/internal/cmds/verify/initdata_test.go
@@ -1,0 +1,335 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// The Genoa fixture's HOST_DATA is 32 zero bytes.
+var (
+	genoaInitDataPin = strings.Repeat("00", 32)
+	wrongInitDataPin = strings.Repeat("ab", 32)
+)
+
+// finalOutcome runs verifyEvidence's post-verification sequence: newOutcome,
+// the verdict policies, then applyInitDataNote on the final verdict.
+func finalOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, plan *verifyPlan) Outcome {
+	oc := newOutcome(cfg, ev, result, nil, plan)
+	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{})
+	applyInitDataNote(&oc, result, plan)
+	return oc
+}
+
+// --init-data parses into the plan exactly once, as 32 bytes; anything else
+// is a usage error naming the flag.
+func TestBuildPolicy_InitDataFlag(t *testing.T) {
+	t.Run("valid digest", func(t *testing.T) {
+		plan := mustPlan(t, config{initDataHex: genoaInitDataPin})
+		if len(plan.initDataHash) != 32 {
+			t.Fatalf("initDataHash = %d bytes, want 32", len(plan.initDataHash))
+		}
+	})
+	t.Run("unset means unpinned", func(t *testing.T) {
+		if plan := mustPlan(t, config{}); plan.initDataHash != nil {
+			t.Fatalf("initDataHash = %x, want nil", plan.initDataHash)
+		}
+	})
+	t.Run("wrong length", func(t *testing.T) {
+		if _, err := buildPolicy(config{initDataHex: strings.Repeat("00", 31)}); err == nil || !strings.Contains(err.Error(), "--init-data") {
+			t.Fatalf("err = %v, want a --init-data length error", err)
+		}
+	})
+	t.Run("not hex", func(t *testing.T) {
+		if _, err := buildPolicy(config{initDataHex: "zz" + strings.Repeat("00", 31)}); err == nil || !strings.Contains(err.Error(), "--init-data") {
+			t.Fatalf("err = %v, want a --init-data hex error", err)
+		}
+	})
+	t.Run("odd-length hex", func(t *testing.T) {
+		if _, err := buildPolicy(config{initDataHex: strings.Repeat("0", 63)}); err == nil || !strings.Contains(err.Error(), "--init-data") {
+			t.Fatalf("err = %v, want a --init-data error", err)
+		}
+	})
+	t.Run("uppercase hex accepted", func(t *testing.T) {
+		plan := mustPlan(t, config{initDataHex: strings.ToUpper(wrongInitDataPin)})
+		if len(plan.initDataHash) != 32 {
+			t.Fatalf("initDataHash = %d bytes, want 32 (uppercase hex must decode)", len(plan.initDataHash))
+		}
+	})
+}
+
+// The pin rides the plan into the engine: evidence committing the pinned
+// digest verifies and the verdict says the digest was compared against
+// --init-data, in text and in the JSON a machine gate reads.
+func TestVerifyEvidence_InitDataPinMatch(t *testing.T) {
+	cfg := config{initDataHex: genoaInitDataPin}
+	plan := mustPlan(t, cfg)
+
+	var out, errOut bytes.Buffer
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	if code != exitVerified {
+		t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
+	}
+	text := out.String()
+	for _, want := range []string{"✓ VERIFIED", "init-data:    " + genoaInitDataPin, "verified: matches --init-data"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("verdict missing %q:\n%s", want, text)
+		}
+	}
+
+	jsonCfg := config{initDataHex: genoaInitDataPin, output: "json"}
+	var jout, jerr bytes.Buffer
+	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), genoaFileEvidence(t), nil, operatorKeysReport{}, &jout, &jerr); code != exitVerified {
+		t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitVerified, jout.String(), jerr.String())
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(jout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json render: %v", err)
+	}
+	if parsed["init_data"] != genoaInitDataPin {
+		t.Errorf("init_data = %v, want the pinned digest", parsed["init_data"])
+	}
+	if note, _ := parsed["init_data_note"].(string); !strings.Contains(note, "matches --init-data") {
+		t.Errorf("init_data_note = %v, want the matched note", parsed["init_data_note"])
+	}
+}
+
+// A "verified"-worded note must never ride a failed verdict, whichever check
+// fails: --measurements fails inside newOutcome; --mesh-ca and --operator-keys
+// fail in applyVerdictPolicies, past newOutcome. On every path
+// both renderers must agree — the JSON must not carry an init-data field the
+// text hides. Regression for the JSON honesty leak (#76).
+func TestVerifyEvidence_InitDataNoteAbsentOnFailedVerdict(t *testing.T) {
+	// --operator-keys resolves a pinned digest, so the served set (never
+	// fetched for a --from-file target) can be compared: it fails in
+	// applySandboxPolicy, past newOutcome.
+	pubPEM, _ := operatorPubPEM(t)
+	keysPath := filepath.Join(t.TempDir(), "op.pub")
+	if err := os.WriteFile(keysPath, pubPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  config
+		ev   func(*testing.T) *evidence
+	}{
+		{
+			name: "measurements (in newOutcome)",
+			cfg:  config{initDataHex: genoaInitDataPin, measurements: []string{strings.Repeat("11", 48)}},
+			ev:   genoaFileEvidence,
+		},
+		{
+			name: "mesh-ca leaf-less (applyVerdictPolicies)",
+			cfg:  config{initDataHex: genoaInitDataPin, meshCA: writeMeshCAPEM(t, mintEndpointIdentity(t).ca)},
+			ev:   genoaFileEvidence,
+		},
+		{
+			name: "operator-keys uncheckable (applyVerdictPolicies)",
+			cfg:  config{initDataHex: genoaInitDataPin, operatorKeys: keysPath},
+			ev:   genoaFileEvidence,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// operatorKeysReport{note:...} stands in for a --from-file target
+			// where the served set was never fetched.
+			opKeys := operatorKeysReport{}
+			if tc.cfg.operatorKeys != "" {
+				opKeys.note = "kind is not cds"
+			}
+
+			jsonCfg := tc.cfg
+			jsonCfg.output = "json"
+			var jout, jerr bytes.Buffer
+			if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), tc.ev(t), nil, opKeys, &jout, &jerr); code != exitFailed {
+				t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitFailed, jout.String(), jerr.String())
+			}
+			var parsed map[string]any
+			if err := json.Unmarshal(jout.Bytes(), &parsed); err != nil {
+				t.Fatalf("json render: %v", err)
+			}
+			if parsed["verified"] != false {
+				t.Errorf("verified = %v, want false", parsed["verified"])
+			}
+			if v, ok := parsed["init_data"]; ok {
+				t.Errorf("a failed verdict must not carry init_data: %v", v)
+			}
+			if v, ok := parsed["init_data_note"]; ok {
+				t.Errorf("a failed verdict must not carry a verified-sounding init_data_note: %v", v)
+			}
+
+			textCfg := tc.cfg
+			textCfg.output = "text"
+			var tout, terr bytes.Buffer
+			verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), tc.ev(t), nil, opKeys, &tout, &terr)
+			if text := tout.String(); strings.Contains(text, "init-data:") || strings.Contains(text, "matches --init-data") {
+				t.Errorf("a failed verdict must render no init-data line:\n%s", text)
+			}
+		})
+	}
+}
+
+// A PARTIAL verdict is not a failure: the init-data pin was verified, and the
+// verdict is partial for an unrelated property (here a WebPKI front door). The
+// note is honest, so it rides — in text and JSON alike, the same surfaces that
+// must agree to hide it on a hard failure.
+func TestVerifyEvidence_InitDataNoteRidesPartialVerdict(t *testing.T) {
+	makeEv := func(t *testing.T) *evidence {
+		ev := genoaFileEvidence(t)
+		ev.publicTLSMode = "webpki"
+		return ev
+	}
+
+	jsonCfg := config{initDataHex: genoaInitDataPin, output: "json"}
+	var jout, jerr bytes.Buffer
+	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), makeEv(t), nil, operatorKeysReport{}, &jout, &jerr); code != exitPartial {
+		t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitPartial, jout.String(), jerr.String())
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(jout.Bytes(), &parsed); err != nil {
+		t.Fatalf("json render: %v", err)
+	}
+	if parsed["partial"] != true {
+		t.Errorf("partial = %v, want true", parsed["partial"])
+	}
+	if parsed["init_data"] != genoaInitDataPin {
+		t.Errorf("init_data = %v, want the pinned digest on a partial verdict", parsed["init_data"])
+	}
+	if note, _ := parsed["init_data_note"].(string); !strings.Contains(note, "matches --init-data") {
+		t.Errorf("init_data_note = %v, want the matched note", parsed["init_data_note"])
+	}
+
+	textCfg := config{initDataHex: genoaInitDataPin, output: "text"}
+	var tout, terr bytes.Buffer
+	verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), makeEv(t), nil, operatorKeysReport{}, &tout, &terr)
+	text := tout.String()
+	for _, want := range []string{"~ PARTIALLY VERIFIED", "init-data:    " + genoaInitDataPin, "matches --init-data"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("partial verdict missing %q:\n%s", want, text)
+		}
+	}
+}
+
+// The issue's negative test: a guest whose init-data does not match the pin
+// is refused by the relying party — a failed verdict (exit 2), not a partial
+// one, and the refusal names the field that failed.
+func TestVerifyEvidence_InitDataPinMismatchIsRefused(t *testing.T) {
+	cfg := config{initDataHex: wrongInitDataPin}
+	plan := mustPlan(t, cfg)
+
+	var out, errOut bytes.Buffer
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	if code != exitFailed {
+		t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitFailed, out.String(), errOut.String())
+	}
+	text := out.String()
+	if !strings.Contains(text, "✗ NOT VERIFIED") || !strings.Contains(text, "HOST_DATA") {
+		t.Errorf("mismatch must render a failed verdict naming HOST_DATA:\n%s", text)
+	}
+	if strings.Contains(text, "✓ VERIFIED") || strings.Contains(text, "PARTIALLY") {
+		t.Errorf("a refused pin must never read as any kind of verified:\n%s", text)
+	}
+}
+
+// Honesty for the unpinned case: the committed digest is reported — it is
+// verified evidence — but the verdict must say it was compared against
+// nothing, in text and JSON alike.
+func TestVerifyEvidence_InitDataUnpinnedIsLabelled(t *testing.T) {
+	cfg := config{output: "json"}
+	plan := mustPlan(t, config{})
+
+	var out, errOut bytes.Buffer
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	if code != exitVerified {
+		t.Fatalf("exit = %d, want %d; output:\n%s", code, exitVerified, out.String())
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("json render: %v", err)
+	}
+	if parsed["verified"] != true {
+		t.Errorf("verified = %v, want true", parsed["verified"])
+	}
+	if parsed["init_data"] != genoaInitDataPin {
+		t.Errorf("init_data = %v, want the fixture's HOST_DATA", parsed["init_data"])
+	}
+	note, _ := parsed["init_data_note"].(string)
+	if !strings.Contains(note, "not pinned") {
+		t.Errorf("init_data_note = %q, want it to say the digest is unpinned", note)
+	}
+	if strings.Contains(note, "verified") {
+		t.Errorf("an unpinned digest must not carry the word verified: %q", note)
+	}
+}
+
+// applyInitDataNote is the single source of truth for the init-data fields: a
+// plan carrying --init-data takes the pinned note, an unpinned plan the
+// unpinned one, and a hard failure (oc.Error set) carries neither — the gate
+// that keeps JSON and text from disagreeing. On az-* the claim is the inner
+// report's HOST_DATA, not the field the pin binds (PCR[8]), so it is not
+// rendered as init-data even when pinned.
+func TestApplyInitDataNote(t *testing.T) {
+	result := &teetypes.VerificationResult{
+		SignatureValid: true,
+		Platform:       teetypes.PlatformSNP,
+		Claims:         teetypes.Claims{LaunchDigest: "ab" + strings.Repeat("00", 47), InitData: make([]byte, 32)},
+	}
+	ev := &evidence{platform: "snp", source: "test"}
+
+	pinned := finalOutcome(config{}, ev, result, &verifyPlan{policy: &ratls.VerifyPolicy{}, initDataHash: make([]byte, 32)})
+	if !strings.Contains(pinned.InitDataNote, "matches --init-data") {
+		t.Errorf("pinned note = %q", pinned.InitDataNote)
+	}
+	unpinned := finalOutcome(config{}, ev, result, &verifyPlan{policy: &ratls.VerifyPolicy{}})
+	if !strings.Contains(unpinned.InitDataNote, "not pinned") {
+		t.Errorf("unpinned note = %q", unpinned.InitDataNote)
+	}
+
+	// A hard failure past newOutcome (here a pre-set oc.Error) carries no note,
+	// even with a matching pin — the leak the gate closes.
+	failed := Outcome{Platform: "snp", Error: "a later policy failed"}
+	applyInitDataNote(&failed, result, &verifyPlan{policy: &ratls.VerifyPolicy{}, initDataHash: make([]byte, 32)})
+	if failed.InitData != "" || failed.InitDataNote != "" {
+		t.Errorf("a failed verdict must carry no init-data fields, got %q / %q", failed.InitData, failed.InitDataNote)
+	}
+
+	azResult := &teetypes.VerificationResult{
+		SignatureValid: true,
+		Platform:       teetypes.PlatformAzSNP,
+		Claims:         teetypes.Claims{LaunchDigest: "ab" + strings.Repeat("00", 47), InitData: make([]byte, 32)},
+	}
+	azEv := &evidence{platform: "az-snp", source: "test"}
+	azPinned := finalOutcome(config{}, azEv, azResult, &verifyPlan{policy: &ratls.VerifyPolicy{}, initDataHash: make([]byte, 32)})
+	if azPinned.InitData != "" {
+		t.Errorf("az verdict must not render the inner HOST_DATA as init-data, got %q", azPinned.InitData)
+	}
+	if !strings.Contains(azPinned.InitDataNote, "PCR[8]") {
+		t.Errorf("a pinned az verdict must report the enforced PCR[8] pin, got %q", azPinned.InitDataNote)
+	}
+	var azOut bytes.Buffer
+	renderText(config{}, azPinned, &azOut)
+	if rendered := azOut.String(); !strings.Contains(rendered, "init-data:") || !strings.Contains(rendered, "PCR[8]") ||
+		strings.Contains(rendered, "init-data:    "+strings.Repeat("00", 32)) {
+		t.Errorf("az render must show the PCR[8] pin, never the inner HOST_DATA:\n%s", rendered)
+	}
+
+	// The az note leaks identically on a failed verdict without the gate.
+	azFailed := Outcome{Platform: "az-snp", Error: "a later policy failed"}
+	applyInitDataNote(&azFailed, azResult, &verifyPlan{policy: &ratls.VerifyPolicy{}, initDataHash: make([]byte, 32)})
+	if azFailed.InitDataNote != "" {
+		t.Errorf("a failed az verdict must carry no init-data note, got %q", azFailed.InitDataNote)
+	}
+
+	azUnpinned := finalOutcome(config{}, azEv, azResult, &verifyPlan{policy: &ratls.VerifyPolicy{}})
+	if azUnpinned.InitData != "" || azUnpinned.InitDataNote != "" {
+		t.Errorf("an unpinned az verdict renders no init-data line, got %q / %q", azUnpinned.InitData, azUnpinned.InitDataNote)
+	}
+}

--- a/internal/cmds/verify/localverify.go
+++ b/internal/cmds/verify/localverify.go
@@ -15,14 +15,18 @@ import (
 // codes: collateral unavailable = exit 3, any other rejection = a security
 // verdict (exit 2). The --measurements pin is not passed down — newOutcome
 // enforces it, so a pin failure still renders the rejected measurement.
+// --init-data goes the other way: the engine binds it per platform (see
+// internal/localverify Params.ExpectedInitDataHash), so it is passed down and
+// a mismatch is the engine's refusal.
 //
 // MinTCB is passed here AND re-checked in newOutcome (enforceMinTCB): the
 // engine consumes it on the SNP path only, and silently drops it on TDX.
-func verifyInProcess(ctx context.Context, ev *evidence, policy *ratls.VerifyPolicy, minTCB *teetypes.SnpTcb) (*teetypes.VerificationResult, error) {
+func verifyInProcess(ctx context.Context, ev *evidence, policy *ratls.VerifyPolicy, initDataHash []byte, minTCB *teetypes.SnpTcb) (*teetypes.VerificationResult, error) {
 	res, err := localverify.Verify(ctx, ev.platform, ev.rawEvidence, localverify.Params{
-		ExpectedReportData: ev.erd,
-		AllowDebug:         policy.AllowDebug,
-		MinTCB:             minTCB,
+		ExpectedReportData:   ev.erd,
+		ExpectedInitDataHash: initDataHash,
+		AllowDebug:           policy.AllowDebug,
+		MinTCB:               minTCB,
 	})
 	if err != nil {
 		var ce *localverify.CollateralError

--- a/internal/cmds/verify/localverify_test.go
+++ b/internal/cmds/verify/localverify_test.go
@@ -47,7 +47,7 @@ func TestVerifyInProcess_KDSFetchBoundedByContext(t *testing.T) {
 	cancel()
 
 	start := time.Now()
-	_, err := verifyInProcess(ctx, bareSnpEvidence(t), &ratls.VerifyPolicy{}, nil)
+	_, err := verifyInProcess(ctx, bareSnpEvidence(t), &ratls.VerifyPolicy{}, nil, nil)
 	if elapsed := time.Since(start); elapsed > 5*time.Second {
 		t.Fatalf("expired ctx took %v, want prompt return", elapsed)
 	}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -28,6 +28,7 @@ import (
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/initdata"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
@@ -118,6 +119,7 @@ type config struct {
 	workload         string
 	allowlistFile    string
 	meshCA           string
+	initDataHex      string
 	allowDebug       bool
 	minTCBBootloader uint
 	minTCBTEE        uint
@@ -207,6 +209,7 @@ serving key is not attestation-bound, or a chain anchor the responder chose).`,
 	f.StringVar(&cfg.workload, "workload", "", "expected matched-workload name on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the stamp (docs/ratls.md)")
 	f.StringVar(&cfg.allowlistFile, "allowlist", "", "file holding the exact canonical allowlist bytes (as served by GET /allowlist); the leaf's stamped policy digest must equal SHA-256 of these bytes and the stamped name must resolve in the document. Requires --mesh-ca")
 	f.StringVar(&cfg.meshCA, "mesh-ca", "", "PEM bundle of the CDS mesh CA; when set, the target's leaf must chain to it, which is what authenticates the reported sandbox ID. On attest-pq it is also what upgrades the chain anchor from responder-chosen (partial verdict) to verified")
+	f.StringVar(&cfg.initDataHex, "init-data", "", "expected init-data digest: SHA-256 hex of the init-data document the target guest must carry. Verification fails unless the evidence commits exactly this digest")
 	f.BoolVar(&cfg.allowDebug, "allow-debug", false, "accept debug-enabled guests")
 	const tcbSNPOnly = " (SEV-SNP evidence only — TDX carries no such component, so against TDX evidence this is a policy error rather than an ignored flag)"
 	f.UintVar(&cfg.minTCBBootloader, "min-tcb-bootloader", 0, "minimum bootloader TCB component"+tcbSNPOnly)
@@ -353,7 +356,7 @@ func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evide
 		ctx, cancel = context.WithTimeout(ctx, cfg.timeout)
 		defer cancel()
 	}
-	result, verr := verifyInProcess(ctx, ev, plan.policy, minTCBFromCfg(cfg))
+	result, verr := verifyInProcess(ctx, ev, plan.policy, plan.initDataHash, minTCBFromCfg(cfg))
 	if isConnectError(verr) {
 		fmt.Fprintf(errOut, "error: could not fetch verification collateral: %v\n", verr)
 		return exitNoEvidence
@@ -362,6 +365,7 @@ func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evide
 	oc.OperatorKeys = opKeys.fingerprints
 	oc.OperatorKeysNote = opKeys.note
 	applyVerdictPolicies(&oc, cfg, ev, held, opKeys)
+	applyInitDataNote(&oc, result, plan)
 	render(cfg, oc, out)
 	return verdictExitCode(oc)
 }
@@ -421,6 +425,31 @@ func applyChainAnchorPolicy(oc *Outcome, cfg config, ev *evidence) {
 	demoteToPartial(oc, "the mesh chain anchor: the leaf chains to a CA the responder committed into its own attestation transcript — the evidence binds those CA bytes, but the anchor is responder-chosen, so which deployment this endpoint belongs to is not proven (pass --mesh-ca to pin it)")
 }
 
+// applyInitDataNote records what --init-data bound to, on the FINAL verdict:
+// it runs after applyVerdictPolicies (which can fail the verdict past
+// newOutcome) and skips a hard failure (oc.Error set) — the gate renderText
+// also applies. On az-* the pin binds vTPM PCR[8], not result.Claims.InitData
+// (the inner report's HOST_DATA), so a pinned az verdict reports the enforced
+// pin without presenting that field.
+func applyInitDataNote(oc *Outcome, result *teetypes.VerificationResult, plan *verifyPlan) {
+	if oc.Error != "" {
+		return
+	}
+	switch {
+	case oc.Platform == string(teetypes.PlatformAzSNP) || oc.Platform == string(teetypes.PlatformAzTDX):
+		if plan.initDataHash != nil {
+			oc.InitDataNote = "verified: pinned via vTPM PCR[8] (matches --init-data)"
+		}
+	case len(result.Claims.InitData) > 0:
+		oc.InitData = hex.EncodeToString(result.Claims.InitData)
+		if plan.initDataHash != nil {
+			oc.InitDataNote = "verified: matches --init-data"
+		} else {
+			oc.InitDataNote = "not pinned: the digest the evidence commits, compared against nothing (pass --init-data to pin it)"
+		}
+	}
+}
+
 // verifyPlan is one run's parsed, validated policy: the verifier policy, the
 // TDX register pins, and the --mesh-ca anchor. Everything file-backed is read
 // exactly ONCE, here, and threaded downstream — a pin resolved twice can be
@@ -432,6 +461,8 @@ type verifyPlan struct {
 	pins   rtmrPins
 	// meshCA is the parsed --mesh-ca bundle, nil when the flag is unset.
 	meshCA *x509.CertPool
+	// initDataHash is the parsed --init-data pin, nil when the flag is unset.
+	initDataHash []byte
 }
 
 // buildPolicy parses the measurement allowlist, resolves the register pins and
@@ -539,6 +570,11 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 		return nil, fmt.Errorf("--allowlist requires --mesh-ca: the stamped policy digest is vouched by CDS's signature on the leaf, not by the hardware evidence")
 	}
 
+	initDataHash, err := parseInitDataPin(cfg.initDataHex)
+	if err != nil {
+		return nil, err
+	}
+
 	return &verifyPlan{
 		// RTMRs is still set: it is what enforces the pin if this policy is
 		// ever verified through the delegated attestation-api path. It is not
@@ -548,9 +584,26 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 			RTMRs:        pins.manual,
 			AllowDebug:   cfg.allowDebug,
 		},
-		pins:   pins,
-		meshCA: caPool,
+		pins:         pins,
+		meshCA:       caPool,
+		initDataHash: initDataHash,
 	}, nil
+}
+
+// parseInitDataPin parses --init-data: the SHA-256 hex digest of the init-data
+// document the target guest must carry. Empty means unpinned.
+func parseInitDataPin(flag string) ([]byte, error) {
+	if flag == "" {
+		return nil, nil
+	}
+	digest, err := hex.DecodeString(strings.TrimSpace(flag))
+	if err != nil {
+		return nil, fmt.Errorf("--init-data is not hex: %v", err)
+	}
+	if len(digest) != initdata.DigestSize {
+		return nil, fmt.Errorf("--init-data is %d bytes, want %d (SHA-256 of the init-data document)", len(digest), initdata.DigestSize)
+	}
+	return digest, nil
 }
 
 // rtmrPins are every TDX register pin resolved from the flags: the image tuple
@@ -955,6 +1008,12 @@ type Outcome struct {
 	Pinned     bool   `json:"measurement_pinned"`
 	Error      string `json:"error,omitempty"`
 
+	// InitData is the init-data digest the verified evidence commits, and
+	// InitDataNote says what stands behind it: compared against --init-data,
+	// or reported unpinned.
+	InitData     string `json:"init_data,omitempty"`
+	InitDataNote string `json:"init_data_note,omitempty"`
+
 	// RTMRsPinned lists the TDX runtime measurement registers this verdict
 	// enforced, as "<index>:<hex>". On TDX the --measurements pin covers only
 	// MRTD (the TDVF firmware): without RTMR[1]/[2] the guest kernel and
@@ -1260,6 +1319,7 @@ func newOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, v
 		}
 		oc.Warnings = append(oc.Warnings, mrtdOnly)
 	}
+
 	return oc
 }
 
@@ -1493,6 +1553,14 @@ func renderText(cfg config, oc Outcome, out io.Writer) {
 	for _, p := range oc.RTMRsPinned {
 		idx, hexVal, _ := strings.Cut(p, ":")
 		fmt.Fprintf(out, "  RTMR[%s]:      %s (matched)\n", idx, hexVal)
+	}
+	if oc.InitDataNote != "" {
+		if oc.InitData != "" {
+			fmt.Fprintf(out, "  init-data:    %s\n", oc.InitData)
+			fmt.Fprintf(out, "                %s\n", oc.InitDataNote)
+		} else {
+			fmt.Fprintf(out, "  init-data:    %s\n", oc.InitDataNote)
+		}
 	}
 	fmt.Fprintf(out, "  TCB:          %s   debug=%t smt=%t\n", oc.CurrentTCB, oc.Debug, oc.SMT)
 	if oc.CertSHA256 != "" {

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -806,7 +806,7 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 	if ev.platform != "az-snp" {
 		t.Fatalf("platform = %q, want az-snp", ev.platform)
 	}
-	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil)
+	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil, nil)
 	if err != nil {
 		t.Fatalf("az-snp evidence with its bound nonce must verify: %v", err)
 	}
@@ -816,7 +816,7 @@ func TestVerifyRealAzSnpEvidence_UnpaddedAnchor(t *testing.T) {
 
 	// A different anchor fails closed, at the nonce gate specifically.
 	ev.erd = []byte("not-the-nonce")
-	if _, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil); err == nil || !strings.Contains(err.Error(), "nonce") {
+	if _, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil, nil); err == nil || !strings.Contains(err.Error(), "nonce") {
 		t.Fatalf("wrong nonce must fail closed at the nonce check, got: %v", err)
 	}
 }
@@ -840,7 +840,7 @@ func TestNewOutcomeFromRealGenoaEvidence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil)
+	res, err := verifyInProcess(context.Background(), ev, &ratls.VerifyPolicy{}, nil, nil)
 	if err != nil {
 		t.Fatalf("the real fixture must verify: %v", err)
 	}

--- a/internal/localverify/initdata_test.go
+++ b/internal/localverify/initdata_test.go
@@ -1,0 +1,92 @@
+package localverify
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+// The Genoa fixture's HOST_DATA is 32 zero bytes; the pin is the digest an
+// operator expects the guest's init-data document to hash to.
+var genoaHostData = make([]byte, 32)
+
+// A supplied init-data pin reaches the engine and the verdict confirms it:
+// the evidence's own HOST_DATA satisfies the pin, and InitDataMatch comes
+// back affirmatively true (enforceResult would refuse anything less).
+func TestVerify_InitDataPinMatchesEvidence(t *testing.T) {
+	platform, evidence := envelopeFixture(t, "snp-evidence-genoa.json")
+
+	res, err := Verify(context.Background(), platform, evidence, Params{ExpectedInitDataHash: genoaHostData})
+	if err != nil {
+		t.Fatalf("the evidence's own HOST_DATA must satisfy the pin: %v", err)
+	}
+	if res.InitDataMatch == nil || !*res.InitDataMatch {
+		t.Fatal("init_data_match must be affirmatively true when a pin was supplied and enforced")
+	}
+	if got := hex.EncodeToString(res.Claims.InitData); got != strings.Repeat("00", 32) {
+		t.Fatalf("claims.InitData = %q, want the fixture's zero HOST_DATA", got)
+	}
+}
+
+// The relying-party refusal the issue asks for: evidence whose init-data
+// digest differs from the pin is rejected by the verifier, not merely
+// reported. This is the engine's refusal — the SNP HOST_DATA and az-snp
+// PCR[8] bindings both fail closed, naming the field.
+func TestVerify_InitDataPinMismatchIsRefused(t *testing.T) {
+	mismatched := bytes.Repeat([]byte{0xab}, 32)
+
+	t.Run("snp HOST_DATA", func(t *testing.T) {
+		platform, evidence := envelopeFixture(t, "snp-evidence-genoa.json")
+		if _, err := Verify(context.Background(), platform, evidence, Params{ExpectedInitDataHash: mismatched}); err == nil {
+			t.Fatal("a HOST_DATA that differs from the pin must be refused")
+		} else if !strings.Contains(err.Error(), "HOST_DATA") {
+			t.Fatalf("the refusal must name the failing field, got: %v", err)
+		}
+	})
+
+	// The az-snp fixture's PCR[8] is zero — no init-data was extended into the
+	// vTPM — so any pin refuses at the PCR[8] binding.
+	t.Run("az-snp PCR[8]", func(t *testing.T) {
+		platform, evidence := envelopeFixture(t, "azsnp-evidence-v1.json")
+		if _, err := Verify(context.Background(), platform, evidence, Params{ExpectedInitDataHash: mismatched}); err == nil {
+			t.Fatal("a PCR[8] binding that differs from the pin must be refused")
+		} else if !strings.Contains(err.Error(), "PCR[8]") {
+			t.Fatalf("the refusal must name the failing field, got: %v", err)
+		}
+	})
+}
+
+// enforceResult is the fail-closed backstop: a pin the verdict does not
+// confirm must fail even when dispatch returned no error.
+func TestEnforceResult_InitDataPin(t *testing.T) {
+	pin := bytes.Repeat([]byte{0xab}, 32)
+	passing := func(match *bool) *teetypes.VerificationResult {
+		return &teetypes.VerificationResult{SignatureValid: true, InitDataMatch: match}
+	}
+
+	for _, tc := range []struct {
+		name    string
+		p       Params
+		res     *teetypes.VerificationResult
+		wantErr bool
+	}{
+		{"pin confirmed", Params{ExpectedInitDataHash: pin}, passing(teetypes.Ptr(true)), false},
+		{"pin unconfirmed", Params{ExpectedInitDataHash: pin}, passing(nil), true},
+		{"pin contradicted", Params{ExpectedInitDataHash: pin}, passing(teetypes.Ptr(false)), true},
+		{"no pin, no claim", Params{}, passing(nil), false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := enforceResult(tc.res, tc.p)
+			if tc.wantErr && err == nil {
+				t.Fatal("want a refusal")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("want a pass, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/localverify/localverify.go
+++ b/internal/localverify/localverify.go
@@ -50,6 +50,10 @@ type Params struct {
 	// Measurements pins the launch digest (SNP MEASUREMENT / TDX MR_TD).
 	// Empty = no pin; with a pin, a missing launch digest fails closed.
 	Measurements [][]byte
+	// ExpectedInitDataHash, when set, pins the init-data digest: the engine
+	// compares it against SNP HOST_DATA, TDX MRCONFIGID (zero-padded to 48),
+	// or the az vTPM PCR[8] binding, and a mismatch fails verification.
+	ExpectedInitDataHash []byte
 }
 
 // VerifyFunc is the signature of [Verify], taken as a parameter by consumers
@@ -68,14 +72,15 @@ func (e *CollateralError) Unwrap() error { return e.Err }
 var ErrMeasurementNotAllowed = errors.New("launch measurement not in the allowed set")
 
 // Verify verifies a self-describing evidence envelope and enforces p. The
-// chain, binding, debug, and min-TCB checks are attestation-go's verdict; the
-// measurement pin is enforced here on its claims. ctx bounds any AMD KDS
-// collateral fetch.
+// chain, binding, debug, min-TCB, and init-data checks are attestation-go's
+// verdict; the measurement pin is enforced here on its claims. ctx bounds any
+// AMD KDS collateral fetch.
 func Verify(ctx context.Context, platform string, evidence json.RawMessage, p Params) (*teetypes.VerificationResult, error) {
 	params := teetypes.VerifyParams{
-		ExpectedReportData: p.ExpectedReportData,
-		AllowDebug:         p.AllowDebug,
-		MinTCB:             p.MinTCB,
+		ExpectedReportData:   p.ExpectedReportData,
+		ExpectedInitDataHash: p.ExpectedInitDataHash,
+		AllowDebug:           p.AllowDebug,
+		MinTCB:               p.MinTCB,
 	}
 
 	res, err := dispatch(ctx, platform, evidence, params)
@@ -104,6 +109,9 @@ func enforceResult(res *teetypes.VerificationResult, p Params) error {
 	}
 	if p.ExpectedReportData != nil && (res.ReportDataMatch == nil || !*res.ReportDataMatch) {
 		return fmt.Errorf("REPORTDATA does not match the expected binding (report_data_match not true)")
+	}
+	if p.ExpectedInitDataHash != nil && (res.InitDataMatch == nil || !*res.InitDataMatch) {
+		return fmt.Errorf("init-data digest does not match the expected binding (init_data_match not true)")
 	}
 	if len(p.Measurements) > 0 {
 		mb, err := hex.DecodeString(res.Claims.LaunchDigest)

--- a/pkg/attestationclient/verify.go
+++ b/pkg/attestationclient/verify.go
@@ -76,6 +76,10 @@ func EnforceVerdict(req types.VerifyRequest, resp types.VerifyResponse) error {
 			return ErrReportDataMismatch
 		}
 	}
+	// The init-data pin is enforced on the in-process engine path
+	// (internal/localverify Params.ExpectedInitDataHash), not on this delegated
+	// one: wiring req.Params.ExpectedInitDataHash must add a matching
+	// InitDataMatch gate here — see #89.
 	return nil
 }
 

--- a/pkg/initdata/guard_test.go
+++ b/pkg/initdata/guard_test.go
@@ -1,0 +1,140 @@
+package initdata
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The init-data anchor holds only while every HOST_DATA read comes from a
+// verifier's claims: one call site parsing a raw report blob ahead of
+// verification is the #63 defect again. Pin it: no non-test file in this
+// module may call the raw report/quote parsers or their field getters.
+// (Test files are exempt — fixtures parse reports legitimately.)
+func TestNoRawReportFieldReads(t *testing.T) {
+	if hits := rawReportFieldReads(t, moduleRoot(t)); len(hits) > 0 {
+		t.Fatalf("report fields must be read from a verifier's claims, never parsed off a raw report:\n  %s",
+			strings.Join(hits, "\n  "))
+	}
+}
+
+// The guard must be able to fire: a poisoned tree is caught, at the right
+// line, for every banned accessor — SNP and TDX alike.
+func TestRawReportFieldReadsFires(t *testing.T) {
+	for _, tc := range []struct{ needle, call string }{
+		{"ReportToProto", "_, _ = abi.ReportToProto(report)"},
+		{"QuoteToProto", "_, _ = abi.QuoteToProto(quote)"},
+		{"GetHostData", "_ = report.GetHostData()"},
+		{"GetMrConfigId", "_ = body.GetMrConfigId()"},
+	} {
+		t.Run(tc.needle, func(t *testing.T) {
+			dir := t.TempDir()
+			src := "package x\n\nfunc f(report, quote, body any) {\n\t" + tc.call + "\n}\n"
+			if err := os.WriteFile(filepath.Join(dir, "x.go"), []byte(src), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			hits := rawReportFieldReads(t, dir)
+			if len(hits) != 1 || !strings.Contains(hits[0], "x.go:4") || !strings.Contains(hits[0], tc.needle) {
+				t.Fatalf("hits = %v, want the poisoned %s call at x.go:4", hits, tc.needle)
+			}
+		})
+	}
+}
+
+// Test files are exempt — fixtures parse reports legitimately and a production
+// build omits them — so a banned call in a _test.go is not a hit.
+func TestRawReportFieldReadsExemptsTestFiles(t *testing.T) {
+	dir := t.TempDir()
+	src := "package x\n\nfunc f(report any) {\n\t_ = report.GetHostData()\n}\n"
+	if err := os.WriteFile(filepath.Join(dir, "x_test.go"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if hits := rawReportFieldReads(t, dir); len(hits) != 0 {
+		t.Fatalf("test files must be exempt, got hits: %v", hits)
+	}
+}
+
+// rawReportFieldReads scans every non-test Go file under root for calls to
+// the raw report/quote parsers and field getters.
+func rawReportFieldReads(t *testing.T, root string) []string {
+	t.Helper()
+	banned := map[string]string{
+		"ReportToProto": "parses a raw SNP report blob",
+		"QuoteToProto":  "parses a raw TDX quote blob",
+		"GetHostData":   "reads SNP HOST_DATA off a parsed report",
+		"GetMrConfigId": "reads TDX MRCONFIGID off a parsed quote",
+	}
+
+	var hits []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "vendor" || d.Name() == "testdata" || strings.HasPrefix(d.Name(), ".") {
+				return filepath.SkipDir
+			}
+			// A nested module (its own go.mod, e.g. test/mock-*) is a separate
+			// build, not part of this module's guarded tree.
+			if path != root {
+				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if what, bad := banned[sel.Sel.Name]; bad {
+				r, rerr := filepath.Rel(root, path)
+				if rerr != nil {
+					r = path
+				}
+				hits = append(hits, r+":"+strconv.Itoa(fset.Position(sel.Pos()).Line)+" "+sel.Sel.Name+" ("+what+")")
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return hits
+}
+
+// moduleRoot walks up from the package dir to the go.mod root, so the guard
+// covers the whole module wherever the test binary runs from.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		up := filepath.Dir(dir)
+		if up == dir {
+			t.Fatal("no go.mod found above the package dir")
+		}
+		dir = up
+	}
+}


### PR DESCRIPTION
# Pin the guest init-data digest at the relying party

Closes the remaining half of confidential-dot-ai/c8s-workspace#63's acceptance criteria (tracked as confidential-dot-ai/c8s-workspace#103).

## What

`c8s verify` (and the `c8s cds verify` shorthand) gains **`--init-data <sha256-hex>`**: the digest of the init-data document the target guest must carry. The kata shim commits `sha256(document)` into SNP `HOST_DATA` at launch (zero-padded into TDX `MRCONFIGID`); with the flag set, verification **fails** unless the evidence commits exactly that digest.

```bash
c8s verify https://workload.example.com:8443 --measurements <sha384-hex> --init-data <sha256-hex>
```

The verdict now also surfaces the committed init-data digest with an explicit note about what stands behind it:

- pinned and matching (SNP/TDX): `init_data` + `init_data_note: "verified: matches --init-data"`
- pinned and matching (az-snp/az-tdx): `init_data_note: "verified: pinned via vTPM PCR[8]"` — the pin binds PCR[8], so the note confirms the enforced pin without presenting the inner `HOST_DATA` as the pinned field
- unpinned: `init_data` + `init_data_note: "not pinned: ... compared against nothing (pass --init-data to pin it)"` — an unpinned digest never reads as verified (#76 honesty rule)
- mismatch: failed verdict, exit 2, naming `HOST_DATA` — not a partial verdict, never a pass

The note rides only a verdict that survives every check. If the pin matches but another check fails — a measurement inside the verifier, or a post-verification policy like `--mesh-ca` / `--sandbox-id` / `--operator-keys` — the verdict is NOT VERIFIED and carries no init-data line in text or JSON, so the two output surfaces never disagree. A **partial** verdict (the pin verified, an unrelated property such as a WebPKI front door unproven) does show the note: it was earned.

## Why

`ExpectedInitDataHash` / `InitDataMatch` were declared in the verify types and set by nothing: a guest proved only that *some* correctly-signed report carries a `HOST_DATA` matching the document on its disk — the anchor was self-referential. With the pin, the value an operator cares about (which CDS measurements the guest trusts, and soon the role/seed/operator-key bindings of #59/#62) is anchored outside the host's reach: the host still chooses the document, but it cannot choose one and commit another, and now the relying party decides which commitment is acceptable.

**Who pins — the design choice.** The operator running `c8s verify` is today the only relying party with a channel the host cannot rewrite — the same out-of-band path `--measurements` already rides. The document renders deterministically from the pod's role and CDS measurement set (`pkg/initdata`), so the digest comes from the same deployment pipeline that chose those measurements; rotate the pin alongside them. The in-cluster alternative — CDS pinning what nodes report — needs a trust-relevant value delivered over a channel the adversarial control plane cannot rewrite, the same problem #89 tracks for the verifier endpoint; it stays out of scope and should be solved once for both. The delegated attestation-api path (`pkg/types.VerifyParams.ExpectedInitDataHash`) is deliberately left unwired: its only init-data caller is policymonitor's self-check, where a pin would be the guest's own value on both sides of the comparison.

**How it's enforced.** The verification engine (attestation-go, the Go port of the cluster's attestation-rs) already checks `ExpectedInitDataHash` per platform — SNP `HOST_DATA`, TDX `MRCONFIGID` (zero-padded to 48), az vTPM PCR[8] — with a hard refusal on mismatch, constant-time. This PR plumbs the pin to it (`localverify.Params.ExpectedInitDataHash`) and adds a fail-closed re-check: a passing verdict must affirmatively confirm `init_data_match`, so a pin can never be accepted by the CLI and enforced by nobody. On the az-* platforms the pin binds vTPM PCR[8] rather than the reported `HOST_DATA` field, so a pinned verdict reports the PCR[8] pin without rendering that inner field as init-data.

Also included: the guard #63 called out as the cheapest open item. A test walks the module's non-test Go files and fails on any reference to the raw report/quote parsers (`ReportToProto`, `QuoteToProto`) or their field getters (`GetHostData`, `GetMrConfigId`) — no call site may parse report fields ahead of verification, and the next caller to reach for a raw report blob is caught. A companion test proves the guard fires.

## Scope

This PR delivers the enforcement mechanism and the operator-CLI relying party. Deliberately out of scope, tracked separately:

- **AC4 (allowlist floor-growth)** — "allowlist entries merged from an unverified source can no longer grow the floor permanently" is a distinct property from the init-data pin; tracked as confidential-dot-ai/c8s-workspace#114.
- **In-cluster / CDS-side pinning** — needs a trust-relevant value delivered over a channel the adversarial control plane cannot rewrite (#89, "solve the channel once"). The delegated attestation-api path (`pkg/types.VerifyParams.ExpectedInitDataHash`) stays unwired until such a caller exists; `EnforceVerdict` carries a breadcrumb that wiring it must add the matching `InitDataMatch` gate.
- **Digest-derivation tooling** — no `c8s` subcommand computes `sha256(rendered document)`; the operator pipeline that selects measurements already renders the document via `pkg/initdata` and computes the digest.

## Test plan

- `internal/localverify`: real fixture evidence through the engine — pin matching the fixture's `HOST_DATA` verifies with `init_data_match` affirmatively true; a mismatched pin is refused (SNP `HOST_DATA` and az-snp PCR[8] paths); `enforceResult` fails closed when a verdict doesn't confirm a supplied pin.
- `internal/cmds/verify`: flag parsing (valid / wrong length / odd-length / non-hex / uppercase-accepted / unset); full-path exit codes on the offline Genoa fixture — match → exit 0 with the verified note in text and JSON, mismatch → exit 2 naming `HOST_DATA` (never partial, never "✓"), unpinned → exit 0 with the "not pinned" note in text and JSON; a failed-verdict regression across a check inside the verifier (`--measurements`) and two post-verification policies (`--mesh-ca`, `--operator-keys`), asserting neither renderer shows an init-data line on `verified:false`, plus a partial verdict that still shows the earned note in both surfaces; the az-* display gate renders the PCR[8] pin, never the inner `HOST_DATA`.
- `pkg/initdata`: the no-raw-report-field-reads guard, a self-test that it fires on each of the four banned accessors, and that `_test.go` files are exempt; the walk skips nested modules and `testdata`.
- `go build ./...`, `make lint`, and `go test -race ./...` for the touched packages and repo-wide `pkg/...` + `internal/...` all pass (Go 1.26, no TEE hardware — engine enforcement is exercised on the vendored SNP/az-SNP fixtures; the TDX `MRCONFIGID` path is engine-covered, not exercised end-to-end here).

## Threat-model notes

- The pin value is operator-supplied config, validated for shape (exactly 32 bytes hex) before any evidence is gathered; it never travels through the host.
- Enforcement happens inside the verification engine after signature validation; a mismatch is a security verdict (exit 2), classified with the same taxonomy #76 established — evidence obtained and rejected, never a connect error, never partial.
- The guest-side self-check (#63) is unchanged: policymonitor still compares the verified `HOST_DATA` claim against the document on its disk. This PR adds the external anchor; it does not move the self-check.
- Rotation is operator-driven (pin changes when the CDS measurement set changes); no in-band update channel exists, by design — that is the #89 problem.
