### PR TITLE
fix(ratlsmesh,cds): CA refresh through the provisioning client; bound…

### DIFF
--- a/internal/cmds/ratlsmesh/ca_refresh.go
+++ b/internal/cmds/ratlsmesh/ca_refresh.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package ratlsmesh
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls/cdsclient"
+)
+
+// caBundleRefresh polls CDS /ca and pushes each accepted bundle into the cert
+// managers, so mesh peers holding certs from a rotated CA still verify. Shared
+// by the host and in-guest runs, which differ only in logPrefix ("cds" vs
+// "in-guest cds").
+//
+// It refreshes through the Provider the cdsUpgrade goroutine provisions with,
+// which owns the trust state the refresh continuity-checks against. Ticks
+// before the first successful provision fail closed and warn.
+type caBundleRefresh struct {
+	logger    *slog.Logger
+	logPrefix string
+	provider  *cdsclient.Provider
+
+	interval  time.Duration
+	opTimeout time.Duration
+
+	serverCertMgr *ratls.CertManager
+	clientCertMgr *ratls.CertManager
+}
+
+func (r caBundleRefresh) run(ctx context.Context) {
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		refreshCtx, cancel := context.WithTimeout(ctx, r.opTimeout)
+		newCerts, err := r.provider.RefreshCABundle(refreshCtx)
+		cancel()
+		if err != nil {
+			r.logger.Warn(r.logPrefix+" CA bundle refresh failed", "error", err)
+			continue
+		}
+
+		r.serverCertMgr.UpdateCACerts(newCerts)
+		if r.clientCertMgr != nil {
+			r.clientCertMgr.UpdateCACerts(newCerts)
+		}
+		r.logger.Debug(r.logPrefix+" CA bundle refreshed", "count", len(newCerts))
+	}
+}

--- a/internal/cmds/ratlsmesh/ca_refresh_test.go
+++ b/internal/cmds/ratlsmesh/ca_refresh_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package ratlsmesh
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls/cdsclient"
+)
+
+// unseededProvider builds a provider whose /ca endpoint always fails, so
+// refresh ticks take the error path without a CDS fake.
+func unseededProvider(t *testing.T) *cdsclient.Provider {
+	t.Helper()
+	ca := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(ca.Close)
+
+	p, err := cdsclient.NewProvider(&cdsclient.Config{
+		CDSURL:            "http://unused",
+		AttestationApiURL: "http://unused",
+		CDSCAURL:          ca.URL,
+		NodeIP:            "10.0.0.1",
+		TEEType:           ratls.TEETypeSEVSNP,
+		HTTPClient:        &http.Client{Timeout: time.Second},
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestCABundleRefreshWarnsAndExits covers the loop's failure path: a refresh
+// that errors must warn under the run's prefix and must not push certs into
+// the managers (nil managers panic if it does), and cancelling the run ctx
+// must stop the loop.
+func TestCABundleRefreshWarnsAndExits(t *testing.T) {
+	var buf syncBuffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		caBundleRefresh{
+			logger:    slog.New(slog.NewJSONHandler(&buf, nil)),
+			logPrefix: "in-guest cds",
+			provider:  unseededProvider(t),
+			interval:  10 * time.Millisecond,
+			opTimeout: time.Second,
+		}.run(ctx)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !hasMsg(decodeLogRecords(buf.String()), "in-guest cds CA bundle refresh failed") {
+		if time.Now().After(deadline) {
+			t.Fatalf("refresh never warned; logs: %s", buf.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("run did not return after context cancel")
+	}
+}

--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -464,8 +464,17 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 			clientCertMgr:   clientCertMgr,
 			metrics:         m,
 		}.run(ctx)
+
+		go caBundleRefresh{
+			logger:        logger,
+			logPrefix:     "in-guest cds",
+			provider:      provider,
+			interval:      c.caPollInterval,
+			opTimeout:     c.cdsOpTimeout,
+			serverCertMgr: serverCertMgr,
+			clientCertMgr: clientCertMgr,
+		}.run(ctx)
 	}
-	go runInGuestCABundleRefresh(ctx, logger, c, cdsCfg, serverCertMgr, clientCertMgr)
 
 	logger.Info("ratls-mesh in-guest listening",
 		"outbound", proxy.outboundAddr,
@@ -476,37 +485,6 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 		return fmt.Errorf("in-guest proxy: %w", err)
 	}
 	return nil
-}
-
-func runInGuestCABundleRefresh(
-	ctx context.Context,
-	logger *slog.Logger,
-	c *inGuestConfig,
-	cdsCfg *cdsclient.Config,
-	serverCertMgr, clientCertMgr *ratls.CertManager,
-) {
-	client := cdsclient.NewClient(cdsCfg)
-	ticker := time.NewTicker(c.caPollInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-		refreshCtx, cancel := context.WithTimeout(ctx, c.cdsOpTimeout)
-		newCerts, err := client.RefreshCABundle(refreshCtx)
-		cancel()
-		if err != nil {
-			logger.Warn("in-guest CA bundle refresh failed", "error", err)
-			continue
-		}
-		serverCertMgr.UpdateCACerts(newCerts)
-		if clientCertMgr != nil {
-			clientCertMgr.UpdateCACerts(newCerts)
-		}
-		logger.Debug("in-guest CA bundle refreshed", "count", len(newCerts))
-	}
 }
 
 // inGuestResolver is the stub Resolver used by `ratls-mesh in-guest`.

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -411,13 +411,6 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 	// goroutine contacts CDS, gets CA-signed certs, and hot-swaps them via
 	// CertManager.SwapProvider. cds serves both attestation and CA bundle on
 	// one URL, so CDSURL and CDSCAURL both take --cds-url.
-	//
-	// cdsClient is shared between that upgrade goroutine (which seeds the trusted
-	// CA bundle during provisioning) and the CA bundle refresh goroutine below.
-	// /ca refreshes continuity-check against that seed, so they must use the same
-	// client — a fresh client would have an empty bundle and every refresh would
-	// fail with "requires a trusted CA from CDS".
-	var cdsClient *cdsclient.Client
 	if c.certMode == "cds" {
 		cdsCfg := &cdsclient.Config{
 			CDSURL:            c.cdsURL,
@@ -429,10 +422,9 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 			TEEType:           teeType,
 			CDSMeasurements:   cdsMeasurements,
 		}
-		cdsClient = cdsclient.NewClient(cdsCfg)
 		// A provider-construction failure (config validation) is logged and
 		// the mesh keeps serving self-signed certs; it never blocks startup.
-		if provider, err := cdsclient.NewProviderWithClient(cdsClient, logger); err != nil {
+		if provider, err := cdsclient.NewProvider(cdsCfg, logger); err != nil {
 			logger.Error("cds provider creation failed", "error", err)
 		} else {
 			go cdsUpgrade{
@@ -446,40 +438,18 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 				clientCertMgr:   clientCertMgr,
 				metrics:         m,
 			}.run(ctx)
+
+			go caBundleRefresh{
+				logger:        logger,
+				logPrefix:     "cds",
+				provider:      provider,
+				interval:      c.caPollInterval,
+				opTimeout:     c.cdsOpTimeout,
+				serverCertMgr: serverCertMgr,
+				clientCertMgr: clientCertMgr,
+			}.run(ctx)
+			logger.Info("CA bundle refresh enabled", "url", effectiveCAURL, "interval", c.caPollInterval)
 		}
-	}
-
-	// CA bundle refresh: periodically poll CDS /ca for updated CA bundle. Uses
-	// the same client the upgrade goroutine seeds — refresh continuity-checks
-	// against that trusted bundle, so a fresh client would never accept a
-	// refresh. Early ticks before the first successful provision are expected to
-	// warn until the seed is established.
-	if effectiveCAURL != "" && cdsClient != nil {
-		go func() {
-			ticker := time.NewTicker(c.caPollInterval)
-			defer ticker.Stop()
-
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					refreshCtx, cancel := context.WithTimeout(ctx, c.cdsOpTimeout)
-					newCerts, err := cdsClient.RefreshCABundle(refreshCtx)
-					cancel()
-					if err != nil {
-						logger.Warn("CA bundle refresh failed", "url", effectiveCAURL, "error", err)
-						continue
-					}
-					serverCertMgr.UpdateCACerts(newCerts)
-					if clientCertMgr != nil {
-						clientCertMgr.UpdateCACerts(newCerts)
-					}
-					logger.Debug("CA bundle refreshed from CDS", "count", len(newCerts))
-				}
-			}
-		}()
-		logger.Info("CA bundle refresh enabled", "url", effectiveCAURL, "interval", c.caPollInterval)
 	}
 
 	// Cert pipeline health probe: periodically check CDS /readyz.

--- a/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
+++ b/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
@@ -369,7 +369,7 @@ func TestRunProxyCDSModeDegraded(t *testing.T) {
 		return capture.hasMsg("cds certificate upgrade attempt failed (will retry)")
 	}, "cds upgrade retry warning never logged")
 	assertEventually(t, 10*time.Second, func() bool {
-		return capture.hasMsg("CA bundle refresh failed")
+		return capture.hasMsg("cds CA bundle refresh failed")
 	}, "CA refresh failure never logged")
 
 	// Configured cds, still running self-signed: the mode gauges must expose

--- a/internal/readiness/checker.go
+++ b/internal/readiness/checker.go
@@ -56,8 +56,16 @@ func (c *Checker) Run(ctx context.Context) {
 	}
 }
 
+// maxProbeTimeout bounds a single probe when the poll interval is long.
+const maxProbeTimeout = 5 * time.Second
+
 func (c *Checker) check(ctx context.Context) {
-	healthResp, err := c.attestationClient.Health(ctx)
+	// Per-probe deadline, always under one interval: a peer that accepts the
+	// connection and never answers must not park this goroutine.
+	probeCtx, cancel := context.WithTimeout(ctx, min(c.interval/2, maxProbeTimeout))
+	defer cancel()
+
+	healthResp, err := c.attestationClient.Health(probeCtx)
 	ready := err == nil && healthResp.Status == "ok"
 	c.ready.Store(ready)
 

--- a/internal/readiness/checker_test.go
+++ b/internal/readiness/checker_test.go
@@ -30,6 +30,73 @@ func healthServer(t *testing.T, status string, code int) attestationclient.Clien
 	return attestationclient.NewClientWithHTTP(srv.URL, srv.Client())
 }
 
+// hangingHealthServer accepts the request and never answers, the shape a
+// wedged attestation-api takes on the wire.
+func hangingHealthServer(t *testing.T) attestationclient.Client {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	// Cleanup is LIFO: release the handler before Close waits on it.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return attestationclient.NewClientWithHTTP(srv.URL, srv.Client())
+}
+
+// TestCheckBoundsAHungProbe pins the per-check deadline: without one, check
+// parks forever on a peer that never responds and /readyz keeps serving the
+// last stored result.
+func TestCheckBoundsAHungProbe(t *testing.T) {
+	c := NewChecker(hangingHealthServer(t), 100*time.Millisecond)
+	c.SetReady(true)
+
+	start := time.Now()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.check(context.Background())
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("check did not return within the per-check timeout")
+	}
+
+	// The lower bound distinguishes a deadline derived from the interval from
+	// one that fires immediately.
+	if d := time.Since(start); d < 40*time.Millisecond || d > time.Second {
+		t.Errorf("check took %v, want about interval/2 (50ms)", d)
+	}
+	if c.Ready() {
+		t.Error("readiness stayed true after a hung probe")
+	}
+}
+
+// TestRunReturnsOnContextCancelWithHungAPI proves the per-check ctx still
+// derives from the loop ctx.
+func TestRunReturnsOnContextCancelWithHungAPI(t *testing.T) {
+	c := NewChecker(hangingHealthServer(t), time.Hour)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		c.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancel")
+	}
+}
+
 func TestCheckerInitiallyNotReady(t *testing.T) {
 	c := NewChecker(healthServer(t, "ok", http.StatusOK), time.Second)
 	if c.Ready() {

--- a/pkg/ratls/cdsclient/client.go
+++ b/pkg/ratls/cdsclient/client.go
@@ -159,12 +159,13 @@ func (c *Client) RequestCert(ctx context.Context) (*ecdsa.PrivateKey, []byte, []
 	return key, certutil.EncodeCertPEM(certs[0].Raw), encodeCABundlePEM(certs[1:]), nil
 }
 
-// RefreshCABundle fetches the CA certificate bundle from CDS's
+// refreshCABundle fetches the CA certificate bundle from CDS's
 // /ca endpoint. A candidate is accepted only when it is already trusted or
 // when it is a CA certificate signed by an already trusted CA. This keeps
 // unauthenticated CA bundle refreshes from expanding trust without signature
-// continuity.
-func (c *Client) RefreshCABundle(ctx context.Context) ([]*x509.Certificate, error) {
+// continuity. Reached only through [Provider.RefreshCABundle], over the client
+// [Provider.Provision] seeds that trust on.
+func (c *Client) refreshCABundle(ctx context.Context) ([]*x509.Certificate, error) {
 	certs, err := c.fetchAndParseCABundle(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/ratls/cdsclient/provider.go
+++ b/pkg/ratls/cdsclient/provider.go
@@ -21,6 +21,9 @@ type Logger = ratls.Logger
 // CDS CA endpoint. Each Provision call performs:
 // authenticate -> attest -> obtain cert and authenticated CA bundle -> return
 // CA-signed certificate.
+//
+// Provision and RefreshCABundle share one client: the CA bundle Provision
+// accepts is the trust the refresh continuity-checks against.
 type Provider struct {
 	client *Client
 	logger Logger
@@ -35,13 +38,10 @@ func NewProvider(cfg *Config, logger Logger) (*Provider, error) {
 		return nil, err
 	}
 
-	return NewProviderWithClient(NewClient(cfg), logger)
+	return newProviderWithClient(NewClient(cfg), logger)
 }
 
-// NewProviderWithClient creates an CDS-backed CertProvider using an existing
-// Client. Reusing the client lets certificate provisioning seed the CA trust
-// state that later /ca refreshes continuity-check.
-func NewProviderWithClient(client *Client, logger Logger) (*Provider, error) {
+func newProviderWithClient(client *Client, logger Logger) (*Provider, error) {
 	if client == nil || client.cfg == nil {
 		return nil, fmt.Errorf("cdsclient: client is required")
 	}
@@ -79,6 +79,13 @@ func validateConfig(cfg *Config) error {
 	}
 
 	return nil
+}
+
+// RefreshCABundle fetches the current CA bundle from CDS's /ca endpoint.
+// Provision must have run first: the refresh only accepts candidates with
+// signature continuity to the bundle provisioning already established.
+func (p *Provider) RefreshCABundle(ctx context.Context) ([]*x509.Certificate, error) {
+	return p.client.refreshCABundle(ctx)
 }
 
 // Provision performs the full CDS attestation flow and returns a CA-signed

--- a/pkg/ratls/cdsclient/provider_test.go
+++ b/pkg/ratls/cdsclient/provider_test.go
@@ -305,6 +305,43 @@ func TestProviderProvision(t *testing.T) {
 	}
 }
 
+// TestProviderRefreshCABundleAfterProvision is the regression test for the
+// in-guest refresh that could never succeed: Provision and RefreshCABundle
+// must run over one client, or the continuity check has nothing to check
+// against and every refresh fails closed.
+func TestProviderRefreshCABundleAfterProvision(t *testing.T) {
+	caKey, caCert := testCA(t)
+	cdsSrv, attestSvc, issuer := mockServers(t, caKey, caCert)
+	defer cdsSrv.Close()
+	defer attestSvc.Close()
+	defer issuer.Close()
+
+	p, err := NewProvider(&Config{
+		CDSURL:            cdsSrv.URL,
+		AttestationApiURL: attestSvc.URL,
+		CDSCAURL:          issuer.URL,
+		NodeIP:            "10.0.0.1",
+		TEEType:           ratls.TEETypeSEVSNP,
+		HTTPClient:        plainHTTPClient(),
+		NodeName:          "test-node",
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := p.Provision(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	certs, err := p.RefreshCABundle(context.Background())
+	if err != nil {
+		t.Fatalf("refresh after provision: %v", err)
+	}
+	if len(certs) != 1 || !sameCertificate(certs[0], caCert) {
+		t.Fatalf("refreshed bundle = %d cert(s), want the provisioning CA", len(certs))
+	}
+}
+
 // TestProviderProvisionRejectsLeafOutsideValidityWindow proves an issued leaf
 // the mesh could never serve — expired, or NotBefore beyond the shared
 // clock-skew allowance — fails issuance instead of being cached.
@@ -371,7 +408,7 @@ func TestRefreshCABundle(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, caCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -409,7 +446,7 @@ func TestRefreshCABundleUsesExplicitCACertURL(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, caCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +476,7 @@ func TestRefreshCABundleRejectsUntrustedInitialBundle(t *testing.T) {
 		HTTPClient:        plainHTTPClient(),
 	})
 
-	_, err := client.RefreshCABundle(context.Background())
+	_, err := client.refreshCABundle(context.Background())
 	if err == nil {
 		t.Fatal("RefreshCABundle succeeded before certificate provisioning seeded trust")
 	}
@@ -465,7 +502,7 @@ func TestRefreshCABundleDoesNotAddUnverifiedRotationRoot(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, oldCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +534,7 @@ func TestRefreshCABundleDoesNotTrustPublicKeyCloneChain(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, trustedCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -528,7 +565,7 @@ func TestRefreshCABundleRejectsTrustedSignerPublicKeyClone(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, trustedCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -591,7 +628,7 @@ func TestProviderProvisionRetainsPreviouslyTrustedPublishedCA(t *testing.T) {
 		NodeName:          "test-node",
 	})
 	seedTrustedCABundle(t, client, oldCert)
-	p, err := NewProviderWithClient(client, nil)
+	p, err := newProviderWithClient(client, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -878,7 +915,7 @@ func TestRefreshCABundleAcceptsContinuitySignedRotationCA(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, oldCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -910,7 +947,7 @@ func TestRefreshCABundleAcceptsContinuitySignedRotationChainInBundleOrder(t *tes
 	})
 	seedTrustedCABundle(t, client, oldCert)
 
-	certs, err := client.RefreshCABundle(context.Background())
+	certs, err := client.refreshCABundle(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -936,7 +973,7 @@ func TestRefreshCABundleRejectsReplacementWithoutOverlap(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, oldCert)
 
-	_, err := client.RefreshCABundle(context.Background())
+	_, err := client.refreshCABundle(context.Background())
 	if err == nil {
 		t.Fatal("RefreshCABundle accepted replacement bundle with no overlap")
 	}
@@ -962,7 +999,7 @@ func TestRefreshCABundleRejectsExpiredTrustedOnlyBundle(t *testing.T) {
 	})
 	seedTrustedCABundle(t, client, currentCert, expiredCert)
 
-	_, err := client.RefreshCABundle(context.Background())
+	_, err := client.refreshCABundle(context.Background())
 	if err == nil {
 		t.Fatal("RefreshCABundle accepted a bundle containing only an expired trusted CA")
 	}


### PR DESCRIPTION
## cds readiness checker could hang on a wedged attestation-api

`readiness.Checker.check()` called `Health` on the long-lived loop ctx with no
deadline, over a client whose non-unix path is `http.DefaultClient` (no
`Timeout`). A peer that accepts the connection and never responds parked the
check goroutine forever while `/readyz` kept serving the last stored
`ready=true`.

Each probe is now bounded by `min(interval/2, 5s)` — the same clamp
`policymonitor`'s allowlist refresh already applies — so a wedged peer flips
readiness inside one interval. `Health` builds its request with the ctx, so no
transport change is needed.

Note this does not add flapping that wasn't already there: a single failed probe
already stored `ready=false`, so the timeout adds one more failure mode to that
path rather than changing its shape.

## Tests

- `TestProviderRefreshCABundleAfterProvision` — provision against the CDS fake,
  then refresh through the provider succeeds. Fails if anything reintroduces a
  second client behind `Provider.RefreshCABundle`.
- `TestCABundleRefreshWarnsAndExits` — the shared loop warns under its run's
  prefix on a failing `/ca`, does not touch the cert managers on failure (nil
  managers would panic), and exits on ctx cancel.
- `TestCheckBoundsAHungProbe` — `httptest` handler that accepts and never
  answers; `check` returns in about `interval/2` and readiness goes false. The
  lower time bound is what distinguishes a derived deadline from one that fires
  immediately.
- `TestRunReturnsOnContextCancelWithHungAPI` — the per-probe ctx still derives
  from the loop ctx.
- `TestRunProxyCDSModeDegraded` keeps covering the host loop; its expected
  warning gains the `cds` prefix.

`make lint` and `make test` (`-race`) green.

## Behaviour change

Host mode is otherwise unchanged. The refresh failure log gains the `cds` prefix
the upgrade loop already used, and the refresh goroutine now starts from the same
branch as the upgrade goroutine rather than from a separate `effectiveCAURL != ""`
guard — equivalent, since `effectiveCDSCAURL` returns `""` for every mode but
`cds`.