### PR TITLE
fix(node-guest-image): pin cloud-init to the baked NoCloud seed

### DIFF
--- a/.github/scripts/cidata-tripwire.sh
+++ b/.github/scripts/cidata-tripwire.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tripwire for the tdx-metal-e2e lane: the CVM boot attaches a bait cloud-init
+# disk, and with the node image's datasource pin the measured baked seed is the
+# only cloud-init input, so the node must register under the baked hostname.
+# The bait name means host user-data executed as root. Reads the guest cluster
+# through /tmp/guest.kubeconfig.
+
+set -euo pipefail
+NODE=""
+for _ in $(seq 1 30); do
+  NODE=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  if [ -n "$NODE" ]; then break; fi
+  sleep 10
+done
+echo "registered node name: $NODE"
+case "$NODE" in
+  c8s-node) ;;
+  cidata-bait)
+    echo "::error title=SECURITY REGRESSION::host-supplied cidata user-data reached cloud-init in the attested node CVM"
+    exit 1 ;;
+  *) echo "::error::node name '$NODE' is neither the baked c8s-node nor the cidata bait — first-boot initialisation changed; update this tripwire"; exit 1 ;;
+esac

--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# node-guest-image invariants gate, run by the node-guest-image-lint workflow.
+# Runs from the repo root against the pinned confos checkout at ./confos.
+#
+# Inputs (env):
+#   CONFOS_REF   pinned confos ref the workflow resolved; names the pass line.
+
+set -euo pipefail
+
+: "${CONFOS_REF:?CONFOS_REF must be set}"
+ngi=node-guest-image
+
+# kernel/c8s.config must be a superset of confos kernel/gpu.config:
+# only one --kernel-config-fragment is accepted per build, so the
+# c8s fragment duplicates the gpu lines verbatim. Catch drift when
+# gpu.config changes under the pinned CONFOS_REF.
+missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' confos/kernel/gpu.config \
+          | grep -vFxf "$ngi/kernel/c8s.config" || true)
+if [ -n "$missing" ]; then
+  echo "::error::$ngi/kernel/c8s.config must contain every effective line of confos kernel/gpu.config; missing:"
+  echo "$missing"
+  exit 1
+fi
+
+# c8s-dev.config (C8S_DEV=1 demo builds) is the union of c8s.config
+# and confos dev.config, committed verbatim for the same one-fragment
+# reason.
+for src in "$ngi/kernel/c8s.config" confos/kernel/dev.config; do
+  missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' "$src" \
+            | grep -vFxf "$ngi/kernel/c8s-dev.config" || true)
+  if [ -n "$missing" ]; then
+    echo "::error::$ngi/kernel/c8s-dev.config must contain every effective line of $src; missing:"
+    echo "$missing"
+    exit 1
+  fi
+done
+
+# The baked NRI floor is a template whose always_allow entries are
+# @-tokens the sync fills with ref-resolved digests; a hardcoded
+# sha256 would bake a stale digest the fail-closed floor can't
+# reconcile with the ref. The marked block is exempt: systemfloor
+# generates it from the pinned RKE2 airgap bundles (see mkosi.sync).
+policy="$ngi/c8s/image-policy.yaml.in"
+[ -f "$policy" ] || { echo "::error::NRI floor template $policy not found"; exit 1; }
+if sed '/# BEGIN rke2 system floor/,/# END rke2 system floor/d' "$policy"               | grep -qE '^[[:space:]]*"sha256:[a-f0-9]{64}"[[:space:]]*:'; then
+  echo "::error::$policy has a hardcoded always_allow digest outside the generated system floor; use @NRI_DIGEST@/@CDS_DIGEST@ tokens (rendered from C8S_REF by mkosi.sync)"
+  exit 1
+fi
+
+# The c8s node is normally nested in an outer RKE2 cluster: its pod
+# CIDR must not fall back to the outer cluster's default, and
+# Cilium's pool must exactly match the RKE2 server setting or pods
+# receive unroutable IPs.
+rke2_config="$ngi/c8s/mkosi.extra/etc/rancher/rke2/config.yaml"
+cilium_config="$ngi/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml"
+rke2_pod_cidr=$(sed -n 's/^cluster-cidr:[[:space:]]*//p' "$rke2_config")
+cilium_pod_cidr=$(sed -n '/clusterPoolIPv4PodCIDRList:/,/^[^[:space:]]/s/^[[:space:]]*-[[:space:]]*//p' "$cilium_config" | head -n 1)
+if [ -z "$rke2_pod_cidr" ] || [ "$rke2_pod_cidr" = "10.42.0.0/16" ]; then
+  echo "::error::c8s RKE2 cluster-cidr must be explicit and must not overlap the outer RKE2 default"
+  exit 1
+fi
+if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
+  echo "::error::c8s RKE2 cluster-cidr ($rke2_pod_cidr) must match Cilium IPAM ($cilium_pod_cidr)"
+  exit 1
+fi
+
+# The rke2-role drop-ins only bind if mkosi.sync keeps staging the
+# rke2 tarball's units under /usr/local (systemd's search path);
+# the systemd harness installs its fakes at the same prefix.
+if ! grep -q 'tar -xzf .* -C "\$STAGE_DIR/usr/local"' "$ngi/c8s/mkosi.sync"; then
+  echo "::error::mkosi.sync no longer stages rke2 under /usr/local; rke2-role drop-ins and the systemd harness depend on that unit dir"
+  exit 1
+fi
+
+# cloud-init datasource pin (node-as-CVM): the guest's cloud-init
+# takes input from the measured baked seed only. A host-supplied
+# cidata disk or cmdline/DMI seed redirect is otherwise root code
+# execution inside the attested node.
+dscfg="$ngi/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg"
+if [ ! -f "$dscfg" ]; then
+  echo "::error::$dscfg missing: the node image must pin cloud-init to the baked NoCloud seed"
+  exit 1
+fi
+if ! grep -qE '^datasource_list: \[ ?NoCloud ?\]$' "$dscfg"; then
+  echo "::error::$dscfg must restrict datasource_list to exactly [ NoCloud ]"
+  exit 1
+fi
+if ! grep -qE '^    seedfrom: file:///var/lib/cloud/seed/nocloud/$' "$dscfg"; then
+  echo "::error::$dscfg must pin NoCloud seedfrom to the baked seed dir (overrides cmdline/DMI redirects)"
+  exit 1
+fi
+if ! grep -qE '^    fs_label: null$' "$dscfg"; then
+  echo "::error::$dscfg must set fs_label: null so cloud-init never scans attached disks for a cidata seed"
+  exit 1
+fi
+# The pin must be the only datasource config in the composed image:
+# cloud.cfg.d merges lexically, so a later-sorting file from any
+# confos tree would silently win.
+if grep -rn --include='*.cfg' -E '^datasource' confos/mkosi "$ngi/c8s/mkosi.extra" | grep -v "$dscfg"; then
+  echo "::error::datasource keys found outside $dscfg; the c8s pin must be the only datasource config in the composed image"
+  exit 1
+fi
+# mkosi.sync generates image content at build time; a datasource
+# drop-in written there would evade the static grep above.
+# Comment lines cannot write content; skip them.
+if grep -vE '^[ 	]*#' "$ngi/c8s/mkosi.sync" | grep -n 'datasource'; then
+  echo "::error::$ngi/c8s/mkosi.sync writes datasource config; build-time drop-ins must not bypass the pin check"
+  exit 1
+fi
+# The pin is only meaningful while the build bakes the seed dir it
+# points at.
+if ! grep -q -- '--cloud-init "\$NGI_DIR/c8s/user-data"' "$ngi/build"; then
+  echo "::error::$ngi/build no longer bakes the seed the datasource pin points at"
+  exit 1
+fi
+# tdx-metal-e2e.yml is vendored from confidential-ci; the bait +
+# tripwire are a c8s-local patch until the source takes the same
+# edit — a re-vendor would silently delete them.
+for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert'; do
+  if ! grep -qF "$marker" .github/workflows/tdx-metal-e2e.yml; then
+    echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped the cidata bait/tripwire — re-apply the c8s-local patch"
+    exit 1
+  fi
+done
+
+echo "all node-guest-image invariants hold at CONFOS_REF $CONFOS_REF"

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -54,10 +54,10 @@ jobs:
   # so a public repo cannot `uses:` the private reusable workflows and must keep
   # local copies. cvm-e2e.yml here is byte-identical to its original; edit
   # the original, then copy across. tdx-metal-e2e.yml is byte-identical
-  # except for a c8s-local cidata bait/tripwire patch (c8s-workspace#117)
-  # carried until the source takes the same edit; node-guest-image-lint.yml
-  # guards those markers. snp-metal-e2e.yml is c8s-owned (the c8s payload
-  # lives in this copy); edit it here.
+  # except for a c8s-local cidata bait/tripwire patch carried until the
+  # source takes the same edit; node-guest-image-lint.yml guards those
+  # markers. snp-metal-e2e.yml is c8s-owned (the c8s payload lives in this
+  # copy); edit it here.
   #
   # NOT a `matrix:`. A reusable-workflow `uses:` takes no expressions, so a
   # matrix would need an if-gated dispatcher, and because every row instantiates

--- a/.github/workflows/e2e-c8s.yml
+++ b/.github/workflows/e2e-c8s.yml
@@ -52,9 +52,12 @@ jobs:
   # ── ONE JOB PER PLATFORM ─────────────────────────────────────────────────
   # Vendored from confidential-ci. c8s is PUBLIC and confidential-ci is PRIVATE,
   # so a public repo cannot `uses:` the private reusable workflows and must keep
-  # local copies. cvm-e2e.yml and tdx-metal-e2e.yml here are byte-identical to
-  # their originals; edit the original, then copy across. snp-metal-e2e.yml is
-  # c8s-owned (the c8s payload lives in this copy); edit it here.
+  # local copies. cvm-e2e.yml here is byte-identical to its original; edit
+  # the original, then copy across. tdx-metal-e2e.yml is byte-identical
+  # except for a c8s-local cidata bait/tripwire patch (c8s-workspace#117)
+  # carried until the source takes the same edit; node-guest-image-lint.yml
+  # guards those markers. snp-metal-e2e.yml is c8s-owned (the c8s payload
+  # lives in this copy); edit it here.
   #
   # NOT a `matrix:`. A reusable-workflow `uses:` takes no expressions, so a
   # matrix would need an if-gated dispatcher, and because every row instantiates

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -20,6 +20,8 @@ on:
       # The lint guards this vendored file's c8s-local bait/tripwire markers;
       # a re-vendor PR touches nothing else and must fail here.
       - ".github/workflows/tdx-metal-e2e.yml"
+      # The invariants gate body; a script-only change must run the gate.
+      - ".github/scripts/node-guest-image-invariants.sh"
   workflow_dispatch:
 
 permissions:
@@ -49,124 +51,9 @@ jobs:
           path: confos
 
       - name: node-guest-image invariants
-        run: |
-          set -euo pipefail
-          ngi=node-guest-image
-
-          # kernel/c8s.config must be a superset of confos kernel/gpu.config:
-          # only one --kernel-config-fragment is accepted per build, so the
-          # c8s fragment duplicates the gpu lines verbatim. Catch drift when
-          # gpu.config changes under the pinned CONFOS_REF.
-          missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' confos/kernel/gpu.config \
-                    | grep -vFxf "$ngi/kernel/c8s.config" || true)
-          if [ -n "$missing" ]; then
-            echo "::error::$ngi/kernel/c8s.config must contain every effective line of confos kernel/gpu.config; missing:"
-            echo "$missing"
-            exit 1
-          fi
-
-          # c8s-dev.config (C8S_DEV=1 demo builds) is the union of c8s.config
-          # and confos dev.config, committed verbatim for the same one-fragment
-          # reason.
-          for src in "$ngi/kernel/c8s.config" confos/kernel/dev.config; do
-            missing=$(grep -E '^CONFIG_|^# CONFIG_.* is not set$' "$src" \
-                      | grep -vFxf "$ngi/kernel/c8s-dev.config" || true)
-            if [ -n "$missing" ]; then
-              echo "::error::$ngi/kernel/c8s-dev.config must contain every effective line of $src; missing:"
-              echo "$missing"
-              exit 1
-            fi
-          done
-
-          # The baked NRI floor is a template whose always_allow entries are
-          # @-tokens the sync fills with ref-resolved digests; a hardcoded
-          # sha256 would bake a stale digest the fail-closed floor can't
-          # reconcile with the ref. The marked block is exempt: systemfloor
-          # generates it from the pinned RKE2 airgap bundles (see mkosi.sync).
-          policy="$ngi/c8s/image-policy.yaml.in"
-          [ -f "$policy" ] || { echo "::error::NRI floor template $policy not found"; exit 1; }
-          if sed '/# BEGIN rke2 system floor/,/# END rke2 system floor/d' "$policy"               | grep -qE '^[[:space:]]*"sha256:[a-f0-9]{64}"[[:space:]]*:'; then
-            echo "::error::$policy has a hardcoded always_allow digest outside the generated system floor; use @NRI_DIGEST@/@CDS_DIGEST@ tokens (rendered from C8S_REF by mkosi.sync)"
-            exit 1
-          fi
-
-          # The c8s node is normally nested in an outer RKE2 cluster: its pod
-          # CIDR must not fall back to the outer cluster's default, and
-          # Cilium's pool must exactly match the RKE2 server setting or pods
-          # receive unroutable IPs.
-          rke2_config="$ngi/c8s/mkosi.extra/etc/rancher/rke2/config.yaml"
-          cilium_config="$ngi/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/rke2-cilium-config.yaml"
-          rke2_pod_cidr=$(sed -n 's/^cluster-cidr:[[:space:]]*//p' "$rke2_config")
-          cilium_pod_cidr=$(sed -n '/clusterPoolIPv4PodCIDRList:/,/^[^[:space:]]/s/^[[:space:]]*-[[:space:]]*//p' "$cilium_config" | head -n 1)
-          if [ -z "$rke2_pod_cidr" ] || [ "$rke2_pod_cidr" = "10.42.0.0/16" ]; then
-            echo "::error::c8s RKE2 cluster-cidr must be explicit and must not overlap the outer RKE2 default"
-            exit 1
-          fi
-          if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
-            echo "::error::c8s RKE2 cluster-cidr ($rke2_pod_cidr) must match Cilium IPAM ($cilium_pod_cidr)"
-            exit 1
-          fi
-
-          # The rke2-role drop-ins only bind if mkosi.sync keeps staging the
-          # rke2 tarball's units under /usr/local (systemd's search path);
-          # the systemd harness installs its fakes at the same prefix.
-          if ! grep -q 'tar -xzf .* -C "\$STAGE_DIR/usr/local"' "$ngi/c8s/mkosi.sync"; then
-            echo "::error::mkosi.sync no longer stages rke2 under /usr/local; rke2-role drop-ins and the systemd harness depend on that unit dir"
-            exit 1
-          fi
-
-          # cloud-init datasource pin (node-as-CVM): the guest's cloud-init
-          # takes input from the measured baked seed only. A host-supplied
-          # cidata disk or cmdline/DMI seed redirect is otherwise root code
-          # execution inside the attested node.
-          dscfg="$ngi/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg"
-          if [ ! -f "$dscfg" ]; then
-            echo "::error::$dscfg missing: the node image must pin cloud-init to the baked NoCloud seed"
-            exit 1
-          fi
-          if ! grep -qE '^datasource_list: \[ ?NoCloud ?\]$' "$dscfg"; then
-            echo "::error::$dscfg must restrict datasource_list to exactly [ NoCloud ]"
-            exit 1
-          fi
-          if ! grep -qE '^    seedfrom: file:///var/lib/cloud/seed/nocloud/$' "$dscfg"; then
-            echo "::error::$dscfg must pin NoCloud seedfrom to the baked seed dir (overrides cmdline/DMI redirects)"
-            exit 1
-          fi
-          if ! grep -qE '^    fs_label: null$' "$dscfg"; then
-            echo "::error::$dscfg must set fs_label: null so cloud-init never scans attached disks for a cidata seed"
-            exit 1
-          fi
-          # The pin must be the only datasource config in the composed image:
-          # cloud.cfg.d merges lexically, so a later-sorting file from any
-          # confos tree would silently win.
-          if grep -rn --include='*.cfg' -E '^datasource' confos/mkosi "$ngi/c8s/mkosi.extra" | grep -v "$dscfg"; then
-            echo "::error::datasource keys found outside $dscfg; the c8s pin must be the only datasource config in the composed image"
-            exit 1
-          fi
-          # mkosi.sync generates image content at build time; a datasource
-          # drop-in written there would evade the static grep above.
-          # Comment lines cannot write content; skip them.
-          if grep -vE '^[ 	]*#' "$ngi/c8s/mkosi.sync" | grep -n 'datasource'; then
-            echo "::error::$ngi/c8s/mkosi.sync writes datasource config; build-time drop-ins must not bypass the pin check"
-            exit 1
-          fi
-          # The pin is only meaningful while the build bakes the seed dir it
-          # points at.
-          if ! grep -q -- '--cloud-init "\$NGI_DIR/c8s/user-data"' "$ngi/build"; then
-            echo "::error::$ngi/build no longer bakes the seed the datasource pin points at"
-            exit 1
-          fi
-          # tdx-metal-e2e.yml is vendored from confidential-ci; the bait +
-          # tripwire are a c8s-local patch until the source takes the same
-          # edit — a re-vendor would silently delete them.
-          for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert'; do
-            if ! grep -qF "$marker" .github/workflows/tdx-metal-e2e.yml; then
-              echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped the cidata bait/tripwire — re-apply the c8s-local patch (c8s-workspace#117)"
-              exit 1
-            fi
-          done
-
-          echo "all node-guest-image invariants hold at CONFOS_REF ${{ steps.ref.outputs.ref }}"
+        env:
+          CONFOS_REF: ${{ steps.ref.outputs.ref }}
+        run: .github/scripts/node-guest-image-invariants.sh
 
   system-floor:
     name: system floor lockstep

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -17,6 +17,9 @@ on:
       # The rke2-role job runs via make; a broken/renamed target must fail
       # here, not on the next node-guest-image change.
       - "Makefile"
+      # The lint guards this vendored file's c8s-local bait/tripwire markers;
+      # a re-vendor PR touches nothing else and must fail here.
+      - ".github/workflows/tdx-metal-e2e.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -1,12 +1,13 @@
-# PERMANENT lint for node-guest-image/ — the four invariants that moved here
-# with the c8s profile from confos bin/lint (c8s#264). Unlike the TEMP
-# node-guest-image-sync workflow (byte-diff, deleted at the flip), these
-# outlive the migration: they lint content this repo owns. The fragment
-# superset checks compare against confos's gpu/dev fragments at the pinned
-# CONFOS_REF — the exact tree the image builds with.
+# PERMANENT lint for node-guest-image/ — the invariants that moved here with
+# the c8s profile from confos bin/lint (c8s#264), plus the cloud-init
+# datasource pin. Unlike the TEMP node-guest-image-sync workflow (byte-diff,
+# deleted at the flip), these outlive the migration: they lint content this
+# repo owns. The fragment superset checks compare against confos's gpu/dev
+# fragments at the pinned CONFOS_REF — the exact tree the image builds with.
 #
-# The rke2-role jobs run the role-dispatch tests (script and systemd
-# level, node-guest-image/tests/).
+# The rke2-role jobs run the role-dispatch tests (script and systemd level)
+# and cloud-init-datasource the datasource-resolution harness — both in
+# node-guest-image/tests/.
 name: node-guest-image lint
 
 on:
@@ -112,6 +113,41 @@ jobs:
             exit 1
           fi
 
+          # cloud-init datasource pin (node-as-CVM): the guest's cloud-init
+          # takes input from the measured baked seed only. A host-supplied
+          # cidata disk or cmdline/DMI seed redirect is otherwise root code
+          # execution inside the attested node.
+          dscfg="$ngi/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg"
+          if [ ! -f "$dscfg" ]; then
+            echo "::error::$dscfg missing: the node image must pin cloud-init to the baked NoCloud seed"
+            exit 1
+          fi
+          if ! grep -qE '^datasource_list: \[ ?NoCloud ?\]$' "$dscfg"; then
+            echo "::error::$dscfg must restrict datasource_list to exactly [ NoCloud ]"
+            exit 1
+          fi
+          if ! grep -qE '^    seedfrom: file:///var/lib/cloud/seed/nocloud/$' "$dscfg"; then
+            echo "::error::$dscfg must pin NoCloud seedfrom to the baked seed dir (overrides cmdline/DMI redirects)"
+            exit 1
+          fi
+          if ! grep -qE '^    fs_label: null$' "$dscfg"; then
+            echo "::error::$dscfg must set fs_label: null so cloud-init never scans attached disks for a cidata seed"
+            exit 1
+          fi
+          # The pin must be the only datasource config in the composed image:
+          # cloud.cfg.d merges lexically, so a later-sorting file from any
+          # confos tree would silently win.
+          if grep -rn --include='*.cfg' -E '^datasource' confos/mkosi "$ngi/c8s/mkosi.extra" | grep -v "$dscfg"; then
+            echo "::error::datasource keys found outside $dscfg; the c8s pin must be the only datasource config in the composed image"
+            exit 1
+          fi
+          # The pin is only meaningful while the build bakes the seed dir it
+          # points at.
+          if ! grep -q -- '--cloud-init "\$NGI_DIR/c8s/user-data"' "$ngi/build"; then
+            echo "::error::$ngi/build no longer bakes the seed the datasource pin points at"
+            exit 1
+          fi
+
           echo "all node-guest-image invariants hold at CONFOS_REF ${{ steps.ref.outputs.ref }}"
 
   system-floor:
@@ -188,3 +224,19 @@ jobs:
 
       - name: Run the systemd-level harness
         run: make test-node-guest-image-role-systemd
+
+  cloud-init-datasource:
+    name: cloud-init datasource pin (semantic)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install cloud-init (the datasource implementation under test)
+        run: |
+          python3 -c "import cloudinit" 2>/dev/null && exit 0
+          sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends cloud-init
+
+      - name: Run the datasource-resolution harness
+        # System python3: the harness drives the distro cloud-init module,
+        # the same code the guest boots with.
+        run: make test-node-guest-image-cloud-init

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -1,9 +1,8 @@
 # PERMANENT lint for node-guest-image/ — the invariants that moved here with
 # the c8s profile from confos bin/lint (c8s#264), plus the cloud-init
-# datasource pin. Unlike the TEMP node-guest-image-sync workflow (byte-diff,
-# deleted at the flip), these outlive the migration: they lint content this
-# repo owns. The fragment superset checks compare against confos's gpu/dev
-# fragments at the pinned CONFOS_REF — the exact tree the image builds with.
+# datasource pin. These lint content this repo owns. The fragment superset
+# checks compare against confos's gpu/dev fragments at the pinned
+# CONFOS_REF — the exact tree the image builds with.
 #
 # The rke2-role jobs run the role-dispatch tests (script and systemd level)
 # and cloud-init-datasource the datasource-resolution harness — both in
@@ -46,7 +45,7 @@ jobs:
           ref: ${{ steps.ref.outputs.ref }}
           path: confos
 
-      - name: Fragment supersets, NRI floor template, nested pod CIDRs
+      - name: node-guest-image invariants
         run: |
           set -euo pipefail
           ngi=node-guest-image
@@ -141,12 +140,27 @@ jobs:
             echo "::error::datasource keys found outside $dscfg; the c8s pin must be the only datasource config in the composed image"
             exit 1
           fi
+          # mkosi.sync generates image content at build time; a datasource
+          # drop-in written there would evade the static grep above.
+          if grep -n 'datasource' "$ngi/c8s/mkosi.sync"; then
+            echo "::error::$ngi/c8s/mkosi.sync writes datasource config; build-time drop-ins must not bypass the pin check"
+            exit 1
+          fi
           # The pin is only meaningful while the build bakes the seed dir it
           # points at.
           if ! grep -q -- '--cloud-init "\$NGI_DIR/c8s/user-data"' "$ngi/build"; then
             echo "::error::$ngi/build no longer bakes the seed the datasource pin points at"
             exit 1
           fi
+          # tdx-metal-e2e.yml is vendored from confidential-ci; the bait +
+          # tripwire are a c8s-local patch until the source takes the same
+          # edit — a re-vendor would silently delete them.
+          for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert'; do
+            if ! grep -qF "$marker" .github/workflows/tdx-metal-e2e.yml; then
+              echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped the cidata bait/tripwire — re-apply the c8s-local patch (c8s-workspace#117)"
+              exit 1
+            fi
+          done
 
           echo "all node-guest-image invariants hold at CONFOS_REF ${{ steps.ref.outputs.ref }}"
 
@@ -237,6 +251,5 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends cloud-init
 
       - name: Run the datasource-resolution harness
-        # System python3: the harness drives the distro cloud-init module,
-        # the same code the guest boots with.
+        # System python3: the harness drives the distro cloud-init the guest boots with.
         run: make test-node-guest-image-cloud-init

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -1,6 +1,6 @@
 # PERMANENT lint for node-guest-image/ — the invariants that moved here with
 # the c8s profile from confos bin/lint (c8s#264), plus the cloud-init
-# datasource pin. These lint content this repo owns. The fragment superset
+# datasource pin. These jobs lint content this repo owns. The fragment superset
 # checks compare against confos's gpu/dev fragments at the pinned
 # CONFOS_REF — the exact tree the image builds with.
 #
@@ -145,7 +145,8 @@ jobs:
           fi
           # mkosi.sync generates image content at build time; a datasource
           # drop-in written there would evade the static grep above.
-          if grep -n 'datasource' "$ngi/c8s/mkosi.sync"; then
+          # Comment lines cannot write content; skip them.
+          if grep -vE '^[ 	]*#' "$ngi/c8s/mkosi.sync" | grep -n 'datasource'; then
             echo "::error::$ngi/c8s/mkosi.sync writes datasource config; build-time drop-ins must not bypass the pin check"
             exit 1
           fi
@@ -254,5 +255,5 @@ jobs:
           sudo apt-get update -qq && sudo apt-get install -y -qq --no-install-recommends cloud-init
 
       - name: Run the datasource-resolution harness
-        # System python3: the harness drives the distro cloud-init the guest boots with.
+        # System python3: the harness drives the distro-packaged cloud-init, as the guest does.
         run: make test-node-guest-image-cloud-init

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -262,9 +262,9 @@ jobs:
           metadata: {name: $VM-cloudinit, namespace: $NS}
           type: Opaque
           # Bait, not configuration: the node image pins cloud-init to its
-          # measured baked seed, so this host-supplied cidata disk must have
-          # no effect. The tripwire step after the kubeconfig fetch asserts
-          # the node registers under the baked hostname, not this one.
+          # measured baked seed, so this host disk must be inert (asserted
+          # by the tripwire step below). c8s-local patch — mirror to
+          # confidential-ci before re-vendoring (c8s-workspace#117).
           stringData:
             userdata: |
               #cloud-config
@@ -413,7 +413,12 @@ jobs:
         # hostname — the bait name means host user-data executed as root.
         run: |
           set -euo pipefail
-          NODE=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+          NODE=""
+          for _ in $(seq 1 30); do
+            NODE=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$NODE" ]; then break; fi
+            sleep 10
+          done
           echo "registered node name: $NODE"
           case "$NODE" in
             c8s-node) ;;

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -261,10 +261,14 @@ jobs:
           kind: Secret
           metadata: {name: $VM-cloudinit, namespace: $NS}
           type: Opaque
+          # Bait, not configuration: the node image pins cloud-init to its
+          # measured baked seed, so this host-supplied cidata disk must have
+          # no effect. The tripwire step after the kubeconfig fetch asserts
+          # the node registers under the baked hostname, not this one.
           stringData:
             userdata: |
               #cloud-config
-              hostname: ${VM}
+              hostname: cidata-bait
           ---
           apiVersion: kubevirt.io/v1
           kind: VirtualMachine
@@ -401,6 +405,23 @@ jobs:
           [ "$WHO" = operator ] || { echo "::error::unexpected identity '$WHO'"; exit 1; }
           echo "OK: attested kubeconfig, identity=$WHO"
           KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes
+
+      - name: assert the host cidata disk is inert
+        # The boot attaches a bait cloud-init disk ($VM-cloudinit). With the
+        # node image's datasource pin, the measured baked seed is the only
+        # cloud-init input, so the node must register under the baked
+        # hostname — the bait name means host user-data executed as root.
+        run: |
+          set -euo pipefail
+          NODE=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+          echo "registered node name: $NODE"
+          case "$NODE" in
+            c8s-node) ;;
+            cidata-bait)
+              echo "::error title=SECURITY REGRESSION::host-supplied cidata user-data reached cloud-init in the attested node CVM"
+              exit 1 ;;
+            *) echo "::error::node name '$NODE' is neither the baked c8s-node nor the cidata bait — first-boot initialisation changed; update this tripwire"; exit 1 ;;
+          esac
 
       - name: install the c8s bundle under test
         run: |

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -264,7 +264,7 @@ jobs:
           # Bait, not configuration: the node image pins cloud-init to its
           # measured baked seed, so this host disk must be inert (asserted
           # by the tripwire step below). c8s-local patch — mirror to
-          # confidential-ci before re-vendoring (c8s-workspace#117).
+          # confidential-ci before re-vendoring.
           stringData:
             userdata: |
               #cloud-config
@@ -407,26 +407,7 @@ jobs:
           KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes
 
       - name: assert the host cidata disk is inert
-        # The boot attaches a bait cloud-init disk ($VM-cloudinit). With the
-        # node image's datasource pin, the measured baked seed is the only
-        # cloud-init input, so the node must register under the baked
-        # hostname — the bait name means host user-data executed as root.
-        run: |
-          set -euo pipefail
-          NODE=""
-          for _ in $(seq 1 30); do
-            NODE=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-            if [ -n "$NODE" ]; then break; fi
-            sleep 10
-          done
-          echo "registered node name: $NODE"
-          case "$NODE" in
-            c8s-node) ;;
-            cidata-bait)
-              echo "::error title=SECURITY REGRESSION::host-supplied cidata user-data reached cloud-init in the attested node CVM"
-              exit 1 ;;
-            *) echo "::error::node name '$NODE' is neither the baked c8s-node nor the cidata bait — first-boot initialisation changed; update this tripwire"; exit 1 ;;
-          esac
+        run: .github/scripts/cidata-tripwire.sh
 
       - name: install the c8s bundle under test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-node-guest-image-role test-node-guest-image-role-systemd test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-node-guest-image-role test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -139,6 +139,12 @@ test-node-guest-image-role:
 # Needs only docker.
 test-node-guest-image-role-systemd:
 	./node-guest-image/tests/rke2-role-systemd-test.sh
+
+# The cloud-init datasource pin against the distro's real DataSourceNoCloud:
+# a host cidata disk or cmdline seed redirect must lose to the baked seed.
+# Needs the distro cloud-init package; no root.
+test-node-guest-image-cloud-init:
+	python3 ./node-guest-image/tests/cloud-init-datasource-test.py
 
 # Advisory mutation testing of code changed vs BASE (default origin/main).
 mutation-check:

--- a/Makefile
+++ b/Makefile
@@ -140,9 +140,8 @@ test-node-guest-image-role:
 test-node-guest-image-role-systemd:
 	./node-guest-image/tests/rke2-role-systemd-test.sh
 
-# The cloud-init datasource pin against the distro's real DataSourceNoCloud:
-# a host cidata disk or cmdline seed redirect must lose to the baked seed.
-# Needs the distro cloud-init package; no root.
+# The datasource pin against the distro's real DataSourceNoCloud: host
+# input must lose to the baked seed. Needs the distro cloud-init package; no root.
 test-node-guest-image-cloud-init:
 	python3 ./node-guest-image/tests/cloud-init-datasource-test.py
 

--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -508,7 +508,7 @@ func sandboxTokenSigner(cfg *config, logger *slog.Logger) (*workloadclaims.Sandb
 func digestsAdvertiseHost(cfg *config) (string, error) {
 	// Config first, then the file the chart's installer writes, then the
 	// environment — the node image bakes the plugin without an installer, so
-	// cloud-init supplies it there. None of these needs to be trustworthy: a
+	// nri-node-ip.service writes it there. None of these needs to be trustworthy: a
 	// wrong host makes CDS fetch a key the token signature fails under, so it
 	// can only fail closed, never redirect.
 	host := cfg.WorkloadClaims.AdvertiseHost

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -50,8 +50,7 @@ Migration state (see [#264] for the full plan):
    invariants that moved here from confos `bin/lint` (fragment supersets
    vs confos's gpu/dev fragments at the pinned `CONFOS_REF`, the NRI
    floor template's no-hardcoded-digest rule, and the nested RKE2/Cilium
-   pod-CIDR match), plus the cloud-init datasource pin
-   (c8s-workspace#117).
+   pod-CIDR match), plus the cloud-init datasource pin.
 2. The switch was gated on building the same c8s ref both ways (confos
    in-tree vs staged from here) with identical `manifest.json`
    measurements; `c8s-image.yml`'s `gate=true` dispatch input reruns that

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -46,11 +46,12 @@ Migration state (see [#264] for the full plan):
    `node-guest-image/build`, which stages `c8s/` into a confos checkout
    with `--profile-dir` and passes the kernel fragment and
    `c8s-ref`/`c8s-registry` sync inputs explicitly. The
-   `node-guest-image lint` workflow is permanent: it carries the four
+   `node-guest-image lint` workflow is permanent: it carries the
    invariants that moved here from confos `bin/lint` (fragment supersets
    vs confos's gpu/dev fragments at the pinned `CONFOS_REF`, the NRI
    floor template's no-hardcoded-digest rule, and the nested RKE2/Cilium
-   pod-CIDR match).
+   pod-CIDR match), plus the cloud-init datasource pin
+   (c8s-workspace#117).
 2. The switch was gated on building the same c8s ref both ways (confos
    in-tree vs staged from here) with identical `manifest.json`
    measurements; `c8s-image.yml`'s `gate=true` dispatch input reruns that

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -8,7 +8,7 @@
 # composing the attest (or attest-gpu) profile, whose service the baked NRI
 # plugin config points at (127.0.0.1:8400).
 #
-# The full GPU node composition is `bin/build-c8s` (the canonical
+# The full GPU node composition is `node-guest-image/build` (the canonical
 # entrypoint: kernel build + GPU staging + `confos build` with the
 # gpu/attest-gpu/c8s profiles and the c8s kernel fragment). The profile also
 # builds standalone (no gpu profiles) for GPU-less validation:

--- a/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
+++ b/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
@@ -2,7 +2,8 @@
 # (the host is adversarial): no other datasources, no cidata device scan
 # (fs_label: null), no cmdline/DMI seed redirect (pinned seedfrom).
 # cloud-init's cc: cmdline config overrides this file by design; cmdline
-# integrity comes from the UKI->RTMR[2] pin at attestation, not from here.
+# integrity comes from the measured-cmdline pin at attestation
+# (UKI->RTMR[2] on TDX), not from here.
 datasource_list: [ NoCloud ]
 datasource:
   NoCloud:

--- a/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
+++ b/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
@@ -1,6 +1,8 @@
 # cloud-init's only input is the seed baked into the measured verity root
 # (the host is adversarial): no other datasources, no cidata device scan
 # (fs_label: null), no cmdline/DMI seed redirect (pinned seedfrom).
+# cloud-init's cc: cmdline config overrides this file by design; cmdline
+# integrity comes from the UKI->RTMR[2] pin at attestation, not from here.
 datasource_list: [ NoCloud ]
 datasource:
   NoCloud:

--- a/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
+++ b/node-guest-image/c8s/mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg
@@ -1,0 +1,8 @@
+# cloud-init's only input is the seed baked into the measured verity root
+# (the host is adversarial): no other datasources, no cidata device scan
+# (fs_label: null), no cmdline/DMI seed redirect (pinned seedfrom).
+datasource_list: [ NoCloud ]
+datasource:
+  NoCloud:
+    seedfrom: file:///var/lib/cloud/seed/nocloud/
+    fs_label: null

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -53,12 +53,12 @@ RKE2_IMAGES_CILIUM_SHA256="1ab41422cc16f5d030b8f62889133dff5d9dce985fbf13360c160
 # floor — resolve from a single c8s ref, so they never drift from each other or
 # from the images the chart later deploys. C8S_REF pins a specific commit (short
 # SHA) for testing an unmerged build; it arrives via
-# `confos build --sync-input c8s-ref=...` (passed by bin/build-c8s — an
+# `confos build --sync-input c8s-ref=...` (passed by node-guest-image/build — an
 # exported var never reaches this sandbox: mkosi runs under sudo, stripping
 # the env). Empty = the pinned default below. The tag must be published (c8s
 # docker.yml on main, or workflow_dispatch for a feature branch).
 # The registry the two component images resolve from. Overridable via
-# `--sync-input c8s-registry=...` (passed by bin/build-c8s from C8S_REGISTRY)
+# `--sync-input c8s-registry=...` (passed by node-guest-image/build from C8S_REGISTRY)
 # so an unmerged or air-gapped build can bake components from a local registry
 # without publishing them. Defaults to the published org.
 SYNC_INPUTS="$SRCDIR/mkosi.local/.confos-sync-inputs"

--- a/node-guest-image/c8s/user-data
+++ b/node-guest-image/c8s/user-data
@@ -9,9 +9,10 @@
 # pin (mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg) keeps
 # host-presented cidata disks and ds= cmdline/DMI redirects away from this
 # root interpreter; cloud-init's cc: cmdline config overrides cfg.d by
-# design and is closed only by the UKI->RTMR[2] attestation pin. Anything
-# per-host (secrets, IPs, join material) rides a data disk (e.g. the
-# joindata disk rke2-role.sh reads), not cloud-init.
+# design and is closed only by the measured-cmdline attestation pin
+# (UKI->RTMR[2] on TDX). Anything per-host (secrets, IPs, join material)
+# rides a data disk (e.g. the joindata disk rke2-role.sh reads), not
+# cloud-init.
 #
 # The bulk of node setup is baked rather than scripted at first boot — see
 # this profile's mkosi.extra/ tree. The role-gated rke2 units are started

--- a/node-guest-image/c8s/user-data
+++ b/node-guest-image/c8s/user-data
@@ -4,11 +4,14 @@
 #
 # This payload is BAKED INTO the verity root at build time (via
 # node-guest-image/build passing --cloud-init) and therefore measured into
-# the launch digest. It is cloud-init's only input — the datasource pin at
-# mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg keeps every
-# host-presented source (cidata disk, cmdline/DMI redirect) away from this
-# root interpreter. Anything per-host (secrets, IPs, join material) rides
-# a data disk (e.g. the joindata disk rke2-role.sh reads), not cloud-init.
+# the launch digest. The baked seed — this payload plus the meta-data
+# confos injects beside it — is cloud-init's only input: the datasource
+# pin (mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg) keeps
+# host-presented cidata disks and ds= cmdline/DMI redirects away from this
+# root interpreter; cloud-init's cc: cmdline config overrides cfg.d by
+# design and is closed only by the UKI->RTMR[2] attestation pin. Anything
+# per-host (secrets, IPs, join material) rides a data disk (e.g. the
+# joindata disk rke2-role.sh reads), not cloud-init.
 #
 # The bulk of node setup is baked rather than scripted at first boot — see
 # this profile's mkosi.extra/ tree. The role-gated rke2 units are started

--- a/node-guest-image/c8s/user-data
+++ b/node-guest-image/c8s/user-data
@@ -3,10 +3,12 @@
 # disk selects the role at runtime (see rke2-role.sh).
 #
 # This payload is BAKED INTO the verity root at build time (via
-# bin/build-c8s passing --cloud-init) and therefore measured into the
-# launch digest. Anything per-host (hostname, secrets, IPs) that needs to
-# differ between deployments belongs in NoCloud `meta-data` (which lives
-# outside the measurement) or in a config drop-in on a data disk.
+# node-guest-image/build passing --cloud-init) and therefore measured into
+# the launch digest. It is cloud-init's only input — the datasource pin at
+# mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg keeps every
+# host-presented source (cidata disk, cmdline/DMI redirect) away from this
+# root interpreter. Anything per-host (secrets, IPs, join material) rides
+# a data disk (e.g. the joindata disk rke2-role.sh reads), not cloud-init.
 #
 # The bulk of node setup is baked rather than scripted at first boot — see
 # this profile's mkosi.extra/ tree. The role-gated rke2 units are started
@@ -19,8 +21,7 @@
 # drop-ins on top of the baked /etc/rancher/rke2/config.yaml without
 # rebuilding the image.
 
-# Hostname is settable per-deployment via NoCloud meta-data's
-# `local-hostname`. Default below applies when meta-data doesn't override.
+# One hostname for every node: the baked seed is cloud-init's only input.
 preserve_hostname: false
 hostname: c8s-node
 

--- a/node-guest-image/kernel/c8s-dev.config
+++ b/node-guest-image/kernel/c8s-dev.config
@@ -13,7 +13,7 @@
 #   bin/confos kernel --kernel-config-fragment kernel/c8s.config
 #   bin/confos build  --kernel-config-fragment kernel/c8s.config \
 #       --profile gpu --profile attest-gpu --profile c8s
-# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# (wired through node-guest-image/build). Only one --kernel-config-fragment is accepted
 # per build, so this file is a superset: it contains every effective line of
 # kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
 # gpu.config first, then mirror here), followed by the container/k8s set.

--- a/node-guest-image/kernel/c8s.config
+++ b/node-guest-image/kernel/c8s.config
@@ -5,7 +5,7 @@
 #   bin/confos kernel --kernel-config-fragment kernel/c8s.config
 #   bin/confos build  --kernel-config-fragment kernel/c8s.config \
 #       --profile gpu --profile attest-gpu --profile c8s
-# (wired through bin/build-c8s). Only one --kernel-config-fragment is accepted
+# (wired through node-guest-image/build). Only one --kernel-config-fragment is accepted
 # per build, so this file is a superset: it contains every effective line of
 # kernel/gpu.config VERBATIM (bin/lint enforces that inclusion — edit
 # gpu.config first, then mirror here), followed by the container/k8s set.

--- a/node-guest-image/tests/cloud-init-datasource-test.py
+++ b/node-guest-image/tests/cloud-init-datasource-test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# Semantic gate for the node image's cloud-init datasource pin
+# (mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg). Runs the
+# distro's real DataSourceNoCloud._get_data against the SHIPPED pin and a
+# hostile host: a bait cidata disk and a cmdline seed redirect. Asserts the
+# baked seed's user-data is the only one cloud-init will execute, and that
+# the pin is load-bearing (the same host input wins without it).
+#
+# No root needed: device/DMI/cmdline reads are faked in-process. Uses the
+# system python3 (distro cloud-init package); the asserted precedence rules
+# are stable across cloud-init versions, and the metal e2e tripwire covers
+# the exact shipped one. Output keeps the tests/lib.sh "FAIL:" prefix (CI
+# greps it).
+
+import os
+import shutil
+import sys
+import tempfile
+
+import yaml  # pyyaml, a cloud-init dependency
+from cloudinit import dmi, helpers, util
+from cloudinit.sources import DataSourceNoCloud as ncm
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+PROFILE = os.path.join(TESTS_DIR, "..", "c8s")
+PIN_FILE = os.path.join(
+    PROFILE, "mkosi.extra", "etc", "cloud", "cloud.cfg.d",
+    "99-c8s-datasource.cfg",
+)
+BAKED_UD = os.path.join(PROFILE, "user-data")
+# confos's inject_cloud_init writes this meta-data next to the baked
+# user-data (src/commands/build.rs).
+BAKED_MD = "instance-id: confos-sealed\nlocal-hostname: confos\n"
+CANONICAL_SEED = "file:///var/lib/cloud/seed/nocloud/"
+
+BAIT_UD = "#cloud-config\nhostname: cidata-bait\nruncmd: [touch /run/host-pwned]\n"
+BAIT_MD = "instance-id: i-host\nlocal-hostname: cidata-bait\n"
+EVIL_UD = "#cloud-config\nhostname: cmdline-evil\nruncmd: [touch /run/cmdline-pwned]\n"
+
+PASS = 0
+FAIL = 0
+FAILURES = []
+CASE = ""
+
+
+def ok(desc, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+    else:
+        FAIL += 1
+        FAILURES.append(f"{CASE}: {desc}")
+        print(f"  FAIL: {CASE}: {desc}")
+
+
+def summarize(title):
+    print()
+    print(f"==== {title} ====")
+    print(f"PASS: {PASS}  FAIL: {FAIL}")
+    if FAIL:
+        for f in FAILURES:
+            print(f"   {f}")
+        sys.exit(1)
+
+
+def stage(work):
+    """The baked seed (real user-data + confos meta-data) and a redirect target."""
+    seed = os.path.join(work, "seed")
+    os.makedirs(os.path.join(seed, "nocloud"))
+    shutil.copy(BAKED_UD, os.path.join(seed, "nocloud", "user-data"))
+    with open(os.path.join(seed, "nocloud", "meta-data"), "w") as f:
+        f.write(BAKED_MD)
+    evil = os.path.join(work, "evil")
+    os.makedirs(evil)
+    with open(os.path.join(evil, "user-data"), "w") as f:
+        f.write(EVIL_UD)
+    with open(os.path.join(evil, "meta-data"), "w") as f:
+        f.write("instance-id: i-evil\n")
+    return seed, evil
+
+
+def resolve(sys_cfg, cmdline=""):
+    """Run the distro DataSourceNoCloud against a hostile host.
+
+    A bait cidata disk is always attached. Returns (user-data str, scanned
+    bool). Host-side reads (DMI, /proc/cmdline, device mount) are faked.
+    """
+    work = tempfile.mkdtemp(prefix="cictl-")
+    try:
+        seed, evil = stage(work)
+        cfg = dict(sys_cfg)
+        ds_cfg = cfg.get("datasource", {}).get("NoCloud") or {}
+        cfg["datasource"] = {"NoCloud": dict(ds_cfg)}
+        sf = cfg["datasource"]["NoCloud"].get("seedfrom")
+        if sf:
+            cfg["datasource"]["NoCloud"]["seedfrom"] = sf.replace(
+                CANONICAL_SEED, f"file://{seed}/nocloud/"
+            )
+        ds = ncm.DataSourceNoCloud(cfg, None, helpers.Paths({"seed_dir": seed}))
+
+        saved = (dmi.read_dmi_data, util.get_cmdline, util.mount_cb)
+        scanned = []
+
+        def fake_mount_cb(dev, cb, data):
+            return {
+                "meta-data": BAIT_MD,
+                "user-data": BAIT_UD,
+                "vendor-data": None,
+                "network-config": None,
+            }
+
+        try:
+            dmi.read_dmi_data = lambda *a, **k: None
+            util.get_cmdline = lambda: cmdline.replace("EVIL", evil)
+            util.mount_cb = fake_mount_cb
+            ds._get_devices = lambda label: scanned.append(label) or [
+                "/dev/fake-cidata"
+            ]
+            assert ds._get_data(), "datasource did not claim the guest"
+        finally:
+            dmi.read_dmi_data, util.get_cmdline, util.mount_cb = saved
+
+        ud = ds.userdata_raw or ""
+        if isinstance(ud, bytes):
+            ud = ud.decode("utf-8", "replace")
+        return ud, bool(scanned)
+    finally:
+        shutil.rmtree(work)
+
+
+def main():
+    global CASE
+    CASE = "pin file present"
+    ok(f"{os.path.relpath(PIN_FILE)} exists", os.path.isfile(PIN_FILE))
+    if FAIL:
+        summarize("cloud-init datasource pin")
+    with open(PIN_FILE) as f:
+        pin = yaml.safe_load(f)
+
+    CASE = "shipped pin shape"
+    ok("datasource_list is exactly [NoCloud]", pin.get("datasource_list") == ["NoCloud"])
+    ds_cfg = pin.get("datasource", {}).get("NoCloud", {})
+    ok("seedfrom pins the baked seed dir", ds_cfg.get("seedfrom") == CANONICAL_SEED)
+    ok("fs_label is null (no device scan)", "fs_label" in ds_cfg and ds_cfg["fs_label"] is None)
+
+    baked_marker = "c8s node cloud-init complete"
+
+    CASE = "unpinned image, host cidata disk"
+    ud, scanned = resolve({})
+    ok("bait user-data wins without the pin (attack reproduces)", "cidata-bait" in ud)
+
+    CASE = "pinned image, host cidata disk"
+    ud, scanned = resolve(pin)
+    ok("baked user-data wins", baked_marker in ud)
+    ok("cidata device never scanned", not scanned)
+
+    CASE = "pinned image, cmdline seed redirect"
+    ud, scanned = resolve(pin, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ok("baked user-data wins", baked_marker in ud)
+
+    CASE = "unpinned image, cmdline seed redirect"
+    ud, scanned = resolve({}, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ok("redirected seed wins without the pin (pin is load-bearing)", "cmdline-evil" in ud)
+
+    summarize("cloud-init datasource pin")
+
+
+if __name__ == "__main__":
+    main()

--- a/node-guest-image/tests/cloud-init-datasource-test.py
+++ b/node-guest-image/tests/cloud-init-datasource-test.py
@@ -2,15 +2,15 @@
 # Semantic gate for the node image's cloud-init datasource pin
 # (mkosi.extra/etc/cloud/cloud.cfg.d/99-c8s-datasource.cfg). Runs the
 # distro's real DataSourceNoCloud._get_data against the SHIPPED pin and a
-# hostile host: a bait cidata disk and a cmdline seed redirect. Asserts the
+# hostile host: a bait cidata disk and cmdline/DMI seed redirects. Asserts the
 # baked seed's user-data is the only one cloud-init will execute, and that
 # the pin is load-bearing (the same host input wins without it).
 #
 # No root needed: device/DMI/cmdline reads are faked in-process. Uses the
 # system python3 (distro cloud-init package); the asserted precedence rules
 # are stable across cloud-init versions, and the metal e2e tripwire covers
-# the exact shipped one. Output keeps the tests/lib.sh "FAIL:" prefix (CI
-# greps it).
+# the exact shipped one. Output keeps the tests/lib.sh "FAIL:" prefix
+# convention; failure is the exit code.
 
 import os
 import shutil
@@ -79,11 +79,12 @@ def stage(work):
     return seed, evil
 
 
-def resolve(sys_cfg, cmdline=""):
+def resolve(sys_cfg, cmdline="", dmi_serial=None):
     """Run the distro DataSourceNoCloud against a hostile host.
 
     A bait cidata disk is always attached. Returns (user-data str, scanned
-    bool). Host-side reads (DMI, /proc/cmdline, device mount) are faked.
+    bool, claimed bool). Host-side reads (DMI, /proc/cmdline, device mount)
+    are faked; dmi_serial is a hostile system-serial-number, if given.
     """
     work = tempfile.mkdtemp(prefix="cictl-")
     try:
@@ -96,7 +97,9 @@ def resolve(sys_cfg, cmdline=""):
             cfg["datasource"]["NoCloud"]["seedfrom"] = sf.replace(
                 CANONICAL_SEED, f"file://{seed}/nocloud/"
             )
-        ds = ncm.DataSourceNoCloud(cfg, None, helpers.Paths({"seed_dir": seed}))
+        # Paths derives seed_dir from cloud_dir: the staged seed is on the
+        # default search path, as on the node.
+        ds = ncm.DataSourceNoCloud(cfg, None, helpers.Paths({"cloud_dir": work}))
 
         saved = (dmi.read_dmi_data, util.get_cmdline, util.mount_cb)
         scanned = []
@@ -109,21 +112,26 @@ def resolve(sys_cfg, cmdline=""):
                 "network-config": None,
             }
 
+        def fake_dmi(key, *a, **k):
+            if key == "system-serial-number" and dmi_serial:
+                return dmi_serial.replace("EVIL", evil)
+            return None
+
         try:
-            dmi.read_dmi_data = lambda *a, **k: None
+            dmi.read_dmi_data = fake_dmi
             util.get_cmdline = lambda: cmdline.replace("EVIL", evil)
             util.mount_cb = fake_mount_cb
             ds._get_devices = lambda label: scanned.append(label) or [
                 "/dev/fake-cidata"
             ]
-            assert ds._get_data(), "datasource did not claim the guest"
+            claimed = ds._get_data()
         finally:
             dmi.read_dmi_data, util.get_cmdline, util.mount_cb = saved
 
         ud = ds.userdata_raw or ""
         if isinstance(ud, bytes):
             ud = ud.decode("utf-8", "replace")
-        return ud, bool(scanned)
+        return ud, bool(scanned), claimed
     finally:
         shutil.rmtree(work)
 
@@ -146,20 +154,29 @@ def main():
     baked_marker = "c8s node cloud-init complete"
 
     CASE = "unpinned image, host cidata disk"
-    ud, scanned = resolve({})
+    ud, scanned, claimed = resolve({})
+    ok("datasource claims the guest", claimed)
     ok("bait user-data wins without the pin (attack reproduces)", "cidata-bait" in ud)
 
     CASE = "pinned image, host cidata disk"
-    ud, scanned = resolve(pin)
+    ud, scanned, claimed = resolve(pin)
+    ok("datasource claims the guest", claimed)
     ok("baked user-data wins", baked_marker in ud)
     ok("cidata device never scanned", not scanned)
 
     CASE = "pinned image, cmdline seed redirect"
-    ud, scanned = resolve(pin, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ud, scanned, claimed = resolve(pin, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ok("datasource claims the guest", claimed)
+    ok("baked user-data wins", baked_marker in ud)
+
+    CASE = "pinned image, DMI-serial seed redirect"
+    ud, scanned, claimed = resolve(pin, dmi_serial="ds=nocloud;s=file://EVIL/")
+    ok("datasource claims the guest", claimed)
     ok("baked user-data wins", baked_marker in ud)
 
     CASE = "unpinned image, cmdline seed redirect"
-    ud, scanned = resolve({}, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ud, scanned, claimed = resolve({}, cmdline="root=/dev/dm-0 ro ds=nocloud;s=file://EVIL/ ")
+    ok("datasource claims the guest", claimed)
     ok("redirected seed wins without the pin (pin is load-bearing)", "cmdline-evil" in ud)
 
     summarize("cloud-init datasource pin")


### PR DESCRIPTION
The node image shipped cloud-init with unrestricted datasources, so a host-supplied cidata disk yielded root in the attested node CVM.

## Fix
`99-c8s-datasource.cfg` baked into the measured rootfs: `datasource_list: [NoCloud]` only, `fs_label: null` kills the cidata device scan, and a pinned `seedfrom` re-read forces the baked seed over cmdline/DMI redirects. Attack reproduced unpinned against real cloud-init 26.1; closed pinned. The one remaining override channel (`cc:` cmdline YAML) is closed by the measured-UKI chain (RTMR[2] on TDX / LAUNCH_DIGEST on SNP) — documented as a one-line invariant at the pin.

## Test evidence
cloud-init gate harness 15/15; pin mutations fail with named FAILs; verbatim lint block passes at both confos refs (e564279, e29cd92) and 6/6 guard negatives fire; role suite 337/337 (+40/40 systemd with sudo); actionlint clean; full go suite 66 pkgs green. Two full review rounds + an independent final verification (GO), all with mutation batteries.

## Decisions
- Per-deployment hostname via host meta-data deliberately dropped (nodes uniformly `c8s-node`, as the SNP lane already) — hostname-via-cidata was only ever reachable through this vulnerability.
- No confos change required: the pin lands via the c8s profile's `mkosi.extra`; the lint gate cross-checks the confos base stays datasource-clean at its pinned ref.
- The kata pod-side cloud-init path is the latent twin of this finding — tracked in a separate follow-up issue.
