### PR TITLE
chart: close the values root, and drop the dead key from chart-verify

### DIFF
--- a/.github/scripts/chart-verify.sh
+++ b/.github/scripts/chart-verify.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Lint and render the c8s Helm chart for .github/workflows/chart.yml. Runs three
+# Lint and render the c8s Helm chart for .github/workflows/chart.yml. Runs two
 # checks in sequence (they always ran together, unconditionally):
 #   1. helm lint
 #   2. helm template                       (renders cleanly)
-#   3. helm template --set webhook.enabled=true
 #
 # The image tags/digests below are CI placeholders: helm must resolve every
 # `required`/digest reference for lint+template to pass, but nothing is deployed,
@@ -50,14 +49,5 @@ helm template c8s "$CHART_DIR" \
   --kube-version v1.30.0 \
   --namespace c8s-system \
   "${common_set[@]}" \
-  > /dev/null
-echo "::endgroup::"
-
-echo "::group::helm template (webhook enabled)"
-helm template c8s "$CHART_DIR" \
-  --kube-version v1.30.0 \
-  --namespace c8s-system \
-  "${common_set[@]}" \
-  --set webhook.enabled=true \
   > /dev/null
 echo "::endgroup::"

--- a/internal/helmchart/c8s/values.schema.json
+++ b/internal/helmchart/c8s/values.schema.json
@@ -1,15 +1,21 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "$comment": "Partial by design: only the four subtrees operators hand-write are sealed, so an unknown or misspelled key there is a render-time error instead of a silently dropped value. Every key of those subtrees in values.yaml must appear here; leaf types are deliberately unconstrained. Maps whose keys belong to the consumer (label maps, digest maps, resources) are left open.",
+  "$comment": "The root key set is closed, and the four subtrees operators hand-write are sealed, so an unknown or misspelled key is a render-time error instead of a silently dropped value. Every key of those subtrees in values.yaml must appear here. Leaf types stay unconstrained except where a wrong value is otherwise accepted silently (see the enums and ranges below). Maps whose keys belong to the consumer (label maps, digest maps, resources) are left open.",
   "type": "object",
   "properties": {
     "cds": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
         "allowlistDB": {},
         "ca": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "certValidity": {},
@@ -24,7 +30,10 @@
         "earIssuer": {},
         "expectedIssuer": {},
         "handoff": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {},
@@ -32,7 +41,10 @@
           }
         },
         "image": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "digest": {},
@@ -48,7 +60,10 @@
         "measurements": {},
         "namedCertTTL": {},
         "node": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "selector": {},
@@ -57,7 +72,10 @@
         },
         "operatorKeys": {},
         "persistence": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {},
@@ -66,7 +84,10 @@
           }
         },
         "podDisruptionBudget": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {},
@@ -89,11 +110,28 @@
         "secretsMaxPaths": {},
         "secretsMaxPathsPerWorkload": {},
         "service": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
-            "nodePort": {},
-            "type": {}
+            "nodePort": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "minimum": 30000,
+              "maximum": 32767
+            },
+            "type": {
+              "enum": [
+                "NodePort",
+                "ClusterIP",
+                "LoadBalancer",
+                null
+              ]
+            }
           }
         },
         "tokenSignerOverlap": {},
@@ -102,11 +140,17 @@
       }
     },
     "nriImagePolicy": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
         "bootstrapAllowlist": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "deriveComponents": {},
@@ -115,14 +159,20 @@
           }
         },
         "cds": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "url": {}
           }
         },
         "containerd": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "configDir": {},
@@ -132,11 +182,17 @@
           }
         },
         "containerdPrep": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "image": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "additionalProperties": false,
               "properties": {
                 "digest": {},
@@ -151,7 +207,10 @@
         "enabled": {},
         "healthSocketName": {},
         "hostPaths": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "cacheDir": {},
@@ -161,7 +220,10 @@
           }
         },
         "image": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "digest": {},
@@ -173,7 +235,10 @@
         "imagePullSecrets": {},
         "logLevel": {},
         "nodeAffinity": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "excludeLabels": {}
@@ -182,19 +247,31 @@
         "pluginFilename": {},
         "pluginName": {},
         "policy": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "denyMissingAnnotation": {},
             "enforceExisting": {},
             "exemptNamespaces": {},
             "labelRules": {},
-            "mode": {}
+            "mode": {
+              "enum": [
+                "fail-closed",
+                "audit",
+                null
+              ]
+            }
           }
         },
         "priorityClassName": {},
         "refresh": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "interval": {}
@@ -202,14 +279,20 @@
         },
         "resources": {},
         "sandboxDigests": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "advertiseHost": {}
           }
         },
         "uninstall": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {}
@@ -218,17 +301,26 @@
       }
     },
     "tlsLb": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
         "allowlist": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {},
             "proxyPort": {},
             "rateLimit": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "additionalProperties": false,
               "properties": {
                 "burst": {},
@@ -238,7 +330,10 @@
               }
             },
             "readRateLimit": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "additionalProperties": false,
               "properties": {
                 "burst": {},
@@ -249,7 +344,10 @@
           }
         },
         "attest": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "attestationApiURL": {},
@@ -262,7 +360,10 @@
           }
         },
         "certProvisioning": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "renewInterval": {},
@@ -270,7 +371,10 @@
           }
         },
         "cors": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "allowCredentials": {},
@@ -284,7 +388,10 @@
           }
         },
         "discovery": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "cdsCertPath": {},
@@ -297,7 +404,10 @@
         },
         "enabled": {},
         "hostPort": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "enabled": {},
@@ -306,7 +416,10 @@
         },
         "imagePullSecrets": {},
         "meshCA": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "expose": {}
@@ -314,12 +427,18 @@
         },
         "nameOverride": {},
         "nginx": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "httpsPort": {},
             "image": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "additionalProperties": false,
               "properties": {
                 "digest": {},
@@ -337,7 +456,10 @@
           }
         },
         "publicTLS": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "certKey": {},
@@ -349,7 +471,10 @@
         "routes": {},
         "san": {},
         "service": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "annotations": {},
@@ -361,13 +486,19 @@
         "strategy": {},
         "tlsMountPath": {},
         "upstream": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "address": {},
             "protocol": {},
             "tls": {
-              "type": ["object", "null"],
+              "type": [
+                "object",
+                "null"
+              ],
               "additionalProperties": false,
               "properties": {
                 "serverName": {},
@@ -382,12 +513,18 @@
       }
     },
     "volumed": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "additionalProperties": false,
       "properties": {
         "enabled": {},
         "hostPaths": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "cgroupRoot": {},
@@ -395,7 +532,10 @@
           }
         },
         "image": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "additionalProperties": false,
           "properties": {
             "digest": {},
@@ -412,6 +552,24 @@
         "resources": {},
         "tolerations": {}
       }
+    },
+    "c8sComponents": {},
+    "image": {},
+    "operator": {},
+    "imagePullSecrets": {},
+    "imagePullSecret": {},
+    "certProvisioning": {},
+    "serviceAccount": {},
+    "statusMirror": {},
+    "hostNamespacePolicy": {},
+    "webhook": {},
+    "attestationApi": {},
+    "kata": {},
+    "ratlsMesh": {},
+    "podSecurityContext": {},
+    "teeProxy": {
+      "$comment": "Removed component, listed only so validations.yaml can answer with the migration message rather than a generic unknown-key refusal."
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7685,3 +7685,60 @@ func TestChartCDSNodePortMatchesTheBakedNRIFloor(t *testing.T) {
 			want, got, bakedPath)
 	}
 }
+
+// The root key set is closed, so a values file carried over from an older
+// release — or one with a typo above the sealed subtrees — is refused instead
+// of being silently dropped. This is the class that caused the incident the
+// schema was added for; sealing only four subtrees left it open everywhere else.
+func TestChartValuesSchemaRejectsUnknownRootKeys(t *testing.T) {
+	for _, key := range []string{"webhookk", "clusterName", "nriImagePolicyy"} {
+		t.Run(key, func(t *testing.T) {
+			out, err := helmTemplate(t, "--set", key+".enabled=true")
+			if err == nil {
+				t.Fatalf("helm template accepted unknown root key %q\n%s", key, out)
+			}
+			// Wording differs across helm versions; match the shared stem.
+			if lower := strings.ToLower(out); !strings.Contains(lower, "additional propert") ||
+				!strings.Contains(lower, strings.ToLower(key)) {
+				t.Errorf("failure does not name %q as an unknown key:\n%s", key, out)
+			}
+		})
+	}
+}
+
+// teeProxy stays in the schema on purpose: validations.yaml answers it with a
+// migration message, which a generic unknown-key refusal would replace.
+func TestChartTeeProxyKeepsItsMigrationMessage(t *testing.T) {
+	out, err := helmTemplate(t, "--set", "teeProxy.hostPort.enabled=true")
+	if err == nil {
+		t.Fatalf("helm template accepted teeProxy values\n%s", out)
+	}
+	if kind := parseValidationErrorKind(out); kind != "removed_component" {
+		t.Errorf("validation kind = %q, want removed_component (the schema swallowed it)", kind)
+	}
+}
+
+// A NodePort outside the service range, a mistyped service type, or a mistyped
+// policy mode were all accepted silently: nothing in the chart checked any of
+// the three, and the last one only surfaced when the plugin refused its config
+// on the node.
+func TestChartValuesSchemaConstrainsTheEnumsAndRanges(t *testing.T) {
+	for _, tc := range []struct{ name, set string }{
+		{"nodePort below the service range", "cds.service.nodePort=8443"},
+		{"nodePort above the service range", "cds.service.nodePort=40000"},
+		{"unknown service type", "cds.service.type=NodePortt"},
+		{"unknown policy mode", "nriImagePolicy.policy.mode=failclosed"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if out, err := helmTemplate(t, "--set", tc.set); err == nil {
+				t.Fatalf("helm template accepted --set %s\n%s", tc.set, out)
+			}
+		})
+	}
+
+	// The in-range default and the other real mode still render.
+	if out, err := helmTemplate(t, "--set", "cds.service.nodePort=31234",
+		"--set-string", "nriImagePolicy.policy.mode=audit"); err != nil {
+		t.Fatalf("a valid nodePort and mode were refused: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## The problem

`values.schema.json` sealed four subtrees and left **the root open**. The failure
it was written for — a value accepted, silently dropped, cluster bricked — still
worked one level up:

```
$ helm template … --set clusterName=prod        # renders clean, means nothing
$ helm template … --set webhookk.failurePolicy=Ignore
```

14 of the 18 top-level keys were entirely unconstrained. `chart-verify.sh` proved
the cost a second time: after #410 removed its stray
`nriImagePolicy.cds.node.selector.role`, it still carried
`--set webhook.enabled=true` — a key no template reads and `values.yaml` does not
define, inside the chart's own CI check.

## The fix

**Root closed.** All 18 top-level keys listed, `additionalProperties: false`.

**Three targeted constraints**, each where a wrong value is accepted in silence today:

| key | constraint | what it catches |
|---|---|---|
| `cds.service.nodePort` | integer, 30000–32767 | the chart checked no port range anywhere |
| `cds.service.type` | enum | a typo rendered a Service with no NodePort |
| `nriImagePolicy.policy.mode` | enum `fail-closed`/`audit` | a typo rendered fine and surfaced as the plugin refusing its own config *on the node* |

**`chart-verify.sh`** loses `--set webhook.enabled=true`. Its whole invocation was
byte-identical to the render above it once the dead flag went, so the invocation
goes too — three checks become two, and the header comment says so.

## Where I did not follow the acceptance criteria

**"Leaf types unconstrained" stays, mostly.** The AC asks for types on the values
tree. #410 argued against it explicitly and recently: `tlsLb.san` is a list in one
fleet cluster and `""` in another, so typing leaves fights consumers without
catching the failure the schema exists for. That reasoning has not changed, and I
did not want to overturn a documented decision from the same week to satisfy a
checkbox. The three constraints above are in because each encodes an invariant
the code enforces later and worse — not to fill in the type table.

**No `required` at the root.** Helm merges chart defaults before validating, so
every top-level key is always present and `required` would add nothing — except
against a cluster overlay that nulls a whole block, which #410 deliberately kept
working (`type: ["object", "null"]` throughout).

**`teeProxy` is still in the schema.** The component is gone, but
`validations.yaml` answers it with a migration message
(`teeProxy.hostPort` → `tlsLb.hostPort`, `teeProxy.upstream` →
`tlsLb.upstream.address`). Closing the root would have replaced that with
"additional properties 'teeProxy' not allowed". It is listed with a `$comment`
saying why, and a test asserts the migration message still wins.

**The `kindIs "bool"` guard on `tlsLb.hostPort.enabled` stays.** The AC says to
delete hand-written guards the schema now covers. A schema `"type": "boolean"`
catches the same mistake with a worse message — the hand-written one names
`--set-string` as the cause, which is the actual thing the operator did.

## Acceptance criteria

- [x] Unknown keys are rejected at `helm install`/`template` time — now at the root too.
- [x] Enums and ranges where they encode a real invariant.
- [x] The dead key in `chart-verify.sh` is removed and the script passes.
- [x] Cross-field rules stay in `validations.yaml`.
- [~] "Types on the values tree" / "delete hand-written type guards" — deliberately partial, reasoning above.
- [x] `chart_test.go`: rendering with an unknown key fails; a wrong-typed value fails with the schema's message.

## Risk

Closing the root means a values file with **any** stray top-level key now fails
where it previously rendered. That is the point, but it is the change most likely
to surprise a consumer. #410 already recorded that the three `c8s-fleet` value
sets do not render against `main` for unrelated reasons; they should be re-checked
against this before it merges.

## Testing

`go test ./internal/helmchart/ ./cmd/c8s/` green (28.9s + 7.0s), which covers
`render-values` for all four `--cvm-mode` values.
`CHART_DIR=internal/helmchart/c8s .github/scripts/chart-verify.sh` green.

Three new tests: unknown root keys rejected (three spellings), the teeProxy
migration message surviving, and the enum/range set — including a positive arm
asserting an in-range nodePort and `mode=audit` still render.
