### PR TITLE
fix(cds): classify a non-JSON refusal from attestation-api as final

### DIFF
--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -551,7 +551,6 @@ func (h AttestHandler) caChainPEM() []byte {
 // message). A rejected verdict — bad signature, REPORTDATA mismatch, or a 4xx
 // the attestation-api returns for malformed/unacceptable evidence — is the
 // caller's fault and must not be reported as attestation_api_unreachable.
-// Only a transport failure or a 5xx/garbage upstream response is a real outage.
 // Upstream 408 (timeout) and 429 (rate-limited) are retryable availability
 // conditions, not evidence rejections, so they classify as unreachable too.
 func classifyVerifyError(err error) (int, string, string) {
@@ -562,10 +561,31 @@ func classifyVerifyError(err error) (int, string, string) {
 		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "challenge mismatch in attestation evidence"
 	}
 	var apiErr *attestationclient.APIError
-	if errors.As(err, &apiErr) && apiErr.Status >= 400 && apiErr.Status < 500 &&
-		apiErr.Status != http.StatusRequestTimeout && apiErr.Status != http.StatusTooManyRequests {
+	if errors.As(err, &apiErr) && refusesEvidence(apiErr.Status) {
 		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation evidence rejected by attestation-api"
+	}
+	// The api answers its own refusals in the JSON envelope, so a non-JSON body
+	// names the request rather than the evidence, and only where there is a
+	// body to have named it.
+	var unexpected *attestationclient.UnexpectedError
+	if errors.As(err, &unexpected) && rejectsRequest(unexpected.Status) && unexpected.Text != "" {
+		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation-api rejected the request"
 	}
 	return http.StatusBadGateway, types.ErrorCodeAttestationApiUnreachable,
 		fmt.Sprintf("failed to reach attestation-api: %s", err)
+}
+
+// refusesEvidence reports whether a status names the evidence rather than the
+// service; 408 and 429 are availability.
+func refusesEvidence(status int) bool {
+	return status >= 400 && status < 500 &&
+		status != http.StatusRequestTimeout && status != http.StatusTooManyRequests
+}
+
+// rejectsRequest reports whether a status names what was sent. These are the
+// statuses axum's extractors reject a body with, outside the JSON envelope.
+func rejectsRequest(status int) bool {
+	return status == http.StatusBadRequest ||
+		status == http.StatusUnsupportedMediaType ||
+		status == http.StatusUnprocessableEntity
 }

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -484,60 +484,223 @@ func TestAttest_RejectedEvidenceReturns4xxNotUnreachable(t *testing.T) {
 	}
 }
 
+// A 4xx whose body is not the api's JSON envelope — an axum extractor
+// rejection, or an on-path proxy — is still terminal for this request, so it
+// must not be reported as attestation_api_unreachable and retried.
+func TestAttest_NonJSONRejectionReturns422NotUnreachable(t *testing.T) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	t.Cleanup(bad.Close)
+	h := newTestAttestHandler(t, bad.URL, nil)
+	challenge := issueChallenge(t, h)
+	csrPEM, _ := generateCSR(t)
+
+	w := postAttest(t, h, challenge, csrPEM)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status: got %d, want 422; body=%s", w.Code, w.Body.String())
+	}
+	var resp types.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode error response: %v; body=%s", err, w.Body.String())
+	}
+	if resp.Error != types.ErrorCodeVerificationFailed {
+		t.Fatalf("error code: got %q, want %q", resp.Error, types.ErrorCodeVerificationFailed)
+	}
+}
+
+const (
+	msgEvidenceRejected = "attestation evidence rejected by attestation-api"
+	msgRequestRejected  = "attestation-api rejected the request"
+	msgUnreachable      = "failed to reach attestation-api: "
+)
+
+// anyUnreachableMsg is the wantMsg for the outage arm, whose message
+// interpolates the error and so is pinned by prefix.
+const anyUnreachableMsg = ""
+
 func TestClassifyVerifyError(t *testing.T) {
+	// VerifyEnforced wraps, so the call site never sees a bare error.
+	wrapped := func(err error) error { return fmt.Errorf("verify enforced: %w", err) }
+
 	for _, tc := range []struct {
 		name       string
 		err        error
 		wantStatus int
 		wantCode   string
+		wantMsg    string
 	}{
 		{
 			name:       "signature invalid",
-			err:        fmt.Errorf("wrap: %w", attestationclient.ErrSignatureInvalid),
+			err:        wrapped(attestationclient.ErrSignatureInvalid),
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    "attestation signature invalid",
 		},
 		{
 			name:       "report data mismatch",
-			err:        fmt.Errorf("wrap: %w", attestationclient.ErrReportDataMismatch),
+			err:        wrapped(attestationclient.ErrReportDataMismatch),
 			wantStatus: http.StatusUnauthorized,
 			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    "challenge mismatch in attestation evidence",
 		},
 		{
 			name:       "api 400 is client fault",
-			err:        &attestationclient.APIError{Status: http.StatusBadRequest},
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusBadRequest}),
 			wantStatus: http.StatusUnprocessableEntity,
 			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgEvidenceRejected,
 		},
 		{
 			name:       "api 403 is client fault",
-			err:        &attestationclient.APIError{Status: http.StatusForbidden},
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusForbidden}),
 			wantStatus: http.StatusUnprocessableEntity,
 			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgEvidenceRejected,
+		},
+		{
+			// Deliberately bare: the sentinel arms above are wrapped, so this
+			// is the one row that would still pass a plain type assertion.
+			name:       "api 400 unwrapped is client fault",
+			err:        &attestationclient.APIError{Status: http.StatusBadRequest},
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgEvidenceRejected,
 		},
 		{
 			name:       "api 500 is upstream outage",
-			err:        &attestationclient.APIError{Status: http.StatusInternalServerError},
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusInternalServerError}),
 			wantStatus: http.StatusBadGateway,
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
 		},
 		{
 			name:       "api 408 is retryable unavailability",
-			err:        &attestationclient.APIError{Status: http.StatusRequestTimeout},
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusRequestTimeout}),
 			wantStatus: http.StatusBadGateway,
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
 		},
 		{
 			name:       "api 429 is retryable unavailability",
-			err:        &attestationclient.APIError{Status: http.StatusTooManyRequests},
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusTooManyRequests}),
 			wantStatus: http.StatusBadGateway,
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "api 399 is not a refusal",
+			err:        wrapped(&attestationclient.APIError{Status: 399}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "api 302 is not a refusal",
+			err:        wrapped(&attestationclient.APIError{Status: http.StatusFound}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 400 is a request rejection",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusBadRequest, Text: "Failed to parse the request body as JSON"}),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgRequestRejected,
+		},
+		{
+			name:       "non-json 415 is a request rejection",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusUnsupportedMediaType, Text: "Expected request with `Content-Type: application/json`"}),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgRequestRejected,
+		},
+		{
+			name:       "non-json 422 is a request rejection",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusUnprocessableEntity, Text: "Failed to deserialize the JSON body into the target type"}),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+			wantMsg:    msgRequestRejected,
+		},
+		{
+			// A body cut mid-response names nothing, so it is not a rejection.
+			name:       "non-json 400 with no body is an outage",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusBadRequest}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			// The api has no 403; an on-path proxy does.
+			name:       "non-json 403 is an outage",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusForbidden, Text: "<html>403 Forbidden</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 404 is an outage",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusNotFound, Text: "<html>404 Not Found</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 413 is an outage",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusRequestEntityTooLarge, Text: "<html>413 Request Entity Too Large</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 500 is upstream outage",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusInternalServerError, Text: "<html>500 Internal Server Error</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 408 is retryable unavailability",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusRequestTimeout, Text: "<html>408 Request Timeout</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 429 is retryable unavailability",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusTooManyRequests, Text: "<html>429 Too Many Requests</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 399 is not a rejection",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: 399, Text: "unknown"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "non-json 302 is not a rejection",
+			err:        wrapped(&attestationclient.UnexpectedError{Status: http.StatusFound, Text: "<html>302 Found</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
 		},
 		{
 			name:       "transport failure is unreachable",
-			err:        errors.New("dial tcp: connection refused"),
+			err:        wrapped(&attestationclient.RequestError{Err: errors.New("dial tcp: connection refused")}),
 			wantStatus: http.StatusBadGateway,
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
+		},
+		{
+			name:       "deadline exceeded is unreachable",
+			err:        wrapped(context.DeadlineExceeded),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+			wantMsg:    anyUnreachableMsg,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -548,10 +711,55 @@ func TestClassifyVerifyError(t *testing.T) {
 			if code != tc.wantCode {
 				t.Errorf("code = %q, want %q", code, tc.wantCode)
 			}
-			if msg == "" {
-				t.Error("message empty")
+			switch {
+			case tc.wantMsg != anyUnreachableMsg:
+				if msg != tc.wantMsg {
+					t.Errorf("message = %q, want %q", msg, tc.wantMsg)
+				}
+			case !strings.HasPrefix(msg, msgUnreachable):
+				t.Errorf("message = %q, want prefix %q", msg, msgUnreachable)
 			}
 		})
+	}
+}
+
+// refusesEvidence and rejectsRequest are what the two arms are gated on, and
+// the statuses either side of each boundary are not all reachable from
+// classifyVerifyError's table, so the predicates are pinned directly.
+func TestStatusPredicates(t *testing.T) {
+	t.Run("refusesEvidence", func(t *testing.T) {
+		for status, want := range map[int]bool{
+			399: false, 400: true, 407: true, 408: false, 409: true,
+			428: true, 429: false, 430: true, 499: true, 500: false, 501: false,
+		} {
+			if got := refusesEvidence(status); got != want {
+				t.Errorf("refusesEvidence(%d) = %v, want %v", status, got, want)
+			}
+		}
+	})
+	t.Run("rejectsRequest", func(t *testing.T) {
+		for status, want := range map[int]bool{
+			399: false, 400: true, 403: false, 408: false, 413: false,
+			414: false, 415: true, 421: false, 422: true, 429: false, 500: false,
+		} {
+			if got := rejectsRequest(status); got != want {
+				t.Errorf("rejectsRequest(%d) = %v, want %v", status, got, want)
+			}
+		}
+	})
+}
+
+// UnexpectedError.Text is untrusted upstream body and classifyVerifyError's
+// message is written to the remote peer, so the rejection arm must not carry it.
+func TestClassifyVerifyErrorDoesNotEchoUpstreamBody(t *testing.T) {
+	const leak = "s3cret-internal-hostname.cluster.local"
+	_, _, msg := classifyVerifyError(fmt.Errorf("verify enforced: %w",
+		&attestationclient.UnexpectedError{Status: http.StatusBadRequest, Text: leak}))
+	if strings.Contains(msg, leak) {
+		t.Fatalf("message echoes upstream body: %q", msg)
+	}
+	if msg != msgRequestRejected {
+		t.Fatalf("message = %q, want %q", msg, msgRequestRejected)
 	}
 }
 

--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -241,8 +241,7 @@ func initDataAnchor(claim []byte) ([]byte, error) {
 // classifyVerifyError splits a refusal of the report from a failure to reach
 // the verifier, which is what decides whether the caller retries. The
 // attestation-api refuses with a 4xx status rather than with a false verdict,
-// so the status arm is the one a conforming verifier takes. That arm is shared
-// with cds.classifyVerifyError; the sentinel arms are not.
+// so the status arm is the one a conforming verifier takes.
 func classifyVerifyError(err error) error {
 	switch {
 	case errors.Is(err, attestationclient.ErrSignatureInvalid),
@@ -253,12 +252,12 @@ func classifyVerifyError(err error) error {
 		errors.Is(err, attestationclient.ErrUnsupportedPlatform):
 		return errAttestVerdict
 	}
-	// A refusal whose body is not the api's JSON error shape arrives as
-	// UnexpectedError, carrying the same status.
 	var apiErr *attestationclient.APIError
 	if errors.As(err, &apiErr) && refusesEvidence(apiErr.Status) {
 		return errAttestVerdict
 	}
+	// A refusal whose body is not the api's JSON error shape arrives as
+	// UnexpectedError, carrying the same status.
 	var unexpected *attestationclient.UnexpectedError
 	if errors.As(err, &unexpected) && refusesEvidence(unexpected.Status) {
 		return errAttestVerdict

--- a/test/mock-cds/main.go
+++ b/test/mock-cds/main.go
@@ -266,7 +266,8 @@ func handleAttest(store *challengeStore, verifier attestationclient.Client) http
 
 // classifyVerifyError maps a VerifyEnforced error to the status/code/message
 // production CDS answers /attest with (internal/cmds/cds/attest.go): 401 bad
-// signature/report-data, 422 api rejection, 502 transport or 5xx outage.
+// signature/report-data, 422 api evidence refusal or request rejection, 502
+// transport or 5xx outage.
 func classifyVerifyError(err error) (int, string, string) {
 	switch {
 	case errors.Is(err, attestationclient.ErrSignatureInvalid):
@@ -275,12 +276,33 @@ func classifyVerifyError(err error) (int, string, string) {
 		return http.StatusUnauthorized, types.ErrorCodeVerificationFailed, "challenge mismatch in attestation evidence"
 	}
 	var apiErr *attestationclient.APIError
-	if errors.As(err, &apiErr) && apiErr.Status >= 400 && apiErr.Status < 500 &&
-		apiErr.Status != http.StatusRequestTimeout && apiErr.Status != http.StatusTooManyRequests {
+	if errors.As(err, &apiErr) && refusesEvidence(apiErr.Status) {
 		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation evidence rejected by attestation-api"
+	}
+	// The api answers its own refusals in the JSON envelope, so a non-JSON body
+	// names the request rather than the evidence, and only where there is a
+	// body to have named it.
+	var unexpected *attestationclient.UnexpectedError
+	if errors.As(err, &unexpected) && rejectsRequest(unexpected.Status) && unexpected.Text != "" {
+		return http.StatusUnprocessableEntity, types.ErrorCodeVerificationFailed, "attestation-api rejected the request"
 	}
 	return http.StatusBadGateway, types.ErrorCodeAttestationApiUnreachable,
 		fmt.Sprintf("failed to reach attestation-api: %s", err)
+}
+
+// refusesEvidence reports whether a status names the evidence rather than the
+// service; 408 and 429 are availability.
+func refusesEvidence(status int) bool {
+	return status >= 400 && status < 500 &&
+		status != http.StatusRequestTimeout && status != http.StatusTooManyRequests
+}
+
+// rejectsRequest reports whether a status names what was sent. These are the
+// statuses axum's extractors reject a body with, outside the JSON envelope.
+func rejectsRequest(status int) bool {
+	return status == http.StatusBadRequest ||
+		status == http.StatusUnsupportedMediaType ||
+		status == http.StatusUnprocessableEntity
 }
 
 func writeJSON(w http.ResponseWriter, v any) {

--- a/test/mock-cds/main_test.go
+++ b/test/mock-cds/main_test.go
@@ -13,7 +13,9 @@ import (
 // TestClassifyVerifyError mirrors internal/cmds/cds.TestClassifyVerifyError: a
 // rejected verdict is the caller's 401/422, only a transport or 5xx/408/429
 // outage is a 502. The api-422 row is the shape mock-attestation returns for a
-// report-data mismatch or garbage evidence.
+// report-data mismatch or garbage evidence. The non-json rows are the second
+// arm: a body-rejection status with a body is a rejection, anything else on
+// that type is an outage.
 func TestClassifyVerifyError(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
@@ -70,8 +72,38 @@ func TestClassifyVerifyError(t *testing.T) {
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
 		},
 		{
+			name:       "non-json 400 is a request rejection",
+			err:        fmt.Errorf("wrap: %w", &attestationclient.UnexpectedError{Status: http.StatusBadRequest, Text: "Failed to parse the request body as JSON"}),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "non-json 415 is a request rejection",
+			err:        fmt.Errorf("wrap: %w", &attestationclient.UnexpectedError{Status: http.StatusUnsupportedMediaType, Text: "Expected request with `Content-Type: application/json`"}),
+			wantStatus: http.StatusUnprocessableEntity,
+			wantCode:   types.ErrorCodeVerificationFailed,
+		},
+		{
+			name:       "non-json 400 with no body is an outage",
+			err:        fmt.Errorf("wrap: %w", &attestationclient.UnexpectedError{Status: http.StatusBadRequest}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
+			name:       "non-json 403 is an outage",
+			err:        fmt.Errorf("wrap: %w", &attestationclient.UnexpectedError{Status: http.StatusForbidden, Text: "<html>403 Forbidden</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
+			name:       "non-json 500 is upstream outage",
+			err:        fmt.Errorf("wrap: %w", &attestationclient.UnexpectedError{Status: http.StatusInternalServerError, Text: "<html>500 Internal Server Error</html>"}),
+			wantStatus: http.StatusBadGateway,
+			wantCode:   types.ErrorCodeAttestationApiUnreachable,
+		},
+		{
 			name:       "transport failure is unreachable",
-			err:        errors.New("dial tcp: connection refused"),
+			err:        fmt.Errorf("wrap: %w", &attestationclient.RequestError{Err: errors.New("dial tcp: connection refused")}),
 			wantStatus: http.StatusBadGateway,
 			wantCode:   types.ErrorCodeAttestationApiUnreachable,
 		},


### PR DESCRIPTION
`classifyVerifyError` matched only `*APIError`, so a 4xx whose body is not the api's JSON envelope arrived as `*UnexpectedError`, fell through to the outage arm, and CDS retried a rejection while logging it as a reachable-service problem. An end-to-end case driving a plaintext 400 through the real client shows it on `main`:

```
status 502  {"error":"attestation_api_unreachable","message":"failed to reach attestation-api: unexpected response (400): boom"}
```

The two error types do not mean the same thing, so they no longer share a predicate. attestation-api answers every one of its own refusals through a single `(status, Json(body))` response (`src/error.rs`, all seven `ApiError` variants), so a non-JSON 4xx did not come from the verdict path — it is an extractor rejection, an intermediary, or a cut connection. Under `cvmMode=node` the api is reached over plaintext HTTP across a network hop (`_helpers.tpl`), so an on-path 4xx is reachable in practice. Treating all of them as "your evidence was refused" would cure one signal inversion by installing its mirror — and blame a tenant's TEE evidence for a CDS-side or network fault.

So `*APIError` keeps `refusesEvidence` (any 4xx but 408/429), and `*UnexpectedError` gets `rejectsRequest` — 400, 415, 422, axum's extractor-rejection statuses — plus a non-empty body, since a truncated response names nothing. Both answer 422 with different messages, so an operator can tell a refused evidence set from a refused request. Everything else still classifies as an outage and is retried.

Whether the second arm deserves its own error code is a wire-contract question and is deliberately left alone here.

The tests now pin the predicates directly rather than inferring them from a handful of statuses. Thirteen single-token mutations that previously survived are killed: both boundaries pinned from each side, the 408/429 carve-outs, substituting either predicate for the other, dropping the empty-body gate, and echoing the upstream body into the message. Every typed fixture is wrapped so the `errors.As` contract is exercised (one row stays bare deliberately); messages are exact-matched; and one case asserts the refusal message cannot leak `Text`.

`test/mock-cds` carried a copy of the old predicate behind a comment claiming it mirrors production, so it moves with it.

Note `policymonitor.classifyVerifyError` still applies the broad predicate to its `*UnexpectedError` arm. Its blast radius differs — it classifies its own self-report to decide retry-vs-give-up, with no tenant being told anything — so it is left for a separate change.