### PR TITLE
fix(cdsconn): refuse to sign for an unpinned CDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,14 @@ c8s allowlist upload allowlist.json \
 
 `--measurements` identifies the trusted build of the endpoint you connected
 to. For the default public route, use the tls-lb launch digest; the CLI reads
-tls-lb's discovery document and verifies its attestation automatically. An
-empty set accepts any attested endpoint and is unsafe outside development.
+tls-lb's discovery document and verifies its attestation automatically.
 Direct CDS URLs remain supported, in which case pin the CDS launch digest.
+
+An empty set accepts any attested endpoint. Reads run with a warning; anything
+that signs with the operator key — every `c8s allowlist` write and
+`c8s secrets put`/`explain` — is **refused**, because the credential and its
+payload would go to whatever answered. A plaintext `--insecure` dev endpoint is
+exempt: it already declares that nothing about it is attested.
 
 Do not point this CLI at tls-lb when `tlsLb.publicTLS.secretName` is set. That
 front door uses WebPKI (`public_tls.mode=webpki`), and its public certificate is

--- a/internal/cmds/allowlist/cmd_test.go
+++ b/internal/cmds/allowlist/cmd_test.go
@@ -347,7 +347,7 @@ func TestSignerPrefersFlagOverEnv(t *testing.T) {
 	keyPath := writeOperatorKey(t, dir)
 	t.Setenv(cdsconn.EnvOperatorKey, filepath.Join(dir, "nonexistent.key"))
 
-	o := &options{Options: cdsconn.Options{OperatorKey: keyPath}}
+	o := &options{Options: cdsconn.Options{OperatorKey: keyPath, Measurements: []string{"abababababababababababababababababababababababababababababababababababababababababababababababab"}}}
 	if _, err := o.signer(); err != nil {
 		t.Fatalf("flag should take precedence over (broken) env, got %v", err)
 	}
@@ -358,7 +358,7 @@ func TestSignerFallsBackToEnv(t *testing.T) {
 	keyPath := writeOperatorKey(t, dir)
 	t.Setenv(cdsconn.EnvOperatorKey, keyPath)
 
-	o := &options{} // no flags
+	o := &options{Options: cdsconn.Options{Measurements: []string{"abababababababababababababababababababababababababababababababababababababababababababababababab"}}} // no key flag
 	if _, err := o.signer(); err != nil {
 		t.Fatalf("env fallback should work, got %v", err)
 	}

--- a/internal/cmds/allowlist/read_write_test.go
+++ b/internal/cmds/allowlist/read_write_test.go
@@ -104,7 +104,7 @@ func TestSignerRejectsGarbagePEM(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a pem"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	o := &options{Options: cdsconn.Options{OperatorKey: path}}
+	o := &options{Options: cdsconn.Options{OperatorKey: path, Measurements: []string{"abababababababababababababababababababababababababababababababababababababababababababababababab"}}}
 	if _, err := o.signer(); err == nil || !strings.Contains(err.Error(), "load operator key") {
 		t.Fatalf("expected a key-parse error, got %v", err)
 	}

--- a/internal/cmds/cdsconn/cdsconn.go
+++ b/internal/cmds/cdsconn/cdsconn.go
@@ -138,7 +138,8 @@ func (o *Options) loadMeasurements() ([][]byte, error) {
 
 // Signer builds the operator credential from the flag or the environment. The
 // private key never leaves the CLI: it signs a short-lived token bound to the
-// exact method, path, and body of one write.
+// exact method, path, and body of one write. It refuses an unpinned endpoint —
+// see requirePinnedEndpoint.
 func (o *Options) Signer() (*operatorauth.Signer, error) {
 	keyPath := o.OperatorKey
 	if keyPath == "" {
@@ -155,7 +156,34 @@ func (o *Options) Signer() (*operatorauth.Signer, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load operator key: %w", err)
 	}
+	if err := o.requirePinnedEndpoint(); err != nil {
+		return nil, err
+	}
 	return signer, nil
+}
+
+// requirePinnedEndpoint refuses to mint an operator token for an endpoint whose
+// build is not pinned. RA-TLS proves the peer is *a* TEE, not that it is the CDS
+// this operator meant; with no --measurements, `c8s secrets put` hands a secret,
+// and `c8s allowlist` a policy change, to whatever attested thing answered the
+// URL. Reads stay a warning (HTTPClient): they carry no credential and no
+// payload, and refusing them would break discovery against a fresh cluster.
+//
+// A plaintext endpoint is left to HTTPClient, which refuses it outright without
+// --insecure and announces it with; adding a pinning complaint on top would only
+// bury the specific error under a general one.
+func (o *Options) requirePinnedEndpoint() error {
+	if u, err := url.Parse(o.URL); err == nil && u.Scheme == "http" {
+		return nil
+	}
+	measurements, err := o.loadMeasurements()
+	if err != nil {
+		return err
+	}
+	if len(measurements) == 0 {
+		return fmt.Errorf("refusing to authorize against an unpinned CDS: --measurements is empty, so any attested build would be accepted and this operator credential would be presented to it. Pass --measurements <endpoint build ID> (or --measurements-file); use the tls-lb value for a CDS-issued public TLS front door, the CDS value for a direct URL")
+	}
+	return nil
 }
 
 func (o *Options) verifyFunc() localverify.VerifyFunc {

--- a/internal/cmds/cdsconn/cdsconn_test.go
+++ b/internal/cmds/cdsconn/cdsconn_test.go
@@ -165,7 +165,7 @@ func TestSignerReadsTheEnvAndPrefersTheFlag(t *testing.T) {
 	key := writeTestKey(t)
 	t.Setenv(EnvOperatorKey, key)
 
-	var o Options
+	o := Options{Measurements: []string{"abababababababababababababababababababababababababababababababababababababababababababababababab"}}
 	if _, err := o.Signer(); err != nil {
 		t.Fatalf("env fallback: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestSignerRejectsGarbagePEM(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not a pem"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	o := Options{OperatorKey: path}
+	o := Options{OperatorKey: path, Measurements: []string{"abababababababababababababababababababababababababababababababababababababababababababababababab"}}
 	if _, err := o.Signer(); err == nil || !strings.Contains(err.Error(), "load operator key") {
 		t.Fatalf("expected a key-parse error, got %v", err)
 	}
@@ -226,4 +226,50 @@ func TestBindFlagsNamesEveryOption(t *testing.T) {
 	if o.URL != "https://cds.example" || o.OperatorKey != "/k.pem" {
 		t.Fatalf("parsed into %+v", o)
 	}
+}
+
+// An https CDS with no --measurements is attested but not identified: RA-TLS
+// proves the peer is a TEE, not that it is the CDS this operator meant. Reads
+// only warn, but a signed token hands `c8s secrets put`'s secret and
+// `c8s allowlist`'s policy change to whatever answered, so minting one is
+// refused outright.
+func TestSignerRefusesAnUnpinnedEndpoint(t *testing.T) {
+	key := writeTestKey(t)
+
+	o := Options{URL: "https://cds.example:8443", OperatorKey: key}
+	_, err := o.Signer()
+	if err == nil || !strings.Contains(err.Error(), "unpinned CDS") {
+		t.Fatalf("err = %v, want a refusal naming the unpinned CDS", err)
+	}
+	if !strings.Contains(err.Error(), "--measurements") {
+		t.Errorf("the refusal must name the flag that fixes it, got %q", err)
+	}
+
+	// Pinned by either flag.
+	o.Measurements = []string{strings.Repeat("ab", 48)}
+	if _, err := o.Signer(); err != nil {
+		t.Fatalf("--measurements should satisfy the pin, got %v", err)
+	}
+	o.Measurements = nil
+	o.MeasurementsFile = writeMeasurementsFile(t, strings.Repeat("cd", 48))
+	if _, err := o.Signer(); err != nil {
+		t.Fatalf("--measurements-file should satisfy the pin, got %v", err)
+	}
+
+	// Plaintext is HTTPClient's call, not this gate's: without --insecure it is
+	// refused there, and that error is the specific one.
+	o.MeasurementsFile = ""
+	o.URL = "http://cds.example:8080"
+	if _, err := o.Signer(); err != nil {
+		t.Fatalf("plaintext must fall through to the HTTPClient refusal, got %v", err)
+	}
+}
+
+func writeMeasurementsFile(t *testing.T, hexes ...string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "measurements.txt")
+	if err := os.WriteFile(p, []byte(strings.Join(hexes, "\n")+"\n"), 0o600); err != nil {
+		t.Fatalf("write measurements file: %v", err)
+	}
+	return p
 }


### PR DESCRIPTION
## The problem

`cdsconn.Options.HTTPClient` handled an empty `--measurements` like this:

```go
if len(measurements) == 0 {
    fmt.Fprintln(os.Stderr, "warning: no --measurements set; accepting any attested endpoint build (UNSAFE)")
}
```

…and carried on. RA-TLS proves the peer is *a* TEE. It does not prove it is the
CDS this operator meant. With no measurement pinned, `c8s secrets put` hands a
secret — and `c8s allowlist upload` a policy change — to whatever attested thing
answered the URL, together with an operator token minted for it.

Every operator command carrying connection flags was affected:
`allowlist add/remove/upload`, `allowlist workload apply/edit/delete`,
`secrets put`, `volume create`.

## The fix

The refusal lives in `Signer()`, not at each call site. A write *must* sign, so
one check covers all eight sites and a new subcommand cannot forget it:

```
$ c8s allowlist add sha256:… --url https://tls-lb.example --operator-key operator.key
Error: refusing to authorize against an unpinned CDS: --measurements is empty, so
any attested build would be accepted and this operator credential would be
presented to it. Pass --measurements <endpoint build ID> (or --measurements-file);
use the tls-lb value for a CDS-issued public TLS front door, the CDS value for a
direct URL
```

Three deliberate edges:

**Reads keep the warning.** They carry no credential and no payload, RA-TLS still
gives them integrity, and refusing them would break reading an allowlist off a
cluster before you know its measurement — which is how you *find* the
measurement.

**Plaintext falls through untouched.** `HTTPClient` already refuses `http://`
without `--insecure` and announces it with. Stacking a pinning complaint on top
would bury the specific error under a general one, which is what happened when I
first put the check ahead of the scheme handling —
`TestPutRefusesPlaintextWithoutInsecure` caught it.

**The check runs after the key loads,** so `operator key required` still wins
when both are missing. That is the more actionable of the two errors, and it
keeps the missing-key/bad-PEM tests asserting what they were written to assert.

## `secrets explain` is refused too

It is a read, but it signs. Under the rule "a credential only goes to a pinned
endpoint" it is refused, and I think that is correct rather than an oversight:
it presents the same operator credential to the same unidentified peer, and the
answer tells the peer which workload may read which secret path. Flagging it
because it is the one behaviour change here that is not a write.

## Acceptance criteria

- [x] `c8s secrets put` and `c8s allowlist` writes refuse an unpinned CDS — error, not warning.
- [x] Consistent across every operator command carrying connection flags (one gate in `Signer()`).
- [x] README updated: reads warn, anything that signs is refused, `--insecure` dev endpoints are exempt.
- [ ] Empty measurement set at install → separate PR (#428).
- [ ] Default-deny NetworkPolicies → separate PR.

## Testing

`go test ./internal/cmds/... ./cmd/...` green.
`TestSignerRefusesAnUnpinnedEndpoint` covers the refusal (and that it names the
flag), both satisfying flags (`--measurements`, `--measurements-file`), and the
plaintext fall-through.

Four existing `Signer` tests constructed `Options` with no endpoint at all and
now pass a measurement — they were exercising key loading, not connection
policy, and the diff shows exactly that.
