### PR TITLE
build(kata-guest-base): make the staged-overlay marker deterministic

### DIFF
--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -285,6 +285,11 @@ randomness:
   committed `snapshot.ubuntu.com` timestamp so the guest packages don't
   drift with build date. (Noble's snapshot Release files carry no
   `Valid-Until`, so no apt override is needed.)
+- The staged-overlay marker `/usr/local/share/c8s/.kata-guest-base-baked`
+  — it is inside the measured rootfs, so `fetch.sh` names each staged
+  binary by its sha256 rather than by its build-host path, and the wall
+  clock stays in `manifest.json` (`built_at`), outside the measured
+  bytes.
 
 Additionally, `image_builder.sh` populates the partition by mounting an
 empty ext4 and `cp -a`-ing files in, which leaves block allocation,
@@ -303,6 +308,64 @@ knows exactly what to install; `REPRO_E2FSPROGS_VERSION` /
 `REPRO_CRYPTSETUP_VERSION` make a version mismatch fatal (the CI
 publish path pins both in `kata-guest-base.yml`). Running the re-lay
 inside a version-pinned container is the tracked longer-term fix.
+
+### Reproducing a published root_hash
+
+Everything a rebuild needs is in the artifact's own `manifest.json`, so a
+third party can recompute the value they are asked to pin without
+trusting the build host.
+
+```sh
+# 1. Fetch the published artifact and read the inputs it was built from.
+oras pull ghcr.io/confidential-dot-ai/kata-guest-base:<tag>
+jq '.inputs, .relay_toolchain, .kernel_verity_params' manifest.json
+```
+
+```sh
+# 2. Check out each input at the ref manifest.json names. The three repos
+#    must sit side by side: fetch.sh derives their paths from its own
+#    location.
+git -C c8s              checkout <inputs.c8s_ref>
+git -C attestation-rs   checkout <inputs.attestation_rs_ref>
+git -C confidential-os-builder checkout <inputs.confos_ref>
+```
+
+```sh
+# 3. Install the exact re-lay toolchain. mkfs.ext4 and veritysetup run on
+#    the build host, and their versions change root_hash; a mismatch is
+#    fatal rather than silent.
+export REPRO_E2FSPROGS_VERSION=<relay_toolchain.e2fsprogs>
+export REPRO_CRYPTSETUP_VERSION=<relay_toolchain.cryptsetup>
+```
+
+```sh
+# 4. Build the in-guest binaries, then stage and seal.
+#    VERSION is linked into every binary, so pass the ref explicitly:
+#    the default is `git describe --dirty`, which differs on any tree
+#    that is not a clean checkout of that exact ref.
+cd c8s
+make build-c8s-node build-policy-monitor build-rtmr3-measurer build-volumed \
+  VERSION=<inputs.c8s_ref>
+cd kata-guest-base
+IMAGE_TAG=<inputs.c8s_ref> ./scripts/fetch.sh
+./scripts/build.sh
+```
+
+```sh
+# 5. Compare. root_hash is the value pinned as a measurement; the whole
+#    manifest should match apart from built_at, which is a wall clock and
+#    not a baked byte.
+jq -r .kernel_verity_params output/manifest.json
+diff <(jq 'del(.built_at)' manifest.json) \
+     <(jq 'del(.built_at)' output/manifest.json)
+```
+
+Two inputs still resolve through a mutable registry tag at build time:
+`fetch.sh` resolves the bootstrap allowlist digests from `IMAGE_TAG`, and
+`mkosi.sync` resolves the NRI floor from `C8S_REF`. Both record what they
+resolved — the allowlist digests in the bake marker, the floor digests in
+the rendered `image-policy.yaml` — so a mismatch is diagnosable, but a
+rebuild after those tags move will not match.
 
 ## Component pins
 

--- a/kata-guest-base/scripts/fetch.sh
+++ b/kata-guest-base/scripts/fetch.sh
@@ -159,13 +159,20 @@ echo "==> attestation-service: ${BIN_DIR}/attestation-service ($(stat -c '%s' "$
 # gamble.
 KATA_VERSION="${KATA_VERSION:-3.30.0}"
 
-# Drop a marker so we know which inputs produced this baked overlay.
+# Drop a marker so we know which inputs produced this baked overlay. It lands
+# inside the measured rootfs, so every line has to be a function of the inputs:
+# a binary is named by its content, and the wall clock lives in manifest.json,
+# outside the measured bytes.
+bin_sha256() { sha256sum "$1" | cut -d' ' -f1; }
+
 mkdir -p "${EXTRA_DIR}/usr/local/share/c8s"
 {
-    printf 'kata-guest-base overlay staged at: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    printf 'c8s_node_bin: %s\n' "${C8S_NODE_BIN}"
-    printf 'policy_monitor_bin: %s\n' "${POLICY_MONITOR_BIN}"
-    printf 'attestation_api_bin: %s\n' "${ATTESTATION_BIN}"
+    printf 'kata-guest-base overlay\n'
+    printf 'c8s_node_bin_sha256: %s\n' "$(bin_sha256 "${C8S_NODE_BIN}")"
+    printf 'policy_monitor_bin_sha256: %s\n' "$(bin_sha256 "${POLICY_MONITOR_BIN}")"
+    printf 'rtmr3_measurer_bin_sha256: %s\n' "$(bin_sha256 "${RTMR3_MEASURER_BIN}")"
+    printf 'volumed_bin_sha256: %s\n' "$(bin_sha256 "${VOLUMED_BIN}")"
+    printf 'attestation_api_bin_sha256: %s\n' "$(bin_sha256 "${ATTESTATION_BIN}")"
     printf 'kata_version: %s\n' "${KATA_VERSION}"
 } > "${EXTRA_DIR}/usr/local/share/c8s/.kata-guest-base-baked"
 


### PR DESCRIPTION
## The problem

`docs/kata-guest-base.md` opens with:

> Two builds from the same inputs produce a bit-for-bit identical dm-verity
> `root_hash` — the property that lets a verifier rebuild the image from source
> and recompute the launch measurement instead of taking the build on trust.

and `build.sh` repeats it above the mtime scrub. **Neither was true.**

`fetch.sh` writes `/usr/local/share/c8s/.kata-guest-base-baked` into `EXTRA_DIR`;
`build.sh:476` rsyncs that tree into the measured rootfs. The file contained:

```
kata-guest-base overlay staged at: 2026-08-19T21:14:07Z   <- wall clock
c8s_node_bin: /home/runner/work/c8s/c8s/build/c8s-node    <- build-host path
policy_monitor_bin: /home/runner/work/c8s/c8s/build/policy-monitor
attestation_api_bin: /home/runner/work/attestation-rs/target/release/attestation-api
```

Two builds a second apart differ. A third party who checked out to a different
directory differs again. Nothing scrubs it — the pre-seal cleanup covers
`resolv.conf`, umoci `*.mtree` files and mtimes, and the marker is gitignored so
it never showed up in a diff either.

So the measurement operators are told to pin was not reproducible by anyone, and
a `root_hash` nobody can recompute is trust-on-first-publication.

## The fix

The marker's stated purpose is to record which inputs produced the overlay. It
now records them in terms that survive a rebuild:

```
kata-guest-base overlay
c8s_node_bin_sha256: 9f2c…
policy_monitor_bin_sha256: 41ab…
rtmr3_measurer_bin_sha256: 0e77…
volumed_bin_sha256: c3d1…
attestation_api_bin_sha256: 88fe…
kata_version: 3.30.0
```

A content hash identifies the input; a path never did. The wall clock is dropped
— `manifest.json` already carries `built_at`, outside the measured bytes, which
is where a build timestamp belongs. `rtmr3-measurer` and `volumed` join the list:
both are staged into the same rootfs and the marker never mentioned them.

After this, the only remaining wall clock anywhere in the build is
`build.sh:652`'s `built_at`, and it is not a baked byte.

## Reproduction recipe

`docs/kata-guest-base.md` gains **Reproducing a published root_hash** — the
recipe the audit asked for, driven entirely off the published artifact's own
`manifest.json`: read `inputs`/`relay_toolchain`, check the three repos out side
by side (`fetch.sh` derives their paths from its own location), pin the re-lay
toolchain, build, compare.

The one non-obvious step is `VERSION`. The Makefile defaults it to
`git describe --tags --always --dirty` and links it into every in-guest binary,
so a tree that is not a clean checkout of that exact ref produces different
bytes and a different `root_hash`. The recipe passes it explicitly.

It also states, rather than glosses, that two inputs still resolve through a
mutable registry tag at build time (`fetch.sh`'s allowlist digests from
`IMAGE_TAG`, `mkosi.sync`'s NRI floor from `C8S_REF`), so a rebuild after those
tags move will not match. Both record what they resolved, so a mismatch is at
least diagnosable.

## Why this is its own PR

This is what a `kata-guest-base` repro gate would have failed on within its first
run, so it lands before the gate rather than with it. The gate itself needs
`kata-guest-base.yml` restructured into a reusable workflow with a
publish-suppressing `gate` input (it is one monolithic job today, with no
`workflow_call` interface and no `pull_request` trigger), which is a bigger and
separately reviewable change.

## Acceptance criteria (issue-level)

- [x] The measured rootfs no longer embeds a timestamp or build-host paths.
- [x] A published reproduction recipe lets a third party rebuild and recompute the digest they are asked to pin.
- [ ] Two independent builds demonstrated identical in CI — needs the repro gate.
- [ ] No measured input resolves through a mutable tag — documented here, not fixed.
- [ ] cosign / SBOM / provenance — not started.

## Testing

`bash -n` clean. **Not built** — the guest rootfs build needs mkosi, a
self-hosted runner and ~45 minutes, none of which exist here. The change is to
which strings get written into one marker file, and the two removed inputs
(`date`, `$BIN` paths) are the two the audit identified; the added `sha256sum`
calls are over files the script has already validated exist by that point.

The honest verification is a double build. That is the gate this unblocks, and I
would not call the issue's first criterion met until it has run.
