### PR TITLE
ci(grype): record CVE-2026-14456 as not applicable to the tls-lb nginx

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,0 +1,16 @@
+# Scoped exceptions for the image scans in .github/workflows/grype.yml.
+# Each entry names one CVE and the packages it applies to; remove an entry as
+# soon as a fixed package is published upstream.
+ignore:
+  # OpenSSL QUIC server listener DoS. tls-lb's nginx terminates TLS over TCP
+  # (`listen ... ssl`, no UDP port, no http_v3 module), so the QUIC listener
+  # this reaches is never instantiated. Unfixed in every Alpine branch through
+  # edge, so there is no image to move to.
+  - vulnerability: CVE-2026-14456
+    package:
+      name: libcrypto3
+      type: apk
+  - vulnerability: CVE-2026-14456
+    package:
+      name: libssl3
+      type: apk

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1373,6 +1373,7 @@ tlsLb:
       # stable-alpine-slim (nginx 1.30.4). The slim variant carries only the
       # core modules tls-lb uses; the full/perl variants ship image-filter,
       # perl and friends whose CVEs would otherwise trip the grype.yml image scan.
+      # Accepted CVEs against this pin live in .grype.yaml.
       digest: "sha256:e88d990b349df8cf4aa82f16642d7a23375016638c9ace4e5c6ca25028e62e65"
       tag: ""
       pullPolicy: IfNotPresent


### PR DESCRIPTION
The `tls-lb-image` job is failing on every open PR. It is not caused by any of them — grype scans the **pinned** third-party nginx digest, and a fresh advisory landed against it:

```
libcrypto3     3.5.7-r0    CVE-2026-14456  High     <- fails the 'high' cutoff
libssl3        3.5.7-r0    CVE-2026-14456  High     <- fails the 'high' cutoff
busybox        1.37.0-r31  CVE-2025-60876  Medium   (below cutoff, not addressed)
```

## There is no image to bump to

Checked rather than assumed:

- `libcrypto3`/`libssl3` are **3.5.7-r0 in Alpine v3.22, v3.23, v3.24 *and* edge**, and edge publishes no newer openssl package at all. No fixed Alpine package exists yet on any branch.
- The newest slim build — mainline `1.31.3-alpine-slim`, rebuilt 2026-08-17 — carries a **byte-identical** package set to the pinned stable `1.30.4-alpine-slim`. Verified by pulling `/lib/apk/db/installed` out of the first layer of both images: same `libcrypto3`, `libssl3`, `busybox`, `alpine-baselayout`. Same method reproduces exactly the versions grype reports for the current pin, so it is checking the right thing.
- Moving to mainline would also change release track for no benefit, and the full/perl variants are excluded by the existing pin comment for unrelated reasons.

The stable line simply has not been rebuilt since 2026-07-20, which is why it carries July's packages — but rebuilding would not help while the fix does not exist upstream.

## It is also not reachable in this deployment

CVE-2026-14456 (published 2026-08-13, still `Received` at NVD) is an unbounded-allocation DoS in **OpenSSL's QUIC server listener**: a peer that can make many QUIC Initial packets for unknown destination connection IDs reach the listener faster than the application accepts connections can grow queued-channel memory without limit.

tls-lb's nginx does not run QUIC:

- `internal/helmchart/c8s/templates/tls-lb-configmap.yaml:135` has a single `listen {{ .Values.tlsLb.nginx.httpsPort }} ssl;` — TLS over TCP.
- No UDP port is exposed; the deployment declares one `containerPort` (plus an optional hostPort), no `protocol: UDP`.
- No `quic`, `http3`, `http_v3` or `reuseport` directive anywhere in the chart, and the slim variant ships only the core modules.

So the vulnerable listener is never instantiated.

## What this changes

A new `.grype.yaml` with two rules naming **one CVE and two packages**. The `severity-cutoff: high` is unchanged, no other advisory is suppressed, and any future openssl CVE against this pin — including one that does reach us — still fails the job. The entry is meant to be deleted the moment Alpine ships a fixed package; the file's comment says so.

The pin comment in `values.yaml` gains a one-line pointer, so the exception is visible where the digest is chosen rather than only in a config file at the repo root.

## Two things to check before merging

1. **I could not run grype locally** — it is not available in my environment — so the ignore rules are written to grype's documented schema but not empirically confirmed to match. The scan job on this PR is the verification. Touching `values.yaml` is what makes it run: `.grype.yaml` is not in `grype.yml`'s `paths` filter, so a change to it alone would not trigger the workflow it configures.
2. **`.grype.yaml` should be added to that `paths` filter**, so future edits to the exception list are themselves scanned. That is a change to `.github/workflows/grype.yml`, which needs a token scope this branch does not have.

If you would rather not carry a CVE exception list, the alternative is `only-fixed: true` on the scan step — it suppresses anything with no available fix and self-clears when one lands, at the cost of being a blanket policy rather than a named, auditable exception. I went with the narrow version.