### PR TITLE
ci(cvm-e2e): allow booting a CVM at a non-default vCPU count

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -54,7 +54,11 @@ on:
         type: string
         default: ''
       memory_override:
-        description: 'override the per-platform guest RAM (e.g. 48Gi for a standing multi-runner CVM). vCPU is NOT overridable — it is baked into the measured IGVM (smp4). RAM is not in the launch measurement, so this keeps the same golden digest. Empty = per-platform default.'
+        description: 'override the per-platform guest RAM (e.g. 48Gi for a standing multi-runner CVM). RAM is not in the launch measurement, so this keeps the same golden digest. Empty = per-platform default.'
+        type: string
+        default: ''
+      cores_override:
+        description: 'boot at a non-default vCPU count. The SNP launch measurement covers initial vCPU state, so this selects a DIFFERENT measured IGVM (guest-smp{cores}.igvm) and a different launch digest — only cells publishing igvmFilePattern can serve it, and the golden drift check is skipped because the cell golden pins the default. For confirming a published per-SMP digest against hardware. Empty = per-platform default.'
         type: string
         default: ''
     secrets:
@@ -92,12 +96,22 @@ jobs:
                                  echo "NODE_LABEL=confidential.ai/sev-snp"; echo "GUEST_MARKER=sev-snp-guest" ;;
             *) echo "::error::cell '${{ inputs.platform }}/${{ inputs.flavor }}' not wired here (tdx-metal has its own lane: tdx-metal-e2e.yml; gke-* are stubs)" >&2; exit 1 ;;
           esac >> "$GITHUB_ENV"
-          # RAM override (standing multi-runner CVM). Overrides ONLY memory —
-          # CORES stays the measured smp4, or attestation breaks. Not in the
-          # launch digest, so the golden is unchanged.
+          # RAM override (standing multi-runner CVM). Not in the launch digest,
+          # so the golden is unchanged.
           if [ -n '${{ inputs.memory_override }}' ]; then
             echo "MEMORY=${{ inputs.memory_override }}" >> "$GITHUB_ENV"
-            echo "guest RAM overridden to ${{ inputs.memory_override }} (cores unchanged: measured smp4)"
+            echo "guest RAM overridden to ${{ inputs.memory_override }}"
+          fi
+          # vCPU override. Unlike RAM this DOES change the launch measurement:
+          # the count selects a different measured IGVM, so the cell golden no
+          # longer applies and the drift check is skipped for this run.
+          if [ -n '${{ inputs.cores_override }}' ]; then
+            case '${{ inputs.cores_override }}' in
+              ''|*[!0-9]*) echo "::error::cores_override '${{ inputs.cores_override }}' is not a positive integer"; exit 1 ;;
+            esac
+            echo "CORES=${{ inputs.cores_override }}" >> "$GITHUB_ENV"
+            echo "CORES_OVERRIDDEN=1" >> "$GITHUB_ENV"
+            echo "guest vCPU overridden to ${{ inputs.cores_override }} — a different measured IGVM and launch digest than this cell's default"
           fi
 
       - name: tools (kubectl + virtctl pinned to host KubeVirt + expect)
@@ -119,6 +133,12 @@ jobs:
             # rke2-image-refs pins one file (igvmFile); base-image-refs publishes a
             # per-core-count pattern (igvmFilePattern: guest-smp{cores}.igvm)
             IGVMFILE=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFile}')
+            if [ -n "$IGVMFILE" ] && [ -n "${CORES_OVERRIDDEN:-}" ]; then
+              # A pinned igvmFile is one measured vCPU count. Booting it on a
+              # different one leaves the guest attesting the pinned image's
+              # digest against a VM it does not describe.
+              echo "::error::cores_override needs a cell publishing igvmFilePattern; $REFS_CM pins igvmFile=$IGVMFILE (one measured vCPU count)"; exit 1
+            fi
             if [ -z "$IGVMFILE" ]; then
               PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
               [ -n "$PAT" ] || { echo "::error::$REFS_CM has neither igvmFile nor igvmFilePattern"; exit 1; }
@@ -395,7 +415,12 @@ jobs:
           #   kubectl -n confai-images patch cm <refs-cm> --type merge \
           #     -p '{"data":{"runtimeLaunchDigest":"<measurement from a green run>"}}'
           GOLD=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.runtimeLaunchDigest}' 2>/dev/null)
-          if [ -n "$GOLD" ] && [ -n "$M" ] && [ "${GOLD,,}" != "${M,,}" ]; then
+          if [ -n "${CORES_OVERRIDDEN:-}" ]; then
+            # The golden pins the cell's default vCPU count, so it cannot match
+            # a deliberate override. Print the measurement instead: that is the
+            # value a per-SMP digest is confirmed against.
+            echo "::notice title=launch measurement (smp$CORES)::$M — cores_override in effect, golden drift check skipped (the golden pins this cell's default vCPU count)"
+          elif [ -n "$GOLD" ] && [ -n "$M" ] && [ "${GOLD,,}" != "${M,,}" ]; then
             echo "::warning title=launch measurement drift::runtime $M != $REFS_CM.runtimeLaunchDigest $GOLD — image bumped without refreshing the golden, or unexpected boot-config change"
           fi
           if [ -z "$ok" ]; then


### PR DESCRIPTION
## Problem

SNP nodes are meant to run at any of the vCPU counts the image ships, and the
published image ships four measured IGVMs: `guest-smp{2,4,8,16}.igvm`. An SNP
launch measurement covers initial vCPU state, so each count has its own launch
digest, and the manifest publishes one per variant.

`cvm-e2e.yml` pins the vCPU count per cell (`CORES=4`), so **CI only ever boots
one of the four.** The other three are accepted by the trust gate
(`checkSNPMeasuredIdentity` takes any member of the pinned set) without ever
having been booted or measured here.

| smp | digest | booted in CI | confirmed vs hardware |
|---|---|---|---|
| 2 | `e9dd4de2…` | no | yes (#394, build 9ce1642) |
| 4 | `a0185a3b…` | yes | yes (#394, build 9ce1642) |
| 8 | `5312c29a…` | no | no |
| 16 | `c27a3115…` | no | no |

If a published digest is wrong for one of the unbooted counts, the failure lands
on a real node: it boots normally, then `get-kubeconfig` refuses it with a
launch-digest mismatch that reads like an attestation failure rather than a bad
pin. `cvm-e2e.yml:391-394` already warns that this class of value "has been
wrong twice", and nothing in the repo can currently confirm or refute it for
smp2, smp8 or smp16.

## Fix

`cores_override` boots a cell at a different vCPU count, selecting the matching
measured IGVM via the existing `igvmFilePattern`, and prints the resulting
measurement as a notice — the value a published per-SMP digest is confirmed
against.

Two guards, because this input changes a measured property:

- Refused on a cell that pins a single `igvmFile` (`rke2-node`): booting one
  measured image on a vCPU count it does not describe would leave the guest
  attesting a digest for a VM it isn't.
- The golden drift check is skipped for the run, since the cell golden pins the
  default count and would warn about drift that was deliberately requested.

Default is empty, so every existing lane keeps `CORES=4` and its current golden
behaviour. `base-cpu` is the cell that can serve it today.

## Testing

Cannot be exercised from CI here — it needs SNP metal, and the run that matters
is a dispatch someone with hardware makes. What I did verify:

- Simulated the override logic across every branch: default unchanged
  (`guest-smp4.igvm`, drift check on), override 8/16 resolving
  `guest-smp8.igvm`/`guest-smp16.igvm` with the drift check skipped, override
  refused on a pinned-`igvmFile` cell, and a non-integer rejected.
- `actionlint` v1.7.12 (the version CI pins): finding count identical to
  `main`, so no new lint.

## Next

Dispatch `base-cpu` at smp 2, 8 and 16 and compare each printed measurement
against the digest above. If they match, the "wrong twice" note is stale and
should be deleted rather than left contradicting the shipped gate. If any
diverges, the manifest is publishing a digest a legitimate node cannot produce,
and that variant is a node that boots and then cannot get credentials.
