### PR TITLE
docs+test(allowlist): name the enforcer that honours mounts and env

### DIFF
--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -201,10 +201,13 @@ constrained exactly as much as it was before.
 
 Two limits worth stating. They bind only digests a `workloads` entry names —
 floor digests are admitted on the digest alone, so `c8s allowlist add` does not
-produce a mount-gated image. And an enforcer that cannot observe a field leaves
-it unset, which is treated as nothing-to-refuse rather than a violation: the
-host-side NRI plugin gates images on a node CVM and never sees a guest's mount
-table.
+produce a mount-gated image. And **the in-guest `policy-monitor` is the enforcer
+that honours them**: it reads the guest's own OCI spec, so it sees both the
+mount table and the environment. The host NRI plugin sees the CRI container and
+reports neither, and an unobserved field is treated as nothing-to-refuse rather
+than as a violation — so under `--cvm-mode=node`, where that plugin is the only
+enforcer, a `mounts` or `env` policy admits every container. `c8s allowlist
+lint` warns when a document carries one; `--cvm-mode=pod` silences it.
 
 ## Secret grants (`secrets`)
 
@@ -240,14 +243,17 @@ Three independent points enforce, at different strengths:
 
 1. **Host NRI plugin** (`nri-image-policy`), at CreateContainer, per container.
    Resolves the image digest and checks the effective argv against the allowlist
-   index. Fail-closed before the allowlist first loads. Runs on the untrusted
+   index. Digest and argv are its whole scope: it reports no mount table and no
+   environment, so `mounts` and `env` policy is vacuously satisfied here. Fail-closed before the allowlist first loads. Runs on the untrusted
    side of the TEE boundary for kata pods, so it is defense-in-depth there, and
    the primary gate for non-kata (base-mode) pods.
 
 2. **In-guest policy-monitor** (under kata), watching each new container's
    `config.json`. This is the load-bearing gate for confidential pods: the host
    is untrusted, guest-pull is forced, and a violation is a SIGKILL of the
-   container. It reads the digest and `process.args` and applies the same index.
+   container. It reads the digest, `process.args`, the bind-mount destinations
+   and the environment variable names out of the guest OCI spec, and applies the
+   same index — so it is the enforcer that honours `mounts` and `env` policy.
 
 3. **CDS at cert issuance**, in `resolveSandboxWorkload`. Before signing a leaf
    for a pod, CDS asks that pod's own inventory which images its sandbox is
@@ -401,8 +407,9 @@ confirm loop, and the signed write is always a separate, reviewed `apply`.
 shared digest whose union is widened to `any` by some entry, a digest that is
 floor-listed while also carrying a workload policy — the floor admits it by
 digest alone, so the argv policy is silently not enforced — tag-form labels
-(which can move under the operator), and a summary of how many `any` policies a
-document carries. `--online` cross-checks digests against the registry with
+(which can move under the operator), a `mounts` or `env` policy no host-path
+enforcer can observe (pass `--cvm-mode=pod` when the allowlist targets kata),
+and a summary of how many `any` policies a document carries. `--online` cross-checks digests against the registry with
 `crane`; `--strict` turns warnings into a non-zero exit for CI.
 
 Two entries declaring the same containers with the same argv policy are an

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -16,6 +16,7 @@ import (
 
 func newLintCmd(o *options) *cobra.Command {
 	var online, strict bool
+	var cvmMode string
 	cmd := &cobra.Command{
 		Use:   "lint <file|->",
 		Short: "Validate an allowlist file and report semantic warnings",
@@ -23,7 +24,8 @@ func newLintCmd(o *options) *cobra.Command {
 findings: entries with no containers, a container that can never start, digests
 whose effective policy is unconstrained, a digest that is floor-listed while also
 carrying a workload policy (the floor short-circuits it), tag-form image labels
-(TOCTOU), and root-subtree path grants. --online additionally checks each digest
+(TOCTOU), root-subtree path grants, and mount/env policy on a deployment whose
+enforcer cannot observe those fields. --online additionally checks each digest
 exists in its registry via crane.
 
 Two entries declaring the same containers with the same argv policy are an
@@ -41,6 +43,7 @@ same.`,
 				return err
 			}
 			findings := lintOffline(al)
+			findings = append(findings, unobservedFieldPolicies(al, cvmMode)...)
 			if online {
 				if err := crane.Require(); err != nil {
 					return err
@@ -66,6 +69,7 @@ same.`,
 	}
 	cmd.Flags().BoolVar(&online, "online", false, "also check each digest exists in its registry via crane")
 	cmd.Flags().BoolVar(&strict, "strict", false, "exit non-zero if there are any warnings")
+	cmd.Flags().StringVar(&cvmMode, "cvm-mode", "", "deployment mode the allowlist targets (pod, node, gke, aks); pod silences the mount/env scope warning")
 	return cmd
 }
 
@@ -213,6 +217,34 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 
 	if anyCount > 0 {
 		warnings = append(warnings, warnf("%d 'any' (unconstrained) policy value(s) across all entries", anyCount))
+	}
+	return warnings
+}
+
+// unobservedFieldPolicies reports mount and env policy that the deployment's
+// enforcer cannot see. Only the in-guest policy-monitor reads the guest OCI
+// spec; the host NRI plugin sees the CRI container, reports neither field, and
+// an unobserved field is vacuously satisfied — so outside pod mode such a
+// policy admits every container with no signal at write, install or deny time.
+func unobservedFieldPolicies(al *pkgallowlist.Allowlist, cvmMode string) []finding {
+	if cvmMode == "pod" {
+		return nil
+	}
+	var warnings []finding
+	for _, name := range sortedWorkloadNames(al.Workloads) {
+		for _, c := range allContainers(al.Workloads[name]) {
+			var fields []string
+			if c.Mounts.Policy == pkgallowlist.PolicyExact {
+				fields = append(fields, "mounts")
+			}
+			if c.Env.Policy == pkgallowlist.PolicyExact {
+				fields = append(fields, "env")
+			}
+			if fields == nil {
+				continue
+			}
+			warnings = append(warnings, warnf("workload %q container %s constrains %s; only the in-guest policy-monitor observes those fields, so on a deployment enforced by the host NRI plugin this policy admits every container (pass --cvm-mode=pod if this allowlist targets kata)", name, c.Digest.String(), strings.Join(fields, " and ")))
+		}
 	}
 	return warnings
 }

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -344,3 +344,33 @@ func TestWorkloadApplyDoesNotDoubleReportInFileCollision(t *testing.T) {
 		t.Fatal("the file lint should have reported it")
 	}
 }
+
+// A mounts or env policy is enforced only by the in-guest policy-monitor. On a
+// node-as-CVM deployment the host NRI plugin is the only enforcer and reports
+// neither field, so the policy admits every container — silently, at write,
+// install and deny time. lint is the one place that can say so.
+func TestLintWarnsOnUnobservedMountAndEnvPolicy(t *testing.T) {
+	const ctr = `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/x"]},"args":{"policy":"exact","argv":["--serve"]},` +
+		`"mounts":{"policy":"exact","destinations":["/config"]},"env":{"policy":"exact","names":["PATH"]}}`
+	f := writeFile(t, "al.json", `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[`+ctr+`]}}}`)
+
+	out, _, err := runCmd("lint", f)
+	if err != nil {
+		t.Fatalf("lint: %v", err)
+	}
+	for _, want := range []string{"constrains mounts and env", "policy-monitor", "--cvm-mode=pod"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("lint output %q missing %q", out, want)
+		}
+	}
+
+	// The warning is about the deployment, not the document: under pod mode the
+	// enforcer does observe both fields, so the same file is clean.
+	out, _, err = runCmd("lint", "--cvm-mode=pod", f)
+	if err != nil {
+		t.Fatalf("lint --cvm-mode=pod: %v", err)
+	}
+	if out != "ok: no findings\n" {
+		t.Fatalf("lint --cvm-mode=pod output = %q, want no findings", out)
+	}
+}

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -1417,3 +1417,35 @@ func TestConfigure_SetsCreateContainerMask(t *testing.T) {
 		t.Fatalf("mask = %v, want %v", mask, want)
 	}
 }
+
+// TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath pins the host
+// path's field scope. Both policies are `exact` with an empty list, so an
+// enforcer that reported any bind destination or any environment name would
+// refuse this container; admitting it is the assertion that this plugin passes
+// neither. Node-as-CVM operators are warned about the consequence by
+// `c8s allowlist lint`.
+func TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath(t *testing.T) {
+	al := workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"})
+	c := al.Workloads["w"].Containers[0]
+	c.Mounts = allowlist.MountPolicy{Policy: allowlist.PolicyExact}
+	c.Env = allowlist.EnvPolicy{Policy: allowlist.PolicyExact}
+	al.Workloads["w"].Containers[0] = c
+
+	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}}, al)
+
+	verdict, reason := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
+		"registry/repo@"+pushDigestB, []string{"/bin/app", "--serve"})
+	if verdict != verdictAllow {
+		t.Fatalf("host path must leave mounts and env unobserved, got verdict %d (reason=%q)", verdict, reason)
+	}
+
+	// Non-vacuity: the same entry refuses a container that does report one, so
+	// the admit above is this plugin's silence rather than a dead policy.
+	if p.policy.current().index.AdmitsContainer(allowlist.RunningContainer{
+		Digest:     pushDigestB,
+		Argv:       []string{"/bin/app", "--serve"},
+		BindMounts: []string{"/injected"},
+	}) {
+		t.Error("the entry admitted a reported bind mount; the exact-empty policy is not live")
+	}
+}

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -2,20 +2,18 @@ package allowlist
 
 import "fmt"
 
-// RunningContainer is one container an inventory reports: the bytes, and the
-// effective argv they were told to run.
+// RunningContainer is one container as an enforcer observes it: the bytes, the
+// effective argv they were told to run, the destinations of its BIND mounts
+// (the ones that can carry host-supplied content in), and its environment
+// variable names without values.
 //
 // A local type rather than the inventory's own keeps this package a pure
 // function of the allowlist — the caller converts.
-// RunningContainer is an observed container, as an enforcer sees it.
-//
-// BindMounts holds the destinations of its BIND mounts only — the mounts whose
-// source is a guest path, and so the ones that can carry host-supplied content
-// in. EnvNames holds its environment variable names, without values.
 //
 // An enforcer that cannot observe a field leaves it nil, which an exact policy
-// treats as "nothing to refuse" rather than as a violation: the host-side NRI
-// plugin gates images on a node CVM and does not see the guest's mount table.
+// treats as "nothing to refuse" rather than as a violation. The in-guest
+// policy-monitor reads the guest OCI spec and fills all four; the host-side NRI
+// plugin gates images on a node CVM and fills Digest and Argv only.
 type RunningContainer struct {
 	Digest     string
 	Argv       []string


### PR DESCRIPTION
## The problem

**Decision: env and bind mounts are out of scope for the host NRI image policy.**
The host-path plugin gates digest and argv; env and mount policy is enforced
only under kata, where policy-monitor reads the guest OCI spec.

That was already what `internal/cmds/nri-image-policy/plugin.go` said in its own
comment — the problem was that nothing outside that comment agreed. The README
half landed earlier. What was left:

- `docs/allowlist-and-capabilities.md` described the fields at length but never
  named the enforcer that honours them. Its "Where it's enforced" list said
  policy-monitor "reads the digest and `process.args`" — omitting the two fields
  that are the whole reason the section exists.
- On node-as-CVM the NRI plugin is the only enforcer, and `pkg/allowlist`
  treats an unobserved field as vacuously satisfied (`everyIn`,
  `match.go:175-177`). An operator who writes an `env` or `mounts` policy there
  gets a silent pass — no warning at write time, install time or deny time. The
  `LD_PRELOAD` injection that motivates the feature is not gated on that path.
- No test pinned the host path's field scope, so a future change that started
  populating `BindMounts` from the CRI container would have been caught by
  nothing.

## The fix

**Docs.** The mount/env section now names the in-guest `policy-monitor` as the
enforcer that reads both fields out of the guest OCI spec, and states the
consequence under `--cvm-mode=node` positively. Item 1 of "Where it's enforced"
says digest and argv are the host plugin's whole scope; item 2 says
policy-monitor is the one that honours `mounts` and `env`. A reader arriving
from either direction lands on the same answer.

**`c8s allowlist lint`** warns per container when a document carries a `mounts`
or `env` policy, and `--cvm-mode=pod` silences it:

```
$ c8s allowlist lint al.json
warning: workload "w" container sha256:aaaa… constrains mounts and env; only the
in-guest policy-monitor observes those fields, so on a deployment enforced by the
host NRI plugin this policy admits every container (pass --cvm-mode=pod if this
allowlist targets kata)

$ c8s allowlist lint --cvm-mode=pod al.json
ok: no findings
```

**A test pins the host path's scope.** Both policies are `exact` with an empty
list, so an enforcer reporting *any* bind destination or environment name would
refuse the container — admitting it is the assertion that the plugin passes
neither. A second arm drives the same entry through the index with a bind mount
present to prove the policy is live, so the test cannot pass vacuously.

## Design notes

**Warning, not refusal.** Runtime fail-closed was the alternative, but these
fields default to `any` and the vacuous-satisfaction rule is exactly what stops
the host plugin denying every pod it checks. Failing closed would start denying
containers in clusters that pass today, for a behaviour that is a documented
non-goal.

**Scoped to `lint`, not `lintOffline`.** `upload` and `workload apply` also run
`lintOffline` and honour `--strict`. Putting the check there would make a kata
operator's existing `--strict` write start failing on a caveat that does not
apply to them. The check lives in the `lint` command, which is where the issue
asks for it.

**`--cvm-mode` is not validated against the mode list.** `allowedCvmModes` lives
in `package main` and is not importable; duplicating it is worse than the
failure mode, which is fail-safe — a typo yields the warning rather than
suppressing it.

**`match.go`'s vacuous-satisfaction invariant already carried its one-line
statement** (`match.go:175-177`), so no comment was added. The type's doc
comment did have two spliced "RunningContainer is…" openings; that is tidied,
and now says which enforcer fills which fields.

## Acceptance criteria

- [x] `docs/allowlist-and-capabilities.md` says which enforcer honours env/mounts policy.
- [x] `pkg/allowlist/match.go`'s vacuous-satisfaction rule carries the invariant at the code (pre-existing).
- [x] A test pins the host path's field scope.
- [x] An operator writing an env or mounts policy for a node-as-CVM deployment is told it will not be enforced.
- [x] README scope statements — landed earlier, unchanged here.

## Testing

`go test ./internal/cmds/allowlist/... ./pkg/allowlist/... ./internal/cmds/nri-image-policy/...`
green; `go vet` and `gofmt` clean.
