### PR TITLE
install: read the values file before deciding a pod install is unpinned

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -155,8 +155,7 @@ func chartComponents(ctx context.Context, chartPath string) ([]c8sComponent, err
 // file that could carry cds.operatorKeys — it requires --force, because the
 // resulting CDS has allowlist writes disabled and nobody could add/remove/upload
 // allowlist entries via `c8s allowlist`. When keys are supplied, or the operator
-// is managing values via -f, it is a no-op (consistent with the other -f-gated
-// preflights). It returns a warning to print when --force lets it pass.
+// is managing values via -f, it is a no-op.
 func operatorKeysPreflight(operatorKeys string, valuesFiles []string, force bool) (warn string, err error) {
 	if operatorKeys != "" || len(valuesFiles) > 0 {
 		return "", nil
@@ -174,15 +173,19 @@ func operatorKeysPreflight(operatorKeys string, valuesFiles []string, force bool
 // an unpinned CDS from inside a kata guest"): CDS and tls-lb come up, but no
 // confidential.ai/cw pod ever gets a leaf, and the refusal is only visible in an
 // init container's log inside a locked guest. Requiring --force here surfaces
-// that before the install. -f owners may carry cds.measurements in their values
-// file, so it is a no-op for them (consistent with the other -f-gated
-// preflights). It returns a warning to print when --force lets it pass.
+// that before the install. Satisfied by --measurements or by a -f values file
+// that sets a non-empty cds.measurements. It returns a warning to print when
+// --force lets it pass.
 func podModeMeasurementsPreflight(cvmMode string, measurements []string, valuesFiles []string, force bool) (warn string, err error) {
-	if !cvmModeIsPod(cvmMode) || len(measurements) > 0 || len(valuesFiles) > 0 {
+	if !cvmModeIsPod(cvmMode) || len(measurements) > 0 {
 		return "", nil
 	}
+	set, err := valuesFilesSetMeasurements(valuesFiles)
+	if err != nil || set {
+		return "", err
+	}
 	if !force {
-		return "", fmt.Errorf("--cvm-mode=pod without --measurements: the injected get-cert refuses to reach an unpinned CDS from inside a kata guest, so no confidential.ai/cw workload can start. Re-run with --measurements <kata guest launch digest> (read it from a running cluster with `c8s verify https://<tls-lb> --kind lb`), or --force to install anyway (CDS/tls-lb only; no cw workloads until you reinstall pinned)")
+		return "", fmt.Errorf("--cvm-mode=pod without a pinned CDS measurement: the injected get-cert refuses to reach an unpinned CDS from inside a kata guest, so no confidential.ai/cw workload can start. Re-run with --measurements <kata guest launch digest> (read it from a running cluster with `c8s verify https://<tls-lb> --kind lb`), set a non-empty cds.measurements in a -f values file, or --force to install anyway (CDS/tls-lb only; no cw workloads until you reinstall pinned)")
 	}
 	return "installing --cvm-mode=pod with no --measurements: CDS and tls-lb will run, but no confidential.ai/cw workload can obtain a certificate until you reinstall with --measurements", nil
 }
@@ -874,6 +877,25 @@ func valuesFilesSetDistro(files []string) (bool, error) {
 		}
 		for _, path := range []string{"kata.distro", "nriImagePolicy.distro"} {
 			if v, err := stringAtPath(tree, path); err == nil && v != "" {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// valuesFilesSetMeasurements reports whether any -f values file pins a CDS
+// launch measurement. cds.measurements is the one the injected get-cert reads,
+// so it alone decides whether a pod-mode install is pinned; ratlsMesh.measurements
+// travels with it but does not substitute for it.
+func valuesFilesSetMeasurements(files []string) (bool, error) {
+	for _, f := range files {
+		tree, err := decodeValuesFile(f)
+		if err != nil {
+			return false, err
+		}
+		if v, ok := valueAtPath(tree, "cds.measurements"); ok {
+			if list, isList := v.([]any); isList && len(list) > 0 {
 				return true, nil
 			}
 		}

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -44,9 +44,25 @@ func TestPodModeMeasurementsPreflight(t *testing.T) {
 	if warn, err := podModeMeasurementsPreflight("pod", nil, nil, true); err != nil || warn == "" {
 		t.Fatalf("pod + no measurements + force: want warn and no error, got warn=%q err=%v", warn, err)
 	}
-	// -f supplied → operator owns cds.measurements in their values file; no gate.
-	if warn, err := podModeMeasurementsPreflight("pod", nil, []string{"custom.yaml"}, false); err != nil || warn != "" {
-		t.Fatalf("-f supplied: want no error/warn, got warn=%q err=%v", warn, err)
+	// -f that pins cds.measurements → satisfied, no gate.
+	pinned := writeValuesFile(t, "cds:\n  measurements:\n    - \"ab\"\n")
+	if warn, err := podModeMeasurementsPreflight("pod", nil, []string{pinned}, false); err != nil || warn != "" {
+		t.Fatalf("-f with cds.measurements: want no error/warn, got warn=%q err=%v", warn, err)
+	}
+
+	// A -f that carries other values but no measurement is the hole this
+	// preflight had: helm renders it green and no cw workload ever gets a leaf.
+	for _, body := range []string{
+		"cds:\n  port: 8443\n",
+		"cds:\n  measurements: []\n",
+	} {
+		f := writeValuesFile(t, body)
+		if _, err := podModeMeasurementsPreflight("pod", nil, []string{f}, false); err == nil {
+			t.Fatalf("-f %q: expected the unpinned-CDS refusal", body)
+		}
+		if warn, err := podModeMeasurementsPreflight("pod", nil, []string{f}, true); err != nil || warn == "" {
+			t.Fatalf("-f %q with --force: want warn and no error, got warn=%q err=%v", body, warn, err)
+		}
 	}
 }
 
@@ -64,6 +80,8 @@ func TestOperatorKeysPreflight(t *testing.T) {
 		t.Fatalf("no keys + force: want warn and no error, got warn=%q err=%v", warn, err)
 	}
 	// -f supplied → operator owns cds.operatorKeys in their values file; no gate.
+	// This is the same hole podModeMeasurementsPreflight just lost; closing it
+	// here is a separate change (five exec tests install through it today).
 	if warn, err := operatorKeysPreflight("", []string{"custom.yaml"}, false); err != nil || warn != "" {
 		t.Fatalf("-f supplied: want no error/warn, got warn=%q err=%v", warn, err)
 	}

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -75,9 +75,9 @@ injected get-cert runs inside a kata guest whose argv the host writes, so it
 refuses to dial an unpinned CDS; an unpinned pod-mode cluster brings up CDS
 and tls-lb but no `confidential.ai/cw` workload ever obtains a certificate,
 and the refusal is only visible in an init container's log inside a locked
-guest. `c8s install` therefore refuses a pod-mode install with no
-`--measurements` (and no `-f` values file that could carry
-`cds.measurements`) unless you pass `--force`, which installs the control
+guest. `c8s install` therefore refuses a pod-mode install that pins no CDS
+measurement — neither `--measurements` nor a non-empty `cds.measurements` in
+a `-f` values file — unless you pass `--force`, which installs the control
 plane only. Under SNP the value comes from `c8s kata measure`; under TDX,
 until the guest image publishes its predicted MRTD, read it from a running
 cluster with `c8s verify https://<tls-lb> --kind lb` and reinstall pinned.


### PR DESCRIPTION
## The problem

`podModeMeasurementsPreflight` (`install.go:181`) skipped itself whenever any
`-f` was passed:

```go
if !cvmModeIsPod(cvmMode) || len(measurements) > 0 || len(valuesFiles) > 0 {
    return "", nil
}
```

The reasoning at the time (#388) was that a values-file owner may carry
`cds.measurements` themselves. Most do not. So:

```
c8s install --cvm-mode=pod -f cluster.yaml     # no measurement anywhere
```

installs **green** — CDS Ready, tls-lb Ready, `helm --wait` satisfied — and then
no `confidential.ai/cw` workload ever obtains a leaf, because the injected
get-cert refuses to dial an unpinned CDS from inside a kata guest. That refusal
is visible only in an init container's log inside a locked guest. The preflight
exists to surface exactly this before the install, and the one flag most real
installs pass turned it off.

## The fix

It reads the file. A non-empty `cds.measurements` in any `-f` satisfies the
preflight; anything else takes the same refusal the flagless path takes:

| `-f` contents | before | after |
|---|---|---|
| `cds.measurements: ["ab"]` | pass | pass |
| `cds.port: 8443` (no measurement) | **pass** | refuse (or `--force`) |
| `cds.measurements: []` | **pass** | refuse (or `--force`) |
| *(no `-f`, no `--measurements`)* | refuse | refuse |

The scan is the narrow `decodeValuesFile` + `valueAtPath` shape already used by
`valuesFilesSetDistro` and `valuesFilesSetTEESelector`, so the preflight stays
where it is — ahead of the helm invocation — rather than waiting on
`effectiveValues`, which shells out to `helm show values` and is not computed
until 140 lines later.

**`cds.measurements` alone decides it.** That is the value the injected get-cert
reads. `ratlsMesh.measurements` travels with it (the CLI's `--measurements` sets
both), but a values file pinning only the mesh still leaves get-cert dialling an
unpinned CDS, so it does not substitute.

`--force` is unchanged and still installs with the loud warning.

## The identical hole next door, deliberately left

`operatorKeysPreflight` (`install.go:161`) has the same `len(valuesFiles) > 0`
skip. I implemented the same fix for it and backed it out: **five exec tests
install through that hole today** (`TestInstallValuesFromStdin`,
`TestInstallHostedLaneKeepsOperatorExemptNamespaces`,
`TestInstallRefusesPolicyDenyingPlatformPods`,
`TestInstallAuditPolicySkipsPlatformPodCheck`,
`TestInstallHostedLaneKeepsExemptNamespacesFromStdin`), which means real `-f`
flows are silently installing with allowlist writes disabled too.

That is a wider behaviour change than this issue's acceptance criteria name, and
it deserves its own PR where those five test updates are the visible subject
rather than collateral. Flagged rather than folded in. The comment at the
`operatorKeysPreflight` test now says so.

## Acceptance criteria

- [x] `c8s install` with an empty `cds.measurements` fails without `--force`, naming the flag and what it disables.
- [x] With `--force` → allowed, with a loud warning.
- [x] `docs/kata.md` updated to match.
- [ ] `secrets put` / allowlist writes against an unpinned CDS — separate PR.
- [ ] Default-deny NetworkPolicies — separate PR.

## Testing

`go test ./cmd/c8s/` green (7.2s, whole package). `TestPodModeMeasurementsPreflight`
gains the two cases that were the hole — a `-f` carrying unrelated values, and a
`-f` with an explicitly empty list — each asserted both without and with `--force`.
