### PR TITLE
fix(snp-metal-e2e): pin the sandbox-digests bound on the June image

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -158,6 +158,18 @@ jobs:
           $OPPUB
             handoff:
               enabled: true
+            # HOLDING ACTION, delete with console delivery (research/guest-transport.md).
+            # c8s#385 has CDS derive this from the node list and dropped it here. That
+            # cannot work on THIS guest: it boots the June rke2 image, which predates the
+            # 08-11 node-image fix and still uses RKE2's default cluster-cidr
+            # 10.42.0.0/16 — the same range the outer cluster hands the CVM its own IP
+            # from. NodeHostCIDRs then excludes the node address for sitting inside a pod
+            # range (correctly: a bound covering the node covers every pod), the bound is
+            # empty and every sandbox-token CSR is refused. values.yaml says to pin the
+            # bound where node and pod addresses are not separable, so pin it.
+            # The real fix is an agent-bearing image, which needs the console-free
+            # transport; until then the lane cannot move off the June image.
+            sandboxInventoryCIDRs: ["NODE_CIDR"]
           attestationApi:
             image:
               tag: "$AATAG"
@@ -202,7 +214,7 @@ jobs:
           CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
 
           # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
-          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' > /tmp/gate-vals.yaml
+          printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' | sed 's|NODE_CIDR|10.0.0.1/32|' > /tmp/gate-vals.yaml
           helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
           echo "render gate: chart+values validate clean"
 
@@ -218,8 +230,11 @@ jobs:
           \$K create ns c8s-system >/dev/null 2>&1
           \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
           if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
+          NODEIP=\$(\$K get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
+          { printf '%s' "\$NODEIP" | grep -qE '^[0-9.]+\$'; } || { say FAIL_NODEIP; exit 0; }
+          say "NODE_CIDR \$NODEIP/32"
           { printf 'apiVersion: helm.cattle.io/v1\nkind: HelmChart\nmetadata:\n  name: c8s\n  namespace: kube-system\nspec:\n  chartContent: %s\n  targetNamespace: c8s-system\n  createNamespace: false\n  valuesContent: |\n' "\$CC"
-            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed 's/^/    /'
+            printf %s '$VALS' | base64 -d | sed "\$MSED" | sed "s|NODE_CIDR|\$NODEIP/32|" | sed 's/^/    /'
           } | \$K apply -f - 2>&1 | sed 's/^/@@HCAPPLY /;s/\$/@@/'
           say \$MMARK
           HOK=0

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -214,6 +214,12 @@ jobs:
           CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
 
           # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
+          # Both substitutions are throwaway stand-ins so `helm template` has
+          # something well-formed to validate — the 96 zeros for the launch
+          # measurement, 10.0.0.1/32 for the node route. Neither can come from
+          # config: the real measurement is read out of the booted guest, and the
+          # real node address is whatever KubeVirt assigns the VMI this run. The
+          # payload substitutes both again in-guest; nothing here reaches runtime.
           printf %s "$VALS" | base64 -d | sed 's/RUNTIME_MEASUREMENT/000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000/' | sed 's|NODE_CIDR|10.0.0.1/32|' > /tmp/gate-vals.yaml
           helm template c8s c8s/internal/helmchart/c8s -f /tmp/gate-vals.yaml > /dev/null
           echo "render gate: chart+values validate clean"


### PR DESCRIPTION
snp-metal has been red since #385 with every sandbox-token CSR refused:

```
csr_denied: "sandbox token presented but the inventory callback has no node addresses to bound it"
@@NODEADDR rke2-node internalIP=10.42.0.251 podCIDR=10.42.0.0/24
```

**This is a holding action, it is not a defect in #385, and it is a deliberate weakening.** The derivation is correct and is refusing a topology it cannot safely bound. The node's address sits inside its own podCIDR, so `NodeHostCIDRs` excludes it.

Be clear about what pinning costs. The bound is "what stops a workload pointing the sandbox-digests callback at its own pod IP and answering as the inventory". Where the pod IPAM pool covers the node's address, a `/32` of that address is not a node-only identity: a pod landing on it would be admitted. `values.yaml` says to set this "only when the node network is separate from the pod network", which is exactly not the case here, so this pin goes against that guidance knowingly.

What it restores is the pre-#385 posture: the lane pinned this same `/32` until #385 removed it, so the exposure is not new. It is bounded to an ephemeral single-node CI CVM with no untrusted tenants, which is why it is acceptable as a stopgap and would not be on a real cluster.

Why this guest is that topology: it boots `ghcr.io/confidential-dot-ai/rke2@sha256:79d45313`, built 2026-06-19, which predates the 08-11 node-image change and still uses RKE2's default `cluster-cidr: 10.42.0.0/16`. The outer cluster hands the CVM its own IP from that same range, so inner pods and the node collide. The current node image fixed this (`cluster-cidr: 10.52.0.0/16`) with a comment describing the hazard.

The lane cannot simply move to that image: console delivery needs a serial autologin shell, which production images correctly do not ship (it is `C8S_DEV=1` only). I tried the repin and it fails earlier, at `guest console never showed an autologin shell`. The real fix is the in-guest agent transport in confidential-ci's `research/guest-transport.md`, gated on base-images shipping an agent-bearing image. Delete this pin when that lands.

Restores three things #385 removed together: the value, the render-gate substitution, and the in-guest `NODEIP` lookup that resolves `NODE_CIDR` to the node's own `InternalIP/32`.

Verified: YAML parses, `bash -n` on the payload step, and the heredoc expanded exactly as the step does so the generated `payload.sh` was inspected directly and passes `bash -n`:

```
NODEIP=$($K get nodes -o jsonpath='{...InternalIP...}')
{ printf '%s' "$NODEIP" | grep -qE '^[0-9.]+$'; } || { say FAIL_NODEIP; exit 0; }
sed "s|NODE_CIDR|$NODEIP/32|"
```

Not verified end to end: I have not seen snp-metal green with this. It removes the provable cause of the empty bound, and the lane has not completed a run since 08-17, so there may be more behind it.

This file is vendored byte-identical into confidential-ci and needs re-vendoring there after merge.

