### PR TITLE
chart: seal the hand-written values subtrees with values.schema.json

### DIFF
--- a/.github/scripts/chart-verify.sh
+++ b/.github/scripts/chart-verify.sh
@@ -27,7 +27,6 @@ common_set=(
   --set nriImagePolicy.image.tag=ci
   --set nriImagePolicy.image.digest=sha256:aaaa000000000000000000000000000000000000000000000000000000000000
   --set cds.image.digest=sha256:0000000000000000000000000000000000000000000000000000000000000001
-  --set nriImagePolicy.cds.node.selector.role=cds-node
   # tls-lb has no default upstream; a c8s-<id> headless-Service address (what
   # `c8s install --upstream` derives, recognized as mesh-wrapped) is the
   # representative configuration.

--- a/internal/helmchart/c8s/values.schema.json
+++ b/internal/helmchart/c8s/values.schema.json
@@ -1,0 +1,417 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$comment": "Partial by design: only the four subtrees operators hand-write are sealed, so an unknown or misspelled key there is a render-time error instead of a silently dropped value. Every key of those subtrees in values.yaml must appear here; leaf types are deliberately unconstrained. Maps whose keys belong to the consumer (label maps, digest maps, resources) are left open.",
+  "type": "object",
+  "properties": {
+    "cds": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "allowlistDB": {},
+        "ca": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "certValidity": {},
+            "commonName": {},
+            "minValidity": {}
+          }
+        },
+        "certTTL": {},
+        "challengeTTL": {},
+        "cnPattern": {},
+        "dnsSanPatterns": {},
+        "earIssuer": {},
+        "expectedIssuer": {},
+        "handoff": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "peerUrl": {}
+          }
+        },
+        "image": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "digest": {},
+            "pullPolicy": {},
+            "repository": {},
+            "tag": {}
+          }
+        },
+        "jwtClockSkew": {},
+        "logLevel": {},
+        "maxRequestSize": {},
+        "maxTTL": {},
+        "measurements": {},
+        "namedCertTTL": {},
+        "node": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "selector": {},
+            "tolerations": {}
+          }
+        },
+        "operatorKeys": {},
+        "persistence": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "size": {},
+            "storageClassName": {}
+          }
+        },
+        "podDisruptionBudget": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "maxUnavailable": {}
+          }
+        },
+        "port": {},
+        "rateBurst": {},
+        "rateLimit": {},
+        "rateLimiterEvictInterval": {},
+        "rateLimiterIdleTimeout": {},
+        "rateLimiterMaxEntries": {},
+        "ratlsCertTTL": {},
+        "ratlsPlatform": {},
+        "readinessInterval": {},
+        "requestTimeout": {},
+        "resources": {},
+        "sanValidation": {},
+        "sandboxInventoryCIDRs": {},
+        "secretsMaxPaths": {},
+        "secretsMaxPathsPerWorkload": {},
+        "service": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "nodePort": {},
+            "type": {}
+          }
+        },
+        "tokenSignerOverlap": {},
+        "tokenSignerRotationInterval": {},
+        "tokenSignerRotationJitter": {}
+      }
+    },
+    "nriImagePolicy": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "bootstrapAllowlist": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "deriveComponents": {},
+            "digests": {},
+            "workloads": {}
+          }
+        },
+        "cds": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "url": {}
+          }
+        },
+        "containerd": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "configDir": {},
+            "namespace": {},
+            "restartCommand": {},
+            "socket": {}
+          }
+        },
+        "containerdPrep": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "image": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "digest": {},
+                "pullPolicy": {},
+                "repository": {},
+                "tag": {}
+              }
+            }
+          }
+        },
+        "distro": {},
+        "enabled": {},
+        "healthSocketName": {},
+        "hostPaths": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "cacheDir": {},
+            "configDir": {},
+            "pluginDir": {},
+            "runtimeDir": {}
+          }
+        },
+        "image": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "digest": {},
+            "pullPolicy": {},
+            "repository": {},
+            "tag": {}
+          }
+        },
+        "imagePullSecrets": {},
+        "logLevel": {},
+        "nodeAffinity": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "excludeLabels": {}
+          }
+        },
+        "pluginFilename": {},
+        "pluginName": {},
+        "policy": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "denyMissingAnnotation": {},
+            "enforceExisting": {},
+            "exemptNamespaces": {},
+            "labelRules": {},
+            "mode": {}
+          }
+        },
+        "priorityClassName": {},
+        "refresh": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "interval": {}
+          }
+        },
+        "resources": {},
+        "sandboxDigests": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "advertiseHost": {}
+          }
+        },
+        "uninstall": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {}
+          }
+        }
+      }
+    },
+    "tlsLb": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "allowlist": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "proxyPort": {},
+            "rateLimit": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "burst": {},
+                "requestsPerSecond": {},
+                "totalBurst": {},
+                "totalRequestsPerSecond": {}
+              }
+            },
+            "readRateLimit": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "burst": {},
+                "requestsPerSecond": {}
+              }
+            },
+            "resources": {}
+          }
+        },
+        "attest": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "attestationApiURL": {},
+            "enabled": {},
+            "expectedWorkload": {},
+            "generation": {},
+            "platform": {},
+            "port": {},
+            "resources": {}
+          }
+        },
+        "certProvisioning": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "renewInterval": {},
+            "verbose": {}
+          }
+        },
+        "cors": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "allowCredentials": {},
+            "allowHeaders": {},
+            "allowMethods": {},
+            "allowOrigins": {},
+            "enabled": {},
+            "exposeHeaders": {},
+            "maxAge": {},
+            "protocolEndpoints": {}
+          }
+        },
+        "discovery": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "cdsCertPath": {},
+            "enabled": {},
+            "fileName": {},
+            "meshCAPath": {},
+            "mountPath": {},
+            "path": {}
+          }
+        },
+        "enabled": {},
+        "hostPort": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {},
+            "https": {}
+          }
+        },
+        "imagePullSecrets": {},
+        "meshCA": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "expose": {}
+          }
+        },
+        "nameOverride": {},
+        "nginx": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "httpsPort": {},
+            "image": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "digest": {},
+                "pullPolicy": {},
+                "repository": {},
+                "tag": {}
+              }
+            },
+            "replicas": {},
+            "resolver": {},
+            "resources": {},
+            "runAsGroup": {},
+            "runAsNonRoot": {},
+            "runAsUser": {}
+          }
+        },
+        "publicTLS": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "certKey": {},
+            "keyKey": {},
+            "mountPath": {},
+            "secretName": {}
+          }
+        },
+        "routes": {},
+        "san": {},
+        "service": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "annotations": {},
+            "externalTrafficPolicy": {},
+            "port": {},
+            "type": {}
+          }
+        },
+        "strategy": {},
+        "tlsMountPath": {},
+        "upstream": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "address": {},
+            "protocol": {},
+            "tls": {
+              "type": ["object", "null"],
+              "additionalProperties": false,
+              "properties": {
+                "serverName": {},
+                "trustedCAPath": {},
+                "useCDSClientCert": {},
+                "verify": {},
+                "verifyDepth": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "volumed": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "hostPaths": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "cgroupRoot": {},
+            "kubeletRoot": {}
+          }
+        },
+        "image": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "properties": {
+            "digest": {},
+            "pullPolicy": {},
+            "repository": {},
+            "tag": {}
+          }
+        },
+        "imagePullSecrets": {},
+        "maxMounts": {},
+        "nodeSelector": {},
+        "priorityClassName": {},
+        "reapInterval": {},
+        "resources": {},
+        "tolerations": {}
+      }
+    }
+  }
+}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7406,3 +7406,106 @@ func TestChartIptablesSyncCarriesClusterDNS(t *testing.T) {
 		t.Error("iptables-sync command does not carry --cluster-dns-ip")
 	}
 }
+
+// schemaCoveredPaths are the values subtrees values.schema.json seals: the
+// component blocks the docs tell operators to write by hand.
+var schemaCoveredPaths = []string{"cds", "nriImagePolicy", "tlsLb", "volumed"}
+
+// readChartFile decodes a file from the chart directory. JSON is a subset of
+// YAML, so one decoder serves values.yaml and values.schema.json alike.
+func readChartFile(t *testing.T, name string, into any) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("c8s", name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	if err := yaml.Unmarshal(data, into); err != nil {
+		t.Fatalf("decode %s: %v", name, err)
+	}
+}
+
+// Helm accepts values a chart never reads, so a misspelled key under a
+// documented path is applied, silently dropped at render, and shows up only as
+// whatever the un-applied value was protecting against. The schema turns that
+// into a render-time error naming the key.
+func TestChartValuesSchemaRejectsUnknownKeys(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		set  string
+	}{
+		// The singular of the key whose loss bricked a cluster.
+		{"nriImagePolicy.policy", "nriImagePolicy.policy.exemptNamespace=kube-system"},
+		{"nriImagePolicy top level", "nriImagePolicy.exemptNamespaces=kube-system"},
+		{"tlsLb.hostPort", "tlsLb.hostPort.enable=false"},
+		{"cds.persistence", "cds.persistence.enable=true"},
+		{"volumed", "volumed.enable=true"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key, _, _ := strings.Cut(tc.set, "=")
+			out, err := helmTemplate(t, "--set", tc.set)
+			if err == nil {
+				t.Fatalf("helm template accepted the unknown key %s\n%s", key, out)
+			}
+			// Helm's wording for the same rejection differs by version
+			// ("Additional property X is not allowed" vs "additional
+			// properties 'X' not allowed"), so match on the shared stem.
+			unknown := key[strings.LastIndexByte(key, '.')+1:]
+			if !strings.Contains(strings.ToLower(out), "additional propert") || !strings.Contains(out, unknown) {
+				t.Errorf("render failure does not name the unknown key %q:\n%s", unknown, out)
+			}
+		})
+	}
+}
+
+// The schema is only as good as its coverage: a key added to values.yaml but
+// not to the schema makes every render of the chart fail on its own default.
+// This is the lockstep guard, checked against the chart's own values.
+func TestChartValuesSchemaCoversValuesYAML(t *testing.T) {
+	var values map[string]any
+	readChartFile(t, "values.yaml", &values)
+	var schema struct {
+		Properties map[string]any `yaml:"properties"`
+	}
+	readChartFile(t, "values.schema.json", &schema)
+
+	for _, top := range schemaCoveredPaths {
+		node, ok := schema.Properties[top]
+		if !ok {
+			t.Errorf("values.schema.json does not cover %s", top)
+			continue
+		}
+		assertSchemaCovers(t, values[top], node, top)
+	}
+}
+
+// assertSchemaCovers walks a values subtree against its schema node: every key
+// of a sealed object (one carrying "properties") must be declared, and the
+// walk continues into each. A node with no "properties" is deliberately open —
+// a label map, a digest map, a resources block — and ends the walk.
+func assertSchemaCovers(t *testing.T, values, node any, path string) {
+	t.Helper()
+	schema, ok := node.(map[string]any)
+	if !ok {
+		t.Errorf("%s: schema node is not an object (%T)", path, node)
+		return
+	}
+	props, sealed := schema["properties"].(map[string]any)
+	if !sealed {
+		return
+	}
+	if blocked, ok := schema["additionalProperties"].(bool); !ok || blocked {
+		t.Errorf("%s: declares properties but does not set additionalProperties: false, so a typo still passes", path)
+	}
+	m, ok := values.(map[string]any)
+	if !ok {
+		return
+	}
+	for k, v := range m {
+		child, ok := props[k]
+		if !ok {
+			t.Errorf("values.yaml sets %s.%s but values.schema.json does not declare it; every render would fail", path, k)
+			continue
+		}
+		assertSchemaCovers(t, v, child, path+"."+k)
+	}
+}


### PR DESCRIPTION
## The problem

Helm does not error on values a chart does not consume. During the 2026-08-19 run, `nriImagePolicy.policy.exemptNamespaces: [kube-system]` was passed to a CLI whose **embedded** chart predated #396. The value was accepted, silently dropped, the rendered node config contained no `exempt_namespaces` stanza, and the cluster bricked. The only symptom was a generic readiness timeout.

The failure mode is: *operator applies the documented mitigation, it is ignored, the cluster goes down.*

## The fix

`internal/helmchart/c8s/values.schema.json`, covering the four subtrees the docs tell operators to write by hand — `nriImagePolicy`, `tlsLb`, `cds`, `volumed` — with `additionalProperties: false`:

```
$ helm template … --set nriImagePolicy.policy.exemptNamespace=kube-system
Error: values don't meet the specifications of the schema(s) in the following chart(s):
c8s:
- at '/nriImagePolicy/policy': additional properties 'exemptNamespace' not allowed
```

### Scoped deliberately

A schema over the whole values tree is a maintenance burden that fights every new key, so this one is partial by design:

- **No constraint at the root** — only those four subtrees are sealed.
- **Consumer-owned maps stay open**: label maps (`cds.node.selector`, `volumed.nodeSelector`), `bootstrapAllowlist.digests` / `.workloads`, `tlsLb.service.annotations`, `tlsLb.strategy`, and every `resources` block.
- **Leaf types are unconstrained.** `tlsLb.san` is a list in one fleet cluster and `""` in another; typing leaves would fight consumers without catching the failure this exists for. The value is in rejecting unknown keys, not in re-stating types the templates already enforce.
- Containers accept `null` as well as `object`, so `--single-node`'s `cds.node.selector=null` and a cluster overlay that nulls a whole block still validate.

`TestChartValuesSchemaCoversValuesYAML` is the lockstep guard: a key added to `values.yaml` but not to the schema would make **every** render fail on the chart's own default, so this catches that at test time instead. (Confirmed non-vacuous by adding a probe key and watching it fail.)

## Incidental find

`chart-verify.sh` set `--set nriImagePolicy.cds.node.selector.role=cds-node`, which no template reads — almost certainly a stray `nriImagePolicy.` prefix on `cds.node.selector.role`. It rendered nothing, and it is the first thing the schema caught. Removed.

## Acceptance criteria

- [x] `helm template` fails with a named error on a misspelled key under a covered path.
- [x] `internal/helmchart/chart_test.go` gains a case asserting the failure — `TestChartValuesSchemaRejectsUnknownKeys` covers five misspellings across all four subtrees.
- [x] Every values file in the repo and in `c8s-workspace` still renders.

## Testing

Validated on **helm 3.14.4** (the version `chart.yml` pins) and **3.21.3**. The two emit different wording for the same rejection (`Additional property X is not allowed` vs `additional properties 'X' not allowed`), so the test matches the shared stem.

Passing schema validation on both: the chart's own defaults, `helm lint` + both `chart-verify.sh` templates, the `c8s render-values` bundle for all four `--cvm-mode` values, `--single-node`, and the merged values of all three `c8s-fleet` clusters (base HelmRelease + `c8s-allowlist` ConfigMap + cluster overlay).

> **Unrelated, noted while validating:** those three fleet value sets no longer render against current `main` for reasons that predate this PR — `teeProxy.*` (removed component), `tlsLb.san: ""` as a string, and `tlsLb.routes[0]` failing `tlslb_unsecured_route`. They fail at *template* validation, well past the schema stage.
