### PR TITLE
fix(runtimemeasure): read the TDX tuple from a real build manifest

### DIFF
--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -396,10 +396,20 @@ jobs:
       - name: get an attested, operator-key-bound kubeconfig (RA-TLS)
         run: |
           set -euo pipefail
-          # The trust gate pins the whole image tuple, not MRTD alone; the
-          # manifest is written from the same refs CM the boot used, in the
-          # nested shape a confos build manifest actually publishes.
-          printf '{"version":3,"build":{"platform":"tdx"},"tdx":{"mrtd":"%s","rtmr1":"%s","rtmr2":"%s"}}\n' "$mrtd" "$rtmr1" "$rtmr2" > /tmp/image-manifest.json
+          # Pull the manifest the image build published rather than writing
+          # one: a hand-built stub only ever proves the gate accepts the shape
+          # this step chose. The CDI tag the CVM boots and the oras artifact
+          # carrying manifest.json are the same build under sibling tags, so
+          # the manifest is fetched by stripping the -cdi suffix.
+          oras_ref="${image%-cdi}"
+          [ "$oras_ref" != "$image" ] || { echo "::error::refs CM 'image' ($image) is not a -cdi tag, so the sibling oras artifact carrying manifest.json cannot be derived"; exit 1; }
+          digest=$(crane manifest "$oras_ref" | jq -r '.layers[] | select(.annotations["org.opencontainers.image.title"] == "manifest.json") | .digest')
+          [ -n "$digest" ] || { echo "::error::$oras_ref publishes no manifest.json layer"; exit 1; }
+          crane blob "${oras_ref%%:*}@${digest}" > /tmp/image-manifest.json
+          # The published manifest must describe the image this run booted, or
+          # the gate would be pinned to a different build's measurements.
+          got_mrtd=$(jq -r '.tdx.mrtd' /tmp/image-manifest.json)
+          [ "$got_mrtd" = "$mrtd" ] || { echo "::error::published manifest MRTD ($got_mrtd) != the refs CM pin ($mrtd): $oras_ref is not the build this CVM booted"; exit 1; }
           c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --image-manifest /tmp/image-manifest.json --out /tmp/guest.kubeconfig --timeout 180s
           [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }
           WHO=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -397,8 +397,9 @@ jobs:
         run: |
           set -euo pipefail
           # The trust gate pins the whole image tuple, not MRTD alone; the
-          # manifest is written from the same refs CM the boot used.
-          printf '{"mrtd":"%s","rtmr1":"%s","rtmr2":"%s"}\n' "$mrtd" "$rtmr1" "$rtmr2" > /tmp/image-manifest.json
+          # manifest is written from the same refs CM the boot used, in the
+          # nested shape a confos build manifest actually publishes.
+          printf '{"version":3,"build":{"platform":"tdx"},"tdx":{"mrtd":"%s","rtmr1":"%s","rtmr2":"%s"}}\n' "$mrtd" "$rtmr1" "$rtmr2" > /tmp/image-manifest.json
           c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --image-manifest /tmp/image-manifest.json --out /tmp/guest.kubeconfig --timeout 180s
           [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }
           WHO=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -486,11 +486,12 @@ On TDX, `--measurements` pins MRTD, which covers only the TDVF firmware: the
 guest kernel and rootfs live in RTMR[1] and RTMR[2], and a verdict pinned on
 MRTD alone warns that they are unmeasured by that policy. To pin the whole
 image, pass `--image-manifest <file>` — a build-artifact manifest published
-with the guest image build, a JSON object carrying `mrtd`, `rtmr1` and
-`rtmr2` (96 lowercase hex chars each, each named once). The three registers
-are loaded atomically from that one provenanced manifest and all three are
-compared exactly, the same rule `c8s get-kubeconfig` applies to the same
-manifest — MRTD is deliberately not merged into the `--measurements`
+with the guest image build, carrying `mrtd`, `rtmr1` and `rtmr2` (96
+lowercase hex chars each, each named once) under its `tdx` object, as a
+confos manifest publishes them; a flat top-level tuple is also accepted. The
+three registers are loaded atomically from that one provenanced manifest and
+all three are compared exactly, the same rule `c8s get-kubeconfig` applies to
+the same manifest — MRTD is deliberately not merged into the `--measurements`
 allowlist, since an allowlist is satisfied by any member and a launch digest
 from a different build would then pass alongside this manifest's
 RTMR[1]/RTMR[2].
@@ -585,8 +586,8 @@ and again on the RA-TLS credential-release connection:
 - **platform** — TDX only; any other platform is refused up front;
 - **guest image** — MRTD, RTMR[1] and RTMR[2] must match the tuple from
   `--image-manifest` (required), an explicitly selected, provenanced
-  build-artifact manifest carrying all three fields. A generic artifact-hash
-  `manifest.json` is not an image pin and is rejected;
+  build-artifact manifest carrying all three fields under its `tdx` object. A
+  generic artifact-hash `manifest.json` is not an image pin and is rejected;
 - **RTMR[3] chain** — the register must equal the operator-key seed
   (`pkg/runtimemeasure.ForOperatorKey` over the exact pubkey PEM bytes)
   extended, in order, by each digest-pinned `--workload-image` ref (tags are

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -488,7 +488,10 @@ MRTD alone warns that they are unmeasured by that policy. To pin the whole
 image, pass `--image-manifest <file>` — a build-artifact manifest published
 with the guest image build, carrying `mrtd`, `rtmr1` and `rtmr2` (96
 lowercase hex chars each, each named once) under its `tdx` object, as a
-confos manifest publishes them; a flat top-level tuple is also accepted. The
+confos manifest publishes them; a flat top-level tuple is also accepted.
+The manifest ships as a `manifest.json` layer in the image's oras artifact
+(the tag the CDI ref carries without its `-cdi` suffix), so it can be
+fetched with `crane blob` for the exact build a node booted. The
 three registers are loaded atomically from that one provenanced manifest and
 all three are compared exactly, the same rule `c8s get-kubeconfig` applies to
 the same manifest — MRTD is deliberately not merged into the `--measurements`

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -578,28 +578,34 @@ Caveats the output surfaces:
 
 ### Trust gate: `c8s get-kubeconfig`
 
-`c8s get-kubeconfig` obtains an admin kubeconfig from a measured TDX node CVM.
+`c8s get-kubeconfig` obtains an admin kubeconfig from a measured node CVM.
 Before any credential flows it enforces the node's **full measured identity**,
 and it enforces the identical policy twice — on the initial attestation gate
 and again on the RA-TLS credential-release connection:
 
-- **platform** — TDX only; any other platform is refused up front;
-- **guest image** — MRTD, RTMR[1] and RTMR[2] must match the tuple from
+- **platform** — the `--image-manifest` shape selects it (a TDX tuple or SNP
+  `snp_variants`); a node of any other platform is refused up front;
+- **guest image (TDX)** — MRTD, RTMR[1] and RTMR[2] must match the tuple from
   `--image-manifest` (required), an explicitly selected, provenanced
   build-artifact manifest carrying all three fields under its `tdx` object. A
   generic artifact-hash `manifest.json` is not an image pin and is rejected;
-- **RTMR[3] chain** — the register must equal the operator-key seed
+- **RTMR[3] chain (TDX)** — the register must equal the operator-key seed
   (`pkg/runtimemeasure.ForOperatorKey` over the exact pubkey PEM bytes)
   extended, in order, by each digest-pinned `--workload-image` ref (tags are
   rejected). With no `--workload-image` the register must equal the bare seed;
+- **guest image + operator key (SEV-SNP)** — the report's MEASUREMENT must be
+  one of the per-SMP launch digests pinned by `snp_variants` (one image has
+  one digest per vCPU count), and HOSTDATA must equal `SHA-256(operator
+  pubkey)`. SNP has no runtime-extend register, so `--workload-image` is a
+  usage error there rather than a silently ignored flag;
 - **certificate body** — the credential-release serving cert must sit inside
   its validity window (NotBefore with a bounded 5-minute skew, NotAfter with
   none) and, being self-signed, verify its own signature with its attested
   key.
 
-What the gate proves: a genuine TDX guest booted exactly the pinned image,
-was launched to trust exactly this operator key, and ran exactly the expected
-measured workloads. What it does not prove: anything about images or keys the
+What the gate proves: a genuine guest of the manifest's platform booted
+exactly the pinned image, was launched to trust exactly this operator key,
+and (on TDX) ran exactly the expected measured workloads. What it does not prove: anything about images or keys the
 manifest and flags do not name, or the provenance of the manifest file itself
 — select it deliberately from the trusted image build. An RTMR[3]-only gate
 would prove much less: the untrusted host stages the operator public key, so

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -21,13 +21,14 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-kubeconfig",
 		Short: "Attest a c8s CVM and obtain an operator kubeconfig via the measured image + operator-key gate",
-		Long: "get-kubeconfig attests a measured c8s TDX CVM and enforces its full\n" +
-			"measured identity: the guest image tuple (MRTD, RTMR[1], RTMR[2]) from\n" +
-			"an explicitly selected build-artifact manifest, plus the RTMR[3] chain\n" +
+		Long: "get-kubeconfig attests a measured c8s CVM and enforces its full\n" +
+			"measured identity. The build-artifact manifest selects the platform:\n" +
+			"on TDX the image tuple (MRTD, RTMR[1], RTMR[2]) plus the RTMR[3] chain\n" +
 			"seeded by the operator's key and extended by the expected workload\n" +
-			"images. It then exchanges a CSR for a short-lived kube client cert over\n" +
-			"the cred-release endpoint and writes a kubeconfig. Verification runs\n" +
-			"in-process (attestation-go).",
+			"images; on SEV-SNP the pinned per-SMP launch digest plus the\n" +
+			"operator-key HOSTDATA binding. It then exchanges a CSR for a\n" +
+			"short-lived kube client cert over the cred-release endpoint and writes\n" +
+			"a kubeconfig. Verification runs in-process (attestation-go).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cfg.OperatorKeyPath == "" || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
 				return fmt.Errorf("--operator-key, --image-manifest and --out are required")
@@ -70,7 +71,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ReleaseBaseURL, "release-url", "", "cred-release base URL (overrides --node)")
 	f.StringVar(&cfg.APIServerURL, "apiserver-url", "", "apiserver URL for the kubeconfig (overrides --node)")
 	f.StringVar(&cfg.OperatorKeyPath, "operator-key", "", "operator ECDSA private key PEM (its public half is bound into RTMR[3]) (required)")
-	f.StringVar(&cfg.ImageManifestPath, "image-manifest", "", "an explicitly selected, provenanced build-artifact manifest carrying the expected guest image's measured identity — TDX: the full tuple (mrtd, rtmr1, rtmr2); SNP: the per-SMP launch digests (snp_variants). The manifest's shape selects the platform, and the gate pins every value, so a host cannot substitute the guest image and replay the operator-key binding (required)")
+	f.StringVar(&cfg.ImageManifestPath, "image-manifest", "", "an explicitly selected, provenanced build-artifact manifest carrying the expected guest image's measured identity — TDX: mrtd/rtmr1/rtmr2; SNP: snp_variants. Its shape selects the platform, and the gate pins every value (required)")
 	f.StringArrayVar(&cfg.WorkloadImages, "workload-image", nil, "digest-pinned image ref (\"sha256:<hex>\" or \"name@sha256:<hex>\"; tags rejected) the node's measurer is expected to have extended into RTMR[3]; repeatable, in first-extend order. Omit if the node runs no measured workloads. TDX only — SNP has no runtime-extend register")
 	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")

--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -132,7 +132,7 @@ func newTestEnv(t *testing.T, attestURL string, releaseStatus int, releaseBody s
 	if err != nil {
 		t.Fatal(err)
 	}
-	manifestPath := writeTestManifest(t)
+	manifestPath := writeTestManifest(t, tdxManifest())
 	exp, err := policyFor(manifestPath, pub, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -402,7 +402,7 @@ func TestCheckMeasuredIdentityNoRTMR3Claim(t *testing.T) {
 // register.
 func TestPolicyForWorkloadImages(t *testing.T) {
 	pub := operatorPub(t)
-	manifest := writeTestManifest(t)
+	manifest := writeTestManifest(t, tdxManifest())
 	digA := "sha256:" + strings.Repeat("aa", 32)
 	digB := "ghcr.io/acme/api@sha256:" + strings.Repeat("bb", 32)
 
@@ -445,7 +445,7 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 // error, including when the two spellings differ but the digest does not.
 func TestPolicyForRejectsDuplicateWorkloadImages(t *testing.T) {
 	pub := operatorPub(t)
-	manifest := writeTestManifest(t)
+	manifest := writeTestManifest(t, tdxManifest())
 	dig := "sha256:" + strings.Repeat("aa", 32)
 
 	for _, tc := range []struct {

--- a/internal/cmds/getkubeconfig/getkubeconfig_test.go
+++ b/internal/cmds/getkubeconfig/getkubeconfig_test.go
@@ -18,7 +18,7 @@ import (
 // RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)), via the shared convention.
 func TestPolicyForSeedMatchesGuestConvention(t *testing.T) {
 	pub := []byte("-----BEGIN PUBLIC KEY-----\nMFk...\n-----END PUBLIC KEY-----\n")
-	exp, err := policyFor(writeTestManifest(t), pub, nil)
+	exp, err := policyFor(writeTestManifest(t, tdxManifest()), pub, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -33,24 +33,39 @@ var (
 	testMRTDHex  = strings.Repeat("1a", 48)
 	testRTMR1Hex = strings.Repeat("2b", 48)
 	testRTMR2Hex = strings.Repeat("3c", 48)
+
+	// The per-SMP launch digests the SNP test manifests pin.
+	testSNPSMP2Hex = strings.Repeat("4d", 48)
+	testSNPSMP4Hex = strings.Repeat("5e", 48)
 )
 
-// writeTestManifest writes a build-artifact manifest carrying the test tuple.
-func writeTestManifest(t *testing.T) string {
+// writeTestManifest writes a build-artifact manifest with the given body.
+func writeTestManifest(t *testing.T, content string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "manifest.json")
-	content := `{"mrtd":"` + testMRTDHex + `","rtmr1":"` + testRTMR1Hex + `","rtmr2":"` + testRTMR2Hex + `"}`
 	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return p
 }
 
+// tdxManifest is the TDX tuple the test manifests pin.
+func tdxManifest() string {
+	return `{"mrtd":"` + testMRTDHex + `","rtmr1":"` + testRTMR1Hex + `","rtmr2":"` + testRTMR2Hex + `"}`
+}
+
+// snpManifest is a two-variant SNP manifest (smp2 + smp4) for one image.
+func snpManifest() string {
+	return `{"version":3,"snp_variants":[
+	  {"smp":2,"measurement":{"snp_launch_digest":"` + testSNPSMP2Hex + `","algorithm":"sha384"}},
+	  {"smp":4,"measurement":{"snp_launch_digest":"` + testSNPSMP4Hex + `","algorithm":"sha384"}}]}`
+}
+
 // testPolicy builds the full measured policy for the test tuple + operator
 // key, with no workload images (bare-seed RTMR[3]).
 func testPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
 	t.Helper()
-	exp, err := policyFor(writeTestManifest(t), operatorPubPEM, nil)
+	exp, err := policyFor(writeTestManifest(t, tdxManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,20 +372,10 @@ func TestVerifyServerCertAuthenticatesBody(t *testing.T) {
 	})
 }
 
-// snpTestPolicy builds an SNP gate from a two-variant manifest carrying the
-// digests confirmed against hardware on build 9ce1642 (smp2 and smp4).
+// snpTestPolicy builds an SNP gate from a two-variant manifest.
 func snpTestPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
 	t.Helper()
-	const smp2 = "e9dd4de2ddc59700fa8842fff7e9d80605d433d8d32e8b4112afd761b96506e4e67d97139df5cad76dfa5881c7b11ff5"
-	const smp4 = "a0185a3b93d8a10438fc2c2445edf9908c6de694350a3eaf2f55277d5287fd3532a02994c1e2932809da4147d8b58c97"
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	body := `{"version":3,"snp_variants":[
-	  {"smp":2,"measurement":{"snp_launch_digest":"` + smp2 + `","algorithm":"sha384"}},
-	  {"smp":4,"measurement":{"snp_launch_digest":"` + smp4 + `","algorithm":"sha384"}}]}`
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	exp, err := policyFor(p, operatorPubPEM, nil)
+	exp, err := policyFor(writeTestManifest(t, snpManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,12 +451,7 @@ func TestSNPGateFailsClosed(t *testing.T) {
 // SNP has no runtime-extend register, so claiming workload enforcement is a
 // usage error rather than a silently-ignored flag.
 func TestSNPPolicyRejectsWorkloadImages(t *testing.T) {
-	const smp2 = "e9dd4de2ddc59700fa8842fff7e9d80605d433d8d32e8b4112afd761b96506e4e67d97139df5cad76dfa5881c7b11ff5"
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	body := `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + smp2 + `","algorithm":"sha384"}}]}`
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	p := writeTestManifest(t, snpManifest())
 	_, err := policyFor(p, operatorPub(t), []string{"repo@sha256:" + strings.Repeat("c", 64)})
 	if err == nil || !strings.Contains(err.Error(), "requires a TDX node") {
 		t.Fatalf("want workload-image rejection, got %v", err)

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -1,10 +1,11 @@
 // Package getkubeconfig implements the operator-side client (B4 client) that
-// obtains a kube credential from a measured TDX CVM: it attests the node,
-// confirms the full measured identity — the guest image tuple (MRTD,
-// RTMR[1], RTMR[2]) from an explicitly selected build-artifact manifest plus
-// the RTMR[3] chain seeded by the operator's key and extended by the expected
-// workload images — then exchanges a CSR for a short-lived kube client cert
-// over the cred-release endpoint and assembles a kubeconfig.
+// obtains a kube credential from a measured CVM: it attests the node,
+// confirms the full measured identity — on TDX the image tuple (MRTD,
+// RTMR[1], RTMR[2]) plus the RTMR[3] chain seeded by the operator's key and
+// extended by the expected workload images; on SEV-SNP the pinned per-SMP
+// launch digest plus the operator-key HOSTDATA binding — then exchanges a CSR
+// for a short-lived kube client cert over the cred-release endpoint and
+// assembles a kubeconfig.
 package getkubeconfig
 
 import (
@@ -38,9 +39,9 @@ var verifyEnvelope = teeverify.Verify
 // and reproduce the bare operator-key register — which is why the image tuple
 // anchors the policy and RTMR[3] then binds the key and workload set.
 type measuredPolicy struct {
-	// platform is the TEE this policy gates: PlatformTDX or PlatformSNP,
-	// inferred from the manifest's shape (see policyFor). Evidence from any
-	// other platform is refused before the claims are read.
+	// platform is the TEE this policy gates, inferred from the manifest's
+	// shape (see policyFor). Other platforms are refused before the claims
+	// are read.
 	platform teetypes.PlatformType
 
 	pins runtimemeasure.ImagePins
@@ -49,11 +50,9 @@ type measuredPolicy struct {
 	// expected. TDX only.
 	rtmr3 [runtimemeasure.Size]byte
 
-	// SNP: the per-SMP launch-digest set (image identity — SNP's MEASUREMENT
-	// covers initial vCPU state, so one image has one digest per vCPU count)
-	// and the operator-key binding committed as HOSTDATA at launch. SNP has
-	// no runtime-extend register, so there is no workload chain to pin
-	// (c8s#331).
+	// SNP: the pinned per-SMP launch digests plus the operator-key binding
+	// committed as HOSTDATA at launch. No runtime-extend register, so there
+	// is no workload chain to pin (c8s#331).
 	snpPins  runtimemeasure.SNPImagePins
 	hostData [runtimemeasure.HostDataSize]byte
 }
@@ -67,26 +66,37 @@ type measuredPolicy struct {
 func policyFor(manifestPath string, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
 	// The manifest's shape names the platform: a TDX build publishes the
 	// mrtd/rtmr1/rtmr2 tuple, an SNP build publishes snp_variants (per-SMP
-	// launch digests). Trying TDX first keeps the existing error text for a
-	// manifest that is neither.
+	// launch digests). TDX is tried first so a manifest that is neither keeps
+	// the TDX error text.
 	pins, tdxErr := runtimemeasure.LoadImageManifest(manifestPath)
-	if tdxErr != nil {
-		snpPins, snpErr := runtimemeasure.LoadSNPImageManifest(manifestPath)
-		if snpErr != nil {
-			return measuredPolicy{}, fmt.Errorf("--image-manifest: %w", tdxErr)
-		}
-		// SNP has no runtime-extend register, so workload extends cannot be
-		// verified at all — accepting the flag would claim an enforcement
-		// that does not exist.
-		if len(workloadImages) > 0 {
-			return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
-		}
-		return measuredPolicy{
-			platform: teetypes.PlatformSNP,
-			snpPins:  snpPins,
-			hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
-		}, nil
+	if tdxErr == nil {
+		return tdxPolicy(pins, operatorPubPEM, workloadImages)
 	}
+	snpPins, snpErr := runtimemeasure.LoadSNPImageManifest(manifestPath)
+	if snpErr != nil {
+		return measuredPolicy{}, fmt.Errorf("--image-manifest: %w", tdxErr)
+	}
+	return snpPolicy(snpPins, operatorPubPEM, workloadImages)
+}
+
+// snpPolicy pins the per-SMP launch-digest set and the HOSTDATA operator-key
+// binding. SNP has no runtime-extend register, so there is no workload chain.
+func snpPolicy(pins runtimemeasure.SNPImagePins, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
+	// Accepting --workload-image here would claim an enforcement that cannot
+	// exist rather than silently ignoring the flag.
+	if len(workloadImages) > 0 {
+		return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
+	}
+	return measuredPolicy{
+		platform: teetypes.PlatformSNP,
+		snpPins:  pins,
+		hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
+	}, nil
+}
+
+// tdxPolicy pins the image tuple and the RTMR[3] chain: the operator-key seed
+// extended, in first-extend order, by each digest-pinned workload image.
+func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
 	digests := make([]string, 0, len(workloadImages))
 	seen := make(map[string]string, len(workloadImages))
 	for _, ref := range workloadImages {
@@ -120,10 +130,6 @@ func policyFor(manifestPath string, operatorPubPEM []byte, workloadImages []stri
 // Both paths funnel through here so the two gates cannot diverge. Fails
 // closed on any missing piece.
 func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy) (*teetypes.VerificationResult, error) {
-	// The trust gate is TDX-only — MRTD/RTMRs exist nowhere else — so reject
-	// other platforms up front with a clear error instead of a late "claims
-	// carry no rtmr_3" (e.g. a SEV-SNP node can never satisfy the policy,
-	// however genuine its quote).
 	var env teetypes.AttestationEvidence
 	if err := json.Unmarshal(envelopeJSON, &env); err != nil {
 		return nil, fmt.Errorf("parse evidence envelope: %w", err)
@@ -207,15 +213,10 @@ func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy)
 }
 
 // checkSNPMeasuredIdentity asserts the verified claims match the SNP policy:
-// the launch digest against the pinned per-SMP set (image identity), and
-// HOSTDATA against the operator-key binding the launcher committed. Together
-// these are the SNP analog of TDX's image tuple + RTMR[3] — see c8s#331.
-// Absent or malformed claims fail closed.
-//
-// Accepting any digest in the set is as tight as pinning a scalar: every
-// entry comes from the same provenanced manifest describing the same image,
-// differing only in the vCPU count it was launched with (SNP's MEASUREMENT
-// covers initial vCPU state).
+// the launch digest against the pinned per-SMP set, and HOSTDATA against the
+// operator-key binding the launcher committed. Together these are the SNP
+// analog of TDX's image tuple + RTMR[3] (c8s#331). Absent or malformed claims
+// fail closed.
 func checkSNPMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy) error {
 	launch := strings.ToLower(strings.TrimSpace(res.Claims.LaunchDigest))
 	if launch == "" {
@@ -228,12 +229,8 @@ func checkSNPMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPoli
 	}
 	copy(got[:], raw)
 	if !exp.snpPins.Has(got) {
-		wants := make([]string, 0, len(exp.snpPins.BySMP))
-		for _, d := range exp.snpPins.Digests() {
-			wants = append(wants, hex.EncodeToString(d[:]))
-		}
 		return fmt.Errorf("launch digest mismatch: node reports %s, image manifest pins %s (a different guest image booted, or a vCPU count the manifest has no variant for)",
-			launch, strings.Join(wants, ", "))
+			launch, exp.snpPins)
 	}
 
 	// HOSTDATA carries the operator-key binding. A VM launched without

--- a/pkg/runtimemeasure/manifest.go
+++ b/pkg/runtimemeasure/manifest.go
@@ -22,8 +22,16 @@ type ImagePins struct {
 
 // imageManifest is the JSON subset LoadImageManifest reads. Extra fields are
 // allowed (build manifests carry other data); the three registers are not
-// optional.
+// optional. A confos build manifest nests them under "tdx"; the flat form is
+// also accepted so a hand-written pin stays valid.
 type imageManifest struct {
+	MRTD  string           `json:"mrtd"`
+	RTMR1 string           `json:"rtmr1"`
+	RTMR2 string           `json:"rtmr2"`
+	TDX   *tdxMeasurements `json:"tdx"`
+}
+
+type tdxMeasurements struct {
 	MRTD  string `json:"mrtd"`
 	RTMR1 string `json:"rtmr1"`
 	RTMR2 string `json:"rtmr2"`
@@ -47,7 +55,12 @@ func LoadImageManifest(path string) (ImagePins, error) {
 	if err := json.Unmarshal(data, &m); err != nil {
 		return pins, fmt.Errorf("image manifest %s is not a JSON object: %w", path, err)
 	}
-	if err := rejectDuplicateRegisters(data); err != nil {
+	scope := "" // top level; a confos manifest nests the tuple under "tdx"
+	if m.TDX != nil {
+		m.MRTD, m.RTMR1, m.RTMR2 = m.TDX.MRTD, m.TDX.RTMR1, m.TDX.RTMR2
+		scope = "tdx"
+	}
+	if err := rejectDuplicateRegisters(data, scope); err != nil {
 		return ImagePins{}, fmt.Errorf("image manifest %s: %w", path, err)
 	}
 	for _, f := range []struct {
@@ -77,7 +90,11 @@ func LoadImageManifest(path string) (ImagePins, error) {
 // while a human (and any diff or signature-over-the-published-line review)
 // reads the other. Unknown extra fields stay tolerated — build manifests carry
 // plenty — but the three registers this pin is made of must be unambiguous.
-func rejectDuplicateRegisters(data []byte) error {
+//
+// scope names the object the registers were read from: "" for the top level,
+// or "tdx" for a confos manifest that nests them. The check must follow the
+// tuple, or a duplicate inside the nested object would go unnoticed.
+func rejectDuplicateRegisters(data []byte, scope string) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.Token()
 	if err != nil {
@@ -101,6 +118,12 @@ func rejectDuplicateRegisters(data []byte) error {
 		var value json.RawMessage
 		if err := dec.Decode(&value); err != nil {
 			return nil
+		}
+		if scope != "" {
+			if key == scope {
+				return rejectDuplicateRegisters(value, "")
+			}
+			continue
 		}
 		switch key {
 		case "mrtd", "rtmr1", "rtmr2":

--- a/pkg/runtimemeasure/manifest_snp.go
+++ b/pkg/runtimemeasure/manifest_snp.go
@@ -1,23 +1,21 @@
 package runtimemeasure
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
+	"strings"
 )
 
-// SNPImagePins is the complete SEV-SNP measurement identity of one guest
-// image: the set of launch digests the image can legitimately produce, keyed
-// by vCPU count.
-//
-// Unlike TDX's single MRTD, an SNP launch measurement covers the initial vCPU
-// state, so ONE image has one digest per SMP count — which is why the build
-// ships a per-SMP IGVM (guest-smp2.igvm, guest-smp4.igvm, …) and publishes a
-// digest for each. All entries come from one provenanced build manifest
-// describing one image, so pinning the set is as tight as pinning a scalar:
-// every member attests the same rootfs, differing only in how many vCPUs it
-// was launched with.
+// SNPImagePins is the SEV-SNP measurement identity of one guest image: the
+// launch digests it can legitimately produce, keyed by vCPU count. An SNP
+// launch measurement covers the initial vCPU state, so one image has one
+// digest per SMP count, and the build ships a per-SMP IGVM. Every entry comes
+// from the same provenanced manifest, so pinning the set is as tight as
+// pinning a scalar.
 type SNPImagePins struct {
 	// BySMP maps vCPU count to that variant's launch digest.
 	BySMP map[int][Size]byte
@@ -26,11 +24,7 @@ type SNPImagePins struct {
 // Digests returns the pinned launch digests in ascending SMP order, for
 // verifiers that accept any variant of the pinned image.
 func (p SNPImagePins) Digests() [][Size]byte {
-	smps := make([]int, 0, len(p.BySMP))
-	for smp := range p.BySMP {
-		smps = append(smps, smp)
-	}
-	sort.Ints(smps)
+	smps := slices.Sorted(maps.Keys(p.BySMP))
 	out := make([][Size]byte, 0, len(smps))
 	for _, smp := range smps {
 		out = append(out, p.BySMP[smp])
@@ -38,14 +32,21 @@ func (p SNPImagePins) Digests() [][Size]byte {
 	return out
 }
 
+// String renders the pinned digests as hex in ascending SMP order, so
+// operator-facing output is stable.
+func (p SNPImagePins) String() string {
+	smps := slices.Sorted(maps.Keys(p.BySMP))
+	out := make([]string, 0, len(smps))
+	for _, smp := range smps {
+		d := p.BySMP[smp]
+		out = append(out, hex.EncodeToString(d[:]))
+	}
+	return strings.Join(out, ", ")
+}
+
 // Has reports whether digest is one of the pinned variants.
 func (p SNPImagePins) Has(digest [Size]byte) bool {
-	for _, want := range p.BySMP {
-		if want == digest {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slices.Collect(maps.Values(p.BySMP)), digest)
 }
 
 // snpImageManifest is the JSON subset LoadSNPImageManifest reads. Extra
@@ -61,13 +62,11 @@ type snpImageManifest struct {
 	} `json:"snp_variants"`
 }
 
-// LoadSNPImageManifest loads an SEV-SNP image pin — the per-SMP launch-digest
-// set — from one provenanced build-artifact manifest. Every variant must
-// carry a positive smp, a sha384 algorithm, and a digest of exactly 96
-// lowercase hex chars; a malformed or duplicate variant fails the whole load,
-// so a policy can never pin part of an image or a value other than the one it
-// reads. A TDX manifest (mrtd/rtmr1/rtmr2) or a generic artifact-hash
-// manifest.json carries no snp_variants and is rejected by the same rule.
+// LoadSNPImageManifest loads the per-SMP launch-digest set from one
+// provenanced build-artifact manifest. A malformed or duplicate variant fails
+// the whole load, so a policy can never pin part of an image. A TDX tuple or
+// a generic artifact-hash manifest.json carries no snp_variants and is
+// rejected by the same rule.
 func LoadSNPImageManifest(path string) (SNPImagePins, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/runtimemeasure/manifest_test.go
+++ b/pkg/runtimemeasure/manifest_test.go
@@ -194,3 +194,60 @@ func TestLoadSNPImageManifestRejects(t *testing.T) {
 		})
 	}
 }
+
+// The loaders must read a real confos build manifest, not just a hand-written
+// pin. These fixtures are verbatim gate artifacts (confos manifest schema
+// version 3): the TDX tuple nests under "tdx", the SNP set under
+// "snp_variants", and both carry build/inputs/outputs the loaders ignore.
+func TestLoadImageManifestReadsConfosBuild(t *testing.T) {
+	pins, err := LoadImageManifest("testdata/confos-tdx-manifest.json")
+	if err != nil {
+		t.Fatalf("LoadImageManifest on a real confos manifest: %v", err)
+	}
+	const wantMRTD = "9309eaae9c151e766de0f97b1d1aaeb76b8c8c366080803943fb566521c8f0cf00a142d8b7b0683ed1d42c5a27198ba1"
+	if got := hex.EncodeToString(pins.MRTD[:]); got != wantMRTD {
+		t.Errorf("mrtd = %s, want %s", got, wantMRTD)
+	}
+	var zero [Size]byte
+	if pins.RTMR1 == zero || pins.RTMR2 == zero {
+		t.Error("rtmr1/rtmr2 must be read from the nested tdx object")
+	}
+}
+
+func TestLoadSNPImageManifestReadsConfosBuild(t *testing.T) {
+	pins, err := LoadSNPImageManifest("testdata/confos-snp-manifest.json")
+	if err != nil {
+		t.Fatalf("LoadSNPImageManifest on a real confos manifest: %v", err)
+	}
+	// The build ships one IGVM per supported vCPU count.
+	for _, smp := range []int{2, 4, 8, 16} {
+		if _, ok := pins.BySMP[smp]; !ok {
+			t.Errorf("no pinned variant for smp %d", smp)
+		}
+	}
+	const wantSMP2 = "e7df3a8f1dbe619607154ce994c1f4d7299c539b120b5560e137f7787e4ece304f270c1444b47c863fde54bc863291d7"
+	if got := pins.BySMP[2]; hex.EncodeToString(got[:]) != wantSMP2 {
+		t.Errorf("smp2 digest = %x, want %s", got, wantSMP2)
+	}
+}
+
+// A TDX manifest carries no snp_variants and an SNP manifest no tdx tuple, so
+// each loader must reject the other platform's real manifest. This is what
+// get-kubeconfig's platform inference rests on.
+func TestLoadersRejectTheOtherPlatformsConfosBuild(t *testing.T) {
+	if _, err := LoadSNPImageManifest("testdata/confos-tdx-manifest.json"); err == nil {
+		t.Error("SNP loader accepted a real TDX manifest")
+	}
+	if _, err := LoadImageManifest("testdata/confos-snp-manifest.json"); err == nil {
+		t.Error("TDX loader accepted a real SNP manifest")
+	}
+}
+
+// The duplicate-key guard must follow the tuple into the nested object, or a
+// nested manifest could name a register twice and load the last value.
+func TestLoadImageManifestRejectsDuplicateNestedRegister(t *testing.T) {
+	p := writeManifest(t, `{"tdx":{"mrtd":"`+mrtdHex+`","mrtd":"`+strings.Repeat("9f", Size)+`","rtmr1":"`+rtmr1Hex+`","rtmr2":"`+rtmr2Hex+`"}}`)
+	if _, err := LoadImageManifest(p); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("error = %v, want a duplicate-key rejection", err)
+	}
+}

--- a/pkg/runtimemeasure/manifest_test.go
+++ b/pkg/runtimemeasure/manifest_test.go
@@ -1,7 +1,6 @@
 package runtimemeasure
 
 import (
-	"bytes"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -132,17 +131,8 @@ const (
 	snpSMP4Digest = "a0185a3b93d8a10438fc2c2445edf9908c6de694350a3eaf2f55277d5287fd3532a02994c1e2932809da4147d8b58c97"
 )
 
-func snpManifest(t *testing.T, body string) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
-
 func TestLoadSNPImageManifestValid(t *testing.T) {
-	p := snpManifest(t, `{"version":3,"snp_variants":[
+	p := writeManifest(t, `{"version":3,"snp_variants":[
 	  {"smp":2,"measurement":{"snp_launch_digest":"`+snpSMP2Digest+`","algorithm":"sha384"}},
 	  {"smp":4,"measurement":{"snp_launch_digest":"`+snpSMP4Digest+`","algorithm":"sha384"}}]}`)
 	pins, err := LoadSNPImageManifest(p)
@@ -152,25 +142,26 @@ func TestLoadSNPImageManifestValid(t *testing.T) {
 	if len(pins.BySMP) != 2 {
 		t.Fatalf("got %d variants, want 2", len(pins.BySMP))
 	}
-	want2, _ := hex.DecodeString(snpSMP2Digest)
-	if got := pins.BySMP[2]; !bytes.Equal(got[:], want2) {
-		t.Errorf("smp2 digest = %x, want %s", got, snpSMP2Digest)
-	}
-	// Both variants are accepted: one image, two legitimate vCPU shapes.
-	var d2, d4 [Size]byte
-	copy(d2[:], want2)
-	w4, _ := hex.DecodeString(snpSMP4Digest)
-	copy(d4[:], w4)
-	if !pins.Has(d2) || !pins.Has(d4) {
-		t.Error("Has must accept every pinned variant")
+	for _, v := range []struct {
+		smp  int
+		want string
+	}{{2, snpSMP2Digest}, {4, snpSMP4Digest}} {
+		got := pins.BySMP[v.smp]
+		if hex.EncodeToString(got[:]) != v.want {
+			t.Errorf("smp%d digest = %x, want %s", v.smp, got, v.want)
+		}
+		// Both variants are accepted: one image, two legitimate vCPU shapes.
+		if !pins.Has(got) {
+			t.Errorf("Has must accept the smp%d variant", v.smp)
+		}
 	}
 	var other [Size]byte
 	if pins.Has(other) {
 		t.Error("Has must reject a digest outside the set")
 	}
-	// Digests are ordered by SMP so operator-facing output is stable.
-	if got := pins.Digests(); len(got) != 2 || !bytes.Equal(got[0][:], want2) {
-		t.Errorf("Digests() not in ascending SMP order: %x", got)
+	// Rendered in ascending SMP order so operator-facing output is stable.
+	if got, want := pins.String(), snpSMP2Digest+", "+snpSMP4Digest; got != want {
+		t.Errorf("String() = %s, want %s", got, want)
 	}
 }
 
@@ -188,7 +179,7 @@ func TestLoadSNPImageManifestRejects(t *testing.T) {
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, err := LoadSNPImageManifest(snpManifest(t, body)); err == nil {
+			if _, err := LoadSNPImageManifest(writeManifest(t, body)); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})

--- a/pkg/runtimemeasure/testdata/confos-snp-manifest.json
+++ b/pkg/runtimemeasure/testdata/confos-snp-manifest.json
@@ -1,0 +1,97 @@
+{
+  "build": {
+    "format": "raw",
+    "memory": "16G",
+    "platform": "snp",
+    "timestamp": "2026-08-18T22:56:53Z"
+  },
+  "inputs": {
+    "base_image": {
+      "path": "image.raw",
+      "sha256": "8da0bb9d5b36fad19c1223df38e772342f7760c134bf5c453bd9b9ff36b2083b"
+    },
+    "firmware": {
+      "path": "OVMF.fd",
+      "sha256": "97d21d0b7af4511d57b31c6c14f77a573cb0fc2559fd2afd3d5428490e381d2b"
+    },
+    "initrd": {
+      "path": "combined-initrd.img",
+      "sha256": "5d25095fbb9574d181f6e3f9d9d34ee73f7020c7981f19a670934a3c748b26d9"
+    },
+    "kernel": {
+      "hardening_config_sha256": "6d11310996c8d7805ca9ed95d790e86e9ec0932ec8a555107434373de34bc66b",
+      "kernel_extra_config_sha256": "649c53e9e590a6c36a6e48243e3cf649329c1015fb154c1a6555181d6e0cca1c",
+      "linux_version": "6.16.12",
+      "module_signing_cert_sha256": "7d63b4c90d89cd795edbad8d48c484b9b9d14e9bb65d029561e70b617735727a",
+      "randstruct_seed_sha256": "7d6b81e63586f80ea22920623630caee43ec2eeab3113be606ab75da779ce317",
+      "required_config_sha256": "ea97d2774893e2d33674db7bab601a2e029402ee3058b1f414fe14ace19618f2",
+      "snapshot_config_sha256": "237a5293c9482b873670c81daa5dcb64b626bd0923a12a72de6b424dc6f8f47b",
+      "vmlinuz_sha256": "541ccfb3caf7e9c7c944d96ebbe44225dbfc38968917c14f7ac5dbb37831a858"
+    }
+  },
+  "outputs": {
+    "disk_image": {
+      "path": "disk.raw",
+      "sha256": "8da0bb9d5b36fad19c1223df38e772342f7760c134bf5c453bd9b9ff36b2083b"
+    },
+    "uki": {
+      "path": "uki.efi",
+      "sha256": "7096002bd8eedb6beac7a4fa452d17357aabaca2c26a33f7988b3ad77251324a"
+    }
+  },
+  "snp_variants": [
+    {
+      "igvm": {
+        "path": "guest-smp2.igvm",
+        "sha256": "6b0975765c3acf2d6fbd24da6cf0ee357cbb9b84d639c4bd48754b5df9598f60"
+      },
+      "measurement": {
+        "algorithm": "sha384",
+        "page_count": 37944,
+        "snp_launch_digest": "e7df3a8f1dbe619607154ce994c1f4d7299c539b120b5560e137f7787e4ece304f270c1444b47c863fde54bc863291d7",
+        "vmsa_count": 2
+      },
+      "smp": 2
+    },
+    {
+      "igvm": {
+        "path": "guest-smp4.igvm",
+        "sha256": "01e58c3d36c92d230ffc1e252b1761d40f27347805979dd47142ff15a2b5d530"
+      },
+      "measurement": {
+        "algorithm": "sha384",
+        "page_count": 37946,
+        "snp_launch_digest": "e0615da999afd20375d64ec9aaf0c480d6854198c01ed3e4157f881a96f635e532f7ad528ef69b408ef10319be5db106",
+        "vmsa_count": 4
+      },
+      "smp": 4
+    },
+    {
+      "igvm": {
+        "path": "guest-smp8.igvm",
+        "sha256": "38231022470daeced687f43160aac60260da8fb1dc6f4227d08b232a6195ba0b"
+      },
+      "measurement": {
+        "algorithm": "sha384",
+        "page_count": 37950,
+        "snp_launch_digest": "7e32c5c22d2eee8044d0206ec183783fb1c442a4089cf41491a2c3e1805ec99a7e571eca98eddd80d521e69716033157",
+        "vmsa_count": 8
+      },
+      "smp": 8
+    },
+    {
+      "igvm": {
+        "path": "guest-smp16.igvm",
+        "sha256": "7f5652620c94f6995a40962a1e9e4bc51aaf2b956475c332d478a20dfb3ad531"
+      },
+      "measurement": {
+        "algorithm": "sha384",
+        "page_count": 37958,
+        "snp_launch_digest": "3d77864bca73abbe93a00192e39daf23abe1d8a95b059e12d0189f8c17c6af3144be01713c6d6def0eb858361701ea5b",
+        "vmsa_count": 16
+      },
+      "smp": 16
+    }
+  ],
+  "version": 3
+}

--- a/pkg/runtimemeasure/testdata/confos-tdx-manifest.json
+++ b/pkg/runtimemeasure/testdata/confos-tdx-manifest.json
@@ -1,0 +1,48 @@
+{
+  "build": {
+    "format": "raw",
+    "memory": "16G",
+    "platform": "tdx",
+    "timestamp": "2026-08-18T22:55:34Z"
+  },
+  "inputs": {
+    "base_image": {
+      "path": "image.raw",
+      "sha256": "1730d795ecb7eab8b9d1d0fb13147d3707d2468b5d37e0759e4c03fa11a3d5fd"
+    },
+    "initrd": {
+      "path": "combined-initrd.img",
+      "sha256": "5d25095fbb9574d181f6e3f9d9d34ee73f7020c7981f19a670934a3c748b26d9"
+    },
+    "kernel": {
+      "hardening_config_sha256": "6d11310996c8d7805ca9ed95d790e86e9ec0932ec8a555107434373de34bc66b",
+      "kernel_extra_config_sha256": "649c53e9e590a6c36a6e48243e3cf649329c1015fb154c1a6555181d6e0cca1c",
+      "linux_version": "6.16.12",
+      "module_signing_cert_sha256": "7d63b4c90d89cd795edbad8d48c484b9b9d14e9bb65d029561e70b617735727a",
+      "randstruct_seed_sha256": "7d6b81e63586f80ea22920623630caee43ec2eeab3113be606ab75da779ce317",
+      "required_config_sha256": "ea97d2774893e2d33674db7bab601a2e029402ee3058b1f414fe14ace19618f2",
+      "snapshot_config_sha256": "237a5293c9482b873670c81daa5dcb64b626bd0923a12a72de6b424dc6f8f47b",
+      "vmlinuz_sha256": "541ccfb3caf7e9c7c944d96ebbe44225dbfc38968917c14f7ac5dbb37831a858"
+    }
+  },
+  "outputs": {
+    "disk_image": {
+      "path": "disk.raw",
+      "sha256": "1730d795ecb7eab8b9d1d0fb13147d3707d2468b5d37e0759e4c03fa11a3d5fd"
+    },
+    "uki": {
+      "path": "uki.efi",
+      "sha256": "14bd10c0575dc04291fa3890f11c474d61e55156a79a4e2407b37db80d3afec5"
+    }
+  },
+  "tdx": {
+    "firmware": {
+      "path": "OVMF.tdx.fd",
+      "sha256": "a7edaeff6fc4bef8924461cb0fb68a194c3595d08ccad2720cca926dea12f7cf"
+    },
+    "mrtd": "9309eaae9c151e766de0f97b1d1aaeb76b8c8c366080803943fb566521c8f0cf00a142d8b7b0683ed1d42c5a27198ba1",
+    "rtmr1": "fc0e743e04e2d7531c8b0e4168f5814ac769905bedd75333b64984a84f33082be89125a523df2febe9ec85ed912719a9",
+    "rtmr2": "deda5c913487bf3cde10497c260ce2333267fa107c98740ef7849a74034911a29e9d1327b1e8a16b44664079ec62a8d6"
+  },
+  "version": 3
+}


### PR DESCRIPTION
## Problem

`c8s get-kubeconfig` requires `--image-manifest`, and it cannot read the
manifest the image build publishes. A confos manifest nests the tuple under
`tdx`:

```json
{"version": 3, "build": {"platform": "tdx"},
 "tdx": {"mrtd": "...", "rtmr1": "...", "rtmr2": "...", "firmware": {...}}}
```

`LoadImageManifest` only read `mrtd`/`rtmr1`/`rtmr2` at the top level, so the
whole load failed with `missing "mrtd"`.

That manifest is not hard to come by: it ships as a `manifest.json` layer in
the image's own oras artifact, on the same floating tags as the image.
Confirmed against the live registry — `ghcr.io/…/node-guest-base:rke2-tdx-dev`
carries it (1969 B), as does `:rke2-snp-dev` (3311 B). Pulling the published
TDX manifest and loading it on `main` reproduces the failure.

So the mandatory flag on the one command that requires it rejects the file that
ships with every published image. The SNP loader was already correct: the same
artifact loads as 4 variants (smp 2/4/8/16).

Nothing caught this because `tdx-metal-e2e` built its own manifest with
`printf` — the one shape a real build never emits — so the loader and the lane
agreed with each other and both disagreed with what is published.

## Fix

- Read the tuple from the nested `tdx` object, keeping the flat top-level form
  so a hand-written pin stays valid.
- Carry `rejectDuplicateRegisters` into whichever object the tuple came from.
  Without this a nested manifest could name `mrtd` twice and silently load the
  last value, which is the exact substitution that guard exists to stop.
- `tdx-metal-e2e` now fetches `manifest.json` from the oras artifact that ships
  with the image (the CDI tag without its `-cdi` suffix) and asserts its MRTD
  equals the refs CM pin, so a manifest from another build fails the run rather
  than pinning the gate to the wrong measurements.

## Tests

Both loaders run against verbatim confos artifacts committed as fixtures
(~5 KB), replacing a schema asserted only by hand-written literals: each loader
reads its own platform's real manifest, and each rejects the other's (what
`get-kubeconfig`'s platform inference rests on). Plus a duplicate-key case
inside the nested object.

Confirmed the TDX fixture test fails on `main` with the original
`missing "mrtd"` and passes here, and that the fetch logic the e2e now runs
resolves the layer and loads through the fixed parser against the live
registry.

Includes #400, merged into this branch.
