### PR TITLE
docs(overenc): correct the cross-repo claims on the transcript vectors

### DIFF
--- a/pkg/overenc/identity_test.go
+++ b/pkg/overenc/identity_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 )
 
+// Cross-language contract: c8s-verify-js/test/identity.test.ts must reproduce
+// the v1 transcript vector pinned here.
 func TestIdentityTranscriptHashBindsEveryField(t *testing.T) {
 	pub := PublicKey{
 		X25519:   bytes.Repeat([]byte{0x11}, X25519PubBytes),
@@ -120,9 +122,9 @@ func TestLBTranscriptHashValidatesShape(t *testing.T) {
 	}
 }
 
-// TestLBTranscriptGoldenVectors pins the attest-lb transcript encoding against
-// the shared cross-repo vectors (copied verbatim into c8s-verify-js and
-// TEErminator), so the three parsers cannot drift.
+// TestLBTranscriptGoldenVectors pins the attest-lb transcript encoding.
+// Cross-repo contract: TEErminator reimplements this transcript; its
+// internal/verifier/endpoint_test.go must reproduce these vectors.
 func TestLBTranscriptGoldenVectors(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("testdata", "attest_lb_transcript_vectors.json"))
 	if err != nil {

--- a/pkg/overenc/testdata/attest_lb_transcript_vectors.json
+++ b/pkg/overenc/testdata/attest_lb_transcript_vectors.json
@@ -16,7 +16,7 @@
     "report_data_b64": "LTuGpmM9qbEUCqWy1qGCYcMof8Yu+iI2ISbyspGrtRVOmP5fr8J4wFQmI3uAUnhF"
   },
   {
-    "description": "identical serving and mesh leaf bytes still hash distinct positions",
+    "description": "duplicate serving and mesh leaf bytes are hashed twice, not deduplicated",
     "nonce_b64": "//////////////////////////////////////////8=",
     "serving_leaf_der_b64": "c2FtZS1kZXI=",
     "mesh_leaf_der_b64": "c2FtZS1kZXI=",


### PR DESCRIPTION
`TestLBTranscriptGoldenVectors` said its vectors were "copied verbatim into c8s-verify-js and TEErminator, so the three parsers cannot drift". c8s-verify-js does not implement attest-lb at all — `PROTOCOL.md` states browsers cannot see peer certificates, and `src/verify.ts` rejects the `c8s/attest-lb/v1` bundle version outright. Only TEErminator reproduces these vectors, so the comment overstated the contract by one implementation and named a repo that would never catch the drift.

Narrowed to what is real, and pointed at the peer's consuming test so the pair is checkable from this side.

Two related corrections in the same file:

- `TestIdentityTranscriptHashBindsEveryField` is the one contract here that *is* three-way — its vector is mirrored byte-for-byte in c8s-verify-js with identical inputs — and it carried no comment at all. It now does. Documenting the unverifiable claim while leaving the provable one invisible was the wrong half.
- A testdata description claimed a vector shows "identical serving and mesh leaf bytes still hash distinct positions". With the two leaves equal their digests are equal, so a positional swap is a no-op and that vector cannot demonstrate position binding — which is proven separately by the swap case. What it actually pins is that duplicate leaves are hashed twice rather than deduplicated.

Comment and testdata only; no production or test-logic change. The vector bytes are untouched.