### PR TITLE
fix(node-guest-image): give each node-CVM its own node name via joindata

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/rke2-role.sh
@@ -11,6 +11,7 @@
 # joindata contract (v0), all files a single <=256-byte ASCII line (edge
 # whitespace tolerated and trimmed; interior whitespace rejected):
 #   role              server|agent            (both roles)
+#   node-name         RFC1123 label, optional (both roles; absent = /etc/hostname)
 #   node-ip           IPv4, optional          (both roles; absent or 0.0.0.0 = autodetect)
 #   node-external-ip  routable IPv4, optional (both roles)
 #   server            IPv4, no scheme/port    (agent only; forbidden on server)
@@ -60,6 +61,13 @@ is_ipv4() {
     for o in $ip; do (( o <= 255 )) || return 1; done
 }
 
+# The image bakes one hostname, so every node-CVM would register under the
+# same node name and a second node's registration would collide with the
+# first. RFC1123 label: what kubelet accepts as a node name, lowercased
+# alphanumerics and dashes, no leading/trailing dash. 63 bytes is the label
+# limit; read_field has already bounded the line at 256.
+is_node_name() { [[ "$1" =~ ^[a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?$ ]]; }
+
 # allow_only NAME... — reject any disk entry outside this role's list.
 allow_only() {
     local f name a allowed
@@ -90,7 +98,15 @@ write_atomic() {
 
 # Common address fields, validated the same way for both roles.
 stage_addresses() {
-    local node_ip node_ext
+    local node_ip node_ext node_name
+    # node-name is optional: absent keeps the image's baked hostname, which
+    # is correct for single-node. A multinode pair MUST set it per CVM.
+    NODE_NAME=""
+    if [[ -e "$MNT/node-name" || -L "$MNT/node-name" ]]; then
+        node_name=$(read_field node-name)
+        is_node_name "$node_name" || fail "node-name: not an RFC1123 label"
+        NODE_NAME="$node_name"
+    fi
     # node-ip is optional: absent, like the kubelet sentinel 0.0.0.0, means
     # rke2 resolves the address itself (Kubernetes ChooseHostInterface).
     # Passing a literal 0.0.0.0 through registers InternalIP 0.0.0.0 and
@@ -120,6 +136,9 @@ stage_addresses() {
 # Infallible: runs inside the fragment pipe, where a failure would stage a
 # truncated fragment. Everything fallible (stage_addresses) runs before it.
 emit_node_addr_lines() {
+    if [[ -n "$NODE_NAME" ]]; then
+        printf 'node-name: %s\n' "$NODE_NAME"
+    fi
     if [[ -n "$NODE_IP" ]]; then
         printf 'node-ip: %s\n' "$NODE_IP"
     fi
@@ -133,7 +152,7 @@ emit_node_addr_lines() {
 
 set_server_role() {
     local server_token agent_token
-    allow_only role node-ip node-external-ip server-token agent-token
+    allow_only role node-name node-ip node-external-ip server-token agent-token
     server_token=$(read_field server-token)
     agent_token=$(read_field agent-token)
     is_hex_token "$server_token" || fail "server-token: not 64 lowercase hex"
@@ -154,7 +173,7 @@ set_server_role() {
 
 set_agent_role() {
     local server_addr agent_token
-    allow_only role node-ip node-external-ip server agent-token
+    allow_only role node-name node-ip node-external-ip server agent-token
     server_addr=$(read_field server)
     agent_token=$(read_field agent-token)
     is_ipv4 "$server_addr" || fail "server: not IPv4"

--- a/node-guest-image/tests/rke2-role-test.sh
+++ b/node-guest-image/tests/rke2-role-test.sh
@@ -157,6 +157,34 @@ ok "fragment exact (node-ip omitted)" \
 server: https://192.168.7.10:$JOIN_PORT"
 ok "role-agent verdict" test -f "$RUN/role-agent"
 
+# node-name is what lets a multinode pair exist at all: the image bakes one
+# hostname, so without it every node-CVM registers under the same node name
+# and the second registration collides with the first (#418). Optional —
+# absent keeps the baked hostname, which is what single-node wants.
+CASE="server-disk+node-name"
+reset_state; server_dir "$WORK/d"; write_f "$WORK/d" node-name mn-server
+make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment carries node-name" grep -qx 'node-name: mn-server' "$FRAG"
+
+# Both roles share stage_addresses, so the agent must get it too — and the
+# pair must be able to pick DIFFERENT names, which is the whole point.
+CASE="agent-disk+node-name"
+reset_state; agent_dir "$WORK/d"; write_f "$WORK/d" node-name mn-agent
+make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment exact (node-name first)" \
+   test "$(cat "$FRAG")" = "token-file: $RUN/rke2-agent-token
+server: https://192.168.7.10:$JOIN_PORT
+node-name: mn-agent
+node-ip: 192.168.7.11"
+
+# Absent node-name keeps the baked hostname: single-node must not regress.
+CASE="server-disk+absent-node-name"
+reset_state; server_dir "$WORK/d"; make_iso "$WORK/d"; run_script
+ok "exit 0" test "$RC" -eq 0
+ok "fragment omits node-name" bash -c '! grep -q "^node-name:" "'"$FRAG"'"'
+
 # No autodetect for external addresses: the sentinel there is a config
 # error and must reject, not pass through as ExternalIP 0.0.0.0.
 CASE="server-disk+zero-external-ip"
@@ -219,6 +247,13 @@ m_equal_tokens()      { server_dir "$1"; write_f "$1" server-token "$ATOK"; }
 m_tok_63()            { server_dir "$1"; write_f "$1" server-token "${STOK:0:63}"; }
 m_tok_upper()         { server_dir "$1"; write_f "$1" server-token "$(tr a A <<<"$STOK" | tr -d '\n')"; }
 m_tok_nonhex()        { agent_dir "$1";  write_f "$1" agent-token "${ATOK:0:63}g"; }
+m_name_upper()        { server_dir "$1"; write_f "$1" node-name Upper; }
+m_name_underscore()   { server_dir "$1"; write_f "$1" node-name under_score; }
+m_name_dotted()       { server_dir "$1"; write_f "$1" node-name a.b; }
+m_name_lead_dash()    { server_dir "$1"; write_f "$1" node-name -lead; }
+m_name_trail_dash()   { server_dir "$1"; write_f "$1" node-name trail-; }
+m_name_empty()        { server_dir "$1"; write_f "$1" node-name ""; }
+m_name_too_long()     { server_dir "$1"; write_f "$1" node-name "$(printf 'a%.0s' $(seq 64))"; }
 m_ip_range()          { server_dir "$1"; write_f "$1" node-ip 999.1.1.1; }
 m_ip_short()          { server_dir "$1"; write_f "$1" node-ip 1.2.3; }
 m_ip_leading_zero()   { server_dir "$1"; write_f "$1" node-ip 010.2.3.4; }
@@ -245,7 +280,9 @@ for c in wrong_role role_missing forbid_server forbid_stok extra_file_server \
          ip_short ip_leading_zero ip_octet_08 srv_scheme srv_port interior_ws \
          multiline oversize_file oversize_line nul_byte symlink \
          dangling_ext_ip dangling_node_ip nonregular_dir empty_ext_ip \
-         agent_no_server server_no_atok; do
+         agent_no_server server_no_atok \
+         name_upper name_underscore name_dotted name_lead_dash \
+         name_trail_dash name_empty name_too_long; do
     reject_case "reject-$c" "m_$c"
 done
 


### PR DESCRIPTION
## Problem

Multinode node-CVMs broke: a freshly launched pair leaves the server `Ready` alone and the agent never registers.

```
NAME       STATUS   ROLES
c8s-node   Ready    control-plane,etcd     <-- only one node
```

On the agent CVM kubelet:10250 is closed — `rke2-agent` never started — while everything the host controls is correct: joindata complete (`role=agent`, `server=<ClusterIP>`, `node-ip=0.0.0.0`, agent-token byte-identical to the server's), the server's supervisor port reachable, no pending CSRs.

## Root cause

The image bakes `/etc/hostname` = `c8s-node`, and #386 **disabled cloud-init** — correctly: it closed a real hole where a host-supplied kernel cmdline could run `runcmd` as root inside an attested node CVM. But userdata `hostname:` was how a launcher gave each CVM a distinct identity, and nothing replaced it.

So every node-CVM boots as `c8s-node`. RKE2 derives the node name from the hostname, both CVMs claim the same identity, and the agent's registration collides with the already-registered server. Single-node is unaffected (one CVM, one name), which is why CI stayed green.

## Fix

Add an optional `node-name` to the joindata contract — the measured, contract-checked channel that already carries `role`/`server`/`node-ip`/tokens, with no cloud-init involved:

```
node-name   RFC1123 label, optional (both roles; absent = /etc/hostname)
```

`rke2-role.sh` validates it as an RFC1123 label (what kubelet accepts as a node name) and emits `node-name:` into the role fragment beside `node-ip`, following the same absent/optional shape as #337/#338. Absent keeps the baked hostname — single-node behaviour is unchanged.

## Tests

Three positive cases (server emits it, agent emits it with the exact fragment asserted, absent omits it) and seven reject cases (uppercase, underscore, dotted, leading/trailing dash, empty, >63 bytes) wired into the existing reject loop.

**Verified the tests detect the bug rather than passing vacuously:** with the emit line removed the suite goes from **385 pass / 0 fail** to **267 pass / 62 fail**.

Refs #418. Launcher side (`confai --join-node-name`, defaulting to the VM name) is a companion PR in confidential-metal.