### PR TITLE
feat(nri-image-policy): admit exempt namespaces by captured digest, not by name

### DIFF
--- a/docs/getcert-workload-binding.md
+++ b/docs/getcert-workload-binding.md
@@ -592,6 +592,62 @@ see Enablement.
 
 ---
 
+## Corner 8 — exempt namespaces admit on a captured digest, not the name
+
+On the hosted lanes (pod/gke/aks) the provider owns the platform pods in
+`kube-system` — kube-proxy, CoreDNS, the CNI, CSI drivers — and their images are
+not on the c8s allowlist. Nothing baked into the node measures them either;
+unlike node-CVM, whose image carries the RKE2 system floor, these nodes run the
+provider's unmeasured OS and containerd. So admission there needs a source of
+truth for "the platform images this node runs" that the c8s allowlist does not
+supply.
+
+`policy.exempt_namespaces` supplies it **without** re-introducing the
+namespace-name key that admission keyed on before it was removed. A namespace
+name is API-server metadata the pod's creator chooses, so keying admission on it
+let an allowlist-denied image run by being named into `kube-system`. Here the
+name is only a **capture selector**: when the plugin first connects to a
+containerd that already requires it — the platform pods having come up before
+the `required_plugins` gate — it resolves each listed namespace's running images
+to their content-store digests and freezes that set, scoped per namespace. From
+then on a container in a listed namespace is admitted only if its resolved
+digest is in that namespace's frozen set. The key is the digest — a local fact
+the plugin reads from the store — not the relayed name.
+
+What this does and does not grant:
+
+- **An unlisted image in a listed namespace is denied**, and audited
+  `exempt_snapshot_miss` so drift (a provider rotating a platform image between
+  chart upgrades) is alertable from the log. It is **denied, never killed**:
+  stopping a running kube-proxy or CoreDNS can cut the node, so enforcement is
+  at the next create, not retroactive.
+- **A captured digest does not admit in a tenant namespace.** The set is scoped
+  to the namespace it was captured in, so this does not widen tenant admission
+  the way a namespace-global floor entry would.
+- **The exemption only downgrades a denial** (`checkContainer`), so the label
+  rules and the allowlist still run and still audit; the exemption event names
+  the denial it overturned (`overrides`).
+
+Freezing and regeneration. The captured set is persisted under the plugin's
+cache dir and is **loaded, not recaptured, on a plain restart or reboot** — on a
+reboot containerd gates every container on this plugin, so the plugin sees an
+empty node at connect time and a recapture would freeze nothing. The one event
+that recaptures is the installer rewriting the boot config (a chart install or
+upgrade), which deletes the snapshot file; the next connect re-freezes from
+what is running then. An operator changing the exempt list is such a rewrite.
+
+Scope of trust. This is a hosted-lane mechanism and it does not claim a
+node-CVM guarantee: the captured digests come from an unmeasured store on an
+unmeasured host, and anything an adversarial control plane had already planted
+in a listed namespace before the plugin first connected is captured along with
+the genuine platform set. That is strictly narrower than the removed
+namespace-name exemption — bounded to one capture window per node and to
+concrete digests rather than "any image, forever" — but it is weaker than the
+node-CVM floor, which is why `exempt_namespaces` is left empty on `cvmMode=node`
+and the baked floor stands alone there.
+
+---
+
 ## Enablement
 
 Always on in both shapes. On node-CVM the chart wires the NRI inventory socket,

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -8,6 +8,7 @@ type Event struct {
 	Action    string // allow, deny
 	Reason    string
 	Rule      string // label rule name, if any
+	Overrides string // the denial this allow overturned, if any
 	Namespace string
 	Pod       string
 	Container string
@@ -35,6 +36,9 @@ func (l *Logger) Log(event Event) {
 	}
 	if event.Rule != "" {
 		attrs = append(attrs, "rule", event.Rule)
+	}
+	if event.Overrides != "" {
+		attrs = append(attrs, "overrides", event.Overrides)
 	}
 	if event.Error != "" {
 		attrs = append(attrs, "error", event.Error)

--- a/internal/cmds/nri-image-policy/config.go
+++ b/internal/cmds/nri-image-policy/config.go
@@ -89,6 +89,14 @@ type policyConfig struct {
 	EnforceExisting       bool        `yaml:"enforce_existing"`        // kill non-allowlisted containers on startup
 	DenyMissingAnnotation bool        `yaml:"deny_missing_annotation"` // deny containers without image annotation
 	LabelRules            []labelRule `yaml:"label_rules"`
+
+	// ExemptNamespaces admits a namespace's containers by the digests captured
+	// running in it at first admission, not by a name the control plane picks.
+	// See exempt.go and docs/getcert-workload-binding.md — Corner 8.
+	ExemptNamespaces []string `yaml:"exempt_namespaces"`
+	// ExemptSnapshotPath persists the captured per-namespace digest set. Required
+	// when ExemptNamespaces is set; must sit on a filesystem that survives reboot.
+	ExemptSnapshotPath string `yaml:"exempt_snapshot_path"`
 }
 
 // labelRule defines a constraint on pod labels. Pods that do not satisfy
@@ -239,6 +247,9 @@ func (c *config) Validate() error {
 	}
 	if c.WorkloadClaims.SocketDir != "" && !c.AllowlistEnabled() {
 		return fmt.Errorf("workload_claims.socket_dir requires allowlist.always_allow or allowlist.pull: the inventory reports digests for CDS to match against the allowlist")
+	}
+	if len(c.Policy.ExemptNamespaces) > 0 && c.Policy.ExemptSnapshotPath == "" {
+		return fmt.Errorf("policy.exempt_namespaces requires policy.exempt_snapshot_path: the captured digest set must persist across restarts")
 	}
 	return validateLabelRules(c.Policy.LabelRules)
 }

--- a/internal/cmds/nri-image-policy/config_test.go
+++ b/internal/cmds/nri-image-policy/config_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -178,12 +179,9 @@ allowlist:
 	}
 }
 
-// A config written before the namespace exemption was removed still carries
-// exempt_namespaces. The loader is not field-strict, so the unknown key is
-// dropped and the plugin starts fail-closed; a strict loader would instead
-// refuse the config and wedge node-wide container creation via
-// required_plugins.
-func TestLoadConfig_StaleExemptNamespacesIgnored(t *testing.T) {
+// exempt_namespaces is parsed into the policy config alongside the snapshot
+// path the plugin persists its captured digest set to.
+func TestLoadConfig_ExemptNamespacesParsed(t *testing.T) {
 	const body = `
 allowlist:
   always_allow:
@@ -194,6 +192,7 @@ allowlist:
 policy:
   mode: fail-closed
   exempt_namespaces: [kube-system, local-path-storage]
+  exempt_snapshot_path: /var/lib/nri-image-policy/exempt-snapshot.json
 `
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -201,10 +200,25 @@ policy:
 	}
 	cfg, err := loadConfig(path)
 	if err != nil {
-		t.Fatalf("a config still carrying exempt_namespaces must load: %v", err)
+		t.Fatalf("loadConfig: %v", err)
 	}
-	if cfg.Policy.Mode != ModeFailClosed {
-		t.Errorf("Mode = %q, want fail-closed after loading a stale config", cfg.Policy.Mode)
+	if got, want := cfg.Policy.ExemptNamespaces, []string{"kube-system", "local-path-storage"}; !slices.Equal(got, want) {
+		t.Errorf("ExemptNamespaces = %v, want %v", got, want)
+	}
+	if cfg.Policy.ExemptSnapshotPath == "" {
+		t.Error("ExemptSnapshotPath not parsed")
+	}
+}
+
+// exempt_namespaces without a snapshot path is refused: the captured set must
+// have somewhere to persist, or it would silently recapture (and on a reboot
+// freeze empty) every restart.
+func TestValidate_ExemptNamespacesRequireSnapshotPath(t *testing.T) {
+	cfg := validConfig()
+	cfg.Policy.ExemptNamespaces = []string{"kube-system"}
+	cfg.Policy.ExemptSnapshotPath = ""
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected error when exempt_namespaces is set without exempt_snapshot_path")
 	}
 }
 

--- a/internal/cmds/nri-image-policy/exempt.go
+++ b/internal/cmds/nri-image-policy/exempt.go
@@ -1,0 +1,147 @@
+package nriimagepolicy
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+)
+
+// exemptSnapshot admits a container in an exempt namespace when its image
+// digest matches one captured running in that same namespace. The name selects
+// what to capture; the resolved digest is what admits — see
+// docs/getcert-workload-binding.md, Corner 8.
+//
+// The set is captured once, when the plugin first connects to a containerd that
+// already requires it (Synchronize sees the platform pods that came up before
+// the required_plugins gate), and then frozen. The installer deletes the file
+// whenever it rewrites the boot config, so a chart install or upgrade is the
+// only event that recaptures. A plain restart or node reboot loads the frozen
+// file, and load must win there: on a reboot containerd gates every container
+// on this plugin, so Synchronize sees an empty node and a recapture would
+// freeze nothing.
+type exemptSnapshot struct {
+	// Namespaces is the exempt set this was captured for. Diagnostic only —
+	// regeneration is keyed off the installer deleting the file, not off this.
+	Namespaces []string `json:"namespaces"`
+	// Digests maps an exempt namespace to the image digests captured under it.
+	Digests map[string][]string `json:"digests"`
+
+	index map[string]map[string]struct{} // namespace -> digest set, for lookup
+}
+
+// newExemptSnapshot returns an empty snapshot ready to accumulate captures for
+// the given exempt namespaces.
+func newExemptSnapshot(namespaces []string) *exemptSnapshot {
+	return &exemptSnapshot{
+		Namespaces: slices.Clone(namespaces),
+		Digests:    map[string][]string{},
+		index:      map[string]map[string]struct{}{},
+	}
+}
+
+// add records a captured (namespace, digest). A blank digest is dropped: an
+// unresolved image cannot be an admission key.
+func (s *exemptSnapshot) add(namespace, digest string) {
+	if digest == "" {
+		return
+	}
+	set := s.index[namespace]
+	if set == nil {
+		set = map[string]struct{}{}
+		s.index[namespace] = set
+	}
+	if _, ok := set[digest]; ok {
+		return
+	}
+	set[digest] = struct{}{}
+	s.Digests[namespace] = append(s.Digests[namespace], digest)
+	slices.Sort(s.Digests[namespace])
+}
+
+// admits reports whether digest was captured running in namespace.
+func (s *exemptSnapshot) admits(namespace, digest string) bool {
+	if s == nil || digest == "" {
+		return false
+	}
+	_, ok := s.index[namespace][digest]
+	return ok
+}
+
+// empty reports whether the snapshot captured no digest in any namespace.
+func (s *exemptSnapshot) empty() bool {
+	return s == nil || len(s.index) == 0
+}
+
+// count is the total number of captured digests across all namespaces.
+func (s *exemptSnapshot) count() int {
+	n := 0
+	for _, set := range s.index {
+		n += len(set)
+	}
+	return n
+}
+
+// buildIndex populates the lookup index from the decoded Digests map.
+func (s *exemptSnapshot) buildIndex() {
+	s.index = make(map[string]map[string]struct{}, len(s.Digests))
+	for ns, digests := range s.Digests {
+		set := make(map[string]struct{}, len(digests))
+		for _, d := range digests {
+			set[d] = struct{}{}
+		}
+		s.index[ns] = set
+	}
+}
+
+// loadExemptSnapshot reads a persisted snapshot. It returns (nil, nil) when the
+// file is absent — the caller then captures. A present-but-unreadable file is
+// an error: on a host lane the file is host-controlled, so a corrupt snapshot
+// is treated as a fault to surface, not silently recaptured.
+func loadExemptSnapshot(path string) (*exemptSnapshot, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var s exemptSnapshot
+	if err := json.Unmarshal(b, &s); err != nil {
+		return nil, fmt.Errorf("parse exempt snapshot %q: %w", path, err)
+	}
+	s.buildIndex()
+	return &s, nil
+}
+
+// persist writes the snapshot atomically (tmp + rename) so a crash mid-write
+// cannot leave a truncated file the next start would load.
+func (s *exemptSnapshot) persist(path string) error {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(b); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return err
+	}
+	return nil
+}

--- a/internal/cmds/nri-image-policy/exempt_plugin_test.go
+++ b/internal/cmds/nri-image-policy/exempt_plugin_test.go
@@ -1,0 +1,197 @@
+package nriimagepolicy
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/audit"
+	"github.com/containerd/nri/pkg/api"
+)
+
+// exemptPlugin builds a fail-closed floor plugin (floor admits pushDigestA)
+// whose listed namespaces are admitted by a captured digest snapshot at
+// snapshotPath. The containerd stop hook is unset, so any kill panics by name.
+func exemptPlugin(t *testing.T, snapshotPath string, namespaces ...string) *plugin {
+	t.Helper()
+	cfg := &config{
+		Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "floor-image"}},
+		Policy: policyConfig{
+			Mode:                  ModeFailClosed,
+			EnforceExisting:       true,
+			DenyMissingAnnotation: true,
+			ExemptNamespaces:      namespaces,
+			ExemptSnapshotPath:    snapshotPath,
+		},
+	}
+	p := &plugin{
+		cfg:        cfg,
+		policy:     newPolicyStore(floorAllowlist(cfg.Allowlist.AlwaysAllow)),
+		audit:      audit.NewLogger(),
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		containerd: &fakeContainerd{},
+	}
+	p.inventory = newAdmissionInventory("/proc")
+	return p
+}
+
+// A non-floor image running in an exempt namespace when the plugin connects is
+// captured, persisted, and admitted on a later create — without a kill, since
+// the running container is downgraded to skip during the same Synchronize.
+func TestExempt_CaptureAtSyncAdmitsLaterCreate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	p := exemptPlugin(t, path, "kube-system")
+	p.SetReady()
+
+	pod := makePod("kube-system", "coredns")
+	running := makeCtrWithImage(pod.Id, "coredns", "registry/repo@"+pushDigestB)
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{running}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("snapshot not persisted: %v", err)
+	}
+	if !p.exempt.Load().admits("kube-system", pushDigestB) {
+		t.Fatal("the running kube-system digest was not captured")
+	}
+
+	next := makeCtrWithImage(pod.Id, "coredns-2", "registry/repo@"+pushDigestB)
+	if _, _, err := p.CreateContainer(context.Background(), pod, next); err != nil {
+		t.Fatalf("a captured kube-system image must be admitted on create: %v", err)
+	}
+}
+
+// A non-floor image never captured in an exempt namespace is denied there.
+func TestExempt_UncapturedDigestDeniedInExemptNamespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	p := exemptPlugin(t, path, "kube-system")
+	p.SetReady()
+
+	pod := makePod("kube-system", "pod")
+	captured := makeCtrWithImage(pod.Id, "captured", "registry/repo@"+pushDigestC)
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{captured}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+
+	uncaptured := makeCtrWithImage(pod.Id, "evil", "registry/repo@"+pushDigestB)
+	if _, _, err := p.CreateContainer(context.Background(), pod, uncaptured); err == nil {
+		t.Fatal("an uncaptured non-floor image in an exempt namespace must be denied")
+	}
+}
+
+// The capture is namespace-scoped: a digest captured in kube-system does not
+// admit the same digest in a tenant namespace.
+func TestExempt_CapturedDigestNotAdmittedInTenantNamespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	p := exemptPlugin(t, path, "kube-system")
+	p.SetReady()
+
+	ksPod := makePod("kube-system", "ks")
+	ks := makeCtrWithImage(ksPod.Id, "c", "registry/repo@"+pushDigestB)
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{ksPod}, []*api.Container{ks}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+
+	tenantPod := makePod("default", "tenant")
+	tenant := makeCtrWithImage(tenantPod.Id, "c", "registry/repo@"+pushDigestB)
+	if _, _, err := p.CreateContainer(context.Background(), tenantPod, tenant); err == nil {
+		t.Fatal("a kube-system-captured digest must not admit in a tenant namespace")
+	}
+}
+
+// A running container in an exempt namespace whose digest is not in the frozen
+// snapshot is denied at create but never killed: stopping a platform container
+// can cut the node.
+func TestExempt_CheckExistingDoesNotKillExemptNamespace(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	pre := newExemptSnapshot([]string{"kube-system"})
+	pre.add("kube-system", pushDigestA)
+	if err := pre.persist(path); err != nil {
+		t.Fatal(err)
+	}
+
+	p := exemptPlugin(t, path, "kube-system")
+	p.SetReady()
+
+	pod := makePod("kube-system", "pod")
+	drifted := makeCtrWithImage(pod.Id, "drift", "registry/repo@"+pushDigestB) // not in snapshot, not floor
+
+	// The unset stop hook panics if a kill is attempted.
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{drifted}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+}
+
+// A reboot gates every container on the plugin, so Synchronize sees an empty
+// node; the frozen snapshot must be loaded from disk, not recaptured to empty.
+func TestExempt_RebootLoadsPersistedNotRecaptured(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	pre := newExemptSnapshot([]string{"kube-system"})
+	pre.add("kube-system", pushDigestA)
+	if err := pre.persist(path); err != nil {
+		t.Fatal(err)
+	}
+
+	p := exemptPlugin(t, path, "kube-system")
+	if _, err := p.Synchronize(context.Background(), nil, nil); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+	if !p.exempt.Load().admits("kube-system", pushDigestA) {
+		t.Fatal("a reboot must load the frozen snapshot, not recapture an empty node")
+	}
+}
+
+// An empty capture is not persisted: freezing it would deny every platform pod,
+// so a later start recaptures instead.
+func TestExempt_EmptyCaptureNotPersisted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	p := exemptPlugin(t, path, "kube-system")
+
+	// Nothing is running in kube-system at connect.
+	pod := makePod("default", "tenant")
+	tenant := makeCtrWithImage(pod.Id, "c", "registry/repo@"+pushDigestA)
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{tenant}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("an empty capture must not write a snapshot; stat err = %v", err)
+	}
+	if !p.exempt.Load().empty() {
+		t.Fatal("an empty capture must leave the snapshot empty")
+	}
+}
+
+// Without exempt namespaces the plugin is unchanged: no snapshot, and a
+// non-floor image in kube-system is still killed by enforce_existing.
+func TestExempt_NoExemptNamespacesIsNoop(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "snap.json")
+	p := exemptPlugin(t, path) // no namespaces
+	p.SetReady()
+
+	var killed []string
+	p.containerd = &fakeContainerd{stop: func(_ context.Context, id string) error {
+		killed = append(killed, id)
+		return nil
+	}}
+
+	pod := makePod("kube-system", "pod")
+	running := makeCtrWithImage(pod.Id, "c", "registry/repo@"+pushDigestB)
+	if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{pod}, []*api.Container{running}); err != nil {
+		t.Fatalf("Synchronize: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatal("no snapshot must be written when exempt_namespaces is empty")
+	}
+	if p.exempt.Load() != nil {
+		t.Fatal("p.exempt must stay nil without exempt namespaces")
+	}
+	if len(killed) != 1 || killed[0] != running.Id {
+		t.Fatalf("without an exemption a non-floor kube-system image is still killed, got %v", killed)
+	}
+}

--- a/internal/cmds/nri-image-policy/exempt_test.go
+++ b/internal/cmds/nri-image-policy/exempt_test.go
@@ -1,0 +1,99 @@
+package nriimagepolicy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExemptSnapshot_AdmitsIsNamespaceScoped(t *testing.T) {
+	s := newExemptSnapshot([]string{"kube-system"})
+	s.add("kube-system", pushDigestA)
+
+	if !s.admits("kube-system", pushDigestA) {
+		t.Error("a captured digest must admit in its own namespace")
+	}
+	if s.admits("default", pushDigestA) {
+		t.Error("a digest captured in kube-system must not admit in another namespace")
+	}
+	if s.admits("kube-system", pushDigestB) {
+		t.Error("an uncaptured digest must not admit")
+	}
+}
+
+func TestExemptSnapshot_AddIgnoresBlankAndDedupes(t *testing.T) {
+	s := newExemptSnapshot([]string{"kube-system"})
+	s.add("kube-system", "")
+	s.add("kube-system", pushDigestA)
+	s.add("kube-system", pushDigestA)
+
+	if s.count() != 1 {
+		t.Fatalf("count = %d, want 1 (blank dropped, duplicate folded)", s.count())
+	}
+	if got := s.Digests["kube-system"]; len(got) != 1 || got[0] != pushDigestA {
+		t.Fatalf("Digests[kube-system] = %v, want [%s]", got, pushDigestA)
+	}
+}
+
+func TestExemptSnapshot_NilAdmitsNothing(t *testing.T) {
+	var s *exemptSnapshot
+	if s.admits("kube-system", pushDigestA) {
+		t.Error("a nil snapshot must admit nothing")
+	}
+	if !s.empty() {
+		t.Error("a nil snapshot is empty")
+	}
+}
+
+func TestExemptSnapshot_PersistLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "exempt-snapshot.json")
+	s := newExemptSnapshot([]string{"kube-system", "gmp-system"})
+	s.add("kube-system", pushDigestA)
+	s.add("kube-system", pushDigestB)
+	s.add("gmp-system", pushDigestC)
+	if err := s.persist(path); err != nil {
+		t.Fatalf("persist: %v", err)
+	}
+
+	loaded, err := loadExemptSnapshot(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("load returned nil for a written file")
+	}
+	for _, tc := range []struct {
+		ns, digest string
+	}{
+		{"kube-system", pushDigestA},
+		{"kube-system", pushDigestB},
+		{"gmp-system", pushDigestC},
+	} {
+		if !loaded.admits(tc.ns, tc.digest) {
+			t.Errorf("loaded snapshot does not admit %s in %s", tc.digest, tc.ns)
+		}
+	}
+	if loaded.admits("gmp-system", pushDigestA) {
+		t.Error("load must preserve namespace scoping")
+	}
+}
+
+func TestExemptSnapshot_LoadAbsentReturnsNil(t *testing.T) {
+	loaded, err := loadExemptSnapshot(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("an absent file is not an error: %v", err)
+	}
+	if loaded != nil {
+		t.Fatal("an absent file must load as nil so the caller captures")
+	}
+}
+
+func TestExemptSnapshot_LoadCorruptErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "exempt-snapshot.json")
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadExemptSnapshot(path); err == nil {
+		t.Fatal("a corrupt snapshot must surface as an error, not be silently recaptured")
+	}
+}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -104,6 +105,11 @@ type plugin struct {
 	logger     *slog.Logger
 	ready      atomic.Bool
 	containerd containerdOps
+
+	// exempt admits an exempt namespace's containers by the digest set captured
+	// running in it, not by the namespace name. nil ⇔ not opted in
+	// (policy.exempt_namespaces empty) or not yet captured. See exempt.go.
+	exempt atomic.Pointer[exemptSnapshot]
 
 	// inventory serves the sandbox-identity flow (docs/ratls.md). nil ⇔ the flow
 	// is disabled (no workload_claims.socket_dir) — configuration, not a
@@ -274,6 +280,24 @@ func (p *plugin) recordDigest(ctr *api.Container, digest string) {
 	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest, ctr.GetArgs())
 }
 
+// resolveDigest returns the canonical store digest for imageRef using the same
+// path checkImage admits on: the inline digest if present, else the containerd
+// content store. Empty on an unresolvable or absent reference. Quiet — the
+// callers that need an audit trail (checkImage) do their own logging.
+func (p *plugin) resolveDigest(ctx context.Context, imageRef string) string {
+	if d := extractDigest(imageRef); d != "" {
+		return d
+	}
+	if imageRef == "" {
+		return ""
+	}
+	resolved, err := p.containerd.Resolve(ctx, imageRef)
+	if err != nil {
+		return ""
+	}
+	return resolved
+}
+
 // evaluateRule checks whether a pod satisfies a compiled Kubernetes selector.
 // Returns true if the pod satisfies the rule (i.e. should be allowed).
 func evaluateRule(rule labelRule, podLabels map[string]string) bool {
@@ -423,16 +447,46 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 // checkContainer runs the label rules and the image allowlist over a
 // container. Only the image digest (answered by the containerd content
 // store) admits; label rules can only deny.
+//
+// A denial in an exempt namespace is downgraded to skip when the container's
+// digest was captured running in that namespace (the frozen snapshot), and only
+// then. The exemption runs last, only downgrades, and is keyed on the resolved
+// digest — a local fact — not the namespace name the control plane chooses.
 func (p *plugin) checkContainer(ctx context.Context, cfg *config, pod *api.PodSandbox, ctr *api.Container, imageRef string) (imageVerdict, string) {
 	namespace, podName, ctrName := pod.GetNamespace(), pod.GetName(), ctr.GetName()
 
 	verdict, reason := p.checkLabels(cfg, namespace, podName, ctrName, pod.GetLabels())
-	if verdict == verdictDeny {
-		return verdict, reason
+	if verdict != verdictDeny && cfg.AllowlistEnabled() {
+		verdict, reason = p.checkImage(ctx, cfg, namespace, podName, ctrName, imageRef, ctr.GetArgs())
 	}
 
-	if cfg.AllowlistEnabled() {
-		verdict, reason = p.checkImage(ctx, cfg, namespace, podName, ctrName, imageRef, ctr.GetArgs())
+	if verdict == verdictDeny && slices.Contains(cfg.Policy.ExemptNamespaces, namespace) {
+		digest := p.resolveDigest(ctx, imageRef)
+		if p.exempt.Load().admits(namespace, digest) {
+			p.logger.Info("exempt namespace: admitting a container whose digest was captured running here",
+				"namespace", namespace, "pod", podName, "container", ctrName, "digest", digest, "denial", reason)
+			p.audit.Log(audit.Event{
+				Action:    "allow",
+				Reason:    "namespace_exempt",
+				Overrides: reason,
+				Namespace: namespace,
+				Pod:       podName,
+				Container: ctrName,
+				Image:     imageRef,
+			})
+			return verdictSkip, ""
+		}
+		// Exempt namespace, digest not in the frozen snapshot: a drifted or
+		// newly-introduced image. Denied (and never killed — see checkExisting),
+		// audited under a distinct reason so drift is alertable from the log.
+		p.audit.Log(audit.Event{
+			Action:    "deny",
+			Reason:    "exempt_snapshot_miss",
+			Namespace: namespace,
+			Pod:       podName,
+			Container: ctrName,
+			Image:     imageRef,
+		})
 	}
 
 	return verdict, reason
@@ -442,6 +496,84 @@ func (p *plugin) checkContainer(ctx context.Context, cfg *config, pod *api.PodSa
 // inventory recovery, or both. See docs/getcert-workload-binding.md, Corner 4.
 func (p *plugin) shouldCheckExisting() bool {
 	return p.cfg.Policy.EnforceExisting || p.inventory != nil
+}
+
+// initExempt loads or captures the exempt-namespace digest snapshot from the
+// Synchronize state. A persisted file is authoritative and frozen: the
+// installer removes it on a boot config rewrite, so its presence means "already
+// captured". Absent, this is the first admission under this config, so it
+// captures what is running in the exempt namespaces now — the platform pods
+// that came up before containerd's required_plugins gate — and freezes that.
+// See exempt.go for why load must win on a reboot.
+func (p *plugin) initExempt(ctx context.Context, pods []*api.PodSandbox, ctrs []*api.Container) {
+	cfg := p.cfg
+	if len(cfg.Policy.ExemptNamespaces) == 0 {
+		return
+	}
+
+	loaded, err := loadExemptSnapshot(cfg.Policy.ExemptSnapshotPath)
+	if err != nil {
+		p.logger.Error("cannot read the exempt-namespace snapshot; exempt namespaces admit nothing until it is regenerated",
+			"path", cfg.Policy.ExemptSnapshotPath, "error", err)
+		return
+	}
+	if loaded != nil {
+		p.exempt.Store(loaded)
+		p.logger.Info("loaded exempt-namespace snapshot",
+			"path", cfg.Policy.ExemptSnapshotPath, "namespaces", loaded.Namespaces, "digests", loaded.count())
+		return
+	}
+
+	captured := p.captureExempt(ctx, pods, ctrs)
+	if captured.empty() {
+		// Freezing an empty capture would deny every platform pod. Leave the
+		// file absent so a later start — once containerd hands over the running
+		// set — captures instead. On a cold boot the file is present and loaded
+		// above, so this only guards a config-rewrite restart that momentarily
+		// saw nothing.
+		p.logger.Warn("no containers running in the exempt namespaces at first admission; snapshot not written",
+			"namespaces", cfg.Policy.ExemptNamespaces)
+		return
+	}
+	p.exempt.Store(captured)
+	if err := captured.persist(cfg.Policy.ExemptSnapshotPath); err != nil {
+		p.logger.Error("cannot persist the exempt-namespace snapshot; it will be recaptured on the next restart",
+			"path", cfg.Policy.ExemptSnapshotPath, "error", err)
+	}
+	p.logger.Info("captured exempt-namespace snapshot",
+		"path", cfg.Policy.ExemptSnapshotPath, "namespaces", captured.Namespaces, "digests", captured.count())
+}
+
+// captureExempt builds a snapshot of the image digests running in the exempt
+// namespaces, keyed by namespace. A container whose digest will not resolve is
+// skipped, not frozen: an unresolved image cannot be an admission key, and
+// admitting it later would need a resolvable digest anyway.
+func (p *plugin) captureExempt(ctx context.Context, pods []*api.PodSandbox, ctrs []*api.Container) *exemptSnapshot {
+	snap := newExemptSnapshot(p.cfg.Policy.ExemptNamespaces)
+
+	podByID := make(map[string]*api.PodSandbox, len(pods))
+	for _, pod := range pods {
+		podByID[pod.GetId()] = pod
+	}
+	for _, ctr := range ctrs {
+		pod := podByID[ctr.GetPodSandboxId()]
+		if pod == nil {
+			continue
+		}
+		namespace := pod.GetNamespace()
+		if !slices.Contains(p.cfg.Policy.ExemptNamespaces, namespace) {
+			continue
+		}
+		imageRef := ctr.GetAnnotations()[annotationImageName]
+		digest := p.resolveDigest(ctx, imageRef)
+		if digest == "" {
+			p.logger.Warn("exempt namespace: skipping a running container whose image digest will not resolve",
+				"namespace", namespace, "container", ctr.GetName(), "image", imageRef)
+			continue
+		}
+		snap.add(namespace, digest)
+	}
+	return snap
 }
 
 // Synchronize is called when the plugin connects to containerd. It records every
@@ -457,6 +589,10 @@ func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, ctrs [
 			p.inventory.recordSandbox(pod.GetId())
 		}
 	}
+
+	// Load or capture the exempt-namespace snapshot from this connect-time set,
+	// before any container check reads it and regardless of readiness.
+	p.initExempt(ctx, pods, ctrs)
 
 	if !p.shouldCheckExisting() {
 		p.logger.Info("startup check disabled", "pods", len(pods), "containers", len(ctrs))
@@ -501,6 +637,15 @@ func (p *plugin) checkExisting(ctx context.Context, cfg *config, pods []*api.Pod
 			continue
 		}
 		if verdict, _ := p.checkContainer(ctx, cfg, pod, ctr, imageRef); verdict != verdictDeny {
+			continue
+		}
+		// A running container in an exempt namespace is never killed: stopping a
+		// platform container (kube-proxy, CoreDNS) can cut the node. A snapshot
+		// miss is denied at the next create and audited; it is not enforced
+		// retroactively against something already running.
+		if slices.Contains(cfg.Policy.ExemptNamespaces, pod.GetNamespace()) {
+			p.logger.Warn("exempt namespace: leaving a running container whose digest is not in the snapshot",
+				"namespace", pod.GetNamespace(), "container", ctr.GetName())
 			continue
 		}
 		// enforce_existing off: the check only feeds the inventory.

--- a/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
@@ -53,6 +53,13 @@ IMAGE_POLICY_EOF
 then
   config_changed=1
   echo "boot config updated"
+{{- if $root.Values.nriImagePolicy.policy.exemptNamespaces }}
+  # A rewritten boot config is the one event that re-captures the exempt-namespace
+  # snapshot: drop the stale file so the plugin freezes a fresh one from what is
+  # running now. A plain restart or reboot leaves the config unchanged and keeps
+  # the frozen snapshot — the plugin reloads it rather than re-learning.
+  rm -f "/host{{ $root.Values.nriImagePolicy.hostPaths.cacheDir }}/exempt-snapshot.json"
+{{- end }}
 fi
 
 binary_changed=0
@@ -220,6 +227,13 @@ policy:
   mode: {{ $root.Values.nriImagePolicy.policy.mode | quote }}
   enforce_existing: {{ $root.Values.nriImagePolicy.policy.enforceExisting }}
   deny_missing_annotation: {{ $root.Values.nriImagePolicy.policy.denyMissingAnnotation }}
+{{- if $root.Values.nriImagePolicy.policy.exemptNamespaces }}
+  exempt_namespaces:
+{{- range $root.Values.nriImagePolicy.policy.exemptNamespaces }}
+    - {{ . | quote }}
+{{- end }}
+  exempt_snapshot_path: {{ printf "%s/exempt-snapshot.json" $root.Values.nriImagePolicy.hostPaths.cacheDir | quote }}
+{{- end }}
   label_rules:
 {{- if $root.Values.nriImagePolicy.policy.labelRules }}
 {{- toYaml $root.Values.nriImagePolicy.policy.labelRules | nindent 4 }}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -895,6 +895,14 @@ nriImagePolicy:
     mode: fail-closed  # fail-closed | audit
     enforceExisting: true
     denyMissingAnnotation: true
+    # exemptNamespaces: on the hosted lanes (pod/gke/aks), admit each listed
+    # namespace's provider platform pods — which are not on the c8s allowlist —
+    # by the image digests captured running in it, frozen at first admission and
+    # scoped to that namespace. Set to [kube-system] there. Empty (the default)
+    # keeps digest-only admission; leave it empty on cvmMode=node, whose baked
+    # floor already carries the system digests. See
+    # docs/getcert-workload-binding.md, Corner 8.
+    exemptNamespaces: []
     # labelRules: Kubernetes-style label selectors evaluated against pod
     # labels at container creation time. With the host-process model there
     # is one plugin per node, so these rules apply globally on each node;

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -6176,7 +6176,9 @@ type installerBootConfig struct {
 		} `yaml:"push"`
 	} `yaml:"allowlist"`
 	Policy struct {
-		Mode string `yaml:"mode"`
+		Mode               string   `yaml:"mode"`
+		ExemptNamespaces   []string `yaml:"exempt_namespaces"`
+		ExemptSnapshotPath string   `yaml:"exempt_snapshot_path"`
 	} `yaml:"policy"`
 }
 
@@ -6229,9 +6231,9 @@ func TestChartBootConfigParsesAsPluginYAML(t *testing.T) {
 	}
 }
 
-// The rendered worker boot config admits by the digest floor alone: no
-// exempt_namespaces key. Mirrors the node-image lockstep pin in
-// image_policy_template_test.go.
+// By default the rendered worker boot config admits by the digest floor alone:
+// no exempt_namespaces key. Mirrors the node-image lockstep pin in
+// image_policy_template_test.go. The opt-in render is covered below.
 func TestChartBootConfigHasNoExemptNamespaces(t *testing.T) {
 	out, err := helmTemplate(t)
 	if err != nil {
@@ -6245,6 +6247,32 @@ func TestChartBootConfigHasNoExemptNamespaces(t *testing.T) {
 	}
 	if strings.Contains(m[1], "exempt_namespaces") {
 		t.Errorf("worker boot config still renders exempt_namespaces:\n%s", m[1])
+	}
+}
+
+// Setting nriImagePolicy.policy.exemptNamespaces renders the exempt_namespaces
+// list, a snapshot path under the cache dir, and the install-time rm that
+// re-captures on a boot config rewrite. Decoding through yaml.v3 also proves
+// the block does not collide with the rest of the boot config.
+func TestChartBootConfigRendersExemptNamespaces(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "nriImagePolicy.policy.exemptNamespaces={kube-system,gatekeeper-system}",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := bootConfigFromInstaller(t, out, "c8s-nri-image-policy-worker")
+	if got := cfg.Policy.ExemptNamespaces; !slices.Equal(got, []string{"kube-system", "gatekeeper-system"}) {
+		t.Errorf("exempt_namespaces = %v, want [kube-system gatekeeper-system]", got)
+	}
+	if !strings.HasSuffix(cfg.Policy.ExemptSnapshotPath, "/exempt-snapshot.json") {
+		t.Errorf("exempt_snapshot_path = %q, want a .../exempt-snapshot.json path", cfg.Policy.ExemptSnapshotPath)
+	}
+
+	ds := renderedDaemonSet(t, out, "c8s-nri-image-policy-worker")
+	script := strings.Join(containerArgs(t, &ds, "install"), "\n")
+	if !strings.Contains(script, "rm -f") || !strings.Contains(script, "exempt-snapshot.json") {
+		t.Error("install script must delete the exempt snapshot on a boot config change so it re-captures")
 	}
 }
 


### PR DESCRIPTION
  Restores kube-system admission on the hosted lanes (pod/gke/aks) that #370's
  digest-only policy broke. policy.exempt_namespaces now captures the digests
  running in a listed namespace at first connect and freezes them, scoped per
  namespace — so the key is a store-resolved digest, not a name the control plane
  picks. Persisted across reboots, recaptured only on a boot config rewrite; a
  miss is denied (never killed) and audited. See Corner 8.