### PR TITLE
fix(kata-guest-base): deny OCI spec hooks in the baked kata-agent policy

### DIFF
--- a/docs/kata-image-policy.md
+++ b/docs/kata-image-policy.md
@@ -158,8 +158,8 @@ It exists because:
 
 - kata-agent has no upstream-supported pre-start callout we can
   intercept other than the in-process OPA policy, and that policy
-  is structurally permissive (see "Why the OPA policy is permissive"
-  below).
+  carries no digest allowlist (see "Why the digest allowlist is not
+  in the baked policy" below).
 - Userspace inotify delivers events asynchronously; the kernel
   doesn't pause the writer until a userspace consumer reads the
   event.
@@ -203,11 +203,14 @@ logs at error instead: a denied container that exited on its own is
 indistinguishable from one that never got a cgroup, and that must not power off
 a healthy guest.
 
-## Why the OPA policy is permissive
+## Why the digest allowlist is not in the baked policy
 
-kata-agent's bootstrap OPA policy in this image is
-`allow-all.rego`-plus-`SetPolicyRequest := false`. We don't carry a
-per-image-digest Rego rule there because:
+kata-agent's baked OPA policy fails closed: it binds each request to
+itself — container id shape, storages, mounts, spec hooks,
+`guest_hook_path` — and denies the RPCs that would let the host reach
+into a running container, with `SetPolicyRequest := false` so the host
+cannot swap it at runtime. The one decision it does not carry is a
+per-image-digest Rego rule, because:
 
 1. **Regorus crypto.** Adding `data.agent_policy.allow if
    input.digest in allowed_digests` to the baked Rego would couple
@@ -507,7 +510,7 @@ workload container. kata-agent gets two CreateContainerRequest calls
 in succession.
 
 **Flow.** Both calls are evaluated against the same baked OPA policy in
-kata-agent (allow-all on CreateContainerRequest). policy-monitor sees an
+kata-agent (fails closed on each). policy-monitor sees an
 inotify event per container bundle and evaluates each independently
 against the in-memory allowlist — except the sandbox (pause) container,
 which is out of allowlist scope (see Outcome).

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -304,12 +304,14 @@ func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
 	}
 }
 
-// Spec hooks ride inside an otherwise-admitted CreateContainerRequest and
-// execute as guest root during do_create_container, ahead of the
-// admission verdict. Pin the guard the same way as the CRI-O marker: one
-// no_spec_hooks rule holding one line per hook list, conjoined into
-// CreateContainerRequest — a commented-out or relocated line still leaves
-// the substrings present, so read the rule bodies.
+// Spec hooks ride inside an otherwise-admitted CreateContainerRequest;
+// Prestart and CreateContainer execute as guest root ahead of the
+// admission verdict, the remaining lists after it (CreateRuntime never
+// fires in the agent). Pin the guard the same
+// way as the CRI-O marker: one no_spec_hooks rule holding one line per
+// hook list, conjoined into CreateContainerRequest — a commented-out or
+// relocated line still leaves the substrings present, so read the rule
+// bodies.
 func TestBakedPolicyRejectsSpecHooks(t *testing.T) {
 	policy := readPolicy(t)
 

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -307,11 +307,10 @@ func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
 // Spec hooks ride inside an otherwise-admitted CreateContainerRequest;
 // Prestart and CreateContainer execute as guest root ahead of the
 // admission verdict, the remaining lists after it (CreateRuntime never
-// fires in the agent). Pin the guard the same
-// way as the CRI-O marker: one no_spec_hooks rule holding one line per
-// hook list, conjoined into CreateContainerRequest — a commented-out or
-// relocated line still leaves the substrings present, so read the rule
-// bodies.
+// fires in the agent). Pin the guard the same way as the CRI-O marker:
+// one no_spec_hooks rule holding one line per hook list, conjoined into
+// CreateContainerRequest — a commented-out or relocated line still
+// leaves the substrings present, so read the rule bodies.
 func TestBakedPolicyRejectsSpecHooks(t *testing.T) {
 	policy := readPolicy(t)
 

--- a/internal/kataspec/policy_lockstep_test.go
+++ b/internal/kataspec/policy_lockstep_test.go
@@ -304,6 +304,50 @@ func TestSandboxPredicateAgreesWithBakedPolicy(t *testing.T) {
 	}
 }
 
+// Spec hooks ride inside an otherwise-admitted CreateContainerRequest and
+// execute as guest root during do_create_container, ahead of the
+// admission verdict. Pin the guard the same way as the CRI-O marker: one
+// no_spec_hooks rule holding one line per hook list, conjoined into
+// CreateContainerRequest — a commented-out or relocated line still leaves
+// the substrings present, so read the rule bodies.
+func TestBakedPolicyRejectsSpecHooks(t *testing.T) {
+	policy := readPolicy(t)
+
+	hookBodies := ruleBodies(t, policy, "no_spec_hooks")
+	if len(hookBodies) != 1 {
+		t.Fatalf("baked policy has %d no_spec_hooks rules, want exactly one (a second would OR another predicate past the guard)", len(hookBodies))
+	}
+	for _, list := range []string{"Prestart", "CreateRuntime", "CreateContainer", "StartContainer", "Poststart", "Poststop"} {
+		guard := "not input.OCI.Hooks." + list + "[0]"
+		line := regexp.MustCompile(`(?m)^\t` + regexp.QuoteMeta(guard) + `$`)
+		if !line.MatchString(hookBodies[0]) {
+			t.Errorf("no_spec_hooks does not carry the guard line %q", guard)
+		}
+	}
+
+	containerBodies := ruleBodies(t, policy, "CreateContainerRequest")
+	if len(containerBodies) != 1 {
+		t.Fatalf("baked policy has %d CreateContainerRequest rules, want exactly one", len(containerBodies))
+	}
+	if !strings.Contains(containerBodies[0], "\tno_spec_hooks\n") {
+		t.Error("CreateContainerRequest does not conjoin no_spec_hooks")
+	}
+}
+
+// add_hooks arms every container with executables from the guest_hook_path
+// directory, so the baked policy holds it empty, matching upstream
+// genpolicy's CreateSandboxRequest guard.
+func TestBakedPolicyRejectsGuestHookPath(t *testing.T) {
+	bodies := ruleBodies(t, readPolicy(t), "CreateSandboxRequest")
+	if len(bodies) != 1 {
+		t.Fatalf("baked policy has %d CreateSandboxRequest rules, want exactly one", len(bodies))
+	}
+	line := regexp.MustCompile(`(?m)^\t` + regexp.QuoteMeta("count(input.guest_hook_path) == 0") + `$`)
+	if !line.MatchString(bodies[0]) {
+		t.Error("CreateSandboxRequest does not carry the guest_hook_path guard")
+	}
+}
+
 // A rule that silently reverts to `default … := true` is a no-op with no
 // symptom, so pin the decisions the guest's integrity rests on.
 func TestBakedPolicyKeepsItsFailClosedDefaults(t *testing.T) {

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -183,10 +183,12 @@ CreateContainerRequest if {
 	print("CreateContainerRequest: allowed")
 }
 
-# Spec hooks execute as guest root during do_create_container, ahead of the
-# admission verdict; prestart runs in the agent's own namespaces. The runtime
-# sends none — the GPU hook is CDI-injected by the agent after this check —
-# so a hook in the request is host-smuggled.
+# Prestart and CreateContainer hooks execute as guest root during
+# do_create_container, ahead of the admission verdict — prestart in the
+# agent's own namespaces. The remaining lists run after the verdict, with
+# the admitted container (CreateRuntime has no execution site in the
+# agent). The runtime sends none — the GPU hook is CDI-injected by the
+# agent after this check — so a hook in the request is host-smuggled.
 no_spec_hooks if {
 	not input.OCI.Hooks.Prestart[0]
 	not input.OCI.Hooks.CreateRuntime[0]

--- a/kata-guest-base/extra/etc/kata-opa/default-policy.rego
+++ b/kata-guest-base/extra/etc/kata-opa/default-policy.rego
@@ -151,6 +151,9 @@ CreateContainerRequest if {
 	not input.OCI.Annotations["io.kubernetes.cri-o.ContainerType"]
 	print("CreateContainerRequest: no foreign container-type marker")
 
+	no_spec_hooks
+	print("CreateContainerRequest: no spec hooks")
+
 	pull := sole_guest_pull_storage
 	print("CreateContainerRequest: one image_guest_pull storage")
 
@@ -178,6 +181,19 @@ CreateContainerRequest if {
 
 	pull_source_bound(pull)
 	print("CreateContainerRequest: allowed")
+}
+
+# Spec hooks execute as guest root during do_create_container, ahead of the
+# admission verdict; prestart runs in the agent's own namespaces. The runtime
+# sends none — the GPU hook is CDI-injected by the agent after this check —
+# so a hook in the request is host-smuggled.
+no_spec_hooks if {
+	not input.OCI.Hooks.Prestart[0]
+	not input.OCI.Hooks.CreateRuntime[0]
+	not input.OCI.Hooks.CreateContainer[0]
+	not input.OCI.Hooks.StartContainer[0]
+	not input.OCI.Hooks.Poststart[0]
+	not input.OCI.Hooks.Poststop[0]
 }
 
 container_rootfs := concat("/", ["/run/kata-containers", input.container_id, "rootfs"])
@@ -382,6 +398,9 @@ crio_pull_metadata(pull) if {
 default CreateSandboxRequest := false
 
 CreateSandboxRequest if {
+	# add_hooks arms every container with executables from this guest directory
+	count(input.guest_hook_path) == 0
+
 	every s in input.storages {
 		not container_rootfs_shaped(s.mount_point)
 		not layered_rootfs_storage(s)

--- a/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
+++ b/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
@@ -1,0 +1,57 @@
+Subject: [PATCH] agent: refuse OCI spec hooks in createcontainer
+
+Spec hooks ride inside an otherwise-admitted CreateContainerRequest and
+execute as guest root during do_create_container: prestart hooks run in
+the agent's own mount and PID namespaces, and all of them run before the
+admission verdict patch 0002 waits for. The baked policy denies them, so
+a request carrying hooks never reaches this point -- refuse them here
+anyway, so a policy-engine bypass (an agent built without agent-policy)
+cannot execute host-supplied hooks.
+
+The check sits right after the spec is taken from the request, which is
+before handle_cdi_devices and append_guest_hooks: the hooks the agent
+injects itself -- the nvidia-cdi-hook from the in-guest CDI registry,
+and guest hooks -- are appended afterwards and stay working.
+
+--- a/src/agent/src/rpc.rs
++++ b/src/agent/src/rpc.rs
+@@ -228,6 +228,8 @@ impl AgentService {
+             }
+         };
+ 
++        c8s_refuse_spec_hooks(&oci)?;
++
+         let container_name = k8s::container_name(&oci);
+ 
+         // c8s: the guest console is host-visible; the spec carries env/argv.
+@@ -2175,6 +2177,30 @@ async fn c8s_await_admission(cid: &str) -> Result<()> {
+     }
+ }
+ 
++// c8s: spec hooks run as guest root during do_create_container, before the
++// admission verdict. The baked policy already denies them; refuse them here
++// too, so a policy-engine bypass cannot execute host-supplied hooks. Hooks
++// the agent adds itself (CDI injection, guest hooks) come after this check.
++fn c8s_refuse_spec_hooks(oci: &Spec) -> Result<()> {
++    let Some(hooks) = oci.hooks().as_ref() else {
++        return Ok(());
++    };
++    let lists = [
++        ("prestart", hooks.prestart()),
++        ("createRuntime", hooks.create_runtime()),
++        ("createContainer", hooks.create_container()),
++        ("startContainer", hooks.start_container()),
++        ("poststart", hooks.poststart()),
++        ("poststop", hooks.poststop()),
++    ];
++    for (name, list) in lists {
++        if list.as_ref().is_some_and(|l| !l.is_empty()) {
++            return Err(anyhow!("refusing OCI spec {name} hooks"));
++        }
++    }
++    Ok(())
++}
++
+ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
+     let path = PathBuf::from(req.path.as_str());
+ 

--- a/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
+++ b/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
@@ -12,8 +12,8 @@ agent-policy) cannot execute host-supplied hooks.
 
 The check sits right after the spec is taken from the request, which is
 before handle_cdi_devices and append_guest_hooks: the hooks the agent
-injects itself -- the nvidia-cdi-hook from the in-guest CDI registry,
-and guest hooks -- are appended afterwards and stay working.
+injects itself -- the nvidia-cdi-hook from the in-guest CDI registry --
+are appended afterwards and stay working.
 
 --- a/src/agent/src/rpc.rs
 +++ b/src/agent/src/rpc.rs

--- a/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
+++ b/kata-guest-base/patches/0009-agent-refuse-oci-spec-hooks.patch
@@ -1,12 +1,14 @@
 Subject: [PATCH] agent: refuse OCI spec hooks in createcontainer
 
-Spec hooks ride inside an otherwise-admitted CreateContainerRequest and
-execute as guest root during do_create_container: prestart hooks run in
-the agent's own mount and PID namespaces, and all of them run before the
-admission verdict patch 0002 waits for. The baked policy denies them, so
-a request carrying hooks never reaches this point -- refuse them here
-anyway, so a policy-engine bypass (an agent built without agent-policy)
-cannot execute host-supplied hooks.
+Spec hooks ride inside an otherwise-admitted CreateContainerRequest.
+Prestart and CreateContainer hooks execute as guest root during
+do_create_container, before the admission verdict patch 0002 waits for
+-- prestart in the agent's own mount and PID namespaces; the remaining
+lists run after the verdict, with the admitted container (CreateRuntime
+has no execution site in the agent). The baked policy denies all six,
+so a request carrying hooks never reaches this point -- refuse them
+here anyway, so a policy-engine bypass (an agent built without
+agent-policy) cannot execute host-supplied hooks.
 
 The check sits right after the spec is taken from the request, which is
 before handle_cdi_devices and append_guest_hooks: the hooks the agent
@@ -15,7 +17,7 @@ and guest hooks -- are appended afterwards and stay working.
 
 --- a/src/agent/src/rpc.rs
 +++ b/src/agent/src/rpc.rs
-@@ -228,6 +228,8 @@ impl AgentService {
+@@ -228,6 +228,8 @@
              }
          };
  
@@ -24,14 +26,16 @@ and guest hooks -- are appended afterwards and stay working.
          let container_name = k8s::container_name(&oci);
  
          // c8s: the guest console is host-visible; the spec carries env/argv.
-@@ -2175,6 +2177,30 @@ async fn c8s_await_admission(cid: &str) -> Result<()> {
+@@ -2175,6 +2177,32 @@
      }
  }
  
-+// c8s: spec hooks run as guest root during do_create_container, before the
-+// admission verdict. The baked policy already denies them; refuse them here
-+// too, so a policy-engine bypass cannot execute host-supplied hooks. Hooks
-+// the agent adds itself (CDI injection, guest hooks) come after this check.
++// c8s: Prestart and CreateContainer spec hooks run as guest root during
++// do_create_container, before the admission verdict; the remaining lists
++// run after it. The baked policy already denies all six; refuse them here
++// too, so a policy-engine bypass cannot execute host-supplied hooks.
++// Hooks the agent adds itself (CDI injection, guest hooks) come after
++// this check.
 +fn c8s_refuse_spec_hooks(oci: &Spec) -> Result<()> {
 +    let Some(hooks) = oci.hooks().as_ref() else {
 +        return Ok(());
@@ -55,3 +59,91 @@ and guest hooks -- are appended afterwards and stay working.
  fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
      let path = PathBuf::from(req.path.as_str());
  
+@@ -3605,4 +3633,87 @@
+             assert_eq!(d.result, result, "{msg}");
+         }
+     }
++
++    #[test]
++    fn test_c8s_refuse_spec_hooks() {
++        fn spec_with(hooks: Option<Hooks>) -> Spec {
++            let mut spec = Spec::default();
++            spec.set_hooks(hooks);
++            spec
++        }
++        let hook = || {
++            HookBuilder::default()
++                .path(PathBuf::from("/bin/bash"))
++                .build()
++                .unwrap()
++        };
++
++        assert!(c8s_refuse_spec_hooks(&spec_with(None)).is_ok());
++        assert!(c8s_refuse_spec_hooks(&spec_with(Some(Hooks::default()))).is_ok());
++        let empty_lists = HooksBuilder::default()
++            .prestart(vec![])
++            .create_runtime(vec![])
++            .create_container(vec![])
++            .start_container(vec![])
++            .poststart(vec![])
++            .poststop(vec![])
++            .build()
++            .unwrap();
++        assert!(c8s_refuse_spec_hooks(&spec_with(Some(empty_lists))).is_ok());
++
++        // One hook in any of the six lists must be refused, naming the list.
++        let cases: [(&str, Hooks); 6] = [
++            (
++                "prestart",
++                HooksBuilder::default()
++                    .prestart(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++            (
++                "createRuntime",
++                HooksBuilder::default()
++                    .create_runtime(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++            (
++                "createContainer",
++                HooksBuilder::default()
++                    .create_container(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++            (
++                "startContainer",
++                HooksBuilder::default()
++                    .start_container(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++            (
++                "poststart",
++                HooksBuilder::default()
++                    .poststart(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++            (
++                "poststop",
++                HooksBuilder::default()
++                    .poststop(vec![hook()])
++                    .build()
++                    .unwrap(),
++            ),
++        ];
++        for (name, hooks) in cases {
++            let result = c8s_refuse_spec_hooks(&spec_with(Some(hooks)));
++            assert!(result.is_err(), "{} hooks must be refused", name);
++            assert!(
++                result.unwrap_err().to_string().contains(name),
++                "refusal must name the {} list",
++                name
++            );
++        }
++    }
+ }

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -233,6 +233,8 @@ done
 [[ -f "${PATCH_DIR}/0002-agent-wait-for-the-admission-verdict.patch" ]] || die "the admission-verdict patch is missing from ${PATCH_DIR}."
 # Without it every pod start logs the container's env/argv to the host console.
 [[ -f "${PATCH_DIR}/0005-agent-stop-logging-the-createcontainer-spec.patch" ]] || die "the createcontainer spec-log patch is missing from ${PATCH_DIR}."
+# Without it a policy-engine bypass runs host-supplied spec hooks as guest root.
+[[ -f "${PATCH_DIR}/0009-agent-refuse-oci-spec-hooks.patch" ]] || die "the spec-hooks patch is missing from ${PATCH_DIR}."
 
 # A prior run's images must not survive to publish time: CI pushes the output
 # dirs verbatim (oras push ./*), and on a persistent runner the root-owned

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -695,10 +695,12 @@ test_mount_allows_projected_volume_names if {
 
 # --- spec hooks ---------------------------------------------------------
 #
-# Hooks ride inside the OCI spec of an otherwise-admitted request and
-# execute as guest root before the admission verdict. All six lists must be
-# empty; the honest shapes are an absent Hooks, null (what the protobuf
-# serializer emits for an unset message), and empty lists.
+# Hooks ride inside the OCI spec of an otherwise-admitted request; Prestart
+# and CreateContainer execute as guest root before the admission verdict,
+# the remaining lists after it (CreateRuntime never fires in the agent).
+# All six lists must be empty; the honest shapes are an absent Hooks, null
+# (what the protobuf serializer emits for an unset message), an empty Hooks
+# message, and empty lists.
 
 # object.union is shallow, so merge at the OCI level to keep the fixture.
 with_hooks(base, hooks) := object.union(base, {"OCI": object.union(base.OCI, {"Hooks": hooks})})

--- a/kata-guest-base/tests/default-policy_test.rego
+++ b/kata-guest-base/tests/default-policy_test.rego
@@ -209,7 +209,7 @@ test_local_driver_denied if {
 		"options": ["mode=0777"],
 		"driver_options": [],
 	}])
-	not CreateSandboxRequest with input as {"storages": [{"driver": "local", "mount_point": "/run/kata-containers/shared/containers/x", "source": "", "fstype": "local"}]}
+	not CreateSandboxRequest with input as sandbox_req([{"driver": "local", "mount_point": "/run/kata-containers/shared/containers/x", "source": "", "fstype": "local"}])
 }
 
 # CDS's own /data volume is a default-medium emptyDir when persistence is off,
@@ -495,19 +495,22 @@ test_conflicting_container_type_markers_denied if {
 # the trees a container binds from, so both carry a container storage's
 # constraints.
 
+# guest_hook_path always serializes; an honest request carries it empty.
+sandbox_req(ss) := {"guest_hook_path": "", "storages": ss}
+
 # The fixture is otherwise admissible, so only the rootfs shape can deny it. A
 # sandbox-tree path can be rootfs-shaped too, which is the case that isolates
 # this rule from the mount-point prefix rule.
 test_sandbox_storage_shaped_like_a_rootfs_denied if {
 	every mount_point in [rootfs, "/run/kata-containers/sandbox/rootfs"] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": mount_point, "source": "shm", "fstype": "tmpfs"}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": mount_point, "source": "shm", "fstype": "tmpfs"}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": mount_point, "source": "tmpfs", "fstype": "tmpfs"}]}
 	}
 }
 
 test_sandbox_storage_elsewhere_allowed if {
-	CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/shm", "source": "shm", "fstype": "tmpfs"}]}
-	CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/x", "source": "", "fstype": "tmpfs"}]}
+	CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/shm", "source": "shm", "fstype": "tmpfs"}])
+	CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/x", "source": "", "fstype": "tmpfs"}])
 	UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/y", "source": "tmpfs", "fstype": "tmpfs"}]}
 }
 
@@ -516,7 +519,7 @@ test_sandbox_storage_elsewhere_allowed if {
 # storage claiming a host-attached filesystem there is host bytes for the pod.
 test_sandbox_storage_with_host_backed_fstype_denied if {
 	every fstype in ["9p", "erofs", "ext4", "hugetlbfs", "iso9660", "overlay", "vfat", "virtiofs"] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/x", "source": "tmpfs", "fstype": fstype}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/x", "source": "tmpfs", "fstype": fstype}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/ephemeral/x", "source": "tmpfs", "fstype": fstype}]}
 	}
 }
@@ -526,7 +529,7 @@ test_sandbox_storage_with_host_backed_fstype_denied if {
 # more absolute than a PCI path. Only container_storage_allowed reaches that rule.
 test_sandbox_encrypted_block_storage_denied if {
 	every source in ["", "shm", "tmpfs"] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "blk", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "ext4", "driver_options": ["encryption_key=ephemeral"]}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "blk", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "ext4", "driver_options": ["encryption_key=ephemeral"]}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "blk", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "ext4", "driver_options": ["encryption_key=ephemeral"]}]}
 	}
 }
@@ -537,7 +540,7 @@ test_sandbox_encrypted_block_storage_denied if {
 # tree is what every container then binds from.
 test_sandbox_layered_storage_denied if {
 	every options in [["X-kata.multi-layer=true"], ["X-kata.overlay-lower=/run/c8s"], ["X-kata.overlay-rw"]] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/hijack", "source": "tmpfs", "fstype": "tmpfs", "options": options}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/shared/containers/hijack", "source": "tmpfs", "fstype": "tmpfs", "options": options}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/ephemeral/hijack", "source": "tmpfs", "fstype": "tmpfs", "options": options}]}
 	}
 }
@@ -546,7 +549,7 @@ test_sandbox_layered_storage_denied if {
 # The seeding tree is the sandbox-time prize — every container binds from it.
 test_sandbox_storage_with_host_backed_driver_denied if {
 	every driver in ["blk", "blk-ccw", "erofs.multi-layer", "mmioblk", "nvdimm", "overlayfs", "scsi", "virtio-fs", "watchable-bind"] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": driver, "mount_point": "/run/kata-containers/shared/containers/x", "source": "tmpfs", "fstype": "tmpfs"}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": driver, "mount_point": "/run/kata-containers/shared/containers/x", "source": "tmpfs", "fstype": "tmpfs"}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": driver, "mount_point": "/run/kata-containers/sandbox/ephemeral/x", "source": "tmpfs", "fstype": "tmpfs"}]}
 	}
 }
@@ -563,7 +566,7 @@ test_sandbox_storage_outside_the_runtime_dirs_denied if {
 		"/run/kata-containers/sandbox/../../c8s",
 		"/run/kata-containers/sandbox/ephemeral/../../../c8s",
 	] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": mount_point, "source": "tmpfs", "fstype": "tmpfs"}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": mount_point, "source": "tmpfs", "fstype": "tmpfs"}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": mount_point, "source": "tmpfs", "fstype": "tmpfs"}]}
 	}
 }
@@ -572,7 +575,7 @@ test_sandbox_storage_outside_the_runtime_dirs_denied if {
 # content the ephemeral handler would mount verbatim.
 test_sandbox_storage_with_path_source_denied if {
 	every source in ["/", "/run", "/run/kata-containers/other/rootfs", "../.."] {
-		not CreateSandboxRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "tmpfs"}]}
+		not CreateSandboxRequest with input as sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "tmpfs"}])
 		not UpdateEphemeralMountsRequest with input as {"storages": [{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/x", "source": source, "fstype": "tmpfs"}]}
 	}
 }
@@ -688,6 +691,47 @@ test_mount_allows_projected_volume_names if {
 		honest_mounts,
 		[bind_from("/run/kata-containers/shared/containers/pod-vol/..data")],
 	))
+}
+
+# --- spec hooks ---------------------------------------------------------
+#
+# Hooks ride inside the OCI spec of an otherwise-admitted request and
+# execute as guest root before the admission verdict. All six lists must be
+# empty; the honest shapes are an absent Hooks, null (what the protobuf
+# serializer emits for an unset message), and empty lists.
+
+# object.union is shallow, so merge at the OCI level to keep the fixture.
+with_hooks(base, hooks) := object.union(base, {"OCI": object.union(base.OCI, {"Hooks": hooks})})
+
+spec_hook := {"Path": "/bin/bash", "Args": ["bash", "-c", "true"], "Env": [], "Timeout": 0}
+
+test_spec_hooks_denied if {
+	every list_name in ["Prestart", "CreateRuntime", "CreateContainer", "StartContainer", "Poststart", "Poststop"] {
+		not CreateContainerRequest with input as with_hooks(workload_input, {list_name: [spec_hook]})
+		not CreateContainerRequest with input as with_hooks(sandbox_input, {list_name: [spec_hook]})
+	}
+}
+
+test_honest_hook_shapes_allowed if {
+	CreateContainerRequest with input as with_hooks(workload_input, null)
+	CreateContainerRequest with input as with_hooks(workload_input, {})
+	CreateContainerRequest with input as with_hooks(workload_input, {
+		"Prestart": [],
+		"CreateRuntime": [],
+		"CreateContainer": [],
+		"StartContainer": [],
+		"Poststart": [],
+		"Poststop": [],
+	})
+}
+
+# A non-empty guest_hook_path is denied even on an otherwise-admitted
+# sandbox: add_hooks would arm every container from that guest directory.
+test_guest_hook_path_denied if {
+	not CreateSandboxRequest with input as object.union(
+		sandbox_req([{"driver": "ephemeral", "mount_point": "/run/kata-containers/sandbox/shm", "source": "shm", "fstype": "tmpfs"}]),
+		{"guest_hook_path": "/run/kata-containers/shared/containers/x"},
+	)
 }
 
 # --- CopyFile -----------------------------------------------------------


### PR DESCRIPTION
OCI hooks were unconstrained by the baked kata-agent policy, so a host could ride hooks inside the OCI spec of an admitted `CreateContainerRequest` and execute as guest root in an attested kata guest (prestart runs in the agent's own mount/PID namespaces).

## Fix
- `default-policy.rego`: `CreateContainerRequest` now conjoins `no_spec_hooks` — all six hook lists (Prestart, CreateRuntime, CreateContainer, StartContainer, Poststart, Poststop) must be empty; honest `null`/`{}`/empty shapes still admit.
- kata patch 0009: belt-and-braces refuse in the agent — a hook reaching that point means the policy was bypassed, so it fails loudly (holds with and without `agent-policy`; carries `test_c8s_refuse_spec_hooks` per the patch-0008 convention).
- `docs/kata-image-policy.md`: stale "allow-all / structurally permissive" claims rewritten to the policy as it is.

## Scope addition (disclosed and ratified in review)
`CreateSandboxRequest` additionally holds `guest_hook_path` empty — same hook-RCE class (add_hooks would arm every container with executables from that guest directory), exact upstream genpolicy parity, nothing in-stack sets it. Easy to drop if you disagree.

## Test evidence
policy-test 62/62; the issue's verbatim exploit evaluates `false` (old policy: `true`); Go lockstep pins the rego guard lines; patch series applies to pinned kata 86e5975 at fuzz 0 and cargo-checks/tests ±agent-policy; two independent review rounds incl. mutation batteries (9/9 killed) and adversarial bypass enumeration. GPU/CDI needs no allowlist: `is_allowed` runs before `handle_cdi_devices`, so agent-injected nvidia-cdi hooks never reach the policy (verified in pinned kata source by two reviewers).

## Notes
- Guest image rebuild changes the launch measurement, as expected for kata-guest-base changes — the self-hosted runner builds it.
- Follow-ups filed from review (not this PR): c8s-workspace #122 (kernel_modules unpinned), #123 (CDI-path spec log), #125 (CDI-annotation pre-verdict hook trigger).
- If squash-merging, use the corrected hook-timing text (only Prestart + CreateContainer fire pre-verdict) — the first commit body carries the pre-correction wording.