### PR TITLE
ci(meat): drop tests from the reading diff

### DIFF
--- a/.github/workflows/meat.yml
+++ b/.github/workflows/meat.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # meat diffs base...head, so both sides' history must be present.
+          # The base commit must be present to stage the diff against it.
           fetch-depth: 0
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -55,6 +55,16 @@ jobs:
           test "$sum" = "$MEAT_SUM"
           go install "meat.dev/cmd/meat@${MEAT_VER}"
 
+      # meat has no pathspec filter, so hand it a pre-filtered index instead:
+      # index := head tree, HEAD := base, tests unstaged. The worktree stays at
+      # head so meat's read-only tools still see the real source.
+      - name: Stage the PR diff without tests
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git reset -q --soft "$BASE"
+          git restore --staged -- ':(glob)**/*_test.go' ':(glob)**/testdata/**'
+
       - name: Abridge the PR diff
         id: meat
         env:
@@ -62,9 +72,8 @@ jobs:
           # A missing LLM degrades the advisory to a skip (with a notice), not a red row.
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          RANGE: ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}
         run: |
-          if "$(go env GOPATH)/bin/meat" -json "$RANGE" > meat.json 2> meat.err; then
+          if "$(go env GOPATH)/bin/meat" -json -staged > meat.json 2> meat.err; then
             echo "ran=true" >> "$GITHUB_OUTPUT"
           else
             echo "ran=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
meat has no pathspec filter, so stage the PR diff against the base commit with `*_test.go` and `testdata/` unstaged and run `meat -staged`. The worktree stays at head so meat's read-only tools still see the real source.