### PR TITLE
security(ci): close CI-FORK-RCE on meat and image-repro-gate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,6 +2,5 @@ self-hosted-runner:
   # Custom labels beyond the GitHub-hosted set, so actionlint's runner-label
   # check knows them.
   labels:
-    - meaty-runner
     - the-machine
     - cvm-launcher-tdx

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,44 @@
+name: actionlint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install actionlint (checksum-pinned)
+        env:
+          # SHA256 from the v1.7.12 release's checksums.txt (linux_amd64).
+          SHA256: 8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        run: |
+          set -euo pipefail
+          curl -fsSL -o actionlint.tar.gz \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "$SHA256  actionlint.tar.gz" | sha256sum -c -
+          tar xzf actionlint.tar.gz actionlint
+
+      - name: Lint workflows
+        # Ignores clear findings that pre-exist on origin/main (c8s-image.yml's
+        # undeclared workflow_call input; shellcheck hits in the metal e2e
+        # workflows, surfaced by the runners' preinstalled shellcheck) so only
+        # new findings fail the gate.
+        run: |
+          set -euo pipefail
+          ./actionlint \
+            -ignore 'property "gate_intree" is not defined in object type' \
+            -ignore 'SC2006' \
+            -ignore 'SC2013' \
+            -ignore 'SC2015' \
+            -ignore 'SC2016' \
+            -ignore 'SC2034' \
+            -ignore 'SC2086' \
+            -ignore 'SC2129'

--- a/.github/workflows/image-repro-gate.yml
+++ b/.github/workflows/image-repro-gate.yml
@@ -1,8 +1,9 @@
 # Reproducibility gate for the node image: PRs touching the image definition
 # or its pins build the image TWICE (parallel legs, separate runners) and fail
-# unless every measured value matches (c8s#264). Runs on EVERY PR and decides
+# unless every measured value matches (c8s#264). Runs on every PR and decides
 # relevance itself — a paths: filter would leave the required `compare` check
-# forever pending on unrelated PRs.
+# forever pending on unrelated PRs. Fork PRs are exempt from the gate
+# (security-over-coverage); the post-merge main build remains the published gate.
 name: image repro gate
 on:
   pull_request:
@@ -17,6 +18,8 @@ concurrency:
 
 jobs:
   changes:
+    # The gate build legs run on the-machine (self-hosted); never fork-trigger.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.diff.outputs.image }}
@@ -99,8 +102,9 @@ jobs:
       gate_signing_artifact: module-signing-${{ github.run_id }}
 
   compare:
-    # The required check: green fast on image-irrelevant PRs, otherwise only
-    # after both legs built and every measured value matched.
+    # The required check: green fast on image-irrelevant PRs (and fork PRs,
+    # whose changes job is skipped), otherwise only after both legs built
+    # and every measured value matched.
     needs: [changes, build-a, build-b]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/meat.yml
+++ b/.github/workflows/meat.yml
@@ -1,7 +1,6 @@
 name: Meat
 
-# Abridge each PR's diff into a "reading diff" with meat
-# (https://github.com/boldsoftware/meat) and post it as a sticky PR comment.
+# Abridges each PR's diff for faster reading, via meat (github.com/boldsoftware/meat).
 
 on:
   pull_request:
@@ -18,8 +17,11 @@ permissions:
 jobs:
   meat:
     name: Reading diff (advisory)
-    runs-on: meaty-runner
+    runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: meat-review
+    # Fork PRs can't post comments (read-only token) and must not touch secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     # Advisory: a flaky LLM run never blocks the PR.
     continue-on-error: true
     steps:
@@ -28,22 +30,12 @@ jobs:
           # meat diffs base...head, so both sides' history must be present.
           fetch-depth: 0
 
-      - uses: ./.github/actions/setup-go-c8s
-
-      # meat caches results in ~/.meat, content-keyed by (rubric, model, diff).
-      # A persistent runner keeps that directory between jobs on its own; only
-      # when the job starts cold do we route it through the Actions cache.
-      - name: Detect runner-local meat cache
-        id: meat-cache
-        run: |
-          if compgen -G "$HOME/.meat/*.json" > /dev/null; then
-            echo "persisted=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "persisted=false" >> "$GITHUB_OUTPUT"
-          fi
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+          cache: false
 
       - name: Restore meat cache
-        if: steps.meat-cache.outputs.persisted != 'true'
         uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.meat
@@ -53,18 +45,21 @@ jobs:
           restore-keys: |
             meat-
 
-      - name: Install meat
-        run: go install meat.dev/cmd/meat@latest
+      - name: Install meat (digest-pinned)
+        env:
+          MEAT_VER: v0.0.0-20260803201634-f39f41dfe7b5
+          MEAT_SUM: h1:DGi7NSbQm8PUF/2qFXoclFJ6Or3CO+WbbIS32+KoNDI=
+        run: |
+          set -euo pipefail
+          sum="$(go mod download -json "meat.dev@${MEAT_VER}" 2>/dev/null | jq -r '.Sum')"
+          test "$sum" = "$MEAT_SUM"
+          go install "meat.dev/cmd/meat@${MEAT_VER}"
 
       - name: Abridge the PR diff
         id: meat
         env:
-          # Real keys (when the secrets exist) take precedence; empty values
-          # fall through to the runner's managed LLM gateway. Not every
-          # runner that picks this job up has the gateway, so a missing-LLM
-          # failure degrades to a skip (with a notice) instead of a red row —
-          # job-level continue-on-error already keeps this non-blocking, but
-          # it cannot keep the check GREEN.
+          # Provided via the `meat-review` environment (required approval).
+          # A missing LLM degrades the advisory to a skip (with a notice), not a red row.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
@@ -77,7 +72,7 @@ jobs:
           fi
 
       - name: Save meat cache
-        if: steps.meat-cache.outputs.persisted != 'true' && steps.meat.outputs.ran == 'true'
+        if: steps.meat.outputs.ran == 'true'
         uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.meat
@@ -121,8 +116,7 @@ jobs:
 
             await core.summary.addRaw(body).write();
 
-            // Fork PRs run with a read-only token; for them the run summary
-            // above is all we can publish.
+            // Defense-in-depth: the job-level if: already skips fork PRs.
             if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) return;
 
             const {data: comments} = await github.rest.issues.listComments({


### PR DESCRIPTION
## What & why

Closes the HIGH CI-FORK-RCE finding (fork PRs could obtain arbitrary code execution on the persistent self-hosted `meaty-runner`, with LLM API keys in the environment, via a PR-rewritable in-repo composite action and an unpinned `go install meat@latest`).

### meat.yml
- `runs-on: meaty-runner` → `ubuntu-latest` (ephemeral hosted runner; no persistent state to poison).
- Job-level `if:` skips fork PRs (`head.repo.full_name == repository`).
- API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`) are now provided only through the protected `environment: meat-review` (required approval).
- Dropped the PR-rewritable in-repo composite `setup-go-c8s` in favour of SHA-pinned `actions/setup-go@… (v6.4.0)` reading `go.mod`.
- `meat` pinned to `v0.0.0-20260803201634-f39f41dfe7b5` with a checksum-database H1 digest verified fail-closed before install.

### image-repro-gate.yml
- The `changes` job now skips fork PRs, so the self-hosted `the-machine` repro legs (`build-a`/`build-b` → `c8s-image.yml`) never run fork content; the required `compare` check still passes green.

### actionlint gate (new)
- Repeatable `.github/workflows/actionlint.yml` CI job on pull_request + push to main, checking out `.github/workflows` on a hosted runner with `contents: read` and a SHA256-checksum-pinned actionlint binary.

## Fork-triggerable workflow audit (AC)
Workflows triggered by `pull_request`/`pull_request_target`:
- `meat.yml`, `chart.yml`, `ci.yml`, `docker.yml`, `govulncheck.yml`, `grype.yml`, `node-guest-image-lint.yml`, `signed-commits.yml`, `cla.yml` (pull_request_target, no PR checkout), `image-repro-gate.yml` — all run on GitHub-hosted `ubuntu-latest` (ephemeral) only. `meat.yml` and `image-repro-gate.yml` additionally skip fork PRs.
- Self-hosted workflows (`c8s-image.yml`, `kata-guest-base.yml`, `kernel-snapshot.yml`, `tdx-metal-e2e.yml`, `confidential-e2e.yml` chain) have no `pull_request` trigger (workflow_run/call/dispatch only) and guard `head_repository.full_name == repository` in the workflow_run-driven jobs.

## Trade-offs / decisions
- **image-repro-gate**: fork PRs touching image paths now pass the required `compare` check without the reproducibility gate running (`security-over-coverage`). The post-merge main build remains the actual measured/published gate. Documented in the workflow header.
- **actionlint `-ignore`**: exact-string ignore for the pre-existing `gate_intree` warning in `c8s-image.yml` (unchanged on origin/main); every other workflow error still fails the gate.
- **Digest resolver job**: the meat digest-pin is already fail-closed; a continuous resolver is deferred as a follow-up (belt-and-braces).
- **Toolchain**: `actions/setup-go` with `go-version-file` installs exact `go.mod` version rather than the repo's usual float-to-minor convention. Purely informational.

## Required admin actions (not coverable by code; must be done by an operator before this is fully closed)
1. Deregister/wipe `meaty-runner`; ensure `the-machine`/`cvm-launcher`/`cvm-launcher-tdx` runner groups reject fork-PR workflows (or remove those runners from the fork-PR path) — SEC critical: fork PRs run the fork's copy of workflow files.
2. Create the `meat-review` GitHub Actions environment with required reviewers and the two LLM API key secrets (repo-level keys removed).
3. Rotate `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` (assume compromised).
4. Clear `meat-*` Actions cache keys.
5. Confirm `compare` is a required check.
6. After merge, run one real fork-PR scratch test confirming the meat job and the gate legs do not run for a fork PR.

## Verification
- actionlint v1.7.12 clean on the modified/new workflow files (gate's exact command exits 0; confirmed the `-ignore` is narrow by an injected-error test).
- `meat` pin independently confirmed against proxy.golang.org and sum.golang.org.
