### PR TITLE
fix(release): reserve latest for stable images

### DIFF
--- a/.github/scripts/calculate-release-version.sh
+++ b/.github/scripts/calculate-release-version.sh
@@ -60,9 +60,25 @@ if [ "$latest_series_tag" = "$candidate" ]; then
   update_series=true
 fi
 
+latest_release_tag="$(
+  {
+    git tag --list 'v*'
+    printf '%s\n' "$candidate"
+  } \
+    | grep -E '^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$' \
+    | sort -Vu \
+    | tail -n 1
+)"
+test -n "$latest_release_tag"
+update_latest=false
+if [ "$latest_release_tag" = "$candidate" ]; then
+  update_latest=true
+fi
+
 {
   echo "publish=$publish"
   echo "tag=$candidate"
+  echo "update-latest=$update_latest"
   echo "update-series=$update_series"
   echo "version=$version"
 } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,11 +74,10 @@ jobs:
   # every image. The final release job rebuilds the complete component set from
   # this exact revision before applying its SemVer aliases.
   #
-  # On a push to main, unchanged components keep their existing
-  # `latest` / `main` tag pointing at the previous build's manifest —
+  # On a push to main, unchanged components keep their existing `main` tag
+  # pointing at the previous build's manifest —
   # which is the correct state, since nothing changed for them.
-  # Deploys pinned to `latest` continue to consume the normal main build;
-  # stable release aliases consume the complete release rebuild below.
+  # `latest` is reserved for the complete stable release rebuild below.
   changes:
     name: Detect changed components
     runs-on: ubuntu-latest
@@ -213,7 +212,6 @@ jobs:
           tags: |
             type=sha,prefix=
             type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
@@ -231,9 +229,9 @@ jobs:
           # to pin their digests into the measured bootstrap allowlist. tags[0]
           # is the highest-priority *human* tag (main), so with the old
           # single-tag push the short-SHA tag never reached GHCR and that lookup
-          # could not resolve. Pushing the full set also makes `latest` real on
-          # main (deploys pin it). A later release job performs the separate,
-          # version-stamped all-component build used by SemVer aliases.
+          # could not resolve. A later release job performs the separate,
+          # version-stamped all-component build and is the only writer of
+          # `latest`.
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # GHA layer caching. ignore-error: a cache-service blip during the

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -35,6 +35,7 @@ jobs:
       image-matrix: ${{ steps.release-images.outputs.matrix }}
       publish: ${{ steps.version.outputs.publish }}
       tag: ${{ steps.version.outputs.tag }}
+      update-latest: ${{ steps.version.outputs.update-latest }}
       update-series: ${{ steps.version.outputs.update-series }}
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -504,11 +505,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.calculate.outputs.tag }}
           TARGET_SHA: ${{ inputs.target-sha }}
+          UPDATE_LATEST: ${{ needs.calculate.outputs.update-latest }}
           UPDATE_SERIES: ${{ needs.calculate.outputs.update-series }}
           VERSION: ${{ needs.calculate.outputs.version }}
         run: |
           set -euo pipefail
 
+          [[ "$UPDATE_LATEST" =~ ^(true|false)$ ]]
           [[ "$UPDATE_SERIES" =~ ^(true|false)$ ]]
           series="${VERSION%.*}"
           short_sha="${TARGET_SHA:0:7}"
@@ -529,6 +532,12 @@ jobs:
                 new_tags+=("$series")
               fi
             fi
+            if [ "$UPDATE_LATEST" = true ]; then
+              if ! grep -Fxq -- latest <<< "$repo_tags" || \
+                 [ "$(oras resolve "$image:latest")" != "$source_digest" ]; then
+                new_tags+=(latest)
+              fi
+            fi
             # The downstream Kata build resolves component manifests by this
             # commit tag. Point it at the canonical all-components release
             # rebuild before the parent Docker workflow completes.
@@ -545,6 +554,9 @@ jobs:
             test "$(oras resolve "$image:$short_sha")" = "$source_digest"
             if [ "$UPDATE_SERIES" = true ]; then
               test "$(oras resolve "$image:$series")" = "$source_digest"
+            fi
+            if [ "$UPDATE_LATEST" = true ]; then
+              test "$(oras resolve "$image:latest")" = "$source_digest"
             fi
           done < "$RUNNER_TEMP/release-image-digests"
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -45,8 +45,9 @@ Release publication stays inside the successful main-push `Docker` run:
    then creates a create-only annotated Git tag with the built-in
    `GITHUB_TOKEN`.
 6. The verified manifests are promoted to `vX.Y.Z`, `X.Y.Z`, the moving `X.Y`
-   compatibility tag, and the commit's short-SHA tag used by the measured Kata
-   build. The same job publishes chart `X.Y.Z`.
+   compatibility tag, `latest` when this is the newest stable release, and the
+   commit's short-SHA tag used by the measured Kata build. The same job
+   publishes chart `X.Y.Z`. Normal branch builds update `main`, never `latest`.
 7. Completion of the original Docker run starts the existing measured node,
    Kata guest, and e2e workflows. The node workflow builds both TDX/SNP formats,
    then promotes their exact commit manifests to
@@ -107,8 +108,9 @@ tag whose digest differs. A pulled existing Helm chart must match the
 deterministic package byte-for-byte.
 
 The moving `X.Y` image aliases advance only when the run's Git tag is the latest
-stable patch in that series. Re-running an older workflow therefore cannot roll
-the compatibility alias backward.
+stable patch in that series. The global `latest` alias advances only for the
+newest stable version across all series. Re-running an older workflow therefore
+cannot roll either compatibility alias backward.
 
 - A non-release commit completes without creating a stable tag.
 - A failed build creates no tag because release calculation depends on every


### PR DESCRIPTION
## Summary

- keep `main` owned by ordinary main-branch component builds
- stop ordinary builds from writing `latest`
- promote `latest` from the verified all-component stable release digest
- guard `latest` against rollback across all stable release series

## Release behavior

PR #375 already published `v0.1.0`. Merging this Conventional Commit will publish `v0.1.1`, whose six component images will establish the canonical `latest` aliases.

## Validation

- full Actionlint with repository CI exclusions
- ShellCheck and Bash syntax validation
- YAML parsing and whitespace checks
- version-order fixtures: newest stable advances `latest`; older stable repair does not; prerelease tags are ignored
- embedded ORAS promotion fixtures: `UPDATE_LATEST=true` moves the alias and `false` preserves it
- static tag-ownership invariant: ordinary Docker metadata contains no `latest` writer