### PR TITLE
fix(policy-monitor): make the in-guest inventory and init-data pin work on TDX

### DIFF
--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -305,11 +305,12 @@ field rather than passing silently.
 On a mismatch, or with no document, the guest falls back to the baked
 seed.
 
-**TDX has no equivalent path yet:** the digest goes to `MRCONFIGID`,
-which is 48 bytes where the anchor is 32, so the guest refuses the
-claim and enforces the baked seed alone. Empty `cds.measurements` (the chart
-default) also leaves the refresh disabled on every platform — operator
-additions then reach the host-side enforcer but not running guests.
+**TDX takes the same path through `MRCONFIGID`:** the shim commits
+`sha256(document)` zero-padded to the 48-byte `MRCONFIGID`, and the guest
+accepts that shape as the 32-byte anchor (a non-zero tail is refused as
+ill-shaped). Empty `cds.measurements` (the chart default) leaves the refresh
+disabled on every platform — operator additions then reach the host-side
+enforcer but not running guests.
 
 ## Scenarios
 

--- a/internal/cmds/policymonitor/cds_refresh.go
+++ b/internal/cmds/policymonitor/cds_refresh.go
@@ -16,8 +16,9 @@ package policymonitor
 // Gated on a configured CDS URL: with C8S_CDS_URL unset the monitor
 // stays baked-seed-only and never opens the network.
 //
-// It does not run until a CDS measurement is pinned, which --cvm-mode=pod
-// does not yet deliver.
+// It does not run until a CDS measurement is pinned; under --cvm-mode=pod the
+// pin arrives through the init-data document (initdata.go), on SNP via
+// HOST_DATA and on TDX via MRCONFIGID.
 
 import (
 	"context"

--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -28,10 +28,15 @@ var errAttestUnavailable = errors.New("policy-monitor: attestation service unava
 // The verifier refused this guest's report, which every retry reproduces.
 var errAttestVerdict = errors.New("policy-monitor: self-report refused")
 
-// The verified report carries no 32-byte anchor to compare the document
-// against. TDX reports the digest padded into a 48-byte MRCONFIGID, so this is
-// what an ordinary TDX boot reaches, not a hostile one.
-var errNoHostDataAnchor = errors.New("policy-monitor: HOST_DATA claim is not a 32-byte anchor")
+// The verified report carries no usable init-data anchor to compare the
+// document against: neither SNP's 32-byte HOST_DATA nor TDX's 48-byte
+// MRCONFIGID carrying a zero-padded 32-byte digest.
+var errNoHostDataAnchor = errors.New("policy-monitor: init-data claim is not a 32-byte anchor")
+
+// mrConfigIDSize is the width of TDX's MRCONFIGID, into which the shim commits
+// sha256(document) zero-padded — the same shape attestation-rs's TDX verifier
+// binds expected_init_data_hash against (pad_report_data(expected, 48)).
+const mrConfigIDSize = 48
 
 // Bounds the self-attestation; on expiry the caller falls back to the seed.
 const initDataTimeout = 15 * time.Second
@@ -210,10 +215,27 @@ func verifiedSelfHostData(ctx context.Context, cfg *Config) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: not hex: %w", errNoHostDataAnchor, err)
 	}
-	if len(hostData) != initdata.DigestSize {
-		return nil, fmt.Errorf("%w: %d bytes, want %d", errNoHostDataAnchor, len(hostData), initdata.DigestSize)
+	return initDataAnchor(hostData)
+}
+
+// initDataAnchor extracts the 32-byte sha256(document) anchor from the
+// platform's init-data claim: SNP HOST_DATA carries it verbatim; TDX
+// MRCONFIGID carries it zero-padded to 48 bytes, so the tail must be zero for
+// the prefix to be that anchor rather than an arbitrary 48-byte value.
+func initDataAnchor(claim []byte) ([]byte, error) {
+	switch len(claim) {
+	case initdata.DigestSize:
+		return claim, nil
+	case mrConfigIDSize:
+		for _, b := range claim[initdata.DigestSize:] {
+			if b != 0 {
+				return nil, fmt.Errorf("%w: %d-byte MRCONFIGID is not a zero-padded %d-byte digest", errNoHostDataAnchor, mrConfigIDSize, initdata.DigestSize)
+			}
+		}
+		return claim[:initdata.DigestSize], nil
+	default:
+		return nil, fmt.Errorf("%w: %d bytes, want %d (SNP HOST_DATA) or %d (TDX MRCONFIGID)", errNoHostDataAnchor, len(claim), initdata.DigestSize, mrConfigIDSize)
 	}
-	return hostData, nil
 }
 
 // classifyVerifyError splits a refusal of the report from a failure to reach

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -488,12 +488,14 @@ func TestVerifiedSelfHostDataBindsTheAnchorItRequested(t *testing.T) {
 	}
 }
 
-// A claim that is not a 32-byte anchor is refused rather than padded or
-// truncated, and is not a verifier refusal.
+// A claim that is neither a 32-byte anchor nor a zero-padded one in a 48-byte
+// MRCONFIGID is refused rather than padded or truncated, and is not a verifier
+// refusal.
 func TestVerifiedSelfHostDataRejectsIllShapedClaim(t *testing.T) {
 	for _, tc := range []struct{ name, claim string }{
 		{"absent", ""},
-		{"tdx mrconfigid", strings.Repeat("00", 48)},
+		{"tdx mrconfigid with a non-zero tail", strings.Repeat("aa", 48)},
+		{"neither width", strings.Repeat("00", 40)},
 		{"not hex", "not-hex"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -655,13 +657,31 @@ func TestAwaitInitDataMeasurementsStopsOnRefusedReport(t *testing.T) {
 	}
 }
 
+// The TDX shim commits sha256(document) into MRCONFIGID zero-padded to 48
+// bytes, so that shape resolves the pin exactly like SNP's 32-byte HOST_DATA.
+func TestVerifiedSelfHostDataAcceptsZeroPaddedMRCONFIGID(t *testing.T) {
+	digest := initdata.Digest([]byte("doc"))
+	padded := make([]byte, 48)
+	copy(padded, digest[:])
+	v := testattest.PassingVerdict("")
+	v.Claims.InitData = hex.EncodeToString(padded)
+
+	got, err := verifiedSelfHostData(context.Background(), &Config{AttestationServiceURL: attesterWithVerdict(t, v)})
+	if err != nil {
+		t.Fatalf("verifiedSelfHostData: %v", err)
+	}
+	if !bytes.Equal(got, digest[:]) {
+		t.Fatalf("anchor = %x, want the 32-byte digest %x", got, digest[:])
+	}
+}
+
 // A missing anchor is terminal like a refusal, but not at a refusal's level.
 func TestAwaitInitDataMeasurementsStopsOnMissingAnchor(t *testing.T) {
 	writeInitData(t, testDocument(t, "aabb"))
 	shortInitDataWait(t, time.Minute, 10*time.Second)
 
-	// MRCONFIGID's width.
-	cfg := &Config{AttestationServiceURL: attesterServing(t, make([]byte, 48))}
+	// MRCONFIGID's width, but not carrying a zero-padded digest.
+	cfg := &Config{AttestationServiceURL: attesterServing(t, bytes.Repeat([]byte{0xaa}, 48))}
 	rec := &levelRecorder{}
 	start := time.Now()
 	awaitInitDataMeasurements(context.Background(), slog.New(rec), cfg)

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -2,6 +2,7 @@ package policymonitor
 
 import (
 	"context"
+	"crypto/sha512"
 	"fmt"
 	"log/slog"
 	"net"
@@ -12,7 +13,6 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
-	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
@@ -303,9 +303,36 @@ func startAdmissionInventory(ctx context.Context, logger *slog.Logger, inventory
 
 // startSandboxDigests serves the CDS-facing digests endpoint inside the guest
 // over mutually-attested RA-TLS (docs/ratls.md, "Sandbox identity").
+//
+// The endpoint's RA-TLS certificate stamps the guest's TEE family, and CDS
+// verifies the evidence under that family's rules, so the platform is read
+// from the in-guest attestation-api rather than assumed: a TDX guest whose
+// leaf claimed SEV-SNP would carry a TDX envelope under the SNP TEE type, and
+// CDS would refuse every sandbox token it signs.
 func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *Config, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner, measurements [][]byte) error {
+	platform, err := detectGuestPlatform(ctx, cfg.AttestationServiceURL)
+	if err != nil {
+		return fmt.Errorf("detect guest TEE platform: %w", err)
+	}
+	logger.Info("sandbox-digests endpoint platform", "platform", platform)
 	return workloadclaims.StartDigestsEndpoint(ctx, logger, inventory, signer.PublicKeyDER(),
-		string(types.PlatformSnp),
+		platform,
 		attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), cfg.AttestationServiceURL),
 		cfg.AttestationServiceURL, measurements)
+}
+
+// detectGuestPlatform asks the in-guest attestation-api which TEE it is
+// running on by generating one throwaway piece of evidence (platform "auto")
+// and reading the platform it reports. Evidence generation is the same call
+// every RA-TLS handshake makes, so this adds no new capability requirement.
+func detectGuestPlatform(ctx context.Context, attestationServiceURL string) (string, error) {
+	var probe [sha512.Size384]byte
+	resp, err := attestclient.NewClient("").GenerateEvidenceContext(ctx, attestationServiceURL, probe[:])
+	if err != nil {
+		return "", err
+	}
+	if resp.Platform == "" {
+		return "", fmt.Errorf("attestation-api reported no platform")
+	}
+	return resp.Platform, nil
 }

--- a/internal/cmds/policymonitor/platform_test.go
+++ b/internal/cmds/policymonitor/platform_test.go
@@ -1,0 +1,55 @@
+package policymonitor
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// TestDetectGuestPlatformFollowsAttestationAPI pins that the sandbox-digests
+// endpoint takes its TEE family from the in-guest attestation-api instead of
+// assuming SEV-SNP: on a TDX guest the SNP assumption stamps a TDX envelope
+// under the SNP TEE type and CDS refuses every sandbox token.
+func TestDetectGuestPlatformFollowsAttestationAPI(t *testing.T) {
+	for _, platform := range []string{string(types.PlatformSnp), string(types.PlatformTdx)} {
+		t.Run(platform, func(t *testing.T) {
+			var gotReq types.AttestRequest
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/attest" {
+					http.NotFound(w, r)
+					return
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+					t.Errorf("decode attest request: %v", err)
+				}
+				_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: platform, Evidence: json.RawMessage(`{}`)})
+			}))
+			defer srv.Close()
+
+			got, err := detectGuestPlatform(context.Background(), srv.URL)
+			if err != nil {
+				t.Fatalf("detectGuestPlatform: %v", err)
+			}
+			if got != platform {
+				t.Fatalf("platform = %q, want %q", got, platform)
+			}
+			if gotReq.Platform != types.PlatformAuto {
+				t.Fatalf("probe requested platform %q, want %q (let the attestation-api detect it)", gotReq.Platform, types.PlatformAuto)
+			}
+		})
+	}
+}
+
+func TestDetectGuestPlatformRejectsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.AttestResponse{Evidence: json.RawMessage(`{}`)})
+	}))
+	defer srv.Close()
+	if _, err := detectGuestPlatform(context.Background(), srv.URL); err == nil {
+		t.Fatal("expected an error for an empty platform")
+	}
+}


### PR DESCRIPTION
Two guest-side fixes without which `--cvm-mode=pod --hardware-platform=tdx` cannot run any `confidential.ai/cw` workload. Both found bringing up pod-as-CVM on a bare-metal TDX host (Xeon 6527P, RKE2); the tdx metal e2e lane runs `--cvm-mode node` and never exercises the in-guest policy-monitor.

**1. Sandbox-digests endpoint stamped SEV-SNP on every platform.** `startSandboxDigests` hardcoded `PlatformSnp`, so on a TDX guest the served leaf carried a TDX evidence envelope under the SNP TEE type and CDS refused every sandbox token:

```
csr_denied: resolve inventory key: workloadclaims: reach inventory 10.42.0.83: Get "https://10.42.0.83:1019/identity": ratls: peer attestation failed: ratls: unsupported TEE platform: online verification not implemented for platform "tdx"
```

CDS and tls-lb never hit this because their platform comes from chart values; the guest-side inventory had no such input. Now read once from the in-guest attestation-api (`platform: auto`, the same call every RA-TLS handshake makes) — the source `RATLSEvidence` already dispatches on.

**2. Init-data pin refused on TDX.** The shim commits `sha256(document)` into MRCONFIGID zero-padded to 48 bytes (the shape attestation-rs's TDX verifier binds `expected_init_data_hash` against), but policy-monitor only accepted SNP's 32-byte HOST_DATA, logged `not a 32-byte anchor`, never learned the CDS pin, and enforced the baked seed alone — so under pod-mode TDX no `c8s allowlist add` ever reached a running guest and any image outside the baked seed was refused. Accept a zero-tailed 48-byte claim and take the 32-byte prefix; a non-zero tail stays ill-shaped. `docs/kata-image-policy.md` updated (it documented TDX as having no path).

Both are baked into kata-guest-base, so they need a guest-image rebuild to take effect. Validated live on the TDX host with a guest image built from this branch.
