### PR TITLE
fix(verify): ground the lb front-door verdict in the live handshake, not public_tls.mode

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -540,20 +540,24 @@ body. A self-signed leaf authenticates its own body under the attested key; a
 CA-issued one does not, and `x509` parsing verifies no signature — so a
 CA-issued leaf is accepted only when its chain verifies against `--mesh-ca`,
 or when a live TLS handshake proves the peer holds the attested key. For
-`--mode discovery` that handshake doubles as the front-door check below: a
-CA-issued discovery certificate the live door presents byte-identically is
-authenticated by possession, and only a door serving some other certificate
+`--mode discovery` on an https target that handshake doubles as the front-door
+check below: a CA-issued discovery certificate the live door presents
+byte-identically is authenticated by possession. A door serving some other
+certificate — or a fetch with no handshake to observe (a non-https target) —
 still requires `--mesh-ca` (the document publishes `cds_tls.mesh_ca_url`).
 
 Exit codes are a CI contract: `0` verified, `1` usage error, `2`
 verification/policy failed (e.g. wrong measurement), `3` evidence unavailable
 (unreachable/unparseable), `4` partially verified — the evidence verified, but
-a property it presents is not proven. The two partial cases today: the front
-door's live TLS handshake presenting a serving certificate the discovery
+a property it presents is not proven. The three partial cases today: the
+front door's live TLS handshake presenting a serving certificate the discovery
 evidence does not attest (a WebPKI front door, whatever the document's
-`public_tls.mode` declares — the verdict keys on the observed handshake, not
-the host-served declaration; what is proven is the tls-lb pod's TEE residency
-and measurement, not the TLS endpoint clients reach), and attest-pq or
+`public_tls.mode` declares — the verdict keys on the handshake observed on the
+verifier's own connection at verify time, not the host-served declaration;
+what is proven is the tls-lb pod's TEE residency and measurement, not the TLS
+endpoint clients reach), a discovery target fetched over a non-TLS connection
+(no live handshake observed — the declared `public_tls.mode` is then the only
+mode signal, a host-served claim nothing authenticates), and attest-pq or
 saved-bundle evidence without `--mesh-ca` (the mesh chain anchors to a CA the
 responder committed into its own transcript, so which deployment the endpoint
 belongs to is not proven). JSON renders these as

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -539,22 +539,24 @@ Certificate-sourced evidence must also carry an authenticated certificate
 body. A self-signed leaf authenticates its own body under the attested key; a
 CA-issued one does not, and `x509` parsing verifies no signature — so a
 CA-issued leaf is accepted only when its chain verifies against `--mesh-ca`,
-or when a live RA-TLS handshake proves the peer holds the attested key.
-Notably, `--mode discovery` fetches an unauthenticated public document over a
-connection that is not bound to the certificate inside it, so verifying a
-CA-issued discovery certificate requires `--mesh-ca` (the document publishes
-`cds_tls.mesh_ca_url`).
+or when a live TLS handshake proves the peer holds the attested key. For
+`--mode discovery` that handshake doubles as the front-door check below: a
+CA-issued discovery certificate the live door presents byte-identically is
+authenticated by possession, and only a door serving some other certificate
+still requires `--mesh-ca` (the document publishes `cds_tls.mesh_ca_url`).
 
 Exit codes are a CI contract: `0` verified, `1` usage error, `2`
 verification/policy failed (e.g. wrong measurement), `3` evidence unavailable
 (unreachable/unparseable), `4` partially verified — the evidence verified, but
-a property it presents is not proven. The two partial cases today: a
-discovery document declaring `public_tls.mode=webpki` (the front door's
-serving key is not attestation-bound — what is proven is the tls-lb pod's TEE
-residency and measurement, not the TLS endpoint clients reach), and attest-pq
-or saved-bundle evidence without `--mesh-ca` (the mesh chain anchors to a CA
-the responder committed into its own transcript, so which deployment the
-endpoint belongs to is not proven). JSON renders these as
+a property it presents is not proven. The two partial cases today: the front
+door's live TLS handshake presenting a serving certificate the discovery
+evidence does not attest (a WebPKI front door, whatever the document's
+`public_tls.mode` declares — the verdict keys on the observed handshake, not
+the host-served declaration; what is proven is the tls-lb pod's TEE residency
+and measurement, not the TLS endpoint clients reach), and attest-pq or
+saved-bundle evidence without `--mesh-ca` (the mesh chain anchors to a CA the
+responder committed into its own transcript, so which deployment the endpoint
+belongs to is not proven). JSON renders these as
 `verified: false, partial: true` with a `not_proven` list, so a gate checking
 `verified` fails closed while scripts can still tell partial from failure.
 

--- a/internal/cmds/verify/certbody_test.go
+++ b/internal/cmds/verify/certbody_test.go
@@ -117,7 +117,7 @@ func TestUnauthenticatedCertBodyRejected(t *testing.T) {
 	t.Run("discovery document", func(t *testing.T) {
 		doc := discoveryDocWith(t, string(certutil.EncodeCertPEM(forged.Raw)), []byte("challenge"),
 			`{"attestation_report":"AAAA"}`)
-		_, err := evidenceFromDiscovery(doc, "test", leafTrust{})
+		_, err := evidenceFromDiscovery(doc, "test", leafTrust{}, nil)
 		if err == nil {
 			t.Fatal("a replayed discovery document with a re-minted certificate must not verify")
 		}
@@ -203,7 +203,7 @@ func TestMeshCAAuthenticatesCAIssuedCertBody(t *testing.T) {
 
 	doc := discoveryDocWith(t, string(certutil.EncodeCertPEM(leaf.Raw)), []byte("challenge"),
 		`{"attestation_report":"AAAA"}`)
-	ev, err := evidenceFromDiscovery(doc, "test", leafTrust{meshCA: pool})
+	ev, err := evidenceFromDiscovery(doc, "test", leafTrust{meshCA: pool}, nil)
 	if err != nil {
 		t.Fatalf("a CA-issued discovery cert chaining to --mesh-ca must be accepted: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestEvidenceFromDiscoveryAuthenticatesCertBody(t *testing.T) {
 		cert := mintAttestedLeaf(t, &key.PublicKey, key, now.Add(-2*time.Hour), now.Add(-time.Minute))
 		doc := discoveryDocWith(t, string(certutil.EncodeCertPEM(cert.Raw)), []byte("challenge"),
 			`{"attestation_report":"AAAA"}`)
-		_, err := evidenceFromDiscovery(doc, "test", leafTrust{})
+		_, err := evidenceFromDiscovery(doc, "test", leafTrust{}, nil)
 		if err == nil || !strings.Contains(err.Error(), "expired") {
 			t.Fatalf("want NotAfter rejection, got %v", err)
 		}
@@ -302,7 +302,7 @@ func TestEvidenceFromDiscoveryAuthenticatesCertBody(t *testing.T) {
 		cert := mintAttestedLeaf(t, &key.PublicKey, signer, now.Add(-time.Hour), now.Add(time.Hour))
 		doc := discoveryDocWith(t, string(certutil.EncodeCertPEM(cert.Raw)), []byte("challenge"),
 			`{"attestation_report":"AAAA"}`)
-		if _, err := evidenceFromDiscovery(doc, "test", leafTrust{}); err == nil {
+		if _, err := evidenceFromDiscovery(doc, "test", leafTrust{}, nil); err == nil {
 			t.Fatal("want self-signature rejection on the discovery cert")
 		}
 	})
@@ -311,7 +311,7 @@ func TestEvidenceFromDiscoveryAuthenticatesCertBody(t *testing.T) {
 		cert := mintAttestedLeaf(t, &key.PublicKey, key, now.Add(-time.Hour), now.Add(time.Hour))
 		doc := discoveryDocWith(t, string(certutil.EncodeCertPEM(cert.Raw)), []byte("challenge"),
 			`{"attestation_report":"AAAA"}`)
-		ev, err := evidenceFromDiscovery(doc, "test", leafTrust{})
+		ev, err := evidenceFromDiscovery(doc, "test", leafTrust{}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -209,13 +209,19 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust, observed
 	if err != nil {
 		return nil, err
 	}
+	sum := sha256.Sum256(cert.Raw)
 	chainVerified, err := authorizeLeafBody(cert, body, trust)
 	if err != nil {
+		// A mismatching door is the actionable signal: lead the failure
+		// with the observed-vs-attested digests, then the body check.
+		if frontDoor == frontDoorOther {
+			err = fmt.Errorf("the front door's live TLS handshake presented serving certificate sha256 %s, not the sha256 %s this evidence attests: %w",
+				observedSHA256, hex.EncodeToString(sum[:]), err)
+		}
 		return nil, err
 	}
 	sandboxID, sandboxErr := ratls.SandboxIDFromCert(cert)
 	workload, workloadErr := ratls.MatchedWorkloadFromCert(cert)
-	sum := sha256.Sum256(cert.Raw)
 	bindingNote := "REPORTDATA binds the CDS cert key + issuance challenge from the discovery doc (ships the VCEK; no per-request nonce — replayable within the authenticated certificate validity window)"
 	if frontDoor == frontDoorAttested {
 		bindingNote += "; the live handshake presented the attested serving certificate"

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -105,8 +105,10 @@ func dialFrontDoor(ctx context.Context, addr, serverName string, timeout time.Du
 // singleConnClient serves requests over the one dialed connection and never
 // redials: the handshake leaf the gather compares is this connection's, so a
 // second dial could reach a different tls-lb replica serving a different cert.
-// Redirects are not followed for the same reason — a non-200 is a fetch
-// failure (connectError), as before.
+// Redirects are not followed for the same reason — a non-200, including a
+// redirect, is a fetch failure (connectError).
+// dialFrontDoor + this guard are a sibling of internal/lbdiscovery's
+// dialFrontDoor + newSingleConnClient — port fixes both ways.
 func singleConnClient(conn *tls.Conn, timeout time.Duration) *http.Client {
 	var dialed atomic.Bool
 	return &http.Client{

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -1,15 +1,21 @@
 package verify
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -19,39 +25,114 @@ import (
 // defaultDiscoveryPath is the path the tls-lb serves its discovery document on.
 const defaultDiscoveryPath = "/v1/discovery"
 
+// frontDoorObservation is what a discovery gather's live TLS handshake showed
+// about the serving key the front door actually speaks.
+type frontDoorObservation int
+
+const (
+	// frontDoorNone: the evidence is not discovery-sourced; no front-door
+	// property is presented.
+	frontDoorNone frontDoorObservation = iota
+	// frontDoorUnobserved: discovery-sourced, but the target connection was
+	// not TLS, so no handshake showed the serving key.
+	frontDoorUnobserved
+	// frontDoorAttested: the handshake presented byte-identically the
+	// certificate the evidence attests — the peer holds the attestation-bound
+	// key.
+	frontDoorAttested
+	// frontDoorOther: the handshake presented a certificate the evidence does
+	// not attest.
+	frontDoorOther
+)
+
 // gatherFromDiscovery fetches the tls-lb discovery document and builds evidence
 // from the embedded attestation, bound to the CDS cert key + the issuance
 // challenge. The challenge is fixed at issuance time, so this is NOT a freshness
 // proof (fresh=false) — but it ships the VCEK, so it verifies offline.
+//
+// An https target is dialed once and the document fetched over that one
+// connection: the handshake leaf is the front door's serving key made
+// observable, and serving certs are per replica, so the observation and the
+// document must ride the same connection. The document stays unauthenticated
+// public bytes (anyone who once fetched a genuine one can replay it with the
+// certificate re-minted — see authorizeLeafBody); what the handshake adds is
+// which key the door THIS connection reached actually speaks.
 func gatherFromDiscovery(ctx context.Context, base, path, serverName string, timeout time.Duration, trust leafTrust) (*evidence, error) {
-	data, src, err := fetchDiscoveryDoc(ctx, base, path, serverName, timeout)
+	u, err := url.Parse(base)
+	if err != nil {
+		return nil, fmt.Errorf("parse url %q: %w", base, err)
+	}
+	client := insecureClient(serverName, timeout)
+	var conn *tls.Conn
+	if u.Scheme == "https" {
+		conn, err = dialFrontDoor(ctx, u.Host, serverName, timeout)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+		client = singleConnClient(conn, timeout)
+	}
+	data, src, err := fetchDiscoveryDoc(ctx, client, u, path)
 	if err != nil {
 		return nil, err
 	}
-	// No keyProven here, deliberately: fetchDiscoveryDoc dials with
-	// InsecureSkipVerify and no VerifyPeerCertificate, so nothing binds the
-	// certificate INSIDE the document to the leaf that served it. The document
-	// is unauthenticated public bytes — anyone who once fetched a genuine one
-	// can replay it with the certificate re-minted. See authorizeLeafBody.
-	return evidenceFromDiscovery(data, src, trust)
+	var observed *x509.Certificate
+	if conn != nil {
+		if peers := conn.ConnectionState().PeerCertificates; len(peers) > 0 {
+			observed = peers[0]
+		}
+	}
+	return evidenceFromDiscovery(data, src, trust, observed)
 }
 
-// fetchDiscoveryDoc GETs the discovery document from a component's
-// (unauthenticated) discovery endpoint and returns the raw bytes plus a
-// human-readable source string. PKI is intentionally not verified — the trust
-// anchor is the hardware attestation inside the document, checked downstream.
-func fetchDiscoveryDoc(ctx context.Context, base, path, serverName string, timeout time.Duration) ([]byte, string, error) {
+// dialFrontDoor opens the TLS connection the discovery document is fetched
+// over. PKI is intentionally not verified — the trust anchor is the
+// attestation in the document, checked downstream, and the handshake leaf is
+// compared against the document's attested certificate after the fetch.
+func dialFrontDoor(ctx context.Context, addr, serverName string, timeout time.Duration) (*tls.Conn, error) {
+	dialer := &tls.Dialer{
+		NetDialer: &net.Dialer{Timeout: timeout},
+		Config:    &tls.Config{InsecureSkipVerify: true, ServerName: serverName}, //nolint:gosec
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, &connectError{err: fmt.Errorf("dial %s: %w", addr, err)}
+	}
+	// tls.Dialer.DialContext always returns a *tls.Conn.
+	return conn.(*tls.Conn), nil
+}
+
+// singleConnClient serves requests over the one dialed connection and never
+// redials: the handshake leaf the gather compares is this connection's, so a
+// second dial could reach a different tls-lb replica serving a different cert.
+// Redirects are not followed for the same reason — a non-200 is a fetch
+// failure (connectError), as before.
+func singleConnClient(conn *tls.Conn, timeout time.Duration) *http.Client {
+	var dialed atomic.Bool
+	return &http.Client{
+		Timeout:       timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Transport: &http.Transport{
+			DialTLSContext: func(context.Context, string, string) (net.Conn, error) {
+				if dialed.Swap(true) {
+					return nil, errors.New("the attested connection was lost and redialing could reach a different tls-lb replica; re-run the command")
+				}
+				return conn, nil
+			},
+		},
+	}
+}
+
+// fetchDiscoveryDoc GETs the discovery document over client and returns the
+// raw bytes plus a human-readable source string.
+func fetchDiscoveryDoc(ctx context.Context, client *http.Client, base *url.URL, path string) ([]byte, string, error) {
 	if path == "" {
 		path = defaultDiscoveryPath
 	}
-	u, err := url.Parse(base)
-	if err != nil {
-		return nil, "", fmt.Errorf("parse url %q: %w", base, err)
-	}
+	u := *base
 	u.Path = path
 	u.RawQuery = ""
 
-	client := insecureClient(serverName, timeout)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
 		return nil, "", err
@@ -78,17 +159,21 @@ func fetchDiscoveryDoc(ctx context.Context, base, path, serverName string, timeo
 // gets the same body authentication as every other cert-sourced path, and is
 // retained as the evidence leaf so the --mesh-ca / --sandbox-id / --workload
 // pins work against discovery targets too. A CDS-issued (CA-vouched) cert in
-// the document is authenticated only by a --mesh-ca chain check; without one
-// the document is rejected rather than verified against a body nothing signed
-// for (authorizeLeafBody).
+// the document is authenticated by a --mesh-ca chain check, or by the live
+// handshake below; with neither the document is rejected rather than verified
+// against a body nothing signed for (authorizeLeafBody).
 //
-// public_tls.mode travels with the evidence to the verdict: a "webpki" front
-// door terminates public TLS on a certificate this evidence says nothing
-// about, so the verdict is demoted to partial downstream
-// (applyFrontDoorPolicy). An unknown mode fails closed here — a
-// securityError, so auto mode cannot fall through to the serving cert past a
-// document it cannot classify.
-func evidenceFromDiscovery(data []byte, source string, trust leafTrust) (*evidence, error) {
+// observed is the leaf the target connection's TLS handshake presented (nil
+// when no handshake was made). Byte-identical to the attested cert, the
+// completed handshake proves the peer holds the attestation-bound key — the
+// same possession backstop as the RA-TLS path — and the verdict may stand on
+// the front door speaking the attested key (applyFrontDoorPolicy).
+//
+// An unknown public_tls.mode fails closed here — a securityError, so auto
+// mode cannot fall through to the serving cert past a document it cannot
+// classify. A known mode is classification only: the verdict keys on the
+// live handshake observation (applyFrontDoorPolicy).
+func evidenceFromDiscovery(data []byte, source string, trust leafTrust, observed *x509.Certificate) (*evidence, error) {
 	var d types.DiscoveryDocument
 	if err := json.Unmarshal(data, &d); err != nil {
 		return nil, fmt.Errorf("parse discovery document: %w", err)
@@ -103,6 +188,21 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust) (*eviden
 	if err != nil {
 		return nil, err
 	}
+	frontDoor := frontDoorUnobserved
+	var observedSHA256 string
+	if observed != nil {
+		sum := sha256.Sum256(observed.Raw)
+		observedSHA256 = hex.EncodeToString(sum[:])
+		if bytes.Equal(observed.Raw, cert.Raw) {
+			frontDoor = frontDoorAttested
+			// The possession backstop admits the body only where no pinned CA
+			// authenticates it instead: with --mesh-ca the chain check is the
+			// stronger authentication, and authorizeLeafBody reports it.
+			trust.keyProven = trust.meshCA == nil
+		} else {
+			frontDoor = frontDoorOther
+		}
+	}
 	body, err := authenticateLeafBody(cert)
 	if err != nil {
 		return nil, err
@@ -114,21 +214,27 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust) (*eviden
 	sandboxID, sandboxErr := ratls.SandboxIDFromCert(cert)
 	workload, workloadErr := ratls.MatchedWorkloadFromCert(cert)
 	sum := sha256.Sum256(cert.Raw)
+	bindingNote := "REPORTDATA binds the CDS cert key + issuance challenge from the discovery doc (ships the VCEK; no per-request nonce — replayable within the authenticated certificate validity window)"
+	if frontDoor == frontDoorAttested {
+		bindingNote += "; the live handshake presented the attested serving certificate"
+	}
 	return &evidence{
-		platform:          platformOrDefault(d.Attestation.Platform),
-		rawEvidence:       d.Attestation.Evidence,
-		erd:               keyAnchor(rd),
-		fresh:             false,
-		source:            source,
-		certSHA256:        hex.EncodeToString(sum[:]),
-		bindingNote:       "REPORTDATA binds the CDS cert key + issuance challenge from the discovery doc (ships the VCEK; no per-request nonce — replayable within the authenticated certificate validity window)",
-		leaf:              cert,
-		leafBody:          body,
-		leafChainVerified: chainVerified,
-		publicTLSMode:     d.PublicTLS.Mode,
-		sandboxID:         sandboxID,
-		sandboxErr:        sandboxErr,
-		workload:          workload,
-		workloadErr:       workloadErr,
+		platform:            platformOrDefault(d.Attestation.Platform),
+		rawEvidence:         d.Attestation.Evidence,
+		erd:                 keyAnchor(rd),
+		fresh:               false,
+		source:              source,
+		certSHA256:          hex.EncodeToString(sum[:]),
+		bindingNote:         bindingNote,
+		leaf:                cert,
+		leafBody:            body,
+		leafChainVerified:   chainVerified,
+		leafKeyProven:       trust.keyProven,
+		frontDoor:           frontDoor,
+		frontDoorCertSHA256: observedSHA256,
+		sandboxID:           sandboxID,
+		sandboxErr:          sandboxErr,
+		workload:            workload,
+		workloadErr:         workloadErr,
 	}, nil
 }

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -222,10 +222,6 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust, observed
 	}
 	sandboxID, sandboxErr := ratls.SandboxIDFromCert(cert)
 	workload, workloadErr := ratls.MatchedWorkloadFromCert(cert)
-	bindingNote := "REPORTDATA binds the CDS cert key + issuance challenge from the discovery doc (ships the VCEK; no per-request nonce — replayable within the authenticated certificate validity window)"
-	if frontDoor == frontDoorAttested {
-		bindingNote += "; the live handshake presented the attested serving certificate"
-	}
 	return &evidence{
 		platform:            platformOrDefault(d.Attestation.Platform),
 		rawEvidence:         d.Attestation.Evidence,
@@ -233,7 +229,7 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust, observed
 		fresh:               false,
 		source:              source,
 		certSHA256:          hex.EncodeToString(sum[:]),
-		bindingNote:         bindingNote,
+		bindingNote:         "REPORTDATA binds the CDS cert key + issuance challenge from the discovery doc (ships the VCEK; no per-request nonce — replayable within the authenticated certificate validity window)",
 		leaf:                cert,
 		leafBody:            body,
 		leafChainVerified:   chainVerified,

--- a/internal/cmds/verify/discovery.go
+++ b/internal/cmds/verify/discovery.go
@@ -184,7 +184,7 @@ func evidenceFromDiscovery(data []byte, source string, trust leafTrust, observed
 	case "", "cds", "webpki":
 	default:
 		return nil, &securityError{err: fmt.Errorf(
-			"unknown public_tls.mode %q in discovery document (this build knows cds and webpki): the front door's serving-key binding cannot be established", d.PublicTLS.Mode)}
+			"unknown public_tls.mode %q in discovery document (this build knows cds and webpki) — failing closed on a document it cannot classify", d.PublicTLS.Mode)}
 	}
 	cert, rd, err := ratls.AttestedCertFromDiscovery(&d)
 	if err != nil {

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -164,8 +164,17 @@ func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
 		if ev.frontDoor != frontDoorAttested {
 			t.Errorf("frontDoor = %v, want attested", ev.frontDoor)
 		}
-		if !strings.Contains(ev.bindingNote, "live handshake") {
-			t.Errorf("bindingNote = %q, want it to record the observed handshake", ev.bindingNote)
+		// The passing verdict states the observed handshake as its basis,
+		// scoped to the one observation made.
+		oc := snpVerifiedOutcome(t, config{}, ev)
+		if !oc.Verified {
+			t.Fatalf("verified=%v error=%q, want a verified verdict", oc.Verified, oc.Error)
+		}
+		if !strings.Contains(oc.Binding, "live handshake presented the attested serving certificate") {
+			t.Errorf("Binding = %q, want it to state the observed handshake as the verdict's basis", oc.Binding)
+		}
+		if len(oc.Warnings) != 1 || !strings.Contains(oc.Warnings[0], "single connection") {
+			t.Errorf("Warnings = %v, want the one-connection/one-replica/one-instant scope caveat", oc.Warnings)
 		}
 	})
 

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -17,6 +17,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/overenc"
 )
 
 func TestEvidenceFromDiscovery_Malformed(t *testing.T) {
@@ -324,6 +326,79 @@ func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
 			t.Errorf("error = %q, want it to name the 302: the redirect is refused, not followed", err)
 		}
 	})
+}
+
+// Evidence gathered off the discovery path observes no front door, so it
+// presents none: every non-discovery constructor records frontDoorNone, and
+// the verdict then says nothing about a front door — no attested-door note,
+// no scope caveat, no demotion for an unobserved one. The RA-TLS dial is
+// what auto mode falls back to when the discovery fetch fails, so this is
+// the state that reaches the verdict on that path.
+func TestNonDiscoveryEvidencePresentsNoFrontDoor(t *testing.T) {
+	nonce := make([]byte, nonceSize)
+	endpointJSON := buildEndpointJSON(t, mintEndpointIdentity(t), nonce, make([]byte, 64), []byte("vcek"),
+		make([]byte, overenc.X25519PubBytes), make([]byte, overenc.MLKEM768EKBytes))
+
+	for _, tc := range []struct {
+		name        string
+		get         func(t *testing.T) (*evidence, error)
+		wantVerdict string
+	}{
+		{"RA-TLS serving cert: auto mode's fallback", func(t *testing.T) (*evidence, error) {
+			srv := attestedTLSServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+			return gatherFromRATLSCert(context.Background(), strings.TrimPrefix(srv.URL, "https://"), "", 5*time.Second, leafTrust{})
+		}, "verified"},
+		{"attest-pq endpoint", func(*testing.T) (*evidence, error) {
+			return evidenceFromEndpointJSON(endpointJSON, nonce, "attestation endpoint")
+		}, "partial"},
+		{"saved bare evidence", func(*testing.T) (*evidence, error) {
+			return evidenceFromBareJSON([]byte(`{"evidence":{"attestation_report":"AAAA"}}`), make([]byte, 48), "file")
+		}, "verified"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ev, err := tc.get(t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ev.frontDoor != frontDoorNone {
+				t.Errorf("frontDoor = %v, want none: this evidence is not discovery-sourced", ev.frontDoor)
+			}
+			if ev.frontDoorCertSHA256 != "" {
+				t.Errorf("frontDoorCertSHA256 = %q, want empty: no handshake leaf was compared", ev.frontDoorCertSHA256)
+			}
+
+			oc := snpVerifiedOutcome(t, config{}, ev)
+			if got := verdictShape(oc); got != tc.wantVerdict {
+				t.Errorf("verdict = %s (error=%q not_proven=%v), want %s", got, oc.Error, oc.NotProven, tc.wantVerdict)
+			}
+			if strings.Contains(oc.Binding, "live handshake presented the attested serving certificate") {
+				t.Errorf("Binding = %q, want no attested-front-door claim on evidence that observed none", oc.Binding)
+			}
+			for _, w := range oc.Warnings {
+				if strings.Contains(w, "attested front door") {
+					t.Errorf("Warnings = %v, want no front-door scope caveat", oc.Warnings)
+				}
+			}
+			for _, np := range oc.NotProven {
+				if strings.Contains(np, "front door") {
+					t.Errorf("NotProven = %v, want no front-door demotion", oc.NotProven)
+				}
+			}
+		})
+	}
+}
+
+// verdictShape names the verdict a test expects, so a mismatch prints the
+// shape rather than a pair of bools.
+func verdictShape(oc Outcome) string {
+	switch {
+	case oc.Verified:
+		return "verified"
+	case oc.Partial:
+		return "partial"
+	default:
+		return "failed"
+	}
 }
 
 // The document and the observed handshake leaf must ride ONE connection:

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -3,20 +3,18 @@ package verify
 import (
 	"context"
 	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
-	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -91,6 +89,15 @@ func TestGatherFromDiscoveryConnectErrors(t *testing.T) {
 		}
 	})
 
+	t.Run("https to a non-TLS service is a connectError", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		t.Cleanup(srv.Close)
+		_, err := gatherFromDiscovery(ctx, "https"+strings.TrimPrefix(srv.URL, "http"), "", "", time.Second, leafTrust{})
+		if err == nil || !isConnectError(err) {
+			t.Fatalf("a TLS handshake failure must be a connectError, got %v", err)
+		}
+	})
+
 	t.Run("connection refused is a connectError", func(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		base := srv.URL
@@ -106,22 +113,18 @@ func TestGatherFromDiscoveryConnectErrors(t *testing.T) {
 // its PEM encoding plus a tls.Certificate a test server can present.
 func selfSignedServerCert(t *testing.T) (string, tls.Certificate) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "lb"},
-		NotBefore:    time.Unix(0, 0),
-		NotAfter:     time.Unix(1<<31-1, 0),
-	}
-	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
-	if err != nil {
-		t.Fatal(err)
-	}
+	key, der := mintSelfSigned(t, "lb", 1, nil)
 	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
 	return certPEM, tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// remintServerCert re-mints cert's body around the same key (new serial): the
+// SPKI matches but the DER does not.
+func remintServerCert(t *testing.T, cert tls.Certificate) tls.Certificate {
+	t.Helper()
+	key := cert.PrivateKey.(*ecdsa.PrivateKey)
+	_, der := mintSelfSigned(t, "lb", 2, key)
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
 }
 
 // discoveryServer starts a TLS server presenting serverCert and serving doc.
@@ -209,6 +212,43 @@ func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
 		}
 	})
 
+	t.Run("lying host: no mode declared, serves another cert", func(t *testing.T) {
+		srv := discoveryServer(t, otherCert, docClaims(""))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorOther {
+			t.Errorf("frontDoor = %v, want other", ev.frontDoor)
+		}
+	})
+
+	t.Run("a re-minted body around the attested key is still another cert", func(t *testing.T) {
+		srv := discoveryServer(t, remintServerCert(t, attestedCert), docClaims("cds"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorOther {
+			t.Errorf("frontDoor = %v, want other: the comparison is byte-equality, not key-equality", ev.frontDoor)
+		}
+	})
+
+	t.Run("a chain at the door is compared by its leaf", func(t *testing.T) {
+		chained := tls.Certificate{
+			Certificate: [][]byte{attestedCert.Certificate[0], otherCert.Certificate[0]},
+			PrivateKey:  attestedCert.PrivateKey,
+		}
+		srv := discoveryServer(t, chained, docClaims("cds"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorAttested {
+			t.Errorf("frontDoor = %v, want attested: the presented leaf is what compares", ev.frontDoor)
+		}
+	})
+
 	t.Run("non-TLS target leaves the door unobserved", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Write(docClaims("cds"))
@@ -233,6 +273,71 @@ func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
 			t.Fatalf("a redirect must fail as a fetch (connect) error, got %v", err)
 		}
 	})
+}
+
+// The document and the observed handshake leaf must ride ONE connection:
+// serving certs are per replica, so a second dial can reach a different
+// replica — or, for an adversarial host, a proxied attested tls-lb pod — and
+// make a WebPKI door look attested. The server below is that host: the door
+// clients reach (first connection) serves a WebPKI stand-in, every later
+// connection gets the attested cert. The observation must be the dialed
+// connection's leaf, and there must be exactly one dial — the count pins the
+// invariant regardless of dial order.
+func TestGatherFromDiscoverySingleConnection(t *testing.T) {
+	challenge := []byte("issuance-challenge")
+	stubEvidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+	attestedPEM, attestedCert := selfSignedServerCert(t)
+	_, otherCert := selfSignedServerCert(t) // a WebPKI stand-in
+	doc := discoveryDocWithPublicTLS(t, "cds", attestedPEM, challenge, stubEvidence)
+
+	// Hand-rolled TLS listener: httptest's StartTLS installs its own
+	// certificate when Certificates is empty, which would shadow
+	// GetCertificate for a client that sends no SNI.
+	var handshakes atomic.Int32
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(doc)
+	})}
+	t.Cleanup(func() { srv.Close() })
+	go srv.Serve(tls.NewListener(ln, &tls.Config{GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		if handshakes.Add(1) == 1 {
+			return &otherCert, nil
+		}
+		return &attestedCert, nil
+	}}))
+
+	ev, err := gatherFromDiscovery(context.Background(), "https://"+ln.Addr().String(), "", "", 5*time.Second, leafTrust{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.frontDoor != frontDoorOther {
+		t.Errorf("frontDoor = %v, want other: the observation must be the dialed connection's leaf (the door clients reach), not a later connection's", ev.frontDoor)
+	}
+	if got := handshakes.Load(); got != 1 {
+		t.Errorf("handshakes = %d, want exactly 1: the document and the observation must ride one connection", got)
+	}
+}
+
+// singleConnClient's second dial fails closed rather than re-reaching a
+// possibly different replica.
+func TestSingleConnClientNeverRedials(t *testing.T) {
+	_, serverCert := selfSignedServerCert(t)
+	srv := discoveryServer(t, serverCert, []byte("{}"))
+	conn, err := tls.Dial("tcp", srv.Listener.Addr().String(), &tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	transport := singleConnClient(conn, 5*time.Second).Transport.(*http.Transport)
+	if _, err := transport.DialTLSContext(context.Background(), "tcp", "unused"); err != nil {
+		t.Fatalf("the first dial hands out the attested connection: %v", err)
+	}
+	if _, err := transport.DialTLSContext(context.Background(), "tcp", "unused"); err == nil {
+		t.Fatal("a second dial must fail closed")
+	}
 }
 
 // A discovery document's CA-vouched serving cert (the chart's shape: issued

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -2,9 +2,18 @@ package verify
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +24,7 @@ import (
 func TestEvidenceFromDiscovery_Malformed(t *testing.T) {
 	certPEM, _ := selfSignedCertPEM(t)
 
-	if _, err := evidenceFromDiscovery([]byte("not json"), "t", leafTrust{}); err == nil {
+	if _, err := evidenceFromDiscovery([]byte("not json"), "t", leafTrust{}, nil); err == nil {
 		t.Error("non-JSON must fail")
 	}
 
@@ -30,7 +39,7 @@ func TestEvidenceFromDiscovery_Malformed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := evidenceFromDiscovery(noEvidence, "t", leafTrust{}); err == nil || !strings.Contains(err.Error(), "no attestation.evidence") {
+	if _, err := evidenceFromDiscovery(noEvidence, "t", leafTrust{}, nil); err == nil || !strings.Contains(err.Error(), "no attestation.evidence") {
 		t.Errorf("missing evidence should fail, got %v", err)
 	}
 	if err := json.Unmarshal(good, &obj); err != nil {
@@ -41,12 +50,12 @@ func TestEvidenceFromDiscovery_Malformed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := evidenceFromDiscovery(badChallenge, "t", leafTrust{}); err == nil || !strings.Contains(err.Error(), "decode challenge") {
+	if _, err := evidenceFromDiscovery(badChallenge, "t", leafTrust{}, nil); err == nil || !strings.Contains(err.Error(), "decode challenge") {
 		t.Errorf("bad challenge base64 should fail, got %v", err)
 	}
 
 	garbageCert := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("garbage")}))
-	if _, err := evidenceFromDiscovery(discoveryDocWith(t, garbageCert, []byte("c"), `{"attestation_report":"AAAA"}`), "t", leafTrust{}); err == nil || !strings.Contains(err.Error(), "parse cds cert") {
+	if _, err := evidenceFromDiscovery(discoveryDocWith(t, garbageCert, []byte("c"), `{"attestation_report":"AAAA"}`), "t", leafTrust{}, nil); err == nil || !strings.Contains(err.Error(), "parse cds cert") {
 		t.Errorf("unparseable cert DER should fail, got %v", err)
 	}
 }
@@ -64,7 +73,7 @@ func TestEvidenceFromDiscovery_DefaultsPlatformToSNP(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ev, err := evidenceFromDiscovery(data, "t", leafTrust{})
+	ev, err := evidenceFromDiscovery(data, "t", leafTrust{}, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,11 +82,11 @@ func TestEvidenceFromDiscovery_DefaultsPlatformToSNP(t *testing.T) {
 	}
 }
 
-func TestFetchDiscoveryDoc(t *testing.T) {
+func TestGatherFromDiscoveryConnectErrors(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("bad base URL", func(t *testing.T) {
-		if _, _, err := fetchDiscoveryDoc(ctx, "https://\x7f", "", "", time.Second); err == nil {
+		if _, err := gatherFromDiscovery(ctx, "https://\x7f", "", "", time.Second, leafTrust{}); err == nil {
 			t.Error("unparseable base must fail")
 		}
 	})
@@ -86,9 +95,201 @@ func TestFetchDiscoveryDoc(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		base := srv.URL
 		srv.Close()
-		_, _, err := fetchDiscoveryDoc(ctx, base, "", "", time.Second)
+		_, err := gatherFromDiscovery(ctx, base, "", "", time.Second, leafTrust{})
 		if err == nil || !isConnectError(err) {
 			t.Fatalf("expected connectError, got %v", err)
+		}
+	})
+}
+
+// selfSignedServerCert mints a throwaway self-signed certificate and returns
+// its PEM encoding plus a tls.Certificate a test server can present.
+func selfSignedServerCert(t *testing.T) (string, tls.Certificate) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "lb"},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	return certPEM, tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// discoveryServer starts a TLS server presenting serverCert and serving doc,
+// the tls-lb's shape: one pod terminates public TLS and serves the document
+// over the same port.
+func discoveryServer(t *testing.T, serverCert tls.Certificate, doc []byte) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(doc)
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{serverCert}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// The discovery gather probes the live handshake on https targets: the
+// verdict about the front door's serving key keys on what the handshake
+// presented, not on the document's declared public_tls.mode — the lying-host
+// case (claims cds, serves another key) and the honest webpki case both
+// record an unbound door, and only the attested cert on the wire records a
+// bound one.
+func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
+	challenge := []byte("issuance-challenge")
+	stubEvidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+
+	attestedPEM, attestedCert := selfSignedServerCert(t) // the key the document attests
+	_, otherCert := selfSignedServerCert(t)              // a WebPKI stand-in
+	docClaims := func(mode string) []byte {
+		return discoveryDocWithPublicTLS(t, mode, attestedPEM, challenge, stubEvidence)
+	}
+
+	t.Run("handshake presents the attested cert", func(t *testing.T) {
+		srv := discoveryServer(t, attestedCert, docClaims("cds"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorAttested {
+			t.Errorf("frontDoor = %v, want attested", ev.frontDoor)
+		}
+		if !strings.Contains(ev.bindingNote, "live handshake") {
+			t.Errorf("bindingNote = %q, want it to record the observed handshake", ev.bindingNote)
+		}
+	})
+
+	t.Run("lying host: claims cds, serves another cert", func(t *testing.T) {
+		srv := discoveryServer(t, otherCert, docClaims("cds"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorOther {
+			t.Fatalf("frontDoor = %v, want other", ev.frontDoor)
+		}
+		served := sha256.Sum256(otherCert.Certificate[0])
+		if ev.frontDoorCertSHA256 != hex.EncodeToString(served[:]) {
+			t.Errorf("frontDoorCertSHA256 = %q, want the served cert's digest %x", ev.frontDoorCertSHA256, served)
+		}
+		// The verdict is partial, never verified: the door clients reach is
+		// not attestation-bound, however the document declares itself.
+		oc := snpVerifiedOutcome(t, config{}, ev)
+		if oc.Verified || !oc.Partial || verdictExitCode(oc) != exitPartial {
+			t.Errorf("verified=%v partial=%v exit=%d, want a partial verdict", oc.Verified, oc.Partial, verdictExitCode(oc))
+		}
+	})
+
+	t.Run("honest webpki: declared and served unbound", func(t *testing.T) {
+		srv := discoveryServer(t, otherCert, docClaims("webpki"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorOther {
+			t.Errorf("frontDoor = %v, want other", ev.frontDoor)
+		}
+	})
+
+	t.Run("declared webpki but serves the attested cert", func(t *testing.T) {
+		srv := discoveryServer(t, attestedCert, docClaims("webpki"))
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorAttested {
+			t.Errorf("frontDoor = %v, want attested: the observed handshake governs, not the declaration", ev.frontDoor)
+		}
+	})
+
+	t.Run("non-TLS target leaves the door unobserved", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write(docClaims("cds"))
+		}))
+		t.Cleanup(srv.Close)
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorUnobserved {
+			t.Errorf("frontDoor = %v, want unobserved", ev.frontDoor)
+		}
+	})
+
+	t.Run("redirect on the discovery path is a fetch failure", func(t *testing.T) {
+		srv := discoveryServer(t, attestedCert, docClaims("cds"))
+		srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/elsewhere", http.StatusFound)
+		})
+		_, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err == nil || !isConnectError(err) {
+			t.Fatalf("a redirect must fail as a fetch (connect) error, got %v", err)
+		}
+	})
+}
+
+// A discovery document's CA-vouched serving cert (the chart's shape: issued
+// by the CDS mesh CA) is authenticated by the live handshake when it presents
+// byte-identically that cert — the same possession backstop as the RA-TLS
+// path — so a live door needs no --mesh-ca. A door serving a different cert
+// gets no such backstop and fails closed.
+func TestDiscoveryHandshakeAuthenticatesCAVouchedBody(t *testing.T) {
+	challenge := []byte("issuance-challenge")
+	stubEvidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+
+	id := mintEndpointIdentity(t) // CA-signed leaf, the CDS-issued serving cert's shape
+	leafPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: id.leaf.Raw}))
+	leafTLSCert := tls.Certificate{Certificate: [][]byte{id.leaf.Raw}, PrivateKey: id.key}
+	doc := discoveryDocWithPublicTLS(t, "cds", leafPEM, challenge, stubEvidence)
+
+	t.Run("handshake presenting the attested CA-vouched leaf needs no --mesh-ca", func(t *testing.T) {
+		srv := discoveryServer(t, leafTLSCert, doc)
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err != nil {
+			t.Fatalf("a live door presenting the attested leaf must authenticate its body: %v", err)
+		}
+		if ev.frontDoor != frontDoorAttested || !ev.leafKeyProven {
+			t.Errorf("frontDoor = %v leafKeyProven = %v, want attested / proven", ev.frontDoor, ev.leafKeyProven)
+		}
+		if got := describeCertBody(config{}, ev); !strings.Contains(got, "live TLS handshake") {
+			t.Errorf("cert-body note = %q, want the possession branch", got)
+		}
+	})
+
+	t.Run("a pinned mesh CA stays the body authentication on a match", func(t *testing.T) {
+		pool := x509.NewCertPool()
+		pool.AddCert(id.ca)
+		srv := discoveryServer(t, leafTLSCert, doc)
+		ev, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{meshCA: pool})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.frontDoor != frontDoorAttested || !ev.leafChainVerified {
+			t.Errorf("frontDoor = %v leafChainVerified = %v, want attested / chain-verified", ev.frontDoor, ev.leafChainVerified)
+		}
+		if got := describeCertBody(config{}, ev); !strings.Contains(got, "verified issuing chain") {
+			t.Errorf("cert-body note = %q, want the verified-chain branch", got)
+		}
+	})
+
+	t.Run("a door serving another cert gets no possession backstop", func(t *testing.T) {
+		_, otherCert := selfSignedServerCert(t)
+		srv := discoveryServer(t, otherCert, doc)
+		_, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
+		if err == nil || !isSecurityError(err) {
+			t.Fatalf("an unauthenticated CA-vouched body must fail closed, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "--mesh-ca") {
+			t.Errorf("error = %q, want it to name the flag that fixes it", err)
 		}
 	})
 }

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -124,9 +124,7 @@ func selfSignedServerCert(t *testing.T) (string, tls.Certificate) {
 	return certPEM, tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
 }
 
-// discoveryServer starts a TLS server presenting serverCert and serving doc,
-// the tls-lb's shape: one pod terminates public TLS and serves the document
-// over the same port.
+// discoveryServer starts a TLS server presenting serverCert and serving doc.
 func discoveryServer(t *testing.T, serverCert tls.Certificate, doc []byte) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -289,5 +289,13 @@ func TestDiscoveryHandshakeAuthenticatesCAVouchedBody(t *testing.T) {
 		if !strings.Contains(err.Error(), "--mesh-ca") {
 			t.Errorf("error = %q, want it to name the flag that fixes it", err)
 		}
+		// The door lie is the actionable signal: the served-vs-attested
+		// digests must reach the operator, not be buried by the body failure.
+		served := sha256.Sum256(otherCert.Certificate[0])
+		attested := sha256.Sum256(id.leaf.Raw)
+		if !strings.Contains(err.Error(), hex.EncodeToString(served[:])) ||
+			!strings.Contains(err.Error(), hex.EncodeToString(attested[:])) {
+			t.Errorf("error = %q, want it to name the served and attested serving-cert digests", err)
+		}
 	})
 }

--- a/internal/cmds/verify/discovery_test.go
+++ b/internal/cmds/verify/discovery_test.go
@@ -109,6 +109,42 @@ func TestGatherFromDiscoveryConnectErrors(t *testing.T) {
 	})
 }
 
+// A host that accepts TCP and then stalls must not hang the gather: the
+// dial timeout bounds connect + TLS handshake as a whole (tls.Dialer applies
+// the NetDialer timeout to HandshakeContext), and the gather ctx carries no
+// deadline of its own. The select — not a sleep — is what fails if the knob
+// goes missing.
+func TestGatherFromDiscoveryBoundsStallingHost(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			defer conn.Close() // accept and hold: never speak TLS
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := gatherFromDiscovery(context.Background(), "https://"+ln.Addr().String(), "", "", 300*time.Millisecond, leafTrust{})
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err == nil || !isConnectError(err) {
+			t.Fatalf("a stalled handshake must surface as a connectError, got %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the gather hung on a stalling host: the dial timeout must bound connect + handshake")
+	}
+}
+
 // selfSignedServerCert mints a throwaway self-signed certificate and returns
 // its PEM encoding plus a tls.Certificate a test server can present.
 func selfSignedServerCert(t *testing.T) (string, tls.Certificate) {
@@ -273,13 +309,19 @@ func TestGatherFromDiscoveryProbesFrontDoor(t *testing.T) {
 	})
 
 	t.Run("redirect on the discovery path is a fetch failure", func(t *testing.T) {
+		// The redirect target answers 200, so only the no-redirect guard
+		// stands between the fetch and a followed redirect.
+		target := discoveryServer(t, attestedCert, docClaims("cds"))
 		srv := discoveryServer(t, attestedCert, docClaims("cds"))
 		srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			http.Redirect(w, r, "/elsewhere", http.StatusFound)
+			http.Redirect(w, r, target.URL+defaultDiscoveryPath, http.StatusFound)
 		})
 		_, err := gatherFromDiscovery(context.Background(), srv.URL, "", "", 5*time.Second, leafTrust{})
 		if err == nil || !isConnectError(err) {
 			t.Fatalf("a redirect must fail as a fetch (connect) error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "302") {
+			t.Errorf("error = %q, want it to name the 302: the redirect is refused, not followed", err)
 		}
 	})
 }

--- a/internal/cmds/verify/evidence.go
+++ b/internal/cmds/verify/evidence.go
@@ -84,11 +84,12 @@ type evidence struct {
 	// hardware evidence, but the anchor is responder-chosen: it is not a
 	// pinned trust anchor and the verdict must never treat it as one.
 	leafChainDerived bool
-	// publicTLSMode is the discovery document's declared front-door TLS mode
-	// ("" when not discovery-sourced): "cds" serves the attestation-bound
-	// CDS leaf, "webpki" an operator WebPKI certificate the evidence says
-	// nothing about.
-	publicTLSMode string
+	// frontDoor is what a discovery gather's live TLS handshake showed about
+	// the front door's serving key (frontDoorNone when not discovery-sourced).
+	frontDoor frontDoorObservation
+	// frontDoorCertSHA256 is the hex SHA-256 of the leaf the live handshake
+	// presented ("" when no handshake was observed).
+	frontDoorCertSHA256 string
 	// leafKeyProven is true when a live TLS handshake with the leaf completed,
 	// which proves the presenter holds the attested private key. A forged body
 	// carrying someone else's attested SubjectPublicKeyInfo cannot complete

--- a/internal/cmds/verify/evidence.go
+++ b/internal/cmds/verify/evidence.go
@@ -150,8 +150,9 @@ type leafTrust struct {
 	keyProven bool
 	// meshCA is the operator's --mesh-ca anchor (nil when unset). It is the
 	// only thing that can authenticate a CA-vouched body on a source with no
-	// proof of possession — a saved file, or a discovery document served
-	// unauthenticated over a connection nothing binds it to.
+	// proof of possession — a saved file, or a discovery document whose gather
+	// made no usable handshake observation (non-TLS target, or a leaf the
+	// document does not attest).
 	meshCA *x509.CertPool
 }
 

--- a/internal/cmds/verify/evidence.go
+++ b/internal/cmds/verify/evidence.go
@@ -268,6 +268,7 @@ func evidenceFromCert(cert *x509.Certificate, source string, trust leafTrust) (*
 		leafBody:          body,
 		leafChainVerified: chainVerified,
 		leafKeyProven:     trust.keyProven,
+		frontDoor:         frontDoorNone,
 		sandboxID:         sandboxID,
 		sandboxErr:        sandboxErr,
 		workload:          workload,
@@ -399,6 +400,7 @@ func evidenceFromEndpointJSON(data, expectNonce []byte, source string) (*evidenc
 		bindingNote:      "REPORTDATA binds the identity transcript: session keys + nonce + the exact mesh leaf and its transcript-committed issuing CA (leaf proof of possession verified)",
 		leaf:             leaf,
 		leafChainDerived: true,
+		frontDoor:        frontDoorNone,
 		sandboxID:        sandboxID,
 		sandboxErr:       sandboxErr,
 		workload:         workload,
@@ -553,6 +555,7 @@ func evidenceFromBareJSON(data []byte, erd []byte, source string) (*evidence, er
 		fresh:       false,
 		source:      source,
 		bindingNote: "REPORTDATA supplied via --expected-report-data (not independently bound)",
+		frontDoor:   frontDoorNone,
 	}, nil
 }
 

--- a/internal/cmds/verify/initdata_test.go
+++ b/internal/cmds/verify/initdata_test.go
@@ -178,13 +178,13 @@ func TestVerifyEvidence_InitDataNoteAbsentOnFailedVerdict(t *testing.T) {
 }
 
 // A PARTIAL verdict is not a failure: the init-data pin was verified, and the
-// verdict is partial for an unrelated property (here a WebPKI front door). The
-// note is honest, so it rides — in text and JSON alike, the same surfaces that
-// must agree to hide it on a hard failure.
+// verdict is partial for an unrelated property (here an unattested front
+// door). The note is honest, so it rides — in text and JSON alike, the same
+// surfaces that must agree to hide it on a hard failure.
 func TestVerifyEvidence_InitDataNoteRidesPartialVerdict(t *testing.T) {
 	makeEv := func(t *testing.T) *evidence {
 		ev := genoaFileEvidence(t)
-		ev.publicTLSMode = "webpki"
+		ev.frontDoor = frontDoorOther
 		return ev
 	}
 

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -138,13 +138,111 @@ func TestWebPKIFrontDoorIsPartialNotVerified(t *testing.T) {
 		t.Errorf("json not_proven = %v", parsed["not_proven"])
 	}
 
-	// A verification failure dominates the mode: exit 2, not partial.
+	// A verification failure dominates the mode: exit 2, not partial — and
+	// the door lie rides the failure instead of being buried by it.
 	verr := &securityError{err: errors.New("rejected")}
 	failed := newOutcome(config{}, ev, nil, verr, mustPlan(t, config{measurements: []string{"ab" + strings.Repeat("00", 47)}}))
 	applyVerdictPolicies(&failed, config{}, ev, nil, operatorKeysReport{})
 	if failed.Partial || verdictExitCode(failed) != exitFailed {
 		t.Errorf("failed evidence + webpki: partial=%v exit=%d, want a plain failure", failed.Partial, verdictExitCode(failed))
 	}
+	if !strings.Contains(failed.Error, ev.frontDoorCertSHA256) || !strings.Contains(failed.Error, ev.certSHA256) {
+		t.Errorf("Error = %q, want it to name the observed and attested serving keys even on a failure", failed.Error)
+	}
+}
+
+// The front-door metadata must never float over the verdict field in JSON:
+// a FAILED verdict carries no attested-door basis clause and no scope caveat
+// (a refusal has no basis to state), a VERIFIED one carries both, and a lying
+// door's digests surface on a failure exactly as on a partial.
+func TestFrontDoorVerdictJSONHonesty(t *testing.T) {
+	mk := func(frontDoor frontDoorObservation) *evidence {
+		return &evidence{
+			platform:            "snp",
+			source:              "discovery document https://lb.example.com/v1/discovery",
+			bindingNote:         "REPORTDATA binds the CDS cert key + issuance challenge",
+			certSHA256:          strings.Repeat("aa", 32),
+			frontDoor:           frontDoor,
+			frontDoorCertSHA256: strings.Repeat("bb", 32),
+		}
+	}
+	failedOutcome := func(ev *evidence) Outcome {
+		verr := &securityError{err: errors.New("rejected")}
+		oc := newOutcome(config{}, ev, nil, verr, mustPlan(t, config{measurements: []string{"ab" + strings.Repeat("00", 47)}}))
+		applyVerdictPolicies(&oc, config{}, ev, nil, operatorKeysReport{})
+		return oc
+	}
+	renderJSON := func(oc Outcome) map[string]any {
+		t.Helper()
+		var jout bytes.Buffer
+		render(config{output: "json"}, oc, &jout)
+		var parsed map[string]any
+		if err := json.Unmarshal(jout.Bytes(), &parsed); err != nil {
+			t.Fatalf("json render: %v", err)
+		}
+		return parsed
+	}
+
+	t.Run("verified + attested door: basis clause and scope caveat ride the tick", func(t *testing.T) {
+		oc := snpVerifiedOutcome(t, config{}, mk(frontDoorAttested))
+		if !oc.Verified {
+			t.Fatalf("verified=%v error=%q, want a verified verdict", oc.Verified, oc.Error)
+		}
+		parsed := renderJSON(oc)
+		if b, _ := parsed["binding"].(string); !strings.Contains(b, "live handshake presented the attested serving certificate") {
+			t.Errorf("json binding = %q, want the handshake basis clause", b)
+		}
+		w, _ := parsed["warnings"].([]any)
+		if len(w) != 1 || !strings.Contains(w[0].(string), "single connection") {
+			t.Errorf("json warnings = %v, want the one-connection scope caveat", parsed["warnings"])
+		}
+		var out bytes.Buffer
+		renderText(config{}, oc, &out)
+		if !strings.Contains(out.String(), "WARNING:") || !strings.Contains(out.String(), "single connection") {
+			t.Errorf("text render missing the scope WARNING:\n%s", out.String())
+		}
+	})
+
+	t.Run("failed + attested door: no basis clause, no caveat", func(t *testing.T) {
+		oc := failedOutcome(mk(frontDoorAttested))
+		if oc.Verified || oc.Error == "" {
+			t.Fatalf("verified=%v error=%q, want a failure", oc.Verified, oc.Error)
+		}
+		if strings.Contains(oc.Binding, "live handshake") || len(oc.Warnings) != 0 {
+			t.Errorf("binding = %q warnings = %v: a refusal must not carry the attested-door basis or scope caveat", oc.Binding, oc.Warnings)
+		}
+		parsed := renderJSON(oc)
+		if parsed["verified"] != false {
+			t.Errorf("json verified = %v, want false", parsed["verified"])
+		}
+		if b, _ := parsed["binding"].(string); strings.Contains(b, "live handshake") {
+			t.Errorf("json binding = %q rides verified:false — the basis clause must not", b)
+		}
+		if _, ok := parsed["warnings"]; ok {
+			t.Errorf("json warnings = %v on a failed verdict, want the key omitted", parsed["warnings"])
+		}
+	})
+
+	t.Run("failed + lying door: the digests ride the failure", func(t *testing.T) {
+		ev := mk(frontDoorOther)
+		oc := failedOutcome(ev)
+		if oc.Partial || verdictExitCode(oc) != exitFailed {
+			t.Fatalf("partial=%v exit=%d, want a plain failure", oc.Partial, verdictExitCode(oc))
+		}
+		if !strings.Contains(oc.Error, ev.frontDoorCertSHA256) || !strings.Contains(oc.Error, ev.certSHA256) ||
+			!strings.Contains(oc.Error, "not attestation-bound") {
+			t.Errorf("Error = %q, want both serving-key digests on the failure", oc.Error)
+		}
+		var out bytes.Buffer
+		renderText(config{}, oc, &out)
+		if !strings.Contains(out.String(), ev.frontDoorCertSHA256) {
+			t.Errorf("text render buries the lying door digest:\n%s", out.String())
+		}
+		parsed := renderJSON(oc)
+		if e, _ := parsed["error"].(string); !strings.Contains(e, ev.frontDoorCertSHA256) || !strings.Contains(e, ev.certSHA256) {
+			t.Errorf("json error = %q, want both serving-key digests", e)
+		}
+	})
 }
 
 // genoaFileEvidence parses the vendored Genoa fixture (VCEK inline, verifies
@@ -202,6 +300,9 @@ func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 		}
 		if !strings.Contains(out.String(), "✓ VERIFIED") {
 			t.Errorf("output:\n%s", out.String())
+		}
+		if !strings.Contains(out.String(), "WARNING:") || !strings.Contains(out.String(), "single connection") {
+			t.Errorf("an attested door's tick must carry the one-connection scope caveat:\n%s", out.String())
 		}
 	})
 

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -36,26 +36,27 @@ func discoveryDocWithPublicTLS(t *testing.T, mode, certPEM string, challenge []b
 	return data
 }
 
-// The discovery gather must read public_tls.mode: cds (and its pre-mode-field
-// empty spelling) and webpki are recorded for the verdict; anything else
-// fails closed as a security verdict — auto mode must not fall through past a
-// document it cannot classify.
+// The discovery gather must classify public_tls.mode: cds (and its
+// pre-mode-field empty spelling) and webpki parse; anything else fails closed
+// as a security verdict — auto mode must not fall through past a document it
+// cannot classify. The declared mode is not recorded: the verdict keys on the
+// live handshake observation, which a parsed-but-unprobed document lacks.
 func TestDiscoveryPublicTLSModeParsing(t *testing.T) {
 	certPEM, _ := selfSignedCertPEM(t)
 	challenge := []byte("issuance-challenge")
 	evidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
 
 	for _, mode := range []string{"", "cds", "webpki"} {
-		ev, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, mode, certPEM, challenge, evidence), "test", leafTrust{})
+		ev, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, mode, certPEM, challenge, evidence), "test", leafTrust{}, nil)
 		if err != nil {
 			t.Fatalf("mode %q: %v", mode, err)
 		}
-		if ev.publicTLSMode != mode {
-			t.Errorf("mode %q: publicTLSMode = %q", mode, ev.publicTLSMode)
+		if ev.frontDoor != frontDoorUnobserved {
+			t.Errorf("mode %q: frontDoor = %v, want unobserved (no handshake was made)", mode, ev.frontDoor)
 		}
 	}
 
-	_, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, "dns", certPEM, challenge, evidence), "test", leafTrust{})
+	_, err := evidenceFromDiscovery(discoveryDocWithPublicTLS(t, "dns", certPEM, challenge, evidence), "test", leafTrust{}, nil)
 	if err == nil || !isSecurityError(err) {
 		t.Fatalf("an unknown public_tls.mode must fail closed as a security verdict, got %v", err)
 	}
@@ -83,38 +84,42 @@ func snpVerifiedOutcome(t *testing.T, cfg config, ev *evidence) Outcome {
 	return oc
 }
 
-// A WebPKI front door terminates public TLS on a certificate the evidence
-// says nothing about: the evidence verifies, but the verdict is partial —
-// never "✓ VERIFIED" — and the exit code tells scripts so.
+// A front door whose live handshake presents a serving key the evidence does
+// not attest (a WebPKI door, whatever the document declares): the evidence
+// verifies, but the verdict is partial — never "✓ VERIFIED" — and the exit
+// code tells scripts so.
 func TestWebPKIFrontDoorIsPartialNotVerified(t *testing.T) {
 	ev := &evidence{
-		platform:      "snp",
-		source:        "discovery document https://lb.example.com/v1/discovery",
-		bindingNote:   "REPORTDATA binds the CDS cert key + issuance challenge",
-		publicTLSMode: "webpki",
+		platform:            "snp",
+		source:              "discovery document https://lb.example.com/v1/discovery",
+		bindingNote:         "REPORTDATA binds the CDS cert key + issuance challenge",
+		certSHA256:          strings.Repeat("aa", 32),
+		frontDoor:           frontDoorOther,
+		frontDoorCertSHA256: strings.Repeat("bb", 32),
 	}
 	oc := snpVerifiedOutcome(t, config{}, ev)
 	if oc.Verified || !oc.Partial {
-		t.Fatalf("webpki front door: verified=%v partial=%v, want a partial verdict", oc.Verified, oc.Partial)
+		t.Fatalf("unbound front door: verified=%v partial=%v, want a partial verdict", oc.Verified, oc.Partial)
 	}
 	if got := verdictExitCode(oc); got != exitPartial {
 		t.Errorf("exit = %d, want %d", got, exitPartial)
 	}
-	if len(oc.NotProven) != 1 || !strings.Contains(oc.NotProven[0], "public_tls.mode=webpki") ||
+	if len(oc.NotProven) != 1 || !strings.Contains(oc.NotProven[0], "live TLS handshake") ||
+		!strings.Contains(oc.NotProven[0], ev.frontDoorCertSHA256) || !strings.Contains(oc.NotProven[0], ev.certSHA256) ||
 		!strings.Contains(oc.NotProven[0], "not attestation-bound") {
-		t.Errorf("NotProven = %v, want it to name the WebPKI serving key", oc.NotProven)
+		t.Errorf("NotProven = %v, want it to name the observed and attested serving keys", oc.NotProven)
 	}
 
 	var out bytes.Buffer
 	renderText(config{}, oc, &out)
 	got := out.String()
-	for _, want := range []string{"~ PARTIALLY VERIFIED", "not proven:", "public_tls.mode=webpki", "measurement:", "binding:"} {
+	for _, want := range []string{"~ PARTIALLY VERIFIED", "not proven:", "not attestation-bound", "measurement:", "binding:"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("partial render missing %q:\n%s", want, got)
 		}
 	}
 	if strings.Contains(got, "✓ VERIFIED") {
-		t.Errorf("a WebPKI front door must never print ✓:\n%s", got)
+		t.Errorf("an unattested front door must never print ✓:\n%s", got)
 	}
 
 	// JSON carries the same honesty: verified stays false (CI fails closed),
@@ -156,15 +161,16 @@ func genoaFileEvidence(t *testing.T) *evidence {
 	return ev
 }
 
-// The full verify path on real offline-verifiable evidence: a WebPKI-mode
-// discovery verdict exits 4, and the same evidence with an attestation-bound
-// front door still exits 0 — the regression pair.
-func TestVerifyEvidenceWebPKIExitCodes(t *testing.T) {
+// The full verify path on real offline-verifiable evidence: a discovery
+// verdict whose live handshake presented an unattested serving key (or could
+// not observe one) exits 4, and the same evidence with the attestation-bound
+// front door observed — or no front-door property at all — still exits 0.
+func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 	plan := &verifyPlan{policy: &ratls.VerifyPolicy{}}
 
-	t.Run("webpki front door exits partial", func(t *testing.T) {
+	t.Run("unbound front door exits partial", func(t *testing.T) {
 		ev := genoaFileEvidence(t)
-		ev.publicTLSMode = "webpki" // as a discovery gather would record it
+		ev.frontDoor = frontDoorOther // as a discovery gather would record it
 		var out, errOut bytes.Buffer
 		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
 		if code != exitPartial {
@@ -175,18 +181,19 @@ func TestVerifyEvidenceWebPKIExitCodes(t *testing.T) {
 		}
 	})
 
-	t.Run("pre-mode discovery document still verifies", func(t *testing.T) {
-		ev := genoaFileEvidence(t) // publicTLSMode "" — a pre-mode-field document
+	t.Run("unobserved front door exits partial", func(t *testing.T) {
+		ev := genoaFileEvidence(t)
+		ev.frontDoor = frontDoorUnobserved // discovery doc fetched over a non-TLS connection
 		var out, errOut bytes.Buffer
 		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
-		if code != exitVerified {
-			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
+		if code != exitPartial {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitPartial, out.String(), errOut.String())
 		}
 	})
 
-	t.Run("attestation-bound front door still verifies", func(t *testing.T) {
+	t.Run("attested front door still verifies", func(t *testing.T) {
 		ev := genoaFileEvidence(t)
-		ev.publicTLSMode = "cds"
+		ev.frontDoor = frontDoorAttested
 		var out, errOut bytes.Buffer
 		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
 		if code != exitVerified {
@@ -194,6 +201,15 @@ func TestVerifyEvidenceWebPKIExitCodes(t *testing.T) {
 		}
 		if !strings.Contains(out.String(), "✓ VERIFIED") {
 			t.Errorf("output:\n%s", out.String())
+		}
+	})
+
+	t.Run("no front-door property still verifies", func(t *testing.T) {
+		ev := genoaFileEvidence(t) // frontDoorNone — not discovery-sourced
+		var out, errOut bytes.Buffer
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		if code != exitVerified {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
 		}
 	})
 }

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -39,8 +39,9 @@ func discoveryDocWithPublicTLS(t *testing.T, mode, certPEM string, challenge []b
 // The discovery gather must classify public_tls.mode: cds (and its
 // pre-mode-field empty spelling) and webpki parse; anything else fails closed
 // as a security verdict — auto mode must not fall through past a document it
-// cannot classify. The declared mode is not recorded: the verdict keys on the
-// live handshake observation, which a parsed-but-unprobed document lacks.
+// cannot classify. A parsed mode gates classification only — the verdict keys
+// on the live handshake observation, which a parsed-but-unprobed document
+// lacks.
 func TestDiscoveryPublicTLSModeParsing(t *testing.T) {
 	certPEM, _ := selfSignedCertPEM(t)
 	challenge := []byte("issuance-challenge")
@@ -340,8 +341,9 @@ func TestEndpointEvidenceMarksChainDerived(t *testing.T) {
 	}
 }
 
-// run() over a served discovery document: WebPKI mode with evidence that
-// itself fails verification is a failure (exit 2), not a partial — the mode
+// run() over a served discovery document: an unattested front door (the
+// helper serves plain HTTP, so no handshake is observed) with evidence that
+// itself fails verification is a failure (exit 2), not a partial — the
 // demotion only ever applies to a passing verdict. An unknown mode is a
 // security verdict, and auto mode must not fall through past it.
 func TestRunDiscoveryPublicTLSModeVerdicts(t *testing.T) {
@@ -358,7 +360,7 @@ func TestRunDiscoveryPublicTLSModeVerdicts(t *testing.T) {
 		return srv.URL
 	}
 
-	t.Run("webpki + failing evidence is a failure, not partial", func(t *testing.T) {
+	t.Run("unattested door + failing evidence is a failure, not partial", func(t *testing.T) {
 		url := serve(t, discoveryDocWithPublicTLS(t, "webpki", certPEM, challenge, stubEvidence))
 		var out, errOut bytes.Buffer
 		code := run(context.Background(), config{url: url, kind: "lb", output: "text"}, &out, &errOut)

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -3,7 +3,9 @@ package verify
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -440,6 +442,49 @@ func TestEndpointEvidenceMarksChainDerived(t *testing.T) {
 			t.Errorf("%s: a responder-chosen anchor is not a verified chain", tc.name)
 		}
 	}
+}
+
+// run() over a lying HTTPS server, end to end — the production shape: TLS
+// dial, same-connection fetch, evidence, verdict. The document claims cds
+// while the door serves another cert; the (stub) evidence then fails
+// verification, so the verdict is a failure — and the door lie's digests
+// ride it rather than being buried. A refused dial is exit 3.
+func TestRunDiscoveryOverLyingHTTPS(t *testing.T) {
+	challenge := []byte("issuance-challenge")
+	stubEvidence := `{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`
+	attestedPEM, attestedCert := selfSignedServerCert(t)
+	_, otherCert := selfSignedServerCert(t)
+	doc := discoveryDocWithPublicTLS(t, "cds", attestedPEM, challenge, stubEvidence)
+
+	t.Run("lying https door + failing evidence is a named failure", func(t *testing.T) {
+		srv := discoveryServer(t, otherCert, doc)
+		var out, errOut bytes.Buffer
+		code := run(context.Background(), config{url: srv.URL, kind: "lb", output: "text"}, &out, &errOut)
+		if code != exitFailed {
+			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitFailed, out.String(), errOut.String())
+		}
+		served := sha256.Sum256(otherCert.Certificate[0])
+		attested := sha256.Sum256(attestedCert.Certificate[0])
+		for _, d := range []string{hex.EncodeToString(served[:]), hex.EncodeToString(attested[:])} {
+			if !strings.Contains(out.String(), d) {
+				t.Errorf("the failure must name the door digest %s:\n%s", d, out.String())
+			}
+		}
+		if strings.Contains(out.String(), "PARTIALLY") || strings.Contains(out.String(), "✓") {
+			t.Errorf("a failure must not read as partial or verified:\n%s", out.String())
+		}
+	})
+
+	t.Run("unreachable https target exits 3", func(t *testing.T) {
+		srv := discoveryServer(t, otherCert, doc)
+		url := srv.URL
+		srv.Close()
+		var out, errOut bytes.Buffer
+		code := run(context.Background(), config{url: url, kind: "lb", output: "text"}, &out, &errOut)
+		if code != exitNoEvidence {
+			t.Errorf("exit = %d, want %d; output:\n%s%s", code, exitNoEvidence, out.String(), errOut.String())
+		}
+	})
 }
 
 // run() over a served discovery document: an unattested front door (the

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -175,8 +175,9 @@ Evidence sources:
 
 Exit codes: 0 verified · 1 usage · 2 verification/policy failed · 3 evidence
 unavailable (unreachable / unparseable) · 4 partially verified (the evidence
-verified, but a property it presents is not proven — a WebPKI front door whose
-serving key is not attestation-bound, or a chain anchor the responder chose).`,
+verified, but a property it presents is not proven — the front door's live
+handshake presented a serving key the evidence does not attest, or a chain
+anchor the responder chose).`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -394,15 +395,20 @@ func demoteToPartial(oc *Outcome, notProven string) {
 	oc.NotProven = append(oc.NotProven, notProven)
 }
 
-// applyFrontDoorPolicy enforces the discovery document's public_tls.mode: a
-// WebPKI front door terminates public TLS on an operator certificate, so the
-// serving key clients reach is not the attestation-bound CDS key the evidence
-// speaks for.
+// applyFrontDoorPolicy settles what the verdict may claim about the front
+// door's serving key, keying on the live handshake the discovery gather
+// observed. A door presenting the attestation-bound certificate leaves the
+// verdict standing; any other serving key, or no TLS observation at all,
+// leaves the endpoint clients reach unproven.
 func applyFrontDoorPolicy(oc *Outcome, ev *evidence) {
-	if ev.publicTLSMode != "webpki" {
-		return
+	switch ev.frontDoor {
+	case frontDoorOther:
+		demoteToPartial(oc, fmt.Sprintf(
+			"the front door's live TLS handshake presented serving certificate sha256 %s, not the sha256 %s this evidence attests — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not attestation-bound",
+			ev.frontDoorCertSHA256, ev.certSHA256))
+	case frontDoorUnobserved:
+		demoteToPartial(oc, "the front door's serving key: the target connection was not TLS, so no live handshake showed what the door serves, and the discovery document's declared public_tls.mode is a host-served claim nothing authenticates — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not")
 	}
-	demoteToPartial(oc, "the front-door serving key is not attestation-bound: public_tls.mode=webpki terminates public TLS on an operator WebPKI certificate, not the CDS-issued key this evidence attests — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not")
 }
 
 // applyChainAnchorPolicy settles what the verdict may claim about an
@@ -1460,7 +1466,7 @@ func describeCertBody(_ config, ev *evidence) string {
 	case ev.leafChainDerived:
 		return "CA-signed: body committed into the identity transcript — the hardware evidence binds these exact bytes" + skew + certutil.LeafValiditySkew.String() + ")"
 	case ev.leafKeyProven:
-		return "CA-signed: body not chain-checked, but the live RA-TLS handshake proves the peer holds the attested key, so this body could not have been minted around it — pass --mesh-ca to also check the issuing chain"
+		return "CA-signed: body not chain-checked, but the live TLS handshake proves the peer holds the attested key, so this body could not have been minted around it — pass --mesh-ca to also check the issuing chain"
 	default:
 		return "CA-signed: body fields are CA-vouched and UNAUTHENTICATED — pass --mesh-ca to check the chain"
 	}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -176,8 +176,9 @@ Evidence sources:
 Exit codes: 0 verified · 1 usage · 2 verification/policy failed · 3 evidence
 unavailable (unreachable / unparseable) · 4 partially verified (the evidence
 verified, but a property it presents is not proven — the front door's live
-handshake presented a serving key the evidence does not attest, or a chain
-anchor the responder chose).`,
+handshake presented a serving key the evidence does not attest, no handshake
+could be observed (a non-TLS discovery target), or a chain anchor the
+responder chose).`,
 		Args:          cobra.MaximumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -396,17 +396,38 @@ func demoteToPartial(oc *Outcome, notProven string) {
 	oc.NotProven = append(oc.NotProven, notProven)
 }
 
+// frontDoorAttestedNote states a verified discovery verdict's basis: the
+// live handshake presented the attested serving certificate. It is appended
+// only to a passing verdict — on a refusal the gather-time fact must not
+// read as the verdict's basis.
+const frontDoorAttestedNote = "; the live handshake presented the attested serving certificate"
+
+// frontDoorScopeWarning bounds an attested front door to the observation made.
+const frontDoorScopeWarning = "the attested front door was observed on this verify's single connection to a single tls-lb replica at a single instant: serving certificates are per-replica, and a later or differently-routed client connection (TOCTOU, source-IP routing) can reach a different door — clients must verify their own connection (see internal/lbdiscovery)"
+
 // applyFrontDoorPolicy settles what the verdict may claim about the front
 // door's serving key, keying on the live handshake the discovery gather
 // observed. A door presenting the attestation-bound certificate leaves the
-// verdict standing; any other serving key, or no TLS observation at all,
-// leaves the endpoint clients reach unproven.
+// verdict standing, scoped to the one observation made; any other serving
+// key, or no TLS observation at all, leaves the endpoint clients reach
+// unproven. A lying door is named on every verdict shape — partial or failed —
+// so a dominating verification failure never buries the signal.
 func applyFrontDoorPolicy(oc *Outcome, ev *evidence) {
 	switch ev.frontDoor {
+	case frontDoorAttested:
+		if oc.Verified {
+			oc.Binding += frontDoorAttestedNote
+			oc.Warnings = append(oc.Warnings, frontDoorScopeWarning)
+		}
 	case frontDoorOther:
-		demoteToPartial(oc, fmt.Sprintf(
-			"the front door's live TLS handshake presented serving certificate sha256 %s, not the sha256 %s this evidence attests — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not attestation-bound",
-			ev.frontDoorCertSHA256, ev.certSHA256))
+		digests := fmt.Sprintf(
+			"the front door's live TLS handshake presented serving certificate sha256 %s, not the sha256 %s this evidence attests",
+			ev.frontDoorCertSHA256, ev.certSHA256)
+		if !oc.Verified {
+			oc.Error += "; " + digests + " — the TLS endpoint clients reach is not attestation-bound"
+			return
+		}
+		demoteToPartial(oc, digests+" — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not attestation-bound")
 	case frontDoorUnobserved:
 		demoteToPartial(oc, "the front door's serving key: the target connection was not TLS, so no live handshake showed what the door serves, and the discovery document's declared public_tls.mode is a host-served claim nothing authenticates — the tls-lb pod's TEE residency and measurement are proven; the TLS endpoint clients reach is not")
 	}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -1054,10 +1054,12 @@ type Outcome struct {
 	Warnings []string `json:"warnings,omitempty"`
 
 	// Partial is true when the hardware evidence verified but a property the
-	// evidence presents is not proven (a WebPKI front door's serving key, a
-	// responder-chosen chain anchor). Verified stays false, so a CI gate
-	// checking verified==true fails closed; the exit code distinguishes the
-	// case (4) from a failure (2). NotProven names each unproven property.
+	// evidence presents is not proven (a front door whose live handshake
+	// presented a serving key the evidence does not attest — or offered no
+	// handshake to observe —, a responder-chosen chain anchor). Verified
+	// stays false, so a CI gate checking verified==true fails closed; the
+	// exit code distinguishes the case (4) from a failure (2). NotProven
+	// names each unproven property.
 	Partial   bool     `json:"partial,omitempty"`
 	NotProven []string `json:"not_proven,omitempty"`
 
@@ -1069,12 +1071,13 @@ type Outcome struct {
 
 	// CertBody says what authenticates the leaf certificate's body fields
 	// (subject/serial/validity): the leaf's own attested key when
-	// self-signed, a verified issuing chain, possession of the attested key on
-	// a live RA-TLS dial, or — on attest-pq — the identity transcript the
-	// hardware evidence binds (whose chain anchor is responder-chosen; see
-	// ChainAnchor). A leaf with none of these is not accepted as evidence at
-	// all (authorizeLeafBody), because checking a validity window inside an
-	// unsigned body bounds nothing.
+	// self-signed, a verified issuing chain, possession of the attested key
+	// proven by a live TLS handshake (the RA-TLS dial, or the discovery
+	// gather's front-door probe), or — on attest-pq — the identity
+	// transcript the hardware evidence binds (whose chain anchor is
+	// responder-chosen; see ChainAnchor). A leaf with none of these is not
+	// accepted as evidence at all (authorizeLeafBody), because checking a
+	// validity window inside an unsigned body bounds nothing.
 	CertBody string `json:"cert_body,omitempty"`
 
 	// OperatorKeys are hex SHA-256 fingerprints (of the PKIX/SPKI DER) of the

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -82,7 +82,7 @@ func TestEvidenceFromDiscovery(t *testing.T) {
 	}
 
 	t.Run("forwards platform + evidence verbatim and binds cert key + challenge", func(t *testing.T) {
-		ev, err := evidenceFromDiscovery(buildDoc("snp", certPEM), "test", leafTrust{})
+		ev, err := evidenceFromDiscovery(buildDoc("snp", certPEM), "test", leafTrust{}, nil)
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}
@@ -109,7 +109,7 @@ func TestEvidenceFromDiscovery(t *testing.T) {
 	})
 
 	t.Run("forwards a non-snp platform (e.g. tdx) rather than rejecting it", func(t *testing.T) {
-		ev, err := evidenceFromDiscovery(buildDoc("tdx", certPEM), "test", leafTrust{})
+		ev, err := evidenceFromDiscovery(buildDoc("tdx", certPEM), "test", leafTrust{}, nil)
 		if err != nil {
 			t.Fatalf("unexpected: %v", err)
 		}
@@ -119,7 +119,7 @@ func TestEvidenceFromDiscovery(t *testing.T) {
 	})
 
 	t.Run("rejects missing certificate", func(t *testing.T) {
-		if _, err := evidenceFromDiscovery(buildDoc("snp", ""), "test", leafTrust{}); err == nil {
+		if _, err := evidenceFromDiscovery(buildDoc("snp", ""), "test", leafTrust{}, nil); err == nil {
 			t.Fatal("expected error when certificate_pem is absent")
 		}
 	})

--- a/internal/cmds/verify/verify_test.go
+++ b/internal/cmds/verify/verify_test.go
@@ -35,17 +35,20 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// selfSignedCertPEM returns a throwaway ECDSA P-256 certificate (PEM) and its
-// public key, for testing REPORTDATA-binding math without real SNP crypto.
-func selfSignedCertPEM(t *testing.T) (string, *ecdsa.PublicKey) {
+// mintSelfSigned creates a throwaway self-signed P-256 certificate (cn,
+// serial) around key — minting a fresh key when nil — and returns the key and
+// the certificate DER.
+func mintSelfSigned(t *testing.T, cn string, serial int64, key *ecdsa.PrivateKey) (*ecdsa.PrivateKey, []byte) {
 	t.Helper()
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
+	if key == nil {
+		var err error
+		if key, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader); err != nil {
+			t.Fatal(err)
+		}
 	}
 	tmpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "cds"},
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: cn},
 		NotBefore:    time.Unix(0, 0),
 		NotAfter:     time.Unix(1<<31-1, 0),
 	}
@@ -53,6 +56,14 @@ func selfSignedCertPEM(t *testing.T) (string, *ecdsa.PublicKey) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return key, der
+}
+
+// selfSignedCertPEM returns a throwaway ECDSA P-256 certificate (PEM) and its
+// public key, for testing REPORTDATA-binding math without real SNP crypto.
+func selfSignedCertPEM(t *testing.T) (string, *ecdsa.PublicKey) {
+	t.Helper()
+	key, der := mintSelfSigned(t, "cds", 1, nil)
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})), &key.PublicKey
 }
 

--- a/internal/lbdiscovery/lbdiscovery.go
+++ b/internal/lbdiscovery/lbdiscovery.go
@@ -239,6 +239,8 @@ func verifyDocument(ctx context.Context, data []byte, verify localverify.VerifyF
 // different tls-lb replica whose leaf that evidence does not cover. A lost
 // connection — server keepalive close, idle eviction, cert rotation — fails
 // closed with a re-run hint. Timeout knobs mirror ratls.NewVerifyingHTTPClient.
+// dialFrontDoor + this guard are a sibling of the verify CLI's dialFrontDoor +
+// singleConnClient (internal/cmds/verify/discovery.go) — port fixes both ways.
 func newSingleConnClient(conn *tls.Conn) *http.Client {
 	var used atomic.Bool
 	return &http.Client{

--- a/pkg/ratls/discovery.go
+++ b/pkg/ratls/discovery.go
@@ -14,11 +14,11 @@ import (
 // together with the expected REPORTDATA: SHA-384(cert pubkey ‖ challenge),
 // get-cert's issuance binding (ReportDataForKey).
 //
-// Policy stays with the caller — public_tls.mode checks, platform defaulting,
-// and actually verifying the evidence — because the two consumers legitimately
-// differ: lbdiscovery binds a live connection to the attested cert (and must
-// refuse webpki mode), while `c8s verify` gathers evidence for offline
-// verification and never binds a connection.
+// Policy stays with the caller — public_tls.mode handling, platform
+// defaulting, and verifying the evidence. Both consumers fetch the document
+// over one live connection and bind it to that connection's leaf: lbdiscovery
+// refuses a mismatched leaf (and webpki mode) outright, while `c8s verify`
+// records the observation and lets its verdict policy demote.
 func AttestedCertFromDiscovery(d *types.DiscoveryDocument) (*x509.Certificate, [64]byte, error) {
 	if len(d.Attestation.Evidence) == 0 {
 		return nil, [64]byte{}, fmt.Errorf("discovery document carries no attestation.evidence")


### PR DESCRIPTION
`c8s verify --kind lb` demoted to a partial verdict based on the `public_tls.mode` field of a host-served, unauthenticated document: a lying host that left the mode claiming the attestation-bound variant kept a ✓ VERIFIED on a WebPKI front door.

## Fix — ground the verdict in the live handshake
Discovery now dials the front door once, fetches the document over that connection, and keys the verdict on the handshake leaf vs the attested cert: match → verified, mismatch → partial (exit 4, both digests named), non-TLS target → partial. The host-served mode field no longer has any effect on the verdict. The same-connection invariant is pinned by a cert-flipping server test (a two-dial mutant fails; the fix's whole point is that one dial is one observation).

Behaviour notes:
- On byte-match the handshake doubles as key possession proof, so a CA-vouched document cert verifies without `--mesh-ca` (gated to `meshCA==nil`; probed adversarially — the backstop admits a cert body only, never attestation, and a WebPKI-only door cannot tick).
- The attested tick now carries a scope caveat in `Outcome.Warnings`: one connection, one replica, one instant — tls-lb serving certs are per-replica, and TOCTOU/source-IP routing caveats apply.
- Verdict JSON honesty: no binding note rides `verified:false`; a lying door's mismatch digests surface on FAILED verdicts symmetric to partial ones.
- **Deliberate change vs shipped behaviour**: the demote-on-declared-`webpki` signal is removed. Rationale: the mode is unauthenticated host-served config, and the observed handshake is strictly stronger ground truth; keying any verdict behaviour on the config implies evidentiary value it does not have. Flagged for review per process.
- `docs/operator.md` + `--help` now enumerate all three partial cases.

## Test evidence
Full `go test -race ./...` green (66 pkgs). Lying-host, CA-vouched possession, exit-code-matrix, dial-timeout/no-redirect/no-redial guard pins (deletion = test failure), and an end-to-end lying-HTTPS-door test. Two full review rounds + independent final verification (GO), with mutation batteries at each stage.
