### PR TITLE
webhook: write the mesh CA alone as ca.crt next to the injected tls.crt/tls.key

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -649,6 +649,7 @@ get-cert \
   --san=<derived from confidential.ai/cw, e.g. c8s-api.default.svc> \
   --out=/etc/c8s/certs/tls.crt \
   --key-out=/etc/c8s/certs/tls.key \
+  --ca-out=/etc/c8s/certs/ca.crt \
   --key-mode=<webhook.certVolume.keyMode> \
   --renew-interval=<webhook.getCert.renewInterval> \
   --reload-nginx=<from annotation> \
@@ -657,6 +658,17 @@ get-cert \
 
 `--key-out` is idempotent: on a kubelet restart of the sidecar it reuses the
 key that's already on disk, so the previously-issued cert chain stays valid.
+`tls.crt` is the full chain (leaf first, mesh CA after); `ca.crt` is the mesh
+CA alone, world-readable, for applications that take the trust anchor as a
+separate file (`mysqld --ssl-ca`, clients doing `VERIFY_CA` against peers on
+the mesh). File names are overridable per pod with `confidential.ai/c8s-cert-file`,
+`confidential.ai/c8s-key-file`, and `confidential.ai/c8s-ca-file`.
+
+`tls.key` is written `0640` owned by the get-cert user (UID/GID 65532, the pod's
+`fsGroup`). An image whose entrypoint starts as root and then drops to a
+service user (`gosu`, `su`) loses supplementary groups and can no longer read
+it; either run the container as UID 65532, or have the entrypoint copy the
+key into a directory the service user owns before dropping privileges.
 The `c8s-cert-wait` init container (`/c8s probe-file --wait /etc/c8s/certs/tls.crt`)
 gates the application containers on the initial cert being written: it blocks
 until the cert exists, then exits, and normal init-completion ordering holds the

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -62,6 +62,7 @@ const (
 	AnnotationCertDir                = "confidential.ai/c8s-cert-dir"
 	AnnotationCertFile               = "confidential.ai/c8s-cert-file"
 	AnnotationKeyFile                = "confidential.ai/c8s-key-file"
+	AnnotationCAFile                 = "confidential.ai/c8s-ca-file"
 	AnnotationRenewInterval          = "confidential.ai/c8s-renew-interval"
 	AnnotationReloadNginx            = "confidential.ai/c8s-reload-nginx"
 	AnnotationReloadWatchPaths       = "confidential.ai/c8s-reload-watch-paths"
@@ -308,6 +309,7 @@ type certSpec struct {
 	Dir           string
 	CertFile      string
 	KeyFile       string
+	CAFile        string
 	RenewInterval time.Duration
 }
 
@@ -352,6 +354,7 @@ func parseAnnotations(pod *corev1.Pod) (*injection, error) {
 			Dir:      annotations[AnnotationCertDir],
 			CertFile: annotations[AnnotationCertFile],
 			KeyFile:  annotations[AnnotationKeyFile],
+			CAFile:   annotations[AnnotationCAFile],
 		},
 		Reload: reloadSpec{
 			WatchVolume:    annotations[AnnotationReloadWatchVolume],
@@ -469,6 +472,7 @@ func hasInjectionDetailAnnotations(annotations map[string]string) bool {
 		AnnotationCertDir,
 		AnnotationCertFile,
 		AnnotationKeyFile,
+		AnnotationCAFile,
 		AnnotationRenewInterval,
 		AnnotationReloadNginx,
 		AnnotationReloadWatchPaths,
@@ -1076,6 +1080,11 @@ func certContainer(inj *injection, cfg Config) corev1.Container {
 		"--san=" + inj.SAN,
 		"--out=" + certPath(inj.Cert.Dir, inj.Cert.CertFile),
 		"--key-out=" + certPath(inj.Cert.Dir, inj.Cert.KeyFile),
+		// The mesh CA alone (0644), next to the leaf+CA bundle in tls.crt: an
+		// app that pins the CA as its own file (mysqld --ssl-ca, any client
+		// doing VERIFY_CA against the mesh) reads it directly instead of
+		// splitting the bundle in an entrypoint.
+		"--ca-out=" + certPath(inj.Cert.Dir, inj.Cert.CAFile),
 		"--key-mode=" + cfg.CertKeyMode,
 		"--renew-interval=" + inj.Cert.RenewInterval.String(),
 		"--reload-nginx=" + strconv.FormatBool(inj.Reload.Nginx),
@@ -1235,6 +1244,9 @@ func (inj *injection) withDefaults(cfg Config) injection {
 	}
 	if effective.Cert.KeyFile == "" {
 		effective.Cert.KeyFile = "tls.key"
+	}
+	if effective.Cert.CAFile == "" {
+		effective.Cert.CAFile = "ca.crt"
 	}
 	if effective.Cert.RenewInterval <= 0 {
 		effective.Cert.RenewInterval = cfg.CertRenewInterval

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -59,6 +59,7 @@ func TestMutatePodInjectsCertSidecar(t *testing.T) {
 		"--san=api",
 		"--out=/etc/c8s/certs/tls.crt",
 		"--key-out=/etc/c8s/certs/tls.key",
+		"--ca-out=/etc/c8s/certs/ca.crt",
 		"--key-mode=0640",
 		"--renew-interval=2h0m0s",
 		"--reload-nginx=false",
@@ -282,6 +283,7 @@ func TestMutatePodSupportsTLSLBProfile(t *testing.T) {
 	for _, want := range []string{
 		"--out=/tls/cert.pem",
 		"--key-out=/tls/key.pem",
+		"--ca-out=/tls/ca.crt",
 		"--renew-interval=1h0m0s",
 		"--reload-nginx=true",
 		"--reload-watch=/edge-tls/public.crt",


### PR DESCRIPTION
The injected cert volume holds `tls.crt` (leaf + mesh CA bundle) and `tls.key` only. Wiring MySQL as a cw workload meant splitting the bundle in an entrypoint just to hand mysqld a `--ssl-ca`; any client that wants `VERIFY_CA` against a mesh peer has the same chore.

get-cert already has `--ca-out` (the chart-side tls-lb helper passes it for the discovery endpoint); this passes it from the webhook too, as `<cert-dir>/ca.crt` (0644, mesh CA alone), overridable per pod with `confidential.ai/c8s-ca-file` for parity with the cert/key file annotations. `docs/operator.md` updated, including a note on the `0640 65532:65532` key for images whose entrypoint drops privileges via gosu/su (which loses supplementary groups): run as 65532 or copy the key before dropping.