### PR TITLE
ci(snp): capture the launch measurement over the attestation-api

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,3 +4,4 @@ self-hosted-runner:
   labels:
     - the-machine
     - cvm-launcher-tdx
+    - cvm-launcher

--- a/.github/workflows/snp-measure-smp.yml
+++ b/.github/workflows/snp-measure-smp.yml
@@ -1,24 +1,23 @@
 # ═══════════════════════════════════════════════════════════════════════════
-# CONSUMER: capture the SNP launch measurement at a given vCPU count.
+# Capture the SNP launch measurement at a given vCPU count.
 # ═══════════════════════════════════════════════════════════════════════════
 #
-# Not an e2e test. It boots a plain attested VM (base-cpu) at one vCPU count
-# and reports the measurement the hardware produced, so a published per-SMP
-# digest can be confirmed against a real launch.
+# Not an e2e test, and deliberately NOT built on cvm-e2e.yml: that primitive
+# delivers its payload over the serial console, and the base-cpu image emits
+# nothing after the EFI stub (no autologin) — the flavor that can boot a
+# non-default vCPU count is the one that cannot take a console payload.
+#
+# Nothing needs to run inside the guest anyway. base-cpu serves the
+# attestation-api on :8400 over the pod network, and an SNP quote carries the
+# MEASUREMENT this lane wants, so the capture is one HTTP request from the
+# runner and `c8s verify --output json` reads the field.
 #
 # WHY: an SNP launch measurement covers initial vCPU state, so the image ships
 # one measured IGVM per supported count and the manifest publishes a digest for
 # each. get-kubeconfig's trust gate accepts any of them, but the e2e lanes only
-# ever boot the cell default, so the other counts are pinned without ever having
-# been launched. A digest that is wrong for a count nobody boots surfaces as a
-# real node booting fine and then being refused credentials.
-#
-# Compare the reported value against that count's snp_launch_digest in the
-# image's published manifest.json:
-#   crane manifest ghcr.io/confidential-dot-ai/node-guest-base:rke2-snp-dev \
-#     | jq -r '.layers[]|select(.annotations["org.opencontainers.image.title"]=="manifest.json")|.digest'
-#   crane blob ghcr.io/confidential-dot-ai/node-guest-base@<digest> \
-#     | jq -r '.snp_variants[]|select(.smp==<cores>)|.measurement.snp_launch_digest'
+# ever boot the cell default, so the other counts are pinned without having been
+# launched. A digest that is wrong for a count nobody boots surfaces as a real
+# node booting fine and then being refused credentials.
 name: snp-measure-smp
 on:
   workflow_dispatch:
@@ -30,42 +29,46 @@ on:
 
 permissions:
   contents: read
-  # Load-bearing: the primitive's reaper asks GitHub whether a CVM's owning run
-  # finished. Without it that call 403s and reaping falls back to age alone.
-  actions: read
 
 concurrency:
   group: snp-measure-smp
   cancel-in-progress: false
 
 jobs:
-  payload:
-    runs-on: ubuntu-latest
+  measure:
+    runs-on: cvm-launcher
+    timeout-minutes: 30
     env:
+      NS: confai-images
+      REFS_CM: base-image-refs
       IMAGE: ghcr.io/confidential-dot-ai/node-guest-base:rke2-snp-dev
-    outputs:
-      b64: ${{ steps.build.outputs.b64 }}
+      VM: cvm-meas-${{ github.run_id }}-${{ github.run_attempt }}
+      CORES: ${{ inputs.cores }}
+      MEMORY: 8Gi
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
-      # Same pin as the other lanes that shell out to crane.
-      - name: install crane
-        run: go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+
+      - name: tools
+        run: |
+          set -euo pipefail
+          mkdir -p "$PWD/bin"
+          curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl
+          chmod +x bin/kubectl; echo "$PWD/bin" >> "$GITHUB_PATH"
+          go install github.com/google/go-containerregistry/cmd/crane@v0.21.6
+          go build -o bin/c8s ./cmd/c8s
 
       - name: validate the requested vCPU count
-        env:
-          CORES: ${{ inputs.cores }}
         run: |
           set -euo pipefail
           case "$CORES" in
             ''|*[!0-9]*) echo "::error::cores '$CORES' is not a positive integer"; exit 1 ;;
           esac
           # A guest can only boot a measured IGVM, so the bootable counts are
-          # exactly the ones the image shipped. Checking here fails a typo on a
-          # cheap runner instead of after the CVM lease starts.
+          # exactly the ones the image shipped.
           ships=$(crane manifest "$IMAGE" \
             | jq -r '.layers[].annotations["org.opencontainers.image.title"] // empty' \
             | sed -n 's/^guest-smp\([0-9]\+\)\.igvm$/\1/p' | sort -n | tr '\n' ' ')
@@ -75,55 +78,152 @@ jobs:
             *) echo "::error::the image ships no guest-smp$CORES.igvm — available: $ships"; exit 1 ;;
           esac
 
-      - name: build the in-guest payload
-        id: build
+      - name: resolve image refs
         run: |
           set -euo pipefail
-          # The primitive reads the runtime measurement from configfs-tsm,
-          # emits it as @@MEAS@@ and exports it as the `measurement` output
-          # before the payload runs, so nothing has to be measured here. The
-          # payload exists only to satisfy the contract's success marker: a
-          # clean boot IS the result this lane wants.
-          cat > payload.sh <<'EOF'
-          echo "@@PAYLOAD_OK@@"
+          ROOTPVC=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.rootPvc}')
+          [ -n "$ROOTPVC" ] || { echo "::error::$REFS_CM missing rootPvc"; exit 1; }
+          PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
+          [ -n "$PAT" ] || { echo "::error::$REFS_CM has no igvmFilePattern, so it cannot serve a per-count IGVM"; exit 1; }
+          echo "ROOTPVC=$ROOTPVC" >> "$GITHUB_ENV"
+          echo "IGVMFILE=${PAT//\{cores\}/$CORES}" >> "$GITHUB_ENV"
+
+      - name: boot the CVM
+        run: |
+          set -euo pipefail
+          echo "booting $VM: $IGVMFILE at ${CORES} vCPU"
+          # Same shape as cvm-e2e.yml's VM, minus the console plumbing. The
+          # ci.confidential.ai labels are what the shared reaper keys on.
+          kubectl apply -f - <<EOF
+          apiVersion: kubevirt.io/v1
+          kind: VirtualMachine
+          metadata:
+            name: $VM
+            namespace: $NS
+            labels:
+              ci.confidential.ai/managed: "true"
+              ci.confidential.ai/standing: "false"
+              ci.confidential.ai/run-id: "${{ github.run_id }}"
+              ci.confidential.ai/run-attempt: "${{ github.run_attempt }}"
+              ci.confidential.ai/platform: "snp-metal"
+              ci.confidential.ai/flavor: "base-cpu"
+            annotations:
+              ci.confidential.ai/repo: "${{ github.repository }}"
+              ci.confidential.ai/run-url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          spec:
+            runStrategy: Always
+            template:
+              metadata:
+                labels:
+                  vm.kubevirt.io/name: $VM
+                annotations:
+                  igvm.confidential.ai/file: "$IGVMFILE"
+                  hooks.kubevirt.io/hookSidecars: '[{"image":"ghcr.io/confidential-dot-ai/igvm-hook-sidecar@sha256:7450bb136bfc4d9434a7c1eb9e478ab3237e7d9acf5c211e7d080f2008b01ba0","imagePullPolicy":"IfNotPresent","args":["--version","v1alpha3"],"pvc":{"name":"igvm-files","volumePath":"/igvm","sharedComputePath":"/var/run/igvm"}}]'
+              spec:
+                nodeSelector:
+                  confidential.ai/sev-snp: "true"
+                domain:
+                  cpu:
+                    model: EPYC-Genoa
+                    cores: ${CORES}
+                  memory:
+                    guest: ${MEMORY}
+                  resources:
+                    requests:
+                      memory: ${MEMORY}
+                  firmware:
+                    bootloader:
+                      efi:
+                        secureBoot: false
+                  launchSecurity:
+                    snp: {}
+                  devices:
+                    disks:
+                      - name: rootdisk
+                        disk:
+                          bus: virtio
+                          # Shared ROX verity PVC — readonly so QEMU takes a
+                          # shared lock and other CVMs on the node still boot.
+                          readonly: true
+                    interfaces:
+                      - name: default
+                        bridge: {}           # masquerade is broken under SNP
+                    rng: {}
+                networks:
+                  - name: default
+                    pod: {}
+                volumes:
+                  - name: rootdisk
+                    persistentVolumeClaim:
+                      claimName: $ROOTPVC
           EOF
-          echo "b64=$(base64 -w0 payload.sh)" >> "$GITHUB_OUTPUT"
 
-  cvm:
-    needs: payload
-    permissions:
-      contents: read
-      actions: read
-    uses: ./.github/workflows/cvm-e2e.yml
-    with:
-      platform: snp-metal
-      # base-cpu publishes igvmFilePattern, so it can serve a non-default vCPU
-      # count. rke2-node pins a single igvmFile and the primitive refuses the
-      # override there.
-      flavor: base-cpu
-      runner: cvm-launcher
-      payload_b64: ${{ needs.payload.outputs.b64 }}
-      cores_override: ${{ inputs.cores }}
-      timeout_minutes: 30
-
-  report:
-    needs: [cvm]
-    runs-on: ubuntu-latest
-    steps:
-      - name: report the measurement
-        env:
-          MEASUREMENT: ${{ needs.cvm.outputs.measurement }}
-          CORES: ${{ inputs.cores }}
+      - name: wait for the guest IP
         run: |
           set -euo pipefail
-          [ -n "$MEASUREMENT" ] || { echo "::error::the run attested no measurement"; exit 1; }
+          deadline=$((SECONDS + 600))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            IP=$(kubectl -n "$NS" get vmi "$VM" -o jsonpath='{.status.interfaces[0].ipAddress}' 2>/dev/null || true)
+            [ -n "$IP" ] && { echo "GUEST_IP=$IP" >> "$GITHUB_ENV"; echo "guest IP: $IP"; break; }
+            sleep 10
+          done
+          grep -q GUEST_IP "$GITHUB_ENV" || {
+            echo "::error::the VMI never reported an IP"
+            kubectl -n "$NS" get vmi "$VM" -o wide 2>/dev/null || true
+            kubectl -n "$NS" describe vmi "$VM" 2>/dev/null | tail -20 || true
+            exit 1
+          }
+
+      - name: capture the launch measurement
+        id: capture
+        run: |
+          set -euo pipefail
+          # base-cpu has no console, so the attestation-api is the only way in.
+          deadline=$((SECONDS + 600))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            H=$(curl -s --connect-timeout 2 --max-time 4 "http://$GUEST_IP:8400/health" 2>/dev/null || true)
+            [ -n "$H" ] && { echo "attestation-api: $H"; break; }
+            sleep 10
+          done
+          [ -n "${H:-}" ] || { echo "::error::attestation-api never answered on $GUEST_IP:8400"; exit 1; }
+          # POST /attest with a fresh nonce as report_data — the same request
+          # get-kubeconfig's gate makes — then read the measurement out of the
+          # verdict. Unpinned on purpose: this lane reports what the hardware
+          # measured, it does not enforce a policy.
+          nonce=$(head -c 32 /dev/urandom | base64 -w0)
+          curl -fsS --max-time 30 -H 'Content-Type: application/json' \
+            -d "{\"platform\":\"auto\",\"report_data\":\"$nonce\"}" \
+            "http://$GUEST_IP:8400/attest" > evidence.json
+          jq -e '.evidence' evidence.json >/dev/null || { echo "::error::/attest returned no evidence object"; head -c 400 evidence.json; exit 1; }
+          erd=$(printf '%s' "$nonce" | base64 -d | xxd -p -c256)
+          bin/c8s verify --from-file evidence.json --expected-report-data "$erd" --output json > verdict.json || true
+          M=$(jq -r '.measurement // empty' verdict.json)
+          [ -n "$M" ] || { echo "::error::no measurement in the verdict"; jq . verdict.json | head -40; exit 1; }
+          echo "measurement=$M" >> "$GITHUB_OUTPUT"
+          echo "smp$CORES measurement: $M"
+
+      - name: compare against the published digest
+        run: |
+          set -euo pipefail
+          M='${{ steps.capture.outputs.measurement }}'
+          d=$(crane manifest "$IMAGE" | jq -r '.layers[]|select(.annotations["org.opencontainers.image.title"]=="manifest.json")|.digest')
+          PUB=$(crane blob "${IMAGE%%:*}@${d}" | jq -r --argjson c "$CORES" '.snp_variants[]|select(.smp==$c)|.measurement.snp_launch_digest')
           {
             echo "### SNP launch measurement — smp${CORES}"
             echo
-            echo '```'
-            echo "$MEASUREMENT"
-            echo '```'
+            echo "| source | value |"
+            echo "|---|---|"
+            echo "| hardware | \`${M}\` |"
+            echo "| manifest | \`${PUB:-(no variant for smp$CORES)}\` |"
             echo
-            echo "Compare against \`snp_variants[smp=${CORES}].measurement.snp_launch_digest\` in the image's published manifest.json."
+            if [ "$M" = "$PUB" ]; then
+              echo "**MATCH** — the published digest for smp${CORES} is what the hardware produces."
+            else
+              echo "**MISMATCH** — the manifest publishes a digest this vCPU count does not produce, so a real smp${CORES} node would be refused by the trust gate."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "smp${CORES} measurement: $MEASUREMENT"
+          [ "$M" = "$PUB" ] || echo "::warning title=digest mismatch (smp$CORES)::hardware $M != manifest ${PUB:-none}"
+
+      - name: teardown
+        if: always()
+        run: kubectl -n "$NS" delete vm "$VM" --ignore-not-found --wait=true


### PR DESCRIPTION
## Problem

`snp-measure-smp` (#422) does not work, and the first dispatch proved it:
[run 32311053353](https://github.com/confidential-dot-ai/c8s/actions/runs/32311053353)
failed with

```
guest console never showed an autologin shell — this image cannot take
console-delivered payloads
```

after waiting ~7½ minutes. That is the exact failure `cvm-e2e.yml` documents
from a probe on 2026-07-15: **the base-cpu image emits nothing after the EFI
stub — no kernel console, no autologin.** The primitive delivers its payload
over the serial console, so the two requirements sit on different flavors:

| | per-count IGVM | console payload |
|---|---|---|
| `base-cpu` | ✓ `igvmFilePattern` | ✗ no autologin |
| `rke2-node` | ✗ single `igvmFile` | ✓ autologins |

I built #422 on `base-cpu` for its `igvmFilePattern` without checking that
flavor could run a payload at all — the same isolation mistake as the knob in
#417 that no caller could reach.

What did work: the override plumbing. The run shows `CORES: 8`,
`CORES_OVERRIDDEN: 1`, `IGVMFILE: guest-smp8.igvm` — #417 resolved the right
IGVM and skipped the golden check. The VM booted. Only delivery failed.

## Fix

Nothing needs to run inside the guest. `base-cpu` serves the attestation-api on
the pod network (`cvm-e2e.yml:91`), and an SNP quote carries the MEASUREMENT
this lane wants, so the capture is an HTTP request from the runner.

The lane no longer calls the primitive. It applies the same VM (minus the
console plumbing, keeping the `ci.confidential.ai` labels the shared reaper
keys on), waits for the VMI address, POSTs a nonce to `/attest` — the same
request `get-kubeconfig`'s gate makes — and reads the measurement from
`c8s verify --from-file --output json`. It then fetches that variant's
`snp_launch_digest` from the published manifest and reports match/mismatch in
the job summary. Teardown runs `if: always()`.

Also adds `cvm-launcher` to `.github/actionlint.yaml`: the SNP lane passes it as
an *input* to the primitive, so nothing had ever used it as a `runs-on` and
actionlint had never seen it.

## Testing

The dispatch needs SNP metal. Verified locally against a stub attestation-api:
health probe, POST with a base64 `report_data`, evidence object extracted, the
nonce converting to exactly 64 hex chars, and `c8s verify --from-file` parsing
the envelope and reaching the SNP report parser (it then rejects the stub's
1-byte fake report, which is the correct behaviour — real hardware supplies a
real one). `actionlint` v1.7.12 clean.

The one thing still unproven is that base-cpu's attestation-api is up and
serving; the health probe fails fast and cheaply if not.
