### PR TITLE
fix(ci): hex-encode the nonce with od, not xxd

### DIFF
--- a/.github/workflows/snp-measure-smp.yml
+++ b/.github/workflows/snp-measure-smp.yml
@@ -195,7 +195,8 @@ jobs:
             -d "{\"platform\":\"auto\",\"report_data\":\"$nonce\"}" \
             "http://$GUEST_IP:8400/attest" > evidence.json
           jq -e '.evidence' evidence.json >/dev/null || { echo "::error::/attest returned no evidence object"; head -c 400 evidence.json; exit 1; }
-          erd=$(printf '%s' "$nonce" | base64 -d | xxd -p -c256)
+          # od, not xxd: xxd ships with vim, which the runner does not have.
+          erd=$(printf '%s' "$nonce" | base64 -d | od -An -tx1 -v | tr -d ' \n')
           bin/c8s verify --from-file evidence.json --expected-report-data "$erd" --output json > verdict.json || true
           M=$(jq -r '.measurement // empty' verdict.json)
           [ -n "$M" ] || { echo "::error::no measurement in the verdict"; jq . verdict.json | head -40; exit 1; }


### PR DESCRIPTION
## Problem

The first real dispatch of `snp-measure-smp`
([run 32396970412](https://github.com/confidential-dot-ai/c8s/actions/runs/32396970412))
got all the way to the capture step and died:

```
line 19: xxd: command not found
Process completed with exit code 127
```

`xxd` ships as part of vim, not coreutils, and the `cvm-launcher` runner does
not have it. My mistake: I used it locally, where it exists, and never checked
the runner.

## Fix

`od -An -tx1 -v | tr -d ' \n'` — coreutils, byte-identical output (verified).

## What the run did prove

Everything up to that line worked, which is most of what #438 was uncertain
about:

- the vCPU validation resolved the shipped IGVMs: `smp8 is one of the shipped IGVMs (2 4 8 16 )`
- the VM booted the right image: `IGVMFILE: guest-smp8.igvm`
- the VMI reported an address: `guest IP: 10.42.0.86`
- **the attestation-api answered over the pod network**:
  `{"status":"ok","platform":"snp",...}`

That last one was the open question in #438 — base-cpu's attestation-api is up
and reachable, so the network path is sound and the console limitation is fully
sidestepped.

Also audited every other external tool the lane calls (`jq`, `curl`, `base64`,
`od`, `tr`, `sed`, `sort`, `head`, plus workflow-installed `kubectl`/`crane`).
`jq` is the only other non-coreutils one and the run proves it is present — it
parsed the crane output in the validation step.
