### PR TITLE
chart: default-deny ingress for cds, operator, volumed and tls-lb

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -892,9 +892,13 @@ They are ingress-only. `ratls-mesh-tcp-only-egress` already selects every pod in
 the namespace and allows all TCP, and NetworkPolicies union, so an egress rule
 on one component would be allowed by that policy regardless.
 
-None of them restricts the *source* of a connection: the API server that dials
-the admission webhook has no address a selector can name, get-cert runs beside
-every adopted workload, and the CDS NodePort route arrives off-cluster.
+**None of them restricts the source of a connection** — no rule carries a
+`from`, so each one narrows which port answers, not who may connect. tls-lb is
+the public front door and stays reachable from off-cluster; the API server that
+dials the admission webhook has no address a selector could name; get-cert runs
+beside every adopted workload in every namespace; and the CDS NodePort route
+arrives off-cluster too. `c8s-volumed-ingress`, which has no `ingress:` rules at
+all, is the only one that refuses everything.
 
 **Opening another port.** Policies are additive, so apply your own
 `NetworkPolicy` selecting the same pods — there is nothing to disable first:

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -874,6 +874,52 @@ The injected get-cert containers also use a locked-down security context:
 - drops all Linux capabilities
 - `seccompProfile: RuntimeDefault`
 
+## Network policies
+
+The chart ships default-deny ingress for every component it runs. Each pod
+accepts only the ports it declares and nothing else on the pod network reaches
+it:
+
+| Policy | Selects | Accepts |
+|---|---|---|
+| `c8s-attestation-api` | attestation-api | nothing (it binds pod loopback) |
+| `c8s-cds-ingress` | cds | `cds.port` (RA-TLS; also the NodePort route) |
+| `c8s-operator-ingress` | operator | 9443 webhook, 8081 probes, 8080 metrics |
+| `c8s-volumed-ingress` | volumed | nothing (it serves a node-local Unix socket) |
+| `c8s-tls-lb-ingress` | tls-lb | `tlsLb.nginx.httpsPort` |
+
+They are ingress-only. `ratls-mesh-tcp-only-egress` already selects every pod in
+the namespace and allows all TCP, and NetworkPolicies union, so an egress rule
+on one component would be allowed by that policy regardless.
+
+None of them restricts the *source* of a connection: the API server that dials
+the admission webhook has no address a selector can name, get-cert runs beside
+every adopted workload, and the CDS NodePort route arrives off-cluster.
+
+**Opening another port.** Policies are additive, so apply your own
+`NetworkPolicy` selecting the same pods — there is nothing to disable first:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cds-extra-port
+  namespace: c8s-system
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: c8s
+      app.kubernetes.io/component: cds
+  policyTypes: [Ingress]
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 9000
+```
+
+These are inert on a cluster whose CNI does not enforce NetworkPolicy.
+
 ## Validation
 
 Run the full Go suite:

--- a/internal/helmchart/c8s/templates/component-ingress-policies.yaml
+++ b/internal/helmchart/c8s/templates/component-ingress-policies.yaml
@@ -1,0 +1,103 @@
+{{- /*
+Default-deny ingress for the components that had none: each pod accepts only
+the ports it declares, and nothing else on the pod network can reach it.
+
+Ingress only. NetworkPolicies union, and ratls-mesh's tcp-only-egress selects
+every pod in the namespace and allows all TCP, so an egress rule added here
+would be allowed by that one anyway.
+
+Escape hatch: policies are additive, so an operator who needs another port open
+applies their own NetworkPolicy selecting the same pods — nothing here has to be
+disabled first. See docs/operator.md.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "c8s.cdsName" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+    app.kubernetes.io/component: cds
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: cds
+  policyTypes:
+    - Ingress
+  ingress:
+    # RA-TLS from anywhere: get-cert runs beside every adopted workload, and the
+    # NodePort route arrives off-cluster.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.cds.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "c8s.operatorName" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: operator
+  policyTypes:
+    - Ingress
+  ingress:
+    # 9443 is the admission webhook, dialled by the API server, whose address no
+    # selector can name; 8081 carries the kubelet's probes; 8080 is metrics.
+    - ports:
+        - protocol: TCP
+          port: 9443
+        - protocol: TCP
+          port: 8081
+        - protocol: TCP
+          port: 8080
+{{- if .Values.volumed.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "c8s.volumedName" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+    app.kubernetes.io/component: volumed
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: c8s-operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: volumed
+  policyTypes:
+    - Ingress
+{{- end }}
+{{- if .Values.tlsLb.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "tls-lb.fullname" . }}-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "tls-lb.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingress-policy
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "tls-lb.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # The front door only. The cds-attest and allowlist-proxy sidecars bind pod
+    # loopback; this keeps an accidental rebind pod-unreachable.
+    - ports:
+        - protocol: TCP
+          port: {{ .Values.tlsLb.nginx.httpsPort }}
+{{- end }}

--- a/internal/helmchart/c8s/templates/component-ingress-policies.yaml
+++ b/internal/helmchart/c8s/templates/component-ingress-policies.yaml
@@ -2,6 +2,11 @@
 Default-deny ingress for the components that had none: each pod accepts only
 the ports it declares, and nothing else on the pod network can reach it.
 
+No rule carries a `from`, so none of them restricts WHO may connect — only
+which port answers. tls-lb stays reachable from off-cluster, cds from every
+node, the operator from the API server. A policy with no `ingress:` key at all
+(volumed) is the one that refuses everything.
+
 Ingress only. NetworkPolicies union, and ratls-mesh's tcp-only-egress selects
 every pod in the namespace and allows all TCP, so an egress rule added here
 would be allowed by that one anyway.
@@ -95,8 +100,10 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    # The front door only. The cds-attest and allowlist-proxy sidecars bind pod
-    # loopback; this keeps an accidental rebind pod-unreachable.
+    # The public front door, from anywhere: the Service's only port targets it,
+    # and so does hostPort when enabled. Naming it leaves the cds-attest and
+    # allowlist-proxy sidecars — which bind pod loopback and are reached through
+    # nginx — unreachable if one ever rebinds.
     - ports:
         - protocol: TCP
           port: {{ .Values.tlsLb.nginx.httpsPort }}

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7792,7 +7792,7 @@ func TestChartComponentIngressPoliciesAreDefaultDeny(t *testing.T) {
 			var got []int32
 			for _, rule := range np.Spec.Ingress {
 				if len(rule.From) != 0 {
-					t.Errorf("ingress rule restricts source (%v); the kube API server and off-cluster NodePort callers cannot be selected", rule.From)
+					t.Errorf("ingress rule restricts source (%v); these policies narrow which port answers, never who connects — tls-lb is a public front door, the API server dialling the webhook has no selectable address, and the CDS NodePort route arrives off-cluster", rule.From)
 				}
 				for _, p := range rule.Ports {
 					if p.Port == nil {
@@ -7805,5 +7805,57 @@ func TestChartComponentIngressPoliciesAreDefaultDeny(t *testing.T) {
 				t.Errorf("allowed ports = %v, want %v", got, tc.ports)
 			}
 		})
+	}
+}
+
+// tls-lb is the public front door, so its policy must leave the front-door port
+// open to every source. A `from` here would also be unsatisfiable in principle:
+// externalTrafficPolicy defaults to Local precisely to preserve arbitrary public
+// client IPs, and no selector can enumerate the internet.
+func TestChartTLSLBIngressPolicyStaysReachableFromOffCluster(t *testing.T) {
+	out, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+
+	var np networkingv1.NetworkPolicy
+	if !findDoc(t, out, "NetworkPolicy", "c8s-tls-lb-ingress", &np) {
+		t.Fatal("render is missing the tls-lb ingress policy")
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("ingress rules = %d, want 1", len(np.Spec.Ingress))
+	}
+	if len(np.Spec.Ingress[0].From) != 0 {
+		t.Fatalf("the front-door rule names sources (%v); external clients would be refused", np.Spec.Ingress[0].From)
+	}
+
+	// The allowed port must be the one the Service and hostPort both target,
+	// or external traffic lands on a port the policy does not name.
+	var svc corev1.Service
+	if !findDoc(t, out, "Service", "c8s-tls-lb", &svc) {
+		t.Fatal("render is missing the tls-lb Service")
+	}
+	if len(svc.Spec.Ports) != 1 {
+		t.Fatalf("tls-lb Service exposes %d ports; the policy names one", len(svc.Spec.Ports))
+	}
+	target := svc.Spec.Ports[0].TargetPort.StrVal
+
+	var deploy appsv1.Deployment
+	if !findDoc(t, out, "Deployment", "c8s-tls-lb", &deploy) {
+		t.Fatal("render is missing the tls-lb Deployment")
+	}
+	var wantPort int32
+	for _, c := range deploy.Spec.Template.Spec.Containers {
+		for _, p := range c.Ports {
+			if p.Name == target {
+				wantPort = p.ContainerPort
+			}
+		}
+	}
+	if wantPort == 0 {
+		t.Fatalf("no containerPort named %q on the tls-lb pod", target)
+	}
+	if got := int32(np.Spec.Ingress[0].Ports[0].Port.IntValue()); got != wantPort {
+		t.Errorf("policy admits :%d but the Service targets containerPort :%d — external traffic would be dropped", got, wantPort)
 	}
 }

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -287,14 +287,23 @@ func TestChartRendersRATLSHostRoutingDefaults(t *testing.T) {
 		}
 	}
 
-	// The default render carries the attestation-api default-deny NetworkPolicy
-	// plus the ratls-mesh tcp-only-egress policy (default-on since the mesh
-	// fails closed on non-TCP). The attestation-api policy must remain; nothing
-	// may select the hostNetwork mesh pods.
-	if kinds := renderedKinds(t, out); kinds["NetworkPolicy"] != 2 ||
-		!renderedManifestHasNamedKind(t, out, "NetworkPolicy", "c8s-attestation-api") ||
-		!renderedManifestHasNamedKind(t, out, "NetworkPolicy", "ratls-mesh-tcp-only-egress") {
-		t.Errorf("default render must carry the attestation-api default-deny and the ratls-mesh tcp-only-egress NetworkPolicies; got %d", kinds["NetworkPolicy"])
+	// The attestation-api policy must remain; nothing may select the hostNetwork
+	// mesh pods. volumed's is absent here because volumed is off by default.
+	wantPolicies := []string{
+		"c8s-attestation-api",
+		"ratls-mesh-tcp-only-egress",
+		"c8s-cds-ingress",
+		"c8s-operator-ingress",
+		"c8s-tls-lb-ingress",
+	}
+	kinds := renderedKinds(t, out)
+	if kinds["NetworkPolicy"] != len(wantPolicies) {
+		t.Errorf("default render NetworkPolicy count = %d, want %d", kinds["NetworkPolicy"], len(wantPolicies))
+	}
+	for _, name := range wantPolicies {
+		if !renderedManifestHasNamedKind(t, out, "NetworkPolicy", name) {
+			t.Errorf("default render is missing NetworkPolicy %q", name)
+		}
 	}
 }
 
@@ -7740,5 +7749,61 @@ func TestChartValuesSchemaConstrainsTheEnumsAndRanges(t *testing.T) {
 	if out, err := helmTemplate(t, "--set", "cds.service.nodePort=31234",
 		"--set-string", "nriImagePolicy.policy.mode=audit"); err != nil {
 		t.Fatalf("a valid nodePort and mode were refused: %v\n%s", err, out)
+	}
+}
+
+// Every component that serves a port had no ingress policy at all, so anything
+// on the pod network could reach any port they happened to bind — the tls-lb
+// sidecars bind loopback by intention, not by enforcement. These policies are
+// default-deny with the declared ports carved back out.
+func TestChartComponentIngressPoliciesAreDefaultDeny(t *testing.T) {
+	out, err := helmTemplate(t, "--set", "volumed.enabled=true")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+
+	for _, tc := range []struct {
+		policy    string
+		component string
+		ports     []int32
+	}{
+		{"c8s-cds-ingress", "cds", []int32{8443}},
+		{"c8s-operator-ingress", "operator", []int32{9443, 8081, 8080}},
+		{"c8s-volumed-ingress", "volumed", nil},
+		{"c8s-tls-lb-ingress", "", []int32{8443}},
+	} {
+		t.Run(tc.policy, func(t *testing.T) {
+			var np networkingv1.NetworkPolicy
+			if !findDoc(t, out, "NetworkPolicy", tc.policy, &np) {
+				t.Fatalf("render is missing NetworkPolicy %q", tc.policy)
+			}
+			// Ingress only: ratls-mesh's tcp-only-egress selects every pod and
+			// allows all TCP, so an egress rule here would be unioned away.
+			if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+				t.Errorf("policyTypes = %v, want [Ingress]", np.Spec.PolicyTypes)
+			}
+			if tc.component != "" && np.Spec.PodSelector.MatchLabels["app.kubernetes.io/component"] != tc.component {
+				t.Errorf("podSelector = %v, want component %q", np.Spec.PodSelector.MatchLabels, tc.component)
+			}
+			if len(np.Spec.PodSelector.MatchLabels) == 0 {
+				t.Error("podSelector is empty: this policy would apply to every pod in the namespace")
+			}
+
+			var got []int32
+			for _, rule := range np.Spec.Ingress {
+				if len(rule.From) != 0 {
+					t.Errorf("ingress rule restricts source (%v); the kube API server and off-cluster NodePort callers cannot be selected", rule.From)
+				}
+				for _, p := range rule.Ports {
+					if p.Port == nil {
+						t.Fatalf("ingress rule opens every port on %s", tc.policy)
+					}
+					got = append(got, int32(p.Port.IntValue()))
+				}
+			}
+			if !slices.Equal(got, tc.ports) {
+				t.Errorf("allowed ports = %v, want %v", got, tc.ports)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## The problem

The chart shipped exactly one default-deny NetworkPolicy —
`c8s-attestation-api` — plus `ratls-mesh-tcp-only-egress`, which is an *egress*
policy over every pod. Nothing constrained ingress to cds, the operator, volumed
or tls-lb: any pod in the cluster could reach any port those pods happened to
bind.

That is sharpest on tls-lb. Its `cds-attest` and `allowlist-proxy` sidecars bind
pod loopback — stated in the template's own comments — with nothing enforcing
it. A rebind, or a future container that binds `0.0.0.0`, was reachable from the
whole pod network.

## The fix

One policy per component, each selecting only that component and allowing only
the ports it declares:

| Policy | Selects | Accepts |
|---|---|---|
| `c8s-cds-ingress` | cds | `cds.port` |
| `c8s-operator-ingress` | operator | 9443 webhook, 8081 probes, 8080 metrics |
| `c8s-volumed-ingress` | volumed | **nothing** |
| `c8s-tls-lb-ingress` | tls-lb | `tlsLb.nginx.httpsPort` |

volumed declares no `ports:` at all and serves a node-local Unix socket, so its
policy is a bare deny — and it is the privileged `hostPID` DaemonSet, so it is
the one worth closing.

Every probe in the chart targets a *declared* port (`https`, `health`), so
kubelet is unaffected. The tls-lb sidecar is probed through nginx, not its own
port, which the template already explains.

## These do not restrict who may connect

Worth stating first, because the shape invites the opposite reading: **no rule
carries a `from`**, so each policy narrows *which port answers*, never *who
connects*. tls-lb stays reachable from off-cluster — the Service's only port
(`443 → targetPort: https → containerPort 8443`) and `hostPort` both land on the
port the rule names, from any source.

What it denies is a connection to some *other* port on that pod, which is what
makes `cds-attest` and `allowlist-proxy` loopback-only by enforcement rather
than by intention. Neither declares a containerPort; nginx proxies to them.

The contrast is inside the file: `c8s-volumed-ingress` has `policyTypes:
[Ingress]` and **no `ingress:` key at all**. That one is a true deny-all — it
declares no ports and serves a node-local Unix socket.

## Two deliberate non-features

**Ingress only.** `ratls-mesh-tcp-only-egress` selects `podSelector: {}` — every
pod in the namespace — and allows all TCP. NetworkPolicies *union*, so an egress
rule added for cds would be allowed by that policy regardless. Writing one would
look like a control and be none. If egress restriction is wanted, the change is
to that policy, not here.

**No source restriction** (above). The `from:` field stays empty everywhere: the
API server that dials the admission webhook has no address a `podSelector` or
`namespaceSelector` can name, get-cert runs beside every adopted workload in
every namespace, and both the tls-lb front door and the CDS NodePort route
arrive off-cluster — `externalTrafficPolicy` defaults to `Local` precisely to
preserve those arbitrary public client IPs. The tests assert `from` is empty so
this stays a decision rather than an omission.

## No new values keys

Following the `attestation-api` precedent: the policies render under each
component's existing `enabled` guard. The documented escape hatch is
NetworkPolicy's own semantics — policies are additive, so an operator who needs
another port applies their own selecting the same pods, with nothing to disable
first. `docs/operator.md` gains the table and a worked example.

This also keeps the four sealed subtrees in `values.schema.json` untouched, so
this does not collide with the schema work.

## Acceptance criteria

- [x] The chart ships default-deny NetworkPolicies for the components that need them, with a documented escape hatch.
- [x] Chart test: the policies render by default.
- [x] Empty measurement set at install → #428.
- [x] Unpinned operator writes → #429.
- [ ] `--cvm-mode=node` applying a CDS measurement pin — that is the node-image baked-config path, not the chart's; tracked separately.

## Testing

`go test ./internal/helmchart/` green (27.7s, whole package).
`TestChartComponentIngressPoliciesAreDefaultDeny` covers all four: ingress-only
policy types, a non-empty pod selector on the right component, empty `from`, and
the exact allowed port set.
`TestChartDefaultRendersReplacementStack`'s hardcoded `NetworkPolicy != 2` becomes
a named list of five (volumed is off by default), so a policy silently
disappearing still fails.

**Not applied to a live cluster.** These are inert where the CNI does not enforce
NetworkPolicy, and where it does the risk is a missed ingress path — worth an
e2e lane's eyes before merge, particularly the operator's 9443 admission webhook.


## Update after review

The first version commented the tls-lb rule "The front door only", which read as
shutting the internet out of the component whose entire job is to face it. The
behaviour was already correct; the comment was not. Both the template header and
`docs/operator.md` now state the port-not-source property once, and name volumed
as the policy that does refuse everything.

`TestChartTLSLBIngressPolicyStaysReachableFromOffCluster` now pins it, resolving
the expected port *through* the Service's `targetPort` to the pod's
`containerPort` rather than asserting a literal — so renaming the port cannot
quietly strand external traffic. Verified non-vacuous both ways: pointing the
policy at :9999 fails it, and adding a `from` fails it.
