### PR TITLE
install: bound the sandbox-digests callback to the pod range(s) under --cvm-mode=pod

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -1114,11 +1114,12 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			fmt.Fprintln(os.Stdout, "+ encrypted volumes: served by `volumed --guest` inside each kata guest; no host DaemonSet is deployed")
 		}
 		// The sandbox-digests callback dials node addresses and nothing else.
-		// Preflight here, where the cluster is reachable, that CDS can bound
+		// Resolve here, where the cluster is reachable, that CDS can bound
 		// it — a default install must not quietly ship with sandbox identity
 		// disabled. Must run before buildValueArgs, which folds an explicit
-		// --node-cidr into the computed values.
-		resolved, err := resolveInventoryCIDRs(cmd.Context(), installInventoryCIDRs)
+		// --node-cidr (or the pod range(s) under --cvm-mode=pod) into the
+		// computed values.
+		resolved, err := resolveInventoryCIDRs(cmd.Context(), installInventoryCIDRs, installCvmMode)
 		if err != nil {
 			return err
 		}
@@ -2357,7 +2358,7 @@ func init() {
 	installCmd.Flags().BoolVar(&installKataDebug, "debug", false, "use the kata-guest-base DEBUG guest variant (<tag>-debug): kubectl logs/exec work on kata pods, but container I/O becomes readable by the untrusted host and the launch measurement differs from the locked image. Requires --cvm-mode=pod; development only")
 	installCmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "resolve each c8s component image tag to its registry digest (via crane), pin it, and add the resolved images to the NRI allowlist (enables deriveComponents). On by default; pass --resolve-digests=false when supplying digests via -f")
 	installCmd.Flags().BoolVar(&installAttestEnabled, "attest", true, "deploy the tls-lb attestation sidecar serving /.well-known/c8s/ (browser/CLI verification via c8s-verify). On by default; pass --attest=false to omit it")
-	installCmd.Flags().StringSliceVar(&installInventoryCIDRs, "node-cidr", nil, "CIDR(s) holding this cluster's node addresses (repeatable/comma-separated). CDS dials a node's admission inventory inside them and nowhere else, which is what stops a workload pointing the sandbox-digests callback at its own pod IP. Defaults to CDS deriving one host route per node from the live node list; set this to a range when the node network is separate from the pod network")
+	installCmd.Flags().StringSliceVar(&installInventoryCIDRs, "node-cidr", nil, "CIDR(s) holding this cluster's sandbox inventories (repeatable/comma-separated): CDS dials an inventory inside them and nowhere else. Under --cvm-mode=node/gke/aks these are node addresses, which is what stops a workload pointing the sandbox-digests callback at its own pod IP; the default is CDS deriving one host route per node from the live node list, so set a range only when the node network is separate from the pod network. Under --cvm-mode=pod the inventory runs inside each kata guest on its pod IP, so the default is the cluster's pod range(s) (from spec.podCIDRs; set this explicitly when the CNI runs its own IPAM)")
 	installCmd.Flags().StringSliceVar(&installMeasurements, "measurements", nil, "expected hex launch measurement(s) of the CVM components that speak to CDS (repeatable/comma-separated). Pins the internal mesh (cds.measurements + ratlsMesh.measurements); empty = no pinning (UNSAFE). Under --cvm-mode=node/gke/aks this is the node image's manifest.json value; under --cvm-mode=pod it is the kata guest launch digest from `c8s kata measure`")
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")

--- a/cmd/c8s/inventory_cidr.go
+++ b/cmd/c8s/inventory_cidr.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os/exec"
 	"strings"
 
@@ -11,16 +12,34 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// resolveInventoryCIDRs returns the operator's --node-cidr when given. Unset,
-// it preflights what CDS will derive at runtime and renders nothing: CDS
-// bounds the callback from the live node list itself (docs/operator.md), so
-// there is no install-time snapshot to go stale on scale-up. Detection
-// failing is fatal: the alternative is installing with sandbox identity
-// silently off, which reads as success and leaves workload certificates
-// carrying no sandbox ID and no issuance-time image gate.
-func resolveInventoryCIDRs(ctx context.Context, explicit []string) ([]string, error) {
+// resolveInventoryCIDRs returns the operator's --node-cidr when given.
+// Unset, the answer depends on where the sandbox inventory lives:
+//
+//   - node/gke/aks: a host process, reachable on the node address. The
+//     install preflights what CDS will derive at runtime and renders nothing:
+//     CDS bounds the callback from the live node list itself
+//     (docs/operator.md), so there is no install-time snapshot to go stale on
+//     scale-up.
+//   - pod: inside each kata guest, answering on the guest's pod IP. The live
+//     node-list bound would then cover addresses no inventory ever uses and
+//     CDS would refuse every sandbox token, so the install infers the
+//     cluster's pod range(s) and pins them statically.
+//
+// Detection failing is fatal: the alternative is installing with sandbox
+// identity silently off, which reads as success and leaves workload
+// certificates carrying no sandbox ID and no issuance-time image gate.
+func resolveInventoryCIDRs(ctx context.Context, explicit []string, cvmMode string) ([]string, error) {
 	if len(explicit) > 0 {
 		return explicit, nil
+	}
+	if cvmModeIsPod(cvmMode) {
+		cidrs, err := inferPodInventoryCIDRs(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("could not determine this cluster's pod ranges for the sandbox-digests callback (under --cvm-mode=pod the inventory runs inside each kata guest and answers on its pod IP): %w\n\nPass --node-cidr <pod-cidr> to set them explicitly", err)
+		}
+		fmt.Printf("==> sandbox-digests callback bounded to the pod range(s): %s\n", strings.Join(cidrs, ", "))
+		fmt.Println("    (--cvm-mode=pod: the inventory answers from inside each kata guest, on the guest's pod IP)")
+		return cidrs, nil
 	}
 	if err := preflightNodeAddressBound(ctx); err != nil {
 		return nil, fmt.Errorf("could not preflight this cluster's node addresses for the sandbox-digests callback: %w\n\nPass --node-cidr <cidr> to set them explicitly", err)
@@ -34,13 +53,9 @@ func resolveInventoryCIDRs(ctx context.Context, explicit []string) ([]string, er
 // ranges — so a cluster that cannot support the bound fails here, where the
 // operator sees it, rather than refusing sandbox tokens at runtime.
 func preflightNodeAddressBound(ctx context.Context) error {
-	out, err := fetchNodeJSON(ctx)
+	nodes, err := fetchNodes(ctx)
 	if err != nil {
-		return fmt.Errorf("kubectl get nodes: %w", withStderr(err))
-	}
-	var nodes corev1.NodeList
-	if err := json.Unmarshal(out, &nodes); err != nil {
-		return fmt.Errorf("parse node list: %w", err)
+		return err
 	}
 	items := make([]*corev1.Node, 0, len(nodes.Items))
 	for i := range nodes.Items {
@@ -54,6 +69,60 @@ func preflightNodeAddressBound(ctx context.Context) error {
 		return fmt.Errorf("no node reported a routable InternalIP")
 	}
 	return nil
+}
+
+// inferPodInventoryCIDRs derives the pod range(s) CDS may dial for a sandbox's
+// admission inventory under --cvm-mode=pod.
+//
+// The pod range is the right boundary here, not a weaker one: what stops a
+// workload standing in for its guest's inventory in pod mode is not the
+// address (workload and inventory share the guest's IP) but the RA-TLS
+// handshake CDS runs against the inventory endpoint, whose leaf only the
+// guest's own attested mesh identity can present. The address bound keeps the
+// callback inside the cluster's pod network and nothing else.
+//
+// Read from spec.podCIDRs, which the cluster populates when kube-controller-
+// manager allocates node ranges. CNIs with their own IPAM (Calico, Cilium
+// cluster-pool) leave it empty; that is a hard error pointing at --node-cidr
+// rather than a guess.
+func inferPodInventoryCIDRs(ctx context.Context) ([]string, error) {
+	nodes, err := fetchNodes(ctx)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var cidrs []string
+	for _, n := range nodes.Items {
+		for _, c := range append([]string{n.Spec.PodCIDR}, n.Spec.PodCIDRs...) {
+			if c == "" {
+				continue
+			}
+			_, network, err := net.ParseCIDR(c)
+			if err != nil {
+				return nil, fmt.Errorf("node %s: podCIDR %q: %w", n.Name, c, err)
+			}
+			if !seen[network.String()] {
+				seen[network.String()] = true
+				cidrs = append(cidrs, network.String())
+			}
+		}
+	}
+	if len(cidrs) == 0 {
+		return nil, fmt.Errorf("no node reports a spec.podCIDR (the CNI runs its own IPAM)")
+	}
+	return cidrs, nil
+}
+
+func fetchNodes(ctx context.Context) (*corev1.NodeList, error) {
+	out, err := fetchNodeJSON(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get nodes: %w", withStderr(err))
+	}
+	var nodes corev1.NodeList
+	if err := json.Unmarshal(out, &nodes); err != nil {
+		return nil, fmt.Errorf("parse node list: %w", err)
+	}
+	return &nodes, nil
 }
 
 // fetchNodeJSON reads the cluster's node list. It is a package variable only so

--- a/cmd/c8s/inventory_cidr_test.go
+++ b/cmd/c8s/inventory_cidr_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -9,7 +10,7 @@ import (
 // An explicit --node-cidr is taken as given: an operator with a separate node
 // network can express it as a range, which survives scale-up.
 func TestResolveInventoryCIDRsPrefersExplicit(t *testing.T) {
-	got, err := resolveInventoryCIDRs(t.Context(), []string{"10.0.1.0/24"})
+	got, err := resolveInventoryCIDRs(t.Context(), []string{"10.0.1.0/24"}, "node")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,7 +31,7 @@ func TestResolveInventoryCIDRsPreflightsCluster(t *testing.T) {
 			return []byte(`{"items":[{"metadata":{"name":"a"},"spec":{"podCIDR":"10.244.0.0/24"},
 				"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}]}`), nil
 		}
-		got, err := resolveInventoryCIDRs(t.Context(), nil)
+		got, err := resolveInventoryCIDRs(t.Context(), nil, "node")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -46,7 +47,7 @@ func TestResolveInventoryCIDRsPreflightsCluster(t *testing.T) {
 			return []byte(`{"items":[{"metadata":{"name":"a"},"spec":{"podCIDR":"10.0.1.0/24"},
 				"status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}}]}`), nil
 		}
-		_, err := resolveInventoryCIDRs(t.Context(), nil)
+		_, err := resolveInventoryCIDRs(t.Context(), nil, "node")
 		if err == nil {
 			t.Fatal("accepted a node address inside the pod range: the callback bound would admit pod IPs")
 		}
@@ -62,7 +63,7 @@ func TestResolveInventoryCIDRsPreflightsCluster(t *testing.T) {
 			`{"items":[{"metadata":{"name":"a"},"status":{"addresses":[{"type":"InternalIP","address":"127.0.0.1"}]}}]}`,
 		} {
 			fetchNodeJSON = func(context.Context) ([]byte, error) { return []byte(body), nil }
-			if _, err := resolveInventoryCIDRs(t.Context(), nil); err == nil {
+			if _, err := resolveInventoryCIDRs(t.Context(), nil, "node"); err == nil {
 				t.Fatalf("accepted a node list with no routable InternalIP: %s", body)
 			}
 		}
@@ -73,7 +74,7 @@ func TestResolveInventoryCIDRsPreflightsCluster(t *testing.T) {
 	// sandbox identity off.
 	t.Run("unreadable cluster fails and names the fix", func(t *testing.T) {
 		fetchNodeJSON = func(context.Context) ([]byte, error) { return nil, errNoCluster }
-		_, err := resolveInventoryCIDRs(t.Context(), nil)
+		_, err := resolveInventoryCIDRs(t.Context(), nil, "node")
 		if err == nil {
 			t.Fatal("install proceeded without checking the sandbox-digests bound")
 		}
@@ -84,10 +85,70 @@ func TestResolveInventoryCIDRsPreflightsCluster(t *testing.T) {
 
 	t.Run("malformed JSON", func(t *testing.T) {
 		fetchNodeJSON = func(context.Context) ([]byte, error) { return []byte("not json"), nil }
-		if _, err := resolveInventoryCIDRs(t.Context(), nil); err == nil {
+		if _, err := resolveInventoryCIDRs(t.Context(), nil, "node"); err == nil {
 			t.Fatal("accepted malformed node JSON")
 		}
 	})
+}
+
+// Under --cvm-mode=pod the inventory answers from inside each kata guest on
+// the guest's pod IP, so the callback is pinned to the pod range(s) rather
+// than left to CDS's live node-host derivation (which would refuse every
+// sandbox token).
+func TestResolveInventoryCIDRsPodModeUsesPodRanges(t *testing.T) {
+	prev := fetchNodeJSON
+	t.Cleanup(func() { fetchNodeJSON = prev })
+
+	fetchNodeJSON = func(context.Context) ([]byte, error) {
+		return []byte(`{"items":[
+			{"metadata":{"name":"a"},"spec":{"podCIDR":"10.42.0.0/24","podCIDRs":["10.42.0.0/24","fd00:42::/64"]},
+			 "status":{"addresses":[{"type":"InternalIP","address":"10.0.1.4"}]}},
+			{"metadata":{"name":"b"},"spec":{"podCIDR":"10.42.1.0/24","podCIDRs":["10.42.1.0/24"]},
+			 "status":{"addresses":[{"type":"InternalIP","address":"10.0.1.5"}]}}
+		]}`), nil
+	}
+	got, err := resolveInventoryCIDRs(t.Context(), nil, "pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"10.42.0.0/24", "fd00:42::/64", "10.42.1.0/24"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("cidrs = %v, want the pod ranges %v, not node host routes", got, want)
+	}
+
+	// The same cluster under node mode still renders nothing (live bound).
+	got, err = resolveInventoryCIDRs(t.Context(), nil, "node")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Fatalf("node mode cidrs = %v, want nil", got)
+	}
+
+	// A CNI with its own IPAM leaves podCIDR empty: fail closed and name the flag.
+	fetchNodeJSON = func(context.Context) ([]byte, error) {
+		return []byte(`{"items":[{"metadata":{"name":"a"},"status":{"addresses":[
+			{"type":"InternalIP","address":"10.0.1.4"}]}}]}`), nil
+	}
+	_, err = resolveInventoryCIDRs(t.Context(), nil, "pod")
+	if err == nil {
+		t.Fatal("pod mode with no podCIDR proceeded with the callback bounded to nothing useful")
+	}
+	if !strings.Contains(err.Error(), "--node-cidr") {
+		t.Fatalf("error = %v, want it to name the flag that fixes it", err)
+	}
+
+	// An unreadable cluster fails in pod mode too.
+	fetchNodeJSON = func(context.Context) ([]byte, error) { return nil, errNoCluster }
+	if _, err := resolveInventoryCIDRs(t.Context(), nil, "pod"); err == nil {
+		t.Fatal("pod mode install proceeded without reading the pod ranges")
+	}
+
+	// Explicit --node-cidr wins in pod mode too.
+	got, err = resolveInventoryCIDRs(t.Context(), []string{"10.42.0.0/16"}, "pod")
+	if err != nil || !slices.Equal(got, []string{"10.42.0.0/16"}) {
+		t.Fatalf("explicit pod-mode cidrs = %v err=%v, want the operator's value untouched", got, err)
+	}
 }
 
 var errNoCluster = errTestCluster("no cluster")

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -106,6 +106,16 @@ support a non-CVM install shape or a bring-your-own CDS endpoint shape.
   On a cluster whose node network is separate from the pod network, pass
   `--node-cidr <range>` instead: CDS then uses the static range and the chart
   grants no node access. (docs/ratls.md, "Sandbox identity".)
+
+  **Under `--cvm-mode=pod` the inventory is inside each kata guest** and answers
+  on the guest's pod IP, so `c8s install` pins `cds.sandboxInventoryCIDRs` to the
+  cluster's **pod range(s)** (read from `spec.podCIDRs`) instead of leaving CDS
+  to derive node host routes. The address bound is not what separates a
+  workload from its guest's inventory there — both share the guest's IP; the
+  RA-TLS handshake CDS runs against the inventory endpoint is, since only the
+  guest's own attested mesh identity can present that leaf. A CNI that runs its
+  own IPAM leaves `spec.podCIDR` empty; the install then fails and asks for
+  `--node-cidr <pod-cidr>` explicitly.
 - `image.tag` or `image.digest`, `attestationApi.image.tag` or
   `attestationApi.image.digest`, and `cds.image.tag` or
   `cds.image.digest` are required; the CLI passes its build version when

--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -570,10 +570,12 @@ injects under kata (and then injects no socket volume). Both endpoints are
 compiled in, so the flag selects a shape and never an address: a wrong setting
 fails closed against a port nothing serves.
 
-CDS must be able to reach every node and kata guest on `:1019`, and the node
+CDS must be able to reach every node and kata guest on `:1019`, and the
 bound must cover those addresses: `cds.sandboxInventoryCIDRs` (`c8s install
 --node-cidr`) when set, else one host route per node derived live from the node
-list — a node added later is covered without a CDS restart.
+list — a node added later is covered without a CDS restart. Under
+`--cvm-mode=pod` the inventory answers from inside the guest on its pod IP, so
+`c8s install` pins the pod range(s) instead.
 
 An empty measurement allowlist does not disable any of this — it tracks the same
 posture `/attest` takes (see "What RA-TLS guarantees"): both ends still require


### PR DESCRIPTION
`c8s install` derives `cds.sandboxInventoryCIDRs` as one host route per node from InternalIP. That is right for `--cvm-mode=node/gke/aks`, where the inventory is a host process. Under `--cvm-mode=pod` the inventory (policy-monitor) runs **inside each kata guest** and `ResolveAdvertiseHost` advertises the guest's own pod IP, so CDS refuses every sandbox token:

```
csr_denied: sandbox token names an inventory outside the configured node CIDRs
```

and no `confidential.ai/cw` pod ever gets a leaf until the operator discovers `--node-cidr <pod-cidr>` (documented as "node addresses").

In pod mode, infer the pod range(s) from `spec.podCIDRs` instead; fail closed naming `--node-cidr` when the CNI runs its own IPAM and leaves it empty; other modes unchanged. The address bound is not what separates a workload from its guest's inventory in pod mode — both share the guest's IP; the RA-TLS handshake against the inventory endpoint is — so the pod range is the correct boundary, not a weaker one. Flag help, `docs/operator.md` and `docs/ratls.md` updated.

Hit on a bare-metal TDX host (RKE2/Canal populates podCIDR); the tdx metal e2e lane installs `--cvm-mode node` and never sees it.