### PR TITLE
feat(attestation): expose optional NVIDIA GPU evidence

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -71,7 +71,7 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  CONFOS_REF: ${{ inputs.confos_ref || 'e56427984177a680f1ee66b13f9de0c8db504b1d' }} # pin: v0.4.2 + attest-gpu serves SNP (platforms + DeviceAllow, confos#102/#103); snapshot-pinned mirror-guarded builds (confos#96)
+  CONFOS_REF: ${{ inputs.confos_ref || 'b5f1eec21a16e83c1f50310c95c15315460eaa87' }} # pin: v0.4.2 + gated GPU evidence collection; attest-gpu serves SNP; snapshot-pinned builds
   # This revision keeps GPU collection behind both the server config and the
   # caller's nvidia_gpu request. The attest-gpu profile enables the server gate.
   ATTESTATION_RS_REF: "41ad0c5495ec3cf4dc7a69d2870084bdf6b92f98" # pin: gated GPU evidence collection (#79)

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -72,7 +72,9 @@ env:
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
   CONFOS_REF: ${{ inputs.confos_ref || 'e56427984177a680f1ee66b13f9de0c8db504b1d' }} # pin: v0.4.2 + attest-gpu serves SNP (platforms + DeviceAllow, confos#102/#103); snapshot-pinned mirror-guarded builds (confos#96)
-  ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
+  # This revision keeps GPU collection behind both the server config and the
+  # caller's nvidia_gpu request. The attest-gpu profile enables the server gate.
+  ATTESTATION_RS_REF: "41ad0c5495ec3cf4dc7a69d2870084bdf6b92f98" # pin: gated GPU evidence collection (#79)
 
 jobs:
   build-and-push:

--- a/internal/cmds/cdsattest/cmd.go
+++ b/internal/cmds/cdsattest/cmd.go
@@ -31,6 +31,7 @@ type config struct {
 	attestationAPIURL    string
 	platform             string
 	generation           string
+	nvidiaGPUEvidence    bool
 	sessionTTL           time.Duration
 	readHeaderTimeout    time.Duration
 
@@ -69,6 +70,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.attestationAPIURL, "attestation-api-url", "", "attestation-api URL (production evidence source)")
 	f.StringVar(&cfg.platform, "platform", "", "REQUIRED: TEE platform: snp|az-snp|az-tdx|tdx")
 	f.StringVar(&cfg.generation, "generation", "genoa", "AMD processor generation for the browser's bare-SNP verifier (platform snp only, ignored otherwise): milan|genoa|turin")
+	f.BoolVar(&cfg.nvidiaGPUEvidence, "nvidia-gpu-evidence", false, "request nonce-bound NVIDIA GPU evidence from the attestation API")
 	f.DurationVar(&cfg.sessionTTL, "session-ttl", 5*time.Minute, "pending-handshake TTL and established-session idle TTL")
 	f.DurationVar(&cfg.readHeaderTimeout, "read-header-timeout", 5*time.Second, "HTTP read-header timeout")
 	f.StringVar(&cfg.upstream, "upstream", "", "backend base URL to forward decrypted traffic to (http:// rides the raTLS mesh; https:// does mTLS). Empty uses an echo backend (demo).")
@@ -105,9 +107,10 @@ func run(cfg config) error {
 			"file", cfg.evidenceFixture)
 	case cfg.attestationAPIURL != "":
 		provider = LiveEvidenceProvider{
-			Client:     attestationclient.NewClient(cfg.attestationAPIURL),
-			Platform:   types.Platform(cfg.platform),
-			Generation: cfg.generation,
+			Client:            attestationclient.NewClient(cfg.attestationAPIURL),
+			Platform:          types.Platform(cfg.platform),
+			Generation:        cfg.generation,
+			NvidiaGPUEvidence: cfg.nvidiaGPUEvidence,
 		}
 	default:
 		return fmt.Errorf("one of --attestation-api-url or --evidence-fixture is required")

--- a/internal/cmds/cdsattest/evidence.go
+++ b/internal/cmds/cdsattest/evidence.go
@@ -1,6 +1,7 @@
 package cdsattest
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,13 +11,20 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// EvidenceProvider yields TEE attestation evidence whose report_data equals
-// the endpoint's transcript hash (overenc.IdentityTranscriptHash for
-// attest-pq, overenc.LBTranscriptHash for attest-lb). The returned evidence is
-// the platform's attestation-rs evidence JSON (SnpEvidence, AzSnpEvidence,
-// TdxEvidence, …) the client verifier consumes verbatim.
+// CollectedEvidence carries CPU evidence and an optional NVIDIA bundle.
+// NvidiaGPU stays opaque so c8s preserves the attestation-rs bundle shape.
+type CollectedEvidence struct {
+	Evidence    json.RawMessage
+	Platform    string
+	Generation  string
+	GPUAttested string
+	NvidiaGPU   json.RawMessage
+}
+
+// EvidenceProvider yields evidence whose report_data equals the endpoint's
+// transcript hash. It also returns raw NVIDIA evidence when requested.
 type EvidenceProvider interface {
-	Evidence(ctx context.Context, reportData []byte) (evidence json.RawMessage, platform, generation string, err error)
+	Evidence(ctx context.Context, reportData []byte) (CollectedEvidence, error)
 }
 
 var _ EvidenceProvider = LiveEvidenceProvider{}
@@ -25,8 +33,9 @@ var _ EvidenceProvider = LiveEvidenceProvider{}
 // bound to reportData. This is the production path; it requires a reachable
 // attestation-api and runs inside the LB's CVM.
 type LiveEvidenceProvider struct {
-	Client   attestationclient.Client
-	Platform types.Platform // e.g. types.PlatformSnp
+	Client            attestationclient.Client
+	Platform          types.Platform // e.g. types.PlatformSnp
+	NvidiaGPUEvidence bool
 	// Generation is the AMD processor generation the browser's bare-SNP
 	// verifier needs. It is meaningful only for PlatformSnp; the other
 	// platforms auto-detect (az-snp) or have no generation concept (TDX),
@@ -35,13 +44,14 @@ type LiveEvidenceProvider struct {
 }
 
 // Evidence implements EvidenceProvider against the attestation-api.
-func (p LiveEvidenceProvider) Evidence(ctx context.Context, reportData []byte) (json.RawMessage, string, string, error) {
+func (p LiveEvidenceProvider) Evidence(ctx context.Context, reportData []byte) (CollectedEvidence, error) {
 	resp, err := p.Client.Attest(ctx, types.AttestRequest{
 		ReportData: types.NewBase64Bytes(reportData),
 		Platform:   p.Platform,
+		NvidiaGPU:  p.NvidiaGPUEvidence,
 	})
 	if err != nil {
-		return nil, "", "", fmt.Errorf("attestation-api: %w", err)
+		return CollectedEvidence{}, fmt.Errorf("attestation-api: %w", err)
 	}
 	platform := resp.Platform
 	if platform == "" {
@@ -51,7 +61,44 @@ func (p LiveEvidenceProvider) Evidence(ctx context.Context, reportData []byte) (
 	if platform != string(types.PlatformSnp) {
 		generation = ""
 	}
-	return resp.Evidence, platform, generation, nil
+	if err := validateGPUCollection(resp, p.NvidiaGPUEvidence); err != nil {
+		return CollectedEvidence{}, fmt.Errorf("attestation-api: %w", err)
+	}
+	return CollectedEvidence{
+		Evidence:    resp.Evidence,
+		Platform:    platform,
+		Generation:  generation,
+		GPUAttested: normalizedGPUStatus(resp.GPUAttested),
+		NvidiaGPU:   resp.NvidiaGPU,
+	}, nil
+}
+
+func normalizedGPUStatus(status string) string {
+	if status == "" {
+		return types.GPUAttestedUnknown
+	}
+	return status
+}
+
+func validateGPUCollection(resp types.AttestResponse, required bool) error {
+	status := normalizedGPUStatus(resp.GPUAttested)
+	hasBundle := len(bytes.TrimSpace(resp.NvidiaGPU)) != 0 && !bytes.Equal(bytes.TrimSpace(resp.NvidiaGPU), []byte("null"))
+	switch status {
+	case types.GPUAttestedUnknown:
+		if hasBundle {
+			return fmt.Errorf("GPU status is unknown but the response carries a bundle")
+		}
+	case types.GPUAttestedEvidenceCollected:
+		if !hasBundle {
+			return fmt.Errorf("GPU status says evidence_collected but the response carries no bundle")
+		}
+	default:
+		return fmt.Errorf("unsupported GPU collection status %q", resp.GPUAttested)
+	}
+	if required && status != types.GPUAttestedEvidenceCollected {
+		return fmt.Errorf("GPU evidence was requested but the service did not collect it")
+	}
+	return nil
 }
 
 // FixtureEvidenceProvider serves a recorded evidence file. DEV/DEMO ONLY: the
@@ -93,6 +140,11 @@ func LoadFixtureEvidence(path, platform, generation string) (FixtureEvidenceProv
 }
 
 // Evidence implements EvidenceProvider; reportData is ignored (see type doc).
-func (p FixtureEvidenceProvider) Evidence(_ context.Context, _ []byte) (json.RawMessage, string, string, error) {
-	return p.Raw, p.Platform, p.Generation, nil
+func (p FixtureEvidenceProvider) Evidence(_ context.Context, _ []byte) (CollectedEvidence, error) {
+	return CollectedEvidence{
+		Evidence:    p.Raw,
+		Platform:    p.Platform,
+		Generation:  p.Generation,
+		GPUAttested: types.GPUAttestedUnknown,
+	}, nil
 }

--- a/internal/cmds/cdsattest/evidence_test.go
+++ b/internal/cmds/cdsattest/evidence_test.go
@@ -33,9 +33,12 @@ func TestLoadFixtureEvidenceBareObject(t *testing.T) {
 	if string(p.Raw) != raw || p.Platform != "snp" || p.Generation != "genoa" {
 		t.Fatalf("unexpected provider: %+v", p)
 	}
-	ev, platform, generation, err := p.Evidence(context.Background(), []byte("ignored"))
-	if err != nil || string(ev) != raw || platform != "snp" || generation != "genoa" {
-		t.Fatalf("Evidence() = %q, %q, %q, %v", ev, platform, generation, err)
+	got, err := p.Evidence(context.Background(), []byte("ignored"))
+	if err != nil || string(got.Evidence) != raw || got.Platform != "snp" || got.Generation != "genoa" {
+		t.Fatalf("Evidence() = %+v, %v", got, err)
+	}
+	if got.GPUAttested != types.GPUAttestedUnknown || len(got.NvidiaGPU) != 0 {
+		t.Fatalf("fixture GPU state = %q, %s", got.GPUAttested, got.NvidiaGPU)
 	}
 }
 
@@ -76,6 +79,7 @@ func TestLoadFixtureEvidenceDefaultsPlatform(t *testing.T) {
 
 func TestLiveEvidenceProvider(t *testing.T) {
 	var gotReq types.AttestRequest
+	gpu := json.RawMessage(`{"devices":[{"arch":"BLACKWELL","uuid":"gpu-1","evidence_b64":"ZXZpZGVuY2U=","cert_chain_b64":"Y2VydA=="}],"binding":{"kind":"concat","algo":"sha256"}}`)
 	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/attest" {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
@@ -84,26 +88,97 @@ func TestLiveEvidenceProvider(t *testing.T) {
 			t.Error(err)
 		}
 		json.NewEncoder(w).Encode(types.AttestResponse{
-			Platform: "snp",
-			Evidence: json.RawMessage(`{"attestation_report":"AAAA"}`),
+			Platform:    "snp",
+			Evidence:    json.RawMessage(`{"attestation_report":"AAAA"}`),
+			GPUAttested: types.GPUAttestedEvidenceCollected,
+			NvidiaGPU:   gpu,
 		})
 	}))
 	defer api.Close()
 
 	p := LiveEvidenceProvider{
-		Client:     attestationclient.NewClient(api.URL),
-		Platform:   types.PlatformSnp,
-		Generation: "genoa",
+		Client:            attestationclient.NewClient(api.URL),
+		Platform:          types.PlatformSnp,
+		Generation:        "genoa",
+		NvidiaGPUEvidence: true,
 	}
-	ev, platform, generation, err := p.Evidence(context.Background(), []byte("report-data"))
+	got, err := p.Evidence(context.Background(), []byte("report-data"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(ev) != `{"attestation_report":"AAAA"}` || platform != "snp" || generation != "genoa" {
-		t.Fatalf("Evidence() = %q, %q, %q", ev, platform, generation)
+	if string(got.Evidence) != `{"attestation_report":"AAAA"}` || got.Platform != "snp" || got.Generation != "genoa" {
+		t.Fatalf("Evidence() = %+v", got)
+	}
+	if got.GPUAttested != types.GPUAttestedEvidenceCollected || string(got.NvidiaGPU) != string(gpu) {
+		t.Fatalf("GPU evidence changed: status=%q bundle=%s", got.GPUAttested, got.NvidiaGPU)
 	}
 	if string(gotReq.ReportData.Bytes()) != "report-data" {
 		t.Fatalf("report_data not forwarded: %q", gotReq.ReportData.Bytes())
+	}
+	if !gotReq.NvidiaGPU {
+		t.Fatal("nvidia_gpu request flag is false")
+	}
+}
+
+func TestLiveEvidenceProviderDoesNotRequestGPUByDefault(t *testing.T) {
+	var gotReq types.AttestRequest
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatal(err)
+		}
+		json.NewEncoder(w).Encode(types.AttestResponse{
+			Platform:    "tdx",
+			Evidence:    json.RawMessage(`{"quote":"AAAA"}`),
+			GPUAttested: types.GPUAttestedUnknown,
+		})
+	}))
+	defer api.Close()
+
+	p := LiveEvidenceProvider{Client: attestationclient.NewClient(api.URL), Platform: types.PlatformTdx}
+	if _, err := p.Evidence(context.Background(), []byte("report-data")); err != nil {
+		t.Fatal(err)
+	}
+	if gotReq.NvidiaGPU {
+		t.Fatal("nvidia_gpu request flag is true by default")
+	}
+}
+
+func TestLiveEvidenceProviderFailsClosedWithoutRequestedGPU(t *testing.T) {
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(types.AttestResponse{
+			Platform:    "tdx",
+			Evidence:    json.RawMessage(`{"quote":"AAAA"}`),
+			GPUAttested: types.GPUAttestedUnknown,
+		})
+	}))
+	defer api.Close()
+
+	p := LiveEvidenceProvider{
+		Client:            attestationclient.NewClient(api.URL),
+		Platform:          types.PlatformTdx,
+		NvidiaGPUEvidence: true,
+	}
+	_, err := p.Evidence(context.Background(), []byte("report-data"))
+	if err == nil || !strings.Contains(err.Error(), "did not collect") {
+		t.Fatalf("expected missing GPU evidence error, got %v", err)
+	}
+}
+
+func TestLiveEvidenceProviderRejectsInconsistentGPUResponse(t *testing.T) {
+	tests := []types.AttestResponse{
+		{GPUAttested: types.GPUAttestedEvidenceCollected},
+		{GPUAttested: types.GPUAttestedUnknown, NvidiaGPU: json.RawMessage(`{"devices":[]}`)},
+		{GPUAttested: "verified", NvidiaGPU: json.RawMessage(`{"devices":[]}`)},
+	}
+	for _, response := range tests {
+		api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			json.NewEncoder(w).Encode(response)
+		}))
+		p := LiveEvidenceProvider{Client: attestationclient.NewClient(api.URL), Platform: types.PlatformTdx}
+		if _, err := p.Evidence(context.Background(), []byte("report-data")); err == nil {
+			t.Errorf("expected response rejection for %+v", response)
+		}
+		api.Close()
 	}
 }
 
@@ -115,12 +190,12 @@ func TestLiveEvidenceProviderPlatformFallback(t *testing.T) {
 	defer api.Close()
 
 	p := LiveEvidenceProvider{Client: attestationclient.NewClient(api.URL), Platform: types.PlatformSnp, Generation: "genoa"}
-	_, platform, _, err := p.Evidence(context.Background(), []byte("rd"))
+	got, err := p.Evidence(context.Background(), []byte("rd"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if platform != string(types.PlatformSnp) {
-		t.Fatalf("platform = %q, want fallback %q", platform, types.PlatformSnp)
+	if got.Platform != string(types.PlatformSnp) {
+		t.Fatalf("platform = %q, want fallback %q", got.Platform, types.PlatformSnp)
 	}
 }
 
@@ -131,7 +206,7 @@ func TestLiveEvidenceProviderError(t *testing.T) {
 	defer api.Close()
 
 	p := LiveEvidenceProvider{Client: attestationclient.NewClient(api.URL), Platform: types.PlatformSnp}
-	_, _, _, err := p.Evidence(context.Background(), []byte("rd"))
+	_, err := p.Evidence(context.Background(), []byte("rd"))
 	if err == nil || !strings.Contains(err.Error(), "attestation-api") {
 		t.Fatalf("expected attestation-api error, got %v", err)
 	}

--- a/internal/cmds/cdsattest/identity_test.go
+++ b/internal/cmds/cdsattest/identity_test.go
@@ -159,6 +159,12 @@ func TestIdentityBoundAttestationAndChannel(t *testing.T) {
 	if bundle.IdentityProof == nil || bundle.SessionPubKey == nil {
 		t.Fatalf("bundle missing identity proof or session key: %+v", bundle)
 	}
+	if bundle.GPUAttested != types.GPUAttestedEvidenceCollected {
+		t.Fatalf("gpu_attested = %q", bundle.GPUAttested)
+	}
+	if string(bundle.NvidiaGPU) != `{"devices":[],"binding":{"kind":"concat","algo":"sha256"}}` {
+		t.Fatalf("nvidia_gpu changed: %s", bundle.NvidiaGPU)
+	}
 
 	x25519, err := base64.RawURLEncoding.DecodeString(bundle.SessionPubKey.X25519)
 	if err != nil {

--- a/internal/cmds/cdsattest/server.go
+++ b/internal/cmds/cdsattest/server.go
@@ -437,7 +437,7 @@ func (s *Server) handleAttestPQ(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	evidence, platform, generation, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
+	collected, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
 	if err != nil {
 		s.log.Error("evidence provider failed", "error", err)
 		writeErr(w, http.StatusBadGateway, types.ErrorCodeAttestationUnavailable, "could not obtain attestation evidence")
@@ -454,12 +454,14 @@ func (s *Server) handleAttestPQ(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, types.AttestationBundle{
-		Version:    types.BindingAttestPQ,
-		Platform:   platform,
-		Generation: generation,
-		Nonce:      nonceB64,
-		Evidence:   evidence,
-		CDSCertPEM: string(identity.bundlePEM),
+		Version:     types.BindingAttestPQ,
+		Platform:    collected.Platform,
+		Generation:  collected.Generation,
+		Nonce:       nonceB64,
+		Evidence:    collected.Evidence,
+		GPUAttested: collected.GPUAttested,
+		NvidiaGPU:   collected.NvidiaGPU,
+		CDSCertPEM:  string(identity.bundlePEM),
 		SessionPubKey: &types.SessionPublicKey{
 			X25519:   base64.RawURLEncoding.EncodeToString(pub.X25519),
 			MLKEM768: base64.RawURLEncoding.EncodeToString(pub.MLKEM768),
@@ -509,7 +511,7 @@ func (s *Server) handleAttestLB(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	evidence, platform, generation, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
+	collected, err := s.cfg.Evidence.Evidence(r.Context(), reportData)
 	if err != nil {
 		s.log.Error("evidence provider failed", "error", err)
 		writeErr(w, http.StatusBadGateway, types.ErrorCodeAttestationUnavailable, "could not obtain attestation evidence")
@@ -519,10 +521,12 @@ func (s *Server) handleAttestLB(w http.ResponseWriter, r *http.Request) {
 	servingLeafHash := sha256.Sum256(servingLeafDER)
 	writeJSON(w, http.StatusOK, types.AttestationBundle{
 		Version:           types.BindingAttestLB,
-		Platform:          platform,
-		Generation:        generation,
+		Platform:          collected.Platform,
+		Generation:        collected.Generation,
 		Nonce:             nonceB64,
-		Evidence:          evidence,
+		Evidence:          collected.Evidence,
+		GPUAttested:       collected.GPUAttested,
+		NvidiaGPU:         collected.NvidiaGPU,
 		CDSCertPEM:        string(identity.bundlePEM),
 		IdentityProof:     proof,
 		ServingLeafSHA256: base64.RawURLEncoding.EncodeToString(servingLeafHash[:]),

--- a/internal/cmds/cdsattest/server_attestlb_test.go
+++ b/internal/cmds/cdsattest/server_attestlb_test.go
@@ -33,9 +33,15 @@ type capturingProvider struct {
 	lastReportData []byte
 }
 
-func (p *capturingProvider) Evidence(_ context.Context, reportData []byte) (json.RawMessage, string, string, error) {
+func (p *capturingProvider) Evidence(_ context.Context, reportData []byte) (CollectedEvidence, error) {
 	p.lastReportData = append([]byte(nil), reportData...)
-	return json.RawMessage(`{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`), "snp", "genoa", nil
+	return CollectedEvidence{
+		Evidence:    json.RawMessage(`{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`),
+		Platform:    "snp",
+		Generation:  "genoa",
+		GPUAttested: types.GPUAttestedEvidenceCollected,
+		NvidiaGPU:   json.RawMessage(`{"devices":[],"binding":{"kind":"concat","algo":"sha256"}}`),
+	}, nil
 }
 
 // writeTestServingLeaf writes a self-signed leaf PEM to a temp file and
@@ -106,6 +112,12 @@ func TestAttestLBBindsServingLeafAndMeshIdentity(t *testing.T) {
 	}
 	if b.Nonce != b64url(nonce) {
 		t.Errorf("nonce not echoed: got %q", b.Nonce)
+	}
+	if b.GPUAttested != types.GPUAttestedEvidenceCollected {
+		t.Errorf("gpu_attested = %q", b.GPUAttested)
+	}
+	if string(b.NvidiaGPU) != `{"devices":[],"binding":{"kind":"concat","algo":"sha256"}}` {
+		t.Errorf("nvidia_gpu changed: %s", b.NvidiaGPU)
 	}
 	servingHash := sha256.Sum256(servingDER)
 	if b.ServingLeafSHA256 != b64url(servingHash[:]) {

--- a/internal/cmds/cdsattest/server_limits_test.go
+++ b/internal/cmds/cdsattest/server_limits_test.go
@@ -30,7 +30,7 @@ type countingEvidence struct {
 	calls atomic.Int64
 }
 
-func (c *countingEvidence) Evidence(ctx context.Context, reportData []byte) (json.RawMessage, string, string, error) {
+func (c *countingEvidence) Evidence(ctx context.Context, reportData []byte) (CollectedEvidence, error) {
 	c.calls.Add(1)
 	return c.inner.Evidence(ctx, reportData)
 }

--- a/internal/cmds/cdsattest/server_test.go
+++ b/internal/cmds/cdsattest/server_test.go
@@ -388,8 +388,8 @@ func TestHTTPBackendRejectsOversizedUpstreamResponse(t *testing.T) {
 // failingProvider always fails, to exercise the evidence-unavailable paths.
 type failingProvider struct{}
 
-func (failingProvider) Evidence(context.Context, []byte) (json.RawMessage, string, string, error) {
-	return nil, "", "", errors.New("no TEE here")
+func (failingProvider) Evidence(context.Context, []byte) (CollectedEvidence, error) {
+	return CollectedEvidence{}, errors.New("no TEE here")
 }
 
 func decodeErr(t *testing.T, resp *http.Response) types.ErrorResponse {

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -121,7 +121,8 @@ func verifiedSelfHostData(ctx context.Context, attestationAPIURL string) ([]byte
 		return nil, fmt.Errorf("attest self: %w", err)
 	}
 	verified, err := attestationclient.NewClient(attestationAPIURL).VerifyEvidence(ctx,
-		types.AttestationEvidence(resp), attestationclient.EvidencePolicy{ExpectedReportData: reportData})
+		types.AttestationEvidence{Platform: resp.Platform, Evidence: resp.Evidence},
+		attestationclient.EvidencePolicy{ExpectedReportData: reportData})
 	if err != nil {
 		return nil, fmt.Errorf("verify self-report: %w", err)
 	}

--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -201,7 +201,8 @@ func verifiedSelfHostData(ctx context.Context, cfg *Config) ([]byte, error) {
 	}
 	// Measurements stay unpinned.
 	verified, err := attestationclient.NewClient(cfg.AttestationServiceURL).VerifyEvidence(ctx,
-		types.AttestationEvidence(resp), attestationclient.EvidencePolicy{ExpectedReportData: reportData})
+		types.AttestationEvidence{Platform: resp.Platform, Evidence: resp.Evidence},
+		attestationclient.EvidencePolicy{ExpectedReportData: reportData})
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", classifyVerifyError(err), err)
 	}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -4,6 +4,9 @@
 Recreate, silently defeating the operator's opt-out. */ -}}
 {{- fail (printf "tlsLb.hostPort.enabled must be a boolean; do not set it via --set-string, got: %v" .Values.tlsLb.hostPort.enabled) -}}
 {{- end -}}
+{{- if not (kindIs "bool" .Values.tlsLb.attest.nvidiaGpuEvidence) -}}
+{{- fail (printf "tlsLb.attest.nvidiaGpuEvidence must be a boolean; do not set it via --set-string, got: %v" .Values.tlsLb.attest.nvidiaGpuEvidence) -}}
+{{- end -}}
 {{- if and .Values.kata.enabled (ne (int .Values.tlsLb.nginx.httpsPort) 8443) -}}
 {{- /* The guest bakes C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443 (a guest-wide
 default in cloudinit.env, not a chart value) and redirects every other inbound
@@ -180,6 +183,9 @@ spec:
             - --port={{ .Values.tlsLb.attest.port }}
             - --platform={{ .Values.tlsLb.attest.platform }}
             - --generation={{ .Values.tlsLb.attest.generation }}
+            {{- if .Values.tlsLb.attest.nvidiaGpuEvidence }}
+            - --nvidia-gpu-evidence
+            {{- end }}
             - --attestation-api-url={{ default (include "c8s.attestationApiURL" .) .Values.tlsLb.attest.attestationApiURL }}
             # attest-lb transport trust rests on the serving key being TEE-held:
             # a publicTLS Secret's key is host-visible, so that front door is

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1320,6 +1320,9 @@ tlsLb:
   # AMD-only generation), so both TEEs advertise correctly out of the box.
   attest:
     enabled: true
+    # -- Request nonce-bound NVIDIA GPU evidence for each public attestation.
+    # Keep this false on generic and CPU-only deployments.
+    nvidiaGpuEvidence: false
     # -- Loopback port the sidecar listens on; nginx proxies `/.well-known/c8s/`
     # to 127.0.0.1 on this port.
     port: 8800

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2527,6 +2527,31 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 	}
 }
 
+func TestChartTLSLBNvidiaGPUEvidenceIsDeploymentScoped(t *testing.T) {
+	out, err := helmTemplate(t, "--set", "tlsLb.attest.enabled=true")
+	if err != nil {
+		t.Fatalf("helm template defaults: %v\n%s", err, out)
+	}
+	defaultSidecar := renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest")
+	assertContainerNoArgPrefix(t, "cds-attest", defaultSidecar.Args, "--nvidia-gpu-evidence")
+
+	out, err = helmTemplate(t,
+		"--set", "tlsLb.attest.enabled=true",
+		"--set", "tlsLb.attest.nvidiaGpuEvidence=true",
+	)
+	if err != nil {
+		t.Fatalf("helm template GPU evidence: %v\n%s", err, out)
+	}
+	gpuSidecar := renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest")
+	assertContainerHasArgPrefix(t, "cds-attest", gpuSidecar.Args, "--nvidia-gpu-evidence")
+
+	out, err = helmTemplate(t, "--set-string", "tlsLb.attest.nvidiaGpuEvidence=true")
+	if err == nil {
+		t.Fatalf("string GPU evidence value must fail\n%s", out)
+	}
+	assertHelmFailMessage(t, out, "tlsLb.attest.nvidiaGpuEvidence must be a boolean; do not set it via --set-string, got: true")
+}
+
 func TestTLSLBCertProvisioningValuesDriveGetCertContainers(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set-string", "tlsLb.certProvisioning.renewInterval=30m",

--- a/internal/issuer/handoff_bootstrap.go
+++ b/internal/issuer/handoff_bootstrap.go
@@ -223,7 +223,10 @@ func (h *localHandoffBootstrap) attestKey(ctx context.Context, pubDER []byte) (s
 	}
 
 	verifyReq := types.VerifyReportData(
-		types.AttestationEvidence(asResp),
+		types.AttestationEvidence{
+			Platform: asResp.Platform,
+			Evidence: asResp.Evidence,
+		},
 		types.NewBase64Bytes(reportDataDigest),
 	)
 	verifyResp, err := h.attestation.Verify(ctx, verifyReq)

--- a/pkg/attestclient/client.go
+++ b/pkg/attestclient/client.go
@@ -230,8 +230,11 @@ func (c Client) AttestKeyWithOperatorKeysHash(ctx context.Context, attestationAp
 	}
 
 	body, err := json.Marshal(types.AttestKeyRequestBody{
-		Challenge:        challengeResp.Challenge,
-		Evidence:         types.AttestationEvidence(asResp),
+		Challenge: challengeResp.Challenge,
+		Evidence: types.AttestationEvidence{
+			Platform: asResp.Platform,
+			Evidence: asResp.Evidence,
+		},
 		PublicKey:        base64.StdEncoding.EncodeToString(pubKeyDER),
 		OperatorKeysHash: operatorKeysHash,
 	})

--- a/pkg/attestclient/ratls.go
+++ b/pkg/attestclient/ratls.go
@@ -104,7 +104,10 @@ func RATLSEvidence(resp types.AttestResponse) (string, error) {
 		return ExtractSNPReport(resp)
 	}
 
-	envelope := types.AttestationEvidence(resp)
+	envelope := types.AttestationEvidence{
+		Platform: resp.Platform,
+		Evidence: resp.Evidence,
+	}
 	if resp.Platform == string(types.PlatformTdx) {
 		stripped, err := stripTDXEventlog(envelope.Evidence)
 		if err != nil {

--- a/pkg/types/attestation.go
+++ b/pkg/types/attestation.go
@@ -115,6 +115,8 @@ const (
 type AttestRequest struct {
 	ReportData Base64Bytes `json:"report_data"`
 	Platform   Platform    `json:"platform"`
+	// NvidiaGPU requests a nonce-bound NVIDIA GPU evidence bundle.
+	NvidiaGPU bool `json:"nvidia_gpu,omitempty"`
 }
 
 // AttestResponse is the response from the attestation-api POST /attest.
@@ -124,8 +126,11 @@ type AttestRequest struct {
 // need to forward evidence to /verify must wrap it in an AttestationEvidence
 // envelope keyed by Platform.
 type AttestResponse struct {
-	Platform string          `json:"platform"`
-	Evidence json.RawMessage `json:"evidence"`
+	Platform    string          `json:"platform"`
+	Evidence    json.RawMessage `json:"evidence"`
+	GPUAttested string          `json:"gpu_attested"`
+	// NvidiaGPU preserves the attestation-rs bundle without a schema change.
+	NvidiaGPU json.RawMessage `json:"nvidia_gpu,omitempty"`
 }
 
 // VerifyRequest is sent to the attestation-api POST /verify. The attestation-api

--- a/pkg/types/verify.go
+++ b/pkg/types/verify.go
@@ -34,6 +34,11 @@ const (
 
 	// MeshIdentityProofECDSASHA384 is the proof-of-possession algorithm.
 	MeshIdentityProofECDSASHA384 = "ecdsa-sha384"
+
+	// GPUAttestedUnknown means that the service did not collect GPU evidence.
+	GPUAttestedUnknown = "unknown"
+	// GPUAttestedEvidenceCollected means that raw GPU evidence exists.
+	GPUAttestedEvidenceCollected = "evidence_collected"
 )
 
 // MeshIdentityProof authenticates the PQ session transcript with the private
@@ -58,11 +63,15 @@ type MeshIdentityProof struct {
 // binding identifier (BindingAttestPQ / BindingAttestLB); a client requires
 // the one its endpoint mode selects.
 type AttestationBundle struct {
-	Version    string          `json:"version"`      // BindingAttestPQ | BindingAttestLB
-	Platform   string          `json:"platform"`     // "snp" | "az-snp" | "az-tdx" | "tdx"
-	Generation string          `json:"generation"`   // AMD gen for "snp": milan|genoa|turin; empty otherwise
-	Nonce      string          `json:"nonce"`        // echoed client nonce (b64url)
-	Evidence   json.RawMessage `json:"evidence"`     // platform-shaped attestation-rs evidence
+	Version    string          `json:"version"`    // BindingAttestPQ | BindingAttestLB
+	Platform   string          `json:"platform"`   // "snp" | "az-snp" | "az-tdx" | "tdx"
+	Generation string          `json:"generation"` // AMD gen for "snp": milan|genoa|turin; empty otherwise
+	Nonce      string          `json:"nonce"`      // echoed client nonce (b64url)
+	Evidence   json.RawMessage `json:"evidence"`   // platform-shaped attestation-rs evidence
+	// GPUAttested reports collection state. It does not report verification.
+	GPUAttested string `json:"gpu_attested"`
+	// NvidiaGPU preserves the opaque attestation-rs NVIDIA evidence bundle.
+	NvidiaGPU  json.RawMessage `json:"nvidia_gpu,omitempty"`
 	CDSCertPEM string          `json:"cds_cert_pem"` // exact mesh leaf + issuing CA committed by report_data
 	// SessionPubKey is the per-session over-encryption key, present only for
 	// the attest-pq response; attest-lb creates no session.


### PR DESCRIPTION
Adds an explicit GPU evidence collection flag. Preserves the opaque attestation-rs NVIDIA bundle. Keeps generic deployments disabled by default. Fails closed when requested evidence is absent. Validation: full Go race suite and diff checks pass. Deployment depends on the confidential-os-builder GPU profile update.