### PR TITLE
test(integration): add kind cluster harness covering install and oper…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,29 @@ jobs:
       - name: Run the integration harness
         run: make test-integration
 
+  integration-cluster:
+    name: Integration (cluster)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup-go-c8s
+
+      - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: v3.14.4
+
+      # kind is not on the runner image; pin the release binary by sha256.
+      - name: Install kind
+        run: |
+          curl -fsSL -o kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
+          echo "517ab7fc89ddeed5fa65abf71530d90648d9638ef0c4cde22c2c11f8097b8889  kind" | sha256sum -c -
+          sudo install kind /usr/local/bin/kind
+
+      - name: Run the cluster integration harness
+        run: make test-integration-cluster
+
   tdx-measure:
     name: TDX MRTD tripwire
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-node-guest-image-role test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -129,6 +129,13 @@ test:
 
 test-integration:
 	./test/integration/run.sh
+
+# Full cluster operation in a single-node kind cluster (no TEE hardware):
+# install, admission, NRI image policy, workload certs, mesh, adoption,
+# uninstall. Needs kind/kubectl/helm/docker; CI runs it in the
+# Integration (cluster) job.
+test-integration-cluster:
+	./test/integration/cluster/run.sh
 
 # The byte-exact rke2-role.sh against real ISO9660 loop devices. Root (loop
 # mounts, writes /run/confos) — sudo on a disposable box.

--- a/README.md
+++ b/README.md
@@ -374,7 +374,9 @@ node-guest-image/  The node-image definition for node-as-CVM (new home;
 docs/              Design and operator docs
 samples/           Example manifests
 scripts/           Dev and CI helpers
-test/              Docker-compose integration tests
+test/              Integration tests: docker-compose get-cert flow
+                   (test/integration) and the kind cluster harness
+                   (test/integration/cluster, see docs/integration-tests.md)
 ```
 
 ## Build

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -1,0 +1,102 @@
+# Integration tests
+
+Two harnesses run in CI on plain GitHub-hosted runners (no TEE hardware), plus
+live-cluster scripts that run on the metal lanes. This doc maps what each
+covers and why the kind harness is shaped the way it is.
+
+| Harness | Entrypoint | CI job | Subject |
+| --- | --- | --- | --- |
+| docker-compose | `make test-integration` | Integration | get-cert's RA-TLS flow against mock CDS + mock attestation-api, nginx serving the issued leaf |
+| kind cluster | `make test-integration-cluster` | Integration (cluster) | the full node-mode control plane and workload path (below) |
+| live-cluster scripts | `test/e2e/*.sh` | snp/tdx-metal-e2e | cw-label policy, mesh enforcement, CA handoff on real TEEs |
+
+## The kind harness
+
+`test/integration/cluster/run.sh` boots a single-node kind cluster, builds the
+component images from the checkout, and runs the real `c8s install
+--cvm-mode=node`. The TEE is substituted at exactly one point: **evidence
+generation**. `test/mock-attestation` serves synthetic SNP reports (launch
+digest all-zero) on the node IP :8400 — the address node-mode consumers dial
+for the node-baked api — and an `attest-proxy` sidecar publishes it on the
+hostPath unix socket the host plugin uses. Every component that delegates
+verification to the attestation-api (get-cert, CDS, ratls-mesh, the NRI
+plugin) works unchanged against it. The all-zero digest is pinned via
+`--measurements`, so every RA-TLS hop is verified exactly as in production.
+
+The NRI image-policy plugin runs for real: the harness renders the chart's
+installer DaemonSet and applies it out-of-band (node mode does not render it —
+production node images bake the plugin). The installer patches the node's
+containerd config and restarts it, which kind survives. The install-time
+allowlist floor is generated from the node containerd's image store, because
+`policy.enforceExisting` checks already-running containers against it.
+
+Two operator-facing commands verify evidence **in-process** with real hardware
+cryptography, which synthetic evidence cannot pass: `c8s verify` and the `c8s
+allowlist` CLI. Those stay on the metal lanes. The harness still exercises the
+allowlist write path server-side: writes are signed with the production
+`pkg/operatorauth` signer (`optoken/`) and CDS performs its full token
+verification — only the client-side evidence check is skipped (curl `-k` over
+a port-forward).
+
+## Covered scenarios
+
+- `c8s install` end-to-end: preflights, helm install, CRDs, RBAC,
+  MutatingWebhookConfiguration, ValidatingAdmissionPolicies.
+- Control-plane readiness: operator, CDS (RA-TLS serving cert via the mock
+  api), tls-lb (mesh cert from CDS), ratls-mesh DaemonSet.
+- NRI plugin: installer writes the binary + config, patches containerd,
+  restarts it, registers, serves the admission inventory socket.
+- Allowlist authorization: unsigned writes and wrong-key writes are 401; a
+  write signed by the pinned operator key lands, is served, and deletes.
+- Webhook injection: `confidential.ai/cw` pods gain the get-cert sidecar, the
+  wait gate, and the cw label; the operator provisions the `c8s-<id>` headless
+  Service.
+- Workload identity: get-cert redeems a sandbox token from the NRI admission
+  inventory, CDS calls the digests endpoint back, and the issued leaf carries
+  the workload's in-cluster DNS SAN.
+- Image admission, fail-closed: a non-allowlisted image is denied at
+  container creation; a signed allowlist write flips the same pod to Running
+  after the plugin's next pull.
+- Admission rejections: cw label/annotation mismatch (webhook) and
+  hostNetwork tenant pods (host-namespace policy).
+- Mesh: a pod-IP dial to a cw workload is wrapped (the inbound counter
+  moves); a dial from a mesh-excluded namespace hits the FORWARD guard and
+  DROPs, and a Service-VIP dial is either dropped or mesh-wrapped — never
+  plaintext — proven by the drop/wrap counters (rule ordering between
+  kube-proxy and the mesh is not stable). Mirrors
+  `test/e2e/mesh-cw-enforcement.sh`.
+- tls-lb front door: HTTPS verified against the CDS mesh CA.
+- Workload adoption: `c8s install --workload-ref` patches a running
+  deployment, its rollout goes through injection, the status mirror reports
+  `kubectl get cwl`, and tls-lb routes the front door to it over the mesh.
+- `c8s uninstall`: release, webhook, and admission policies are removed.
+
+## Deliberately out of scope
+
+No TEE properties are asserted: hardware verification, measurements that mean
+anything, kata guests, encrypted volumes (volumed needs device-mapper control
+of the node kernel), `get-kubeconfig` (SNP-gated), CDS handoff (two CDS
+replicas), and the `c8s allowlist`/`c8s verify` CLIs (in-process hardware
+verification, above). The metal lanes (snp-metal-e2e, tdx-metal-e2e,
+cvm-e2e) own those.
+
+## Running it
+
+```sh
+make test-integration-cluster
+```
+
+Needs docker (or podman with `KIND_EXPERIMENTAL_PROVIDER=podman`), kind,
+kubectl, helm, go, openssl, curl, python3. The kind node image is pinned by
+digest in run.sh; bump it with the kind release. CI installs kind itself
+(`.github/workflows/ci.yml`, pinned binary sha256).
+
+### Failure notes
+
+- A pod stuck `CreateContainerError` with `image not in allowlist` is the NRI
+  plugin doing its job: the image's containerd store digest is missing from
+  the floor. The floor is written from the node's image store before install,
+  so an image first pulled *during* the run lands here — pre-pull it next to
+  the other fixtures in run.sh.
+- The mock-attestation deployment is `Recreate` on purpose: two hostNetwork
+  pods cannot both bind :8400 on a single-node cluster.

--- a/test/integration/cluster/manifests/adopt-me.yaml
+++ b/test/integration/cluster/manifests/adopt-me.yaml
@@ -1,0 +1,26 @@
+# A plain workload with no c8s opt-in, adopted into the mesh by
+# `c8s install --workload-ref web=adopted/deployment/web:80 --upstream web`
+# during the harness's upgrade step.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: adopted
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: adopted
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27-alpine

--- a/test/integration/cluster/manifests/mock-attestation.yaml
+++ b/test/integration/cluster/manifests/mock-attestation.yaml
@@ -1,0 +1,61 @@
+# The node-baked attestation shape, simulated for a cluster without TEE
+# hardware. mock-attestation answers /attest with synthetic SNP reports
+# (launch digest all-zero) and /verify by checking the report-data binding —
+# the wire contract of the real api. It must be reachable at the node IP on
+# :8400 (where cvmMode=node consumers dial the node-baked api), so it runs
+# hostNetwork. attest-proxy is the same sidecar the chart's DaemonSet runs:
+# it publishes the api on the hostPath unix socket the host NRI plugin
+# verifies CDS RA-TLS through.
+#
+# Recreate: on a single-node cluster a rolling update keeps the old pod
+# holding host :8400 and the new pod can never bind.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mock-attestation
+  namespace: kube-system
+  labels:
+    app: mock-attestation
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: mock-attestation
+  template:
+    metadata:
+      labels:
+        app: mock-attestation
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: mock-attestation
+          image: ghcr.io/confidential-dot-ai/mock-attestation:it
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: PORT
+              value: "8400"
+          readinessProbe:
+            httpGet: { path: /health, port: 8400 }
+        - name: attest-proxy
+          image: ghcr.io/confidential-dot-ai/c8s-operator:it
+          imagePullPolicy: IfNotPresent
+          args:
+            - attest-proxy
+            - --socket=/runtime-dir/attestation-api.sock
+            - --upstream=http://127.0.0.1:8400
+          # Root: callers reject a socket owned by anyone but root or
+          # themselves; the NRI plugin (a root host process) is the caller.
+          securityContext:
+            runAsUser: 0
+            runAsGroup: 65532
+          volumeMounts:
+            - name: runtime-dir
+              mountPath: /runtime-dir
+      volumes:
+        - name: runtime-dir
+          hostPath:
+            path: /var/run/nri-image-policy
+            type: DirectoryOrCreate

--- a/test/integration/cluster/manifests/workload.yaml
+++ b/test/integration/cluster/manifests/workload.yaml
@@ -1,0 +1,28 @@
+# A confidential-workload fixture: the confidential.ai/cw annotation opts the
+# pod into webhook injection (get-cert sidecar, mesh identity). The app image
+# is allowlisted/denied by the harness through the CDS allowlist API.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: serving
+  namespace: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: serving
+  template:
+    metadata:
+      labels:
+        app: serving
+      annotations:
+        confidential.ai/cw: vllm
+    spec:
+      containers:
+        - name: app
+          image: nginx:1.27-alpine

--- a/test/integration/cluster/optoken/main.go
+++ b/test/integration/cluster/optoken/main.go
@@ -1,0 +1,42 @@
+// optoken mints the operator Authorization header for a CDS write, using the
+// production signer (pkg/operatorauth). The cluster harness needs it because
+// the `c8s allowlist` CLI verifies CDS's RA-TLS evidence in-process, which
+// the mock attestation-api's synthetic evidence cannot pass; CDS's own
+// server-side token verification is unaffected and fully exercised.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+func main() {
+	hdr, err := run(os.Args)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Print(hdr)
+}
+
+// run is main, extracted for the test: args includes argv[0].
+func run(args []string) (string, error) {
+	if len(args) != 5 {
+		return "", fmt.Errorf("usage: optoken <key.pem> <method> <path> <body-file>")
+	}
+	keyPEM, err := os.ReadFile(args[1])
+	if err != nil {
+		return "", err
+	}
+	body, err := os.ReadFile(args[4])
+	if err != nil {
+		return "", err
+	}
+	signer, err := operatorauth.NewSignerFromKeyPEM(keyPEM)
+	if err != nil {
+		return "", err
+	}
+	return signer.Authorization(args[2], args[3], body)
+}

--- a/test/integration/cluster/optoken/main_test.go
+++ b/test/integration/cluster/optoken/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+// The header optoken prints must satisfy CDS's server-side check: the
+// production Verifier over the pinned public key, bound to method, path, and
+// body.
+func TestRunProducesAuthorizingHeader(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "operator.key")
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bodyPath := filepath.Join(dir, "body.json")
+	body := []byte(`{"digest":"sha256:abc","image":"example.com/img:1"}`)
+	if err := os.WriteFile(bodyPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	header, err := run([]string{"optoken", keyPath, "POST", "/allowlist/digests", bodyPath})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !strings.HasPrefix(header, "Bearer ") {
+		t.Fatalf("header = %q, want a Bearer token", header)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://cds/allowlist/digests", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", header)
+	if err := (operatorauth.Verifier{Keys: []*ecdsa.PublicKey{&key.PublicKey}}).Authorize(req, body); err != nil {
+		t.Fatalf("verifier rejected optoken's header: %v", err)
+	}
+
+	// The body binding must hold: a tampered body fails server-side.
+	if err := (operatorauth.Verifier{Keys: []*ecdsa.PublicKey{&key.PublicKey}}).Authorize(req, []byte(`{}`)); err == nil {
+		t.Fatal("verifier accepted a token against a different body")
+	}
+}
+
+func TestRunUsage(t *testing.T) {
+	if _, err := run([]string{"optoken"}); err == nil {
+		t.Fatal("run with no arguments did not fail")
+	}
+}

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -1,0 +1,663 @@
+#!/usr/bin/env bash
+# Cluster integration harness for c8s.
+#
+# Installs the real c8s chart into a single-node kind cluster — no TEE
+# hardware — and exercises the operational surface the unit tests and the
+# docker-compose harness (test/integration) cannot: helm install via the c8s
+# CLI, CRDs, the admission webhook and ValidatingAdmissionPolicies live in a
+# real API server, the NRI image-admission plugin registered against a real
+# containerd, workload-certificate issuance with sandbox-identity claims, the
+# operator-signed allowlist loop into admission decisions, the RA-TLS mesh
+# wrapping traffic, workload adoption, and uninstall.
+#
+# The TEE is replaced at exactly one point: evidence generation. A
+# mock-attestation deployment (test/mock-attestation) serves synthetic SNP
+# reports — launch digest all-zero — on the node IP :8400, the address
+# cvmMode=node consumers dial for the node-baked api. Every stack component
+# that delegates verification to the attestation-api (get-cert, CDS, the
+# mesh, the NRI plugin) works unchanged. In-process hardware verification
+# (`c8s verify`, the `c8s allowlist` CLI) cannot pass synthetic evidence, so
+# allowlist writes here are signed with the production pkg/operatorauth
+# signer (./optoken) and sent over plain curl; CDS still verifies the
+# operator token server-side.
+#
+# What this deliberately is not: a confidential-cluster test. Nothing here
+# asserts TEE properties — that is what the metal lanes (snp-metal-e2e,
+# tdx-metal-e2e) are for. See docs/integration-tests.md.
+#
+# Prerequisites: docker (or podman via KIND_EXPERIMENTAL_PROVIDER=podman),
+# kind, kubectl, helm, go, openssl, curl, python3. Run from the repo root via
+# `make test-integration-cluster`.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+CLUSTER="${C8S_IT_CLUSTER:-c8s-it}"
+# kind v0.30.0's default node image, pinned by digest.
+NODE_IMAGE="${C8S_IT_NODE_IMAGE:-kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a}"
+IMAGE_TAG=it
+NS=c8s-system
+CDS_LOCAL_PORT=18443
+# The mock attestation-api's synthetic launch digest (all zero). Pinned into
+# cds.measurements / ratlsMesh.measurements so every RA-TLS hop is verified
+# against it, exactly as a pinned production measurement.
+MOCK_MEASUREMENT="000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+# Test-client and workload images. The workload image joins the install-time
+# floor; the test-client image stays out of it so the admission test can
+# drive a deny-then-allow transition through the signed CDS API.
+CURL_IMAGE=curlimages/curl:8.10.1
+WORKLOAD_IMAGE=nginx:1.27-alpine
+
+WORKDIR="$(mktemp -d)"
+PF_PID=""
+
+log() { echo ""; echo "=== $* ==="; }
+
+diagnostics() {
+    echo "--- cluster state (diagnostics) ---"
+    kubectl get pods -A -o wide 2>&1 || true
+    kubectl -n "$NS" logs deploy/c8s-cds --tail=40 2>&1 || true
+    kubectl -n "$NS" logs deploy/c8s-operator --tail=40 2>&1 || true
+}
+
+cleanup() {
+    [ -n "$PF_PID" ] && kill "$PF_PID" 2>/dev/null || true
+    kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+    rm -rf "$WORKDIR"
+}
+trap cleanup EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    diagnostics
+    exit 1
+}
+
+CHECKS=0
+pass() {
+    CHECKS=$((CHECKS + 1))
+    echo "PASS: $*"
+}
+
+for tool in docker kind kubectl helm go openssl curl python3; do
+    command -v "$tool" >/dev/null 2>&1 || { echo "FAIL: $tool not available" >&2; exit 1; }
+done
+
+NODE=""  # kind node container name, resolved after cluster creation
+node_exec() { docker exec "$NODE" "$@"; }
+
+# store_digests prints "digest<TAB>ref" for every real image reference in the
+# node containerd's k8s.io store, one per (digest, ref) pair.
+store_digests() {
+    node_exec ctr -n k8s.io images ls | awk 'NR > 1 && $1 !~ /^sha256:/ {print $3 "\t" $1}'
+}
+
+# --- Build ---
+
+log "Building the c8s binary"
+make build-c8s >/dev/null
+
+log "Building component images"
+docker build -q -f cmd/c8s/Dockerfile               -t "ghcr.io/confidential-dot-ai/c8s-operator:$IMAGE_TAG"     . >/dev/null
+docker build -q -f cmd/cds/Dockerfile               -t "ghcr.io/confidential-dot-ai/cds:$IMAGE_TAG"              . >/dev/null
+docker build -q -f cmd/nri-image-policy/Dockerfile  -t "ghcr.io/confidential-dot-ai/nri-image-policy:$IMAGE_TAG" . >/dev/null
+docker build -q -f cmd/ratls-mesh/Dockerfile        -t "ghcr.io/confidential-dot-ai/ratls-mesh:$IMAGE_TAG"       . >/dev/null
+docker build -q -f test/mock-attestation/Dockerfile -t "ghcr.io/confidential-dot-ai/mock-attestation:$IMAGE_TAG" . >/dev/null
+
+go build -o "$WORKDIR/optoken" ./test/integration/cluster/optoken
+
+# --- Cluster ---
+
+log "Creating the kind cluster"
+kind delete cluster --name "$CLUSTER" >/dev/null 2>&1 || true
+kind create cluster --name "$CLUSTER" --image "$NODE_IMAGE" --wait 120s \
+    || fail "kind cluster did not come up (node image: $NODE_IMAGE)"
+NODE="$(kind get nodes --name "$CLUSTER" | head -1)"
+[ -n "$NODE" ] || fail "kind reported no node"
+
+log "Loading images into the cluster"
+# One at a time: the podman provider crosses images loaded in a single call.
+for img in c8s-operator cds nri-image-policy ratls-mesh mock-attestation; do
+    kind load docker-image "ghcr.io/confidential-dot-ai/$img:$IMAGE_TAG" --name "$CLUSTER" >/dev/null
+done
+
+# Test-client and workload images, pre-pulled so their store digests are
+# known when the floor is written. The curl image is deliberately KEPT OUT of
+# the floor: the admission test needs a digest the plugin has never seen, so
+# denial is deterministic instead of racing the plugin's pull interval.
+node_exec ctr -n k8s.io images pull "docker.io/$CURL_IMAGE" >/dev/null \
+    || fail "could not pull $CURL_IMAGE into the node (registry rate limit?)"
+node_exec ctr -n k8s.io images pull "docker.io/library/$WORKLOAD_IMAGE" >/dev/null \
+    || fail "could not pull $WORKLOAD_IMAGE into the node (registry rate limit?)"
+# tls-lb's nginx is pulled at install time — after the floor scan — so its
+# chart-pinned digest is pulled by reference and seeded up front; otherwise
+# the plugin's enforce-existing check kills the front door's own container.
+TLSLB_NGINX_REF="$(helm show values internal/helmchart/c8s | python3 -c '
+import sys, yaml
+img = yaml.safe_load(sys.stdin)["tlsLb"]["nginx"]["image"]
+repo = img["repository"]
+# Bare docker-hub names (nginxinc/foo) need the registry made explicit for ctr.
+if "/" not in repo or ("." not in repo.split("/")[0] and ":" not in repo.split("/")[0] and repo.split("/")[0] != "localhost"):
+    repo = "docker.io/" + repo
+print(repo + "@" + img["digest"])')"
+node_exec ctr -n k8s.io images pull "$TLSLB_NGINX_REF" >/dev/null \
+    || fail "could not pull $TLSLB_NGINX_REF into the node"
+
+log "Writing the allowlist floor"
+# Every image in the node's store (kind system images, the loaded c8s images,
+# the pre-pulled fixtures) goes into the install-time floor: with
+# enforceExisting the plugin checks already-running containers against CDS's
+# served allowlist at startup, so anything missing is killed.
+store_digests > "$WORKDIR/floor.tsv"
+[ -s "$WORKDIR/floor.tsv" ] || fail "containerd store scan came back empty"
+grep -q "docker.io/library/$WORKLOAD_IMAGE" "$WORKDIR/floor.tsv" || fail "workload image missing from the store scan"
+python3 - "$WORKDIR/floor.tsv" "$WORKDIR/values.yaml" "docker.io/$CURL_IMAGE" <<'PYEOF'
+import sys, yaml
+floor = {}
+for line in open(sys.argv[1]):
+    digest, ref = line.rstrip("\n").split("\t")
+    floor.setdefault(digest, ref)
+# Kept out of the floor on purpose: the admission test's unseen digest.
+floor = {d: r for d, r in floor.items() if r != sys.argv[3]}
+with open(sys.argv[2], "w") as f:
+    yaml.safe_dump({"nriImagePolicy": {"bootstrapAllowlist": {"digests": floor}}}, f)
+print(f"floor: {len(floor)} digests")
+PYEOF
+
+# Digest-alias the loaded c8s images: the NRI installer renders its pod image
+# as repo@<store digest>; the alias makes containerd resolve that reference
+# to the loaded image without a registry pull.
+while IFS=$'\t' read -r digest ref; do
+    case "$ref" in
+        ghcr.io/confidential-dot-ai/*:*) node_exec ctr -n k8s.io images tag "$ref" "${ref%:*}@$digest" >/dev/null ;;
+    esac
+done < "$WORKDIR/floor.tsv"
+
+log "Deploying the mock attestation-api"
+kubectl apply -f test/integration/cluster/manifests/mock-attestation.yaml
+kubectl -n kube-system rollout status deploy/mock-attestation --timeout=120s
+
+openssl ecparam -genkey -name prime256v1 -noout -out "$WORKDIR/operator.key" 2>/dev/null
+openssl ec -in "$WORKDIR/operator.key" -pubout -out "$WORKDIR/operator-pub.pem" 2>/dev/null
+
+log "c8s install"
+./build/c8s install --namespace "$NS" --cvm-mode=node --hardware-platform=sev-snp \
+    --single-node --resolve-digests=false --image-tag="$IMAGE_TAG" \
+    --operator-keys "$WORKDIR/operator-pub.pem" \
+    --measurements "$MOCK_MEASUREMENT" \
+    -f "$WORKDIR/values.yaml" --wait || fail "c8s install failed"
+
+# --- CDS API helpers ---
+
+cds_pf_start() {
+    [ -n "$PF_PID" ] && return 0
+    kubectl -n "$NS" port-forward svc/c8s-cds "$CDS_LOCAL_PORT:8443" >/dev/null 2>&1 &
+    PF_PID=$!
+    for _ in $(seq 1 30); do
+        curl -sSk "https://127.0.0.1:$CDS_LOCAL_PORT/healthz" >/dev/null 2>&1 && return 0
+        sleep 1
+    done
+    fail "CDS port-forward never came up"
+}
+
+# cds_write <method> <path> <body-file> -> http code; signed with the operator key.
+cds_write() {
+    local method="$1" path="$2" bodyfile="$3" token
+    cds_pf_start
+    token="$("$WORKDIR/optoken" "$WORKDIR/operator.key" "$method" "$path" "$bodyfile")"
+    # Always exit 0: curl prints 000 on transport failure, and callers assert
+    # on the code itself.
+    curl -sSk -o /dev/null -w '%{http_code}' -X "$method" \
+        -H "Authorization: $token" -H 'Content-Type: application/json' \
+        --data-binary "@$bodyfile" "https://127.0.0.1:$CDS_LOCAL_PORT$path" || true
+}
+
+# --- NRI image-policy plugin ---
+
+log "Installing the NRI image-policy plugin"
+# Under --cvm-mode=node the chart does not render this DaemonSet (production
+# node images bake the plugin), so the harness renders it from the chart
+# source and applies it out-of-band — same installer, same containerd patch,
+# same plugin.
+NRI_STORE_DIGEST="$(awk -F'\t' '$2 ~ /nri-image-policy:it$/ {print $1; exit}' "$WORKDIR/floor.tsv")"
+CDS_STORE_DIGEST="$(awk -F'\t' '$2 ~ /\/cds:it$/ {print $1; exit}' "$WORKDIR/floor.tsv")"
+[ -n "$NRI_STORE_DIGEST" ] && [ -n "$CDS_STORE_DIGEST" ] || fail "loaded-image digests missing from the floor scan"
+# Client-side render: the chart's kubeVersion floor is checked against the
+# live server version, not helm's compiled-in default.
+KUBE_VERSION="$(kubectl version -o json \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin)["serverVersion"]["gitVersion"])')"
+helm template c8s internal/helmchart/c8s -n "$NS" \
+    --kube-version "$KUBE_VERSION" \
+    --set-string image.tag="$IMAGE_TAG" \
+    --set-string attestationApi.cvmMode=node \
+    --set attestationApi.enabled=false \
+    --set nriImagePolicy.enabled=true \
+    --set-string nriImagePolicy.image.tag="$IMAGE_TAG" \
+    --set-string nriImagePolicy.image.digest="$NRI_STORE_DIGEST" \
+    --set-string cds.image.digest="$CDS_STORE_DIGEST" \
+    --set-string "cds.measurements[0]=$MOCK_MEASUREMENT" \
+    --set tlsLb.enabled=false \
+    --set volumed.enabled=false \
+    --set ratlsMesh.enabled=false \
+    -f "$WORKDIR/values.yaml" \
+    --show-only templates/nri-image-policy-installer-daemonset.yaml > "$WORKDIR/nri-installer.yaml" \
+    || fail "could not render the NRI installer DaemonSet"
+kubectl apply -f "$WORKDIR/nri-installer.yaml"
+# The installer patches the node's containerd config and restarts it; the
+# DaemonSet reports Ready once the plugin answers its health socket.
+kubectl -n "$NS" rollout status ds/c8s-nri-image-policy-worker --timeout=300s \
+    || fail "NRI plugin did not become healthy"
+node_exec test -S /var/run/nri-image-policy/workload-claims.sock \
+    || fail "admission inventory socket missing on the node"
+pass "NRI plugin registered with containerd and serves the admission inventory"
+
+# --- Tests ---
+
+log "Control plane"
+for deploy in c8s-operator c8s-cds c8s-tls-lb; do
+    kubectl -n "$NS" wait --for=condition=Available "deploy/$deploy" --timeout=180s \
+        || fail "$deploy not Available"
+done
+kubectl -n "$NS" rollout status ds/c8s-ratls-mesh --timeout=240s || fail "ratls-mesh not ready"
+pass "operator, CDS, tls-lb and ratls-mesh all Ready after c8s install"
+
+kubectl get crd confidentialworkloads.confidential.ai >/dev/null || fail "ConfidentialWorkload CRD missing"
+kubectl get mutatingwebhookconfiguration c8s-pod-injector >/dev/null || fail "pod-injector webhook config missing"
+kubectl get validatingadmissionpolicy c8s-cw-label-integrity >/dev/null || fail "cw-label policy missing"
+kubectl get validatingadmissionpolicy c8s-deny-host-namespaces >/dev/null || fail "host-namespace policy missing"
+pass "CRD, mutating webhook, and both ValidatingAdmissionPolicies installed"
+
+log "Allowlist API"
+# Unsigned and wrongly-signed writes are refused; a write signed by the
+# pinned operator key lands, is served, and deletes cleanly. Exercised on a
+# throwaway digest so no assertion can pass on the seeded floor.
+cds_pf_start
+THROWAWAY_DIGEST="sha256:$(printf 'ab%.0s' {1..32})"
+printf '{"digest":"%s","image":"example.com/harness/throwaway:1"}' "$THROWAWAY_DIGEST" > "$WORKDIR/add.json"
+code="$(curl -sSk -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
+    --data-binary @"$WORKDIR/add.json" "https://127.0.0.1:$CDS_LOCAL_PORT/allowlist/digests" || true)"
+[ "$code" = "401" ] || fail "unsigned allowlist write: want HTTP 401, got $code"
+pass "unsigned allowlist write rejected (401)"
+
+openssl ecparam -genkey -name prime256v1 -noout -out "$WORKDIR/rogue.key" 2>/dev/null
+rogue_token="$("$WORKDIR/optoken" "$WORKDIR/rogue.key" POST /allowlist/digests "$WORKDIR/add.json")"
+code="$(curl -sSk -o /dev/null -w '%{http_code}' -X POST -H "Authorization: $rogue_token" -H 'Content-Type: application/json' \
+    --data-binary @"$WORKDIR/add.json" "https://127.0.0.1:$CDS_LOCAL_PORT/allowlist/digests" || true)"
+[ "$code" = "401" ] || fail "wrong-key allowlist write: want HTTP 401, got $code"
+pass "allowlist write signed by an unpinned key rejected (401)"
+
+code="$(cds_write POST /allowlist/digests "$WORKDIR/add.json")"
+[ "$code" = "204" ] || fail "signed allowlist write: want HTTP 204, got $code"
+curl -sSk "https://127.0.0.1:$CDS_LOCAL_PORT/allowlist" | grep -q "$THROWAWAY_DIGEST" \
+    || fail "added digest not served from /allowlist"
+printf '{"digests":["%s"]}' "$THROWAWAY_DIGEST" > "$WORKDIR/del.json"
+code="$(cds_write DELETE /allowlist/digests "$WORKDIR/del.json")"
+[ "$code" = "204" ] || fail "signed allowlist delete: want HTTP 204, got $code"
+if curl -sSk "https://127.0.0.1:$CDS_LOCAL_PORT/allowlist" | grep -q "$THROWAWAY_DIGEST"; then
+    fail "deleted digest still served from /allowlist"
+fi
+pass "signed allowlist write + delete round-trip through CDS"
+
+log "Confidential workload"
+kubectl apply -f test/integration/cluster/manifests/workload.yaml
+# Webhook injection: the pod template gains the get-cert sidecar and the cw label.
+for _ in $(seq 1 30); do
+    POD="$(kubectl -n demo get pod -l app=serving -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)" && [ -n "$POD" ] && break
+    sleep 1
+done
+[ -n "$POD" ] || fail "demo workload pod never appeared"
+INIT_NAMES="$(kubectl -n demo get pod "$POD" -o jsonpath='{.spec.initContainers[*].name}')"
+case "$INIT_NAMES" in
+    *c8s-cert*c8s-cert-wait*) : ;;
+    *) fail "webhook did not inject the get-cert containers (init: $INIT_NAMES)" ;;
+esac
+LABELS="$(kubectl -n demo get pod "$POD" --show-labels --no-headers | awk '{print $NF}')"
+case "$LABELS" in
+    *confidential.ai/cw=vllm*) : ;;
+    *) fail "webhook did not stamp the cw label (labels: $LABELS)" ;;
+esac
+pass "webhook injected c8s-cert + c8s-cert-wait and stamped confidential.ai/cw=vllm"
+
+# The operator provisions the workload's headless Service.
+for _ in $(seq 1 30); do
+    kubectl -n demo get svc c8s-vllm >/dev/null 2>&1 && break
+    sleep 1
+done
+CLUSTERIP="$(kubectl -n demo get svc c8s-vllm -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)"
+[ "$CLUSTERIP" = "None" ] || fail "c8s-vllm is not a headless Service (clusterIP: $CLUSTERIP)"
+pass "operator provisioned headless Service c8s-vllm"
+
+# get-cert redeems a sandbox token from the node inventory and CDS issues the
+# workload's leaf — the workload-digest claims flow, fail-closed without the
+# NRI plugin.
+for _ in $(seq 1 60); do
+    kubectl -n demo logs "$POD" -c c8s-cert 2>/dev/null | grep -q "certificate obtained" && break
+    sleep 2
+done
+CERTLOG="$(kubectl -n demo logs "$POD" -c c8s-cert 2>/dev/null || true)"
+echo "$CERTLOG" | grep -q "certificate obtained" || fail "get-cert never obtained a certificate: $CERTLOG"
+echo "$CERTLOG" | grep -q "sandbox_token=true" || fail "get-cert issued without a sandbox token: $CERTLOG"
+pass "workload leaf issued with a sandbox-identity token (NRI inventory + CDS callback)"
+
+kubectl -n demo wait --for=condition=Ready "pod/$POD" --timeout=240s \
+    || fail "workload pod never became Ready"
+pass "workload pod Running behind the full injection + admission path"
+
+# The issued leaf is bound to the workload's in-cluster DNS identity.
+kubectl -n demo exec "$POD" -c app -- cat /etc/c8s/certs/tls.crt > "$WORKDIR/leaf.pem" 2>/dev/null \
+    || fail "could not read the issued leaf from the workload pod"
+SAN="$(openssl x509 -in "$WORKDIR/leaf.pem" -noout -ext subjectAltName 2>/dev/null || true)"
+echo "$SAN" | grep -q "DNS:c8s-vllm.demo.svc" || fail "leaf SAN is not the workload identity: $SAN"
+pass "issued leaf carries SAN c8s-vllm.demo.svc"
+
+log "Admission rejections"
+cat > "$WORKDIR/bad-label.yaml" <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-label
+  namespace: demo
+  labels:
+    confidential.ai/cw: rogue
+spec:
+  containers:
+    - { name: app, image: nginx:1.27-alpine }
+EOF
+OUT="$(kubectl apply -f "$WORKDIR/bad-label.yaml" 2>&1 || true)"
+echo "$OUT" | grep -q "must match" || fail "cw label/annotation mismatch not rejected: $OUT"
+pass "pod with an unmatching cw label rejected at admission"
+
+cat > "$WORKDIR/bad-hostnet.yaml" <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bad-hostnet
+  namespace: demo
+spec:
+  hostNetwork: true
+  containers:
+    - { name: app, image: nginx:1.27-alpine }
+EOF
+OUT="$(kubectl apply -f "$WORKDIR/bad-hostnet.yaml" 2>&1 || true)"
+echo "$OUT" | grep -q "c8s-deny-host-namespaces" || fail "hostNetwork tenant pod not rejected: $OUT"
+pass "hostNetwork tenant pod rejected by the host-namespace policy"
+
+log "Image admission (NRI fail-closed)"
+cat > "$WORKDIR/denied.yaml" <<'EOF'
+apiVersion: v1
+kind: Pod
+metadata:
+  name: denied
+  namespace: demo
+spec:
+  containers:
+    - { name: app, image: curlimages/curl:8.10.1, command: ["sleep", "3600"] }
+EOF
+# The curl image was never seeded into the floor, so the plugin denies it
+# from the start — no delete, no pull-interval race.
+CURL_DIGEST="$(awk -F'\t' -v ref="docker.io/$CURL_IMAGE" '$2 == ref {print $1; exit}' "$WORKDIR/floor.tsv")"
+[ -n "$CURL_DIGEST" ] || fail "curl image digest not resolved"
+kubectl apply -f "$WORKDIR/denied.yaml"
+DENIED=""
+for _ in $(seq 1 45); do
+    if kubectl -n demo get events --field-selector involvedObject.name=denied -o jsonpath='{.items[*].message}' 2>/dev/null | grep -q "image not in allowlist"; then
+        DENIED=1
+        break
+    fi
+    sleep 2
+done
+[ -n "$DENIED" ] || fail "non-allowlisted image was not NRI-denied"
+pass "non-allowlisted image denied at container creation (fail-closed)"
+
+# Allow, and the same pod proceeds.
+printf '{"digest":"%s","image":"docker.io/%s"}' "$CURL_DIGEST" "$CURL_IMAGE" > "$WORKDIR/add-curl.json"
+code="$(cds_write POST /allowlist/digests "$WORKDIR/add-curl.json")"
+[ "$code" = "204" ] || fail "signed allowlist re-add: want HTTP 204, got $code"
+# kubelet's CreateContainerError backoff stretches into the minutes, so this
+# wait must comfortably outlive it.
+kubectl -n demo wait --for=condition=Ready pod/denied --timeout=360s \
+    || fail "pod still blocked after its image was allowlisted"
+pass "signed allowlist write flips a denied pod to Running (plugin pulled the update)"
+
+# run_pod <ns> <name> <shell command>: run a curl-image pod to completion and
+# print its stdout. Exit status is swallowed; callers assert on the output, so
+# reachable (200) and dropped (rc=28) outcomes are both observable. Only for
+# calls whose routing does not depend on the caller's pod IP (metrics scrapes
+# dial the node, which the mesh never intercepts).
+run_pod() {
+    local ns="$1" name="$2" cmd="$3" phase
+    kubectl delete pod "$name" -n "$ns" --ignore-not-found >/dev/null 2>&1 || true
+    kubectl run "$name" -n "$ns" --restart=Never --image="$CURL_IMAGE" --command -- sh -c "$cmd" >/dev/null
+    for _ in $(seq 1 60); do
+        phase="$(kubectl get pod "$name" -n "$ns" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+        case "$phase" in Succeeded|Failed) break ;; esac
+        sleep 2
+    done
+    kubectl logs "$name" -n "$ns" 2>/dev/null || true
+    kubectl delete pod "$name" -n "$ns" --ignore-not-found >/dev/null 2>&1 || true
+}
+
+# mesh_metric <pattern>: sum the matching series of the node's ratls-mesh
+# /metrics (hostNetwork). A missing series reads as 0.
+mesh_metric() {
+    run_pod default it-mesh-metrics "curl -sf --max-time 10 http://$NODE_IP:15021/metrics" \
+        | awk -v pat="$1" '$0 ~ pat {sum += $NF} END {print sum+0}'
+}
+
+# await_metric_above <pattern> <baseline> <what>
+await_metric_above() {
+    local pattern="$1" baseline="$2" what="$3" v
+    for _ in $(seq 1 18); do
+        v="$(mesh_metric "$pattern")"
+        [ "${v:-0}" -gt "$baseline" ] && return 0
+        sleep 5
+    done
+    fail "$what: no increase above baseline $baseline within 90s"
+}
+
+# await_ipset <set> <ip>: the mesh syncs pod IPs into its ipsets on a ~30s
+# tick; dialing before the client pod lands in RATLS-MESH-LOCAL-PODS bypasses
+# interception entirely, so gate every mesh assertion on membership. The kind
+# node has no ipset CLI; the mesh's iptables-sync container does and shares
+# the node's network namespace.
+MESH_POD=""
+await_ipset() {
+    local set="$1" ip="$2"
+    if [ -z "$MESH_POD" ]; then
+        MESH_POD="$(kubectl -n "$NS" get pod -l app=c8s-ratls-mesh -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+        [ -n "$MESH_POD" ] || fail "ratls-mesh pod not found"
+    fi
+    for _ in $(seq 1 18); do
+        kubectl -n "$NS" exec "$MESH_POD" -c iptables-sync -- ipset test "$set" "$ip" 2>/dev/null && return 0
+        sleep 5
+    done
+    fail "$ip never appeared in ipset $set"
+}
+
+log "Mesh"
+# Mirrored from test/e2e/mesh-cw-enforcement.sh: a direct pod-IP dial from a
+# meshed namespace is intercepted and wrapped (the inbound counter moves);
+# the bypasses that skip interception — a Service VIP, a dial from a
+# mesh-excluded namespace — must never reach the workload in plaintext.
+NODE_IP="$(kubectl get node "$NODE" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')"
+POD_IP="$(kubectl -n demo get pod "$POD" -o jsonpath='{.status.podIP}')"
+[ -n "$NODE_IP" ] && [ -n "$POD_IP" ] || fail "could not resolve node or workload pod IP"
+
+kubectl run it-mesh-client --restart=Never --image="$CURL_IMAGE" --command -- sleep 1200 >/dev/null
+kubectl wait --for=condition=Ready pod/it-mesh-client --timeout=120s || fail "mesh client pod not Ready"
+CLIENT_IP="$(kubectl get pod it-mesh-client -o jsonpath='{.status.podIP}')"
+await_ipset RATLS-MESH-LOCAL-PODS "$CLIENT_IP"
+await_ipset RATLS-MESH-CW-PODS "$POD_IP"
+
+inbound='^ratls_mesh_connections_total.*direction="inbound"'
+base_inbound="$(mesh_metric "$inbound")"
+code="$(kubectl exec it-mesh-client -- curl -sS -o /dev/null -w '%{http_code}' --max-time 10 "http://$POD_IP:80/" || true)"
+[ "$code" = "200" ] || fail "pod-IP request to the cw workload failed (got $code); the mesh-wrapped path must work"
+await_metric_above "$inbound" "${base_inbound:-0}" "mesh inbound connection counter"
+pass "pod-IP dial to the cw workload is mesh-wrapped (inbound counter moved)"
+
+# Service VIP over the cw pods: the mesh skips ClusterIPs by design, so the
+# hop must fail closed or ride the mesh — never plaintext (see below).
+cat > "$WORKDIR/vip-svc.yaml" <<'EOF'
+apiVersion: v1
+kind: Service
+metadata:
+  name: it-cw-vip
+  namespace: demo
+spec:
+  type: ClusterIP
+  selector:
+    confidential.ai/cw: vllm
+  ports:
+    - { port: 80, targetPort: 80 }
+EOF
+kubectl apply -f "$WORKDIR/vip-svc.yaml"
+VIP="$(kubectl -n demo get svc it-cw-vip -o jsonpath='{.spec.clusterIP}')"
+for _ in $(seq 1 30); do
+    kubectl get endpointslices -n demo -l kubernetes.io/service-name=it-cw-vip \
+        -o jsonpath='{.items[*].endpoints[*].addresses[*]}' 2>/dev/null | grep -q . && break
+    sleep 2
+done
+# Two secure outcomes, depending on which nat PREROUTING rule runs first:
+# mesh-first -> the VIP matches no pod-IP rule, kube-proxy DNATs, the FORWARD
+# guard DROPs (curl rc 28); kube-proxy-first -> the DNAT'd packet matches the
+# mesh's pod-IP interception and the hop is WRAPPED (rc 0, inbound counter
+# moves). The insecure outcome is plaintext, which no counter move proves.
+drops='^ratls_mesh_iptables_cw_inbound_drops_total'
+base_drops="$(mesh_metric "$drops")"
+base_inbound_vip="$(mesh_metric "$inbound")"
+out="$(kubectl exec it-mesh-client -- sh -c "curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://$VIP:80/; echo rc=\$?" || true)"
+rc="$(echo "$out" | grep -o 'rc=[0-9]*' | cut -d= -f2)"
+case "$rc" in
+    28)
+        await_metric_above "$drops" "${base_drops:-0}" "cw inbound drop counter"
+        pass "Service-VIP plaintext bypass dropped by the cw inbound guard (counter moved)"
+        ;;
+    0)
+        echo "$out" | grep -q "^200" || fail "VIP dial rc=0 but no 200: $out"
+        await_metric_above "$inbound" "${base_inbound_vip:-0}" "mesh inbound counter (VIP hop wrapped)"
+        pass "Service-VIP dial wrapped by the mesh (inbound counter moved; rule-ordering variant)"
+        ;;
+    *)
+        fail "VIP bypass to the cw workload: want rc=28 (dropped) or rc=0 (wrapped), got rc=$rc"
+        ;;
+esac
+
+# A mesh-excluded namespace (kube-system) is not intercepted; its direct dial
+# to the cw pod IP falls through to the FORWARD guard.
+kubectl run it-mesh-excl -n kube-system --restart=Never --image="$CURL_IMAGE" --command -- sleep 600 >/dev/null
+kubectl wait --for=condition=Ready pod/it-mesh-excl -n kube-system --timeout=120s \
+    || fail "excluded-namespace client pod not Ready"
+out="$(kubectl exec -n kube-system it-mesh-excl -- sh -c "curl -s -o /dev/null --max-time 5 http://$POD_IP:80/; echo rc=\$?" || true)"
+rc="$(echo "$out" | grep -o 'rc=[0-9]*' | cut -d= -f2)"
+[ "$rc" = "28" ] || fail "excluded-namespace bypass to the cw workload: want curl rc=28 (DROP timeout), got rc=$rc"
+pass "excluded-namespace plaintext bypass dropped by the cw inbound guard"
+
+log "tls-lb front door"
+kubectl -n "$NS" exec deploy/c8s-tls-lb -c nginx -- cat /tls/ca.pem > "$WORKDIR/mesh-ca.pem" \
+    || fail "could not read the mesh CA from tls-lb"
+kubectl create configmap it-mesh-ca --from-file=ca.pem="$WORKDIR/mesh-ca.pem"
+cat > "$WORKDIR/curl-lb.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: it-curl-lb
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: $CURL_IMAGE
+      command: ["curl", "-sS", "--cacert", "/ca/ca.pem", "https://c8s-tls-lb.$NS.svc/healthz"]
+      volumeMounts:
+        - { name: ca, mountPath: /ca }
+  volumes:
+    - name: ca
+      configMap: { name: it-mesh-ca }
+EOF
+kubectl apply -f "$WORKDIR/curl-lb.yaml"
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/it-curl-lb --timeout=120s \
+    || fail "front-door healthz request failed"
+[ "$(kubectl logs it-curl-lb)" = "ok" ] || fail "front-door /healthz did not return ok"
+pass "tls-lb front door serves HTTPS verified against the CDS mesh CA"
+
+log "Workload adoption"
+kubectl apply -f test/integration/cluster/manifests/adopt-me.yaml
+kubectl -n adopted wait --for=condition=Available deploy/web --timeout=120s \
+    || fail "adoption fixture never became Available"
+./build/c8s install --namespace "$NS" --cvm-mode=node --hardware-platform=sev-snp \
+    --single-node --resolve-digests=false --image-tag="$IMAGE_TAG" \
+    --operator-keys "$WORKDIR/operator-pub.pem" \
+    --measurements "$MOCK_MEASUREMENT" \
+    --workload-ref web=adopted/deployment/web:80 --upstream web \
+    -f "$WORKDIR/values.yaml" --wait || fail "c8s install --workload-ref failed"
+TMPL_ANNOTATION="$(kubectl -n adopted get deploy web -o jsonpath='{.spec.template.metadata.annotations.confidential\.ai/cw}')"
+[ "$TMPL_ANNOTATION" = "web" ] || fail "adopted workload template not stamped (got: $TMPL_ANNOTATION)"
+kubectl -n adopted rollout status deploy/web --timeout=300s || fail "adopted workload never rolled out"
+pass "install adopted a running workload (template stamped, rollout injected)"
+
+# The status mirror aggregates a user-declared ConfidentialWorkload CR over
+# the cw-labeled pods (kubectl get cwl).
+cat > "$WORKDIR/cw.yaml" <<'EOF'
+apiVersion: confidential.ai/v1alpha2
+kind: ConfidentialWorkload
+metadata:
+  name: web
+  namespace: adopted
+spec:
+  workloadRef:
+    kind: Deployment
+    name: web
+EOF
+kubectl apply -f "$WORKDIR/cw.yaml"
+SUMMARY=""
+for _ in $(seq 1 30); do
+    SUMMARY="$(kubectl -n adopted get cwl web -o jsonpath='{.status.attestationSummary.total}/{.status.attestationSummary.attested}' 2>/dev/null || true)"
+    [ "$SUMMARY" = "1/1" ] && break
+    sleep 2
+done
+[ "$SUMMARY" = "1/1" ] || fail "status mirror never reported the adopted workload (got: $SUMMARY)"
+pass "status mirror reports the adopted workload (attestationSummary 1/1)"
+
+# tls-lb now routes its catch-all to the adopted workload over the mesh.
+kubectl delete pod it-curl-lb 2>/dev/null || true
+cat > "$WORKDIR/curl-lb.yaml" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: it-curl-lb
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: $CURL_IMAGE
+      command: ["curl", "-sS", "--cacert", "/ca/ca.pem", "https://c8s-tls-lb.$NS.svc/"]
+      volumeMounts:
+        - { name: ca, mountPath: /ca }
+  volumes:
+    - name: ca
+      configMap: { name: it-mesh-ca }
+EOF
+kubectl apply -f "$WORKDIR/curl-lb.yaml"
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/it-curl-lb --timeout=120s \
+    || fail "front-door request to the adopted workload failed"
+kubectl logs it-curl-lb | grep -q "Welcome to nginx" \
+    || fail "front door did not proxy the adopted workload: $(kubectl logs it-curl-lb)"
+pass "tls-lb routes the front door to the adopted workload over the mesh"
+
+log "Uninstall"
+./build/c8s uninstall --namespace "$NS" || fail "c8s uninstall failed"
+if helm -n "$NS" list -q | grep -q c8s; then
+    fail "helm release still present after uninstall"
+fi
+if kubectl get mutatingwebhookconfiguration c8s-pod-injector >/dev/null 2>&1; then
+    fail "mutating webhook config left behind after uninstall"
+fi
+if kubectl get validatingadmissionpolicy c8s-deny-host-namespaces >/dev/null 2>&1; then
+    fail "ValidatingAdmissionPolicies left behind after uninstall"
+fi
+pass "uninstall removes the release, webhook, and admission policies"
+
+echo ""
+echo "=== All $CHECKS cluster integration checks passed ==="


### PR DESCRIPTION
…ation

CI integration coverage stopped at the get-cert RA-TLS flow (docker-compose) and doc-command parity against a dead kubeconfig: nothing ran c8s install against a live API server or exercised admission, image policy, the mesh, or workload operation without TEE hardware.

test/integration/cluster boots a single-node kind cluster on the CI runner, builds the component images from the checkout, and runs the real `c8s install --cvm-mode=node`. The TEE is substituted at exactly one point: test/mock-attestation serves synthetic SNP reports (all-zero launch digest) on the node IP :8400, the address node-mode consumers dial for the node-baked api, so get-cert, CDS, ratls-mesh, and the NRI plugin — all of which delegate verification to the attestation-api — work unchanged, with the zero digest pinned via --measurements like a production measurement. The NRI installer DaemonSet is rendered from the chart and applied out-of-band (node mode bakes the plugin into the node image in production), so image admission runs against a real containerd, including the installer's containerd restart. The install-time allowlist floor is generated from the node's containerd store because policy.enforceExisting checks already-running containers against it.

In-process hardware verification (`c8s verify`, the `c8s allowlist` CLI) cannot pass synthetic evidence by design; the allowlist write path is exercised server-side instead — optoken signs with the production pkg/operatorauth signer and CDS performs its full token verification. TEE properties stay with the metal lanes.

23 checks: install with preflights/CRDs/webhook/ValidatingAdmission- Policies; allowlist auth (unsigned and wrong-key 401, pinned-key write/delete round-trip); webhook injection and headless-Service provisioning; workload leaf issuance with sandbox-identity claims and the in-cluster DNS SAN; cw-label and host-namespace rejections; NRI fail-closed denial flipping to Running after a signed allowlist write; mesh wrap plus VIP/excluded-namespace bypass never plaintext, proven by the mesh's own counters (mirrors test/e2e/mesh-cw-enforcement.sh); tls-lb front door verified against the CDS mesh CA; --workload-ref adoption with status-mirror aggregation and front-door routing; and uninstall hygiene.

Runs as the Integration (cluster) job in ci.yml (kind binary pinned by sha256, node image pinned by digest); `make test-integration-cluster` locally. docs/integration-tests.md maps the tiers and the non-goals.