### PR TITLE
fix(e2e): derive the oras sibling from a digest-pinned image ref

### DIFF
--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -398,11 +398,37 @@ jobs:
           set -euo pipefail
           # Pull the manifest the image build published rather than writing
           # one: a hand-built stub only ever proves the gate accepts the shape
-          # this step chose. The CDI tag the CVM boots and the oras artifact
-          # carrying manifest.json are the same build under sibling tags, so
-          # the manifest is fetched by stripping the -cdi suffix.
-          oras_ref="${image%-cdi}"
-          [ "$oras_ref" != "$image" ] || { echo "::error::refs CM 'image' ($image) is not a -cdi tag, so the sibling oras artifact carrying manifest.json cannot be derived"; exit 1; }
+          # this step chose. The CDI image the CVM boots and the oras artifact
+          # carrying manifest.json are the same build under sibling tags
+          # (:<variant>-cdi and :<variant>), so the artifact is the CDI tag
+          # without its -cdi suffix.
+          #
+          # The refs CM pins the image by digest, which carries no tag to
+          # strip (the image has no version label or annotation to read one
+          # from either). Resolve the digest back to the -cdi tag that points
+          # at it, then take that tag's sibling. The MRTD cross-check below
+          # is what proves the artifact belongs to the booted build; this only
+          # has to find it.
+          case "$image" in
+            *@sha256:*)
+              repo="${image%%@*}"
+              want="${image##*@}"
+              cdi_tag=""
+              for t in $(crane ls "$repo"); do
+                case "$t" in *-cdi|*-cdi-*) ;; *) continue ;; esac
+                [ "$(crane digest "$repo:$t")" = "$want" ] || continue
+                cdi_tag="$t"
+                break
+              done
+              [ -n "$cdi_tag" ] || { echo "::error::no -cdi tag in $repo resolves to $want, so the sibling oras artifact carrying manifest.json cannot be derived"; exit 1; }
+              echo "refs CM digest resolves to $cdi_tag"
+              oras_ref="$repo:$(printf '%s' "$cdi_tag" | sed 's/-cdi//')"
+              ;;
+            *)
+              oras_ref="${image%-cdi}"
+              [ "$oras_ref" != "$image" ] || { echo "::error::refs CM 'image' ($image) is neither a digest nor a -cdi tag, so the sibling oras artifact carrying manifest.json cannot be derived"; exit 1; }
+              ;;
+          esac
           digest=$(crane manifest "$oras_ref" | jq -r '.layers[] | select(.annotations["org.opencontainers.image.title"] == "manifest.json") | .digest')
           [ -n "$digest" ] || { echo "::error::$oras_ref publishes no manifest.json layer"; exit 1; }
           crane blob "${oras_ref%%:*}@${digest}" > /tmp/image-manifest.json


### PR DESCRIPTION
Fixes #423. Every `tdx-metal` e2e run has failed since #399 merged, at **get an attested, operator-key-bound kubeconfig**: [run 32308636318](https://github.com/confidential-dot-ai/c8s/actions/runs/32308636318/job/96246772725).

## Problem

#399 replaced a self-written manifest stub with a fetch of the published one — right call, since a hand-built stub only proves the gate accepts the shape that step chose. But it derives the sibling oras artifact by stripping a `-cdi` **tag suffix**:

```bash
oras_ref="${image%-cdi}"
```

The refs CM pins `image` by **digest**, which has no suffix to strip, so the guard fires and the run fails closed. The CM predates #399; nothing changed on the cluster.

## Fix

Resolve the digest to the `-cdi` tag that points at it, then take that tag's sibling. The tag path is unchanged, so a tag-pinned CM keeps working.

I checked the alternatives first: the image carries no `org.opencontainers.image.version` label (`.config.Labels` is null) and no tag annotation, so there is nothing to read a tag from — the registry lookup is the available mechanism. The CM itself is seeded by `c8s-e2e/cluster-prep/apply.sh` outside this repo, so adding an `imageTag` key there would work too but needs a change we cannot make here.

The MRTD cross-check below the derivation is what proves the artifact belongs to the booted build; this only has to find it, and a failure to resolve stays fatal.

## Verification

Ran the derivation against the live registry with the exact digest from the failing run:

```
resolved cdi tag:    rke2-tdx-cdi-47c8522
oras_ref:            ghcr.io/confidential-dot-ai/node-guest-base:rke2-tdx-47c8522
manifest.json layer: sha256:e0ab84728f69a6e9ed8b18e9d4b9c825fa43510cacbfd984195661de461b1cd2
mrtd:                9309eaae9c151e766de0f97b1d1aaeb76b8c8c366080803943fb566521c8f0cf00a142d8b7b0683ed1d42c5a27198ba1
```