### PR TITLE
refactor(get-kubeconfig): tidy the SNP gate after #394

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -578,28 +578,34 @@ Caveats the output surfaces:
 
 ### Trust gate: `c8s get-kubeconfig`
 
-`c8s get-kubeconfig` obtains an admin kubeconfig from a measured TDX node CVM.
+`c8s get-kubeconfig` obtains an admin kubeconfig from a measured node CVM.
 Before any credential flows it enforces the node's **full measured identity**,
 and it enforces the identical policy twice — on the initial attestation gate
 and again on the RA-TLS credential-release connection:
 
-- **platform** — TDX only; any other platform is refused up front;
-- **guest image** — MRTD, RTMR[1] and RTMR[2] must match the tuple from
+- **platform** — the `--image-manifest` shape selects it (a TDX tuple or SNP
+  `snp_variants`); a node of any other platform is refused up front;
+- **guest image (TDX)** — MRTD, RTMR[1] and RTMR[2] must match the tuple from
   `--image-manifest` (required), an explicitly selected, provenanced
   build-artifact manifest carrying all three fields under its `tdx` object. A
   generic artifact-hash `manifest.json` is not an image pin and is rejected;
-- **RTMR[3] chain** — the register must equal the operator-key seed
+- **RTMR[3] chain (TDX)** — the register must equal the operator-key seed
   (`pkg/runtimemeasure.ForOperatorKey` over the exact pubkey PEM bytes)
   extended, in order, by each digest-pinned `--workload-image` ref (tags are
   rejected). With no `--workload-image` the register must equal the bare seed;
+- **guest image + operator key (SEV-SNP)** — the report's MEASUREMENT must be
+  one of the per-SMP launch digests pinned by `snp_variants` (one image has
+  one digest per vCPU count), and HOSTDATA must equal `SHA-256(operator
+  pubkey)`. SNP has no runtime-extend register, so `--workload-image` is a
+  usage error there rather than a silently ignored flag;
 - **certificate body** — the credential-release serving cert must sit inside
   its validity window (NotBefore with a bounded 5-minute skew, NotAfter with
   none) and, being self-signed, verify its own signature with its attested
   key.
 
-What the gate proves: a genuine TDX guest booted exactly the pinned image,
-was launched to trust exactly this operator key, and ran exactly the expected
-measured workloads. What it does not prove: anything about images or keys the
+What the gate proves: a genuine guest of the manifest's platform booted
+exactly the pinned image, was launched to trust exactly this operator key,
+and (on TDX) ran exactly the expected measured workloads. What it does not prove: anything about images or keys the
 manifest and flags do not name, or the provenance of the manifest file itself
 — select it deliberately from the trusted image build. An RTMR[3]-only gate
 would prove much less: the untrusted host stages the operator public key, so

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -21,13 +21,14 @@ func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "get-kubeconfig",
 		Short: "Attest a c8s CVM and obtain an operator kubeconfig via the measured image + operator-key gate",
-		Long: "get-kubeconfig attests a measured c8s TDX CVM and enforces its full\n" +
-			"measured identity: the guest image tuple (MRTD, RTMR[1], RTMR[2]) from\n" +
-			"an explicitly selected build-artifact manifest, plus the RTMR[3] chain\n" +
+		Long: "get-kubeconfig attests a measured c8s CVM and enforces its full\n" +
+			"measured identity. The build-artifact manifest selects the platform:\n" +
+			"on TDX the image tuple (MRTD, RTMR[1], RTMR[2]) plus the RTMR[3] chain\n" +
 			"seeded by the operator's key and extended by the expected workload\n" +
-			"images. It then exchanges a CSR for a short-lived kube client cert over\n" +
-			"the cred-release endpoint and writes a kubeconfig. Verification runs\n" +
-			"in-process (attestation-go).",
+			"images; on SEV-SNP the pinned per-SMP launch digest plus the\n" +
+			"operator-key HOSTDATA binding. It then exchanges a CSR for a\n" +
+			"short-lived kube client cert over the cred-release endpoint and writes\n" +
+			"a kubeconfig. Verification runs in-process (attestation-go).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cfg.OperatorKeyPath == "" || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
 				return fmt.Errorf("--operator-key, --image-manifest and --out are required")
@@ -70,7 +71,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ReleaseBaseURL, "release-url", "", "cred-release base URL (overrides --node)")
 	f.StringVar(&cfg.APIServerURL, "apiserver-url", "", "apiserver URL for the kubeconfig (overrides --node)")
 	f.StringVar(&cfg.OperatorKeyPath, "operator-key", "", "operator ECDSA private key PEM (its public half is bound into RTMR[3]) (required)")
-	f.StringVar(&cfg.ImageManifestPath, "image-manifest", "", "an explicitly selected, provenanced build-artifact manifest carrying the expected guest image's measured identity — TDX: the full tuple (mrtd, rtmr1, rtmr2); SNP: the per-SMP launch digests (snp_variants). The manifest's shape selects the platform, and the gate pins every value, so a host cannot substitute the guest image and replay the operator-key binding (required)")
+	f.StringVar(&cfg.ImageManifestPath, "image-manifest", "", "an explicitly selected, provenanced build-artifact manifest carrying the expected guest image's measured identity — TDX: mrtd/rtmr1/rtmr2; SNP: snp_variants. Its shape selects the platform, and the gate pins every value (required)")
 	f.StringArrayVar(&cfg.WorkloadImages, "workload-image", nil, "digest-pinned image ref (\"sha256:<hex>\" or \"name@sha256:<hex>\"; tags rejected) the node's measurer is expected to have extended into RTMR[3]; repeatable, in first-extend order. Omit if the node runs no measured workloads. TDX only — SNP has no runtime-extend register")
 	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")

--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -132,7 +132,7 @@ func newTestEnv(t *testing.T, attestURL string, releaseStatus int, releaseBody s
 	if err != nil {
 		t.Fatal(err)
 	}
-	manifestPath := writeTestManifest(t)
+	manifestPath := writeTestManifest(t, tdxManifest())
 	exp, err := policyFor(manifestPath, pub, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -402,7 +402,7 @@ func TestCheckMeasuredIdentityNoRTMR3Claim(t *testing.T) {
 // register.
 func TestPolicyForWorkloadImages(t *testing.T) {
 	pub := operatorPub(t)
-	manifest := writeTestManifest(t)
+	manifest := writeTestManifest(t, tdxManifest())
 	digA := "sha256:" + strings.Repeat("aa", 32)
 	digB := "ghcr.io/acme/api@sha256:" + strings.Repeat("bb", 32)
 
@@ -445,7 +445,7 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 // error, including when the two spellings differ but the digest does not.
 func TestPolicyForRejectsDuplicateWorkloadImages(t *testing.T) {
 	pub := operatorPub(t)
-	manifest := writeTestManifest(t)
+	manifest := writeTestManifest(t, tdxManifest())
 	dig := "sha256:" + strings.Repeat("aa", 32)
 
 	for _, tc := range []struct {

--- a/internal/cmds/getkubeconfig/getkubeconfig_test.go
+++ b/internal/cmds/getkubeconfig/getkubeconfig_test.go
@@ -18,7 +18,7 @@ import (
 // RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)), via the shared convention.
 func TestPolicyForSeedMatchesGuestConvention(t *testing.T) {
 	pub := []byte("-----BEGIN PUBLIC KEY-----\nMFk...\n-----END PUBLIC KEY-----\n")
-	exp, err := policyFor(writeTestManifest(t), pub, nil)
+	exp, err := policyFor(writeTestManifest(t, tdxManifest()), pub, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -33,24 +33,39 @@ var (
 	testMRTDHex  = strings.Repeat("1a", 48)
 	testRTMR1Hex = strings.Repeat("2b", 48)
 	testRTMR2Hex = strings.Repeat("3c", 48)
+
+	// The per-SMP launch digests the SNP test manifests pin.
+	testSNPSMP2Hex = strings.Repeat("4d", 48)
+	testSNPSMP4Hex = strings.Repeat("5e", 48)
 )
 
-// writeTestManifest writes a build-artifact manifest carrying the test tuple.
-func writeTestManifest(t *testing.T) string {
+// writeTestManifest writes a build-artifact manifest with the given body.
+func writeTestManifest(t *testing.T, content string) string {
 	t.Helper()
 	p := filepath.Join(t.TempDir(), "manifest.json")
-	content := `{"mrtd":"` + testMRTDHex + `","rtmr1":"` + testRTMR1Hex + `","rtmr2":"` + testRTMR2Hex + `"}`
 	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	return p
 }
 
+// tdxManifest is the TDX tuple the test manifests pin.
+func tdxManifest() string {
+	return `{"mrtd":"` + testMRTDHex + `","rtmr1":"` + testRTMR1Hex + `","rtmr2":"` + testRTMR2Hex + `"}`
+}
+
+// snpManifest is a two-variant SNP manifest (smp2 + smp4) for one image.
+func snpManifest() string {
+	return `{"version":3,"snp_variants":[
+	  {"smp":2,"measurement":{"snp_launch_digest":"` + testSNPSMP2Hex + `","algorithm":"sha384"}},
+	  {"smp":4,"measurement":{"snp_launch_digest":"` + testSNPSMP4Hex + `","algorithm":"sha384"}}]}`
+}
+
 // testPolicy builds the full measured policy for the test tuple + operator
 // key, with no workload images (bare-seed RTMR[3]).
 func testPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
 	t.Helper()
-	exp, err := policyFor(writeTestManifest(t), operatorPubPEM, nil)
+	exp, err := policyFor(writeTestManifest(t, tdxManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,20 +372,10 @@ func TestVerifyServerCertAuthenticatesBody(t *testing.T) {
 	})
 }
 
-// snpTestPolicy builds an SNP gate from a two-variant manifest carrying the
-// digests confirmed against hardware on build 9ce1642 (smp2 and smp4).
+// snpTestPolicy builds an SNP gate from a two-variant manifest.
 func snpTestPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
 	t.Helper()
-	const smp2 = "e9dd4de2ddc59700fa8842fff7e9d80605d433d8d32e8b4112afd761b96506e4e67d97139df5cad76dfa5881c7b11ff5"
-	const smp4 = "a0185a3b93d8a10438fc2c2445edf9908c6de694350a3eaf2f55277d5287fd3532a02994c1e2932809da4147d8b58c97"
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	body := `{"version":3,"snp_variants":[
-	  {"smp":2,"measurement":{"snp_launch_digest":"` + smp2 + `","algorithm":"sha384"}},
-	  {"smp":4,"measurement":{"snp_launch_digest":"` + smp4 + `","algorithm":"sha384"}}]}`
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	exp, err := policyFor(p, operatorPubPEM, nil)
+	exp, err := policyFor(writeTestManifest(t, snpManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -446,12 +451,7 @@ func TestSNPGateFailsClosed(t *testing.T) {
 // SNP has no runtime-extend register, so claiming workload enforcement is a
 // usage error rather than a silently-ignored flag.
 func TestSNPPolicyRejectsWorkloadImages(t *testing.T) {
-	const smp2 = "e9dd4de2ddc59700fa8842fff7e9d80605d433d8d32e8b4112afd761b96506e4e67d97139df5cad76dfa5881c7b11ff5"
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	body := `{"snp_variants":[{"smp":2,"measurement":{"snp_launch_digest":"` + smp2 + `","algorithm":"sha384"}}]}`
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
+	p := writeTestManifest(t, snpManifest())
 	_, err := policyFor(p, operatorPub(t), []string{"repo@sha256:" + strings.Repeat("c", 64)})
 	if err == nil || !strings.Contains(err.Error(), "requires a TDX node") {
 		t.Fatalf("want workload-image rejection, got %v", err)

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -1,10 +1,11 @@
 // Package getkubeconfig implements the operator-side client (B4 client) that
-// obtains a kube credential from a measured TDX CVM: it attests the node,
-// confirms the full measured identity — the guest image tuple (MRTD,
-// RTMR[1], RTMR[2]) from an explicitly selected build-artifact manifest plus
-// the RTMR[3] chain seeded by the operator's key and extended by the expected
-// workload images — then exchanges a CSR for a short-lived kube client cert
-// over the cred-release endpoint and assembles a kubeconfig.
+// obtains a kube credential from a measured CVM: it attests the node,
+// confirms the full measured identity — on TDX the image tuple (MRTD,
+// RTMR[1], RTMR[2]) plus the RTMR[3] chain seeded by the operator's key and
+// extended by the expected workload images; on SEV-SNP the pinned per-SMP
+// launch digest plus the operator-key HOSTDATA binding — then exchanges a CSR
+// for a short-lived kube client cert over the cred-release endpoint and
+// assembles a kubeconfig.
 package getkubeconfig
 
 import (

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -228,12 +228,8 @@ func checkSNPMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPoli
 	}
 	copy(got[:], raw)
 	if !exp.snpPins.Has(got) {
-		wants := make([]string, 0, len(exp.snpPins.BySMP))
-		for _, d := range exp.snpPins.Digests() {
-			wants = append(wants, hex.EncodeToString(d[:]))
-		}
 		return fmt.Errorf("launch digest mismatch: node reports %s, image manifest pins %s (a different guest image booted, or a vCPU count the manifest has no variant for)",
-			launch, strings.Join(wants, ", "))
+			launch, exp.snpPins)
 	}
 
 	// HOSTDATA carries the operator-key binding. A VM launched without

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -38,9 +38,9 @@ var verifyEnvelope = teeverify.Verify
 // and reproduce the bare operator-key register — which is why the image tuple
 // anchors the policy and RTMR[3] then binds the key and workload set.
 type measuredPolicy struct {
-	// platform is the TEE this policy gates: PlatformTDX or PlatformSNP,
-	// inferred from the manifest's shape (see policyFor). Evidence from any
-	// other platform is refused before the claims are read.
+	// platform is the TEE this policy gates, inferred from the manifest's
+	// shape (see policyFor). Other platforms are refused before the claims
+	// are read.
 	platform teetypes.PlatformType
 
 	pins runtimemeasure.ImagePins
@@ -49,11 +49,9 @@ type measuredPolicy struct {
 	// expected. TDX only.
 	rtmr3 [runtimemeasure.Size]byte
 
-	// SNP: the per-SMP launch-digest set (image identity — SNP's MEASUREMENT
-	// covers initial vCPU state, so one image has one digest per vCPU count)
-	// and the operator-key binding committed as HOSTDATA at launch. SNP has
-	// no runtime-extend register, so there is no workload chain to pin
-	// (c8s#331).
+	// SNP: the pinned per-SMP launch digests plus the operator-key binding
+	// committed as HOSTDATA at launch. No runtime-extend register, so there
+	// is no workload chain to pin (c8s#331).
 	snpPins  runtimemeasure.SNPImagePins
 	hostData [runtimemeasure.HostDataSize]byte
 }
@@ -67,26 +65,37 @@ type measuredPolicy struct {
 func policyFor(manifestPath string, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
 	// The manifest's shape names the platform: a TDX build publishes the
 	// mrtd/rtmr1/rtmr2 tuple, an SNP build publishes snp_variants (per-SMP
-	// launch digests). Trying TDX first keeps the existing error text for a
-	// manifest that is neither.
+	// launch digests). TDX is tried first so a manifest that is neither keeps
+	// the TDX error text.
 	pins, tdxErr := runtimemeasure.LoadImageManifest(manifestPath)
-	if tdxErr != nil {
-		snpPins, snpErr := runtimemeasure.LoadSNPImageManifest(manifestPath)
-		if snpErr != nil {
-			return measuredPolicy{}, fmt.Errorf("--image-manifest: %w", tdxErr)
-		}
-		// SNP has no runtime-extend register, so workload extends cannot be
-		// verified at all — accepting the flag would claim an enforcement
-		// that does not exist.
-		if len(workloadImages) > 0 {
-			return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
-		}
-		return measuredPolicy{
-			platform: teetypes.PlatformSNP,
-			snpPins:  snpPins,
-			hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
-		}, nil
+	if tdxErr == nil {
+		return tdxPolicy(pins, operatorPubPEM, workloadImages)
 	}
+	snpPins, snpErr := runtimemeasure.LoadSNPImageManifest(manifestPath)
+	if snpErr != nil {
+		return measuredPolicy{}, fmt.Errorf("--image-manifest: %w", tdxErr)
+	}
+	return snpPolicy(snpPins, operatorPubPEM, workloadImages)
+}
+
+// snpPolicy pins the per-SMP launch-digest set and the HOSTDATA operator-key
+// binding. SNP has no runtime-extend register, so there is no workload chain.
+func snpPolicy(pins runtimemeasure.SNPImagePins, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
+	// Accepting --workload-image here would claim an enforcement that cannot
+	// exist rather than silently ignoring the flag.
+	if len(workloadImages) > 0 {
+		return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
+	}
+	return measuredPolicy{
+		platform: teetypes.PlatformSNP,
+		snpPins:  pins,
+		hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
+	}, nil
+}
+
+// tdxPolicy pins the image tuple and the RTMR[3] chain: the operator-key seed
+// extended, in first-extend order, by each digest-pinned workload image.
+func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
 	digests := make([]string, 0, len(workloadImages))
 	seen := make(map[string]string, len(workloadImages))
 	for _, ref := range workloadImages {
@@ -120,10 +129,6 @@ func policyFor(manifestPath string, operatorPubPEM []byte, workloadImages []stri
 // Both paths funnel through here so the two gates cannot diverge. Fails
 // closed on any missing piece.
 func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy) (*teetypes.VerificationResult, error) {
-	// The trust gate is TDX-only — MRTD/RTMRs exist nowhere else — so reject
-	// other platforms up front with a clear error instead of a late "claims
-	// carry no rtmr_3" (e.g. a SEV-SNP node can never satisfy the policy,
-	// however genuine its quote).
 	var env teetypes.AttestationEvidence
 	if err := json.Unmarshal(envelopeJSON, &env); err != nil {
 		return nil, fmt.Errorf("parse evidence envelope: %w", err)
@@ -207,15 +212,10 @@ func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy)
 }
 
 // checkSNPMeasuredIdentity asserts the verified claims match the SNP policy:
-// the launch digest against the pinned per-SMP set (image identity), and
-// HOSTDATA against the operator-key binding the launcher committed. Together
-// these are the SNP analog of TDX's image tuple + RTMR[3] — see c8s#331.
-// Absent or malformed claims fail closed.
-//
-// Accepting any digest in the set is as tight as pinning a scalar: every
-// entry comes from the same provenanced manifest describing the same image,
-// differing only in the vCPU count it was launched with (SNP's MEASUREMENT
-// covers initial vCPU state).
+// the launch digest against the pinned per-SMP set, and HOSTDATA against the
+// operator-key binding the launcher committed. Together these are the SNP
+// analog of TDX's image tuple + RTMR[3] (c8s#331). Absent or malformed claims
+// fail closed.
 func checkSNPMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy) error {
 	launch := strings.ToLower(strings.TrimSpace(res.Claims.LaunchDigest))
 	if launch == "" {

--- a/pkg/runtimemeasure/manifest_snp.go
+++ b/pkg/runtimemeasure/manifest_snp.go
@@ -1,23 +1,21 @@
 package runtimemeasure
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
-	"sort"
+	"slices"
+	"strings"
 )
 
-// SNPImagePins is the complete SEV-SNP measurement identity of one guest
-// image: the set of launch digests the image can legitimately produce, keyed
-// by vCPU count.
-//
-// Unlike TDX's single MRTD, an SNP launch measurement covers the initial vCPU
-// state, so ONE image has one digest per SMP count — which is why the build
-// ships a per-SMP IGVM (guest-smp2.igvm, guest-smp4.igvm, …) and publishes a
-// digest for each. All entries come from one provenanced build manifest
-// describing one image, so pinning the set is as tight as pinning a scalar:
-// every member attests the same rootfs, differing only in how many vCPUs it
-// was launched with.
+// SNPImagePins is the SEV-SNP measurement identity of one guest image: the
+// launch digests it can legitimately produce, keyed by vCPU count. An SNP
+// launch measurement covers the initial vCPU state, so one image has one
+// digest per SMP count, and the build ships a per-SMP IGVM. Every entry comes
+// from the same provenanced manifest, so pinning the set is as tight as
+// pinning a scalar.
 type SNPImagePins struct {
 	// BySMP maps vCPU count to that variant's launch digest.
 	BySMP map[int][Size]byte
@@ -26,11 +24,7 @@ type SNPImagePins struct {
 // Digests returns the pinned launch digests in ascending SMP order, for
 // verifiers that accept any variant of the pinned image.
 func (p SNPImagePins) Digests() [][Size]byte {
-	smps := make([]int, 0, len(p.BySMP))
-	for smp := range p.BySMP {
-		smps = append(smps, smp)
-	}
-	sort.Ints(smps)
+	smps := slices.Sorted(maps.Keys(p.BySMP))
 	out := make([][Size]byte, 0, len(smps))
 	for _, smp := range smps {
 		out = append(out, p.BySMP[smp])
@@ -38,14 +32,21 @@ func (p SNPImagePins) Digests() [][Size]byte {
 	return out
 }
 
+// String renders the pinned digests as hex in ascending SMP order, so
+// operator-facing output is stable.
+func (p SNPImagePins) String() string {
+	smps := slices.Sorted(maps.Keys(p.BySMP))
+	out := make([]string, 0, len(smps))
+	for _, smp := range smps {
+		d := p.BySMP[smp]
+		out = append(out, hex.EncodeToString(d[:]))
+	}
+	return strings.Join(out, ", ")
+}
+
 // Has reports whether digest is one of the pinned variants.
 func (p SNPImagePins) Has(digest [Size]byte) bool {
-	for _, want := range p.BySMP {
-		if want == digest {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(slices.Collect(maps.Values(p.BySMP)), digest)
 }
 
 // snpImageManifest is the JSON subset LoadSNPImageManifest reads. Extra
@@ -61,13 +62,11 @@ type snpImageManifest struct {
 	} `json:"snp_variants"`
 }
 
-// LoadSNPImageManifest loads an SEV-SNP image pin — the per-SMP launch-digest
-// set — from one provenanced build-artifact manifest. Every variant must
-// carry a positive smp, a sha384 algorithm, and a digest of exactly 96
-// lowercase hex chars; a malformed or duplicate variant fails the whole load,
-// so a policy can never pin part of an image or a value other than the one it
-// reads. A TDX manifest (mrtd/rtmr1/rtmr2) or a generic artifact-hash
-// manifest.json carries no snp_variants and is rejected by the same rule.
+// LoadSNPImageManifest loads the per-SMP launch-digest set from one
+// provenanced build-artifact manifest. A malformed or duplicate variant fails
+// the whole load, so a policy can never pin part of an image. A TDX tuple or
+// a generic artifact-hash manifest.json carries no snp_variants and is
+// rejected by the same rule.
 func LoadSNPImageManifest(path string) (SNPImagePins, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/pkg/runtimemeasure/manifest_test.go
+++ b/pkg/runtimemeasure/manifest_test.go
@@ -1,7 +1,6 @@
 package runtimemeasure
 
 import (
-	"bytes"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -132,17 +131,8 @@ const (
 	snpSMP4Digest = "a0185a3b93d8a10438fc2c2445edf9908c6de694350a3eaf2f55277d5287fd3532a02994c1e2932809da4147d8b58c97"
 )
 
-func snpManifest(t *testing.T, body string) string {
-	t.Helper()
-	p := filepath.Join(t.TempDir(), "manifest.json")
-	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	return p
-}
-
 func TestLoadSNPImageManifestValid(t *testing.T) {
-	p := snpManifest(t, `{"version":3,"snp_variants":[
+	p := writeManifest(t, `{"version":3,"snp_variants":[
 	  {"smp":2,"measurement":{"snp_launch_digest":"`+snpSMP2Digest+`","algorithm":"sha384"}},
 	  {"smp":4,"measurement":{"snp_launch_digest":"`+snpSMP4Digest+`","algorithm":"sha384"}}]}`)
 	pins, err := LoadSNPImageManifest(p)
@@ -152,25 +142,26 @@ func TestLoadSNPImageManifestValid(t *testing.T) {
 	if len(pins.BySMP) != 2 {
 		t.Fatalf("got %d variants, want 2", len(pins.BySMP))
 	}
-	want2, _ := hex.DecodeString(snpSMP2Digest)
-	if got := pins.BySMP[2]; !bytes.Equal(got[:], want2) {
-		t.Errorf("smp2 digest = %x, want %s", got, snpSMP2Digest)
-	}
-	// Both variants are accepted: one image, two legitimate vCPU shapes.
-	var d2, d4 [Size]byte
-	copy(d2[:], want2)
-	w4, _ := hex.DecodeString(snpSMP4Digest)
-	copy(d4[:], w4)
-	if !pins.Has(d2) || !pins.Has(d4) {
-		t.Error("Has must accept every pinned variant")
+	for _, v := range []struct {
+		smp  int
+		want string
+	}{{2, snpSMP2Digest}, {4, snpSMP4Digest}} {
+		got := pins.BySMP[v.smp]
+		if hex.EncodeToString(got[:]) != v.want {
+			t.Errorf("smp%d digest = %x, want %s", v.smp, got, v.want)
+		}
+		// Both variants are accepted: one image, two legitimate vCPU shapes.
+		if !pins.Has(got) {
+			t.Errorf("Has must accept the smp%d variant", v.smp)
+		}
 	}
 	var other [Size]byte
 	if pins.Has(other) {
 		t.Error("Has must reject a digest outside the set")
 	}
-	// Digests are ordered by SMP so operator-facing output is stable.
-	if got := pins.Digests(); len(got) != 2 || !bytes.Equal(got[0][:], want2) {
-		t.Errorf("Digests() not in ascending SMP order: %x", got)
+	// Rendered in ascending SMP order so operator-facing output is stable.
+	if got, want := pins.String(), snpSMP2Digest+", "+snpSMP4Digest; got != want {
+		t.Errorf("String() = %s, want %s", got, want)
 	}
 }
 
@@ -188,7 +179,7 @@ func TestLoadSNPImageManifestRejects(t *testing.T) {
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
-			if _, err := LoadSNPImageManifest(snpManifest(t, body)); err == nil {
+			if _, err := LoadSNPImageManifest(writeManifest(t, body)); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})


### PR DESCRIPTION
## Problem

Post-merge cleanup of #394. Four quality issues, no behaviour change:

- `SNPImagePins.Digests()` hand-rolled a key-collect + `sort.Ints` preamble and
  `Has()` a manual scan, on a Go 1.26 module where `slices`/`maps` are used at
  30+ sites. It was also the only new `sort` import in the package.
- The launch-digest mismatch error rebuilt a `[]string` and re-hex-encoded each
  digest at the call site.
- `policyFor` buried the TDX path behind a 17-line SNP block and returned
  `tdxErr` when the SNP load was the one that failed, which reads as a bug even
  though it is deliberate.
- `snpManifest` in `manifest_test.go` was a byte-identical copy of
  `writeManifest` seven lines above it; `ratls_verify_test.go` re-inlined
  tempdir+WriteFile per platform and declared the same 96-hex digest twice.
- The package doc, the command's long help and `docs/operator.md` all still
  described a TDX-only gate, and `verify.go` carried a comment stating an SNP
  node can never satisfy the policy directly above the code that accepts one.

## Fix

- `slices.Sorted(maps.Keys(...))` and `slices.Contains`; add `String()` so the
  error renders the pinned set itself. `Digests()` stays: `verifySNPServerCert`
  needs the raw bytes for `localverify.Params.Measurements`.
- Extract `tdxPolicy` and `snpPolicy` so the dispatch reads linearly and each
  builder owns its own error.
- Parameterize `writeTestManifest` with a body, hoist the SNP digests to
  package-level consts beside the existing tuple vars, and compare in hex like
  `TestLoadImageManifestValid` does.
- Document the SNP leg: manifest-shape platform selection, the launch-digest
  and HOSTDATA checks, and that `--workload-image` is a usage error on SNP.

Trimmed the comment blocks that restated the per-SMP rationale on every field;
the "MEASUREMENT covers initial vCPU state" sentence appeared five times.

## Tests

Existing tests, unchanged in intent. `-race` green across `runtimemeasure`,
`getkubeconfig` and `verify`; each commit builds and passes independently.

Stacked on #399 (both touch `manifest_snp.go`); review that one first.
