### PR TITLE
ci(c8s-image): say in the run name which instance builds

### DIFF
--- a/.github/workflows/c8s-image-publish.yml
+++ b/.github/workflows/c8s-image-publish.yml
@@ -3,6 +3,18 @@
 # builder with a read-only token and no inherited secrets.
 name: c8s-image
 
+# Every Docker run spawns one of these, PR runs included, and only the
+# main-push one builds — so a single merge produces one building run plus
+# several correctly-skipped siblings that are otherwise indistinguishable in
+# the UI and `gh run list` (same name, branch and SHA). Saying which is which
+# in the run name is what stops "my guest-image merge produced no image"
+# being the obvious-but-wrong reading of that list.
+run-name: >-
+  ${{ github.event_name == 'workflow_dispatch' && 'c8s-image (manual dispatch)'
+   || (github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main')
+      && 'c8s-image BUILDS (main push)'
+   || format('c8s-image skipped ({0} on {1}, not a main push)', github.event.workflow_run.event, github.event.workflow_run.head_branch) }}
+
 on:
   # build-c8s resolves cds:<sha> / nri-image-policy:<sha>, which Docker
   # publishes first. Gate on it so those digests exist.


### PR DESCRIPTION
## Problem

Docker runs on every PR as well as on main pushes, and every Docker run spawns a `c8s-image` `workflow_run`. Only the main-push one builds — the PR siblings skip by design, correctly.

The problem is they are indistinguishable. One merge produced this:

```
32311810294 workflow_run skipped     704abe4
32311750193 workflow_run (building)  704abe4   <-- the real one
32311643395 workflow_run skipped     704abe4
32311579731 workflow_run skipped     704abe4
32311571972 workflow_run skipped     704abe4
32311541838 workflow_run skipped     704abe4
```

Same name, same branch, same head SHA, six skips around one build. The obvious reading is "this merge produced no image" — which is false, and leads to dispatching a redundant manual build (I did exactly that while waiting on #419).

## Fix

Name each run for what it does:

- `c8s-image BUILDS (main push)`
- `c8s-image skipped (pull_request on <branch>, not a main push)`
- `c8s-image (manual dispatch)`

No behaviour change — the gating conditions are untouched, and this is presentation only. Both branches of the `&&`/`||` chain yield non-empty strings, so no operand can collapse.

Related: the `docker.yml` comment already documents why that workflow has no paths filter (a path gate there deletes the measured guest image and the SEV-SNP e2e for that merge). This is the same class of problem one layer down: the chain works, but its status was illegible.