### PR TITLE
chart: derive the NRI pull URL from cds.service.nodePort

### DIFF
--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -394,6 +394,18 @@ own IP. Empty in every other shape.
 {{- end -}}
 {{- end -}}
 
+{{- /*
+The URL the host NRI plugin pulls the allowlist from. cds.service.nodePort is
+the source; set nriImagePolicy.cds.url only to override the whole address.
+*/ -}}
+{{- define "c8s.nriCDSURL" -}}
+{{- if .Values.nriImagePolicy.cds.url -}}
+{{ .Values.nriImagePolicy.cds.url }}
+{{- else -}}
+{{ printf "https://127.0.0.1:%d" (int .Values.cds.service.nodePort) }}
+{{- end -}}
+{{- end -}}
+
 {{- define "c8s.cdsURL" -}}
 https://{{ include "c8s.cdsName" . }}.{{ .Release.Namespace }}.svc:{{ .Values.cds.port }}
 {{- end -}}

--- a/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
@@ -197,7 +197,7 @@ workload_claims:
   advertise_host: {{ $root.Values.nriImagePolicy.sandboxDigests.advertiseHost | quote }}
 allowlist:
   pull:
-    url: {{ required "cds.url is required" $root.Values.nriImagePolicy.cds.url | quote }}
+    url: {{ include "c8s.nriCDSURL" $root | quote }}
     interval: {{ $root.Values.nriImagePolicy.refresh.interval | quote }}
     timeout: "30s"
     # Node-local socket served by the DaemonSet's attest-proxy sidecar.

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -1,6 +1,6 @@
 {{- $tlsLB := .Values.tlsLb -}}
 {{- $nri := .Values.nriImagePolicy -}}
-{{- $nriCDSURL := tpl (default "" $nri.cds.url) . -}}
+{{- $nriCDSURL := tpl (include "c8s.nriCDSURL" .) . -}}
 {{- /*
   Helm silently ignores values keys the chart no longer reads, so a values
   file carried over from a release that still had tee-proxy would drop its
@@ -97,6 +97,14 @@
 {{- end -}}
 {{- if and $nri.enabled (not (hasPrefix "https://" $nriCDSURL)) -}}
 {{- fail (printf "nriImagePolicy.cds.url must start with https:// when nriImagePolicy.enabled=true (got %q): the host plugin must fetch the allowlist over RA-TLS" $nriCDSURL) -}}
+{{- end -}}
+{{- /*
+  The derived form is a node-local NodePort address, so there has to be one.
+*/ -}}
+{{- if and $nri.enabled (not $nri.cds.url) -}}
+{{- if or (ne .Values.cds.service.type "NodePort") (not .Values.cds.service.nodePort) -}}
+{{- fail (printf "VALIDATION_ERROR kind=nri_cds_url_underivable: nriImagePolicy.cds.url is empty, so it derives https://127.0.0.1:<cds.service.nodePort>, but cds.service.type is %q and cds.service.nodePort is %v. Set cds.service.type=NodePort with a nodePort, or set nriImagePolicy.cds.url to the address the plugin should pull from." .Values.cds.service.type .Values.cds.service.nodePort) -}}
+{{- end -}}
 {{- end -}}
 {{- /*
   The mirror of require_host_image_policy for evidence: off kata and node,

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -883,7 +883,9 @@ nriImagePolicy:
   cds:
     ## Host-process NRI pulls through the chart-managed CDS NodePort and
     ## verifies CDS RA-TLS instead of trusting cluster DNS or ClusterIP routing.
-    url: "https://127.0.0.1:30808"
+    ## Empty derives https://127.0.0.1:<cds.service.nodePort>; set a full URL
+    ## only to point the plugin somewhere else entirely.
+    url: ""
   policy:
     # Secure by default: match the plugin binary's own default and reject images
     # not on the allowlist. Set to `audit` only for bring-up — it logs would-be

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7615,3 +7615,73 @@ func TestChartVolumedTeardownHookOffWithVolumed(t *testing.T) {
 		t.Error("volumed teardown hook rendered without volumed.enabled")
 	}
 }
+
+// A non-default cds.service.nodePort must reach the NRI plugin's pull URL.
+// The two used to be independent literals, so moving the port left the plugin
+// pulling from 30808 and only validations.yaml's https:// prefix check looking.
+func TestChartNRICDSURLFollowsTheNodePort(t *testing.T) {
+	out, err := helmTemplate(t, "--set", "cds.service.nodePort=31234")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	if want := "https://127.0.0.1:31234"; !strings.Contains(out, want) {
+		t.Errorf("render does not carry the derived NRI pull URL %q", want)
+	}
+	if strings.Contains(out, "https://127.0.0.1:30808") {
+		t.Error("render still carries the default NRI pull URL after moving the NodePort")
+	}
+
+	// An explicit url still wins; it is the escape hatch for a plugin that
+	// should pull from somewhere else entirely.
+	out, err = helmTemplate(t, "--set", "cds.service.nodePort=31234",
+		"--set-string", "nriImagePolicy.cds.url=https://10.0.0.1:9999")
+	if err != nil {
+		t.Fatalf("helm template with an explicit url: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "https://10.0.0.1:9999") {
+		t.Error("an explicit nriImagePolicy.cds.url did not override the derivation")
+	}
+}
+
+// The derived URL is a node-local NodePort address, so a ClusterIP CDS with no
+// nodePort has nothing to derive from and must say so rather than render
+// "https://127.0.0.1:0".
+func TestChartNRICDSURLRefusesAnUnderivableService(t *testing.T) {
+	out, err := helmTemplate(t, "--set-string", "cds.service.type=ClusterIP")
+	if err == nil {
+		t.Fatalf("helm template succeeded, want an underivable-URL failure\n%s", out)
+	}
+	if kind := parseValidationErrorKind(out); kind != "nri_cds_url_underivable" {
+		t.Errorf("validation kind = %q, want nri_cds_url_underivable", kind)
+	}
+}
+
+// The node image bakes its own copy of the pull URL into the NRI floor, and the
+// chart cannot reach it. Keeping the two literals equal in-tree is the half
+// that is enforceable here; a per-install -f override still cannot follow (the
+// node-mode baked-config problem).
+func TestChartCDSNodePortMatchesTheBakedNRIFloor(t *testing.T) {
+	const bakedPath = "../../node-guest-image/c8s/image-policy.yaml.in"
+	baked, err := os.ReadFile(bakedPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", bakedPath, err)
+	}
+	m := regexp.MustCompile(`(?m)^\s*url:\s*"https://127\.0\.0\.1:(\d+)"`).FindSubmatch(baked)
+	if m == nil {
+		t.Fatalf("%s carries no loopback CDS pull url", bakedPath)
+	}
+
+	var values struct {
+		CDS struct {
+			Service struct {
+				NodePort int `yaml:"nodePort"`
+			} `yaml:"service"`
+		} `yaml:"cds"`
+	}
+	readChartFile(t, "values.yaml", &values)
+
+	if got, want := strconv.Itoa(values.CDS.Service.NodePort), string(m[1]); got != want {
+		t.Errorf("baked NRI floor pulls from :%s but cds.service.nodePort is %s — the node image's plugin would pull from the wrong port (%s)",
+			want, got, bakedPath)
+	}
+}


### PR DESCRIPTION
## The problem

`cds.service.nodePort` (`values.yaml:176`) and `nriImagePolicy.cds.url`
(`values.yaml:886`) were independent literals that happened to agree on 30808:

```yaml
cds:
  service:
    type: NodePort
    nodePort: 30808
nriImagePolicy:
  cds:
    url: "https://127.0.0.1:30808"     # nothing ties this to the line above
```

Move the port with `-f` and the host plugin keeps pulling from 30808. The only
check on that value was `validations.yaml:98` asserting an `https://` prefix,
which a wrong port passes cleanly. The plugin then never loads an allowlist —
and under `policy.mode: fail-closed` a plugin with no allowlist denies every
image on its node.

## The fix

`c8s.nriCDSURL`, in the shape `c8s.cdsURL` already establishes:

```
{{- define "c8s.nriCDSURL" -}}
{{- if .Values.nriImagePolicy.cds.url -}}
{{ .Values.nriImagePolicy.cds.url }}
{{- else -}}
{{ printf "https://127.0.0.1:%d" (int .Values.cds.service.nodePort) }}
{{- end -}}
{{- end -}}
```

`values.yaml` drops the literal to `""`. Both consumers — the installer script
and `validations.yaml` — read the helper, so the `required "cds.url is required"`
guard goes with the value it was guarding. An explicit URL still wins: that is
the escape hatch for a plugin that should pull from somewhere else entirely.

**New fail-closed edge.** The derived form is a node-local NodePort address, so
`cds.service.type: ClusterIP` with no nodePort now fails validation
(`kind=nri_cds_url_underivable`) instead of rendering `https://127.0.0.1:0`.

## The third copy

`node-guest-image/c8s/image-policy.yaml.in:107` bakes the same URL into the node
image's NRI floor. The chart cannot reach it — `mkosi.sync`'s substitution has
five tokens (`@NRI_DIGEST@`, `@NRI_IMAGE@`, `@CDS_DIGEST@`, `@CDS_IMAGE@`,
`@PLATFORM@`) and no port among them, and the image is built long before any
chart value exists.

So this PR does the enforceable half: `TestChartCDSNodePortMatchesTheBakedNRIFloor`
pins the baked literal to `values.yaml`, and changing one without the other
fails CI.

**A per-install `-f` override still strands the baked copy.** I considered a
render-time refusal — "nri disabled + non-default nodePort → fail" — and dropped
it: `nriImagePolicy.enabled=false` does not imply the c8s node image is in play,
so it would fire on clusters that have no baked plugin at all. That is the
node-mode-bakes-config-the-chart-can't-reach problem, not this one, and it wants
fixing where the baking happens.

## Scope

This is the H4 half of the chart issue. The `values.schema.json` completion and
the dead-key cleanup are a separate PR, so the schema file is untouched here and
the two do not collide.

## Acceptance criteria

- [x] `nriImagePolicy.cds.url` is derived from `cds.service.nodePort` in a helper; the standalone literal is gone.
- [x] A non-default `cds.service.nodePort` propagates to the NRI plugin URL (`TestChartNRICDSURLFollowsTheNodePort`).
- [x] Fails closed where the derivation has nothing to derive from.
- [x] `helm lint` / `helm template` via `chart-verify.sh` stays green.
- [ ] Schema completion + dead-key cleanup — separate PR.

## Testing

`go test ./internal/helmchart/ ./internal/cmds/nri-image-policy/` green (28.8s).
`CHART_DIR=internal/helmchart/c8s .github/scripts/chart-verify.sh` green — lint
plus both template invocations.

Three new tests: the port propagates and the old literal is gone; an explicit
URL overrides; a ClusterIP CDS is refused with the named validation kind. Plus
the baked-floor lockstep test.
