### PR TITLE
docs+fix(install): repair install docs, plumb -f - stdin, add doc-parity CI

### DIFF
--- a/.github/workflows/docs-install-parity.yml
+++ b/.github/workflows/docs-install-parity.yml
@@ -1,0 +1,40 @@
+name: docs install parity
+
+on:
+  pull_request:
+    paths: &parity-paths
+      - "docs/QUICKSTART.md"
+      - "docs/DEMO.md"
+      # The flag validation and preflights the gate exercises live here.
+      - "cmd/c8s/**"
+      - "scripts/check-doc-install-commands.sh"
+      - ".github/workflows/docs-install-parity.yml"
+  push:
+    branches: [main, "feat/**"]
+    paths: *parity-paths
+
+concurrency:
+  group: docs-install-parity-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  doc-commands:
+    name: Doc install commands
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-go-c8s
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.4
+
+      - name: Build the c8s CLI
+        run: go build -o "$GITHUB_WORKSPACE/bin/c8s" ./cmd/c8s
+
+      - name: Run the documented c8s commands to the cluster boundary
+        run: PATH="$GITHUB_WORKSPACE/bin:$PATH" scripts/check-doc-install-commands.sh

--- a/README.md
+++ b/README.md
@@ -224,16 +224,22 @@ make install
 # Label the node that will run CDS
 kubectl label node <cds-node> role=cds
 
+# Generate the operator keypair whose public half authorizes allowlist writes
+openssl ecparam -name prime256v1 -genkey -noout -out operator.key
+openssl ec -in operator.key -pubout -out operator.pub
+
 # Install the platform (node-as-CVM) and point the bundled TLS load balancer
 # at your workload
-c8s install --cvm-mode=node --namespace c8s-system \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 \
+c8s install --cvm-mode=node --hardware-platform=sev-snp --namespace c8s-system \
+  --operator-keys operator.pub \
+  --workload-ref vllm=vllm/deployment/serving:8000 \
   --upstream vllm
 ```
 
 `--cvm-mode` is required and has no default — `node`, `gke`, and `aks` are the
-node-as-CVM shapes, `pod` is pod-as-CVM. An unstated shape would silently
-mismatch the cluster it lands on, so the install refuses to guess.
+node-as-CVM shapes, `pod` is pod-as-CVM. `--hardware-platform` is required the
+same way: `sev-snp` or `tdx`. An unstated shape would silently mismatch the
+cluster it lands on, so the install refuses to guess.
 
 `--workload-ref` adopts an existing workload as a confidential workload and
 resolves its images into the bootstrap allowlist (see
@@ -268,9 +274,10 @@ because an in-guest `get-cert` refuses to reach a CDS no measurement pins, so an
 unpinned pod-mode install leaves workloads dead at init:
 
 ```sh
-c8s install --cvm-mode=pod --namespace c8s-system \
+c8s install --cvm-mode=pod --hardware-platform=sev-snp --namespace c8s-system \
+  --operator-keys operator.pub \
   --measurements <cds-guest-digest>,<workload-guest-digest> \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 \
+  --workload-ref vllm=vllm/deployment/serving:8000 \
   --upstream vllm
 ```
 

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -473,7 +473,7 @@ func clusterDistroNodes(ctx context.Context) (rke2, other []string, err error) {
 	out, err := exec.CommandContext(ctx, "kubectl", "get", "nodes",
 		"-o", `jsonpath={range .items[*]}{.metadata.name}{"\t"}{.status.nodeInfo.kubeletVersion}{"\n"}{end}`).Output()
 	if err != nil {
-		return nil, nil, fmt.Errorf("kubectl get nodes: %w", err)
+		return nil, nil, fmt.Errorf("kubectl get nodes: %w", withStderr(err))
 	}
 	rke2, other = classifyDistroNodes(strings.Split(strings.TrimSpace(string(out)), "\n"))
 	return rke2, other, nil
@@ -583,6 +583,47 @@ func valuesFilesSetDistro(files []string) (bool, error) {
 	return false, nil
 }
 
+// materializeStdinValues replaces each "-" entry (helm's -f - idiom) with a
+// temp file holding the piped values, so every values consumer — the distro
+// and TEE-selector scans, effectiveValues, and helm itself — reads the same
+// bytes. Stdin is drained once, so a repeated "-" gets an empty file, as does
+// helm's own repeated -f -. The returned cleanup removes the temp files.
+func materializeStdinValues(files []string, stdin io.Reader) ([]string, func(), error) {
+	out := make([]string, 0, len(files))
+	var temps []string
+	cleanup := func() {
+		for _, t := range temps {
+			os.Remove(t)
+		}
+	}
+	for _, f := range files {
+		if f != "-" {
+			out = append(out, f)
+			continue
+		}
+		data, err := io.ReadAll(stdin)
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("read values from stdin: %w", err)
+		}
+		tmp, err := os.CreateTemp("", "c8s-install-stdin-*.yaml")
+		if err != nil {
+			cleanup()
+			return nil, nil, fmt.Errorf("create stdin values file: %w", err)
+		}
+		_, werr := tmp.Write(data)
+		cerr := tmp.Close()
+		if err := errors.Join(werr, cerr); err != nil {
+			os.Remove(tmp.Name())
+			cleanup()
+			return nil, nil, fmt.Errorf("write stdin values file: %w", err)
+		}
+		temps = append(temps, tmp.Name())
+		out = append(out, tmp.Name())
+	}
+	return out, cleanup, nil
+}
+
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install the c8s operator, CRDs, attestation-api, and component charts via Helm",
@@ -654,9 +695,20 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		if err := validateCvmMode(installCvmMode); err != nil {
 			return err
 		}
+		if err := validateHardwarePlatform(installHardwarePlatform); err != nil {
+			return err
+		}
 		if err := validateDebugFlag(installCvmMode, installKataDebug); err != nil {
 			return err
 		}
+		// Substitute any "-f -" before anything reads installValues, so the
+		// preflights and helm all see the piped values at a real path.
+		substituted, stdinCleanup, err := materializeStdinValues(installValues, cmd.InOrStdin())
+		if err != nil {
+			return err
+		}
+		defer stdinCleanup()
+		installValues = substituted
 		adoptions, err := collectWorkloadAdoptions(installWorkloadRefs)
 		if err != nil {
 			return err
@@ -1126,12 +1178,8 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 	if !slices.Contains(allowedCvmModes, cvmMode) {
 		return nil, fmt.Errorf("--%s must be one of %s, got %q", flagCvmMode, strings.Join(allowedCvmModes, ", "), cvmMode)
 	}
-	allowedPlatforms := []string{"sev-snp", "tdx"}
-	if hardwarePlatform == "" {
-		return nil, fmt.Errorf("--%s is required; one of %s", flagHardwarePlatform, strings.Join(allowedPlatforms, ", "))
-	}
-	if !slices.Contains(allowedPlatforms, hardwarePlatform) {
-		return nil, fmt.Errorf("--%s must be one of %s, got %q", flagHardwarePlatform, strings.Join(allowedPlatforms, ", "), hardwarePlatform)
+	if err := validateHardwarePlatform(hardwarePlatform); err != nil {
+		return nil, err
 	}
 	helmArgs = append(helmArgs, "--set-string", "attestationApi.cvmMode="+cvmMode)
 	// Device wiring:
@@ -1263,6 +1311,22 @@ func validateCvmMode(cvmMode string) error {
 	}
 	if !slices.Contains(allowedCvmModes, cvmMode) {
 		return fmt.Errorf("--%s must be one of %s, got %q", flagCvmMode, strings.Join(allowedCvmModes, ", "), cvmMode)
+	}
+	return nil
+}
+
+var allowedPlatforms = []string{"sev-snp", "tdx"}
+
+// validateHardwarePlatform enforces that --hardware-platform is set and known,
+// exactly like its sibling --cvm-mode. install checks it first in RunE, before
+// anything touches the cluster; appendCvmModeInstallArgs re-checks it on the
+// shared builder path so render-values is covered too.
+func validateHardwarePlatform(hardwarePlatform string) error {
+	if hardwarePlatform == "" {
+		return fmt.Errorf("--%s is required; one of %s", flagHardwarePlatform, strings.Join(allowedPlatforms, ", "))
+	}
+	if !slices.Contains(allowedPlatforms, hardwarePlatform) {
+		return fmt.Errorf("--%s must be one of %s, got %q", flagHardwarePlatform, strings.Join(allowedPlatforms, ", "), hardwarePlatform)
 	}
 	return nil
 }
@@ -1807,13 +1871,7 @@ func effectiveValues(ctx context.Context, chartPath string, setArgs []string) (m
 	if err := yaml.Unmarshal(out, &tree); err != nil {
 		return nil, fmt.Errorf("parse chart values: %w", err)
 	}
-	// A "-" (stdin) entry is skipped: stdin is already consumed by the caller,
-	// so a value set only there stays invisible here — a narrow edge next to a
-	// real file, which is the documented path.
 	for _, vf := range installValues {
-		if vf == "-" {
-			continue
-		}
 		raw, err := os.ReadFile(vf)
 		if err != nil {
 			return nil, fmt.Errorf("read values file %q: %w", vf, err)

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -321,11 +321,12 @@ func TestDetectDistroExec(t *testing.T) {
 			t.Fatalf("detectDistro = (%q, %v), want (k8s, nil)", got, err)
 		}
 	})
-	t.Run("kubectl failure surfaces", func(t *testing.T) {
+	t.Run("kubectl failure surfaces its stderr", func(t *testing.T) {
 		f := newFakeBin(t)
-		f.tool(t, "kubectl", "exit 1")
-		if _, err := detectDistro(context.Background()); err == nil {
-			t.Fatal("want error when kubectl fails")
+		f.tool(t, "kubectl", "echo The connection to the server dead was refused >&2; exit 1")
+		_, err := detectDistro(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "The connection to the server dead was refused") {
+			t.Fatalf("want kubectl's own reason in the error, got %v", err)
 		}
 	})
 }
@@ -1110,6 +1111,189 @@ func TestInstallRequiresCLIsOnPath(t *testing.T) {
 		err := runC8s(t, "install", "--cvm-mode=node", "--force")
 		if err == nil || !strings.Contains(err.Error(), "kubectl CLI not found") {
 			t.Fatalf("want a kubectl-not-found error, got %v", err)
+		}
+	})
+}
+
+// helmValuesCapture re-stubs helm so an `upgrade` appends every -f file's
+// content (path header + payload) to captureFile, in argv order. It keeps the
+// installStubs `show values` answer.
+func helmValuesCapture(t *testing.T, s *installStubs, captureFile string) {
+	t.Helper()
+	s.f.tool(t, "helm", `case "$1" in
+show) /bin/cat "$3/values.yaml" ;;
+upgrade)
+  prev=; last=
+  for a in "$@"; do
+    if [ "$prev" = "-f" ]; then
+      echo "== $a" >> '`+captureFile+`'
+      /bin/cat "$a" >> '`+captureFile+`'
+      last="$a"
+    fi
+    prev="$a"
+  done
+  if [ -n "$last" ]; then /bin/cp "$last" '`+s.computed+`'; fi
+  ;;
+esac`)
+}
+
+// `c8s install -f -` pipes stdin into a real values file: the distro scan and
+// effectiveValues must read it, and helm must receive the piped bytes as a
+// -f file ahead of the computed values.
+func TestInstallValuesFromStdin(t *testing.T) {
+	payload := "volumed:\n  enabled: true\nkata:\n  distro: rke2\n"
+
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+	capture := filepath.Join(s.f.dir, "values-stream.log")
+	helmValuesCapture(t, s, capture)
+
+	resetCLIState(t)
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"install", "--cvm-mode=node", "--wait=false", "-f", "-"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	calls := s.f.calls(t)
+
+	// The piped kata.distro owns the distro, so detection never runs.
+	mustNotContainPrefix(t, calls, "kubectl get nodes -o jsonpath")
+
+	// The piped volumed.enabled=true is visible to the digest resolver, which
+	// reads effectiveValues — volumed is pinned only when enabled there.
+	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/volumed:main")
+
+	// Helm received the piped values as a real -f file, followed by the
+	// computed values file (which wins on shared keys).
+	data, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatalf("read values capture: %v", err)
+	}
+	sections := strings.Split(string(data), "== ")
+	if len(sections) != 3 { // leading empty + stdin file + computed file
+		t.Fatalf("helm received %d -f files, want 2:\n%s", len(sections)-1, data)
+	}
+	stdinSection := sections[1]
+	header, content, _ := strings.Cut(stdinSection, "\n")
+	if !strings.Contains(header, "c8s-install-stdin-") {
+		t.Errorf("first -f is %q, want the materialized stdin file", header)
+	}
+	if content != payload {
+		t.Errorf("helm's stdin-derived -f content = %q, want the piped %q", content, payload)
+	}
+	if got := treeAt(t, readYAMLTree(t, s.computed), "attestationApi", "cvmMode"); got != "node" {
+		t.Errorf("computed values cvmMode = %#v, want node (last -f still the computed file)", got)
+	}
+}
+
+// When stdin cannot be materialized, install fails before anything else runs.
+func TestInstallStdinValuesMaterializeFailure(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	t.Setenv("TMPDIR", missing)
+
+	f := newFakeBin(t)
+	resetCLIState(t)
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	rootCmd.SetIn(strings.NewReader("tlsLb:\n  enabled: false\n"))
+	rootCmd.SetArgs([]string{"install", "--cvm-mode=node", "-f", "-"})
+	err := rootCmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "create stdin values file") {
+		t.Fatalf("want the temp-file error, got %v", err)
+	}
+	if got := f.calls(t); len(got) != 0 {
+		t.Errorf("materializing stdin precedes every exec, logged: %v", got)
+	}
+}
+
+// Flag-validation failures must precede every exec — a doc command that
+// stops parsing is exactly what the doc-parity gate keys on.
+func TestInstallFlagValidationPrecedesExec(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing cvm mode", []string{"install"}, "--cvm-mode is required"},
+		{"debug outside pod mode", []string{"install", "--cvm-mode=node", "--debug"}, "--debug selects the kata-guest-base debug image"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeBin(t)
+			err := runC8s(t, tc.args...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("want %q, got %v", tc.want, err)
+			}
+			if got := f.calls(t); len(got) != 0 {
+				t.Errorf("validation must precede every exec, logged: %v", got)
+			}
+		})
+	}
+}
+
+// effectiveValues surfaces a broken chart, a missing -f file, and an
+// unparseable -f file rather than rendering on defaults the operator did not
+// ask for.
+func TestEffectiveValuesErrorPaths(t *testing.T) {
+	t.Run("unparseable chart values", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "helm", helmShowValuesBody)
+		if _, err := effectiveValues(context.Background(), writeChart(t, "	"), nil); err == nil {
+			t.Fatal("want the chart-values parse error")
+		}
+	})
+
+	t.Run("missing values file", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "helm", helmShowValuesBody)
+		prev := installValues
+		t.Cleanup(func() { installValues = prev })
+		installValues = []string{filepath.Join(t.TempDir(), "missing.yaml")}
+		_, err := effectiveValues(context.Background(), writeChart(t, "a: 1\n"), nil)
+		if err == nil || !strings.Contains(err.Error(), "read values file") {
+			t.Fatalf("want the read error, got %v", err)
+		}
+	})
+
+	t.Run("unparseable values file", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "helm", helmShowValuesBody)
+		prev := installValues
+		t.Cleanup(func() { installValues = prev })
+		bad := filepath.Join(t.TempDir(), "bad.yaml")
+		if err := os.WriteFile(bad, []byte("\t"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		installValues = []string{bad}
+		_, err := effectiveValues(context.Background(), writeChart(t, "a: 1\n"), nil)
+		if err == nil || !strings.Contains(err.Error(), "parse values file") {
+			t.Fatalf("want the parse error, got %v", err)
+		}
+	})
+}
+
+// --hardware-platform fails like --cvm-mode does: at flag validation, before
+// any helm/kubectl invocation.
+func TestInstallValidatesHardwarePlatformBeforeTheCluster(t *testing.T) {
+	t.Run("missing", func(t *testing.T) {
+		f := newFakeBin(t)
+		err := runC8s(t, "install", "--cvm-mode=node", "--hardware-platform=")
+		if err == nil || !strings.Contains(err.Error(), "--hardware-platform is required; one of sev-snp, tdx") {
+			t.Fatalf("want the required-platform error, got %v", err)
+		}
+		if got := f.calls(t); len(got) != 0 {
+			t.Errorf("validation must precede every exec, logged: %v", got)
+		}
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		f := newFakeBin(t)
+		err := runC8s(t, "install", "--cvm-mode=node", "--hardware-platform=power9")
+		if err == nil || !strings.Contains(err.Error(), `--hardware-platform must be one of sev-snp, tdx, got "power9"`) {
+			t.Fatalf("want the unknown-platform error, got %v", err)
+		}
+		if got := f.calls(t); len(got) != 0 {
+			t.Errorf("validation must precede every exec, logged: %v", got)
 		}
 	})
 }

--- a/cmd/c8s/install_heal.go
+++ b/cmd/c8s/install_heal.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -55,6 +56,17 @@ func runCommand(ctx context.Context, stdout, stderr io.Writer, name string, args
 	c.Stdout = stdout
 	c.Stderr = stderr
 	return c.Run()
+}
+
+// withStderr appends the stderr an exec failure captured (Cmd.Output records
+// it on ExitError when Cmd.Stderr is unset), so kubectl's own reason reaches
+// the operator instead of a bare "exit status 1".
+func withStderr(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return err
 }
 
 // looksLikeRolloutTimeout narrows the heal to the specific class of helm

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -1591,3 +1592,93 @@ func assertArgsEqual(t *testing.T, got, want []string) {
 		}
 	}
 }
+
+func TestValuesFilesSetDistroErrorPaths(t *testing.T) {
+	if _, err := valuesFilesSetDistro([]string{filepath.Join(t.TempDir(), "missing.yaml")}); err == nil {
+		t.Fatal("want the read error surfaced")
+	}
+	bad := filepath.Join(t.TempDir(), "bad.yaml")
+	if err := os.WriteFile(bad, []byte("\t"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := valuesFilesSetDistro([]string{bad}); err == nil {
+		t.Fatal("want the parse error surfaced")
+	}
+}
+
+func TestMaterializeStdinValues(t *testing.T) {
+	t.Run("no dash passes files through untouched", func(t *testing.T) {
+		got, cleanup, err := materializeStdinValues([]string{"a.yaml", "b.yaml"}, strings.NewReader("ignored"))
+		if err != nil {
+			t.Fatalf("materializeStdinValues: %v", err)
+		}
+		defer cleanup()
+		if !reflect.DeepEqual(got, []string{"a.yaml", "b.yaml"}) {
+			t.Errorf("got %v, want the input unchanged", got)
+		}
+	})
+
+	t.Run("dash becomes a temp file holding the piped bytes, in order", func(t *testing.T) {
+		payload := "tlsLb:\n  enabled: false\n"
+		got, cleanup, err := materializeStdinValues([]string{"base.yaml", "-", "last.yaml"}, strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("materializeStdinValues: %v", err)
+		}
+		defer cleanup()
+		if len(got) != 3 || got[0] != "base.yaml" || got[2] != "last.yaml" || got[1] == "-" {
+			t.Fatalf("substitution broke ordering: %v", got)
+		}
+		data, err := os.ReadFile(got[1])
+		if err != nil {
+			t.Fatalf("read materialized file: %v", err)
+		}
+		if string(data) != payload {
+			t.Errorf("materialized content = %q, want the piped %q", data, payload)
+		}
+	})
+
+	t.Run("cleanup removes the temp files", func(t *testing.T) {
+		got, cleanup, err := materializeStdinValues([]string{"-"}, strings.NewReader("a: 1\n"))
+		if err != nil {
+			t.Fatalf("materializeStdinValues: %v", err)
+		}
+		cleanup()
+		if _, err := os.Stat(got[0]); !os.IsNotExist(err) {
+			t.Errorf("temp file %s survives cleanup: %v", got[0], err)
+		}
+	})
+
+	t.Run("a stdin read failure aborts", func(t *testing.T) {
+		if _, _, err := materializeStdinValues([]string{"-"}, errReader{}); err == nil {
+			t.Fatal("want the read error surfaced")
+		}
+	})
+
+	t.Run("a temp-file write failure aborts", func(t *testing.T) {
+		// RLIMIT_FSIZE=0 fails the payload write (Go swallows the SIGXFSZ).
+		var orig syscall.Rlimit
+		if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &orig); err != nil {
+			t.Skipf("getrlimit: %v", err)
+		}
+		zero := orig
+		zero.Cur = 0
+		if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &zero); err != nil {
+			t.Skipf("setrlimit: %v", err)
+		}
+		t.Cleanup(func() { _ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &orig) })
+		if _, _, err := materializeStdinValues([]string{"-"}, strings.NewReader("a: 1\n")); err == nil {
+			t.Fatal("want the write error surfaced")
+		}
+	})
+
+	t.Run("an uncreatable temp dir aborts", func(t *testing.T) {
+		t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "missing"))
+		if _, _, err := materializeStdinValues([]string{"-"}, strings.NewReader("a: 1\n")); err == nil {
+			t.Fatal("want the temp-file error surfaced")
+		}
+	})
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }

--- a/cmd/c8s/inventory_cidr.go
+++ b/cmd/c8s/inventory_cidr.go
@@ -36,7 +36,7 @@ func resolveInventoryCIDRs(ctx context.Context, explicit []string) ([]string, er
 func preflightNodeAddressBound(ctx context.Context) error {
 	out, err := fetchNodeJSON(ctx)
 	if err != nil {
-		return fmt.Errorf("kubectl get nodes: %w", err)
+		return fmt.Errorf("kubectl get nodes: %w", withStderr(err))
 	}
 	var nodes corev1.NodeList
 	if err := json.Unmarshal(out, &nodes); err != nil {

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -11,14 +11,16 @@ it installs with tls-lb disabled. To also expose a workload through tls-lb, give
 it an upstream instead (see [tls-lb upstream](operator.md#tls-lb-upstream)).
 
 ```sh
-c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem -f - <<'EOF'
+c8s install --namespace c8s-system --cvm-mode=node --hardware-platform=sev-snp \
+  --operator-keys operator-pub.pem -f - <<'EOF'
 tlsLb:
   enabled: false
 EOF
 ```
 
 `--cvm-mode` is required (`pod`, `node`, `gke`, or `aks` — see
-[install-flows.md](install-flows.md)); `--operator-keys` points at a PEM bundle
+[install-flows.md](install-flows.md)), as is `--hardware-platform` (`sev-snp`
+or `tdx`). `--operator-keys` points at a PEM bundle
 of EC public keys authorizing `c8s allowlist` writes (or pass `--force` to
 install with writes disabled).
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -24,13 +24,16 @@ This installs the supported chart-managed CVM shape: operator, RBAC, CRDs,
 webhook, attestation-api, and CDS.
 
 ```sh
-c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --namespace c8s-system --cvm-mode=node --hardware-platform=sev-snp \
+  --operator-keys operator-pub.pem \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 ```
 
 `--cvm-mode` is required — one of `pod` (per-pod kata CVMs), `node`
 (node-as-CVM: the nodes themselves are TDX/SNP CVMs, shown here), `gke`, or
-`aks`. `--operator-keys` takes a PEM bundle of EC public keys that authorize
+`aks`. So is `--hardware-platform`, naming the nodes' CPU TEE: `sev-snp` or
+`tdx` (under `aks` it selects the Azure vTPM shape instead). `--operator-keys`
+takes a PEM bundle of EC public keys that authorize
 `c8s allowlist` writes; without it the install refuses to proceed (pass
 `--force` to install with allowlist writes disabled):
 
@@ -80,8 +83,9 @@ default image tag of its own, so the image tag above is supplied by
 To install without the advisory CRDs:
 
 ```sh
-c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem --install-crds=false \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --namespace c8s-system --cvm-mode=node --hardware-platform=sev-snp \
+  --operator-keys operator-pub.pem --install-crds=false \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 ```
 
 The cluster still runs without CRDs. CRDs only provide demo/status UX such as
@@ -102,9 +106,10 @@ kubectl create secret docker-registry ghcr-pull-secret \
   --docker-username=<user-or-x-access-token> \
   --docker-password="$GITHUB_TOKEN"
 
-c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
+c8s install --namespace c8s-system --cvm-mode=node --hardware-platform=sev-snp \
+  --operator-keys operator-pub.pem \
   --image-pull-secret ghcr-pull-secret \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 ```
 
 `scripts/deploy-image-pull-secret.sh` wraps the secret-creation step
@@ -112,9 +117,10 @@ idempotently (re-run it to rotate the credential in place):
 
 ```sh
 IMAGE_PULL_SECRET=<ghcr-token> NAMESPACE=c8s-system ./scripts/deploy-image-pull-secret.sh
-c8s install --namespace c8s-system --cvm-mode=node --operator-keys operator-pub.pem \
+c8s install --namespace c8s-system --cvm-mode=node --hardware-platform=sev-snp \
+  --operator-keys operator-pub.pem \
   --image-pull-secret ghcr-pull-secret \
-  --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 ```
 
 Pass `NAMESPACE=c8s-system` explicitly — the script defaults to `default`,

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -52,11 +52,10 @@ rke2). An install with `-f` values owns the distro instead: set
 doesn't fit — a mixed cluster cannot be detected and always needs that, plus
 nodeSelectors to partition the install.
 
-The kata-image-puller and node-taint sidecar are on by default under `--cvm-mode=pod`.
-A single-node / local build can switch either off, and pin the guest image
-tag, through a `-f` values file (`kata.guestImage.enabled=false` /
-`kata.nodeTaint.enabled=false` / `kata.guestImage.tag=<tag>`) — there is no
-dedicated CLI flag for these.
+The kata-image-puller is on by default under `--cvm-mode=pod`. A
+single-node / local build can switch it off, and pin the guest image tag,
+through a `-f` values file (`kata.guestImage.enabled=false` /
+`kata.guestImage.tag=<tag>`) — there is no dedicated CLI flag for these.
 
 `--cvm-mode=pod --debug` points the puller at the `<tag>-debug` guest image —
 identical except the baked guest policy allows host log/exec streams, so
@@ -83,13 +82,12 @@ not a cluster resource.
 | kata-deploy DaemonSet | ✗ | ✓ | host (privileged, hostPID/hostNetwork) |
 | kata RuntimeClasses | ✗ | ✓ | cluster |
 | kata-image-puller | ✗ | ✓¹ | host (privileged) |
-| node-taint | ✗ | ✓² | host (kata-deploy sidecar) |
 | kata-enforcement VAP | ✗ | ✓ | cluster |
 | RuntimeClass injection (workloads) | ✗ | ✓ | webhook (admission time) |
 | get-cert injection (`confidential.ai/cw` pods) | ✓ | ✓ | webhook (admission time) |
 | tls-lb (bundled workload) | ✓ | ✓ CVM | runc in base; `kata-qemu-snp` CVM under kata (pinned by the chart) |
 
-¹ on by default; disable via `-f` values (`kata.guestImage.enabled=false`)  ² on by default; disable via `-f` values (`kata.nodeTaint.enabled=false`)
+¹ on by default; disable via `-f` values (`kata.guestImage.enabled=false`)
 
 Under kata, **every host-side security component (attestation-service,
 ratls-mesh, nri-image-policy) moves *inside* the confidential guest**, where
@@ -161,7 +159,7 @@ sequenceDiagram
     participant Op as operator pod
     participant Pods as workloads
 
-    CLI->>K: kubectl apply Namespace (privileged label if --cvm-mode=pod)
+    CLI->>K: kubectl apply Namespace (labelled pod-security=privileged in every mode)
     CLI->>Helm: helm upgrade --install --wait
     Note over Helm: normal resources (kind-order)
     Helm->>K: create operator Deployment, kata-deploy, CDS, ...
@@ -337,25 +335,34 @@ already deleted. See [`kata.md`](kata.md#uninstalling).
 ## Quick reference
 
 ```bash
+# Every flow below also requires --hardware-platform (the nodes' CPU TEE:
+# sev-snp or tdx). --operator-keys authorizes `c8s allowlist` writes; a -f
+# values file may carry the keys instead, and --force installs without.
 # --upstream (with the port on its --workload-ref) points tls-lb at an adopted
-# workload's mesh-wrapped headless Service for every flow below
-# (see operator.md, "tls-lb upstream").
+# workload's mesh-wrapped headless Service (see operator.md, "tls-lb upstream").
 
 # Base — normal cluster, host-side components, no per-pod confidentiality.
-c8s install --cvm-mode=node --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=node --hardware-platform=sev-snp --operator-keys operator-pub.pem \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 
 # Kata (enforcing): every workload pod becomes a kata VM, non-kata pods
 # rejected, host-side mesh/attestation/image-policy replaced by their
-# in-guest counterparts.
-c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+# in-guest counterparts. --measurements pins the kata guest launch digest
+# (from `c8s kata measure`); without it no cw workload can start.
+c8s install --cvm-mode=pod --hardware-platform=sev-snp --operator-keys operator-pub.pem \
+  --measurements <kata-guest-digest> \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 
 # RKE2 host — the distro is detected from the cluster, no extra flag.
-c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm
+c8s install --cvm-mode=pod --hardware-platform=sev-snp --operator-keys operator-pub.pem \
+  --measurements <kata-guest-digest> \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 
 # Single-node / local build (no registry artifact, don't starve the one node).
-# The puller + node-taint are on by default; switch them off via a values file:
-#   kata: {guestImage: {enabled: false}, nodeTaint: {enabled: false}}
-c8s install --cvm-mode=pod --workload-ref vllm=<namespace>/deployment/<vllm-deployment>:8000 --upstream vllm -f single-node.values.yaml
+# The puller is on by default; switch it off via a values file:
+#   kata: {guestImage: {enabled: false}}
+c8s install --cvm-mode=pod --hardware-platform=sev-snp -f single-node.values.yaml \
+  --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 
 # Uninstall: helm uninstall + sweep the kata artifacts off every node.
 c8s uninstall

--- a/scripts/check-doc-install-commands.sh
+++ b/scripts/check-doc-install-commands.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# check-doc-install-commands.sh — doc/CLI parity gate for the install flows.
+#
+# Runs every c8s command from the fenced sh blocks of docs/QUICKSTART.md and
+# docs/DEMO.md exactly as written (line continuations and heredocs included)
+# against a dead kubeconfig. A command passes when it clears flag validation
+# and the pre-cluster preflights: exit 0, or a failure whose output shows it
+# reached cluster contact. Failing earlier — unknown/invalid/missing flag, a
+# preflight refusal, an unreadable values file — fails the gate, so a doc
+# command that stops parsing breaks the build.
+#
+# Usage: scripts/check-doc-install-commands.sh
+# PATH must hold the built c8s binary plus helm, kubectl, and openssl.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+docs=("$repo_root/docs/QUICKSTART.md" "$repo_root/docs/DEMO.md")
+
+for tool in c8s helm kubectl openssl; do
+  command -v "$tool" >/dev/null || { echo "check-doc-install-commands: '$tool' is not on PATH" >&2; exit 2; }
+done
+for doc in "${docs[@]}"; do
+  [[ -f "$doc" ]] || { echo "check-doc-install-commands: $doc is missing" >&2; exit 2; }
+done
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# The doc commands reference operator-pub.pem relative to the working dir.
+openssl ecparam -genkey -name prime256v1 -noout -out "$work/operator.key" 2>/dev/null
+openssl ec -in "$work/operator.key" -pubout -out "$work/operator-pub.pem" 2>/dev/null
+
+# A server that refuses instantly, so cluster contact fails fast and
+# deterministically.
+cat > "$work/kubeconfig" <<'EOF'
+apiVersion: v1
+kind: Config
+clusters: [{name: dead, cluster: {server: https://127.0.0.1:1}}]
+users: [{name: dead, user: {token: dead}}]
+contexts: [{name: dead, context: {cluster: dead, user: dead}}]
+current-context: dead
+EOF
+export KUBECONFIG="$work/kubeconfig"
+
+# Extract c8s command units from the fenced sh blocks of the docs: a unit
+# starts at a line beginning "c8s ", continues over trailing-\ lines, and
+# over a heredoc body when the command opens one. Units are separated by a
+# 0x1E (record separator) byte.
+extract() {
+  awk '
+    function emit() { printf "%s\036", unit; unit = ""; heredoc = "" }
+    /^```/ {
+      if (inblock && unit != "") emit()
+      inblock = ($0 ~ /^```sh[ \t]*$/)
+      next
+    }
+    !inblock { next }
+    {
+      if (unit == "" && $0 !~ /^c8s([ \t]|$)/) next
+      unit = (unit == "") ? $0 : unit "\n" $0
+      if (heredoc != "") { if ($0 == heredoc) emit(); next }
+      if ($0 ~ /\\[ \t]*$/) next
+      if ($0 ~ /<<-?[ \t]*/) {
+        heredoc = $0
+        sub(/^.*<<-?[ \t]*/, "", heredoc)
+        gsub(/[^A-Za-z0-9_]/, "", heredoc)
+        next
+      }
+      emit()
+    }
+    END { if (unit != "") emit() }
+  ' "$@"
+}
+
+# Signatures of a run that reached the cluster-contact stage (kubectl/helm
+# reporting the dead server), as opposed to a pre-cluster failure.
+cluster_re='was refused|connection refused|Unable to connect|unreachable|no configuration has been provided|i/o timeout'
+
+fail=0
+count=0
+while IFS= read -r -d $'\036' unit; do
+  count=$((count + 1))
+  echo "--- doc command #$count"
+  echo "$unit"
+  set +e
+  out="$(cd "$work" && bash -c "$unit" 2>&1)"
+  rc=$?
+  set -e
+  if [[ $rc -eq 0 ]]; then
+    echo "ok: ran to completion"
+  elif grep -Eq "$cluster_re" <<<"$out"; then
+    echo "ok: cleared flag validation and preflights (stopped at cluster contact, exit $rc)"
+  else
+    echo "::error::doc command failed before the cluster stage (exit $rc):"
+    echo "$out"
+    fail=1
+  fi
+  echo
+done < <(extract "${docs[@]}")
+
+if [[ $count -eq 0 ]]; then
+  echo "::error::no c8s commands were extracted from ${docs[*]} — the extractor or the docs are broken" >&2
+  exit 1
+fi
+if [[ $fail -ne 0 ]]; then
+  echo "doc install commands FAILED parity (see ::error lines above)" >&2
+  exit 1
+fi
+echo "all $count documented c8s commands cleared flag validation and the pre-cluster preflights"


### PR DESCRIPTION
## Review Focus Areas

| File / Area | Focus | Why |
|-------------|-------|-----|
| `cmd/c8s/install.go` (stdin materialization, `--hardware-platform` hoist) | Standard | Install flow behavior change |
| `scripts/check-doc-install-commands.sh` + `.github/workflows/docs-install-parity.yml` | Standard | New CI gate: awk/bash extraction and pass/fail classification |
| `cmd/c8s/install_heal.go`, `cmd/c8s/inventory_cidr.go` | Light | Shared stderr-surfacing helper |
| `docs/QUICKSTART.md`, `docs/DEMO.md`, `docs/install-flows.md`, `README.md` | Light | Docs aligned with the CLI |
| `cmd/c8s/install_test.go`, `cmd/c8s/install_exec_test.go` | Light | New and changed tests |

## What Changed

Every documented `c8s install` in QUICKSTART/DEMO (and README) now runs as written through flag validation and the pre-cluster preflights; `-f -` is plumbed end to end instead of half-supported; install-flows.md no longer references chart values that do not exist. A new docs-install-parity CI job runs the docs' `c8s` commands up to the cluster boundary and fails the build when one stops parsing.

## Why

The documented install flows did not run as written:

- All install commands lacked `--hardware-platform` (required since it stopped defaulting), and QUICKSTART's `--workload-ref` used `<placeholder>` values that fail DNS-1123 validation — and parse as shell redirections unquoted, so the command never even reached the CLI.
- DEMO's `c8s install -f - <<EOF` failed with `read values file "-"`, and helm's stdin was never wired either, so the idiom could never have worked — while `effectiveValues` silently skipped `"-"`.
- install-flows.md referenced `kata.nodeTaint` / a node-taint sidecar the chart does not have, and scoped the privileged namespace label to `--cvm-mode=pod` (the install labels it unconditionally).

## Design Doc

N/A

## Verification

- `go build ./...` and `go build -tags c8s_node ./cmd/c8s`, `go vet`, `gofmt`, `golangci-lint run ./cmd/c8s/...` all clean; `go test ./...` green (only the pre-existing host-dependent ratlsmesh iptables failures, identical on main).
- `scripts/check-doc-install-commands.sh` passes the fixed docs (6/6 commands clear validation and stop at cluster contact) and fails on each deliberately broken variant: dropped `--cvm-mode`, dropped `--operator-keys`, dropped `--hardware-platform`, a `<placeholder>` workload ref, a missing values file, an unterminated heredoc.
- New exec test `TestInstallValuesFromStdin`: piped `-f -` values reach `helm upgrade` as a real values file ahead of the computed values; the distro scan and `effectiveValues` read them (skipped distro detection + volumed digest resolution prove it).

## Checklist

- [x] New dependencies justified (none)
- [x] Tests verify invariants, not just output format
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: reproducible build maintained (n/a)
- [x] For crypto code: constant-time, zeroization, audited libraries only (n/a)
