### PR TITLE
build: digest-pin every Dockerfile base

### DIFF
--- a/cmd/c8s/Dockerfile
+++ b/cmd/c8s/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static:nonroot
+# Bump: crane digest gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot@sha256:f7f8f729987ad0fdf6b05eeeae94b26e6a0f613bdf46feea7fc40f7bd72953e6
 
 # The `/c8s` binary path is hardcoded in the c8s-cert-wait gate command
 # (internal/helmchart/c8s/templates/_helpers.tpl "c8s.getCertContainers" and

--- a/cmd/cds/Dockerfile
+++ b/cmd/cds/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static-debian12
+# Bump: crane digest gcr.io/distroless/static-debian12:latest
+FROM gcr.io/distroless/static-debian12:latest@sha256:6447365a6337c3732f412d1b74357b30a633831955b2bc45552b0086be907687
 
 COPY build/c8s /c8s
 

--- a/cmd/get-cert/Dockerfile
+++ b/cmd/get-cert/Dockerfile
@@ -1,4 +1,5 @@
-FROM gcr.io/distroless/static-debian12
+# Bump: crane digest gcr.io/distroless/static-debian12:latest
+FROM gcr.io/distroless/static-debian12:latest@sha256:6447365a6337c3732f412d1b74357b30a633831955b2bc45552b0086be907687
 
 COPY build/c8s /c8s
 

--- a/cmd/nri-image-policy/Dockerfile
+++ b/cmd/nri-image-policy/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm-slim
+# Bump: crane digest debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/cmd/ratls-mesh/Dockerfile
+++ b/cmd/ratls-mesh/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm-slim
+# Bump: crane digest debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \

--- a/cmd/volumed/Dockerfile
+++ b/cmd/volumed/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:bookworm-slim
+# Bump: crane digest debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:abd67ffcfa541b485a3dff59865ab629aa048a6c613e639d36e7456b0b229241
 
 # cryptsetup-bin provides cryptsetup AND veritysetup, the two tools the daemon
 # shells out to (internal/cmds/volumed/systemops.go). The mount itself is a

--- a/test/mock-attestation/Dockerfile
+++ b/test/mock-attestation/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26 AS builder
+# Bump: crane digest golang:1.26
+FROM golang:1.26@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac AS builder
 
 WORKDIR /src
 # Repo-root build context (the module replaces c8s => ../..); #13's .dockerignore must keep these paths.
@@ -7,6 +8,7 @@ COPY pkg/ ./pkg/
 COPY test/mock-attestation/ ./test/mock-attestation/
 RUN CGO_ENABLED=0 go build -C test/mock-attestation -ldflags="-s -w" -o /mock-attestation .
 
-FROM gcr.io/distroless/static-debian12
+# Bump: crane digest gcr.io/distroless/static-debian12:latest
+FROM gcr.io/distroless/static-debian12:latest@sha256:6447365a6337c3732f412d1b74357b30a633831955b2bc45552b0086be907687
 COPY --from=builder /mock-attestation /mock-attestation
 ENTRYPOINT ["/mock-attestation"]

--- a/test/mock-cds/Dockerfile
+++ b/test/mock-cds/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.26 AS builder
+# Bump: crane digest golang:1.26
+FROM golang:1.26@sha256:45a5f7a810238aabcbad211d70b9ae082022d96f7c7259e94041ad1b933575ac AS builder
 
 WORKDIR /src
 # Repo-root build context (the module replaces c8s => ../..); #13's .dockerignore must keep these paths.
@@ -7,6 +8,7 @@ COPY pkg/ ./pkg/
 COPY test/mock-cds/ ./test/mock-cds/
 RUN CGO_ENABLED=0 go build -C test/mock-cds -ldflags="-s -w" -o /mock-cds .
 
-FROM gcr.io/distroless/static-debian12
+# Bump: crane digest gcr.io/distroless/static-debian12:latest
+FROM gcr.io/distroless/static-debian12:latest@sha256:6447365a6337c3732f412d1b74357b30a633831955b2bc45552b0086be907687
 COPY --from=builder /mock-cds /mock-cds
 ENTRYPOINT ["/mock-cds"]


### PR DESCRIPTION
## The problem

Zero of the repo's 8 Dockerfiles digest-pinned their base, and **four named no
tag at all**:

| file | was | tag? |
|---|---|---|
| `cmd/c8s/Dockerfile:1` | `gcr.io/distroless/static:nonroot` | yes |
| `cmd/cds/Dockerfile:1` | `gcr.io/distroless/static-debian12` | **no** |
| `cmd/get-cert/Dockerfile:1` | `gcr.io/distroless/static-debian12` | **no** |
| `cmd/{nri-image-policy,ratls-mesh,volumed}/Dockerfile:1` | `debian:bookworm-slim` | yes |
| `test/mock-{attestation,cds}/Dockerfile:1` | `golang:1.26` | yes |
| `test/mock-{attestation,cds}/Dockerfile:10` | `gcr.io/distroless/static-debian12` | **no** |

These are the runtime bases of attestation-gated components — `nri-image-policy`'s
image is in the measured allowlist floor — and `docker.yml`'s `type=gha` cache
means a repointed base can ride a warm layer unnoticed. The chart already does
this right for `kata-deploy`, `busybox`, `oras` and `nginx-unprivileged`
(`values.yaml:439+`, digest + one-line bump recipe). The images c8s builds
itself did not.

## The fix

Every `FROM` keeps its tag and gains the digest that tag resolves to today:

```dockerfile
# Bump: crane digest debian:bookworm-slim
FROM debian:bookworm-slim@sha256:abd67ffc…
```

Tag **and** digest, matching the chart's "bump in pairs" style: the tag keeps
the line readable and gives Dependabot both halves to compare. The four untagged
bases name `:latest` explicitly — that is the tag they were already resolving
through, so **no image changes here**; the pin only makes the current state
nameable.

The pinned digests are OCI *indexes* (verified: `debian:bookworm-slim` carries
386/amd64/arm/arm64/ppc64le), not single-arch manifests, so multi-arch builds
are unaffected.

Bump notes are one line each — `crane digest <image>:<tag>`. crane is already a
repo dependency (`internal/crane`; `c8s allowlist lint --online` requires it on
PATH), so this adds no new tool.

## Sequencing

3 of 3 for the pinning work. #425 adds the `docker` ecosystem to Dependabot,
which is what keeps these fresh — without it, a digest pin is a freeze. Merging
this **before** the pin-hygiene half of the action-pinning PR keeps that PR's
new Dockerfile check green.

## Acceptance criteria

- [x] Every Dockerfile `FROM` is digest-pinned (prod images and test mocks), with a one-line bump note.
- [x] No Dockerfile `FROM` lacks an `@sha256:` digest.
- [x] Nothing resolves through an implicit `:latest`.

## Testing

Digests resolved from the registries directly (`gcr.io` and `registry-1.docker.io`
manifest HEADs with an index-preferring `Accept`), so each is the same artifact
the tag serves right now.

**Not built locally** — there is no docker daemon in this environment. `docker.yml`
builds all six product images and the two mocks on PR, which is the real check;
worth watching that lane before merge.
