### PR TITLE
fix(net): bound the attestation, allowlist and crane clients

### DIFF
--- a/internal/crane/crane.go
+++ b/internal/crane/crane.go
@@ -11,7 +11,13 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
+
+// commandTimeout bounds one crane invocation. A registry that accepts the
+// connection and then stalls must not park a CI gate for the run's lifetime.
+// Overridden in tests.
+var commandTimeout = 60 * time.Second
 
 // Available reports whether the crane CLI is on PATH. Callers that can
 // degrade (warn and continue) branch on this; callers that cannot use
@@ -34,9 +40,9 @@ func Require() error {
 // Digest resolves an image reference to its registry digest via
 // `crane digest <ref>`. The returned value is a bare "sha256:<hex>".
 func Digest(ctx context.Context, ref string) (string, error) {
-	out, err := exec.CommandContext(ctx, "crane", "digest", ref).Output()
+	out, err := run(ctx, "digest", ref)
 	if err != nil {
-		return "", craneError("digest", ref, err)
+		return "", err
 	}
 	digest := strings.TrimSpace(string(out))
 	if !strings.HasPrefix(digest, "sha256:") {
@@ -48,9 +54,9 @@ func Digest(ctx context.Context, ref string) (string, error) {
 // Config returns the parsed OCI image config for a reference via
 // `crane config <ref>`, exposing the image's baked Entrypoint and Cmd.
 func Config(ctx context.Context, ref string) (*ImageConfig, error) {
-	out, err := exec.CommandContext(ctx, "crane", "config", ref).Output()
+	out, err := run(ctx, "config", ref)
 	if err != nil {
-		return nil, craneError("config", ref, err)
+		return nil, err
 	}
 	var cfg ImageConfig
 	if err := json.Unmarshal(out, &cfg); err != nil {
@@ -62,10 +68,30 @@ func Config(ctx context.Context, ref string) (*ImageConfig, error) {
 // ManifestExists reports whether a specific digest is resolvable in its
 // repository via `crane manifest <repo>@<digest>`.
 func ManifestExists(ctx context.Context, ref string) error {
-	if err := exec.CommandContext(ctx, "crane", "manifest", ref).Run(); err != nil {
-		return craneError("manifest", ref, err)
+	_, err := run(ctx, "manifest", ref)
+	return err
+}
+
+// run executes `crane <sub> <ref>` under commandTimeout, or under the caller's
+// deadline when that is sooner, and returns its stdout.
+func run(ctx context.Context, sub, ref string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, commandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "crane", sub, ref)
+	// The kill signals crane itself; a child still holding stdout would
+	// otherwise keep Wait — and the deadline — open indefinitely.
+	cmd.WaitDelay = 5 * time.Second
+
+	out, err := cmd.Output()
+	if err != nil {
+		// The kill leaves an opaque "signal: killed"; name the deadline instead.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("crane %s %q: %w", sub, ref, ctxErr)
+		}
+		return nil, craneError(sub, ref, err)
 	}
-	return nil
+	return out, nil
 }
 
 // ImageConfig is the subset of an OCI image config the callers read.

--- a/internal/crane/crane_test.go
+++ b/internal/crane/crane_test.go
@@ -3,8 +3,11 @@ package crane
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/crane/cranetest"
 )
@@ -71,5 +74,60 @@ func TestIsNotFound(t *testing.T) {
 				t.Fatalf("IsNotFound(%v) = %t, want %t", tt.err, got, tt.want)
 			}
 		})
+	}
+}
+
+// installHangingCrane puts a crane stub on PATH that accepts the invocation
+// and never answers — a registry that holds the connection open.
+func installHangingCrane(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	// exec replaces the shell, so the deadline's kill has a single process to
+	// signal and no child is left holding stdout.
+	if err := os.WriteFile(filepath.Join(dir, "crane"), []byte("#!/bin/sh\nexec sleep 60\n"), 0o755); err != nil {
+		t.Fatalf("write crane stub: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestBoundsAHungRegistry pins the package's own deadline: `c8s allowlist lint
+// --online` reaches crane with a context that carries none, so without this a
+// stalled registry blocks the gate for the whole run.
+func TestBoundsAHungRegistry(t *testing.T) {
+	installHangingCrane(t)
+	restore := commandTimeout
+	commandTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { commandTimeout = restore })
+
+	done := make(chan error, 1)
+	go func() { done <- ManifestExists(context.Background(), "registry.example.com/app@"+cranetest.DigA) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("ManifestExists error = %v, want context.DeadlineExceeded", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("ManifestExists did not return within its timeout")
+	}
+}
+
+// TestReturnsOnContextCancel pins that the caller's cancellation still wins
+// when it fires before commandTimeout.
+func TestReturnsOnContextCancel(t *testing.T) {
+	installHangingCrane(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { _, err := Digest(ctx, "registry.example.com/app:v1"); done <- err }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Digest error = %v, want context.Canceled", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Digest did not return after context cancel")
 	}
 }

--- a/pkg/allowlistclient/client.go
+++ b/pkg/allowlistclient/client.go
@@ -16,10 +16,14 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
+
+// requestTimeout bounds one CDS call; the peer decides whether it ever answers.
+const requestTimeout = 30 * time.Second
 
 // Client is an HTTP client for the CDS allowlist API.
 type Client struct {
@@ -29,7 +33,7 @@ type Client struct {
 
 // NewClient creates a new allowlist client.
 func NewClient(baseURL string) Client {
-	return Client{baseURL: strings.TrimRight(baseURL, "/"), httpClient: http.DefaultClient}
+	return Client{baseURL: strings.TrimRight(baseURL, "/"), httpClient: &http.Client{Timeout: requestTimeout}}
 }
 
 // NewClientWithHTTP creates a new allowlist client with a custom HTTP client.

--- a/pkg/allowlistclient/contract_test.go
+++ b/pkg/allowlistclient/contract_test.go
@@ -1,0 +1,129 @@
+package allowlistclient
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// hangingServer accepts the connection and never answers.
+func hangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	// Cleanup is LIFO: release the handler before Close waits on it.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return srv
+}
+
+// TestNewClientBoundsRequests pins the overall deadline. This client is the
+// shared transport for both enforcers and the CLI; http.DefaultClient has no
+// timeout, so an unanswered fetch would park the caller indefinitely.
+func TestNewClientBoundsRequests(t *testing.T) {
+	if got := NewClient("https://cds.example.com").httpClient.Timeout; got != requestTimeout {
+		t.Errorf("Timeout = %v, want %v", got, requestTimeout)
+	}
+}
+
+func TestListReturnsWithinItsTimeout(t *testing.T) {
+	srv := hangingServer(t)
+	c := NewClientWithHTTP(srv.URL, &http.Client{Timeout: 100 * time.Millisecond})
+
+	done := make(chan error, 1)
+	go func() { _, _, err := c.List(context.Background()); done <- err }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("List returned no error against a server that never answers")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("List did not return within its timeout")
+	}
+}
+
+func TestListReturnsOnContextCancel(t *testing.T) {
+	srv := hangingServer(t)
+	c := NewClient(srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { _, _, err := c.List(ctx); done <- err }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("List error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("List did not return after context cancel")
+	}
+}
+
+// TestListNonOKYieldsStatusError pins the typed error callers branch on, and
+// that it carries the code and the server's message.
+func TestListNonOKYieldsStatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		io.WriteString(w, "cds is not ready\n")
+	}))
+	defer srv.Close()
+
+	_, _, err := NewClient(srv.URL).List(context.Background())
+	var se *StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("List error = %v (%T), want *StatusError", err, err)
+	}
+	if se.Status != http.StatusServiceUnavailable {
+		t.Errorf("Status = %d, want %d", se.Status, http.StatusServiceUnavailable)
+	}
+	if se.Body != "cds is not ready" {
+		t.Errorf("Body = %q, want %q", se.Body, "cds is not ready")
+	}
+}
+
+// TestListRejectsNonJSONContentType keeps a captive portal or an HTML error
+// page from being parsed as an allowlist.
+func TestListRejectsNonJSONContentType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		io.WriteString(w, `{"schema":"c8s.allowlist/v1","digests":{}}`)
+	}))
+	defer srv.Close()
+
+	if _, _, err := NewClient(srv.URL).List(context.Background()); err == nil ||
+		!strings.Contains(err.Error(), "unexpected content type") {
+		t.Fatalf("List error = %v, want an unexpected-content-type refusal", err)
+	}
+}
+
+// TestListEnforcesTheResponseCap: a compromised or buggy CDS must not be able
+// to OOM the enforcer process by answering with an unbounded body.
+func TestListEnforcesTheResponseCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		chunk := strings.Repeat("a", 64*1024)
+		for written := int64(0); written <= maxAllowlistResponseBytes; written += int64(len(chunk)) {
+			if _, err := io.WriteString(w, chunk); err != nil {
+				return
+			}
+		}
+	}))
+	defer srv.Close()
+
+	if _, _, err := NewClient(srv.URL).List(context.Background()); !errors.Is(err, errAllowlistResponseTooLarge) {
+		t.Fatalf("List error = %v, want %v", err, errAllowlistResponseTooLarge)
+	}
+}

--- a/pkg/attestationclient/client.go
+++ b/pkg/attestationclient/client.go
@@ -21,6 +21,10 @@ import (
 // APIError/UnexpectedError.
 const maxErrorBodyBytes = 8 << 10
 
+// requestTimeout bounds one attestation-api call; the peer decides whether it
+// ever answers.
+const requestTimeout = 60 * time.Second
+
 // Client is an HTTP client for the external attestation-api.
 type Client struct {
 	baseURL    string
@@ -40,12 +44,12 @@ func NewClient(baseURL string) Client {
 	if socket, ok := strings.CutPrefix(baseURL, "unix://"); ok {
 		return Client{
 			baseURL:    "http://unix",
-			httpClient: &http.Client{Transport: unixSocketTransport(socket)},
+			httpClient: &http.Client{Transport: unixSocketTransport(socket), Timeout: requestTimeout},
 		}
 	}
 	return Client{
 		baseURL:    strings.TrimRight(baseURL, "/"),
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{Timeout: requestTimeout},
 	}
 }
 

--- a/pkg/attestationclient/timeout_test.go
+++ b/pkg/attestationclient/timeout_test.go
@@ -1,0 +1,78 @@
+package attestationclient
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// hangingServer accepts the connection and never answers, which is what a
+// hostile host running the attestation-api can always do.
+func hangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-release:
+		case <-r.Context().Done():
+		}
+	}))
+	// Cleanup is LIFO: release the handler before Close waits on it.
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { close(release) })
+	return srv
+}
+
+// TestNewClientBoundsRequests pins the overall deadline on both constructions.
+// http.DefaultClient has none, so without this a peer that never answers pins
+// the calling goroutine for the process's life.
+func TestNewClientBoundsRequests(t *testing.T) {
+	if got := NewClient("https://attestation-api.example.com").httpClient.Timeout; got != requestTimeout {
+		t.Errorf("routable client Timeout = %v, want %v", got, requestTimeout)
+	}
+	if got := NewClient("unix:///run/c8s/attest.sock").httpClient.Timeout; got != requestTimeout {
+		t.Errorf("socket client Timeout = %v, want %v", got, requestTimeout)
+	}
+}
+
+// TestHealthReturnsWithinItsTimeout proves the client's deadline reaches the
+// request rather than only the dial: the server accepts and stalls.
+func TestHealthReturnsWithinItsTimeout(t *testing.T) {
+	srv := hangingServer(t)
+	c := NewClientWithHTTP(srv.URL, &http.Client{Timeout: 100 * time.Millisecond})
+
+	done := make(chan error, 1)
+	go func() { _, err := c.Health(context.Background()); done <- err }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Health returned no error against a server that never answers")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Health did not return within its timeout")
+	}
+}
+
+// TestHealthReturnsOnContextCancel pins cancellation propagation.
+func TestHealthReturnsOnContextCancel(t *testing.T) {
+	srv := hangingServer(t)
+	c := NewClient(srv.URL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { _, err := c.Health(ctx); done <- err }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Health error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Health did not return after context cancel")
+	}
+}


### PR DESCRIPTION
## The problem

`docs/engineering-standards.md` §8 makes an explicit overall deadline a MUST on
every network call. Three clients had none.

- **`pkg/attestationclient`** — `NewClient` returned `http.DefaultClient`, which
  has no `Timeout`. Six production sites construct it (`pkg/ratls/verify.go:326`,
  `internal/cmds/cds/run.go:170`, `policymonitor/initdata.go:208`,
  `credrelease/binding.go:123`, `cdsattest/cmd.go:108`, `attestproxy/cmd.go:86`).
  The routable form of that URL is one a hostile control plane chooses under
  C-05, so a peer that accepts the connection and never answers pins a CDS
  request goroutine for the process's life. The `unix://` form bounded only the
  *dial* (5s), not the request.
- **`pkg/allowlistclient`** — same constructor. Every shipped caller happens to
  pass a client carrying `cdsconn`'s `--timeout`, so this is the footgun rather
  than a live bug — but it is the shared transport for both enforcers and the CLI.
- **`internal/crane`** — the one with a reachable symptom. It shells out rather
  than speaking HTTP, and `c8s allowlist lint --online` runs a `crane manifest`
  per unique digest under a context that is effectively `context.Background()`:
  `cmd/c8s/main.go:42` calls `Execute()`, not `ExecuteContext`, and cobra fills
  `cmd.Context()` with `Background()` itself. A registry that accepts and stalls
  blocks the gate for the whole run.

## The fix

A `requestTimeout` on both constructors (60s attestation-api, matching the
`pkg/attestclient` sibling; 30s allowlist). `NewClientWithHTTP` is untouched —
callers that bring their own client keep owning the policy.

`internal/crane`'s three subcommands now go through one `run` helper that
applies `commandTimeout` (60s), or the caller's deadline when that is sooner,
and reports `context.DeadlineExceeded` rather than crane's opaque
`signal: killed`. `cmd.WaitDelay` covers a crane child that outlives the kill
while still holding stdout — otherwise `Wait` keeps the deadline open anyway.

## Acceptance criteria

- [x] Hung-peer test per client: a server that accepts and never responds, asserting
      the call returns rather than hanging — `TestHealthReturnsWithinItsTimeout`,
      `TestListReturnsWithinItsTimeout`, `TestBoundsAHungRegistry`.
- [x] Cancellation test per client, asserting `context.Canceled` —
      `TestHealthReturnsOnContextCancel`, `TestListReturnsOnContextCancel`,
      `TestReturnsOnContextCancel`.
- [x] `allowlistclient`: non-200 → `*StatusError` carrying the code and body;
      non-JSON content type refused; the 4 MiB cap enforced.
- [x] `internal/readiness` flips to not-ready against a hanging attestation-api —
      already covered by `TestCheckBoundsAHungProbe`; **no change in this PR.**
- [x] `c8s allowlist lint --online` against a hung registry fails with a timeout
      instead of blocking.
- [ ] "No new `context.Background()` on these paths" — see below.

## Deliberately not here

**`cmd.Context()` is still `Background`.** Fixing that means
`signal.NotifyContext` + `ExecuteContext` at the root command, which changes
cancellation for every subcommand — its own PR. The per-call bound added here
holds whatever the caller passes, so `lint --online` is fixed either way; the
context work would only add Ctrl-C responsiveness on top.

**`commandTimeout` is a `var`, not a `const`,** so the test can exercise the
default bound without a 60s test. It is not a knob: nothing outside the test
writes it.

**The `4096` literal in `allowlistclient`'s write path** (`client.go:177`) is
left as-is — it caps an error *message*, not an allowlist body, and conflating
it with `maxAllowlistResponseBytes` would be a behaviour change unrelated to
this issue.

## Testing

`go test ./pkg/attestationclient/... ./pkg/allowlistclient/... ./internal/crane/...
./internal/readiness/... ./internal/cmds/allowlist/... ./internal/cmds/cds/...` green;
`go vet` and `gofmt` clean. The crane hang tests use a `#!/bin/sh` stub that
`exec sleep`s, so the deadline's kill has one process to signal and nothing is
left holding stdout.
