### PR TITLE
install: refuse --cvm-mode=pod without --measurements unless --force

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -158,6 +158,26 @@ func operatorKeysPreflight(operatorKeys string, valuesFiles []string, force bool
 	return "installing with allowlist writes DISABLED (no --operator-keys); `c8s allowlist` add/remove/upload will not work until you set cds.operatorKeys and reinstall", nil
 }
 
+// podModeMeasurementsPreflight enforces that a pod-mode install without a
+// pinned CDS measurement is a deliberate choice. Under --cvm-mode=pod the
+// injected get-cert runs inside a kata guest whose argv the host writes, so it
+// refuses to dial an unpinned CDS ("--measurements is empty: refusing to reach
+// an unpinned CDS from inside a kata guest"): CDS and tls-lb come up, but no
+// confidential.ai/cw pod ever gets a leaf, and the refusal is only visible in an
+// init container's log inside a locked guest. Requiring --force here surfaces
+// that before the install. -f owners may carry cds.measurements in their values
+// file, so it is a no-op for them (consistent with the other -f-gated
+// preflights). It returns a warning to print when --force lets it pass.
+func podModeMeasurementsPreflight(cvmMode string, measurements []string, valuesFiles []string, force bool) (warn string, err error) {
+	if !cvmModeIsPod(cvmMode) || len(measurements) > 0 || len(valuesFiles) > 0 {
+		return "", nil
+	}
+	if !force {
+		return "", fmt.Errorf("--cvm-mode=pod without --measurements: the injected get-cert refuses to reach an unpinned CDS from inside a kata guest, so no confidential.ai/cw workload can start. Re-run with --measurements <kata guest launch digest> (read it from a running cluster with `c8s verify https://<tls-lb> --kind lb`), or --force to install anyway (CDS/tls-lb only; no cw workloads until you reinstall pinned)")
+	}
+	return "installing --cvm-mode=pod with no --measurements: CDS and tls-lb will run, but no confidential.ai/cw workload can obtain a certificate until you reinstall with --measurements", nil
+}
+
 // preflightCDSNode fails fast (before the helm install) when no node carries
 // the CDS node-selector label. The chart pins the singleton CDS pod to that
 // label, so without a matching node CDS stays Pending and `helm --wait` would
@@ -648,6 +668,11 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			return err
 		}
 		if warn, err := operatorKeysPreflight(installOperatorKeys, installValues, installForce); err != nil {
+			return err
+		} else if warn != "" {
+			fmt.Fprintln(os.Stderr, "warning: "+warn)
+		}
+		if warn, err := podModeMeasurementsPreflight(installCvmMode, installMeasurements, installValues, installForce); err != nil {
 			return err
 		} else if warn != "" {
 			fmt.Fprintln(os.Stderr, "warning: "+warn)
@@ -1916,6 +1941,6 @@ func init() {
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")
 	installCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; sets cds.operatorKeys. Without it, allowlist writes are disabled (reads still served). See the README \"Operator allowlist credentials\"")
-	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled)")
+	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), and --cvm-mode=pod without --measurements (no cw workload can start)")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -24,6 +24,29 @@ import (
 
 var errTestResolve = errors.New("simulated resolve failure")
 
+func TestPodModeMeasurementsPreflight(t *testing.T) {
+	// Not pod mode → no gate regardless of measurements.
+	if warn, err := podModeMeasurementsPreflight("node", nil, nil, false); err != nil || warn != "" {
+		t.Fatalf("node mode: want no error/warn, got warn=%q err=%v", warn, err)
+	}
+	// Pod mode with measurements → no gate, no warning.
+	if warn, err := podModeMeasurementsPreflight("pod", []string{"ab"}, nil, false); err != nil || warn != "" {
+		t.Fatalf("pod + measurements: want no error/warn, got warn=%q err=%v", warn, err)
+	}
+	// Pod mode, no measurements, no force → hard error (must acknowledge).
+	if _, err := podModeMeasurementsPreflight("pod", nil, nil, false); err == nil {
+		t.Fatal("pod + no measurements + no force: expected an error requiring --measurements or --force")
+	}
+	// Pod mode, no measurements, --force → allowed, but warns.
+	if warn, err := podModeMeasurementsPreflight("pod", nil, nil, true); err != nil || warn == "" {
+		t.Fatalf("pod + no measurements + force: want warn and no error, got warn=%q err=%v", warn, err)
+	}
+	// -f supplied → operator owns cds.measurements in their values file; no gate.
+	if warn, err := podModeMeasurementsPreflight("pod", nil, []string{"custom.yaml"}, false); err != nil || warn != "" {
+		t.Fatalf("-f supplied: want no error/warn, got warn=%q err=%v", warn, err)
+	}
+}
+
 func TestOperatorKeysPreflight(t *testing.T) {
 	// Keys provided → no gate, no warning.
 	if warn, err := operatorKeysPreflight("operator.pub", nil, false); err != nil || warn != "" {

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -61,13 +61,26 @@ enforcing it are one shape, not two (see [Enforcement](#enforcement)).
 # TEE platform labels are applied automatically from --hardware-platform
 # (see below). tls-lb runs as a kata CVM; --upstream (with the port on its
 # --workload-ref) points tls-lb at an adopted workload's mesh-wrapped headless
-# Service (see operator.md, "tls-lb upstream").
-c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+# Service (see operator.md, "tls-lb upstream"). --measurements pins the kata
+# guest launch digest; without it the install refuses (see below).
+c8s install --cvm-mode=pod --measurements <guest-launch-digest> --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 
 # Dev only: use the -debug guest image so `kubectl logs` and `kubectl exec`
 # work against kata pods (host log/exec RPCs allowed in the guest policy).
-c8s install --cvm-mode=pod --debug --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --debug --measurements <guest-launch-digest> --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
 ```
+
+**`--measurements` is effectively required under `--cvm-mode=pod`.** The
+injected get-cert runs inside a kata guest whose argv the host writes, so it
+refuses to dial an unpinned CDS; an unpinned pod-mode cluster brings up CDS
+and tls-lb but no `confidential.ai/cw` workload ever obtains a certificate,
+and the refusal is only visible in an init container's log inside a locked
+guest. `c8s install` therefore refuses a pod-mode install with no
+`--measurements` (and no `-f` values file that could carry
+`cds.measurements`) unless you pass `--force`, which installs the control
+plane only. Under SNP the value comes from `c8s kata measure`; under TDX,
+until the guest image publishes its predicted MRTD, read it from a running
+cluster with `c8s verify https://<tls-lb> --kind lb` and reinstall pinned.
 
 Confidential pods only schedule to nodes carrying their platform label —
 `confidential.ai/sev-snp=true` for the SNP classes,


### PR DESCRIPTION
A pod-mode install with no `--measurements` comes up green (CDS, tls-lb, operator all Ready) and then cannot start a single `confidential.ai/cw` workload: the injected get-cert refuses to reach an unpinned CDS from inside a kata guest (`--measurements is empty: refusing to reach an unpinned CDS from inside a kata guest, where the host writes this argv`), and that refusal is only visible in an init container's log inside a locked guest.

This adds a preflight guard with the same shape as the operator-keys one: `--cvm-mode=pod` + no `--measurements` + no `-f` → hard error pointing at `--measurements` / `--force`; `--force` installs the control plane with a warning; `-f` owners (who may carry `cds.measurements`) are untouched. `docs/kata.md` Installing section updated, including where the value comes from on SNP vs TDX.

Hit this on a bare-metal TDX host; the tdx metal e2e lane installs `--cvm-mode node` and never sees it.