### PR TITLE
fix(get-kubeconfig): verify SNP attest evidence through localverify

### DIFF
--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -563,3 +563,70 @@ func TestVerifyServerCertSNPPropagatesVerifierError(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 }
+
+// The attest gate must accept bare-metal SNP evidence whose cert_chain is
+// null — the shape the guest attestation-api actually serves (c8s#415). It
+// used to go through attestation-go's offline path, which requires the VCEK
+// inline and fetches nothing, so every real SNP node failed the gate with
+// "evidence is missing cert_chain.vcek" while the RA-TLS dial arm (already on
+// localverify) would have accepted the same node.
+func TestAttestGateAcceptsSNPEvidenceWithoutInlineVCEK(t *testing.T) {
+	exp := snpTestPolicy(t, operatorPub(t))
+	params := stubSNPRATLS(t, snpResultFor(exp, 2), nil)
+
+	// Exactly what the guest serves: a raw report and cert_chain: null.
+	envelope := []byte(`{"platform":"snp","evidence":{"attestation_report":"AAAA","cert_chain":null}}`)
+	nonce := []byte("nonce-bound-to-this-request")
+
+	if _, err := verifyEvidence(envelope, nonce, exp); err != nil {
+		t.Fatalf("verifyEvidence on VCEK-less SNP evidence: %v", err)
+	}
+	// The gate must hand the collateral-fetching verifier the same two pins
+	// the dial arm passes, and the caller's nonce as the binding anchor.
+	if len(params.Measurements) != len(exp.snpPins.BySMP) {
+		t.Errorf("passed %d measurements, want %d", len(params.Measurements), len(exp.snpPins.BySMP))
+	}
+	if !bytes.Equal(params.ExpectedInitDataHash, exp.hostData[:]) {
+		t.Errorf("ExpectedInitDataHash = %x, want %x", params.ExpectedInitDataHash, exp.hostData)
+	}
+	if !bytes.Equal(params.ExpectedReportData, nonce) {
+		t.Errorf("ExpectedReportData = %q, want the caller's nonce %q", params.ExpectedReportData, nonce)
+	}
+}
+
+// The SNP gate keeps failing closed on every claim that contradicts the policy.
+func TestAttestGateSNPFailsClosed(t *testing.T) {
+	exp := snpTestPolicy(t, operatorPub(t))
+	other := snpTestPolicy(t, operatorPub(t))
+	envelope := []byte(`{"platform":"snp","evidence":{"attestation_report":"AAAA","cert_chain":null}}`)
+
+	cases := map[string]func() (*teetypes.VerificationResult, error){
+		"verifier refuses (bad evidence / KDS down)": func() (*teetypes.VerificationResult, error) {
+			return nil, fmt.Errorf("collateral unavailable")
+		},
+		"report_data not bound": func() (*teetypes.VerificationResult, error) {
+			r := snpResultFor(exp, 2)
+			r.ReportDataMatch = teetypes.Ptr(false)
+			return r, nil
+		},
+		"another operator key's HOSTDATA": func() (*teetypes.VerificationResult, error) {
+			r := snpResultFor(exp, 2)
+			r.Claims.InitData = teetypes.HexBytes(other.hostData[:])
+			return r, nil
+		},
+		"unpinned launch digest": func() (*teetypes.VerificationResult, error) {
+			r := snpResultFor(exp, 2)
+			r.Claims.LaunchDigest = strings.Repeat("ab", runtimemeasure.Size)
+			return r, nil
+		},
+	}
+	for name, mk := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, err := mk()
+			stubSNPRATLS(t, res, err)
+			if _, gotErr := verifyEvidence(envelope, []byte("nonce"), exp); gotErr == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+}

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -19,10 +19,12 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
 	"github.com/confidential-dot-ai/attestation-go/attestation/teeverify"
 
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
 
@@ -152,6 +154,16 @@ func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy)
 	}
 	if json.Unmarshal(env.Evidence, &inner) == nil && inner.Platform != "" && len(inner.Evidence) > 0 {
 		return nil, fmt.Errorf("evidence envelope is double-wrapped ({platform,evidence} inside evidence); the envelope must wrap the platform evidence object exactly once")
+	}
+
+	// Bare-metal SNP evidence is a raw report with NO inline VCEK — the guest
+	// attestation-api serves cert_chain: null and offers no endpoint to fetch
+	// one — so attestation-go's offline path cannot verify it. localverify
+	// handles that shape and fetches the VCEK from AMD KDS, and is already
+	// what the RA-TLS dial arm uses; routing the gate through it too keeps
+	// the two halves of one policy able to consume the same evidence (c8s#415).
+	if exp.platform == teetypes.PlatformSNP {
+		return verifySNPEvidence(env, expectedReportData, exp)
 	}
 
 	res, err := verifyEnvelope(envelopeJSON, teetypes.VerifyParams{
@@ -301,4 +313,44 @@ func postAttest(ctx context.Context, attestURL string, nonce []byte) ([]byte, er
 		return nil, fmt.Errorf("attest HTTP %d: %s", resp.StatusCode, respBody)
 	}
 	return respBody, nil
+}
+
+// snpAttestTimeout bounds the gate's verification, whose collateral fetch
+// (VCEK from AMD KDS) crosses the network.
+const snpAttestTimeout = 30 * time.Second
+
+// verifySNPEvidence is verifyEvidence's SNP arm. It verifies a bare-metal SNP
+// envelope through localverify — which accepts the raw-report shape and pulls
+// the VCEK from AMD KDS, rather than requiring the guest to have volunteered
+// it inline — then enforces the same measured identity the RA-TLS dial does.
+//
+// The engine already enforces both pins (Measurements, ExpectedInitDataHash);
+// checkSNPMeasuredIdentity re-checks them over the returned claims so a
+// success the claims contradict is never accepted.
+func verifySNPEvidence(env teetypes.AttestationEvidence, expectedReportData []byte, exp measuredPolicy) (*teetypes.VerificationResult, error) {
+	measurements := make([][]byte, 0, len(exp.snpPins.BySMP))
+	for _, d := range exp.snpPins.Digests() {
+		measurements = append(measurements, append([]byte(nil), d[:]...))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), snpAttestTimeout)
+	defer cancel()
+	res, err := verifySNPRATLS(ctx, string(env.Platform), env.Evidence, localverify.Params{
+		ExpectedReportData:   expectedReportData,
+		Measurements:         measurements,
+		ExpectedInitDataHash: exp.hostData[:],
+	})
+	if err != nil {
+		return nil, fmt.Errorf("verify evidence: %w", err)
+	}
+	if !res.SignatureValid {
+		return nil, fmt.Errorf("quote signature invalid")
+	}
+	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
+		return nil, fmt.Errorf("report_data does not match the expected binding (stale/replayed quote)")
+	}
+	if err := checkSNPMeasuredIdentity(res, exp); err != nil {
+		return nil, err
+	}
+	return res, nil
 }


### PR DESCRIPTION
## Problem

The trust gate enforces one policy at two points — the attest gate and the RA-TLS dial — but only the dial arm could consume bare-metal SNP evidence. First live SNP `get-kubeconfig` run failed:

```
attestation gate: verify evidence: snp: evidence is missing cert_chain.vcek
                  (offline verification requires the VCEK)
```

## Root cause

Bare-metal SNP evidence is a raw report with no inline VCEK. The guest attestation-api serves exactly that:

```
evidence keys: ['attestation_report', 'cert_chain']
  cert_chain:  null
```

and exposes no endpoint to fetch the collateral (`/vcek`, `/certs`, `/cert_chain`, `/ca` → 404). The attest gate verified through attestation-go's offline path, which requires the VCEK inline and fetches nothing, so every real SNP node failed there — after passing the identical policy on the dial arm, which #394 had already routed through `internal/localverify`.

## Fix

Route the SNP attest gate through `localverify` too. It accepts the raw-report shape and pulls the VCEK from AMD KDS (reachable from the operator host: `kdsintf.amd.com` → 200). Same two pins (per-SMP launch digests, HOSTDATA operator binding), same claims re-check via `checkSNPMeasuredIdentity`, same fail-closed edges. The two halves of the policy can now consume the same evidence.

## Verified on hardware

SNP node-CVM (image `551bdbd`) launched with `--operator-key`, both nodes' HOSTDATA == `sha256(opkey.pub)`:

```
BEFORE: attestation gate: verify evidence: snp: evidence is missing cert_chain.vcek
AFTER:  wrote /tmp/kc-new (context "c8s") — attested: image tuple + operator-key chain verified
```

Tests pin the exact envelope shape the guest serves (`cert_chain: null`) and that the gate passes the caller's nonce plus both pins to the collateral-fetching verifier, alongside the fail-closed set (verifier refusal, unbound report_data, another key's HOSTDATA, unpinned launch digest).

Closes #415.