### PR TITLE
install: admit kube-system on the hosted lanes, and refuse a policy that denies the platform

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -488,8 +488,11 @@ const deniedImagesListed = 20
 // every install including -f ones — whoever wrote the policy, a cluster whose
 // own pods it denies is broken the same way. Cluster access is read-only.
 //
+// It also reports to w what an exempt namespace will admit (see
+// reportExemptedImages).
+//
 // --force installs anyway, and returns the same list as a warning.
-func preflightImagePolicy(ctx context.Context, values map[string]any, components []c8sComponent, releaseNamespace string, force bool) (warn string, err error) {
+func preflightImagePolicy(ctx context.Context, w io.Writer, values map[string]any, components []c8sComponent, releaseNamespace string, force bool) (warn string, err error) {
 	if !boolAtPath(values, "nriImagePolicy.enabled") {
 		return "", nil
 	}
@@ -509,8 +512,10 @@ func preflightImagePolicy(ctx context.Context, values map[string]any, components
 		return "", fmt.Errorf("parse pod list: %w", err)
 	}
 
-	denied := deniedPlatformImages(list.Items, releaseNamespace,
-		stringsAtPath(values, exemptNamespacesPath), admissibleDigests(values, components))
+	exempt := stringsAtPath(values, exemptNamespacesPath)
+	reportExemptedImages(w, exempt, exemptedPlatformImages(list.Items, exempt))
+
+	denied := deniedPlatformImages(list.Items, releaseNamespace, exempt, admissibleDigests(values, components))
 	if len(denied) == 0 {
 		return "", nil
 	}
@@ -529,39 +534,69 @@ func deniedSummary(denied []string) string {
 	return fmt.Sprintf("%d platform images", len(denied))
 }
 
-// deniedPlatformImages lists the platform-pod images the policy would deny, as
-// "namespace/pod <image>@<digest>" lines. A DaemonSet runs the same image on
-// every node, so entries are deduplicated by namespace and digest and name the
-// first pod carrying them.
-func deniedPlatformImages(pods []corev1.Pod, releaseNamespace string, exempt []string, admitted map[string]bool) []string {
+// platformImageLines returns one "namespace/pod  repository@digest" line per
+// (namespace, digest) accept keeps, sorted. A DaemonSet runs the same image on
+// every node, so entries are deduplicated and named by the first pod carrying
+// them. A pod the kubelet has finished with is skipped: it has no container the
+// containerd restart will recreate, so the policy never sees its images.
+func platformImageLines(pods []corev1.Pod, accept func(namespace, digest string) bool) []string {
 	seen := map[string]bool{}
-	var denied []string
+	var lines []string
 	for _, p := range pods {
-		if p.Namespace == releaseNamespace || slices.Contains(exempt, p.Namespace) || !platformPod(p) {
-			continue
-		}
-		// A pod the kubelet has finished with has no container the containerd
-		// restart will recreate, so the policy never sees its images.
-		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+		if !platformPod(p) || p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
 			continue
 		}
 		for _, st := range podContainerStatuses(p) {
 			digest := imageDigest(st.ImageID, st.Image)
-			if digest == "" || admitted[digest] {
+			if digest == "" || !accept(p.Namespace, digest) {
 				continue
 			}
 			if key := p.Namespace + "\x00" + digest; !seen[key] {
 				seen[key] = true
-				denied = append(denied, fmt.Sprintf("%s/%s  %s@%s", p.Namespace, p.Name, imageRepository(st.Image, st.ImageID), digest))
+				lines = append(lines, fmt.Sprintf("%s/%s  %s@%s", p.Namespace, p.Name, imageRepository(st.Image, st.ImageID), digest))
 			}
 		}
 	}
-	slices.Sort(denied)
+	slices.Sort(lines)
+	return lines
+}
+
+// deniedPlatformImages lists the platform-pod images the policy would deny.
+func deniedPlatformImages(pods []corev1.Pod, releaseNamespace string, exempt []string, admitted map[string]bool) []string {
+	denied := platformImageLines(pods, func(namespace, digest string) bool {
+		return namespace != releaseNamespace && !slices.Contains(exempt, namespace) && !admitted[digest]
+	})
 	if len(denied) > deniedImagesListed {
 		rest := len(denied) - deniedImagesListed
 		denied = append(denied[:deniedImagesListed:deniedImagesListed], fmt.Sprintf("… and %d more", rest))
 	}
 	return denied
+}
+
+// exemptedPlatformImages lists the platform-pod images an exempt namespace
+// admits by captured digest.
+func exemptedPlatformImages(pods []corev1.Pod, exempt []string) []string {
+	return platformImageLines(pods, func(namespace, _ string) bool {
+		return slices.Contains(exempt, namespace)
+	})
+}
+
+// reportExemptedImages prints what the exemption will admit. The plugin freezes
+// the digest set per node under its own cache dir, so an install is the one
+// place an operator can review it — and the one place where pinning the same
+// digests in the floor instead is still a choice. Uncapped: a truncated audit
+// list is not one.
+func reportExemptedImages(w io.Writer, exempt, images []string) {
+	if len(images) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "+ image policy: %s admitted by captured digest. The plugin freezes what runs\n"+
+		"  there when it first connects; as of now that is %d image(s):\n", strings.Join(exempt, ", "), len(images))
+	for _, image := range images {
+		fmt.Fprintf(w, "    %s\n", image)
+	}
+	fmt.Fprintf(w, "  To pin them explicitly instead, put these digests in\n"+
+		"  nriImagePolicy.bootstrapAllowlist.digests and set %s: [] via -f.\n", exemptNamespacesPath)
 }
 
 // platformPod reports whether a pod belongs to the cluster's own platform
@@ -1158,7 +1193,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// cluster's own platform pods: registering the plugin restarts
 		// containerd, and a denied control-plane static pod takes the API
 		// server with it. Read-only, so it runs with -f too.
-		if warn, err := preflightImagePolicy(cmd.Context(), values, components, installNamespace, installForce); err != nil {
+		if warn, err := preflightImagePolicy(cmd.Context(), os.Stdout, values, components, installNamespace, installForce); err != nil {
 			return err
 		} else if warn != "" {
 			fmt.Fprintln(os.Stderr, "warning: "+warn)

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -83,6 +83,15 @@ const (
 // deployments. There is no default: the shape must be stated explicitly.
 var allowedCvmModes = []string{"pod", "node", "gke", "aks"}
 
+// hostedCvmModes are the lanes whose platform pods belong to the cluster
+// provider rather than to c8s, so they are absent from the allowlist the
+// install derives. cvmMode=node is not one: its baked floor already carries the
+// system digests.
+var hostedCvmModes = []string{"pod", "gke", "aks"}
+
+// platformExemptNamespace is the namespace those provider pods run in.
+const platformExemptNamespace = "kube-system"
+
 // cvmModeIsPod reports whether the mode selects the Kata per-pod-CVM stack.
 func cvmModeIsPod(cvmMode string) bool { return cvmMode == "pod" }
 
@@ -462,6 +471,234 @@ func labelSelector(sel map[string]any) (string, bool) {
 	return strings.Join(pairs, ","), true
 }
 
+// policyModeFailClosed is the image-policy mode that denies. In `audit` the
+// plugin logs the would-be denial and creates the container anyway.
+const policyModeFailClosed = "fail-closed"
+
+// deniedImagesListed caps the images the refusal prints; the rest are counted.
+const deniedImagesListed = 20
+
+// preflightImagePolicy refuses an install whose rendered image policy would
+// deny the cluster's own platform pods. Registering the plugin restarts
+// containerd, which recreates those containers under the new policy: on a
+// self-managed control plane the static pods are denied and the API server
+// never returns, leaving nothing but out-of-band root to recover with.
+//
+// It reads the EFFECTIVE values (chart defaults + -f + computed), so it runs on
+// every install including -f ones — whoever wrote the policy, a cluster whose
+// own pods it denies is broken the same way. Cluster access is read-only.
+//
+// --force installs anyway, and returns the same list as a warning.
+func preflightImagePolicy(ctx context.Context, values map[string]any, components []c8sComponent, releaseNamespace string, force bool) (warn string, err error) {
+	if !boolAtPath(values, "nriImagePolicy.enabled") {
+		return "", nil
+	}
+	// A mode the chart cannot read is the render guard's to reject, not this
+	// preflight's; either way nothing is denied here.
+	if mode, err := stringAtPath(values, "nriImagePolicy.policy.mode"); err != nil || mode != policyModeFailClosed {
+		return "", nil
+	}
+
+	podsJSON, err := exec.CommandContext(ctx, "kubectl", "get", "pods",
+		"--all-namespaces", "-o", "json").Output()
+	if err != nil {
+		return "", fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
+	}
+	var list corev1.PodList
+	if err := json.Unmarshal(podsJSON, &list); err != nil {
+		return "", fmt.Errorf("parse pod list: %w", err)
+	}
+
+	denied := deniedPlatformImages(list.Items, releaseNamespace,
+		stringsAtPath(values, exemptNamespacesPath), admissibleDigests(values, components))
+	if len(denied) == 0 {
+		return "", nil
+	}
+	if force {
+		return "installing a fail-closed image policy that denies " + deniedSummary(denied) + "; those containers will not come back after the containerd restart", nil
+	}
+	return "", fmt.Errorf("fail-closed image admission would deny %s the cluster runs, and registering the plugin restarts containerd — the denied containers would not come back:\n  %s\nAdmit their namespaces with -f setting nriImagePolicy.policy.exemptNamespaces, pin their digests in nriImagePolicy.bootstrapAllowlist.digests, or re-run with --force to install anyway",
+		deniedSummary(denied), strings.Join(denied, "\n  "))
+}
+
+// deniedSummary names the size of the denied set for a one-line message.
+func deniedSummary(denied []string) string {
+	if len(denied) == 1 {
+		return "1 platform image"
+	}
+	return fmt.Sprintf("%d platform images", len(denied))
+}
+
+// deniedPlatformImages lists the platform-pod images the policy would deny, as
+// "namespace/pod <image>@<digest>" lines. A DaemonSet runs the same image on
+// every node, so entries are deduplicated by namespace and digest and name the
+// first pod carrying them.
+func deniedPlatformImages(pods []corev1.Pod, releaseNamespace string, exempt []string, admitted map[string]bool) []string {
+	seen := map[string]bool{}
+	var denied []string
+	for _, p := range pods {
+		if p.Namespace == releaseNamespace || slices.Contains(exempt, p.Namespace) || !platformPod(p) {
+			continue
+		}
+		// A pod the kubelet has finished with has no container the containerd
+		// restart will recreate, so the policy never sees its images.
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		for _, st := range podContainerStatuses(p) {
+			digest := imageDigest(st.ImageID, st.Image)
+			if digest == "" || admitted[digest] {
+				continue
+			}
+			if key := p.Namespace + "\x00" + digest; !seen[key] {
+				seen[key] = true
+				denied = append(denied, fmt.Sprintf("%s/%s  %s@%s", p.Namespace, p.Name, imageRepository(st.Image, st.ImageID), digest))
+			}
+		}
+	}
+	slices.Sort(denied)
+	if len(denied) > deniedImagesListed {
+		rest := len(denied) - deniedImagesListed
+		denied = append(denied[:deniedImagesListed:deniedImagesListed], fmt.Sprintf("… and %d more", rest))
+	}
+	return denied
+}
+
+// platformPod reports whether a pod belongs to the cluster's own platform
+// rather than to a tenant: a static pod (the control plane, which the kubelet
+// mirrors into the API) or a DaemonSet pod (CNI, kube-proxy, CSI and device
+// plugins). Those are the pods a containerd restart takes down and the cluster
+// cannot be repaired without. A tenant Deployment denied by a policy the
+// operator is deliberately installing is theirs to allowlist, not a refusal.
+func platformPod(p corev1.Pod) bool {
+	if _, mirror := p.Annotations[corev1.MirrorPodAnnotationKey]; mirror {
+		return true
+	}
+	return slices.ContainsFunc(p.OwnerReferences, func(o metav1.OwnerReference) bool {
+		return o.Kind == "DaemonSet"
+	})
+}
+
+// podContainerStatuses is every container the kubelet reports for a pod, so
+// init and ephemeral containers are checked alongside the main ones.
+func podContainerStatuses(p corev1.Pod) []corev1.ContainerStatus {
+	return slices.Concat(p.Status.InitContainerStatuses, p.Status.ContainerStatuses, p.Status.EphemeralContainerStatuses)
+}
+
+// imageDigest reads the sha256 the policy matches on out of the first
+// reference that carries one — the runtime's resolved imageID for preference,
+// since a tag says nothing about what admission will see. Empty means no
+// reference carried a digest (a container that has not pulled yet), which
+// nothing here can evaluate.
+//
+// A container status reports imageID as a digested reference, as a bare
+// digest, or — on older runtimes — behind a docker-pullable:// prefix.
+func imageDigest(refs ...string) string {
+	for _, ref := range refs {
+		ref = strings.TrimPrefix(ref, "docker-pullable://")
+		if strings.HasPrefix(ref, "sha256:") {
+			return ref
+		}
+		named, err := reference.ParseDockerRef(ref)
+		if err != nil {
+			continue
+		}
+		if digested, ok := named.(reference.Digested); ok {
+			return digested.Digest().String()
+		}
+	}
+	return ""
+}
+
+// imageRepository normalizes the first parseable reference to the bare
+// repository the digest is reported against — the same form
+// workloadImageAllowlistEntry writes into the floor, so a reported line pastes
+// straight into it.
+func imageRepository(refs ...string) string {
+	for _, ref := range refs {
+		named, err := reference.ParseDockerRef(strings.TrimPrefix(ref, "docker-pullable://"))
+		if err != nil {
+			continue
+		}
+		return reference.TrimNamed(named).String()
+	}
+	return ""
+}
+
+// admissibleDigests collects the image digests the rendered floor admits: the
+// operator-supplied bootstrapAllowlist (digests, and the per-container digests
+// of its workloads) plus every pinned component image the floor derives from.
+// The component digests are taken whether or not derivation is on and whether
+// or not the component renders — a digest here that the chart would not
+// actually emit can only mean one fewer image reported, and no c8s component
+// image runs in a platform pod.
+func admissibleDigests(values map[string]any, components []c8sComponent) map[string]bool {
+	admitted := map[string]bool{}
+	for _, c := range components {
+		if digest, err := stringAtPath(values, c.valuePrefix+".digest"); err == nil && digest != "" {
+			admitted[digest] = true
+		}
+	}
+	if floor, ok := valueAtPath(values, "nriImagePolicy.bootstrapAllowlist.digests"); ok {
+		if m, ok := floor.(map[string]any); ok {
+			for digest := range m {
+				admitted[digest] = true
+			}
+		}
+	}
+	if workloads, ok := nestedMap(values, "nriImagePolicy", "bootstrapAllowlist", "workloads"); ok {
+		for _, w := range workloads {
+			for _, digest := range workloadDigests(w) {
+				admitted[digest] = true
+			}
+		}
+	}
+	return admitted
+}
+
+// workloadDigests pulls the container digests out of one decoded
+// bootstrapAllowlist.workloads entry.
+func workloadDigests(workload any) []string {
+	m, ok := workload.(map[string]any)
+	if !ok {
+		return nil
+	}
+	var out []string
+	for _, field := range []string{"initContainers", "containers"} {
+		list, _ := m[field].([]any)
+		for _, entry := range list {
+			c, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if digest, ok := c["digest"].(string); ok && digest != "" {
+				out = append(out, digest)
+			}
+		}
+	}
+	return out
+}
+
+// stringsAtPath returns the string list at a dotted path; a missing key, a
+// non-list leaf, or a non-string element yields what could be read.
+func stringsAtPath(tree map[string]any, path string) []string {
+	value, ok := valueAtPath(tree, path)
+	if !ok {
+		return nil
+	}
+	list, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(list))
+	for _, entry := range list {
+		if s, ok := entry.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 // clusterDistroNodes reads every node's kubeletVersion via kubectl and splits
 // the nodes into RKE2-built vs upstream-built buckets.
 //
@@ -560,19 +797,45 @@ func stringAtPath(tree map[string]any, path string) (string, error) {
 	return s, nil
 }
 
+// valueAtPath walks a dotted path through a decoded YAML tree. ok reports
+// whether the key is there, so a key written with a null or empty value is
+// distinguishable from one that is absent.
+func valueAtPath(tree map[string]any, path string) (value any, ok bool) {
+	var cur any = tree
+	for _, seg := range strings.Split(path, ".") {
+		m, isMap := cur.(map[string]any)
+		if !isMap {
+			return nil, false
+		}
+		if cur, ok = m[seg]; !ok {
+			return nil, false
+		}
+	}
+	return cur, true
+}
+
+// decodeValuesFile reads and parses one -f values file.
+func decodeValuesFile(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read values file %q: %w", path, err)
+	}
+	var tree map[string]any
+	if err := yaml.Unmarshal(data, &tree); err != nil {
+		return nil, fmt.Errorf("parse values file %q: %w", path, err)
+	}
+	return tree, nil
+}
+
 // valuesFilesSetDistro reports whether any -f values file explicitly sets
 // kata.distro or nriImagePolicy.distro. When one does, that file owns the host
 // containerd layout and cluster auto-detection must stand aside; when none
 // does, detection still applies even though other values were supplied.
 func valuesFilesSetDistro(files []string) (bool, error) {
 	for _, f := range files {
-		data, err := os.ReadFile(f)
+		tree, err := decodeValuesFile(f)
 		if err != nil {
-			return false, fmt.Errorf("read values file %q: %w", f, err)
-		}
-		var tree map[string]any
-		if err := yaml.Unmarshal(data, &tree); err != nil {
-			return false, fmt.Errorf("parse values file %q: %w", f, err)
+			return false, err
 		}
 		for _, path := range []string{"kata.distro", "nriImagePolicy.distro"} {
 			if v, err := stringAtPath(tree, path); err == nil && v != "" {
@@ -624,6 +887,26 @@ func materializeStdinValues(files []string, stdin io.Reader) ([]string, func(), 
 	return out, cleanup, nil
 }
 
+// exemptNamespacesPath is the image-policy value the hosted lanes default.
+const exemptNamespacesPath = "nriImagePolicy.policy.exemptNamespaces"
+
+// valuesFilesSetExemptNamespaces reports whether any -f values file writes
+// nriImagePolicy.policy.exemptNamespaces. Key presence is the test, an empty
+// list included: writing one chooses digest-only admission, and the
+// hosted-lane default must leave that choice standing.
+func valuesFilesSetExemptNamespaces(files []string) (bool, error) {
+	for _, f := range files {
+		tree, err := decodeValuesFile(f)
+		if err != nil {
+			return false, err
+		}
+		if _, ok := valueAtPath(tree, exemptNamespacesPath); ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 var installCmd = &cobra.Command{
 	Use:   "install",
 	Short: "Install the c8s operator, CRDs, attestation-api, and component charts via Helm",
@@ -655,6 +938,15 @@ override kata.distro / nriImagePolicy.distro via -f for a layout detection
 cannot see. On RKE2 the kata-deploy and nri-image-policy DaemonSets carry a
 containerd-prep initContainer that wires up the drop-in import; no node
 preparation is required beyond a running cluster.
+
+On the hosted lanes (--cvm-mode=pod/gke/aks) the provider's kube-system pods are
+not on the c8s allowlist, so the install renders
+nriImagePolicy.policy.exemptNamespaces=[kube-system], admitting them by the
+digests they run at the plugin's first connect. A -f file that sets that key
+owns it. Either way the install refuses, before it touches the cluster, when the
+resolved policy would deny a platform pod the cluster is already running:
+registering the plugin restarts containerd, and a denied control-plane container
+does not come back. --force installs anyway.
 
 By default each component image tag is resolved to its registry digest (via the
 'crane' CLI) and pinned, including the CDS digest the image-policy floor and
@@ -855,6 +1147,23 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			}
 		}
 
+		// The values the release will actually render with (chart defaults + -f
+		// + computed), read once and shared by the checks below.
+		values, err := effectiveValues(cmd.Context(), chartPath, setArgs)
+		if err != nil {
+			return err
+		}
+
+		// Fail fast when the policy this install renders would deny the
+		// cluster's own platform pods: registering the plugin restarts
+		// containerd, and a denied control-plane static pod takes the API
+		// server with it. Read-only, so it runs with -f too.
+		if warn, err := preflightImagePolicy(cmd.Context(), values, components, installNamespace, installForce); err != nil {
+			return err
+		} else if warn != "" {
+			fmt.Fprintln(os.Stderr, "warning: "+warn)
+		}
+
 		// --cvm-mode=pod: label every kata-targeted node for the declared
 		// --hardware-platform (see autoLabelTEENodes), then fail fast if
 		// confidential pods still have nowhere to schedule. Labelling mutates
@@ -864,10 +1173,6 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// --single-node: a one-node cluster needs the label too. A `-f` values
 		// file no longer disables TEE node labelling.
 		if cvmModeIsPod(installCvmMode) {
-			values, err := effectiveValues(cmd.Context(), chartPath, setArgs)
-			if err != nil {
-				return err
-			}
 			selectorInValues, err := valuesFilesSetTEESelector(installValues, installHardwarePlatform)
 			if err != nil {
 				return err
@@ -1480,6 +1785,29 @@ func appendVolumedInstallArgs(setArgs []string, volumes bool, cvmMode string) []
 	return append(setArgs, "--set", "volumed.enabled=true")
 }
 
+// appendExemptNamespacesInstallArgs defaults image admission to admitting
+// kube-system by captured digest on the hosted lanes (see hostedCvmModes),
+// where the provider's platform pods are not on the c8s allowlist. Without it a
+// default install renders digest-only admission and then restarts containerd to
+// register the plugin, which on a self-managed control plane denies the static
+// pods and never brings the API server back.
+//
+// A -f file that writes the key owns it: the computed values are helm's last
+// -f, so injecting unconditionally would override an operator's choice.
+func appendExemptNamespacesInstallArgs(setArgs []string, cvmMode string, valuesFiles []string) ([]string, error) {
+	if !slices.Contains(hostedCvmModes, cvmMode) {
+		return setArgs, nil
+	}
+	set, err := valuesFilesSetExemptNamespaces(valuesFiles)
+	if err != nil {
+		return nil, err
+	}
+	if set {
+		return setArgs, nil
+	}
+	return append(setArgs, "--set-string", exemptNamespacesPath+"[0]="+platformExemptNamespace), nil
+}
+
 type workloadRef struct {
 	kind      string
 	name      string
@@ -1999,6 +2327,6 @@ func init() {
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")
 	installCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; sets cds.operatorKeys. Without it, allowlist writes are disabled (reads still served). See the README \"Operator allowlist credentials\"")
-	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), and --cvm-mode=pod without --measurements (no cw workload can start)")
+	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), --cvm-mode=pod without --measurements (no cw workload can start), and a fail-closed image policy that would deny the cluster's own platform pods (they do not come back after the containerd restart)")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -1297,3 +1297,129 @@ func TestInstallValidatesHardwarePlatformBeforeTheCluster(t *testing.T) {
 		}
 	})
 }
+
+// The hosted lanes must render the exempt-namespace default themselves: a
+// plain `--cvm-mode=aks` install that renders digest-only admission denies the
+// platform's own kube-system pods at the containerd restart it performs.
+func TestInstallHostedLaneDefaultsExemptNamespaces(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+	if err := runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--force", "--resolve-digests=false"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	got := treeAt(t, readYAMLTree(t, s.computed), "nriImagePolicy", "policy", "exemptNamespaces")
+	if want := []any{"kube-system"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("exemptNamespaces = %#v, want %#v", got, want)
+	}
+}
+
+// The computed values are helm's LAST -f, so they win on every key they set.
+// An operator who wrote exemptNamespaces must therefore see it reach helm
+// unchanged — the default must not be emitted at all.
+func TestInstallHostedLaneKeepsOperatorExemptNamespaces(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+	values := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    exemptNamespaces: [gatekeeper-system]\n")
+	if err := runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--resolve-digests=false", "-f", values); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	policy, _ := treeAt(t, readYAMLTree(t, s.computed), "nriImagePolicy").(map[string]any)["policy"].(map[string]any)
+	if got, ok := policy["exemptNamespaces"]; ok {
+		t.Errorf("computed values override the operator's exemptNamespaces with %#v", got)
+	}
+}
+
+// platformPodListKubectl answers the pod list with one static control-plane
+// pod, on top of the healthy-cluster answers.
+func platformPodListKubectl(applied, podsFile string) string {
+	return clusterKubectl(applied, `"get pods --all-namespaces -o json") /bin/cat '`+podsFile+`' ;;
+`)
+}
+
+const etcdDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+
+func staticEtcdPod() corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "kube-system",
+			Name:        "etcd-node-a",
+			Annotations: map[string]string{corev1.MirrorPodAnnotationKey: "mirror"},
+		},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:    "etcd",
+			Image:   "index.docker.io/rancher/hardened-etcd:v3.6.12-k3s1",
+			ImageID: "index.docker.io/rancher/hardened-etcd@" + etcdDigest,
+		}}},
+	}
+}
+
+// A fail-closed policy that admits nothing the control plane runs must be
+// refused BEFORE the namespace apply and the helm install, since registering
+// the plugin restarts containerd and the denied static pods never come back.
+func TestInstallRefusesPolicyDenyingPlatformPods(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	pods := podListFile(t, staticEtcdPod())
+	s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, pods))
+	// exemptNamespaces cleared: the shape a pre-#396 values file installs.
+	values := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    exemptNamespaces: []\n")
+
+	err := runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--resolve-digests=false", "-f", values)
+	if err == nil {
+		t.Fatal("want a refusal when the rendered policy denies the control plane")
+	}
+	for _, want := range []string{
+		"kube-system/etcd-node-a",
+		"docker.io/rancher/hardened-etcd@" + etcdDigest,
+		"nriImagePolicy.policy.exemptNamespaces",
+		"nriImagePolicy.bootstrapAllowlist.digests",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("refusal %q is missing %q", err, want)
+		}
+	}
+	calls := s.f.calls(t)
+	mustNotContainPrefix(t, calls, "helm upgrade")
+	mustNotContainPrefix(t, calls, "kubectl apply")
+}
+
+// The default hosted-lane install exempts kube-system, so the same cluster
+// passes with no values file at all.
+func TestInstallHostedLaneDefaultAdmitsPlatformPods(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, podListFile(t, staticEtcdPod())))
+	if err := runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--force", "--resolve-digests=false"); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
+}
+
+// The refusal is a guard, not a wall: --force installs and says what it gave up.
+func TestInstallForcePastPlatformPodDenial(t *testing.T) {
+	var s *installStubs
+	var err error
+	stderr := captureStderr(t, func() {
+		s = newInstallStubs(t, "", false)
+		s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, podListFile(t, staticEtcdPod())))
+		values := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    exemptNamespaces: []\n")
+		err = runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--force", "--resolve-digests=false", "-f", values)
+	})
+	if err != nil {
+		t.Fatalf("--force must install anyway: %v", err)
+	}
+	if !strings.Contains(stderr, "1 platform image") {
+		t.Errorf("stderr missing the forced-past warning:\n%s", stderr)
+	}
+	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
+}
+
+// audit mode creates the container anyway, so there is nothing to refuse — and
+// no pod list to read.
+func TestInstallAuditPolicySkipsPlatformPodCheck(t *testing.T) {
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, podListFile(t, staticEtcdPod())))
+	values := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    mode: audit\n    exemptNamespaces: []\n")
+	if err := runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--resolve-digests=false", "-f", values); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
+}

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -1469,3 +1469,25 @@ func TestInstallNodeLaneReportsNoExemption(t *testing.T) {
 		t.Errorf("node lane reported an exemption it does not render:\n%s", stdout)
 	}
 }
+
+// The hosted-lane default stands aside for a -f file that writes the key, and
+// `-f -` is such a file: the exempt scan runs after stdin is materialized, so
+// it reads the piped bytes rather than a literal "-".
+func TestInstallHostedLaneKeepsExemptNamespacesFromStdin(t *testing.T) {
+	payload := "nriImagePolicy:\n  policy:\n    exemptNamespaces: [gatekeeper-system]\n"
+
+	s := newInstallStubs(t, "", false)
+	s.f.tool(t, "kubectl", clusterKubectl(s.applied, ""))
+
+	resetCLIState(t)
+	t.Cleanup(func() { rootCmd.SetIn(nil) })
+	rootCmd.SetIn(strings.NewReader(payload))
+	rootCmd.SetArgs([]string{"install", "--cvm-mode=aks", "--wait=false", "--resolve-digests=false", "-f", "-"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	policy, _ := treeAt(t, readYAMLTree(t, s.computed), "nriImagePolicy").(map[string]any)["policy"].(map[string]any)
+	if got, ok := policy["exemptNamespaces"]; ok {
+		t.Errorf("computed values override the piped exemptNamespaces with %#v", got)
+	}
+}

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -1423,3 +1423,49 @@ func TestInstallAuditPolicySkipsPlatformPodCheck(t *testing.T) {
 	}
 	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
 }
+
+// The exempted digest set is what an operator has to review before the plugin
+// freezes it on every node, so a default hosted-lane install must print it.
+func TestInstallReportsWhatTheExemptionAdmits(t *testing.T) {
+	var s *installStubs
+	var err error
+	stdout := captureStdout(t, func() {
+		s = newInstallStubs(t, "", false)
+		s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, podListFile(t, staticEtcdPod())))
+		err = runC8s(t, "install", "--cvm-mode=aks", "--wait=false", "--force", "--resolve-digests=false")
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	for _, want := range []string{
+		"kube-system/etcd-node-a",
+		"docker.io/rancher/hardened-etcd@" + etcdDigest,
+		"nriImagePolicy.bootstrapAllowlist.digests",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("install output does not report %q:\n%s", want, stdout)
+		}
+	}
+	// It has to land before the plugin is installed, or reviewing it is moot.
+	if i, h := strings.Index(stdout, "kube-system/etcd-node-a"), lineIndex(s.f.calls(t), "helm upgrade "); i < 0 || h < 0 {
+		t.Fatalf("missing report (%d) or helm upgrade (%d)", i, h)
+	}
+	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
+}
+
+// Nothing is exempt on the node lane, so there is nothing to report.
+func TestInstallNodeLaneReportsNoExemption(t *testing.T) {
+	var s *installStubs
+	var err error
+	stdout := captureStdout(t, func() {
+		s = newInstallStubs(t, "", false)
+		s.f.tool(t, "kubectl", platformPodListKubectl(s.applied, podListFile(t, staticEtcdPod())))
+		err = runC8s(t, "install", "--cvm-mode=node", "--wait=false", "--force", "--resolve-digests=false")
+	})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if strings.Contains(stdout, "admitted by captured digest") {
+		t.Errorf("node lane reported an exemption it does not render:\n%s", stdout)
+	}
+}

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -3,9 +3,11 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1933,5 +1935,66 @@ func TestImageRepositoryFallsBackToImageID(t *testing.T) {
 	}
 	if got := imageRepository("", ""); got != "" {
 		t.Errorf("imageRepository with nothing parseable = %q, want empty", got)
+	}
+}
+
+// The exemption admits by a digest set the plugin freezes per node under its
+// own cache dir, so the install is the one place an operator can review it.
+func TestExemptedPlatformImages(t *testing.T) {
+	const (
+		etcd  = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		proxy = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		gke   = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+		vllm  = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	)
+	pods := []corev1.Pod{
+		mirrorPod("kube-system", "etcd-node-a", "rancher/hardened-etcd:v3.6.12", "rancher/hardened-etcd@"+etcd),
+		daemonSetPod("kube-system", "kube-proxy-a", "kube-proxy:v1.31.0", "kube-proxy@"+proxy),
+		// Same DaemonSet on a second node: one line, not two.
+		daemonSetPod("kube-system", "kube-proxy-b", "kube-proxy:v1.31.0", "kube-proxy@"+proxy),
+		// Outside the exempt set: not what this admits.
+		daemonSetPod("gke-system", "gke-agent-a", "gke/agent:v1", "gke/agent@"+gke),
+		deploymentPod("tenant", "infer-abc", "example.test/vllm:v1", "example.test/vllm@"+vllm),
+	}
+	got := exemptedPlatformImages(pods, []string{"kube-system"})
+	want := []string{
+		"kube-system/etcd-node-a  docker.io/rancher/hardened-etcd@" + etcd,
+		"kube-system/kube-proxy-a  docker.io/library/kube-proxy@" + proxy,
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("exemptedPlatformImages = %#v, want %#v", got, want)
+	}
+
+	if got := exemptedPlatformImages(pods, nil); len(got) != 0 {
+		t.Errorf("with no exempt namespace, got %#v, want none", got)
+	}
+}
+
+// The report is the audit surface: it must carry every digest (never a
+// truncated list) and name the alternative posture.
+func TestReportExemptedImages(t *testing.T) {
+	images := make([]string, 0, deniedImagesListed+5)
+	for i := range cap(images) {
+		images = append(images, fmt.Sprintf("kube-system/pod-%02d  example.test/img%02d@sha256:%064d", i, i, i))
+	}
+	var buf bytes.Buffer
+	reportExemptedImages(&buf, []string{"kube-system"}, images)
+	out := buf.String()
+
+	for _, image := range images {
+		if !strings.Contains(out, image) {
+			t.Errorf("report omits %q — a truncated audit list is not one:\n%s", image, out)
+		}
+	}
+	for _, want := range []string{"kube-system", "nriImagePolicy.bootstrapAllowlist.digests", exemptNamespacesPath} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report does not mention %q:\n%s", want, out)
+		}
+	}
+
+	buf.Reset()
+	reportExemptedImages(&buf, nil, nil)
+	if buf.Len() != 0 {
+		t.Errorf("nothing exempted must print nothing, got:\n%s", buf.String())
 	}
 }

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1682,3 +1682,256 @@ func TestMaterializeStdinValues(t *testing.T) {
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }
+
+// writeValuesFile writes a -f values file and returns its path.
+func writeValuesFile(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "values.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write values: %v", err)
+	}
+	return p
+}
+
+// A -f file that writes nriImagePolicy.policy.exemptNamespaces owns it, empty
+// list included: the computed values are helm's last -f, so a lane default
+// injected over it would silently replace a deliberate choice.
+func TestValuesFilesSetExemptNamespaces(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want bool
+	}{
+		{"list set", "nriImagePolicy:\n  policy:\n    exemptNamespaces: [gatekeeper-system]\n", true},
+		{"empty list is a choice", "nriImagePolicy:\n  policy:\n    exemptNamespaces: []\n", true},
+		{"null is a choice", "nriImagePolicy:\n  policy:\n    exemptNamespaces:\n", true},
+		{"sibling policy key only", "nriImagePolicy:\n  policy:\n    mode: audit\n", false},
+		{"wrong nesting level", "nriImagePolicy:\n  exemptNamespaces: [kube-system]\n", false},
+		{"unrelated value only", "tlsLb:\n  enabled: false\n", false},
+		{"empty file", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := valuesFilesSetExemptNamespaces([]string{writeValuesFile(t, tc.body)})
+			if err != nil {
+				t.Fatalf("valuesFilesSetExemptNamespaces: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("valuesFilesSetExemptNamespaces(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("no files means default", func(t *testing.T) {
+		got, err := valuesFilesSetExemptNamespaces(nil)
+		if err != nil || got {
+			t.Errorf("valuesFilesSetExemptNamespaces(nil) = (%v, %v), want (false, nil)", got, err)
+		}
+	})
+
+	t.Run("one of several files sets it", func(t *testing.T) {
+		a := writeValuesFile(t, "tlsLb:\n  enabled: false\n")
+		b := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    exemptNamespaces: [kube-system]\n")
+		got, err := valuesFilesSetExemptNamespaces([]string{a, b})
+		if err != nil || !got {
+			t.Errorf("valuesFilesSetExemptNamespaces(two files) = (%v, %v), want (true, nil)", got, err)
+		}
+	})
+}
+
+func TestAppendExemptNamespacesInstallArgs(t *testing.T) {
+	want := []string{"--set-string", "nriImagePolicy.policy.exemptNamespaces[0]=kube-system"}
+	for _, mode := range hostedCvmModes {
+		got, err := appendExemptNamespacesInstallArgs(nil, mode, nil)
+		if err != nil {
+			t.Fatalf("--cvm-mode=%s: %v", mode, err)
+		}
+		assertArgsEqual(t, got, want)
+	}
+
+	// node bakes the system digests into its own floor, so the chart's empty
+	// default stands.
+	got, err := appendExemptNamespacesInstallArgs(nil, "node", nil)
+	if err != nil || got != nil {
+		t.Errorf("--cvm-mode=node = (%v, %v), want (nil, nil)", got, err)
+	}
+
+	t.Run("a -f file that sets it wins", func(t *testing.T) {
+		f := writeValuesFile(t, "nriImagePolicy:\n  policy:\n    exemptNamespaces: [gatekeeper-system]\n")
+		got, err := appendExemptNamespacesInstallArgs(nil, "aks", []string{f})
+		if err != nil || got != nil {
+			t.Errorf("with an exemptNamespaces -f = (%v, %v), want (nil, nil)", got, err)
+		}
+	})
+
+	t.Run("an unrelated -f file does not suppress the default", func(t *testing.T) {
+		f := writeValuesFile(t, "tlsLb:\n  enabled: false\n")
+		got, err := appendExemptNamespacesInstallArgs(nil, "aks", []string{f})
+		if err != nil {
+			t.Fatalf("appendExemptNamespacesInstallArgs: %v", err)
+		}
+		assertArgsEqual(t, got, want)
+	})
+
+	t.Run("an unreadable -f file is an error, not a silent default", func(t *testing.T) {
+		if _, err := appendExemptNamespacesInstallArgs(nil, "aks", []string{"/nonexistent/values.yaml"}); err == nil {
+			t.Error("want an error for an unreadable values file")
+		}
+	})
+}
+
+func TestImageDigest(t *testing.T) {
+	const digest = "sha256:ab12000000000000000000000000000000000000000000000000000000000000"
+	for _, tc := range []struct {
+		name string
+		refs []string
+		want string
+	}{
+		{"digested reference", []string{"docker.io/rancher/hardened-etcd@" + digest}, digest},
+		{"bare digest imageID", []string{digest}, digest},
+		{"docker-pullable prefix", []string{"docker-pullable://nginx@" + digest}, digest},
+		{"imageID wins over the spec tag", []string{"nginx@" + digest, "nginx:1.27"}, digest},
+		{"falls back to a pinned spec image", []string{"", "nginx@" + digest}, digest},
+		{"tag only carries no digest", []string{"", "nginx:1.27"}, ""},
+		{"nothing to read", []string{"", ""}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := imageDigest(tc.refs...); got != tc.want {
+				t.Errorf("imageDigest(%q) = %q, want %q", tc.refs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAdmissibleDigests(t *testing.T) {
+	const (
+		componentDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		floorDigest     = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		workloadDigest  = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+		initDigest      = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+	)
+	values := map[string]any{
+		"cds": map[string]any{"image": map[string]any{"digest": componentDigest}},
+		"nriImagePolicy": map[string]any{"bootstrapAllowlist": map[string]any{
+			"digests": map[string]any{floorDigest: "example.test/etcd@" + floorDigest},
+			"workloads": map[string]any{"infer": map[string]any{
+				"initContainers": []any{map[string]any{"digest": initDigest}},
+				"containers":     []any{map[string]any{"digest": workloadDigest}},
+			}},
+		}},
+	}
+	got := admissibleDigests(values, []c8sComponent{{valuePrefix: "cds.image"}, {valuePrefix: "volumed.image"}})
+	want := map[string]bool{componentDigest: true, floorDigest: true, workloadDigest: true, initDigest: true}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("admissibleDigests = %v, want %v", got, want)
+	}
+}
+
+// platformPod builders for the denial check.
+func daemonSetPod(ns, name, image, imageID string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       ns,
+			Name:            name,
+			OwnerReferences: []metav1.OwnerReference{{Kind: "DaemonSet", Name: "ds"}},
+		},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Image: image, ImageID: imageID}}},
+	}
+}
+
+func mirrorPod(ns, name, image, imageID string) corev1.Pod {
+	p := daemonSetPod(ns, name, image, imageID)
+	p.OwnerReferences = nil
+	p.Annotations = map[string]string{corev1.MirrorPodAnnotationKey: "mirror"}
+	return p
+}
+
+func deploymentPod(ns, name, image, imageID string) corev1.Pod {
+	p := daemonSetPod(ns, name, image, imageID)
+	p.OwnerReferences = []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "rs"}}
+	return p
+}
+
+func TestDeniedPlatformImages(t *testing.T) {
+	const (
+		etcd    = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+		cni     = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+		tenant  = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+		pinned  = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+		release = "c8s-system"
+	)
+	pods := []corev1.Pod{
+		mirrorPod("kube-system", "etcd-node-a", "index.docker.io/rancher/hardened-etcd:v3.6.12", "index.docker.io/rancher/hardened-etcd@"+etcd),
+		daemonSetPod("calico-system", "calico-node-a", "calico/node:v3", "calico/node@"+cni),
+		// The same DaemonSet on a second node must not be reported twice.
+		daemonSetPod("calico-system", "calico-node-b", "calico/node:v3", "calico/node@"+cni),
+		// A tenant Deployment is the operator's to allowlist, not a refusal.
+		deploymentPod("tenant", "infer-abc", "example.test/vllm:v1", "example.test/vllm@"+tenant),
+		// A platform image already in the floor is admitted.
+		daemonSetPod("kube-system", "csi-node-a", "example.test/csi:v1", "example.test/csi@"+pinned),
+		// The release's own components are torn up and replaced by this install.
+		daemonSetPod(release, "c8s-ratls-mesh-a", "ghcr.io/confidential-dot-ai/ratls-mesh:main", "ghcr.io/confidential-dot-ai/ratls-mesh@"+tenant),
+	}
+	admitted := map[string]bool{pinned: true}
+
+	got := deniedPlatformImages(pods, release, nil, admitted)
+	want := []string{
+		"calico-system/calico-node-a  docker.io/calico/node@" + cni,
+		"kube-system/etcd-node-a  docker.io/rancher/hardened-etcd@" + etcd,
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("deniedPlatformImages = %#v, want %#v", got, want)
+	}
+
+	// Exempting a namespace admits everything in it by captured digest.
+	got = deniedPlatformImages(pods, release, []string{"kube-system", "calico-system"}, admitted)
+	if len(got) != 0 {
+		t.Errorf("with both namespaces exempt, denied = %#v, want none", got)
+	}
+}
+
+// A container that has not pulled reports no digest, so there is nothing to
+// evaluate — it must not be reported as denied on a guess.
+func TestDeniedPlatformImagesSkipsUnpulledContainers(t *testing.T) {
+	pod := daemonSetPod("kube-system", "kube-proxy-a", "kube-proxy:v1.31.0", "")
+	if got := deniedPlatformImages([]corev1.Pod{pod}, "c8s-system", nil, nil); len(got) != 0 {
+		t.Errorf("denied = %#v, want none for a container with no resolved imageID", got)
+	}
+}
+
+// Init containers are admitted by the same policy as the main ones, so a
+// denied init image wedges the pod just as hard.
+func TestDeniedPlatformImagesCoversInitContainers(t *testing.T) {
+	const digest = "sha256:5555555555555555555555555555555555555555555555555555555555555555"
+	pod := daemonSetPod("kube-system", "cni-install-a", "main:v1", "")
+	pod.Status.InitContainerStatuses = []corev1.ContainerStatus{{Image: "install-cni:v3", ImageID: "install-cni@" + digest}}
+	got := deniedPlatformImages([]corev1.Pod{pod}, "c8s-system", nil, nil)
+	want := []string{"kube-system/cni-install-a  docker.io/library/install-cni@" + digest}
+	if !slices.Equal(got, want) {
+		t.Errorf("denied = %#v, want %#v", got, want)
+	}
+}
+
+// A pod the kubelet has finished with has no container left for the containerd
+// restart to recreate, so its images are not the policy's to admit.
+func TestDeniedPlatformImagesSkipsTerminalPods(t *testing.T) {
+	const digest = "sha256:6666666666666666666666666666666666666666666666666666666666666666"
+	for _, phase := range []corev1.PodPhase{corev1.PodSucceeded, corev1.PodFailed} {
+		pod := daemonSetPod("kube-system", "cni-migrate-a", "migrate:v1", "migrate@"+digest)
+		pod.Status.Phase = phase
+		if got := deniedPlatformImages([]corev1.Pod{pod}, "c8s-system", nil, nil); len(got) != 0 {
+			t.Errorf("phase %s: denied = %#v, want none", phase, got)
+		}
+	}
+}
+
+// The repository is reported for pasting into the floor, so a status that
+// carries the reference only on imageID must still name one.
+func TestImageRepositoryFallsBackToImageID(t *testing.T) {
+	const digest = "sha256:7777777777777777777777777777777777777777777777777777777777777777"
+	if got, want := imageRepository("", "docker-pullable://calico/node@"+digest), "docker.io/calico/node"; got != want {
+		t.Errorf("imageRepository = %q, want %q", got, want)
+	}
+	if got := imageRepository("", ""); got != "" {
+		t.Errorf("imageRepository with nothing parseable = %q, want empty", got)
+	}
+}

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -51,10 +51,10 @@ var renderValuesDistro string
 // preflight, and no namespace apply.
 //
 // What it does NOT emit: the per-cluster overrides a consumer layers on top
-// (dnsSanPatterns, tls-lb SAN/LB IP/CORS, nodeSelectors, exemptNamespaces) and
-// anything the chart renders off these values internally (e.g. the AKS webhook
-// annotation off attestationApi.cvmMode). The output is the install-computed
-// base, not a full per-cluster values file.
+// (dnsSanPatterns, tls-lb SAN/LB IP/CORS, nodeSelectors) and anything the chart
+// renders off these values internally (e.g. the AKS webhook annotation off
+// attestationApi.cvmMode). The output is the install-computed base, not a full
+// per-cluster values file.
 var renderValuesCmd = &cobra.Command{
 	Use:   "render-values",
 	Short: "Print the resolved Helm values an install would apply (no cluster needed)",
@@ -185,6 +185,12 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, c
 		return nil, err
 	}
 	setArgs = appendKataInstallArgs(setArgs, installCvmMode, installKataDebug)
+	// installValues is empty for render-values, which registers no -f flag, so
+	// the hosted-lane default always applies there.
+	setArgs, err = appendExemptNamespacesInstallArgs(setArgs, installCvmMode, installValues)
+	if err != nil {
+		return nil, err
+	}
 	setArgs = appendSingleNodeInstallArgs(setArgs, installSingleNode)
 	// Ahead of resolveDigests, which pins a component's image only while the
 	// effective values enable it.

--- a/cmd/c8s/render_values_exec_test.go
+++ b/cmd/c8s/render_values_exec_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
@@ -80,5 +81,42 @@ func TestRenderValuesRequiresHelm(t *testing.T) {
 	err := runC8s(t, "render-values", "--cvm-mode=node", "--resolve-digests=false")
 	if err == nil || !strings.Contains(err.Error(), "helm CLI not found") {
 		t.Fatalf("want a helm-not-found error, got %v", err)
+	}
+}
+
+// A GitOps consumer must get the same hosted-lane admission default an install
+// renders: the bundle is the whole policy a HelmRelease applies, and a
+// digest-only one denies the provider's own platform pods.
+func TestRenderValuesHostedLaneExemptNamespaces(t *testing.T) {
+	for _, tc := range []struct {
+		cvmMode string
+		want    any
+	}{
+		{"aks", []any{"kube-system"}},
+		{"gke", []any{"kube-system"}},
+		{"pod", []any{"kube-system"}},
+		// node's baked floor already carries the system digests.
+		{"node", nil},
+	} {
+		t.Run(tc.cvmMode, func(t *testing.T) {
+			f := newFakeBin(t)
+			f.tool(t, "helm", helmShowValuesBody)
+			var err error
+			out := captureStdout(t, func() {
+				err = runC8s(t, "render-values", "--cvm-mode="+tc.cvmMode, "--resolve-digests=false")
+			})
+			if err != nil {
+				t.Fatalf("render-values: %v", err)
+			}
+			var tree map[string]any
+			if err := yaml.Unmarshal([]byte(out), &tree); err != nil {
+				t.Fatalf("output is not a values.yaml: %v\n%s", err, out)
+			}
+			policy, _ := treeAt(t, tree, "nriImagePolicy").(map[string]any)["policy"].(map[string]any)
+			got := policy["exemptNamespaces"]
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("nriImagePolicy.policy.exemptNamespaces = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -898,7 +898,8 @@ nriImagePolicy:
     # exemptNamespaces: on the hosted lanes (pod/gke/aks), admit each listed
     # namespace's provider platform pods — which are not on the c8s allowlist —
     # by the image digests captured running in it, frozen at first admission and
-    # scoped to that namespace. Set to [kube-system] there. Empty (the default)
+    # scoped to that namespace. `c8s install --cvm-mode=pod|gke|aks` sets
+    # [kube-system] unless a -f file writes this key. Empty (the chart default)
     # keeps digest-only admission; leave it empty on cvmMode=node, whose baked
     # floor already carries the system digests. See
     # docs/getcert-workload-binding.md, Corner 8.


### PR DESCRIPTION
## The problem

On the hosted lanes (`--cvm-mode=aks|gke|pod`) the platform's own `kube-system` pods are not on the c8s allowlist. #370 made admission digest-only; #396 added `nriImagePolicy.policy.exemptNamespaces` and the values file states the contract — *"Set to `[kube-system]` there"* — but **`install` never set it**:

```
$ c8s render-values --cvm-mode aks --hardware-platform sev-snp --distro rke2
nriImagePolicy:
    distro: rke2
    image:
        tag: main
```

So a plain `c8s install --cvm-mode aks --hardware-platform sev-snp` rendered digest-only admission and then restarted containerd to register the plugin. On a self-managed RKE2 control plane the static pods are denied and the API server never returns:

```
CreateContainer within sandbox … for name:"etcd" failed:
  failed to get NRI adjustment for container: image not in allowlist:
  index.docker.io/rancher/hardened-etcd:v3.6.12-k3s1-build20260603
```

Silent, total, and recoverable only with out-of-band root. Observed twice on `c8s-cvm` in 24 hours; `--wait` reports a generic readiness timeout that names no cause.

## The fix

**1. Default the value from the lane.** `install` and `render-values` emit `nriImagePolicy.policy.exemptNamespaces=[kube-system]` for `--cvm-mode=pod|gke|aks`. `node` keeps the chart's empty default — its baked floor already carries the system digests.

The computed values are helm's **last** `-f`, so injecting unconditionally would silently override an operator who set the key deliberately. The default is emitted only when no `-f` file writes it, extending the walker that already stands aside for `kata.distro` / `nriImagePolicy.distro` rather than adding a second one. Key presence is the test, `[]` included — writing an empty list chooses digest-only admission.

**2. Pre-flight the resolved policy.** Independent of the default, and the durable half: before anything touches the cluster, `install` enumerates the running **platform pods** and refuses when the resolved policy would deny one, naming the pod, repository and digest. Modelled on `preflightTLSLBHostPort` — it names the blocking object and offers concrete remedies. Read-only; `--force` installs anyway with the same list as a warning.

This covers what the `[kube-system]` default cannot: hosted clusters whose platform pods live in other namespaces.

**3. Print what the exemption admits.** The exemption's weak point against a floor entry is reviewability: what you configure is a namespace *name*, but what admits is a digest set the plugin resolves from the node's content store at first connect and freezes to a per-node file under its cache dir — invisible without node access. The preflight already had every platform pod's repository and digest in hand, so it now prints the covered set before the containerd restart:

```
+ image policy: kube-system admitted by captured digest. The plugin freezes what runs
  there when it first connects; as of now that is 2 image(s):
    kube-system/etcd-c8s-cvm  docker.io/rancher/hardened-etcd@sha256:1111…
    kube-system/kube-proxy-hs4nx  docker.io/library/kube-proxy@sha256:2222…
  To pin them explicitly instead, put these digests in
  nriImagePolicy.bootstrapAllowlist.digests and set nriImagePolicy.policy.exemptNamespaces: [] via -f.
```

Uncapped, unlike the denial list — a truncated audit list is not one.

### Why not just put the kube-system digests in the floor?

That was the alternative considered, and it wins on exactly the point above: a floor is in the rendered values, diffable and editable before go-live. Three things decided against it as the *default*:

- **A floor entry admits in every namespace.** `checkImage` consults the allowlist with no namespace argument at all (`plugin.go:412`), while the exemption is keyed `s.index[namespace][digest]`. Floor-injecting kube-system would let a tenant pod run the CNI and CSI node-driver images. Corner 8 of `docs/getcert-workload-binding.md` rejects this explicitly.
- **Node churn.** The captured set is per node, at that node's first connect. An autoscaled node joining later with a rotated platform image self-captures; under a floor frozen at install time it is denied until someone re-runs install.
- **`render-values` has no cluster**, and the fleet installs through a Flux HelmRelease built from its bundle. `exemptNamespaces: [kube-system]` is a static value a bundle can carry; "the digests running on the target cluster" is not — so a floor-based default would silently not exist for the GitOps lane.

This is not either/or: `values.yaml:977` already names the pinned floor as the production posture. The default is the convenience path, and the printed list is what makes moving to the pinned one an informed choice.

### Judgement call worth reviewing

"Platform pod" is defined as **a static (mirror) pod or a DaemonSet-owned pod**, outside the release namespace — the set a containerd restart takes down and the cluster cannot be repaired without (control plane, CNI, kube-proxy, CSI and device plugins).

Tenant Deployments are deliberately **out of scope**: a tenant pod denied by a policy the operator is installing on purpose is theirs to allowlist, and refusing on it would train operators to reach for `--force` reflexively. The check compares the runtime's own `imageID` against the resolved `exemptNamespaces` *and* the allowlist floor, so an operator who pinned platform digests instead of exempting is not flagged.

## Acceptance criteria

- [x] `c8s render-values --cvm-mode aks` emits `exemptNamespaces: [kube-system]`; `--cvm-mode node` does not — `TestRenderValuesHostedLaneExemptNamespaces` covers all four modes.
- [x] An operator `-f` file setting `exemptNamespaces` to something else survives the install unchanged — `TestInstallHostedLaneKeepsOperatorExemptNamespaces` is the regression test for the last-`-f` override hazard.
- [x] On a cluster whose platform images are absent from the resolved policy, `install` refuses **before** the containerd restart, naming the images — `TestInstallRefusesPolicyDenyingPlatformPods` also asserts no `helm upgrade` and no `kubectl apply` ran.

## Testing

Rebased onto `551bdbdd`. The conflicts were all "both appended here" against #395 (`docs+fix(install): repair install docs, plumb -f - stdin`) — resolved keep-both, with #395's own tests (`TestInstallValuesFromStdin`, `TestInstallStdinValuesMaterializeFailure`, `TestMaterializeStdinValues`, `TestValuesFilesSetDistroErrorPaths`) passing on the result.

That rebase created a real seam: the hosted-lane default stands aside for a `-f` file that writes `exemptNamespaces`, and `-f -` is now such a file. `RunE` replaces `installValues` with the materialized temp file before any of the scans run, so a piped value is honoured — `TestInstallHostedLaneKeepsExemptNamespacesFromStdin` pins that ordering, since getting it wrong fails either loudly (reading a file literally named `-`) or silently (the default overwriting piped values).

`go build ./...`, `go test ./... -count=1`, `go vet`, `gofmt` all clean. **Not run locally:** `scripts/check-doc-install-commands.sh` (also new on main) — it needs `kubectl` on PATH, which this environment lacks. It parses `docs/QUICKSTART.md`/`DEMO.md` rather than CLI help text, and the new preflight sits after `detectDistro` has already contacted the cluster, so it should be unaffected — but CI is the confirmation.

New coverage: `TestValuesFilesSetExemptNamespaces`, `TestAppendExemptNamespacesInstallArgs`, `TestImageDigest`, `TestImageRepositoryFallsBackToImageID`, `TestAdmissibleDigests`, `TestDeniedPlatformImages` (+ unpulled / init-container / terminal-phase cases), `TestExemptedPlatformImages`, `TestReportExemptedImages` (asserts the list is never truncated), and the exec-level install cases: default applies, operator `-f` wins, refusal, `--force`, `audit` mode skips, the report reaches stdout before the plugin is installed, and the node lane reports no exemption.
