### PR TITLE
test(sidecar,workloadclaims): pin the compiled endpoint without probing a port

### DIFF
--- a/internal/cmds/sidecar/endpoint_test.go
+++ b/internal/cmds/sidecar/endpoint_test.go
@@ -1,8 +1,12 @@
 package sidecar
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
+	"errors"
+	"net"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -15,24 +19,36 @@ import (
 // rather than redirecting redemption to a rogue inventory.
 func TestEndpointSelectsCompiledShape(t *testing.T) {
 	if got, want := (Config{}).Endpoint(), workloadclaims.InventoryEndpoint(); got != want {
-		t.Errorf("node-CVM endpoint = %q, want the compiled unix socket %q", got, want)
+		t.Fatalf("node-CVM endpoint = %q, want the compiled unix socket %q", got, want)
 	}
 	guest := Config{WorkloadClaimsGuest: true}.Endpoint()
 	if want := workloadclaims.GuestInventoryEndpoint(); guest != want {
-		t.Errorf("kata endpoint = %q, want the compiled guest loopback %q", guest, want)
+		t.Fatalf("kata endpoint = %q, want the compiled guest loopback %q", guest, want)
 	}
-	// workloadclaims only accepts a unix socket or the compiled guest loopback,
-	// so a shape it refuses would fail every redemption. Use a real key: a nil
-	// one fails at marshalling, short of the endpoint check.
+	u, err := url.Parse(guest)
+	if err != nil {
+		t.Fatalf("kata endpoint %q: %v", guest, err)
+	}
+	if ip := net.ParseIP(u.Hostname()); ip == nil || !ip.IsLoopback() {
+		t.Fatalf("kata endpoint host = %q, want a loopback address", u.Hostname())
+	}
+
+	const timeout = 5 * time.Second
+	// The endpoint check precedes the dial, so with a cancelled context
+	// context.Canceled means workloadclaims accepted this shape. The key must be
+	// real: a nil one fails at marshalling, short of the check.
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = workloadclaims.FetchSandboxToken(t.Context(), guest, time.Millisecond, pub, []byte("nonce"))
-	if err == nil {
-		t.Fatal("expected the guest endpoint to fail with nothing listening")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err = workloadclaims.FetchSandboxToken(ctx, guest, timeout, pub, []byte("nonce"))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("guest endpoint not accepted by the compiled-endpoint check: %v", err)
 	}
-	if strings.Contains(err.Error(), "endpoint must be") {
-		t.Fatalf("guest endpoint rejected by the compiled-endpoint check: %v", err)
+	_, err = workloadclaims.FetchSandboxToken(ctx, "http://127.0.0.1:9999", timeout, pub, []byte("nonce"))
+	if err == nil || errors.Is(err, context.Canceled) || !strings.Contains(err.Error(), "endpoint must be") {
+		t.Fatalf("non-compiled endpoint not rejected ahead of the transport: %v", err)
 	}
 }

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -469,19 +469,22 @@ func TestDigestsEndpointDoesNotServeTokens(t *testing.T) {
 	}
 }
 
-// FetchSandboxToken must be unable to reach anything but the baked unix socket
-// — that is what keeps the inventory un-redirectable
-// (docs/getcert-workload-binding.md, Corner 5).
-func TestFetchRejectsNonUnixEndpoint(t *testing.T) {
+// FetchSandboxToken must reach nothing but the two compiled endpoints, the
+// baked unix socket and the guest loopback: that is what keeps the inventory
+// un-redirectable (docs/getcert-workload-binding.md, Corner 5). Each of these
+// must lose to the endpoint check, not to a failed connection.
+func TestFetchRejectsNonCompiledEndpoint(t *testing.T) {
 	requester := testRequesterKey(t)
 	for _, ep := range []string{
-		"http://127.0.0.1:8080",
+		"http://127.0.0.1:9999",
+		"http://localhost:8401",
 		"https://inventory.example",
 		"/run/c8s/workload-claims/workload-claims.sock",
 		"",
 	} {
-		if _, err := FetchSandboxToken(context.Background(), ep, time.Second, &requester.PublicKey, testNonce); err == nil {
-			t.Fatalf("endpoint %q accepted; only unix:// may be dialed", ep)
+		_, err := FetchSandboxToken(context.Background(), ep, time.Second, &requester.PublicKey, testNonce)
+		if err == nil || !strings.Contains(err.Error(), "endpoint must be") {
+			t.Fatalf("endpoint %q not refused by the compiled-endpoint check: %v", ep, err)
 		}
 	}
 }


### PR DESCRIPTION
`TestEndpointSelectsCompiledShape` dialled the compiled guest endpoint and asserted the connection was **refused**. That is a fact about the host's port table, not about the code: `internal/cmds/getvolume`'s e2e binds 127.0.0.1:8401 for its guest inventory, and Go runs package test binaries concurrently, so when they overlap the dial succeeds and the test fatals. Seen in 2 of 6 full-suite `-race` runs.

With a listener bound and warm, the old assertion fails 19 of 20 runs; the new one passes 20 of 20.

The property worth testing is that `workloadclaims`' compiled-endpoint allowlist accepts the shape `Config.Endpoint()` selects and refuses everything else. That check runs ahead of the transport, so a cancelled context reaches it without dialling — `context.Canceled` means accepted, "endpoint must be" means refused. Asserting **both** directions is what makes it sound: with only the accept case, hoisting a `ctx.Err()` check above the switch in `inventoryDo` makes the test pass for every endpoint, silently proving nothing. The negative assertion turns that into a red.

The guest endpoint's host is now also pinned to loopback. Previously `GuestInventoryEndpoint()` could return an off-host address and the equality check would move with it.

`TestFetchRejectsNonUnixEndpoint` had the same defect class one package over: it asserted only `err != nil`, which any dial failure satisfies — broadening the allowlist to accept *any* loopback port left it green — and it probed a commonly-bound port. It now asserts the refusal reason, and is renamed for what it checks, since the guest loopback is non-unix and allowed.

The alternative fix, giving getvolume a test-allocated port, would require making the endpoint injectable — the invariant these tests exist to defend (`docs/getcert-workload-binding.md`, Corner 5).

Test-only; no production lines.