### PR TITLE
uninstall: reap the volume device-mapper stack instead of leaking it

### DIFF
--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -70,6 +70,12 @@ const chartInstanceLabel = "app.kubernetes.io/instance"
 var kataPodJSONPath = `{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.spec.runtimeClassName}{"\t"}{.metadata.labels.` +
 	strings.ReplaceAll(chartInstanceLabel, ".", `\.`) + `}{"\n"}{end}`
 
+// volumePodJSONPath dumps one "namespace\tname\tphase\tvolumes" line per pod,
+// where volumes is the webhook's volume-request annotation; jsonpath needs the
+// dots in an annotation key escaped.
+var volumePodJSONPath = `{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.status.phase}{"\t"}{.metadata.annotations.` +
+	strings.ReplaceAll(webhook.AnnotationVolumes, ".", `\.`) + `}{"\n"}{end}`
+
 // kataRuntimeNodeLabel is the label kata-deploy stamps on each node once the
 // runtime is installed (and removes again in its cleanup, when that runs to
 // completion).
@@ -150,6 +156,14 @@ release's own chart-managed pods (CDS and tls-lb pin a kata RuntimeClass) do
 not count: they are matched by the release namespace plus the chart's
 app.kubernetes.io/instance label and are torn down by this uninstall.
 
+It refuses the same way while a pod holds a c8s encrypted volume: volumed is
+the only component that unmaps the dm-crypt/dm-verity stack behind one, so
+removing it under a live volume strands the mappings on the node, where they
+keep the backing disk open against the next install. Scale those workloads to
+zero first — volumed tears the volumes down — or pass --force. Whatever is
+still mapped when the release goes is reaped by the chart's volumed pre-delete
+hook, which runs on every node before the daemon is removed.
+
 Left in place by default: the ConfidentialWorkload CRD (helm never deletes
 crds/; --delete-crds removes it ALONG WITH EVERY ConfidentialWorkload object)
 and the release namespace (--delete-namespace).
@@ -204,6 +218,18 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH.`,
 			}
 			if len(pods) > 0 {
 				return kataPodsRunningError(pods, chartManaged, uninstallNamespace, uninstallRelease)
+			}
+		}
+
+		// volumed goes with the release and is the only component that unmaps
+		// a pod's volume devices, so the teardown order is load-bearing.
+		if boolAtPath(values, "volumed.enabled") && !uninstallForce {
+			pods, err := listVolumePods(ctx)
+			if err != nil {
+				return err
+			}
+			if len(pods) > 0 {
+				return volumePodsRunningError(pods)
 			}
 		}
 
@@ -471,6 +497,44 @@ func filterKataPods(lines []string, namespace, release string) ([]string, int) {
 		pods = append(pods, fmt.Sprintf("%s/%s (%s)", fields[0], fields[1], fields[2]))
 	}
 	return pods, chartManaged
+}
+
+// listVolumePods returns "namespace/name" for every pod holding a c8s volume.
+// The annotation is not a server-side field selector, so the filter runs
+// client-side over a one-line-per-pod jsonpath dump.
+func listVolumePods(ctx context.Context) ([]string, error) {
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "pods", "--all-namespaces",
+		"-o", "jsonpath="+volumePodJSONPath).Output()
+	if err != nil {
+		return nil, fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
+	}
+	return filterVolumePods(strings.Split(strings.TrimSpace(string(out)), "\n")), nil
+}
+
+// filterVolumePods keeps the "namespace\tname\tphase\tvolumes" lines of pods
+// that requested a volume and have not finished. A pod in a terminal phase has
+// no container left holding a mapping, so counting it would refuse an
+// uninstall that has nothing to lose.
+func filterVolumePods(lines []string) []string {
+	var pods []string
+	for _, l := range lines {
+		fields := strings.Split(l, "\t")
+		if len(fields) != 4 || fields[3] == "" {
+			continue
+		}
+		if fields[2] == string(corev1.PodSucceeded) || fields[2] == string(corev1.PodFailed) {
+			continue
+		}
+		pods = append(pods, fields[0]+"/"+fields[1])
+	}
+	return pods
+}
+
+// volumePodsRunningError is the volume guard's refusal: it names the pods and
+// the ordering that avoids the leak.
+func volumePodsRunningError(pods []string) error {
+	return fmt.Errorf("pods are still holding c8s encrypted volumes, and volumed is the only thing that unmaps them:\n  %s\nscale those workloads to zero first (volumed then tears the volumes down), or pass --force to uninstall anyway and leave the device-mapper stack on the node",
+		strings.Join(pods, "\n  "))
 }
 
 // kataPodsRunningError is the guard's refusal. It reports the chart-managed
@@ -754,7 +818,7 @@ func init() {
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
 	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep the kata host artifacts (/opt/kata, containerd drop-in, kata-guest-base image, RKE2 prep template, node labels) off every kata node via a short-lived privileged DaemonSet. Skipped automatically when the release was installed without --cvm-mode=pod")
 	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the kata host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry kata artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
-	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart)")
+	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (their mounts go with the pre-delete hook that reaps the node's device-mapper stack)")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteNamespace, "delete-namespace", false, "also delete the release namespace (and everything left in it, e.g. an operator-created image pull Secret)")
 	rootCmd.AddCommand(uninstallCmd)

--- a/cmd/c8s/uninstall_exec_test.go
+++ b/cmd/c8s/uninstall_exec_test.go
@@ -453,3 +453,78 @@ func TestWaitPodsGone(t *testing.T) {
 		}
 	})
 }
+
+// volumedReleaseValuesFile writes the computed-values JSON `helm get values
+// --all` returns for a release with the volume node agent deployed.
+func volumedReleaseValuesFile(t *testing.T) string {
+	t.Helper()
+	path := kataReleaseValuesFile(t, false, "/var/lib/c8s/kata-images", "")
+	tree := map[string]any{}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &tree); err != nil {
+		t.Fatal(err)
+	}
+	tree["volumed"] = map[string]any{"enabled": true}
+	if data, err = json.Marshal(tree); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Deleting volumed under a pod that holds a volume strands the dm stack on the
+// node — nothing else reaps it, and it keeps the disk open against the next
+// install. Refuse, name the pods, and say what to do.
+func TestUninstallRefusesWhileVolumePodsRun(t *testing.T) {
+	values := volumedReleaseValuesFile(t)
+	holding := `*c8s-volumes*) /usr/bin/printf 'default\tinference-0\tRunning\tweights=/tenant-a/volumes/weights\n' ;;
+`
+
+	t.Run("refuses and names the pods", func(t *testing.T) {
+		s := newUninstallStubs(t, values, holding, false)
+		err := runC8s(t, "uninstall")
+		if err == nil || !strings.Contains(err.Error(), "default/inference-0") {
+			t.Fatalf("want the volume-holding pod named, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "scale those workloads to zero") {
+			t.Errorf("refusal %q does not say what to do instead", err)
+		}
+		mustNotContainPrefix(t, s.f.calls(t), "helm uninstall")
+	})
+
+	t.Run("--force proceeds", func(t *testing.T) {
+		s := newUninstallStubs(t, values, holding, false)
+		if err := runC8s(t, "uninstall", "--force"); err != nil {
+			t.Fatalf("uninstall --force: %v", err)
+		}
+		mustContainLine(t, s.f.calls(t), "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+	})
+
+	t.Run("pod listing failure surfaces", func(t *testing.T) {
+		s := newUninstallStubs(t, values, "*c8s-volumes*) exit 1 ;;\n", false)
+		if err := runC8s(t, "uninstall"); err == nil {
+			t.Fatal("want error when the volume pod listing fails")
+		}
+		mustNotContainPrefix(t, s.f.calls(t), "helm uninstall")
+	})
+}
+
+// A release that never deployed volumed has no mappings to strand, so the
+// guard must not query for them at all.
+func TestUninstallWithoutVolumedSkipsTheVolumeGuard(t *testing.T) {
+	values := kataReleaseValuesFile(t, false, "/var/lib/c8s/kata-images", "")
+	s := newUninstallStubs(t, values, "", false)
+	if err := runC8s(t, "uninstall"); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	for _, l := range s.f.calls(t) {
+		if strings.Contains(l, "c8s-volumes") {
+			t.Errorf("volume guard queried for a release without volumed: %q", l)
+		}
+	}
+}

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -508,3 +508,22 @@ func TestValidateSweepPath(t *testing.T) {
 		})
 	}
 }
+
+// The volume guard keys on the webhook's volume-request annotation, and only
+// on pods that still have a container to hold a mapping: a Succeeded or Failed
+// pod has none, so counting it would refuse an uninstall with nothing to lose.
+func TestFilterVolumePodsKeepsOnlyLivePodsHoldingVolumes(t *testing.T) {
+	lines := []string{
+		"default\tinference-0\tRunning\tweights=/tenant-a/volumes/weights",
+		"default\tweb-0\tRunning\t", // no volume annotation
+		"team-a\tloader-1\tPending\tmodel=/tenant-b/volumes/model",
+		"team-b\timport-0\tSucceeded\tmodel=/tenant-b/volumes/model",
+		"team-c\timport-1\tFailed\tmodel=/tenant-b/volumes/model",
+		"", // trailing blank line from kubectl
+		"malformed-line-no-tabs",
+	}
+	want := []string{"default/inference-0", "team-a/loader-1"}
+	if got := filterVolumePods(lines); !reflect.DeepEqual(got, want) {
+		t.Errorf("filterVolumePods = %v, want %v", got, want)
+	}
+}

--- a/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
+++ b/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
@@ -1,0 +1,54 @@
+# volumed teardown — run as a privileged pre-delete hook on every volumed node.
+#
+# Removes the device-mapper stack volumed opened for the pods on this node:
+# unmount each c8s volume, then close the dm-verity and dm-crypt mappings
+# behind it. volumed is the only component that reaps those, so once the
+# release is gone nothing on the node can — the mappings keep the backing disk
+# open and the next install fails to reopen it ("already mapped or mounted").
+# Idempotent: a node with nothing open exits clean.
+#
+# Names come from internal/cmds/volumed/open.go (mapperName): the mappings are
+# c8s-crypt-<pod-uid>-<volume> and c8s-verity-<pod-uid>-<volume>, and the
+# verity device is the mount source.
+set -eu
+
+echo "==> volumed teardown starting"
+
+# 1. Unmount what the verity devices back. /proc/mounts names the source
+#    device, which holds even after kubelet has renamed the pod directory.
+#    Collect the targets before unmounting any: /proc/mounts is generated as
+#    it is read, so unmounting mid-scan would shift the rest of the file.
+targets=""
+while read -r source target _; do
+  case "$source" in
+  /dev/mapper/c8s-verity-*) targets="$targets $target" ;;
+  esac
+done </proc/mounts
+
+for target in $targets; do
+  if umount "$target"; then
+    echo "unmounted $target"
+  else
+    echo "WARNING: umount $target failed" >&2
+  fi
+done
+
+# 2. Close the mappings, verity before crypt: verity is stacked on the crypt
+#    device and holds it open.
+closed=0
+for dev in /dev/mapper/c8s-verity-* /dev/mapper/c8s-crypt-*; do
+  [ -e "$dev" ] || continue
+  name=${dev#/dev/mapper/}
+  close=veritysetup
+  case "$name" in
+  c8s-crypt-*) close=cryptsetup ;;
+  esac
+  if "$close" close "$name"; then
+    closed=$((closed + 1))
+    echo "closed $name"
+  else
+    echo "WARNING: $close close $name failed" >&2
+  fi
+done
+
+echo "==> volumed teardown finished: $closed mapping(s) closed"

--- a/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.volumed.enabled }}
+{{- /*
+  Pre-delete DaemonSet that reaps the device-mapper stack volumed opened on
+  each node (files/scripts/volumed-teardown.sh). Helm waits for it to be Ready
+  before deleting the release, so the reap happens while the mounts are still
+  reachable — and it runs for any chart consumer, not only `c8s uninstall`.
+
+  Same privilege shape as the volumed DaemonSet it cleans up after: unmounting
+  another pod's directory and closing a dm target needs it.
+*/}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "c8s.volumedName" . }}-teardown
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+    app.kubernetes.io/component: volumed-teardown
+  annotations:
+    helm.sh/hook: pre-delete
+    # Ahead of the nri-image-policy uninstaller (weight 0): helm runs pre-delete
+    # hooks in weight order and waits for each, and that one restarts containerd,
+    # which would kill this pod mid-sweep.
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: volumed-teardown
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: c8s-operator
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: volumed-teardown
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      automountServiceAccountToken: false
+      {{- with .Values.volumed.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- include "c8s.imagePullSecrets" (dict "root" $ "local" .Values.volumed.imagePullSecrets) | nindent 6 }}
+      nodeSelector:
+        kubernetes.io/os: linux
+        {{- with .Values.volumed.nodeSelector }}
+{{ toYaml . | indent 8 }}
+        {{- end }}
+      tolerations:
+        {{- toYaml .Values.volumed.tolerations | nindent 8 }}
+      initContainers:
+        - name: teardown
+          image: {{ include "volumed.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+            # The image is nonroot (USER 65532) and privileged grants no
+            # effective caps to a non-root process.
+            runAsUser: 0
+            runAsGroup: 0
+          # The image entrypoint is ["/app/c8s", "volumed"]; this hook runs a
+          # shell script instead, so it overrides both.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+{{ .Files.Get "files/scripts/volumed-teardown.sh" | indent 14 }}
+          volumeMounts:
+            # Bidirectional: the mounts live in the host namespace, so the
+            # unmount has to propagate back out of this pod.
+            - name: kubelet-root
+              mountPath: {{ .Values.volumed.hostPaths.kubeletRoot }}
+              mountPropagation: Bidirectional
+            - name: dev
+              mountPath: /dev
+          resources:
+            {{- toYaml .Values.volumed.resources | nindent 12 }}
+      containers:
+        - name: pause
+          image: {{ include "volumed.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/bin/sh", "-c", "sleep infinity"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 50m
+              memory: 32Mi
+      volumes:
+        - name: kubelet-root
+          hostPath:
+            path: {{ .Values.volumed.hostPaths.kubeletRoot }}
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+{{- end }}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7509,3 +7509,109 @@ func assertSchemaCovers(t *testing.T, values, node any, path string) {
 		assertSchemaCovers(t, v, child, path+"."+k)
 	}
 }
+
+// volumed is the only component that unmaps a pod's dm-crypt/dm-verity stack,
+// so deleting the release under an open volume strands the mappings: they hold
+// the backing disk and the next install cannot reopen it. The pre-delete hook
+// reaps them while the release still exists — for any chart consumer, not just
+// `c8s uninstall`.
+func TestChartVolumedTeardownHook(t *testing.T) {
+	out, err := helmTemplate(t, "--set", "volumed.enabled=true")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	ds := renderedDaemonSet(t, out, "c8s-volumed-teardown")
+
+	// pre-delete, so it runs while the mounts are still reachable; helm waits
+	// for Ready, which the pause container reaches only once the init
+	// container has swept the node.
+	if got := ds.Annotations["helm.sh/hook"]; got != "pre-delete" {
+		t.Errorf("helm.sh/hook = %q, want pre-delete", got)
+	}
+	if got := ds.Annotations["helm.sh/hook-delete-policy"]; !strings.Contains(got, "hook-succeeded") {
+		t.Errorf("helm.sh/hook-delete-policy = %q, want it to clean up after success", got)
+	}
+	// The nri-image-policy uninstaller restarts containerd, which would kill
+	// this pod mid-sweep, so this hook must sort ahead of it.
+	nriWeight := renderedDaemonSet(t, out, "c8s-nri-image-policy-uninstall").Annotations["helm.sh/hook-weight"]
+	weight, err := strconv.Atoi(ds.Annotations["helm.sh/hook-weight"])
+	if err != nil {
+		t.Fatalf("helm.sh/hook-weight is not an int: %v", err)
+	}
+	if nri, err := strconv.Atoi(nriWeight); err != nil || weight >= nri {
+		t.Errorf("teardown hook-weight = %d, want less than the nri uninstaller's %q", weight, nriWeight)
+	}
+
+	spec := ds.Spec.Template.Spec
+	c, ok := findContainer(spec.InitContainers, "teardown")
+	if !ok {
+		t.Fatalf("teardown init container missing; have %v", containerNames(spec.InitContainers))
+	}
+	// cryptsetup/veritysetup live only in volumed's own debian-slim image.
+	if !strings.Contains(c.Image, "/volumed") {
+		t.Errorf("teardown image = %q, want volumed's own image", c.Image)
+	}
+	if c.SecurityContext == nil || c.SecurityContext.Privileged == nil || !*c.SecurityContext.Privileged {
+		t.Error("teardown is not privileged; closing a dm target and unmounting need it")
+	}
+	if c.SecurityContext == nil || c.SecurityContext.RunAsUser == nil || *c.SecurityContext.RunAsUser != 0 {
+		t.Error("teardown must set runAsUser: 0; the nonroot image user has no effective capabilities")
+	}
+	// The image entrypoint is ["/app/c8s", "volumed"]; the hook runs a script.
+	if len(c.Command) == 0 || c.Command[0] != "/bin/sh" {
+		t.Errorf("teardown command = %v, want the shell (the image entrypoint is the daemon)", c.Command)
+	}
+
+	// The unmount happens in this pod's namespace and has to propagate back to
+	// the host, exactly as volumed's own mount does.
+	kubelet, ok := containerVolumeMount(c, "kubelet-root")
+	if !ok {
+		t.Fatal("no kubelet-root mount; the c8s volume mounts are not reachable")
+	}
+	if kubelet.MountPropagation == nil || *kubelet.MountPropagation != corev1.MountPropagationBidirectional {
+		t.Errorf("kubelet-root propagation = %v, want Bidirectional; the unmount would not reach the host", kubelet.MountPropagation)
+	}
+	if _, ok := containerVolumeMount(c, "dev"); !ok {
+		t.Error("missing dev mount; /dev/mapper is where the mappings live")
+	}
+
+	// The script must close both halves of the stack: verity is stacked on the
+	// crypt device, and the crypt device is what holds the disk.
+	script := strings.Join(c.Args, "\n")
+	for _, want := range []string{"c8s-verity-", "c8s-crypt-", "veritysetup", "cryptsetup", "umount"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("teardown script does not mention %q:\n%s", want, script)
+		}
+	}
+}
+
+// The hook targets the nodes volumed ran on: a node selector or toleration
+// that does not track volumed's leaves those nodes' mappings behind.
+func TestChartVolumedTeardownHookTracksVolumedPlacement(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "volumed.enabled=true",
+		"--set-string", "volumed.nodeSelector.storage=nvme",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	volumed := renderedDaemonSet(t, out, "c8s-volumed").Spec.Template.Spec
+	teardown := renderedDaemonSet(t, out, "c8s-volumed-teardown").Spec.Template.Spec
+	if !reflect.DeepEqual(volumed.NodeSelector, teardown.NodeSelector) {
+		t.Errorf("teardown nodeSelector = %v, want volumed's %v", teardown.NodeSelector, volumed.NodeSelector)
+	}
+	if !reflect.DeepEqual(volumed.Tolerations, teardown.Tolerations) {
+		t.Errorf("teardown tolerations = %v, want volumed's %v", teardown.Tolerations, volumed.Tolerations)
+	}
+}
+
+// Nothing to reap where the daemon never ran.
+func TestChartVolumedTeardownHookOffWithVolumed(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	if renderedManifestHasNamedKind(t, out, "DaemonSet", "c8s-volumed-teardown") {
+		t.Error("volumed teardown hook rendered without volumed.enabled")
+	}
+}


### PR DESCRIPTION
## The problem

Deleting a volume-consuming Deployment and then running `c8s uninstall` left, on the node:

```
c8s-crypt-815bbe1b-…-proofvol   (252:3)
c8s-verity-815bbe1b-…-proofvol  (252:4)
/dev/mapper/c8s-verity-815bbe1b-…-proofvol on /var/lib/kubelet/pods/815bbe1b-…/…/c8s-volume-proofvol  erofs ro
/sys/block/sdh/holders/ → dm-3
```

`volumed` is the only component that reaps those and the uninstall removed it, so nothing on the node could clean up. This is not cosmetic — the device stays held and the **next** install cannot reopen it:

```
ERROR volume open failed pod=1a1c237a-… name=proofvol
  error="volumed: open dm-crypt: cryptsetup open … /dev/sdh …:
  exit status 5: Cannot use device /dev/sdh which is in use (already mapped or mounted)."
```

repeating until cleared by hand (`umount` + two `dmsetup remove`).

Teardown through the supported path — scale to zero with `volumed` still running — **is** clean. The leak is specific to teardown concurrent with `volumed`'s removal.

## The fix

Both halves of the brief.

**Guard `uninstall`.** It now refuses while any pod holds a c8s volume, discovered from the `confidential.ai/c8s-volumes` annotation, with `--force` to override — the same shape as the existing kata guard (`listKataPods` / `kataPodsRunningError`). The refusal names the pods and points at the teardown that is clean. Pods in a terminal phase do not count: they have no container left holding a mapping, so counting them would refuse an uninstall with nothing to lose. The guard is skipped entirely for a release that never deployed `volumed`.

**Reap on the way out.** A `pre-delete` hook DaemonSet on `volumed`: a privileged teardown pod on every `volumed` node unmounts each mount backed by a `c8s-verity-*` device, then closes the verity and crypt mappings behind it. It runs while the release still exists, so it also covers a chart consumer who never calls `c8s uninstall`.

Two details worth a look:

- **Hook weight `-5`.** Helm runs `pre-delete` hooks in weight order and waits for each. The nri-image-policy uninstaller is weight `0` and restarts containerd, which would kill this pod mid-sweep. `TestChartVolumedTeardownHook` asserts the ordering rather than the literal number.
- **`mountPropagation: Bidirectional`** on the kubelet root — the mounts live in the host namespace, so the unmount has to propagate back out of the hook pod, exactly as `volumed`'s own mount propagates in. Device names come from `mapperName` in `internal/cmds/volumed/open.go`; the script is POSIX shell in `files/scripts/`, like the other chart scripts, and runs from volumed's own image (the only one carrying `cryptsetup`/`veritysetup`).

## Acceptance criteria

- [x] With a volume-holding pod running, `c8s uninstall` refuses and names the pod; `--force` proceeds — `TestUninstallRefusesWhileVolumePodsRun`.
- [ ] **After a forced or hook-reaped uninstall, the node has no `c8s-crypt-*` / `c8s-verity-*` devices and no `c8s-volume-*` mounts, and a subsequent install can open the same device without manual `dmsetup`.** Not verified on real hardware — see below.
- [ ] **Regression test asserting the teardown-then-uninstall ordering leaves nothing behind.** Same: needs a node with a mapped volume.

## Testing

`go build ./...`, `go test ./... -count=1`, `go vet`, `gofmt` clean; chart tests pass on helm 3.14.4 and 3.21.3.

- Guard: `TestFilterVolumePodsKeepsOnlyLivePodsHoldingVolumes`, `TestUninstallRefusesWhileVolumePodsRun` (refuse / `--force` / listing-failure), `TestUninstallWithoutVolumedSkipsTheVolumeGuard`.
- Hook shape: `TestChartVolumedTeardownHook` (hook annotations, weight ordering vs the nri uninstaller, image, privilege, propagation, and that the script names both halves of the stack), `TestChartVolumedTeardownHookTracksVolumedPlacement` (selector/tolerations track `volumed`'s, or a node's mappings are left behind), `TestChartVolumedTeardownHookOffWithVolumed`.
- Script: dry-run against a simulated `/proc/mounts` and `/dev/mapper` tree — `umount` → `veritysetup close` → `cryptsetup close`, unrelated dm devices untouched, and a clean node exits 0 with no calls.

**The on-node behaviour has not been exercised on real hardware.** The two unchecked criteria above need a node with a mapped volume; worth running the encrypted-volumes e2e against this branch before it leaves draft.
