### PR TITLE
fix(c8s): tag install-only files !c8s_node — main does not build for the node binary

### DIFF
--- a/cmd/c8s/inventory_cidr.go
+++ b/cmd/c8s/inventory_cidr.go
@@ -1,3 +1,5 @@
+//go:build !c8s_node
+
 package main
 
 import (

--- a/cmd/c8s/inventory_cidr_test.go
+++ b/cmd/c8s/inventory_cidr_test.go
@@ -1,3 +1,5 @@
+//go:build !c8s_node
+
 package main
 
 import (

--- a/cmd/c8s/operator_test.go
+++ b/cmd/c8s/operator_test.go
@@ -1,3 +1,5 @@
+//go:build !c8s_node
+
 package main
 
 import (


### PR DESCRIPTION
## Problem

main does not compile under `-tags c8s_node`, which breaks the Kata guest base workflow:

```
cmd/c8s/inventory_cidr.go:35:5: undefined: cvmModeIsPod
```

`inventory_cidr.go` (#389) is install-path code but carries no build tag, so it is compiled into the node binary while its dependency `cvmModeIsPod` — in `install.go`, which is `//go:build !c8s_node` — is not. `go vet -tags c8s_node` surfaces a second instance of the same mismatch: `operator_test.go` is untagged against `operator.go`, which is `!c8s_node`.

Neither was caught because CI builds the node binary only in the kata-guest-base workflow, whose Go build step runs after this package.

## Fix

`//go:build !c8s_node` on `inventory_cidr.go`, `inventory_cidr_test.go`, and `operator_test.go` — the tag their subjects already carry. `install_heal_test.go` is deliberately left untagged: its subject `install_heal.go` is untagged too.

Verified for linux/amd64: `go build` and `go vet` clean under both the default and `c8s_node` tags, and `go test ./cmd/c8s/` passes with the tagged tests still running in the default build (no coverage lost).