### PR TITLE
ci(c8s-image): success-gated inline saves for the tools and gpu-staged trees

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -215,6 +215,9 @@ jobs:
             sudo chown -R "$(id -u):$(id -g)" apt-debs
             sudo apt-get install -y ./apt-debs/*.deb
           fi
+          # iasl (DSDT) and clang (bindgen) shape measured bytes; record the
+          # exact host set until these ride a snapshot mirror (confos#36).
+          { echo "### host build-dep debs"; ls apt-debs | sed 's/^/- /'; } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save build-dep debs
         # Inline: runs only when the install above succeeded.

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -182,20 +182,47 @@ jobs:
         with:
           ref: 84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
+      - name: Restore build-dep debs
+        # Keyed per runner-image release: installing a fixed deb set is only
+        # valid against the preinstalled package state it was resolved for.
+        # Warm runs never touch the apt mirror, whose degradation has taken
+        # out gate legs repeatedly.
+        id: apt-debs
+        uses: actions/cache/restore@v5
+        with:
+          path: apt-debs
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
+
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
         # base ovmf is for the SNP path.
         # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
         # Bounded: a dead mirror connection otherwise hangs until the job's
-        # 3h limit. 10 min, not 5: a degraded-but-alive mirror needs a few
-        # extra minutes of retries, and 5 min turned one degradation event
-        # into three failed legs while a sibling leg squeezed through.
+        # 3h limit.
         timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
-            systemd-container ovmf cpio acpica-tools \
-            libclang-dev clang libtss2-dev
+          set -euo pipefail
+          if compgen -G "apt-debs/*.deb" >/dev/null; then
+            sudo apt-get install -y ./apt-debs/*.deb
+          else
+            sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
+            sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
+              --download-only \
+              systemd-container ovmf cpio acpica-tools \
+              libclang-dev clang libtss2-dev
+            mkdir -p apt-debs
+            sudo cp /var/cache/apt/archives/*.deb apt-debs/
+            sudo chown -R "$(id -u):$(id -g)" apt-debs
+            sudo apt-get install -y ./apt-debs/*.deb
+          fi
+
+      - name: Save build-dep debs
+        # Inline: runs only when the install above succeeded.
+        if: steps.apt-debs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: apt-debs
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache staged GPU tree

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -187,8 +187,10 @@ jobs:
         # base ovmf is for the SNP path.
         # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
         # Bounded: a dead mirror connection otherwise hangs until the job's
-        # 3h limit.
-        timeout-minutes: 5
+        # 3h limit. 10 min, not 5: a degraded-but-alive mirror needs a few
+        # extra minutes of retries, and 5 min turned one degradation event
+        # into three failed legs while a sibling leg squeezed through.
+        timeout-minutes: 10
         run: |
           sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
           sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -217,7 +217,7 @@ jobs:
           fi
           # iasl (DSDT) and clang (bindgen) shape measured bytes; record the
           # exact host set until these ride a snapshot mirror (confos#36).
-          { echo "### host build-dep debs"; ls apt-debs | sed 's/^/- /'; } >> "$GITHUB_STEP_SUMMARY"
+          { echo "### host build-dep debs"; find apt-debs -maxdepth 1 -name '*.deb' -printf '- %f\n' | sort; } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save build-dep debs
         # Inline: runs only when the install above succeeded.

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -203,7 +203,7 @@ jobs:
         # on it; the tools tree still restores unconditionally because the
         # fallback path (stamp mismatch) needs it.
         id: gpu-staged
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             confidential-os-builder/output/gpu/staged
@@ -214,7 +214,11 @@ jobs:
         # mkosi.output (image + stamp) is what the kernel short-circuit path
         # still needs: confos-fetch-gpu compiles modules inside it. mkosi.tools
         # is only an intermediate for building it, so it isn't cached.
-        uses: actions/cache@v5
+        # restore/save split: the built-in post-job save runs even after a
+        # failed build and archives partial trees under a stable key that is
+        # then never re-saved (the #408 gate poisoning).
+        id: tools-tree
+        uses: actions/cache/restore@v5
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
           key: ${{ runner.os }}-tools-v2-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
@@ -363,6 +367,28 @@ jobs:
             confidential-os-builder/mkosi/base/mkosi.tools \
             confidential-os-builder/mkosi/base/mkosi.tools.manifest \
             confidential-os-builder/mkosi/base/mkosi.pkgcache || true
+
+      # Inline saves run only after every prior step succeeded, and only when
+      # the tree actually exists — a kernel-cache-hit build never creates it.
+      - name: Check tools tree presence
+        id: tools-built
+        run: echo "built=$([ -d confidential-os-builder/mkosi/kernel-builder/mkosi.output/image ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+      - name: Save kernel-builder tools tree
+        if: steps.tools-tree.outputs.cache-hit != 'true' && steps.tools-built.outputs.built == 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
+          key: ${{ runner.os }}-tools-v2-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
+
+      - name: Save staged GPU tree
+        if: steps.gpu-staged.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            confidential-os-builder/output/gpu/staged
+            confidential-os-builder/output/gpu/stage.stamp
+          key: ${{ runner.os }}-gpu-staged-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','c8s/node-guest-image/kernel/config-x86_64-*.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt','confidential-os-builder/bin/confos-fetch-gpu') }}
 
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -97,6 +97,8 @@ if [ -d "$GPU_MIRROR" ] && [ "$(cat "$GPU_STAMP" 2>/dev/null)" = "$GPU_FPR" ]; t
     mkdir -p mkosi/base/mkosi.local
     cp -a "$GPU_MIRROR" mkosi/base/mkosi.local/mkosi.extra
 else
+    echo "staged GPU tree unusable (mirror: $([ -d "$GPU_MIRROR" ] && echo present || echo missing);" \
+         "stamp: $(cat "$GPU_STAMP" 2>/dev/null || echo none); want: $GPU_FPR) — running confos-fetch-gpu"
     MODULE_SIG_CERT="$NGI_DIR/module-signing.crt" bin/confos-fetch-gpu
     rm -rf "$GPU_MIRROR"
     mkdir -p "$(dirname "$GPU_MIRROR")"


### PR DESCRIPTION
## Problem

`actions/cache`'s built-in post-job save runs even when the build failed. On #408's gate, attempt 1's snp leg died mid-tools-tree-build and its post-job save archived a **294-byte `mkosi.output` stub** under the stable tools-v2 key — which, per save-on-miss semantics, was then never re-saved. Later legs restored the stub; any leg whose GPU stamp check fell through then died in `confos-fetch-gpu` ("tools tree missing"). Deleting the stub turned the same gate green with no code change, confirming the mechanism. The debugging cost an extra round partly because the build script's fallthrough to `confos-fetch-gpu` is silent.

The kernel and pkgcache entries self-validate downstream (fingerprint check, apt hash verification), so partial saves there self-heal. The tools tree and gpu-staged mirror are consumed blind — they need the gating.

## Fix

- `tools-v2` and `gpu-staged` become restore + inline save: inline steps only run when every prior step succeeded, and the tools save additionally requires `mkosi.output/image` to exist (a kernel-cache-hit build never creates it).
- `node-guest-image/build` prints mirror presence, the restored stamp, and the wanted fingerprint when it falls through to `confos-fetch-gpu`.

The stub entry is already deleted. The build-script edit rotates the kernel/gpu keys once (it is hashed into them).