### PR TITLE
ci: on-demand double-build diff harness for image nondeterminism

### DIFF
--- a/.github/workflows/image-repro-debug.yml
+++ b/.github/workflows/image-repro-debug.yml
@@ -1,0 +1,154 @@
+# Debug harness for #392: builds the node image twice in one job and, when
+# the roothashes diverge, mounts both disks and names the differing files.
+# No CI caches on purpose — clean samples; confos's own in-checkout kernel
+# skip keeps the second build cheap. Dispatch repeatedly to sample.
+name: image repro debug
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "tdx or snp"
+        required: false
+        type: string
+        default: "tdx"
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  double-build:
+    runs-on: the-machine
+    timeout-minutes: 120
+    steps:
+      - name: Checkout c8s
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: c8s
+
+      - name: Read pins from c8s-image.yml
+        # Single source of truth for the confos/attestation-rs/mkosi pins.
+        id: pins
+        run: |
+          set -euo pipefail
+          w=c8s/.github/workflows/c8s-image.yml
+          confos=$(grep -oE "inputs.confos_ref \|\| '[0-9a-f]{40}'" "$w" | grep -oE "[0-9a-f]{40}")
+          attest=$(grep -oE 'ATTESTATION_RS_REF: "[0-9a-f]{40}"' "$w" | grep -oE "[0-9a-f]{40}")
+          mkosi=$(grep -A2 "actions/setup-mkosi" "$w" | grep -oE "ref: [0-9a-f]{40}" | grep -oE "[0-9a-f]{40}")
+          for v in confos attest mkosi; do test -n "${!v}"; echo "$v=${!v}" >> "$GITHUB_OUTPUT"; done
+
+      - name: Checkout attestation-rs
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: confidential-dot-ai/attestation-rs
+          ref: ${{ steps.pins.outputs.attest }}
+          path: attestation-rs
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout confidential-os-builder
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: confidential-dot-ai/confidential-os-builder
+          ref: ${{ steps.pins.outputs.confos }}
+          path: confidential-os-builder
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
+
+      - name: Setup mkosi
+        uses: ./c8s/.github/actions/setup-mkosi
+        with:
+          ref: ${{ steps.pins.outputs.mkosi }}
+
+      - name: Install build deps
+        timeout-minutes: 5
+        run: |
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
+          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
+            systemd-container ovmf cpio acpica-tools libclang-dev clang libtss2-dev
+
+      - name: Setup ORAS
+        uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
+
+      - name: Fetch vendored libnvat
+        env:
+          LIBNVAT_REF: ghcr.io/confidential-dot-ai/libnvat@sha256:4b3c396dbe906b2f60042558ed0f2dc4791a96f840ba0970a6d358027c572819
+          LIBNVAT_SO_SHA256: 1dd6c5429632c8c9ae59aa687cf96593f01c5597afe342f72ec3d8d5ddb0bbae
+          NVAT_H_SHA256: c6c9f32538611c5dfca2a103bfba5a258156a5e7b035ef9f0b7e21f20151314b
+        run: |
+          set -euo pipefail
+          echo "${{ secrets.GITHUB_TOKEN }}" | oras login ghcr.io -u "${{ github.actor }}" --password-stdin
+          mkdir -p vendor/libnvat
+          oras pull "$LIBNVAT_REF" -o vendor/libnvat
+          echo "$LIBNVAT_SO_SHA256  vendor/libnvat/libnvat.so.1.2.0" | sha256sum -c -
+          echo "$NVAT_H_SHA256  vendor/libnvat/nvat.h" | sha256sum -c -
+          sudo install -m0755 vendor/libnvat/libnvat.so.1.2.0 /usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0
+          sudo ln -sf libnvat.so.1.2.0 /usr/lib/x86_64-linux-gnu/libnvat.so.1
+          sudo ln -sf libnvat.so.1 /usr/lib/x86_64-linux-gnu/libnvat.so
+          sudo install -m0644 vendor/libnvat/nvat.h /usr/include/nvat.h
+          sudo ldconfig
+
+      - name: Build attestation-api
+        env:
+          NVAT_USE_SYSTEM_LIB: "1"
+        working-directory: attestation-rs
+        run: |
+          cargo build -p attestation-api --release --features nvidia-gpu-attest --bin attestation-api
+          ldd target/release/attestation-api | grep -q libnvat
+
+      - name: Build twice
+        working-directory: confidential-os-builder
+        env:
+          ATTEST_GPU_BIN: ${{ github.workspace }}/attestation-rs/target/release/attestation-api
+          LIBNVAT: /usr/lib/x86_64-linux-gnu/libnvat.so.1.2.0
+          MODULE_SIG_KEY_PEM: ${{ secrets.MODULE_SIG_KEY_PEM }}
+          PLATFORM: ${{ inputs.platform }}
+        run: |
+          set -euo pipefail
+          export C8S_REF="${GITHUB_SHA::7}"
+          for n in r1 r2; do
+            C8S_PLATFORM="$PLATFORM" C8S_NAME="$n" ../c8s/node-guest-image/build
+          done
+
+      - name: Compare
+        working-directory: confidential-os-builder
+        run: |
+          set -euo pipefail
+          r1=$(cat output/r1/roothash); r2=$(cat output/r2/roothash)
+          if [ "$r1" = "$r2" ]; then
+            echo "pair identical (roothash $r1) — no divergence this sample" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "DIVERGED: r1=$r1 r2=$r2" | tee -a "$GITHUB_STEP_SUMMARY"
+          l1=$(sudo losetup -Pf --show output/r1/disk.raw)
+          l2=$(sudo losetup -Pf --show output/r2/disk.raw)
+          for p1 in "${l1}"p*; do
+            idx=${p1##*p}; p2="${l2}p${idx}"
+            t=$(sudo blkid -o value -s TYPE "$p1" 2>/dev/null || true)
+            case "$t" in erofs|ext4|vfat) ;; *) echo "p${idx}: type=${t:-none}, skipped"; continue ;; esac
+            m1=$(mktemp -d); m2=$(mktemp -d)
+            sudo mount -o ro "$p1" "$m1"; sudo mount -o ro "$p2" "$m2"
+            echo "== p${idx} ($t): content =="
+            sudo diff -qr "$m1" "$m2" | sed "s|$m1|r1|g;s|$m2|r2|g" | tee -a "$GITHUB_STEP_SUMMARY" || true
+            echo "== p${idx} ($t): metadata (first 100) =="
+            diff <(sudo find "$m1" -printf '%P|%y|%s|%m|%U|%G|%T@\n' | sort) \
+                 <(sudo find "$m2" -printf '%P|%y|%s|%m|%U|%G|%T@\n' | sort) | head -100 || true
+            sudo umount "$m1" "$m2"
+          done
+          sudo losetup -d "$l1" "$l2"
+          exit 1
+
+      - name: Upload evidence
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: repro-debug-${{ inputs.platform }}-${{ github.run_id }}
+          path: |
+            confidential-os-builder/output/r1/manifest.json
+            confidential-os-builder/output/r1/roothash
+            confidential-os-builder/output/r2/manifest.json
+            confidential-os-builder/output/r2/roothash
+          if-no-files-found: error


### PR DESCRIPTION
From #392's next-step plan: a dispatch-only workflow that builds the node image twice in one job (no CI caches, clean samples; confos's in-checkout kernel skip keeps the second build cheap) and, when the roothashes diverge, loop-mounts both disks and prints per-partition content and metadata diffs, uploading both manifests as evidence. The confos/attestation-rs/mkosi pins are parsed from c8s-image.yml at run time, so the harness follows the production pins with no duplication to drift. Dispatch repeatedly to sample the ~10% race; a green run means "no divergence this sample", a red run names the files.