### PR TITLE
ci: SHA-pin the last 17 action uses, and gate both pin classes

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -188,7 +188,7 @@ jobs:
         # Warm runs never touch the apt mirror, whose degradation has taken
         # out gate legs repeatedly.
         id: apt-debs
-        uses: actions/cache/restore@v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
           key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
@@ -222,7 +222,7 @@ jobs:
       - name: Save build-dep debs
         # Inline: runs only when the install above succeeded.
         if: steps.apt-debs.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
           key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
@@ -235,7 +235,7 @@ jobs:
         # on it; the tools tree still restores unconditionally because the
         # fallback path (stamp mismatch) needs it.
         id: gpu-staged
-        uses: actions/cache/restore@v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             confidential-os-builder/output/gpu/staged
@@ -250,7 +250,7 @@ jobs:
         # failed build and archives partial trees under a stable key that is
         # then never re-saved (the #408 gate poisoning).
         id: tools-tree
-        uses: actions/cache/restore@v6.1.0
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
           key: ${{ runner.os }}-tools-v2-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
@@ -261,7 +261,7 @@ jobs:
         # lockfiles (written beside the fragments here since confos v0.4.3)
         # ride the cache until they are committed in this repo, at which point
         # the cached copy becomes redundant.
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             confidential-os-builder/output/kernel
@@ -269,7 +269,7 @@ jobs:
           key: ${{ runner.os }}-kernel-v3-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','c8s/node-guest-image/kernel/config-x86_64-*.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
       - name: Cache base image tools
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             confidential-os-builder/mkosi/base/mkosi.tools
@@ -281,7 +281,7 @@ jobs:
         # assembly off snapshot.ubuntu.com, whose fetch latency varies by
         # runner. restore-keys tolerates partial staleness: apt re-fetches
         # only what's missing, and the mirror guard still polices the source.
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             confidential-os-builder/mkosi/base/mkosi.pkgcache
@@ -294,7 +294,7 @@ jobs:
 
       - name: Cache c8s artifact downloads
         # ~3.5G rke2 tarball + airgap bundles, sha256-verified on reuse.
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: confidential-os-builder/mkosi/base/mkosi.pkgcache/c8s
           key: ${{ runner.os }}-c8s-artifacts-${{ hashFiles('c8s/node-guest-image/c8s/mkosi.sync') }}
@@ -304,7 +304,7 @@ jobs:
       - name: Cache NVIDIA driver downloads
         # ~500MB, sha-verified; keyed on the script that carries the pins.
         if: steps.gpu-staged.outputs.cache-hit != 'true'
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: confidential-os-builder/output/gpu/cache
           key: ${{ runner.os }}-gpu-artifacts-${{ hashFiles('confidential-os-builder/bin/confos-fetch-gpu') }}
@@ -316,7 +316,7 @@ jobs:
       - name: Cache attestation-api binary
         # Keyed on the attestation-rs commit plus this workflow (libnvat pin).
         id: attest-bin
-        uses: actions/cache@v6.1.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: attestation-rs/target/release/attestation-api
           key: ${{ runner.os }}-attest-bin-${{ steps.attest-sha.outputs.sha }}-${{ hashFiles('c8s/.github/workflows/c8s-image.yml') }}
@@ -408,14 +408,14 @@ jobs:
 
       - name: Save kernel-builder tools tree
         if: steps.tools-tree.outputs.cache-hit != 'true' && steps.tools-built.outputs.built == 'true'
-        uses: actions/cache/save@v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: confidential-os-builder/mkosi/kernel-builder/mkosi.output
           key: ${{ runner.os }}-tools-v2-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**') }}
 
       - name: Save staged GPU tree
         if: steps.gpu-staged.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v6.1.0
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             confidential-os-builder/output/gpu/staged
@@ -425,7 +425,7 @@ jobs:
       - name: Upload measurement evidence (gate)
         # Gate mode ends here: evidence out, nothing published.
         if: inputs.gate == true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: gate-${{ env.VARIANT }}-${{ github.run_id }}${{ inputs.leg && format('-{0}', inputs.leg) || '' }}
           path: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/setup-go-c8s
 

--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -462,7 +462,7 @@ jobs:
 
       - name: upload console artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: guest-console-${{ inputs.platform }}-${{ inputs.flavor }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/console.log

--- a/.github/workflows/image-repro-debug.yml
+++ b/.github/workflows/image-repro-debug.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload evidence
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: repro-debug-${{ inputs.platform }}-${{ github.run_id }}
           path: |

--- a/.github/workflows/image-repro-gate.yml
+++ b/.github/workflows/image-repro-gate.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           set -euo pipefail
           test "$A" = success && test "$B" = success || { echo "leg results: a=$A b=$B" >&2; exit 1; }
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: needs.changes.outputs.image == 'true'
         with:
           pattern: gate-*-${{ github.run_id }}-*

--- a/.github/workflows/pin-hygiene.yml
+++ b/.github/workflows/pin-hygiene.yml
@@ -4,10 +4,10 @@ name: pin hygiene
 on:
   pull_request:
     paths:
-      - ".github/workflows/c8s-image.yml"
-      - ".github/workflows/kata-guest-base.yml"
-      - ".github/workflows/pin-hygiene.yml"
+      - ".github/workflows/**"
+      - ".github/actions/**"
       - "node-guest-image/c8s/mkosi.sync"
+      - "**/Dockerfile"
   workflow_dispatch:
 
 permissions:
@@ -36,5 +36,29 @@ jobs:
           release_re="^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta|rc)[1-9][0-9]*)?$"
           if [[ ! "$ref" =~ $release_re ]]; then
             echo "::error file=node-guest-image/c8s/mkosi.sync::C8S_REF default must be a published vX.Y.Z[-alphaN|-betaN|-rcN] release tag, got '$ref'"; fail=1
+          fi
+          # Every third-party action is a 40-hex commit. A tag or branch is
+          # whatever its owner repoints it at, on a runner holding GHCR push
+          # credentials.
+          unpinned=$(grep -rnE '^[[:space:]]*-?[[:space:]]*uses:' \
+                       .github/workflows .github/actions \
+                     | grep -vE 'uses:[[:space:]]*\./' \
+                     | grep -vE 'uses:[[:space:]]*[^@[:space:]]+@[0-9a-f]{40}([[:space:]]|$)' || true)
+          if [ -n "$unpinned" ]; then
+            echo "$unpinned" | while IFS= read -r line; do
+              echo "::error file=${line%%:*}::action is not pinned to a 40-hex commit: ${line#*:*:}"
+            done
+            fail=1
+          fi
+
+          # Every base is content-addressed; the tag beside it is for readers
+          # and for Dependabot to compare against.
+          undigested=$(grep -rn '^FROM ' --include=Dockerfile . \
+                       | grep -vE '@sha256:[0-9a-f]{64}' || true)
+          if [ -n "$undigested" ]; then
+            echo "$undigested" | while IFS= read -r line; do
+              echo "::error file=${line%%:*}::base image is not digest-pinned: ${line#*:*:}"
+            done
+            fail=1
           fi
           exit $fail

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       b64: ${{ steps.build.outputs.b64 }}
       short: ${{ steps.build.outputs.short }}
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: confidential-dot-ai/c8s
           ref: ${{ inputs.c8s_ref || 'main' }}   # push/schedule have no inputs

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -101,7 +101,7 @@ jobs:
     # build ~3m + install/converge ~3m + asserts. Headroom for a cold go cache.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: tools (kubectl, go, crane, helm)
         run: |


### PR DESCRIPTION
Every third-party action in the fleet now resolves to a 40-hex commit.
17 `uses:` still went through a tag, 13 of them in c8s-image.yml — a
workflow that runs on the self-hosted runner and holds GHCR push
credentials, where a repointed actions/cache is arbitrary code in the
job that builds the measured node image.

Each one is pinned at the commit its own tag resolves to, and every one
of those commits is already in the tree at the same version, so this
changes no behaviour at all: it writes by digest what was already being
fetched. Dependabot's group bump did the version convergence first
(#434), which is why the two halves line up this cleanly.

actions/checkout is the exception that still needed moving: two sites
sat off the fleet version, one at v6.0.2 and one carrying the v7.0.1
commit mislabelled `# v4`.

pin-hygiene gains the two checks that keep this from rotting: no
non-local `uses:` without a 40-hex commit, and no Dockerfile FROM
without a digest. Its paths filter widens from four named files to the
workflow and action trees plus **/Dockerfile — a rule about every
workflow cannot be gated on four of them.

Not touched: setup-oras is now v2.0.1 fleet-wide, but three sites pin
the oras CLI itself at 1.2.3 in `with:` and four take the action's
default. That inconsistency predates this change and picking a side
means moving the release-publishing lanes, which wants its own PR.
