### PR TITLE
ci(release): automate unified pre-1.0 SemVer releases

### DIFF
--- a/.github/c8s-cliff.toml
+++ b/.github/c8s-cliff.toml
@@ -1,0 +1,18 @@
+# c8s is released as one unit. Breaking changes remain on the 0.x line until
+# maintainers deliberately change both this policy and the workflow major gate.
+[git]
+conventional_commits = true
+filter_unconventional = true
+filter_commits = true
+protect_breaking_commits = true
+tag_pattern = "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+commit_parsers = [
+  { message = '^feat(\([^)]*\))?!?:', group = "Features" },
+  { message = '^fix(\([^)]*\))?!?:', group = "Fixes" },
+  { message = ".*", skip = true },
+]
+
+[bump]
+features_always_bump_minor = true
+breaking_always_bump_major = false
+initial_tag = "v0.1.0"

--- a/.github/scripts/calculate-release-version.sh
+++ b/.github/scripts/calculate-release-version.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Calculate the next stable c8s version and write the release decision to
+# GITHUB_OUTPUT for .github/workflows/semver-tag.yml.
+#
+# Inputs (env):
+#   GIT_CLIFF_BIN   verified git-cliff executable.
+#   RELEASE_MAJOR  release line that the candidate must remain within.
+#   TARGET_SHA     full commit SHA whose Docker build passed.
+#   GITHUB_OUTPUT  step output file.
+
+set -euo pipefail
+
+: "${GIT_CLIFF_BIN:?GIT_CLIFF_BIN must be set}"
+: "${RELEASE_MAJOR:?RELEASE_MAJOR must be set}"
+: "${TARGET_SHA:?TARGET_SHA must be set}"
+: "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
+
+test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+candidate="$(
+  NO_COLOR=1 "$GIT_CLIFF_BIN" \
+    --config .github/c8s-cliff.toml \
+    --bumped-version --use-branch-tags --no-exec
+)"
+if [[ ! "$candidate" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+  echo "::error::calculated tag is not a stable canonical SemVer: $candidate"
+  exit 1
+fi
+
+version="${candidate#v}"
+if [ "${version%%.*}" != "$RELEASE_MAJOR" ]; then
+  echo "::error::$candidate crosses the configured v$RELEASE_MAJOR release line"
+  echo "::error::graduating to v1 requires a deliberate release-policy change"
+  exit 1
+fi
+
+publish=true
+if git show-ref --verify --quiet "refs/tags/$candidate"; then
+  tagged_sha="$(git rev-parse "$candidate^{commit}")"
+  if [ "$tagged_sha" != "$TARGET_SHA" ]; then
+    publish=false
+    echo "no release-worthy commit since $candidate"
+  else
+    echo "repairing or verifying $candidate for $TARGET_SHA"
+  fi
+fi
+
+series="${version%.*}"
+latest_series_tag="$(
+  {
+    git tag --list "v$series.*"
+    printf '%s\n' "$candidate"
+  } \
+    | grep -E "^v${series//./[.]}[.](0|[1-9][0-9]*)$" \
+    | sort -Vu \
+    | tail -n 1
+)"
+test -n "$latest_series_tag"
+update_series=false
+if [ "$latest_series_tag" = "$candidate" ]; then
+  update_series=true
+fi
+
+{
+  echo "publish=$publish"
+  echo "tag=$candidate"
+  echo "update-series=$update_series"
+  echo "version=$version"
+} >> "$GITHUB_OUTPUT"

--- a/.github/scripts/chart-version.sh
+++ b/.github/scripts/chart-version.sh
@@ -2,11 +2,12 @@
 # Derive the Helm chart version published by .github/workflows/chart.yml and
 # write it to GITHUB_OUTPUT as `version`.
 #
-#   - tag push (refs/tags/vX) -> the release version (X), the official artifact
-#   - anything else           -> <Chart.yaml version>-g<short-sha> (a dev build)
+# This path publishes development charts only. Stable X.Y.Z charts are packaged
+# and published by semver-tag.yml in the originating Docker run.
+#
+#   <Chart.yaml version>-g<short-sha>
 #
 # Inputs (env):
-#   GITHUB_REF      the triggering ref.
 #   CHART_DIR       chart directory containing Chart.yaml.
 #   GITHUB_OUTPUT   step output file.
 
@@ -15,14 +16,10 @@ set -euo pipefail
 : "${CHART_DIR:?CHART_DIR must be set}"
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
 
-if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-  v="${GITHUB_REF#refs/tags/v}"
-else
-  base=$(grep -E '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}' | tr -d '"')
-  # Prefix the sha with "g" (git-describe convention) so the SemVer pre-release
-  # segment is never a pure-numeric identifier, which forbids leading zeros: an
-  # all-digit sha like 0091982 would make helm reject "0.1.0-0091982" with
-  # "Version segment starts with 0".
-  v="${base}-g$(git rev-parse --short HEAD)"
-fi
+base=$(grep -E '^version:' "$CHART_DIR/Chart.yaml" | awk '{print $2}' | tr -d '"')
+# Prefix the sha with "g" (git-describe convention) so the SemVer pre-release
+# segment is never a pure-numeric identifier, which forbids leading zeros: an
+# all-digit sha like 0091982 would make helm reject "0.1.0-0091982" with
+# "Version segment starts with 0".
+v="${base}-g$(git rev-parse --short HEAD)"
 echo "version=$v" >> "$GITHUB_OUTPUT"

--- a/.github/scripts/docker-build-matrix.sh
+++ b/.github/scripts/docker-build-matrix.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-# Build the per-image Docker build matrix consumed by the `images` job in
-# .github/workflows/docker.yml.
+# Build the canonical per-image Docker matrix consumed by docker.yml and the
+# all-components release rebuild in semver-tag.yml.
 #
 # A component image is included when ANY of:
-#   - this is a tag push (refs/tags/*)   -> release tags fan out to every image
 #   - this is a manual workflow_dispatch -> rebuild every image (no diff base)
 #   - shared code changed (SHARED=true)  -> pkg/**, root internal/**, go.mod, …
 #   - the component's own paths changed   (its <X>=true flag)
 #
 # The workflow_dispatch fan-out is what makes the manual rebuild work: a
 # dispatch has no before/after diff, so docker.yml skips paths-filter and every
-# per-component flag arrives empty here. Treat it like a tag push and build all
-# of them, so the downstream Kata guest base can resolve every component's
+# per-component flag arrives empty here. Build all of them so the downstream
+# Kata guest base can resolve every component's
 # :<short-sha>.
 #
 # Components NOT included are emitted as a parallel `retag_matrix` so the
@@ -24,7 +23,6 @@
 # Inputs (env), each "true"/"false" from the dorny/paths-filter step:
 #   SHARED             shared-core || shared-cmdsutil || shared-root
 #   C8S, CDS, GET_CERT, RATLS_MESH, NRI_IMAGE_POLICY, VOLUMED
-#   GITHUB_REF         the triggering ref (for the tag-push fan-out)
 #   GITHUB_EVENT_NAME  the triggering event; "workflow_dispatch" fans out to all
 #                      (paths-filter is skipped on dispatch, so the flags above
 #                      are empty and this is the only signal to build them)
@@ -43,7 +41,7 @@ include=()
 exclude=()
 maybe_add() {
   local changed="$1" binary="$2" image="$3" dockerfile="$4"
-  if [[ "$GITHUB_REF" == refs/tags/* || "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" || "$SHARED" == "true" || "$changed" == "true" ]]; then
+  if [[ "${GITHUB_EVENT_NAME:-}" == "workflow_dispatch" || "$SHARED" == "true" || "$changed" == "true" ]]; then
     include+=("{\"binary\":\"$binary\",\"image\":\"$image\",\"dockerfile\":\"$dockerfile\"}")
   else
     exclude+=("{\"binary\":\"$binary\",\"image\":\"$image\"}")

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -42,3 +42,9 @@ jobs:
             -ignore 'SC2034' \
             -ignore 'SC2086' \
             -ignore 'SC2129'
+
+      - name: Shellcheck release scripts
+        run: |
+          shellcheck \
+            .github/scripts/calculate-release-version.sh \
+            kata-guest-base/scripts/ci/publish-release-aliases.sh

--- a/.github/workflows/c8s-image-publish.yml
+++ b/.github/workflows/c8s-image-publish.yml
@@ -35,16 +35,161 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # A rerun of the same parent completion must not race its own alias repair.
+  # The distinct prefix avoids sharing a group with the called builder.
+  group: c8s-image-entrypoint-${{ github.event.workflow_run.id || github.run_id }}
+  cancel-in-progress: false
+
 jobs:
-  build-and-push:
+  # A stable tag is created inside the successful parent Docker run. Resolve it
+  # from that run's exact revision only for the trusted automatic main path;
+  # manual node-image rebuilds must never mint or move release aliases.
+  release-context:
+    name: Resolve stable release context
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+    outputs:
+      tag: ${{ steps.release-tag.outputs.tag }}
+    steps:
+      - name: Checkout the parent Docker revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Find its canonical stable tag
+        id: release-tag
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || \
+             [ "$(git rev-parse HEAD)" != "$HEAD_SHA" ]; then
+            echo "::error::parent Docker revision is not the checked-out full commit SHA"
+            exit 1
+          fi
+          mapfile -t release_tags < <(
+            git tag --points-at "$HEAD_SHA" --list 'v*' \
+              | grep -E '^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$' \
+              | sort -V
+          )
+          if [ "${#release_tags[@]}" -gt 1 ]; then
+            echo "::error::multiple stable release tags name $HEAD_SHA"
+            printf '%s\n' "${release_tags[@]}"
+            exit 1
+          fi
+          echo "tag=${release_tags[0]:-}" >> "$GITHUB_OUTPUT"
+
+  build-and-push:
+    needs: release-context
+    if: |
+      always() &&
+      (needs.release-context.result == 'success' ||
+       needs.release-context.result == 'skipped')
+    permissions:
+      contents: read
+      packages: write # Publish trusted floating and commit-scoped artifacts.
     uses: ./.github/workflows/c8s-image.yml
     with:
       dev: ${{ inputs.dev || false }}
       c8s_ref: ${{ inputs.c8s_ref || '' }}
       confos_ref: ${{ inputs.confos_ref || '' }}
       gate: ${{ inputs.gate || false }}
+      release_tag: ${{ needs.release-context.outputs.tag }}
     secrets:
       MODULE_SIG_KEY_PEM: ${{ secrets.MODULE_SIG_KEY_PEM }}
+
+  # Wait for both TDX/SNP matrix legs, then preflight every exact alias before
+  # creating any of them. Registry publication is not transactional, so a
+  # network failure may leave a subset; a rerun repairs missing aliases and
+  # rejects any existing alias whose digest differs.
+  promote-release:
+    name: Publish stable node-image aliases
+    needs: [release-context, build-and-push]
+    if: |
+      always() &&
+      needs.release-context.result == 'success' &&
+      needs.build-and-push.result == 'success' &&
+      needs.release-context.outputs.tag != ''
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: release
+    permissions:
+      contents: read
+      packages: write # Promote aliases only from this protected job.
+    steps:
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+        with:
+          version: "1.2.3"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Publish or verify exact release aliases
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          IMAGE: ghcr.io/confidential-dot-ai/node-guest-base
+          RELEASE_TAG: ${{ needs.release-context.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] || \
+             [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+            echo "::error::invalid node-image release context"
+            exit 1
+          fi
+          short="${HEAD_SHA:0:7}"
+          repo_tags="$(oras repo tags "$IMAGE")"
+          aliases="$RUNNER_TEMP/node-release-aliases"
+          : > "$aliases"
+
+          for platform in tdx snp; do
+            for format in '' -cdi; do
+              base_tag="rke2-$platform$format"
+              source_tag="$base_tag-$short"
+              release_alias="$base_tag-$RELEASE_TAG"
+              source_digest="$(oras resolve "$IMAGE:$source_tag")"
+              if [[ ! "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+                echo "::error::$IMAGE:$source_tag did not resolve to an OCI digest"
+                exit 1
+              fi
+
+              exists=false
+              if grep -Fxq -- "$release_alias" <<< "$repo_tags"; then
+                exists=true
+                destination_digest="$(oras resolve "$IMAGE:$release_alias")"
+                if [ "$destination_digest" != "$source_digest" ]; then
+                  echo "::error::$IMAGE:$release_alias already names $destination_digest, expected $source_digest"
+                  exit 1
+                fi
+              fi
+              printf '%s\t%s\t%s\n' "$release_alias" "$source_digest" "$exists" >> "$aliases"
+            done
+          done
+
+          while IFS=$'\t' read -r release_alias source_digest exists; do
+            if [ "$exists" = false ]; then
+              oras tag "$IMAGE@$source_digest" "$release_alias"
+            fi
+            test "$(oras resolve "$IMAGE:$release_alias")" = "$source_digest"
+          done < "$aliases"
+
+          {
+            echo "### $RELEASE_TAG node image aliases"
+            cut -f1 "$aliases" | sed 's/^/- `ghcr.io\/confidential-dot-ai\/node-guest-base:/' | sed 's/$/`/'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -2,8 +2,9 @@
 # attestation-api + NVIDIA stack in the verity rootfs). confos is the build
 # tree (pinned CONFOS_REF); callers select the baked commit and publish policy.
 # Output: ghcr.io/confidential-dot-ai/node-guest-base, one image per TEE:
-# tags :rke2-{tdx,snp}[-cdi] / :rke2-{tdx,snp}[-cdi]-<sha>. The pre-matrix
-# :rke2[-cdi]* tags are frozen (TDX builds up to the rename).
+# tags :rke2-{tdx,snp}[-cdi] / :rke2-{tdx,snp}[-cdi]-<sha>. Stable releases
+# also receive :rke2-{tdx,snp}[-cdi]-vX.Y.Z in c8s-image-publish.yml. The
+# pre-matrix :rke2[-cdi]* tags are frozen (TDX builds up to the rename).
 # (named to match kata-guest-base; pre-flip images stay frozen under c8s-base)
 # (CDI image) + :rke2 / :rke2-<sha> (oras artifact). dev=true -> :rke2-dev-*.
 
@@ -19,6 +20,11 @@ on:
         type: string
         default: ""
       confos_ref:
+        required: false
+        type: string
+        default: ""
+      release_tag:
+        description: "Canonical stable tag for this automatic build; forces exact artifacts before downstream promotion."
         required: false
         type: string
         default: ""
@@ -59,7 +65,7 @@ concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event.workflow_run.head_sha || github.sha
     }}-${{ inputs.c8s_ref }}-${{ inputs.dev
-    }}-${{ inputs.confos_ref }}-${{ inputs.gate
+    }}-${{ inputs.confos_ref }}-${{ inputs.release_tag }}-${{ inputs.gate
     }}-${{ inputs.leg }}
   cancel-in-progress: false
 
@@ -109,6 +115,7 @@ jobs:
         # head_sha, not the default (workflow_run's ref is main).
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           path: c8s
 
@@ -129,6 +136,7 @@ jobs:
       - name: Checkout attestation-rs (for the gpu-attest binary)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: confidential-dot-ai/attestation-rs
           ref: ${{ env.ATTESTATION_RS_REF }}
           path: attestation-rs
@@ -137,6 +145,7 @@ jobs:
       - name: Checkout confidential-os-builder (build tree)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: confidential-dot-ai/confidential-os-builder
           ref: ${{ env.CONFOS_REF }}
           path: confidential-os-builder
@@ -341,9 +350,8 @@ jobs:
           # it to rebuild a published release. Definition lives in this repo:
           # the script stages ../c8s/node-guest-image/c8s via --profile-dir.
           export C8S_REF="${C8S_REF_INPUT:-${HEAD_SHA::7}}"
-          # The build script requires an explicit platform (no default). This
-          # workflow publishes the TDX image; the snp variant is built on
-          # demand until M3 adds it to CI.
+          # The build script requires an explicit platform (no default). The
+          # matrix publishes both measured platform variants.
           C8S_PLATFORM="${{ matrix.platform }}" C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
 
       - name: Make the tools trees cache-safe
@@ -374,8 +382,22 @@ jobs:
         working-directory: confidential-os-builder
         env:
           C8S_REF_INPUT: ${{ inputs.c8s_ref }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          set -uo pipefail
+          set -euo pipefail
+          # A stable release always publishes both exact formats from this
+          # build. A matching rootfs alone cannot prove that a prior CDI/ORAS
+          # pair was completed from the same inputs.
+          if [ -n "$RELEASE_TAG" ]; then
+            if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+              echo "::error::invalid stable release tag: $RELEASE_TAG"
+              exit 1
+            fi
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "stable release $RELEASE_TAG requires exact node artifacts"
+            exit 0
+          fi
+
           # A c8s_ref rebuild compares against that release's own tag, not the
           # floating one it never repoints.
           tag="${VARIANT}${C8S_REF_INPUT:+-$C8S_REF_INPUT}"
@@ -420,6 +442,47 @@ jobs:
           bin/confos push "output/${VARIANT}" \
             --registry "$IMAGE" \
             --tag "$ORAS_TAGS"
+
+      # The unchanged-rootfs optimization above skips confos push entirely.
+      # Preserve an exact source tag for downstream release promotion anyway:
+      # the floating aliases are acceptable only after this build proved that
+      # its roothash matches them. Existing exact aliases are create-or-verify.
+      - name: Preserve commit aliases for an unchanged image
+        if: |
+          inputs.gate != true &&
+          inputs.c8s_ref == '' &&
+          steps.changed.outputs.skip == 'true'
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::c8s revision is not a full commit SHA"
+            exit 1
+          fi
+          short="${HEAD_SHA:0:7}"
+          repo_tags="$(oras repo tags "$IMAGE")"
+
+          for base_tag in "$VARIANT" "$VARIANT-cdi"; do
+            commit_tag="$base_tag-$short"
+            source_digest="$(oras resolve "$IMAGE:$base_tag")"
+            if [[ ! "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "::error::$IMAGE:$base_tag did not resolve to an OCI digest"
+              exit 1
+            fi
+
+            if grep -Fxq -- "$commit_tag" <<< "$repo_tags"; then
+              destination_digest="$(oras resolve "$IMAGE:$commit_tag")"
+              if [ "$destination_digest" != "$source_digest" ]; then
+                echo "::error::$IMAGE:$commit_tag already names $destination_digest, expected $source_digest"
+                exit 1
+              fi
+            else
+              oras tag "$IMAGE@$source_digest" "$commit_tag"
+            fi
+            test "$(oras resolve "$IMAGE:$commit_tag")" = "$source_digest"
+          done
 
       - name: Summary
         env:

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,9 +1,8 @@
-name: Release Helm Chart
+name: Helm Chart
 
 on:
   push:
     branches: [main, "feat/**"]
-    tags: ["v*"]
     paths: &chart-paths
       - "internal/helmchart/**"
       - ".github/workflows/chart.yml"
@@ -25,6 +24,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
         with:
@@ -38,21 +39,28 @@ jobs:
         run: .github/scripts/chart-verify.sh
 
       - name: Helm package
+        env:
+          CHART_VERSION: ${{ steps.ver.outputs.version }}
         run: |
           mkdir -p dist
           helm package "$CHART_DIR" \
-            --version "${{ steps.ver.outputs.version }}" \
-            --app-version "${{ steps.ver.outputs.version }}" \
+            --version "$CHART_VERSION" \
+            --app-version "$CHART_VERSION" \
             -d dist/
 
       - name: Log in to GHCR
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: github.event_name == 'push'
+        env:
+          GHCR_TOKEN: ${{ github.token }}
+          GHCR_USERNAME: ${{ github.actor }}
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | \
-            helm registry login "$REGISTRY" -u "${{ github.actor }}" --password-stdin
+          printf '%s' "$GHCR_TOKEN" | \
+            helm registry login "$REGISTRY" -u "$GHCR_USERNAME" --password-stdin
 
       - name: Helm push
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        if: github.event_name == 'push'
+        env:
+          CHART_VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          helm push "dist/c8s-${{ steps.ver.outputs.version }}.tgz" \
+          helm push "dist/c8s-$CHART_VERSION.tgz" \
             "oci://$CHART_REPO"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,9 @@
 name: Docker
 
 on:
-  # Publish component images on EVERY push to main, and on v* release tags.
+  # Publish component images on EVERY push to main.
   # Feature branches don't publish: the kata-guest-base pipeline only builds for
-  # main / release tags (its job if: gates on head_branch == main || v*), so
+  # main (its job if: gates on head_branch == main), so
   # per-branch images had no consumer.
   #
   # NO paths filter on the push trigger, deliberately. This workflow is the head
@@ -30,7 +30,6 @@ on:
   # SEV-SNP e2e (30024734575).
   push:
     branches: [main]
-    tags: ["v*"]
   # PRs stay path-gated: a PR run builds and scans but publishes nothing (see the
   # push/dispatch gates on the login and build-push steps), so a docs-only PR has
   # nothing to gain from it. The list is inlined because the YAML anchor it used
@@ -51,7 +50,7 @@ on:
   # Manual rebuild escape hatch, for a rebuild with NO new commit behind it: a
   # base-image refresh or a registry re-push. workflow_dispatch publishes EVERY
   # component image at this commit's tags (the matrix fans out to all of them,
-  # see docker-build-matrix.sh), exactly as a tag push does, so the downstream
+  # see docker-build-matrix.sh), so the downstream
   # "Kata guest base" workflow can resolve every component's :<short-sha> and
   # cascade off this run (its workflow_run gate accepts a workflow_dispatch
   # origin on main / v*, see kata-guest-base.yml). NOTE: dispatching this
@@ -72,14 +71,14 @@ jobs:
   # internal/cmds/<X> changed (this applies to both PR events and
   # pushes to main). Shared code (pkg/**, root internal/** minus
   # cmds/helmchart, go.mod/sum, Makefile, this workflow) fans out to
-  # every image. Tag pushes (v*) always fan out so semver release
-  # tags land on every image.
+  # every image. The final release job rebuilds the complete component set from
+  # this exact revision before applying its SemVer aliases.
   #
   # On a push to main, unchanged components keep their existing
   # `latest` / `main` tag pointing at the previous build's manifest —
   # which is the correct state, since nothing changed for them.
-  # Deploys pinned to `latest` or to a release tag work without any
-  # CI-side tag aliasing.
+  # Deploys pinned to `latest` continue to consume the normal main build;
+  # stable release aliases consume the complete release rebuild below.
   changes:
     name: Detect changed components
     runs-on: ubuntu-latest
@@ -118,7 +117,7 @@ jobs:
             exit 1; }
       # Skip on workflow_dispatch: a manual run has no before/after diff base for
       # paths-filter to compute against, and we fan out to every component anyway
-      # (docker-build-matrix.sh treats workflow_dispatch like a tag push). With
+      # (docker-build-matrix.sh has an explicit dispatch fan-out). With
       # this step skipped its outputs read empty downstream, which the matrix
       # script correctly sees as "no per-component filter" before falling through
       # to the fan-out.
@@ -214,9 +213,6 @@ jobs:
           tags: |
             type=sha,prefix=
             type=ref,event=branch
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
@@ -233,11 +229,11 @@ jobs:
           # `type=sha,prefix=` (the 7-char short SHA), and the "Kata guest base"
           # build resolves cds/get-cert by that short SHA (IMAGE_TAG=${HEAD_SHA::7})
           # to pin their digests into the measured bootstrap allowlist. tags[0]
-          # is the highest-priority *human* tag (main / semver), so with the old
+          # is the highest-priority *human* tag (main), so with the old
           # single-tag push the short-SHA tag never reached GHCR and that lookup
           # could not resolve. Pushing the full set also makes `latest` real on
-          # main (deploys pin it); latest/semver/tag tags are gated to the
-          # default branch / tag pushes.
+          # main (deploys pin it). A later release job performs the separate,
+          # version-stamped all-component build used by SemVer aliases.
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # GHA layer caching. ignore-error: a cache-service blip during the
@@ -361,3 +357,27 @@ jobs:
           # Idempotent: re-runs of the same commit are no-ops if the
           # tag already points at the same manifest.
           oras tag "${IMAGE}:main" "${SHORT_SHA}"
+
+  # Release publication is the final main-push stage: every build/retag leg must
+  # succeed first. The called workflow rebuilds every component under a
+  # commit-scoped staging tag, promotes the verified digests, and pushes the
+  # chart before this Docker run completes. Its GITHUB_TOKEN-created Git tag
+  # therefore does not need to trigger another workflow.
+  release-tag:
+    name: Publish SemVer release
+    needs: [changes, go-modules, images, retag-unchanged]
+    if: |
+      always()
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.changes.result == 'success'
+      && (needs.go-modules.result == 'success' || needs.go-modules.result == 'skipped')
+      && (needs.images.result == 'success' || needs.images.result == 'skipped')
+      && (needs.retag-unchanged.result == 'success' || needs.retag-unchanged.result == 'skipped')
+    uses: ./.github/workflows/semver-tag.yml
+    permissions:
+      actions: read # The called workflow serializes against older Docker runs.
+      contents: write # Create the annotated release tag.
+      packages: write # Alias component images and publish the Helm chart.
+    with:
+      target-sha: ${{ github.sha }}

--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -34,7 +34,7 @@ on:
   # ghcr.io/confidential-dot-ai/{cds,get-cert}:<IMAGE_TAG>`) are the ones docker.yml
   # just published — not whatever stale digests were on `main` at the moment
   # of a concurrent push. The job-level `if:` below gates on a successful
-  # Docker push to main or a release tag (excludes Docker's own PR runs and
+  # Docker push to main (excludes Docker's own PR runs and
   # side-branch pushes — those never build or publish).
   #
   # No `pull_request:` trigger: the build is long (historically 45+ min;
@@ -94,10 +94,10 @@ jobs:
     name: Build kata-guest-base
     # workflow_run fires for every Docker completion — including its PR runs,
     # which don't publish. Gate the AUTOMATIC path to "Docker succeeded on main
-    # or a release tag (v*)": those are the only refs we publish a
-    # kata-guest-base image for, so a side-branch push never triggers the
-    # ~45-min build or pushes a branch-* tag (head_branch is the source ref of
-    # the triggering Docker event — "main", the tag name, or a branch name).
+    # or a manually dispatched release ref (v*)": those are the only refs we
+    # publish a kata-guest-base image for, so a side-branch push never triggers
+    # the ~45-min build or pushes a branch-* tag (head_branch is the source ref
+    # of the triggering Docker event — "main", a tag name, or a branch name).
     #
     # Accept BOTH origins of that Docker run: a push (the normal merge-to-main
     # path) and a workflow_dispatch (the manual rebuild — e.g. a base-image
@@ -141,24 +141,34 @@ jobs:
         # same commit whose images we'll bake into the allowlist.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 0
+          persist-credentials: false
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
           path: c8s
 
       - name: Checkout attestation-rs
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: confidential-dot-ai/attestation-rs
           ref: ${{ env.ATTESTATION_RS_REF }}
           path: attestation-rs
 
       - name: Record the resolved attestation-rs revision
+        id: attestation-revision
         # The checkout floats on main; the manifest records what it resolved to.
-        run: echo "ATTESTATION_RS_SHA=$(git -C attestation-rs rev-parse HEAD)" >> "$GITHUB_ENV"
+        run: |
+          set -euo pipefail
+
+          revision="$(git -C attestation-rs rev-parse HEAD)"
+          [[ "$revision" =~ ^[0-9a-f]{40}$ ]]
+          echo "sha=$revision" >> "$GITHUB_OUTPUT"
 
       - name: Checkout confidential-os-builder
         # CONFOS_REF above is the single source of truth for the ref.
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: confidential-dot-ai/confidential-os-builder
           ref: ${{ env.CONFOS_REF }}
           path: confidential-os-builder
@@ -519,7 +529,7 @@ jobs:
           # Build provenance, recorded in manifest.json inputs (additive, v2).
           PROV_C8S_REF: ${{ github.event.workflow_run.head_sha || github.sha }}
           PROV_CONFOS_REF: ${{ env.CONFOS_REF }}
-          PROV_ATTESTATION_RS_REF: ${{ env.ATTESTATION_RS_SHA }}
+          PROV_ATTESTATION_RS_REF: ${{ steps.attestation-revision.outputs.sha }}
           # GPU variants are mandatory in CI. build.sh Step 6 grafts the
           # NVIDIA payload from the staged kata-static artifacts
           # (KATA_NVIDIA_CONFIDENTIAL_IMG / KATA_NVIDIA_VMLINUZ, exported by
@@ -645,7 +655,7 @@ jobs:
       # --- Push to GHCR ------------------------------------------------
       #
       # The job-level `if:` already gates the whole job on a successful
-      # Docker push to main / a release tag (or a manual workflow_dispatch),
+      # Docker push to main (or a manual workflow_dispatch),
       # so we publish unconditionally here. Tag derivation uses
       # `head_branch`/`head_sha` from the
       # workflow_run payload so the published tags match the commit Docker
@@ -655,37 +665,75 @@ jobs:
       # We already logged in to GHCR earlier for the digest-resolution step
       # that feeds the bootstrap allowlist, so no second login is needed.
 
+      # The parent Docker run creates a stable release tag before completing.
+      # GITHUB_TOKEN intentionally suppresses a second tag-triggered Docker run,
+      # so discover that tag on the exact built commit and publish its guest
+      # aliases in this existing main-triggered build.
+      - name: Find stable release tag for this revision
+        id: release-tag
+        # Stable aliases are immutable release output. A manual Docker/Kata
+        # rebuild may refresh main and commit-scoped artifacts, but must not
+        # overwrite an existing vX.Y.Z guest image.
+        if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'push'
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Docker revision is not a full commit SHA"
+            exit 1
+          fi
+          mapfile -t release_tags < <(
+            git -C c8s tag --points-at "$HEAD_SHA" --list 'v*' \
+              | grep -E '^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$' \
+              | sort -V
+          )
+          if [ "${#release_tags[@]}" -gt 1 ]; then
+            echo "::error::multiple stable release tags name $HEAD_SHA"
+            printf '%s\n' "${release_tags[@]}"
+            exit 1
+          fi
+          echo "tag=${release_tags[0]:-}" >> "$GITHUB_OUTPUT"
+
       - name: Compute tags
         id: tags
         env:
           # head_branch is the source branch of the triggering Docker event:
-          # "main" for a main push, the tag name (e.g. "v0.1.0") for a tag push.
+          # "main" for a main push, or the selected ref for a manual run.
           # github.ref_name is the workflow_dispatch fallback.
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
         run: c8s/kata-guest-base/scripts/ci/compute-tags.sh
 
       - name: Push to GHCR
         working-directory: c8s/kata-guest-base/output
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}
+          TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           set -euo pipefail
           # The artifact is the kata-native guest: vmlinuz + the dm-verity
           # rootfs image + the verity-params / rootfs-type sidecars +
           # manifest.json. The puller pulls all of these (see
           # kata-image-puller.yaml).
-          oras push "${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.tags }}" \
+          oras push "$IMAGE:$TAGS" \
             --artifact-type application/vnd.confidential.kata-guest.v2 \
             ./*
 
       - name: Push debug variant to GHCR
         working-directory: c8s/kata-guest-base/output-debug
+        env:
+          IMAGE: ${{ steps.tags.outputs.image }}
+          TAGS: ${{ steps.tags.outputs.debug_tags }}
         run: |
           set -euo pipefail
           # Same layout as the locked artifact, one delta: the guest policy
           # allows host log/exec streams (kubectl logs / exec). Published in
           # lockstep at <tag>-debug so kata.guestImage.debug=true can derive
           # the ref from any locked tag (see workflow header).
-          oras push "${{ steps.tags.outputs.image }}:${{ steps.tags.outputs.debug_tags }}" \
+          oras push "$IMAGE:$TAGS" \
             --artifact-type application/vnd.confidential.kata-guest.v2 \
             ./*
 
@@ -724,6 +772,18 @@ jobs:
           oras push "${IMAGE}:${nv_tags}" \
             --artifact-type application/vnd.confidential.kata-guest.v2 \
             ./*
+
+      # Stable aliases are create-or-verify. Keep them out of the oras push
+      # commands above because those commands update every supplied tag; a
+      # retry with different upstream inputs must fail instead of moving an
+      # already published release.
+      - name: Publish or verify stable guest aliases
+        if: steps.tags.outputs.release_tag != ''
+        env:
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          IMAGE: ${{ steps.tags.outputs.image }}
+          RELEASE_TAG: ${{ steps.tags.outputs.release_tag }}
+        run: c8s/kata-guest-base/scripts/ci/publish-release-aliases.sh
 
   # RETIRED: the interim build-nvidia job (repackaging the stock kata GPU
   # rootfs verbatim on ubuntu-latest) is gone — the GPU variants are now real

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -1,0 +1,565 @@
+name: SemVer release
+
+on:
+  workflow_call:
+    inputs:
+      target-sha:
+        description: Commit whose Docker jobs passed and which the release must name
+        required: true
+        type: string
+
+permissions: {}
+
+env:
+  CHART_DIR: internal/helmchart/c8s
+  CHART_IMAGE: ghcr.io/confidential-dot-ai/charts/c8s
+  CHART_REPO: ghcr.io/confidential-dot-ai/charts
+  GH_API_TIMEOUT: 30s
+  GITHUB_API_VERSION: "2026-03-10"
+  GIT_CLIFF_SHA256: 200d2535da6d9703f3bcc8a4d159c3b55eacdb01cf2148c55b3eee9dd04d5249
+  GIT_CLIFF_VERSION: "2.13.1"
+  ORAS_VERSION: "1.2.3"
+  RELEASE_MAJOR: "0"
+  RELEASE_WAIT_ATTEMPTS: "60"
+  RELEASE_WAIT_INTERVAL: 15s
+
+jobs:
+  calculate:
+    name: Calculate release version
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      image-matrix: ${{ steps.release-images.outputs.matrix }}
+      publish: ${{ steps.version.outputs.publish }}
+      tag: ${{ steps.version.outputs.tag }}
+      update-series: ${{ steps.version.outputs.update-series }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Validate release context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" != push ] || [ "$EVENT_REF" != refs/heads/main ]; then
+            echo "::error::releases may only originate from a push to main"
+            exit 1
+          fi
+          if [ "$TARGET_SHA" != "$EVENT_SHA" ] || [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release target must equal the caller event's full commit SHA"
+            exit 1
+          fi
+
+      # Repository-monotonic run IDs serialize release calculation without
+      # dropping a middle merge from the Docker -> Kata/e2e workflow chain.
+      - name: Wait for older Docker runs on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          github_api() {
+            timeout --kill-after=5s "$GH_API_TIMEOUT" \
+              gh api -H "X-GitHub-Api-Version: $GITHUB_API_VERSION" "$@"
+          }
+
+          older=0
+          for ((attempt = 1; attempt <= RELEASE_WAIT_ATTEMPTS; attempt++)); do
+            if ! older="$(
+              github_api "/repos/$GITHUB_REPOSITORY/actions/workflows/docker.yml/runs?event=push&branch=main&per_page=100" \
+                --jq '.workflow_runs[] | select(.status != "completed") | .id' \
+                | awk -v current="$GITHUB_RUN_ID" 'NF && $1+0 < current+0' \
+                | wc -l \
+                | tr -d ' '
+            )"; then
+              echo "::error::could not query older Docker runs"
+              exit 1
+            fi
+
+            if [ "$older" = "0" ]; then
+              echo "no older in-flight Docker run on main"
+              break
+            fi
+
+            echo "waiting on $older older Docker run(s) ($attempt/$RELEASE_WAIT_ATTEMPTS)"
+            sleep "$RELEASE_WAIT_INTERVAL"
+          done
+
+          if [ "$older" != "0" ]; then
+            echo "::error::older Docker runs exceeded the release wait budget"
+            exit 1
+          fi
+
+      # Fetch only after serialization: an older run may create the baseline
+      # tag while this run is waiting.
+      - name: Checkout current release history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ inputs.target-sha }}
+
+      - name: Load complete release image matrix
+        id: release-images
+        env:
+          C8S: "false"
+          CDS: "false"
+          GET_CERT: "false"
+          NRI_IMAGE_POLICY: "false"
+          RATLS_MESH: "false"
+          SHARED: "true"
+          VOLUMED: "false"
+        run: .github/scripts/docker-build-matrix.sh
+
+      - name: Install pinned git-cliff
+        run: |
+          set -euo pipefail
+
+          archive="$RUNNER_TEMP/git-cliff-$GIT_CLIFF_VERSION-x86_64-unknown-linux-musl.tar.gz"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --connect-timeout 10 --max-time 120 --retry 3 --retry-all-errors \
+            --output "$archive" \
+            "https://github.com/orhun/git-cliff/releases/download/v$GIT_CLIFF_VERSION/$(basename "$archive")"
+          printf '%s  %s\n' "$GIT_CLIFF_SHA256" "$archive" | sha256sum --check --status
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+
+          binary="$RUNNER_TEMP/git-cliff-$GIT_CLIFF_VERSION/git-cliff"
+          test -x "$binary"
+          test "$("$binary" --version)" = "git-cliff $GIT_CLIFF_VERSION"
+          echo "GIT_CLIFF_BIN=$binary" >> "$GITHUB_ENV"
+
+      - name: Calculate stable pre-1.0 SemVer
+        id: version
+        env:
+          TARGET_SHA: ${{ inputs.target-sha }}
+        run: .github/scripts/calculate-release-version.sh
+
+  images:
+    name: Build release image (${{ matrix.binary }})
+    needs: calculate
+    if: needs.calculate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.calculate.outputs.image-matrix) }}
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.target-sha }}
+
+      - uses: ./.github/actions/setup-go-c8s
+
+      # Rebuild every release image instead of trusting a mutable :main alias.
+      # This preserves the old tag-triggered release integrity while avoiding a
+      # second workflow run. VERSION stamps the SemVer into the c8s binary even
+      # though the Git tag is reserved only after all staging builds succeed.
+      - name: Build release binary
+        env:
+          RELEASE_TAG: ${{ needs.calculate.outputs.tag }}
+        run: make build-c8s VERSION="$RELEASE_TAG"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+        with:
+          version: ${{ env.ORAS_VERSION }}
+
+      # Preserve a completed staging build across retries. Rebuilding it after
+      # an upstream base image moves could produce a different digest and make
+      # an otherwise repairable partial release impossible to finish.
+      - name: Inspect commit-scoped staging image
+        id: staging
+        env:
+          IMAGE: ${{ matrix.image }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+        run: |
+          set -euo pipefail
+
+          staging_tag="release-$TARGET_SHA"
+          repo_tags="$(oras repo tags "$IMAGE")"
+          if grep -Fxq -- "$staging_tag" <<< "$repo_tags"; then
+            digest="$(oras resolve "$IMAGE:$staging_tag")"
+            [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            echo "reusing $IMAGE:$staging_tag at $digest"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push commit-scoped staging image
+        if: steps.staging.outputs.exists != 'true'
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ matrix.image }}:release-${{ inputs.target-sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ inputs.target-sha }}
+            org.opencontainers.image.version=${{ needs.calculate.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max,ignore-error=true
+
+      - name: Validate commit-scoped staging image
+        env:
+          IMAGE: ${{ matrix.image }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+        run: |
+          set -euo pipefail
+
+          digest="$(oras resolve "$IMAGE:release-$TARGET_SHA")"
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+      - name: Scan release image
+        id: container-scan
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
+        with:
+          image: ${{ matrix.image }}:release-${{ inputs.target-sha }}
+          fail-build: false
+
+      - name: Inspect release image scan report
+        env:
+          SARIF_REPORT: ${{ steps.container-scan.outputs.sarif }}
+        run: |
+          set -euo pipefail
+
+          test -s "$SARIF_REPORT"
+          cat "$SARIF_REPORT"
+
+  chart:
+    name: Build release chart
+    needs: calculate
+    if: needs.calculate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout release source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.target-sha }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.4
+
+      - name: Lint and render chart
+        run: .github/scripts/chart-verify.sh
+
+      - name: Package deterministic release chart
+        env:
+          TARGET_SHA: ${{ inputs.target-sha }}
+          VERSION: ${{ needs.calculate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          [[ "$VERSION" =~ ^0[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]
+          test "$(git rev-parse HEAD)" = "$TARGET_SHA"
+          source_epoch="$(git show -s --format=%ct "$TARGET_SHA")"
+          [[ "$source_epoch" =~ ^[0-9]+$ ]]
+
+          raw="$RUNNER_TEMP/chart-raw"
+          tree="$RUNNER_TEMP/chart-tree"
+          mkdir -p "$raw" "$tree" dist
+          helm package "$CHART_DIR" \
+            --version "$VERSION" \
+            --app-version "$VERSION" \
+            --destination "$raw"
+          tar -xzf "$raw/c8s-$VERSION.tgz" -C "$tree"
+          if find "$tree" -mindepth 1 ! -type d ! -type f -print -quit | grep -q .; then
+            echo "::error::chart package contains a non-regular entry"
+            exit 1
+          fi
+          tar --sort=name --owner=0 --group=0 --numeric-owner \
+            --mtime="@$source_epoch" -C "$tree" -cf - c8s \
+            | gzip -n > "dist/c8s-$VERSION.tgz"
+          (cd dist && sha256sum "c8s-$VERSION.tgz" > SHA256SUMS)
+          helm show chart "dist/c8s-$VERSION.tgz" > /dev/null
+
+      - name: Upload release chart
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: c8s-release-chart-${{ inputs.target-sha }}
+          path: |
+            dist/c8s-*.tgz
+            dist/SHA256SUMS
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  publish:
+    name: Publish release
+    needs: [calculate, images, chart]
+    if: needs.calculate.outputs.publish == 'true' && needs.images.result == 'success' && needs.chart.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: write
+      packages: write
+    environment:
+      name: release
+      deployment: false
+    steps:
+      - name: Download release chart
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: c8s-release-chart-${{ inputs.target-sha }}
+          path: dist
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
+        with:
+          version: ${{ env.ORAS_VERSION }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.4
+
+      - name: Validate release inputs and payload
+        env:
+          RELEASE_MATRIX: ${{ needs.calculate.outputs.image-matrix }}
+          RELEASE_TAG: ${{ needs.calculate.outputs.tag }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+          VERSION: ${{ needs.calculate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$RELEASE_TAG" =~ ^v0[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]
+          test "$RELEASE_TAG" = "v$VERSION"
+
+          mapfile -t payload < <(find dist -mindepth 1 -maxdepth 1 -type f -print | sort)
+          test "${#payload[@]}" -eq 2
+          test -f dist/SHA256SUMS
+          test ! -L dist/SHA256SUMS
+          if find dist -mindepth 1 -maxdepth 1 ! -type f -print -quit | grep -q .; then
+            echo "::error::release payload contains a non-regular entry"
+            exit 1
+          fi
+          chart="dist/c8s-$VERSION.tgz"
+          test -f "$chart"
+          test ! -L "$chart"
+          manifest_hash="$(
+            awk -v file="c8s-$VERSION.tgz" \
+              '$2 == file { count++; digest=$1 } END { if (count == 1) print digest; else exit 1 }' \
+              dist/SHA256SUMS
+          )"
+          [[ "$manifest_hash" =~ ^[0-9a-f]{64}$ ]]
+          actual_hash="$(sha256sum "$chart")"
+          test "${actual_hash%% *}" = "$manifest_hash"
+
+          if ! jq -e '
+            type == "object" and
+            keys == ["include"] and
+            (.include | type == "array" and length > 0) and
+            ([.include[].image] | length == (unique | length)) and
+            all(.include[];
+              type == "object" and
+              keys == ["binary", "dockerfile", "image"] and
+              (.binary | test("^[a-z0-9][a-z0-9-]*$")) and
+              (.dockerfile | test("^cmd/[a-z0-9][a-z0-9-]*/Dockerfile$")) and
+              (.image | test("^ghcr[.]io/confidential-dot-ai/[a-z0-9][a-z0-9-]*$"))
+            )
+          ' <<< "$RELEASE_MATRIX" > /dev/null; then
+            echo "::error::release image matrix is malformed or unsafe"
+            exit 1
+          fi
+          jq -r '.include[].image' <<< "$RELEASE_MATRIX" \
+            | sort > "$RUNNER_TEMP/release-images"
+
+      - name: Log in to GHCR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          printf '%s' "$GH_TOKEN" | oras login ghcr.io \
+            --username "$GITHUB_ACTOR" --password-stdin
+          printf '%s' "$GH_TOKEN" | helm registry login ghcr.io \
+            --username "$GITHUB_ACTOR" --password-stdin
+
+      # Reads must succeed before any tag or package is mutated. Existing exact
+      # release aliases are accepted only when they resolve to this build.
+      - name: Preflight image and chart destinations
+        id: preflight
+        env:
+          TARGET_SHA: ${{ inputs.target-sha }}
+          VERSION: ${{ needs.calculate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          staging_tag="release-$TARGET_SHA"
+          : > "$RUNNER_TEMP/release-image-digests"
+          while IFS= read -r image; do
+            source_digest="$(oras resolve "$image:$staging_tag")"
+            [[ "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+            repo_tags="$(oras repo tags "$image")"
+            for tag in "v$VERSION" "$VERSION"; do
+              if grep -Fxq -- "$tag" <<< "$repo_tags"; then
+                destination_digest="$(oras resolve "$image:$tag")"
+                if [ "$destination_digest" != "$source_digest" ]; then
+                  echo "::error::$image:$tag already names $destination_digest, expected $source_digest"
+                  exit 1
+                fi
+              fi
+            done
+            printf '%s\t%s\n' "$image" "$source_digest" \
+              >> "$RUNNER_TEMP/release-image-digests"
+          done < "$RUNNER_TEMP/release-images"
+
+          chart_tags="$(oras repo tags "$CHART_IMAGE")"
+          chart_exists=false
+          if grep -Fxq -- "$VERSION" <<< "$chart_tags"; then
+            chart_exists=true
+            mkdir -p "$RUNNER_TEMP/chart-preflight"
+            helm pull "oci://$CHART_IMAGE" --version "$VERSION" \
+              --destination "$RUNNER_TEMP/chart-preflight"
+            cmp "dist/c8s-$VERSION.tgz" \
+              "$RUNNER_TEMP/chart-preflight/c8s-$VERSION.tgz"
+          fi
+          echo "chart-exists=$chart_exists" >> "$GITHUB_OUTPUT"
+
+      # The Git reference reserves the version before registry writes. A retry
+      # verifies the exact target and repairs only missing registry aliases.
+      - name: Create or verify annotated release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.calculate.outputs.tag }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+        run: |
+          set -euo pipefail
+
+          github_api() {
+            timeout --kill-after=5s "$GH_API_TIMEOUT" \
+              gh api -H "X-GitHub-Api-Version: $GITHUB_API_VERSION" "$@"
+          }
+
+          refs="$(github_api "/repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$RELEASE_TAG")"
+          exact_ref="refs/tags/$RELEASE_TAG"
+          exact_count="$(jq --arg ref "$exact_ref" '[.[] | select(.ref == $ref)] | length' <<< "$refs")"
+          if [ "$exact_count" = "0" ]; then
+            tagger_name="github-actions[bot]"
+            tagger_id="$(github_api "/users/$tagger_name" --jq .id)"
+            [[ "$tagger_id" =~ ^[0-9]+$ ]]
+            tag_object_sha="$(
+              github_api --method POST "/repos/$GITHUB_REPOSITORY/git/tags" \
+                --raw-field tag="$RELEASE_TAG" \
+                --raw-field message="Release $RELEASE_TAG from $TARGET_SHA" \
+                --raw-field object="$TARGET_SHA" \
+                --raw-field type=commit \
+                --raw-field "tagger[name]=$tagger_name" \
+                --raw-field "tagger[email]=$tagger_id+$tagger_name@users.noreply.github.com" \
+                --jq .sha
+            )"
+            test -n "$tag_object_sha"
+            github_api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
+              --raw-field ref="$exact_ref" \
+              --raw-field sha="$tag_object_sha" > /dev/null
+          elif [ "$exact_count" != "1" ]; then
+            echo "::error::multiple exact refs returned for $RELEASE_TAG"
+            exit 1
+          fi
+
+          IFS=$'\t' read -r ref_type ref_sha <<< "$(
+            github_api "/repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" \
+              --jq '[.object.type, .object.sha] | @tsv'
+          )"
+          test "$ref_type" = tag
+          [[ "$ref_sha" =~ ^[0-9a-f]{40}$ ]]
+          IFS=$'\t' read -r target_type target_sha <<< "$(
+            github_api "/repos/$GITHUB_REPOSITORY/git/tags/$ref_sha" \
+              --jq '[.object.type, .object.sha] | @tsv'
+          )"
+          test "$target_type" = commit
+          test "$target_sha" = "$TARGET_SHA"
+
+      - name: Publish or verify component image aliases
+        env:
+          RELEASE_TAG: ${{ needs.calculate.outputs.tag }}
+          TARGET_SHA: ${{ inputs.target-sha }}
+          UPDATE_SERIES: ${{ needs.calculate.outputs.update-series }}
+          VERSION: ${{ needs.calculate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          [[ "$UPDATE_SERIES" =~ ^(true|false)$ ]]
+          series="${VERSION%.*}"
+          short_sha="${TARGET_SHA:0:7}"
+
+          while IFS=$'\t' read -r image source_digest; do
+            repo_tags="$(oras repo tags "$image")"
+            new_tags=()
+            for tag in "$RELEASE_TAG" "$VERSION"; do
+              if grep -Fxq -- "$tag" <<< "$repo_tags"; then
+                test "$(oras resolve "$image:$tag")" = "$source_digest"
+              else
+                new_tags+=("$tag")
+              fi
+            done
+            if [ "$UPDATE_SERIES" = true ]; then
+              if ! grep -Fxq -- "$series" <<< "$repo_tags" || \
+                 [ "$(oras resolve "$image:$series")" != "$source_digest" ]; then
+                new_tags+=("$series")
+              fi
+            fi
+            # The downstream Kata build resolves component manifests by this
+            # commit tag. Point it at the canonical all-components release
+            # rebuild before the parent Docker workflow completes.
+            if ! grep -Fxq -- "$short_sha" <<< "$repo_tags" || \
+               [ "$(oras resolve "$image:$short_sha")" != "$source_digest" ]; then
+              new_tags+=("$short_sha")
+            fi
+
+            if [ "${#new_tags[@]}" -gt 0 ]; then
+              oras tag "$image@$source_digest" "${new_tags[@]}"
+            fi
+            test "$(oras resolve "$image:$RELEASE_TAG")" = "$source_digest"
+            test "$(oras resolve "$image:$VERSION")" = "$source_digest"
+            test "$(oras resolve "$image:$short_sha")" = "$source_digest"
+            if [ "$UPDATE_SERIES" = true ]; then
+              test "$(oras resolve "$image:$series")" = "$source_digest"
+            fi
+          done < "$RUNNER_TEMP/release-image-digests"
+
+      - name: Publish or verify Helm chart
+        env:
+          CHART_EXISTS: ${{ steps.preflight.outputs.chart-exists }}
+          VERSION: ${{ needs.calculate.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          if [ "$CHART_EXISTS" = false ]; then
+            helm push "dist/c8s-$VERSION.tgz" "oci://$CHART_REPO"
+          fi
+          mkdir -p "$RUNNER_TEMP/chart-verify"
+          helm pull "oci://$CHART_IMAGE" --version "$VERSION" \
+            --destination "$RUNNER_TEMP/chart-verify"
+          cmp "dist/c8s-$VERSION.tgz" \
+            "$RUNNER_TEMP/chart-verify/c8s-$VERSION.tgz"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,14 @@ additionally runs golangci-lint, a CRD/chart consistency check
 - Maintainers review and merge at their discretion; expect requests for
   changes.
 
+## Releases
+
+Merges to `main` are versioned automatically from their Conventional Commit
+messages. Maintainers should not calculate or push release tags manually; see
+[docs/releases.md](docs/releases.md) for the version rules, repository setup,
+and recovery procedure. Automatic releases remain on major version zero until
+the release policy is deliberately graduated to `v1.0.0`.
+
 ## Security issues
 
 Do **not** report vulnerabilities through public issues or PRs. See

--- a/README.md
+++ b/README.md
@@ -486,9 +486,16 @@ wiring is described in [docs/operator.md](docs/operator.md).
 
 ## Docker images
 
-All images are published to GHCR on push to `main` and on `v*` release tags:
-per-role image names remain stable, but each image copies the same multi-mode
-`c8s` binary and sets an appropriate entrypoint.
+All images are published to GHCR on pushes to `main`. Release-worthy merges also
+receive stable `vX.Y.Z`, `X.Y.Z`, and `X.Y` aliases in that same workflow run.
+Per-role image names remain stable, but each image copies the same multi-mode
+`c8s` binary and sets an appropriate entrypoint. See
+[docs/releases.md](docs/releases.md) for the version policy.
+
+The measured `node-guest-base` artifacts follow the same root release with
+platform-qualified exact aliases such as `rke2-tdx-v0.1.0` and
+`rke2-snp-cdi-v0.1.0`; they intentionally have no ambiguous bare or moving
+SemVer alias.
 
 | Image | Base | Notes |
 |---|---|---|

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -64,17 +64,17 @@ matches (override `cds.node.selector` for a different label):
 kubectl label node <cds-node> role=cds
 ```
 
-`c8s install` passes the CLI build version as the chart image tag, but only when
-it is a release tag (for example `v0.1.0`), the version CI publishes a matching
-image for. Any other build (a local `git describe` derivative, a commit SHA, or
-the unstamped default) falls back to the `main` branch tag, the only other tag
-every component publishes.
+`c8s install` passes the CLI build version as the chart image tag when it is a
+stable release version (for example `v0.1.0`), for which CI publishes a matching
+image alias. Any other build (a local `git describe` derivative, a commit SHA,
+or the unstamped default) falls back to the `main` branch tag, the only other
+fallback tag published for every component.
 
 The chart itself is versioned separately. CI publishes it to
-`oci://ghcr.io/confidential-dot-ai/charts` under a SemVer chart version (`1.2.3` for a
-release tag, `<Chart.yaml version>-g<short-sha>` for a `main` build), never a
-`main` tag, because Helm chart versions must be SemVer. The chart carries no
-default image tag of its own, so the image tag above is supplied by
+`oci://ghcr.io/confidential-dot-ai/charts` under a SemVer chart version (`X.Y.Z`
+for a stable release, `<Chart.yaml version>-g<short-sha>` for a development
+build), never a `main` tag, because Helm chart versions must be SemVer. The chart
+carries no default image tag of its own, so the image tag above is supplied by
 `c8s install` rather than baked into the published chart.
 
 To install without the advisory CRDs:

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -339,10 +339,10 @@ The `build.sh` pins carry a re-resolve command in a comment beside each.
 The [`kata-guest-base.yml`](../.github/workflows/kata-guest-base.yml)
 workflow builds the image and pushes it to
 `ghcr.io/confidential-dot-ai/kata-guest-base` (flat at the org level, matching
-every other c8s artifact). It tags images as `<short-sha>` on every
-commit to `main` or `feat/**` branches that touches the recipe or the
-in-guest binaries. On a release tag (`v*`) the same image also gets the
-release version; `latest` moves only on `main`.
+every other c8s artifact). After each successful `Docker` run on `main`, it tags
+the image as `<short-sha>` and `main`. When the parent run created a stable
+release tag on that exact revision, the same build also receives the matching
+`vX.Y.Z` alias. A manual dispatch can publish a branch-scoped alias.
 
 Operators select the artifact tag by setting `kata.guestImage.tag` in a values
 file (`c8s install --cvm-mode=pod -f values.yaml`). The

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,117 @@
+# Releases
+
+c8s is one versioned release unit. A root `vX.Y.Z` tag versions the CLI,
+component images, measured node image, Kata guest image, and Helm chart
+together. Maintainers do not calculate or push release tags manually.
+
+## Automatic versioning
+
+After every build and retag job in the `Docker` workflow succeeds for a push to
+`main`, [`semver-tag.yml`](../.github/workflows/semver-tag.yml) examines the
+Conventional Commits since the latest stable release tag.
+
+| Commit | Version change while on `0.x` |
+| --- | --- |
+| `fix:` | patch |
+| `feat:` | minor |
+| `!` or a `BREAKING CHANGE:` footer | minor |
+| any other type | no release |
+
+Major version zero is deliberate while the public interfaces settle. The
+workflow rejects any automatically calculated tag outside the configured `v0`
+line. Graduating to `v1.0.0` requires a reviewed change to both the git-cliff
+bump policy and the workflow's `RELEASE_MAJOR` gate; a breaking commit alone
+cannot cross that boundary.
+
+Pre-release tags are not stable baselines. The first automatic stable release
+is therefore `v0.1.0`, following the existing `v0.1.0-rc*` series. After that,
+the highest release-worthy change across all unreleased commits wins.
+
+## Publication
+
+Release publication stays inside the successful main-push `Docker` run:
+
+1. The normal main-push image build and retag legs complete successfully.
+2. git-cliff calculates the next stable version after all older main-push
+   Docker runs finish.
+3. Every component image is rebuilt from that exact commit under a
+   commit-scoped staging tag. This retains the old tag-triggered path's
+   all-components rebuild without starting a second workflow or trusting a
+   potentially stale `main` alias. A retry reuses an existing staging digest so
+   mutable upstream base images cannot change a partially published release.
+4. The Helm chart is linted, rendered, and packaged reproducibly for that
+   version in a read-only job.
+5. A job protected by the `release` environment verifies every staging digest,
+   then creates a create-only annotated Git tag with the built-in
+   `GITHUB_TOKEN`.
+6. The verified manifests are promoted to `vX.Y.Z`, `X.Y.Z`, the moving `X.Y`
+   compatibility tag, and the commit's short-SHA tag used by the measured Kata
+   build. The same job publishes chart `X.Y.Z`.
+7. Completion of the original Docker run starts the existing measured node,
+   Kata guest, and e2e workflows. The node workflow builds both TDX/SNP formats,
+   then promotes their exact commit manifests to
+   `rke2-{tdx,snp}[-cdi]-vX.Y.Z` only after every matrix leg succeeds. It does
+   not publish a bare `vX.Y.Z` because that would not identify a platform and
+   format.
+8. The Kata job adds the matching `vX.Y.Z` aliases without rebuilding a second
+   time for a tag event. Existing stable node and Kata aliases are verified by
+   digest and never silently moved by a retry or manual rebuild.
+
+For the first stable release, the measured node aliases are therefore
+`rke2-tdx-v0.1.0`, `rke2-tdx-cdi-v0.1.0`, `rke2-snp-v0.1.0`, and
+`rke2-snp-cdi-v0.1.0` in
+`ghcr.io/confidential-dot-ai/node-guest-base`. There is deliberately no moving
+`v0.1` alias for a measured image; operators pin the exact release whose
+measurement they allowlist.
+
+GitHub intentionally does not start new workflows for the tag created with
+`GITHUB_TOKEN`. That is part of this design: component and chart publication is
+explicit in the originating run, while the existing node/Kata workflows consume
+that run's successful `workflow_run` completion. No OAuth App, GitHub App,
+personal access token, or long-lived release credential is required.
+
+## One-time GitHub setup
+
+1. Create a GitHub Actions environment named `release`.
+2. Set its deployment branches and tags to **Selected branches and tags**, allow
+   only the `main` branch, and disable administrator bypass. Do not add a
+   required reviewer if releases must remain fully automatic.
+3. Ensure organization/repository Actions policy permits the workflow's
+   explicit `contents: write` and `packages: write` permissions.
+4. If a tag ruleset covers `v*`, ensure it permits GitHub Actions to create a
+   new tag. It should continue to reject updates and deletions.
+
+The environment contains no release credential. Its purpose is to gate the
+stable component/chart publisher and the stable node-image alias publisher.
+Calculation and chart construction run in separate read-only jobs, and neither
+publisher checks out or executes repository source.
+
+The Git Data API creates annotated but unsigned tags. A ruleset requiring
+cryptographically signed `v*` tags will reject this workflow; adding a dedicated
+CI signing identity is a separate release-security change.
+
+## Consistency and recovery
+
+Release calculation is sequential by repository-monotonic workflow run ID. It
+does not trust runner clocks. Git and GHCR reads are eventually consistent; a
+timeout, network partition, malformed response, or exhausted wait budget fails
+closed.
+
+Creating `refs/tags/vX.Y.Z` reserves the version. Registry publication is not a
+cross-system transaction, so a failure after tag creation can leave that release
+temporarily incomplete. Re-run the failed **Docker** workflow to repair its
+component/chart publication, or rerun the downstream **c8s-image** workflow to
+repair measured node aliases. Missing aliases are created and matching ones are
+verified; neither workflow moves a Git release tag or overwrites an exact image
+tag whose digest differs. A pulled existing Helm chart must match the
+deterministic package byte-for-byte.
+
+The moving `X.Y` image aliases advance only when the run's Git tag is the latest
+stable patch in that series. Re-running an older workflow therefore cannot roll
+the compatibility alias backward.
+
+- A non-release commit completes without creating a stable tag.
+- A failed build creates no tag because release calculation depends on every
+  image build/retag leg.
+- Never move, delete, or reuse a published stable tag. Fix a bad release with a
+  new Conventional Commit and let automation create the next version.

--- a/kata-guest-base/scripts/ci/compute-tags.sh
+++ b/kata-guest-base/scripts/ci/compute-tags.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 # CI-only: compute the GHCR image ref + tag list for the kata-guest-base oras
-# push in .github/workflows/kata-guest-base.yml. Writes `image`, `tags`, and
-# `debug_tags` (comma-joined) to GITHUB_OUTPUT. `debug_tags` is every tag
+# push in .github/workflows/kata-guest-base.yml. Writes `image`, `tags`,
+# `debug_tags` (comma-joined), and the optional `release_tag` to GITHUB_OUTPUT.
+# `debug_tags` is every mutable/commit tag
 # with a `-debug` suffix — the debug-policy variant (build.sh Step 5/5,
 # output-debug/) publishes under it in lockstep with the locked image, so
 # `kata.guestImage.debug=true` (`c8s install --cvm-mode=pod --debug`) can derive the
 # debug ref from any locked tag.
 #
-# Always publish the immutable, commit-pinned short-SHA tag. Then add exactly one
-# human-friendly pointer, scoped to the ref class:
-#   - release tag push (vX) -> the release tag       (official)
-#   - main                  -> main                  (official)
-#   - any side branch       -> branch-<sanitized branch name>
+# Always publish the commit-scoped short-SHA tag. Then add the
+# human-friendly pointer scoped to the ref class:
+#   - main                  -> main
+#   - any other ref         -> branch-<sanitized ref name>
+#
+# RELEASE_TAG is kept separate. The workflow promotes the four completed guest
+# manifests only after it verifies that an existing stable alias has the same
+# digest, so a retry or manual rebuild cannot silently overwrite a release.
 #
 # :main matches every other c8s artifact (docker.yml: cds, operator,
 # ratls-mesh, …) and cmd/c8s/install.go's fallbackImageTag, so the chart's
@@ -20,14 +24,17 @@
 # A side branch NEVER gets main/vX — nothing a human could mistake for a
 # released, production image. The branch- prefix plus ref sanitization (any char
 # outside [A-Za-z0-9_.-] -> '-') keeps it an obvious dev artifact and a valid OCI
-# tag (leading 'b', <=128 chars).
+# tag. The sanitized ref is truncated so the longest derived
+# `branch-<ref>-nvidia-debug` tag stays within OCI's 128-character limit.
 #
 # Inputs (env):
 #   HEAD_BRANCH     source branch of the triggering Docker event: "main" for a
-#                   main push, the tag name (e.g. "v0.1.0") for a tag push;
+#                   main push, or the selected ref for a manual run;
 #                   github.ref_name on workflow_dispatch.
 #   HEAD_SHA        commit Docker succeeded on (workflow_run head_sha), or
 #                   github.sha on workflow_dispatch.
+#   RELEASE_TAG     optional stable tag created by the successful parent Docker
+#                   run for HEAD_SHA. It is emitted only on the main path.
 #   REGISTRY        container registry host (ghcr.io).
 #   GITHUB_OUTPUT   step output file.
 
@@ -38,21 +45,36 @@ set -euo pipefail
 : "${REGISTRY:?REGISTRY must be set}"
 : "${GITHUB_OUTPUT:?GITHUB_OUTPUT must be set}"
 
+if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid full commit SHA: $HEAD_SHA" >&2
+  exit 1
+fi
+
+RELEASE_TAG="${RELEASE_TAG:-}"
+if [ -n "$RELEASE_TAG" ] && \
+   [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+  echo "invalid stable release tag: $RELEASE_TAG" >&2
+  exit 1
+fi
+
 SHORT_SHA="${HEAD_SHA::7}"
 IMAGE="${REGISTRY}/confidential-dot-ai/kata-guest-base"
 
 tags=("${SHORT_SHA}")
-if [[ "${HEAD_BRANCH}" == v* ]]; then
-  tags+=("${HEAD_BRANCH}")
-elif [[ "${HEAD_BRANCH}" == "main" ]]; then
+if [[ "${HEAD_BRANCH}" == "main" ]]; then
   tags+=("main")
 else
+  RELEASE_TAG=""
   SAFE_BRANCH="$(printf '%s' "${HEAD_BRANCH}" | tr -c 'A-Za-z0-9_.-' '-')"
+  SAFE_BRANCH="${SAFE_BRANCH:0:108}"
   tags+=("branch-${SAFE_BRANCH}")
 fi
 
 joined=$(IFS=,; echo "${tags[*]}")
 debug_joined=$(IFS=,; echo "${tags[*]/%/-debug}")
-echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
-echo "tags=${joined}" >> "$GITHUB_OUTPUT"
-echo "debug_tags=${debug_joined}" >> "$GITHUB_OUTPUT"
+{
+  echo "image=${IMAGE}"
+  echo "tags=${joined}"
+  echo "debug_tags=${debug_joined}"
+  echo "release_tag=${RELEASE_TAG}"
+} >> "$GITHUB_OUTPUT"

--- a/kata-guest-base/scripts/ci/publish-release-aliases.sh
+++ b/kata-guest-base/scripts/ci/publish-release-aliases.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Publish the four stable kata-guest-base aliases after verifying that every
+# existing destination names the commit-scoped source digest. The complete
+# preflight happens before the first write, so a conflict cannot leave a newly
+# partial release.
+#
+# Inputs (env):
+#   HEAD_SHA      full commit SHA whose Docker and Kata workflows succeeded.
+#   IMAGE         kata-guest-base OCI repository.
+#   RELEASE_TAG   stable vX.Y.Z release tag.
+#   RUNNER_TEMP   GitHub-runner-provided temp directory.
+
+set -euo pipefail
+
+: "${HEAD_SHA:?HEAD_SHA must be set}"
+: "${IMAGE:?IMAGE must be set}"
+: "${RELEASE_TAG:?RELEASE_TAG must be set}"
+: "${RUNNER_TEMP:?RUNNER_TEMP must be set}"
+
+if [[ ! "$RELEASE_TAG" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+  echo "invalid stable release tag: $RELEASE_TAG" >&2
+  exit 1
+fi
+if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "invalid full commit SHA: $HEAD_SHA" >&2
+  exit 1
+fi
+
+short="${HEAD_SHA:0:7}"
+repo_tags="$(oras repo tags "$IMAGE")"
+aliases="$RUNNER_TEMP/kata-release-aliases"
+: > "$aliases"
+
+for suffix in '' -debug -nvidia -nvidia-debug; do
+  source_tag="$short$suffix"
+  release_alias="$RELEASE_TAG$suffix"
+  source_digest="$(oras resolve "$IMAGE:$source_tag")"
+  [[ "$source_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+  exists=false
+  if grep -Fxq -- "$release_alias" <<< "$repo_tags"; then
+    exists=true
+    destination_digest="$(oras resolve "$IMAGE:$release_alias")"
+    if [ "$destination_digest" != "$source_digest" ]; then
+      echo "::error::$IMAGE:$release_alias already names $destination_digest, expected $source_digest"
+      exit 1
+    fi
+  fi
+  printf '%s\t%s\t%s\n' "$release_alias" "$source_digest" "$exists" >> "$aliases"
+done
+
+while IFS=$'\t' read -r release_alias source_digest exists; do
+  if [ "$exists" = false ]; then
+    oras tag "$IMAGE@$source_digest" "$release_alias"
+  fi
+  test "$(oras resolve "$IMAGE:$release_alias")" = "$source_digest"
+done < "$aliases"


### PR DESCRIPTION
## Summary

- derive stable pre-1.0 SemVer releases from Conventional Commit squash messages
  - `fix` publishes a patch release
  - `feat` and breaking changes publish a minor release while the project remains on major `0`
  - other commit types do not publish a stable release
- publish component images and the Helm chart from the successful Docker workflow run using only the built-in `GITHUB_TOKEN`
- rebuild and scan all six component images from the exact release commit before promoting immutable aliases
- give the existing downstream Kata and measured node-image builds the same root release identity
- document release behavior, recovery, and the explicit `v0` ceiling

## Release behavior

- the first stable release is `v0.1.0`; existing RC tags are ignored
- component aliases are `vX.Y.Z`, `X.Y.Z`, and the moving `X.Y` compatibility alias
- Kata publishes exact `vX.Y.Z` aliases for its locked, debug, NVIDIA, and NVIDIA-debug variants
- `node-guest-base` publishes exact platform/format aliases:
  - `rke2-tdx-vX.Y.Z`
  - `rke2-tdx-cdi-vX.Y.Z`
  - `rke2-snp-vX.Y.Z`
  - `rke2-snp-cdi-vX.Y.Z`
- measured node images intentionally receive no bare or moving SemVer alias
- release builds force exact node artifacts instead of taking the unchanged-rootfs shortcut
- retries reuse or verify immutable destinations and fail rather than overwrite a conflicting release
- leaving major `0` is rejected until the release policy is deliberately changed for `v1.0.0`

The protected `release` environment is configured for `main` only, with admin bypass disabled and no secrets or variables. No OAuth App, GitHub App, or PAT is required.

## Validation

- full repository `actionlint`, changed-workflow YAML parsing, `shellcheck`, and `git diff --check`
- release-workflow `zizmor`; downstream `workflow_run` findings retain explicit same-repository/event/branch/conclusion guards
- Helm lint and template verification
- Linux-targeted `go vet` and compilation of all Go test packages
- git-cliff fixtures for no-op, patch, feature, and breaking changes
- component matrix/publisher validation for all six images
- node release fixtures for tag discovery, forced exact rebuilds, idempotent promotion, conflict-before-write, and unchanged-image commit aliases
- GHCR collision checks for the initial component, chart, Kata, and node-image stable aliases
