### PR TITLE
test(integration): make the TLS-LB harness able to fail and gate PRs on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ on:
       - "Makefile"
       - ".golangci.yml"
       - "internal/helmchart/c8s/**"
+      # The integration harness (test/integration) and its mocks
+      # (test/mock-*) gate PRs via the Integration job below.
+      - "test/**"
       - "scripts/coverage-gate.sh"
       - "scripts/mutation-check.sh"
       - ".gremlins.yaml"
@@ -183,6 +186,18 @@ jobs:
             while read -r id; do
               gh api -X DELETE "repos/$REPO/actions/caches/$id" || true
             done
+
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-go-c8s
+
+      - name: Run the integration harness
+        run: make test-integration
 
   tdx-measure:
     name: TDX MRTD tripwire

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ Thumbs.db
 *.test
 *.out
 coverage.txt
+# Mock binaries from `go build .` in the test/mock-* modules.
+/test/mock-attestation/mock-attestation
+/test/mock-cds/mock-cds
 
 # Secrets
 *.pem

--- a/go.work
+++ b/go.work
@@ -1,3 +1,7 @@
 go 1.26.3
 
-use .
+use (
+	.
+	./test/mock-attestation
+	./test/mock-cds
+)

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,15 +1,18 @@
 services:
   mock-attestation:
     build:
-      context: ../mock-attestation
+      context: ../..
+      dockerfile: test/mock-attestation/Dockerfile
     environment:
       PORT: "8400"
 
   mock-cds:
     build:
-      context: ../mock-cds
+      context: ../..
+      dockerfile: test/mock-cds/Dockerfile
     environment:
       PORT: "8080"
+      ATTESTATION_API_URL: "http://mock-attestation:8400"
     depends_on:
       - mock-attestation
 
@@ -25,8 +28,10 @@ services:
       context: ../..
       dockerfile: cmd/get-cert/Dockerfile
     command:
-      - --cds-url=http://mock-cds:8080
+      - --cds-url=https://mock-cds:8080
       - --attestation-api-url=http://mock-attestation:8400
+      # The mock attestation-api's launch digest is all-zero; get-cert must pin it.
+      - --cds-measurements=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
       - --san=nginx-lb
       - --out=/tls/cert.pem
       - --key-out=/tls/key.pem

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,85 +1,105 @@
 #!/usr/bin/env bash
 # Integration test for the TLS load balancer.
-# Starts mock services, runs get-cert as an init container, and verifies
-# nginx can serve HTTPS with the obtained certificate.
+# Starts the mock attestation-api and mock CDS, runs get-cert as an init
+# container through the real RA-TLS attestation flow, and verifies nginx
+# serves HTTPS with the issued certificate, chained to the mock CDS CA.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 cd "$SCRIPT_DIR"
+
+WORKDIR="$(mktemp -d)"
+COMPOSE_CMD="docker compose"
 
 cleanup() {
     echo "--- Cleaning up ---"
-    if [ -n "${COMPOSE_CMD:-}" ]; then
-        $COMPOSE_CMD down -v --remove-orphans 2>/dev/null || true
-    fi
+    $COMPOSE_CMD down -v --remove-orphans 2>/dev/null || true
+    rm -rf "$WORKDIR"
 }
 trap cleanup EXIT
 
-COMPOSE_CMD=""
-if docker compose version >/dev/null 2>&1; then
-    COMPOSE_CMD="docker compose"
-elif command -v docker-compose >/dev/null 2>&1; then
-    COMPOSE_CMD="docker-compose"
-else
-    echo "SKIP: docker compose not available"
-    exit 0
-fi
+fail() {
+    echo "FAIL: $*" >&2
+    $COMPOSE_CMD logs 2>&1 || true
+    exit 1
+}
+
+# Hard prerequisites: a missing tool fails the run.
+for tool in docker make openssl curl; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: $tool not available" >&2; exit 1; }
+done
+docker compose version >/dev/null 2>&1 || { echo "FAIL: docker compose (v2) not available" >&2; exit 1; }
+
+echo "=== Building get-cert binary ==="
+make -C "$REPO_ROOT" build-c8s
 
 echo "=== Building and starting services ==="
-$COMPOSE_CMD build
-$COMPOSE_CMD up -d
+# Clean slate: a reused tls-certs volume pairs a stale leaf with a fresh CA.
+$COMPOSE_CMD down -v --remove-orphans 2>/dev/null || true
+$COMPOSE_CMD build || fail "image build failed"
+$COMPOSE_CMD up -d || fail "services did not start"
+
+# The chain anchor, fetched out-of-band from the mock CDS container.
+$COMPOSE_CMD cp mock-cds:/ca/mock-cds-ca.pem "$WORKDIR/mock-cds-ca.pem" || fail "could not fetch the mock CDS CA"
+CACERT="$WORKDIR/mock-cds-ca.pem"
+
+# Verified HTTPS access to the LB: the chain is checked against the mock CDS
+# CA and the hostname against the leaf SAN.
+LB="https://nginx-lb:8443"
+CURL=(curl -sS --cacert "$CACERT" --resolve nginx-lb:8443:127.0.0.1)
 
 echo ""
 echo "=== Verifying TLS endpoint ==="
 
 # Wait for nginx to be ready (it depends on get-cert completing).
-for i in $(seq 1 30); do
-    if curl -sk https://localhost:8443/healthz >/dev/null 2>&1; then
+ready=0
+for _ in $(seq 1 30); do
+    if "${CURL[@]}" "$LB/healthz" >/dev/null 2>&1; then
+        ready=1
         break
-    fi
-    if [ "$i" -eq 30 ]; then
-        echo "FAIL: nginx did not become ready in time"
-        docker compose logs
-        exit 1
     fi
     sleep 1
 done
+[ "$ready" -eq 1 ] || fail "nginx did not become ready in time"
 
-# Test 1: Health endpoint works over TLS.
-HEALTH_RESPONSE=$(curl -sk https://localhost:8443/healthz)
-if [ "$HEALTH_RESPONSE" != "ok" ]; then
-    echo "FAIL: expected 'ok' from /healthz, got: $HEALTH_RESPONSE"
-    exit 1
-fi
-echo "PASS: /healthz returns ok"
+CHECKS=0
+
+# Test 1: Health endpoint works over verified TLS.
+HEALTH_RESPONSE=$("${CURL[@]}" "$LB/healthz") || fail "healthz request failed"
+[ "$HEALTH_RESPONSE" = "ok" ] || fail "expected 'ok' from /healthz, got: $HEALTH_RESPONSE"
+CHECKS=$((CHECKS + 1))
+echo "PASS: /healthz returns ok over a verified chain"
 
 # Test 2: Proxied backend content is served.
-BODY=$(curl -sk https://localhost:8443/)
-if ! echo "$BODY" | grep -q "Welcome to nginx"; then
-    echo "FAIL: expected nginx welcome page from proxy, got: $BODY"
-    exit 1
-fi
+BODY=$("${CURL[@]}" "$LB/") || fail "proxy request failed"
+echo "$BODY" | grep -q "Welcome to nginx" || fail "expected nginx welcome page from proxy, got: $BODY"
+CHECKS=$((CHECKS + 1))
 echo "PASS: reverse proxy serves backend content"
 
-# Test 3: Certificate has the expected SAN.
-SAN_INFO=$(echo | openssl s_client -connect localhost:8443 -servername nginx-lb 2>/dev/null | openssl x509 -noout -ext subjectAltName 2>/dev/null || true)
-if echo "$SAN_INFO" | grep -q "DNS:nginx-lb"; then
-    echo "PASS: certificate contains SAN DNS:nginx-lb"
-elif echo "$SAN_INFO" | grep -qi "nginx-lb"; then
-    echo "PASS: certificate references nginx-lb"
-else
-    echo "WARN: could not verify SAN in certificate (openssl may not be available)"
-    echo "  SAN info: $SAN_INFO"
-fi
+# The leaf nginx serves, for the certificate checks.
+LEAF="$WORKDIR/leaf.pem"
+echo | openssl s_client -connect 127.0.0.1:8443 -servername nginx-lb 2>/dev/null | openssl x509 >"$LEAF" 2>/dev/null || true
+[ -s "$LEAF" ] || fail "could not read the served certificate"
 
-# Test 4: Certificate is signed by an EC key (P-256).
-KEY_INFO=$(echo | openssl s_client -connect localhost:8443 -servername nginx-lb 2>/dev/null | openssl x509 -noout -text 2>/dev/null | grep "Public Key Algorithm" || true)
-if echo "$KEY_INFO" | grep -q "id-ecPublicKey"; then
-    echo "PASS: certificate uses ECDSA key"
-else
-    echo "WARN: could not verify key algorithm"
-    echo "  Key info: $KEY_INFO"
-fi
+# Test 3: Certificate chains to the mock CDS CA.
+openssl verify -CAfile "$CACERT" "$LEAF" >/dev/null || fail "served certificate does not chain to the mock CDS CA"
+CHECKS=$((CHECKS + 1))
+echo "PASS: certificate chains to the mock CDS CA"
+
+# Test 4: Certificate has the expected SAN.
+SAN_INFO=$(openssl x509 -in "$LEAF" -noout -ext subjectAltName 2>/dev/null) || fail "served certificate carries no SAN extension"
+echo "$SAN_INFO" | grep -qE 'DNS:nginx-lb(,|$)' || fail "certificate lacks SAN DNS:nginx-lb: $SAN_INFO"
+CHECKS=$((CHECKS + 1))
+echo "PASS: certificate contains SAN DNS:nginx-lb"
+
+# Test 5: Certificate carries an ECDSA P-256 key.
+KEY_INFO=$(openssl x509 -in "$LEAF" -noout -text 2>/dev/null) || fail "could not read the served certificate"
+echo "$KEY_INFO" | grep -q "Public Key Algorithm: id-ecPublicKey" || fail "certificate is not an ECDSA certificate"
+echo "$KEY_INFO" | grep -q "prime256v1" || fail "certificate key is not P-256"
+CHECKS=$((CHECKS + 1))
+echo "PASS: certificate uses an ECDSA P-256 key"
 
 echo ""
-echo "=== All integration tests passed ==="
+[ "$CHECKS" -eq 5 ] || fail "expected 5 checks, ran $CHECKS"
+echo "=== All $CHECKS integration checks passed ==="

--- a/test/mock-attestation/Dockerfile
+++ b/test/mock-attestation/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1.26 AS builder
 
 WORKDIR /src
-COPY go.mod .
-COPY main.go .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /mock-attestation .
+# Repo-root build context (the module replaces c8s => ../..); #13's .dockerignore must keep these paths.
+COPY go.mod go.sum ./
+COPY pkg/ ./pkg/
+COPY test/mock-attestation/ ./test/mock-attestation/
+RUN CGO_ENABLED=0 go build -C test/mock-attestation -ldflags="-s -w" -o /mock-attestation .
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /mock-attestation /mock-attestation

--- a/test/mock-attestation/go.mod
+++ b/test/mock-attestation/go.mod
@@ -1,3 +1,7 @@
-module mock-attestation
+module github.com/confidential-dot-ai/c8s/test/mock-attestation
 
-go 1.26
+go 1.26.3
+
+require github.com/confidential-dot-ai/c8s v0.0.0
+
+replace github.com/confidential-dot-ai/c8s => ../..

--- a/test/mock-attestation/main.go
+++ b/test/mock-attestation/main.go
@@ -1,14 +1,34 @@
-// mock-attestation is a fake attestation-api for integration testing.
-// It responds to /attest with synthetic evidence and to /health with OK.
-// It does NOT perform real TEE attestation — use only in test environments.
+// mock-attestation is a fake attestation-api for integration testing: the
+// networked counterpart of internal/testattest. /attest answers synthetic
+// SEV-SNP reports binding the requested REPORTDATA; /verify checks that
+// binding and refuses mismatches with the real api's 422 verification_failed
+// shape. Speaks the production wire types (pkg/types). No real TEE — use
+// only in test environments.
 package main
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// SNP report layout (AMD SEV-SNP ABI): the fields the synthetic report
+// carries. The measurement is all zero — the mock's launch identity, which
+// the compose file pins as get-cert's --cds-measurements allowlist.
+const (
+	snpReportSize     = 1184
+	reportDataOffset  = 0x50
+	reportDataSize    = 64
+	measurementOffset = 0x90
+	measurementSize   = 48
 )
 
 func main() {
@@ -19,6 +39,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /attest", handleAttest)
+	mux.HandleFunc("POST /verify", handleVerify)
 	mux.HandleFunc("GET /health", handleHealth)
 
 	slog.Info("mock attestation-api starting", "port", port)
@@ -29,31 +50,117 @@ func main() {
 }
 
 func handleAttest(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		ReportData string `json:"report_data"`
-		Platform   string `json:"platform"`
-	}
+	var req types.AttestRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, fmt.Sprintf(`{"error":"bad_request","message":"%s"}`, err), http.StatusBadRequest)
+		writeDecodeError(w, err)
 		return
 	}
 
-	slog.Info("mock attest called", "platform", req.Platform)
+	platform := req.Platform
+	if platform == "" || platform == types.PlatformAuto {
+		platform = types.PlatformSnp
+	}
+	slog.Info("mock attest called", "platform", platform)
 
-	// Return synthetic evidence that the CDS mock/test mode can accept.
-	resp := map[string]any{
-		"platform": "mock",
-		"evidence": map[string]any{
-			"report_data":  req.ReportData,
-			"mock_payload": "integration-test",
-		},
+	report := make([]byte, snpReportSize)
+	report[0] = 0x02    // report version 2
+	report[0x0A] = 0x03 // SMT-allowed policy
+	copy(report[reportDataOffset:reportDataOffset+reportDataSize], req.ReportData.Bytes())
+
+	evidence, _ := json.Marshal(map[string]string{
+		"attestation_report": base64.StdEncoding.EncodeToString(report),
+	})
+	writeJSON(w, types.AttestResponse{Platform: string(platform), Evidence: evidence})
+}
+
+func handleVerify(w http.ResponseWriter, r *http.Request) {
+	var req types.VerifyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeDecodeError(w, err)
+		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+	report, err := extractSNPReport(req.Evidence)
+	if err != nil {
+		writeError(w, http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, err.Error())
+		return
+	}
+
+	// The evidence carries no real signature chain; the only verdict the mock
+	// can meaningfully enforce is the REPORTDATA binding, requested via
+	// params.expected_report_data. No expectation is the api's no-check shape
+	// (report_data_match: null).
+	var match *bool
+	if req.Params != nil && req.Params.ExpectedReportData != nil {
+		expected := make([]byte, reportDataSize)
+		copy(expected, req.Params.ExpectedReportData.Bytes())
+		m := string(report[reportDataOffset:reportDataOffset+reportDataSize]) == string(expected)
+		if !m {
+			writeError(w, http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "REPORTDATA does not match expected value")
+			return
+		}
+		match = &m
+	}
+
+	writeJSON(w, types.VerifyResponse{
+		Result: types.VerificationResult{
+			Platform:        req.Platform,
+			SignatureValid:  true,
+			ReportDataMatch: match,
+			Claims: types.Claims{
+				LaunchDigest: hex.EncodeToString(report[measurementOffset : measurementOffset+measurementSize]),
+			},
+		},
+	})
+}
+
+// extractSNPReport pulls the raw report out of an SNP evidence envelope and
+// checks it is the shape the mock issues.
+func extractSNPReport(evidence json.RawMessage) ([]byte, error) {
+	var envelope struct {
+		AttestationReport string `json:"attestation_report"`
+	}
+	if err := json.Unmarshal(evidence, &envelope); err != nil {
+		return nil, fmt.Errorf("evidence is not an SNP envelope: %s", err)
+	}
+	report, err := base64.StdEncoding.DecodeString(envelope.AttestationReport)
+	if err != nil {
+		return nil, fmt.Errorf("attestation_report is not valid base64: %s", err)
+	}
+	if len(report) != snpReportSize || report[0] != 0x02 {
+		return nil, fmt.Errorf("not a version-2 SNP report (%d bytes)", len(report))
+	}
+	return report, nil
 }
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
+	platform := string(types.PlatformSnp)
+	writeJSON(w, types.HealthResponse{Status: "ok", Platform: &platform})
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprint(w, `{"status":"ok","platform":"mock"}`)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: code, Message: message})
+}
+
+// writeDecodeError mirrors the attestation-api's axum Json rejection: 400 for a
+// body that is not valid JSON, 422 for one that does not fit the target type,
+// both text/plain with no error code.
+func writeDecodeError(w http.ResponseWriter, err error) {
+	status := http.StatusBadRequest
+	msg := "Failed to parse the request body as JSON: " + err.Error()
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		status = http.StatusUnprocessableEntity
+		msg = "Failed to deserialize the JSON body into the target type: " + err.Error()
+	}
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, msg)
 }

--- a/test/mock-attestation/main_test.go
+++ b/test/mock-attestation/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// TestWriteDecodeErrorShapes mirrors internal/testattest.TestStubRejectsUndecodableBody:
+// axum splits the rejection 400 for a body that is not valid JSON, 422 for one
+// that does not fit the request type; both text/plain with no error code, so
+// callers see UnexpectedError, not APIError. Wired into /attest and /verify.
+func TestWriteDecodeErrorShapes(t *testing.T) {
+	for _, ep := range []struct {
+		path    string
+		handler http.HandlerFunc
+	}{
+		{"/attest", handleAttest},
+		{"/verify", handleVerify},
+	} {
+		for _, tc := range []struct {
+			name       string
+			body       string
+			wantStatus int
+			wantPrefix string
+		}{
+			{"not valid JSON", `not json`, http.StatusBadRequest, "Failed to parse the request body as JSON"},
+			{"wrong field type", `{"platform": 123}`, http.StatusUnprocessableEntity, "Failed to deserialize the JSON body into the target type"},
+		} {
+			t.Run(ep.path+" "+tc.name, func(t *testing.T) {
+				rec := httptest.NewRecorder()
+				ep.handler(rec, httptest.NewRequest(http.MethodPost, ep.path, strings.NewReader(tc.body)))
+
+				res := rec.Result()
+				body, _ := io.ReadAll(res.Body)
+				if res.StatusCode != tc.wantStatus {
+					t.Fatalf("status = %d, want %d (body %q)", res.StatusCode, tc.wantStatus, body)
+				}
+				if ct := res.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+					t.Fatalf("content-type = %q, want text/plain", ct)
+				}
+				if !strings.HasPrefix(string(body), tc.wantPrefix) {
+					t.Fatalf("body = %q, want prefix %q", body, tc.wantPrefix)
+				}
+				var er types.ErrorResponse
+				if json.Unmarshal(body, &er) == nil && er.Error != "" {
+					t.Fatalf("decode error carried code %q, want none", er.Error)
+				}
+			})
+		}
+	}
+}
+
+// TestVerifyRefusesMismatchAndGarbage pins the /verify refusal: a report-data
+// mismatch or unparseable evidence is a 422 verification_failed JSON envelope —
+// the real api's shape mock-cds classifies (never a 200+false verdict).
+func TestVerifyRefusesMismatchAndGarbage(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		evidence json.RawMessage
+		expected []byte
+	}{
+		{
+			name:     "report data mismatch",
+			evidence: snpEvidence(t, bytes.Repeat([]byte{0xAA}, reportDataSize)),
+			expected: bytes.Repeat([]byte{0xBB}, reportDataSize),
+		},
+		{
+			name:     "garbage evidence",
+			evidence: json.RawMessage(`{"attestation_report":"AAAA"}`),
+			expected: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := types.VerifyRequest{Platform: string(types.PlatformSnp), Evidence: tc.evidence}
+			if tc.expected != nil {
+				rd := types.NewBase64Bytes(tc.expected)
+				req.Params = &types.VerifyParams{ExpectedReportData: &rd}
+			}
+			body, err := json.Marshal(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := httptest.NewRecorder()
+			handleVerify(rec, httptest.NewRequest(http.MethodPost, "/verify", bytes.NewReader(body)))
+
+			res := rec.Result()
+			raw, _ := io.ReadAll(res.Body)
+			if res.StatusCode != http.StatusUnprocessableEntity {
+				t.Fatalf("status = %d, want 422 (body %q)", res.StatusCode, raw)
+			}
+			if ct := res.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+				t.Fatalf("content-type = %q, want application/json", ct)
+			}
+			var er types.ErrorResponse
+			if err := json.Unmarshal(raw, &er); err != nil {
+				t.Fatalf("body %q is not an error envelope: %v", raw, err)
+			}
+			if er.Error != types.ErrorCodeVerificationFailed {
+				t.Fatalf("error = %q, want %q", er.Error, types.ErrorCodeVerificationFailed)
+			}
+		})
+	}
+}
+
+// snpEvidence builds an SNP evidence envelope carrying a version-2 report with
+// the given REPORTDATA, the shape the mock's /attest issues.
+func snpEvidence(t *testing.T, reportData []byte) json.RawMessage {
+	t.Helper()
+	report := make([]byte, snpReportSize)
+	report[0] = 0x02
+	copy(report[reportDataOffset:reportDataOffset+reportDataSize], reportData)
+	env, err := json.Marshal(map[string]string{
+		"attestation_report": base64.StdEncoding.EncodeToString(report),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return env
+}

--- a/test/mock-cds/Dockerfile
+++ b/test/mock-cds/Dockerfile
@@ -1,9 +1,11 @@
 FROM golang:1.26 AS builder
 
 WORKDIR /src
-COPY go.mod .
-COPY main.go .
-RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /mock-cds .
+# Repo-root build context (the module replaces c8s => ../..); #13's .dockerignore must keep these paths.
+COPY go.mod go.sum ./
+COPY pkg/ ./pkg/
+COPY test/mock-cds/ ./test/mock-cds/
+RUN CGO_ENABLED=0 go build -C test/mock-cds -ldflags="-s -w" -o /mock-cds .
 
 FROM gcr.io/distroless/static-debian12
 COPY --from=builder /mock-cds /mock-cds

--- a/test/mock-cds/go.mod
+++ b/test/mock-cds/go.mod
@@ -1,3 +1,7 @@
-module mock-cds
+module github.com/confidential-dot-ai/c8s/test/mock-cds
 
-go 1.26
+go 1.26.3
+
+require github.com/confidential-dot-ai/c8s v0.0.0
+
+replace github.com/confidential-dot-ai/c8s => ../..

--- a/test/mock-cds/main.go
+++ b/test/mock-cds/main.go
@@ -1,31 +1,49 @@
-// mock-cds is a fake CDS attestation+signing service for integration testing.
-// It implements /authenticate and /attest endpoints but skips real TEE verification.
-// On /attest it signs the provided CSR with an ephemeral CA, returning a valid certificate.
-// Use only in test environments.
+// mock-cds is a fake CDS for integration testing: it serves the production
+// wire contract (RA-TLS, /authenticate, /attest — internal/cmds/cds) backed
+// by the mock attestation-api instead of a TEE, and signs CSRs with an
+// ephemeral CA. Use only in test environments.
 package main
 
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha512"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
+
+// caOutPath is where the ephemeral CA PEM lands so the harness can anchor
+// chain verification out-of-band (docker compose cp).
+const caOutPath = "/ca/mock-cds-ca.pem"
+
+// mockLaunchDigest is the launch measurement the mock attestation-api
+// reports. Issuance is pinned to it the way production gates /attest on
+// --measurements.
+const mockLaunchDigest = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
 
 var (
 	caKey  ecdsa.PrivateKey
 	caCert x509.Certificate
-	caDER  []byte
+	caPEM  []byte
 )
 
 func init() {
@@ -50,7 +68,7 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("failed to create CA cert: %v", err))
 	}
-	caDER = der
+	caPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 
 	parsed, err := x509.ParseCertificate(der)
 	if err != nil {
@@ -96,17 +114,31 @@ func main() {
 	if port == "" {
 		port = "8080"
 	}
+	attestationAPIURL := os.Getenv("ATTESTATION_API_URL")
+	if attestationAPIURL == "" {
+		slog.Error("ATTESTATION_API_URL is required")
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(caOutPath), 0o755); err != nil {
+		slog.Error("failed to create CA output directory", "error", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(caOutPath, caPEM, 0o644); err != nil {
+		slog.Error("failed to write CA PEM", "error", err)
+		os.Exit(1)
+	}
 
 	store := newChallengeStore()
+	verifier := attestationclient.NewClient(attestationAPIURL)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /authenticate", func(w http.ResponseWriter, r *http.Request) {
 		challenge := store.issue()
 		slog.Info("issued challenge")
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"challenge": challenge})
+		writeJSON(w, types.ChallengeResponse{Challenge: challenge})
 	})
-	mux.HandleFunc("POST /attest", handleAttest(&store))
+	mux.HandleFunc("POST /attest", handleAttest(&store, verifier))
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -114,47 +146,88 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	slog.Info("mock cds starting", "port", port)
-	if err := http.ListenAndServe(":"+port, mux); err != nil {
+	// Serve RA-TLS like production CDS: the attestation-api supplies the
+	// evidence binding the serving key, and callers verify the handshake
+	// against the same api.
+	tlsCfg, _, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+		Platform:   "sev-snp",
+		AttestFunc: attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), attestationAPIURL),
+		Logger:     slog.Default(),
+	})
+	if err != nil {
+		slog.Error("ratls server config failed", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("mock cds starting (RA-TLS)", "port", port)
+	srv := &http.Server{Addr: ":" + port, Handler: mux, TLSConfig: tlsCfg}
+	if err := srv.ListenAndServeTLS("", ""); err != nil {
 		slog.Error("server failed", "error", err)
 		os.Exit(1)
 	}
 }
 
-func handleAttest(store *challengeStore) http.HandlerFunc {
+func handleAttest(store *challengeStore, verifier attestationclient.Client) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req struct {
-			Challenge string          `json:"challenge"`
-			Evidence  json.RawMessage `json:"evidence"`
-			CSR       string          `json:"csr"`
-		}
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, fmt.Sprintf("bad request: %s", err), http.StatusBadRequest)
+		var req types.AttestRequestBody
+		dec := json.NewDecoder(r.Body)
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&req); err != nil {
+			writeError(w, http.StatusUnprocessableEntity, types.ErrorCodeInvalidRequest, err.Error())
 			return
 		}
 
-		if !store.consume(req.Challenge) {
-			http.Error(w, "invalid or expired challenge", http.StatusUnauthorized)
+		challengeBytes, err := base64.StdEncoding.DecodeString(req.Challenge)
+		if err != nil || !store.consume(req.Challenge) {
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidChallenge, "invalid or expired challenge")
 			return
 		}
 
 		// Parse the CSR.
 		block, _ := pem.Decode([]byte(req.CSR))
 		if block == nil {
-			http.Error(w, "invalid CSR: no PEM block", http.StatusBadRequest)
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidCSR, "invalid CSR: no PEM block")
 			return
 		}
 		csr, err := x509.ParseCertificateRequest(block.Bytes)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("invalid CSR: %s", err), http.StatusBadRequest)
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidCSR, fmt.Sprintf("invalid CSR: %s", err))
 			return
 		}
 		if err := csr.CheckSignature(); err != nil {
-			http.Error(w, fmt.Sprintf("CSR signature invalid: %s", err), http.StatusBadRequest)
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidCSR, fmt.Sprintf("CSR signature invalid: %s", err))
+			return
+		}
+		csrPubKey, ok := csr.PublicKey.(*ecdsa.PublicKey)
+		if !ok {
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidCSR, "CSR public key must be ECDSA")
 			return
 		}
 
-		// Sign the certificate with the mock CA.
+		// Verify the evidence binds this CSR key and the consumed challenge,
+		// the same report-data check production CDS delegates to the api.
+		expectedReportData, err := ratls.ReportDataForKey(csrPubKey, challengeBytes)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, types.ErrorCodeInvalidCSR, err.Error())
+			return
+		}
+		reportData := types.NewBase64Bytes(expectedReportData[:sha512.Size384])
+		verifyResp, err := verifier.VerifyEnforced(r.Context(), types.VerifyReportData(req.Evidence, reportData))
+		if err != nil {
+			status, code, msg := classifyVerifyError(err)
+			slog.Warn("attestation verification failed", "status", status, "error", err, "remote_addr", r.RemoteAddr)
+			writeError(w, status, code, msg)
+			return
+		}
+		if digest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest); digest != mockLaunchDigest {
+			slog.Warn("measurement not in allowlist", "launch_digest", digest, "remote_addr", r.RemoteAddr)
+			writeError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
+			return
+		}
+
+		// Sign the certificate with the mock CA. The RA-TLS extension is
+		// copied from the CSR like production's issuer.SignCSR, so the leaf
+		// stays re-verifiable downstream.
 		serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 		template := x509.Certificate{
 			SerialNumber: serial,
@@ -166,14 +239,18 @@ func handleAttest(store *challengeStore) http.HandlerFunc {
 			DNSNames:     csr.DNSNames,
 			IPAddresses:  csr.IPAddresses,
 		}
+		for _, ext := range csr.Extensions {
+			if ext.Id.Equal(ratls.OIDRATLSAttestation) {
+				template.ExtraExtensions = append(template.ExtraExtensions, pkix.Extension{Id: ext.Id, Value: ext.Value})
+				break
+			}
+		}
 
 		certDER, err := x509.CreateCertificate(rand.Reader, &template, &caCert, csr.PublicKey, &caKey)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("failed to sign certificate: %s", err), http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, types.ErrorCodeSignFailed, fmt.Sprintf("failed to sign certificate: %s", err))
 			return
 		}
-
-		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 
 		slog.Info("issued certificate",
 			"dns_names", csr.DNSNames,
@@ -181,7 +258,38 @@ func handleAttest(store *challengeStore) http.HandlerFunc {
 			"serial", serial.String(),
 		)
 
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 		w.Header().Set("Content-Type", "application/x-pem-file")
-		w.Write(certPEM)
+		_, _ = w.Write(append(certPEM, caPEM...))
 	}
+}
+
+// classifyVerifyError maps a VerifyEnforced error to the status/code/message
+// production CDS answers /attest with (internal/cmds/cds/attest.go): 401 bad
+// signature/report-data, 422 api rejection, 502 transport or 5xx outage.
+func classifyVerifyError(err error) (int, string, string) {
+	switch {
+	case errors.Is(err, attestationclient.ErrSignatureInvalid):
+		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "attestation signature invalid"
+	case errors.Is(err, attestationclient.ErrReportDataMismatch):
+		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "challenge mismatch in attestation evidence"
+	}
+	var apiErr *attestationclient.APIError
+	if errors.As(err, &apiErr) && apiErr.Status >= 400 && apiErr.Status < 500 &&
+		apiErr.Status != http.StatusRequestTimeout && apiErr.Status != http.StatusTooManyRequests {
+		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation evidence rejected by attestation-api"
+	}
+	return http.StatusBadGateway, types.ErrorCodeAttestationApiUnreachable,
+		fmt.Sprintf("failed to reach attestation-api: %s", err)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(types.ErrorResponse{Error: code, Message: message})
 }

--- a/test/mock-cds/main_test.go
+++ b/test/mock-cds/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// TestClassifyVerifyError mirrors internal/cmds/cds.TestClassifyVerifyError: a
+// rejected verdict is the caller's 401/422, only a transport or 5xx/408/429
+// outage is a 502. The api-422 row is the shape mock-attestation returns for a
+// report-data mismatch or garbage evidence.
+func TestClassifyVerifyError(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "signature invalid",
+			err:        fmt.Errorf("wrap: %w", attestationclient.ErrSignatureInvalid),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "report data mismatch",
+			err:        fmt.Errorf("wrap: %w", attestationclient.ErrReportDataMismatch),
+			wantStatus: http.StatusUnauthorized,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "api 400 is client fault",
+			err:        &attestationclient.APIError{Status: http.StatusBadRequest},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "api 403 is client fault",
+			err:        &attestationclient.APIError{Status: http.StatusForbidden},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "api 422 is a mismatch or garbage refusal",
+			err:        &attestationclient.APIError{Status: http.StatusUnprocessableEntity},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "api 500 is upstream outage",
+			err:        &attestationclient.APIError{Status: http.StatusInternalServerError},
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
+			name:       "api 408 is retryable unavailability",
+			err:        &attestationclient.APIError{Status: http.StatusRequestTimeout},
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
+			name:       "api 429 is retryable unavailability",
+			err:        &attestationclient.APIError{Status: http.StatusTooManyRequests},
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
+			name:       "transport failure is unreachable",
+			err:        errors.New("dial tcp: connection refused"),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status, code, msg := classifyVerifyError(tc.err)
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+			if code != tc.wantCode {
+				t.Errorf("code = %q, want %q", code, tc.wantCode)
+			}
+			if msg == "" {
+				t.Error("message empty")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes the integration harness (`test/integration/` + `test/mock-cds` + `test/mock-attestation`) so it **can fail**, tests the **production contract**, and runs as a **PR gate**.

**Harness (`test/integration/run.sh`)**
- Missing docker / compose v2 / openssl / curl / make now exits non-zero (previously `SKIP` + exit 0). The compose-v1 fallback is deleted; `$COMPOSE_CMD` is used for every compose invocation, including the log dump on failure.
- All HTTPS checks verify the chain against the mock CDS CA (`curl --cacert` + `--resolve`, plus `openssl verify`) — no more `curl -sk`. The CA is fetched out-of-band from the mock-cds container (`docker compose cp`), not from the served chain.
- The SAN and key-algorithm checks are hard failures (previously `WARN`). The pass line prints only after all 5 checks pass.
- Starts from a clean slate (`down -v`) so a stale volume can't pair an old leaf with a fresh ephemeral CA, and builds `build/c8s` itself so the tested get-cert always matches the checkout.

**Mocks — now the production wire contract, over RA-TLS**
- `mock-attestation` is the networked counterpart of `internal/testattest`: `/attest` issues synthetic SEV-SNP reports binding the requested REPORTDATA; `/verify` checks that binding and refuses mismatches with the real api's **422 `verification_failed`** shape (never 200 + `signature_valid:false`); reports a fixed zero launch measurement; answers an undecodable body with the api's **axum text/plain** rejection (400 unparseable / 422 wrong-type, no error code — an `UnexpectedError`, not an `APIError`, the shape `internal/testattest` models); `/health` answers the production `types.HealthResponse`.
- `mock-cds` serves **RA-TLS exactly like production CDS** (`ratls.NewServerTLSConfig` + `attestclient.MakeSNPRATLSAttestFunc` against the mock api), decodes the production wire types (`types.ChallengeResponse`, `types.AttestRequestBody` with `DisallowUnknownFields`), delegates the same report-data verification to the mock api and maps its failures through the same **401/422/502** taxonomy production CDS uses (`classifyVerifyError`) rather than a blanket 403, gates issuance on the mock measurement like production's `--measurements`, copies the RA-TLS extension's `{Id, Value}` onto the leaf like `issuer.copyRATLSExtension`, and returns leaf+CA PEM as `application/x-pem-file`.
- Both mocks import the production packages (`pkg/types`, `pkg/ratls`, `pkg/attestclient`, `pkg/attestationclient`) instead of re-declaring inline structs, via a repo-root `replace`; both modules are in `go.work`, so `go build ./...` works inside them (previously both declared zero requires and failed under the workspace). Their Docker builds compile them on every harness run — from the **repo-root docker context** (the `replace` needs `go.mod`, `pkg/`, and `test/mock-*/`), so #13's `.dockerignore` tightening must keep those paths in scope or the image builds break.
- get-cert now runs the flow production sidecars run: RA-TLS with a pinned measurement allowlist (the mock's zero digest).

**CI**
- New `Integration` job in `ci.yml` runs `make test-integration` on PRs. The `go-paths` anchor gains `test/**` so harness-only changes trigger it. Runtime: ~5 min cold (go build + image pulls), ~1 min warm; job timeout 15 min. **Repo admin follow-up: mark the `Integration` check as required in branch protection.**

Background: the harness was silently broken since get-cert began refusing plain-`http` `--cds-url` — the mock CDS served plain HTTP, so get-cert failed at startup and nothing ran the harness to notice. Fixing the assertions without fixing the mocks would have left the harness red for the wrong reason.

## Test plan

Green run (this branch, `make test-integration`): all 5 checks pass — healthz over verified chain, proxy body, chain to mock CDS CA, SAN `DNS:nginx-lb`, ECDSA P-256.

Deliberate-red runs:
- Mock CDS signs a wrong SAN (`wrong-name.example`): job goes red (verified-TLS readiness probe refuses the leaf). ✔
- `docker compose` removed from PATH: exits 1 with `FAIL: docker compose (v2) not available` (not green-with-a-warning). ✔
- `openssl` removed from PATH: exits 1 with `FAIL: openssl not available`. ✔
- Compose pins a wrong launch measurement: red — get-cert fails with `ratls: peer attestation failed: ... launch measurement not in allowed set`, proving the RA-TLS measurement allowlist is genuinely exercised. ✔
- `mock-attestation /verify` probe: matching REPORTDATA → 200 `report_data_match:true`; wrong REPORTDATA → 422 `verification_failed`; garbage evidence → 422 `verification_failed`. ✔
- `mock-attestation` decode probe: unparseable body → **400 text/plain**, wrong-type JSON → **422 text/plain**, both with no error code (the axum shape). ✔
- `mock-cds classifyVerifyError`: signature/report-data → **401**, api rejection incl. mock-attestation's 422 → **422**, transport/5xx/timeout/rate-limit → **502** — a verification failure no longer collapses to 403. ✔
- The refusal taxonomy is pinned by committed table tests in each mock module (`test/mock-cds/main_test.go`, `test/mock-attestation/main_test.go`), mirroring the production references they copy (`internal/cmds/cds.TestClassifyVerifyError`, `internal/testattest.TestStubRejectsUndecodableBody`). Mutation-proven: reverting the 422→403 collapse, the decode 422 upgrade, or the `/verify` mismatch refusal each turns a case red. `go test ./...` inside each mock module runs them; root `go test ./...` does not descend into the nested modules (Go module semantics), so running them in CI is #13's lint/CI-parity scope. ✔

`go build ./...`, `go vet ./...`, `make fmt`, and `go test -race ./...` all pass at the repo root; `go build ./...`, `go vet ./...`, and `go test ./...` pass inside each mock module.

## Threat-model notes

No production code changes and no test-only escape hatches: get-cert keeps its RA-TLS-only posture, and the mocks meet it at that bar rather than the other way around. The harness exercises the real attestation wiring — challenge-bound evidence, report-data binding, measurement allowlist — with synthetic evidence standing in for hardware quotes; hardware verification itself stays covered by the TEE lanes. The mocks listen only on the compose-internal network; the zero measurement is self-evidently a test identity.
