### PR TITLE
feat(get-kubeconfig): resolve KubeVirt guests via --vmi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/lestrrat-go/jwx/v3 v3.1.1
 	github.com/prometheus/client_golang v1.24.0
 	github.com/prometheus/client_model v0.6.2
+	github.com/prometheus/common v0.70.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/virtee/sev-snp-measure-go v0.0.0-20260408174629-fd0cc4c95d62
@@ -118,7 +119,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/common v0.70.0 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/confidential-dot-ai/attestation-go v0.4.0 h1:651L7UQZKXN4jX793Yv/xnuPWInnx0mBXG4soRNeCx0=
-github.com/confidential-dot-ai/attestation-go v0.4.0/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
 github.com/confidential-dot-ai/attestation-go v0.4.1 h1:97ZFNO2OJlwzCSdAPMtfXgZ97t2IAmmRFIsnAVe0g3c=
 github.com/confidential-dot-ai/attestation-go v0.4.1/go.mod h1:7I93wu6yTfQZlDu1ikweS5iIA/soIQyOP1/ac7OgxJQ=
 github.com/containerd/cgroups/v3 v3.1.3 h1:eUNflyMddm18+yrDmZPn3jI7C5hJ9ahABE5q6dyLYXQ=

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -1,6 +1,7 @@
 package getkubeconfig
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,6 +16,7 @@ func NewCmd() *cobra.Command {
 	var (
 		cfg  Config
 		node string
+		vmi  string
 	)
 	cmd := &cobra.Command{
 		Use:   "get-kubeconfig",
@@ -30,9 +32,20 @@ func NewCmd() *cobra.Command {
 			if cfg.OperatorKeyPath == "" || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
 				return fmt.Errorf("--operator-key, --image-manifest and --out are required")
 			}
-			// --node <host> is a convenience that fills the three URLs with the
-			// standard ports; explicit --attest-url/--release-url/--apiserver-url
-			// override. At least one of node or the explicit URLs must be set.
+			// --vmi resolves a KubeVirt guest to the address --node would have
+			// been given; --node <host> is a convenience that fills the three
+			// URLs with the standard ports. Explicit --attest-url/--release-url/
+			// --apiserver-url override. At least one of vmi, node, or the
+			// explicit URLs must be set.
+			if vmi != "" {
+				ctx, cancel := context.WithTimeout(cmd.Context(), cfg.Timeout)
+				defer cancel()
+				addr, err := resolveVMIAddress(ctx, vmi)
+				if err != nil {
+					return fmt.Errorf("resolve --vmi %q: %w", vmi, err)
+				}
+				node = addr
+			}
 			if node != "" {
 				if cfg.AttestURL == "" {
 					cfg.AttestURL = fmt.Sprintf("http://%s:8400/attest", node)
@@ -45,13 +58,14 @@ func NewCmd() *cobra.Command {
 				}
 			}
 			if cfg.AttestURL == "" || cfg.ReleaseBaseURL == "" || cfg.APIServerURL == "" {
-				return fmt.Errorf("set --node, or all of --attest-url/--release-url/--apiserver-url")
+				return fmt.Errorf("set --node or --vmi, or all of --attest-url/--release-url/--apiserver-url")
 			}
 			return Run(cmd.Context(), cfg)
 		},
 	}
 	f := cmd.Flags()
 	f.StringVar(&node, "node", "", "guest host/IP; fills --attest-url/--release-url/--apiserver-url with standard ports (8400/8443/6443)")
+	f.StringVar(&vmi, "vmi", "", "guest as KubeVirt VMI [namespace/]name; resolves its address through the current kubeconfig and uses it as --node (namespace defaults to the kubeconfig context's)")
 	f.StringVar(&cfg.AttestURL, "attest-url", "", "attestation-api /attest URL (overrides --node)")
 	f.StringVar(&cfg.ReleaseBaseURL, "release-url", "", "cred-release base URL (overrides --node)")
 	f.StringVar(&cfg.APIServerURL, "apiserver-url", "", "apiserver URL for the kubeconfig (overrides --node)")
@@ -62,5 +76,6 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")
 	f.StringVar(&cfg.OutPath, "out", "", "output kubeconfig path (required)")
 	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
+	cmd.MarkFlagsMutuallyExclusive("node", "vmi")
 	return cmd
 }

--- a/internal/cmds/getkubeconfig/cmd_test.go
+++ b/internal/cmds/getkubeconfig/cmd_test.go
@@ -1,7 +1,9 @@
 package getkubeconfig
 
 import (
+	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -42,6 +44,51 @@ func TestNewCmdValidation(t *testing.T) {
 		err := execCmd(t, "--operator-key", "k.pem", "--image-manifest", "m.json", "--out", "kc")
 		if err == nil || !strings.Contains(err.Error(), "set --node") {
 			t.Fatalf("want set-node error, got %v", err)
+		}
+	})
+
+	t.Run("vmi resolves to node", func(t *testing.T) {
+		restore := resolveVMIAddress
+		resolveVMIAddress = func(_ context.Context, ref string) (string, error) {
+			if ref != "mn-server" {
+				t.Fatalf("want ref mn-server, got %q", ref)
+			}
+			return "10.42.0.158", nil
+		}
+		t.Cleanup(func() { resolveVMIAddress = restore })
+		// A nonexistent operator key makes Run fail at its first step, which
+		// proves the resolved address satisfied the URL validation.
+		err := execCmd(t,
+			"--vmi", "mn-server",
+			"--operator-key", filepath.Join(t.TempDir(), "nope.key"),
+			"--image-manifest", filepath.Join(t.TempDir(), "m.json"),
+			"--out", filepath.Join(t.TempDir(), "kc"))
+		if err == nil || !strings.Contains(err.Error(), "read operator key") {
+			t.Fatalf("want read-key error from Run, got %v", err)
+		}
+	})
+
+	t.Run("vmi resolution failure aborts", func(t *testing.T) {
+		restore := resolveVMIAddress
+		resolveVMIAddress = func(_ context.Context, _ string) (string, error) {
+			return "", errors.New("guest confai-images/mn-server has no reported address")
+		}
+		t.Cleanup(func() { resolveVMIAddress = restore })
+		err := execCmd(t,
+			"--vmi", "mn-server",
+			"--operator-key", "k.pem", "--image-manifest", "m.json", "--out", "kc")
+		if err == nil || !strings.Contains(err.Error(), `resolve --vmi "mn-server"`) ||
+			!strings.Contains(err.Error(), "no reported address") {
+			t.Fatalf("want wrapped resolution error, got %v", err)
+		}
+	})
+
+	t.Run("vmi and node are mutually exclusive", func(t *testing.T) {
+		err := execCmd(t,
+			"--vmi", "mn-server", "--node", "127.0.0.1",
+			"--operator-key", "k.pem", "--image-manifest", "m.json", "--out", "kc")
+		if err == nil || !strings.Contains(err.Error(), "none of the others can be") {
+			t.Fatalf("want mutual-exclusion error, got %v", err)
 		}
 	})
 

--- a/internal/cmds/getkubeconfig/vmi.go
+++ b/internal/cmds/getkubeconfig/vmi.go
@@ -1,0 +1,82 @@
+package getkubeconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// vmiGVR is KubeVirt's VirtualMachineInstance resource. The dynamic client
+// keeps the KubeVirt API types out of the module graph.
+var vmiGVR = schema.GroupVersionResource{
+	Group:    "kubevirt.io",
+	Version:  "v1",
+	Resource: "virtualmachineinstances",
+}
+
+// resolveVMIAddress is a seam for tests.
+var resolveVMIAddress = resolveVMI
+
+// resolveVMI returns the first reported interface address of the KubeVirt
+// guest "name" or "namespace/name", looked up through the current kubeconfig
+// context, which also supplies the namespace when the ref carries none. The
+// guest's name is neither a DNS host nor an IP on the operator's machine, and
+// resolving at call time means a restarted VMI cannot leave a stale entry
+// behind.
+func resolveVMI(ctx context.Context, ref string) (string, error) {
+	namespace, name, hasNamespace := strings.Cut(ref, "/")
+	if !hasNamespace {
+		namespace, name = "", ref
+	}
+	if name == "" || (hasNamespace && namespace == "") {
+		return "", fmt.Errorf("ref %q is not name or namespace/name", ref)
+	}
+
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	if namespace == "" {
+		var err error
+		if namespace, _, err = kubeCfg.Namespace(); err != nil {
+			return "", fmt.Errorf("namespace from kubeconfig: %w", err)
+		}
+	}
+	restCfg, err := kubeCfg.ClientConfig()
+	if err != nil {
+		return "", fmt.Errorf("load kubeconfig: %w", err)
+	}
+	client, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return "", fmt.Errorf("build kubernetes client: %w", err)
+	}
+	vmi, err := client.Resource(vmiGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("get virtualmachineinstance %s/%s: %w", namespace, name, err)
+	}
+	return vmiAddress(vmi)
+}
+
+// vmiAddress returns the guest's first non-empty status interface address. A
+// booting VMI reports no status.interfaces, an empty list, or entries without
+// an ipAddress yet; all of those are "no reported address", not lookup errors.
+func vmiAddress(vmi *unstructured.Unstructured) (string, error) {
+	ifaces, _, err := unstructured.NestedSlice(vmi.Object, "status", "interfaces")
+	if err != nil {
+		return "", fmt.Errorf("read status.interfaces of %s/%s: %w", vmi.GetNamespace(), vmi.GetName(), err)
+	}
+	for _, entry := range ifaces {
+		iface, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if ip, _ := iface["ipAddress"].(string); ip != "" {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("guest %s/%s has no reported address", vmi.GetNamespace(), vmi.GetName())
+}

--- a/internal/cmds/getkubeconfig/vmi.go
+++ b/internal/cmds/getkubeconfig/vmi.go
@@ -23,6 +23,26 @@ var vmiGVR = schema.GroupVersionResource{
 // resolveVMIAddress is a seam for tests.
 var resolveVMIAddress = resolveVMI
 
+// newVMIClient builds a dynamic client from the current kubeconfig context
+// and reports that context's namespace. A seam for tests.
+var newVMIClient = func() (dynamic.Interface, string, error) {
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	namespace, _, err := kubeCfg.Namespace()
+	if err != nil {
+		return nil, "", fmt.Errorf("namespace from kubeconfig: %w", err)
+	}
+	restCfg, err := kubeCfg.ClientConfig()
+	if err != nil {
+		return nil, "", fmt.Errorf("load kubeconfig: %w", err)
+	}
+	client, err := dynamic.NewForConfig(restCfg)
+	if err != nil {
+		return nil, "", fmt.Errorf("build kubernetes client: %w", err)
+	}
+	return client, namespace, nil
+}
+
 // resolveVMI returns the first reported interface address of the KubeVirt
 // guest "name" or "namespace/name", looked up through the current kubeconfig
 // context, which also supplies the namespace when the ref carries none. The
@@ -38,21 +58,12 @@ func resolveVMI(ctx context.Context, ref string) (string, error) {
 		return "", fmt.Errorf("ref %q is not name or namespace/name", ref)
 	}
 
-	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		clientcmd.NewDefaultClientConfigLoadingRules(), &clientcmd.ConfigOverrides{})
+	client, contextNamespace, err := newVMIClient()
+	if err != nil {
+		return "", err
+	}
 	if namespace == "" {
-		var err error
-		if namespace, _, err = kubeCfg.Namespace(); err != nil {
-			return "", fmt.Errorf("namespace from kubeconfig: %w", err)
-		}
-	}
-	restCfg, err := kubeCfg.ClientConfig()
-	if err != nil {
-		return "", fmt.Errorf("load kubeconfig: %w", err)
-	}
-	client, err := dynamic.NewForConfig(restCfg)
-	if err != nil {
-		return "", fmt.Errorf("build kubernetes client: %w", err)
+		namespace = contextNamespace
 	}
 	vmi, err := client.Resource(vmiGVR).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {

--- a/internal/cmds/getkubeconfig/vmi_test.go
+++ b/internal/cmds/getkubeconfig/vmi_test.go
@@ -225,8 +225,8 @@ func TestNewVMIClientFailures(t *testing.T) {
 	})
 
 	t.Run("context without a usable cluster", func(t *testing.T) {
-		// The namespace loads, but client-config validation rejects the
-		// server-less cluster.
+		// clientcmd validates the whole config on the first read, so even a
+		// non-namespace defect like a server-less cluster surfaces there.
 		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
 		if err := os.WriteFile(kubeconfig, []byte(`apiVersion: v1
 kind: Config
@@ -245,8 +245,8 @@ current-context: outer
 		}
 		t.Setenv("KUBECONFIG", kubeconfig)
 		if _, _, err := newVMIClient(); err == nil ||
-			!strings.Contains(err.Error(), "load kubeconfig") {
-			t.Fatalf("want load-kubeconfig error, got %v", err)
+			!strings.Contains(err.Error(), "namespace from kubeconfig") {
+			t.Fatalf("want namespace error, got %v", err)
 		}
 	})
 

--- a/internal/cmds/getkubeconfig/vmi_test.go
+++ b/internal/cmds/getkubeconfig/vmi_test.go
@@ -2,10 +2,16 @@ package getkubeconfig
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
 
 func vmiWithStatus(status map[string]any) *unstructured.Unstructured {
@@ -43,6 +49,20 @@ func TestVMIAddress(t *testing.T) {
 			name: "address-less interface is skipped",
 			status: map[string]any{"interfaces": []any{
 				map[string]any{"name": "default"},
+				map[string]any{"ipAddress": "10.42.0.201"},
+			}},
+			want: "10.42.0.201",
+		},
+		{
+			// A malformed object surfaces the read error, not no-address.
+			name:    "interfaces of the wrong type",
+			status:  map[string]any{"interfaces": "bogus"},
+			wantErr: "read status.interfaces",
+		},
+		{
+			name: "non-map interface entry is skipped",
+			status: map[string]any{"interfaces": []any{
+				"bogus",
 				map[string]any{"ipAddress": "10.42.0.201"},
 			}},
 			want: "10.42.0.201",
@@ -93,4 +113,153 @@ func TestResolveVMIRejectsMalformedRefs(t *testing.T) {
 			t.Fatalf("ref %q: want malformed-ref error, got %v", ref, err)
 		}
 	}
+}
+
+// fakeVMIClient stubs newVMIClient with a fake dynamic client holding the
+// given objects and reporting contextNS as the kubeconfig context namespace.
+func fakeVMIClient(t *testing.T, contextNS string, objects ...runtime.Object) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	scheme.AddKnownTypeWithName(
+		schema.GroupVersionKind{Group: "kubevirt.io", Version: "v1", Kind: "VirtualMachineInstanceList"},
+		&unstructured.UnstructuredList{})
+	client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme,
+		map[schema.GroupVersionResource]string{vmiGVR: "VirtualMachineInstanceList"}, objects...)
+	restore := newVMIClient
+	newVMIClient = func() (dynamic.Interface, string, error) {
+		return client, contextNS, nil
+	}
+	t.Cleanup(func() { newVMIClient = restore })
+}
+
+func TestResolveVMI(t *testing.T) {
+	t.Run("bare name uses the context namespace", func(t *testing.T) {
+		fakeVMIClient(t, "confai-images", vmiWithStatus(map[string]any{
+			"interfaces": []any{map[string]any{"ipAddress": "10.42.0.158"}},
+		}))
+		got, err := resolveVMI(context.Background(), "mn-server")
+		if err != nil {
+			t.Fatalf("resolveVMI: %v", err)
+		}
+		if got != "10.42.0.158" {
+			t.Fatalf("want 10.42.0.158, got %q", got)
+		}
+	})
+
+	t.Run("namespace/name overrides the context namespace", func(t *testing.T) {
+		fakeVMIClient(t, "elsewhere", vmiWithStatus(map[string]any{
+			"interfaces": []any{map[string]any{"ipAddress": "10.42.0.158"}},
+		}))
+		if _, err := resolveVMI(context.Background(), "confai-images/mn-server"); err != nil {
+			t.Fatalf("resolveVMI: %v", err)
+		}
+	})
+
+	t.Run("missing guest wraps the lookup error", func(t *testing.T) {
+		fakeVMIClient(t, "confai-images")
+		_, err := resolveVMI(context.Background(), "absent-cvm")
+		if err == nil || !strings.Contains(err.Error(), "get virtualmachineinstance confai-images/absent-cvm") {
+			t.Fatalf("want wrapped get error, got %v", err)
+		}
+	})
+
+	t.Run("guest without an address fails", func(t *testing.T) {
+		fakeVMIClient(t, "confai-images", vmiWithStatus(nil))
+		_, err := resolveVMI(context.Background(), "mn-server")
+		if err == nil || !strings.Contains(err.Error(), "no reported address") {
+			t.Fatalf("want no-address error, got %v", err)
+		}
+	})
+
+	t.Run("client construction failure propagates", func(t *testing.T) {
+		t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing"))
+		_, err := resolveVMI(context.Background(), "mn-server")
+		if err == nil || !strings.Contains(err.Error(), "namespace from kubeconfig") {
+			t.Fatalf("want kubeconfig error, got %v", err)
+		}
+	})
+}
+
+// TestNewVMIClient exercises the real kubeconfig path: clientcmd loads the
+// fixture without contacting a cluster, so the context namespace and client
+// construction are fully covered.
+func TestNewVMIClient(t *testing.T) {
+	kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: outer
+  cluster: {server: "https://127.0.0.1:6443"}
+users:
+- name: op
+  user: {}
+contexts:
+- name: outer
+  context: {cluster: outer, user: op, namespace: confai-images}
+current-context: outer
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("KUBECONFIG", kubeconfig)
+
+	client, namespace, err := newVMIClient()
+	if err != nil {
+		t.Fatalf("newVMIClient: %v", err)
+	}
+	if client == nil {
+		t.Fatal("want a client")
+	}
+	if namespace != "confai-images" {
+		t.Fatalf("want context namespace confai-images, got %q", namespace)
+	}
+}
+
+func TestNewVMIClientFailures(t *testing.T) {
+	t.Run("missing kubeconfig", func(t *testing.T) {
+		// With no configuration at all, even the namespace read fails.
+		t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "missing"))
+		if _, _, err := newVMIClient(); err == nil ||
+			!strings.Contains(err.Error(), "namespace from kubeconfig") {
+			t.Fatalf("want namespace error, got %v", err)
+		}
+	})
+
+	t.Run("context without a usable cluster", func(t *testing.T) {
+		// The namespace loads, but client-config validation rejects the
+		// server-less cluster.
+		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+		if err := os.WriteFile(kubeconfig, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- name: outer
+  cluster: {}
+users:
+- name: op
+  user: {}
+contexts:
+- name: outer
+  context: {cluster: outer, user: op, namespace: confai-images}
+current-context: outer
+`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("KUBECONFIG", kubeconfig)
+		if _, _, err := newVMIClient(); err == nil ||
+			!strings.Contains(err.Error(), "load kubeconfig") {
+			t.Fatalf("want load-kubeconfig error, got %v", err)
+		}
+	})
+
+	t.Run("malformed kubeconfig", func(t *testing.T) {
+		kubeconfig := filepath.Join(t.TempDir(), "kubeconfig")
+		if err := os.WriteFile(kubeconfig, []byte("{not yaml"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("KUBECONFIG", kubeconfig)
+		// The parse failure surfaces at the first read, the namespace.
+		if _, _, err := newVMIClient(); err == nil ||
+			!strings.Contains(err.Error(), "namespace from kubeconfig") {
+			t.Fatalf("want namespace error, got %v", err)
+		}
+	})
 }

--- a/internal/cmds/getkubeconfig/vmi_test.go
+++ b/internal/cmds/getkubeconfig/vmi_test.go
@@ -1,0 +1,96 @@
+package getkubeconfig
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func vmiWithStatus(status map[string]any) *unstructured.Unstructured {
+	obj := map[string]any{
+		"apiVersion": "kubevirt.io/v1",
+		"kind":       "VirtualMachineInstance",
+		"metadata": map[string]any{
+			"name":      "mn-server",
+			"namespace": "confai-images",
+		},
+	}
+	if status != nil {
+		obj["status"] = status
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func TestVMIAddress(t *testing.T) {
+	cases := []struct {
+		name    string
+		status  map[string]any
+		want    string
+		wantErr string
+	}{
+		{
+			name: "first interface wins",
+			status: map[string]any{"interfaces": []any{
+				map[string]any{"ipAddress": "10.42.0.158"},
+				map[string]any{"ipAddress": "10.42.0.201"},
+			}},
+			want: "10.42.0.158",
+		},
+		{
+			// A booting guest can report an interface before its address.
+			name: "address-less interface is skipped",
+			status: map[string]any{"interfaces": []any{
+				map[string]any{"name": "default"},
+				map[string]any{"ipAddress": "10.42.0.201"},
+			}},
+			want: "10.42.0.201",
+		},
+		{
+			name:    "no status",
+			status:  nil,
+			wantErr: "no reported address",
+		},
+		{
+			name:    "empty interfaces",
+			status:  map[string]any{"interfaces": []any{}},
+			wantErr: "no reported address",
+		},
+		{
+			name: "empty ipAddress",
+			status: map[string]any{"interfaces": []any{
+				map[string]any{"ipAddress": ""},
+			}},
+			wantErr: "no reported address",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := vmiAddress(vmiWithStatus(tc.status))
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("want error containing %q, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("vmiAddress: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveVMIRejectsMalformedRefs(t *testing.T) {
+	// Ref validation runs before any kubeconfig or cluster access, so these
+	// fail fast with the ref error regardless of the test environment.
+	for _, ref := range []string{"", "/mn-server", "confai-images/", "/"} {
+		if _, err := resolveVMI(context.Background(), ref); err == nil ||
+			!strings.Contains(err.Error(), "is not name or namespace/name") {
+			t.Fatalf("ref %q: want malformed-ref error, got %v", ref, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

An operator dialling a confai-launched CVM has only its VMI name. On the host that name is neither a DNS host nor an IP, so every `get-kubeconfig` invocation starts with a kubectl jsonpath dig for the guest address to feed `--node`.

## Change

Add `--vmi [namespace/]name`, mutually exclusive with `--node`: it resolves the VMI's first reported interface address through the current kubeconfig context, which also supplies the namespace when the ref carries none, and uses it as `--node`. Resolving at call time means a restarted VMI cannot leave a stale entry behind. The dynamic client keeps the KubeVirt API types out of the module graph.

Address extraction skips interfaces that have not reported an address yet; a guest with none fails with `no reported address` instead of a dial failure downstream.

## Validation

- `go test ./internal/cmds/getkubeconfig/` — extraction table, malformed refs, resolution seam at the command level, `--node`/`--vmi` mutual exclusion
- `go vet ./internal/cmds/getkubeconfig/`
- `golangci-lint run internal/cmds/getkubeconfig/` — 0 issues
