### PR TITLE
fix(tls-lb): resolve the catch-all upstream at startup unless it is mesh-wrapped

### DIFF
--- a/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-configmap.yaml
@@ -6,6 +6,7 @@
 {{- $defaultMeshCAPath := printf "%s/ca.pem" .Values.tlsLb.tlsMountPath -}}
 {{- $upstreamTrustedCAPath := default $defaultMeshCAPath .Values.tlsLb.upstream.tls.trustedCAPath -}}
 {{- $upstreamAddress := .Values.tlsLb.upstream.address | trim -}}
+{{- $upstreamMeshWrapped := eq (include "tls-lb.meshWrappedUpstream" $upstreamAddress) "true" -}}
 {{- $renderAllowlistRoute := eq (include "tls-lb.renderAllowlistRoute" .) "true" -}}
 {{- $allowlistProxyPort := 0 -}}
 {{- $allowlistWriteRate := 0 -}}
@@ -111,11 +112,17 @@ data:
         limit_req_zone $allowlist_read_rate_key zone=allowlist_read_per_client:10m rate={{ $allowlistReadRate }}r/s;
 {{- end }}
 
-        # The catch-all upstream is dialed via a variable (see location /), so
-        # nginx re-resolves it here at request time per record TTL. A static
-        # upstream block would pin the pod IPs a headless-Service name (an
-        # adopted workload) resolved to at startup and 502 after pod churn.
+        {{- if $upstreamMeshWrapped }}
+        # A mesh-wrapped catch-all is dialed via a variable (see location /), so
+        # nginx re-resolves it here at request time per record TTL: a static
+        # upstream block would pin the pod IPs the adopted workload's headless
+        # Service resolved to at startup and 502 after pod churn. Nothing
+        # authenticates the answer -- the app-layer hop is plaintext and the
+        # mesh binds the pod IP it is handed, not the name -- so an adversary
+        # who can forge cluster DNS retargets this hop. Every other upstream
+        # gets a static block below and no resolver is rendered at all.
         resolver {{ include "c8s.tlsLb.resolver" . }};
+        {{- end }}
 
         {{- range $i, $route := .Values.tlsLb.routes }}
         {{- if hasKey $route "upstream" }}
@@ -131,6 +138,12 @@ data:
         }
 
         {{- end }}
+        {{- if and $upstreamAddress (not $upstreamMeshWrapped) }}
+        upstream catch_all {
+            server {{ $upstreamAddress }};
+        }
+        {{- end }}
+
         server {
             listen {{ .Values.tlsLb.nginx.httpsPort }} ssl;
             server_name {{ $serverNames }};
@@ -294,8 +307,12 @@ data:
                 {{- if eq .Values.tlsLb.upstream.protocol "https" }}
                 {{- include "tls-lb.proxySSLDirectives" (dict "protocol" .Values.tlsLb.upstream.protocol "tls" .Values.tlsLb.upstream.tls "serverName" $upstreamServerName "trustedCAPath" $upstreamTrustedCAPath "tlsMountPath" .Values.tlsLb.tlsMountPath) | nindent 16 }}
                 {{- end }}
+                {{- if $upstreamMeshWrapped }}
                 set $backend_addr {{ $upstreamAddress }};
                 proxy_pass {{ .Values.tlsLb.upstream.protocol }}://$backend_addr;
+                {{- else }}
+                proxy_pass {{ .Values.tlsLb.upstream.protocol }}://catch_all;
+                {{- end }}
                 proxy_set_header Host $host;
                 proxy_set_header X-Real-IP $remote_addr;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -565,3 +565,19 @@ list.
   "extraMounts" (join "\n" $mounts)
 ) -}}
 {{- end }}
+
+{{/*
+tls-lb.meshWrappedUpstream — "true" when the address is an operator-managed
+headless Service (c8s-<id>.<ns>.svc.cluster.local:<port>, the exact
+webhook.WorkloadServiceFQDN form). c8s-<id> is a DNS-1035 label, <ns> a
+DNS-1123 label. That shape is the one upstream whose backing pod IPs churn, so
+it is dialed through a variable and re-resolved per request; every other
+address gets a static upstream block resolved once at startup. validations.yaml
+(kind=workload_https_upstream, kind=tlslb_unsecured_upstream) branches on the
+same predicate. Call with the address string.
+*/}}
+{{- define "tls-lb.meshWrappedUpstream" -}}
+{{- if regexMatch "^c8s-[a-z]([-a-z0-9]*[a-z0-9])?\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.svc\\.cluster\\.local:[0-9]+$" . -}}
+true
+{{- end -}}
+{{- end -}}

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -124,9 +124,7 @@
      leave the hop unprotected. There is no plaintext-to-unattested escape hatch.
 */ -}}
 {{- if and $tlsLB.enabled $tlsLB.upstream.address -}}
-{{- /* c8s-<id> is a DNS-1035 label, <ns> a DNS-1123 label — the exact
-  webhook.WorkloadServiceFQDN form the operator provisions and the mesh wraps. */ -}}
-{{- if regexMatch "^c8s-[a-z]([-a-z0-9]*[a-z0-9])?\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?\\.svc\\.cluster\\.local:[0-9]+$" $tlsLB.upstream.address -}}
+{{- if eq (include "tls-lb.meshWrappedUpstream" $tlsLB.upstream.address) "true" -}}
 {{- if eq $tlsLB.upstream.protocol "https" -}}
 {{- fail "VALIDATION_ERROR kind=workload_https_upstream: a c8s-<id> headless-Service upstream is plaintext http at the app layer (the mesh wraps the hop in attested mTLS), but tlsLb.upstream.protocol=https; use protocol http for a mesh-wrapped upstream" -}}
 {{- end -}}

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1386,13 +1386,15 @@ tlsLb:
     #    (targetPort references the named `https` port), so public 443 is
     #    unaffected; front it with a LoadBalancer for external ingress.
     httpsPort: 8443
-    # -- DNS server nginx queries to re-resolve the catch-all upstream address
-    #    at request time (per record TTL). Headless-Service upstreams (an adopted
-    #    workload) resolve to pod IPs that change on pod churn; without
-    #    runtime re-resolution nginx would pin the IPs it saw at startup and
-    #    502 until the next config reload. This name is resolved once at nginx
-    #    startup through the pod's /etc/resolv.conf, and nginx exits (crash-
-    #    loops) if it does not resolve. Empty derives from the distro values
+    # -- DNS server nginx queries to re-resolve a mesh-wrapped catch-all
+    #    upstream at request time (per record TTL). Only the adopted-workload
+    #    headless Service is dialed that way: its pod IPs change on pod churn,
+    #    so a static upstream block would pin the IPs seen at startup and 502
+    #    until the next config reload. Every other upstream address is static
+    #    and this value is unused (no resolver directive is rendered at all).
+    #    The name itself is resolved once at nginx startup through the pod's
+    #    /etc/resolv.conf, and nginx exits (crash-loops) if it does not
+    #    resolve. Empty derives from the distro values
     #    (kata.distro / nriImagePolicy.distro): rke2 ->
     #    rke2-coredns-rke2-coredns.kube-system, else kube-dns.kube-system.
     #    Set explicitly on clusters whose DNS Service is named differently.

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -2267,7 +2267,8 @@ func TestChartRendersTLSLBPublicTLSAndDiscovery(t *testing.T) {
 	defaultRoute.assertDirective(t, "proxy_ssl_name", "my-backend.other-ns.svc.cluster.local")
 	defaultRoute.assertDirective(t, "proxy_ssl_verify", "on")
 	defaultRoute.assertDirective(t, "proxy_ssl_trusted_certificate", "/tls/cert.pem")
-	defaultRoute.assertDirective(t, "proxy_pass", "https://$backend_addr")
+	defaultRoute.assertDirective(t, "proxy_pass", "https://catch_all")
+	cfg.upstream(t, "catch_all").assertServer(t, "my-backend.other-ns.svc:8443")
 
 	spec := renderedDeployment(t, out, "c8s-tls-lb").Spec.Template.Spec
 	if _, ok := podVolume(spec, "tls-certs"); !ok {
@@ -2757,6 +2758,29 @@ func TestChartTLSLBMeshWrappedUpstreamIsWorkloadDirect(t *testing.T) {
 	cfg.assertNoDirectivePrefix(t, "proxy_ssl_")
 }
 
+// A manual upstream is dialed through a static upstream block, so nginx
+// resolves it once at startup instead of per request. Per-request resolution
+// asks cluster DNS -- plaintext UDP the mesh does not intercept -- where to
+// send every request, so a forged answer retargets the hop mid-session; a
+// loose tls.serverName or a wildcard SAN pattern leaves nothing to catch it.
+// Only the mesh-wrapped headless shape keeps the variable dial, because its
+// pod IPs churn; the resolver is rendered for that shape alone.
+func TestChartTLSLBManualUpstreamResolvesAtStartup(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set-string", "tlsLb.upstream.address=my-backend.other-ns.svc:8443",
+		"--set", "tlsLb.upstream.protocol=https",
+		"--set", "tlsLb.upstream.tls.verify=true")
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cfg := renderedTLSLBNginxConfig(t, out)
+	cfg.upstream(t, "catch_all").assertServer(t, "my-backend.other-ns.svc:8443")
+	route := cfg.location(t, "prefix", "/")
+	route.assertDirective(t, "proxy_pass", "https://catch_all")
+	route.assertNoDirective(t, "set")
+	cfg.http.assertNoDirective(t, "resolver")
+}
+
 // nginx exits at startup on a resolver name that does not resolve, and RKE2
 // names its CoreDNS Service rke2-coredns-rke2-coredns — the kube-dns default
 // crash-loops tls-lb on every RKE2 cluster. The resolver therefore derives
@@ -3111,8 +3135,8 @@ func TestTLSLBAdditionalRoutesConfigureNginxLocations(t *testing.T) {
 	}
 
 	defaultRoute := cfg.location(t, "prefix", "/")
-	defaultRoute.assertDirective(t, "set", "$backend_addr", "vllm:8000")
-	defaultRoute.assertDirective(t, "proxy_pass", "https://$backend_addr")
+	defaultRoute.assertDirective(t, "proxy_pass", "https://catch_all")
+	cfg.upstream(t, "catch_all").assertServer(t, "vllm:8000")
 	cfg.upstream(t, "route_0").assertServer(t, "cds.c8s-system.svc:8080")
 	cfg.upstream(t, "route_1").assertServer(t, "tenant-router.c8s-system.svc:8080")
 }
@@ -5727,18 +5751,16 @@ func Example_tlsLBConfig() {
 	//
 	//     sendfile on;
 	//     keepalive_timeout 65;
-	//
-	//     # The catch-all upstream is dialed via a variable (see location /), so
-	//     # nginx re-resolves it here at request time per record TTL. A static
-	//     # upstream block would pin the pod IPs a headless-Service name (an
-	//     # adopted workload) resolved to at startup and 502 after pod churn.
-	//     resolver kube-dns.kube-system.svc.cluster.local;
 	//     upstream route_0 {
 	//         server c8s-cds.c8s-system.svc:8443;
 	//     }
 	//     upstream route_1 {
 	//         server tenant-router.c8s-system.svc:8080;
 	//     }
+	//     upstream catch_all {
+	//         server vllm:8000;
+	//     }
+	//
 	//     server {
 	//         listen 8443 ssl;
 	//         server_name c8s-tls-lb.c8s-system.svc;
@@ -5792,8 +5814,7 @@ func Example_tlsLBConfig() {
 	//             proxy_ssl_verify on;
 	//             proxy_ssl_verify_depth 2;
 	//             proxy_ssl_trusted_certificate /tls/cert.pem;
-	//             set $backend_addr vllm:8000;
-	//             proxy_pass https://$backend_addr;
+	//             proxy_pass https://catch_all;
 	//             proxy_set_header Host $host;
 	//             proxy_set_header X-Real-IP $remote_addr;
 	//             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -6796,17 +6817,27 @@ func TestChartKataPullerAnonymousWithoutSecrets(t *testing.T) {
 	}
 }
 
-// tlsLbUpstreamAddress returns the address from the catch-all location's
-// `set $backend_addr <addr>;` directive in the rendered tls-lb nginx config.
+// tlsLbUpstreamAddress returns the catch-all upstream address from the
+// rendered tls-lb nginx config: the `upstream catch_all` block's server for a
+// static dial, or the `set $backend_addr <addr>;` directive for the
+// mesh-wrapped shape that is re-resolved per request.
 func tlsLbUpstreamAddress(t *testing.T, manifest string) string {
 	t.Helper()
-	sets := renderedTLSLBNginxConfig(t, manifest).location(t, "prefix", "/").directives["set"]
+	cfg := renderedTLSLBNginxConfig(t, manifest)
+	if block, ok := cfg.upstreams["catch_all"]; ok {
+		servers := block.directives["server"]
+		if len(servers) != 1 || len(servers[0]) != 1 {
+			t.Fatalf("upstream catch_all must carry exactly one server; got %v", servers)
+		}
+		return servers[0][0]
+	}
+	sets := cfg.location(t, "prefix", "/").directives["set"]
 	for _, args := range sets {
 		if len(args) == 2 && args[0] == "$backend_addr" {
 			return args[1]
 		}
 	}
-	t.Fatalf("location / has no `set $backend_addr <addr>;` directive; got %v", sets)
+	t.Fatalf("catch-all has neither an `upstream catch_all` block nor a `set $backend_addr <addr>;` directive; got %v", sets)
 	return ""
 }
 


### PR DESCRIPTION
The tls-lb catch-all upstream was always dialed through a variable `proxy_pass`, so nginx re-resolved the address on every request. Only one upstream shape needs that: the adopted-workload headless Service, whose backing pod IPs change on churn. Every other address is stable for the life of the pod and now renders as a static `upstream catch_all` block, resolved once at startup.

`resolver` renders only for the shape that still re-resolves. A deployment that does not use one no longer carries the directive, so it cannot crash-loop on a resolver name that does not resolve.

The headless-shape predicate moves into `tls-lb.meshWrappedUpstream`, shared with the `validations.yaml` guard that already branched on the same regex.