### PR TITLE
chore(deps): cover gomod and docker in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,47 @@
 # and image pins are deliberate measurement changes and stay manual. The image
 # repro gate gives every image-relevant PR a throwaway module-signing key; never
 # copy the production MODULE_SIG_KEY_PEM into Dependabot secrets.
+#
+# "Image pins" above means the measured component digests in
+# internal/helmchart/c8s/values.yaml and node-guest-image/c8s/mkosi.sync. No
+# ecosystem below reads either file: docker covers Dockerfile FROM bases only.
 version: 2
 updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directories:
+      - /
+      - /test/mock-attestation
+      - /test/mock-cds
+    schedule:
+      interval: weekly
+    groups:
+      go-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  # The runtime bases of attestation-gated components: nri-image-policy's image
+  # is in the measured allowlist floor, and docker.yml's type=gha cache means a
+  # repointed base can otherwise ride a warm layer unnoticed.
+  - package-ecosystem: docker
+    directories:
+      - /cmd/c8s
+      - /cmd/cds
+      - /cmd/get-cert
+      - /cmd/nri-image-policy
+      - /cmd/ratls-mesh
+      - /cmd/volumed
+      - /test/mock-attestation
+      - /test/mock-cds
+    schedule:
+      interval: weekly
+    groups:
+      base-images:
+        patterns: ["*"]


### PR DESCRIPTION
## The problem

`.github/dependabot.yml` covers exactly one ecosystem — `github-actions` at `/`.
Nothing bumps:

- **the Go module graph** — `go.mod`, plus `test/mock-attestation/go.mod` and
  `test/mock-cds/go.mod` (all three are in `go.work`);
- **the Dockerfile bases** — 8 Dockerfiles, whose `FROM` lines are the runtime
  bases of attestation-gated components. `nri-image-policy`'s image is in the
  measured allowlist floor, and `docker.yml`'s `type=gha` cache means a
  repointed base can ride a warm layer unnoticed.

## The fix

Adds the `gomod` and `docker` ecosystems. Grouped so a weekly run lands two
reviewable PRs rather than a dozen: Go minor+patch in one (majors stay
separate), base images in another. The existing `github-actions` entry is
grouped the same way.

## On the "image pins stay manual" header

The file's existing header says component and image pins are deliberate
measurement changes and stay manual. That still holds, and the comment now says
what it refers to: the measured digests in `internal/helmchart/c8s/values.yaml`
and `node-guest-image/c8s/mkosi.sync`. **No ecosystem here reads either file** —
`docker` matches Dockerfile `FROM` lines only.

A base bump *does* re-measure the node image. That is the point of routing it
through a PR: today the same drift happens invisibly whenever an untagged
`gcr.io/distroless/static-debian12` is re-pulled.

## Not coverable

`ATTESTATION_RS_REF` and `CONFOS_REF` are raw commit SHAs in workflow `env:`,
which no Dependabot ecosystem models. `pin-hygiene.yml` already asserts both are
full 40-hex; bumping them is a deliberate measurement roll with a
`--measurements` refresh in the same PR, per the pin comments at
`c8s-image.yml:80-81`. No follow-up planned — a bot cannot make that call.

## Sequencing

This is 1 of 3 for the pinning work, and lands first on purpose: the other two
SHA-pin the remaining action `uses:` and digest-pin every Dockerfile `FROM`,
which is what gives this bot something to bump.

## Verification

The config parses. The real check is behavioural — the bot should open at least
one update PR within a day of merge; worth confirming before this is called
done.
