### PR TITLE
ci(snp-metal-e2e): report why the sandbox-digests bound is empty

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -296,6 +296,18 @@ jobs:
             if [ "\$WOK" != "1" ]; then
               \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
               \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
+              # csr_denied with "the inventory callback has no node addresses"
+              # is CDS-side, and CERTLOG only shows the workload's half. With
+              # cds.sandboxInventoryCIDRs unset CDS derives the bound from the
+              # node list, and it can come back empty two ways that read
+              # identically from here: no in-cluster config, or every node
+              # address excluded for sitting inside a pod range. CDS logs a
+              # distinct line for each; without them the cause is a guess.
+              \$K -n c8s-system logs -l app.kubernetes.io/component=cds -c cds --tail=40 2>&1 \\
+                | grep -iE 'sandbox-digests|node inventory|in-cluster|pod range|bound' \\
+                | tail -10 | sed 's/^/@@CDSBOUND /;s/\$/@@/'
+              \$K get nodes -o jsonpath='{range .items[*]}{.metadata.name} internalIP={.status.addresses[?(@.type=="InternalIP")].address} podCIDR={.spec.podCIDR}{"\\n"}{end}' 2>&1 \\
+                | sed 's/^/@@NODEADDR /;s/\$/@@/'
             fi
           fi
           \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | tail -10 | sed 's/^/@@EV /;s/\$/@@/'


### PR DESCRIPTION
snp-metal is red on the workload step and the dump cannot say why.

Since #385 the lane leaves `cds.sandboxInventoryCIDRs` unset, so CDS derives the sandbox-digests bound from the node list. In this lane it derives nothing, and every sandbox-token CSR is refused:

```
csr_denied: "sandbox token presented but the inventory callback has no node addresses to bound it"
```

The workload retries for 10 minutes and the payload never reaches `PAYLOAD_OK`. Reproduced twice (runs 32232920330, 32285305392).

`CERTLOG` only captures the workload's half of that exchange. The bound can come back empty two ways that are indistinguishable from there:

- no in-cluster config, which logs `--sandbox-inventory-cidr not set and no in-cluster config`
- every node address excluded for sitting inside a pod range, which logs `node address inside the pod range excluded from the sandbox-digests bound`

CDS logs a distinct line for each and the payload captures neither, so picking between them today is a guess. This adds `@@CDSBOUND` (CDS's own bound lines) and `@@NODEADDR` (each node's InternalIP against its podCIDR, which is the input to the exclusion in `NodeHostCIDRs`) to the existing failure-only diagnostic block.

Diagnostics only. It changes nothing the lane asserts and cannot turn a red run green.

Verified by expanding the payload heredoc exactly as the step does and inspecting what reaches the guest: `$K` stays unexpanded, the jsonpath survives with `{"\n"}` intact, and the generated `payload.sh` passes `bash -n`. Plus a YAML parse on the workflow.

Note this file is vendored byte-identical into confidential-ci, so it needs re-vendoring there after this merges.
