### PR TITLE
fix(ratls-mesh): make the cw DNS carve-out reachable in its own chain

### DIFF
--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -826,7 +826,14 @@ theater), and CDS and tls-lb run in their own kata CVMs.
   UDP/53 to the cluster DNS server. The host takes it from the chart
   (`ratlsMesh.clusterDNSIP` → `--cluster-dns-ip`); the guest reads
   `C8S_CLUSTER_DNS_IP` baked in kata-guest-base. Set both to the same value
-  or one side drops the other's DNS; the c8s default is 10.53.0.10 on both.
+  or one side drops the other's DNS; the c8s default is 10.53.0.10 on both,
+  which is the c8s node image's `cluster-dns` — stock RKE2 uses 10.43.0.10
+  and kubeadm 10.96.0.10, so a cluster off that image must set it. The host
+  logs a warning naming the mismatch when the configured server is not one
+  its own pod resolver lists. The host guard hangs off `FORWARD`, downstream
+  of kube-proxy's Service DNAT, so it carves out both the packet's
+  destination and the connection's original one — whichever survives on the
+  cluster's dataplane.
 
 ## Which certificate is used where
 

--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -862,6 +862,14 @@ func buildInGuestIptablesRules(outboundPort, inboundPort, healthPort int, inboun
 // ESTABLISHED/RELATED replies on INPUT, and the ICMPv6 types IPv6 needs. The
 // guest enforces this locally so it does not depend on an external node.
 func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
+	// The guest runs no kube-proxy, so its nat table holds only the mesh's own
+	// TCP redirects and a query still carries the DNS server address on OUTPUT.
+	// The carve-out is installed in the client that owns that address; the
+	// drop below is family-agnostic, so tagging it wrong drops the guest's DNS.
+	dnsFamily := iptablesFamilyIPv4
+	if ip := net.ParseIP(dnsServerIP); ip != nil && ip.To4() == nil {
+		dnsFamily = iptablesFamilyIPv6
+	}
 	rules := []iptablesRule{
 		iptablesRule{
 			table: "filter", chain: guestFilterOutputChain,
@@ -871,7 +879,7 @@ func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
 		iptablesRule{
 			table: "filter", chain: guestFilterOutputChain,
 			label:  "in-guest-output-return-dns",
-			family: iptablesFamilyIPv4,
+			family: dnsFamily,
 			args:   []string{"-p", "udp", "--dport", "53", "-d", dnsServerIP, "-j", "RETURN"},
 		},
 	}
@@ -904,7 +912,7 @@ func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
 		iptablesRule{
 			table: "filter", chain: guestFilterInputChain,
 			label:  "in-guest-input-return-dns-reply",
-			family: iptablesFamilyIPv4,
+			family: dnsFamily,
 			args:   []string{"-p", "udp", "--sport", "53", "-s", dnsServerIP, "-j", "RETURN"},
 		},
 	)

--- a/internal/cmds/ratlsmesh/in_guest_linux_test.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux_test.go
@@ -642,3 +642,32 @@ func TestRunInGuestConfigErrors(t *testing.T) {
 		}
 	})
 }
+
+// The guest's non-TCP drop is family-agnostic while the DNS carve-out is
+// installed in one client, so an IPv6 cluster DNS whose carve-out is tagged
+// IPv4 loses the guest's own name resolution.
+func TestBuildInGuestFailClosedRulesTagsDNSByFamily(t *testing.T) {
+	dnsRules := func(t *testing.T, dnsIP string) []iptablesRule {
+		t.Helper()
+		var got []iptablesRule
+		for _, r := range buildInGuestFailClosedRules(dnsIP) {
+			if strings.Contains(r.label, "dns") {
+				got = append(got, r)
+			}
+		}
+		if len(got) != 2 {
+			t.Fatalf("%s: got %d dns rules, want the OUTPUT query and the INPUT reply", dnsIP, len(got))
+		}
+		return got
+	}
+	for _, r := range dnsRules(t, "10.53.0.10") {
+		if r.family != iptablesFamilyIPv4 {
+			t.Errorf("%s family = %q, want ipv4", r.label, r.family)
+		}
+	}
+	for _, r := range dnsRules(t, "fd00::10") {
+		if r.family != iptablesFamilyIPv6 {
+			t.Errorf("%s family = %q, want ipv6", r.label, r.family)
+		}
+	}
+}

--- a/internal/cmds/ratlsmesh/iptables.go
+++ b/internal/cmds/ratlsmesh/iptables.go
@@ -61,9 +61,10 @@ var managedIPSetNames = []string{
 
 // clusterDNSClusterIP is the cluster DNS Service ClusterIP the DNS carve-out
 // is destination-scoped to. The c8s node guest image sets cluster-dns
-// 10.53.0.10 (rke2 config.yaml); operators override via --cluster-dns-ip.
-// The egress guard returns only UDP/53 traffic to this server so a cw pod
-// cannot ship arbitrary bytes to an un-scoped external resolver.
+// 10.53.0.10 (rke2 config.yaml); stock RKE2 uses 10.43.0.10 and kubeadm
+// 10.96.0.10, so a cluster off the c8s node image needs --cluster-dns-ip.
+// The scope makes the cluster resolver the only non-TCP destination a cw pod
+// can reach; queries it forwards upstream are the resolver's to police.
 const clusterDNSClusterIP = "10.53.0.10"
 
 // essentialICMPv6Types are the ICMPv6 types IPv6 needs to operate (RFC 4890):
@@ -437,9 +438,17 @@ func buildCWGuardRules(passthrough []cwPassthrough) []iptablesRule {
 // IPv6 needs. dnsIPs maps each family to the cluster DNS server IP(s) the DNS
 // carve-out is restricted to. TCP egress never reaches this chain: pod-
 // destination TCP is intercepted in PREROUTING and non-pod TCP is out of
-// scope here. NOTE: kube-proxy DNATs the ClusterIP to a pod IP in PREROUTING
-// before FORWARD, so the -d <ClusterIP> RETURN may miss; confirm on a live
-// cluster (post-DNAT vs pre-DNAT).
+// scope here.
+//
+// INVARIANT: the DNS carve-out is emitted twice per server, once against the
+// packet's destination and once against the connection's original one. This
+// chain hangs off FORWARD, which kube-proxy's nat/PREROUTING DNAT precedes: by
+// then a query to the DNS ClusterIP carries a CoreDNS pod IP and -d matches
+// nothing, while the conntrack original tuple still holds the ClusterIP. Where
+// the flow is untracked, or the dataplane translates the Service outside
+// netfilter, the reverse holds and -d is the row that fires. Both carry the
+// same destination scope, so whichever matches admits the same traffic: the
+// only non-TCP destination a cw pod may reach is the named resolver.
 func buildCWEgressGuardRules(dnsIPs map[iptablesFamily][]string) []iptablesRule {
 	var rules []iptablesRule
 	for _, spec := range []struct {
@@ -462,18 +471,22 @@ func buildCWEgressGuardRules(dnsIPs map[iptablesFamily][]string) []iptablesRule 
 			},
 		})
 		for _, ip := range dnsIPs[spec.family] {
-			rules = append(rules, iptablesRule{
-				table:  "filter",
-				chain:  cwEgressChainName,
-				label:  "cw-egress-dns-query",
-				family: spec.family,
-				args: []string{
-					"-m", "set", "--match-set", spec.setName, "src",
-					"-p", "udp", "--dport", "53",
-					"-d", ip,
-					"-j", "RETURN",
-				},
-			})
+			for _, scope := range [][]string{
+				{"-m", "conntrack", "--ctorigdst", ip},
+				{"-d", ip},
+			} {
+				rules = append(rules, iptablesRule{
+					table:  "filter",
+					chain:  cwEgressChainName,
+					label:  "cw-egress-dns-query",
+					family: spec.family,
+					args: slices.Concat(
+						[]string{"-m", "set", "--match-set", spec.setName, "src", "-p", "udp", "--dport", "53"},
+						scope,
+						[]string{"-j", "RETURN"},
+					),
+				})
+			}
 		}
 		if spec.family == iptablesFamilyIPv6 {
 			for _, t := range essentialICMPv6Types {

--- a/internal/cmds/ratlsmesh/iptables_sync_run_test.go
+++ b/internal/cmds/ratlsmesh/iptables_sync_run_test.go
@@ -3,8 +3,12 @@
 package ratlsmesh
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -44,6 +48,7 @@ func defaultTestSyncConfig() *iptablesSyncConfig {
 		watchdogPeriod:          2 * time.Second,
 		ipsetMaxElem:            defaultIPSetMaxElem,
 		cwInboundPassthrough:    formatCWPassthrough(defaultCWPassthrough),
+		clusterDNSIPs:           []string{clusterDNSClusterIP},
 		logLevel:                "error",
 	}
 }
@@ -262,5 +267,48 @@ func TestDiscoverMissingFamilyNodeIPsRealHostSmoke(t *testing.T) {
 	}
 	if _, ok := got[iptablesFamilyIPv4]; ok {
 		t.Errorf("discover returned IPv4 %q even though it was provided", got[iptablesFamilyIPv4])
+	}
+}
+
+// The shipped carve-out default is the c8s node image's cluster-dns, so on any
+// other distribution it names a server no pod resolves against — a cluster-wide
+// cw DNS outage whose only symptom is a drop counter. resolv.conf is read to
+// contradict a wrong value, never to supply one.
+func TestWarnUnlessClusterDNSResolves(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "resolv.conf")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write resolv.conf: %v", err)
+		}
+		return path
+	}
+	warnings := func(t *testing.T, configured []string, path string) string {
+		t.Helper()
+		var buf bytes.Buffer
+		warnUnlessClusterDNSResolves(slog.New(slog.NewJSONHandler(&buf, nil)), configured, path)
+		return buf.String()
+	}
+
+	pod := write(t, "search demo.svc.cluster.local svc.cluster.local\nnameserver 10.43.0.10\n")
+	if got := warnings(t, []string{"10.53.0.10"}, pod); !strings.Contains(got, "10.53.0.10") {
+		t.Errorf("a carve-out naming a server the node does not resolve against went unreported: %q", got)
+	}
+	if got := warnings(t, []string{"10.43.0.10"}, pod); got != "" {
+		t.Errorf("matching server warned anyway: %q", got)
+	}
+
+	// Dual-stack: each configured server is judged on its own.
+	dual := write(t, "nameserver 10.43.0.10\nnameserver fd00::a\n")
+	if got := warnings(t, []string{"10.43.0.10", "fd00::a"}, dual); got != "" {
+		t.Errorf("both configured servers are listed, yet one warned: %q", got)
+	}
+
+	// A resolv.conf with nothing to compare against says nothing either way.
+	if got := warnings(t, []string{"10.53.0.10"}, write(t, "search cluster.local\n")); got != "" {
+		t.Errorf("nameserver-less resolv.conf produced a mismatch claim: %q", got)
+	}
+	if got := warnings(t, []string{"10.53.0.10"}, filepath.Join(t.TempDir(), "absent")); !strings.Contains(got, "cannot check") {
+		t.Errorf("unreadable resolv.conf went unreported: %q", got)
 	}
 }

--- a/internal/cmds/ratlsmesh/iptables_test.go
+++ b/internal/cmds/ratlsmesh/iptables_test.go
@@ -339,19 +339,19 @@ func TestBuildCWEgressGuardRulesGolden(t *testing.T) {
 		{iptablesFamilyIPv4, cwPodIPSetName4, "10.53.0.10"},
 		{iptablesFamilyIPv6, cwPodIPSetName6, "fd00::10"},
 	}
-	// Per family: established RETURN, 1 DNS RETURN, [14 ICMPv6 RETURN for v6],
-	// nontcp DROP. v4 = 4 rules, v6 = 4 + 14.
+	// Per family: established RETURN, 2 DNS RETURNs (one per destination
+	// scope), [14 ICMPv6 RETURN for v6], nontcp DROP. v4 = 5, v6 = 5 + 14.
 	var offset int
 	for _, spec := range specs {
 		icmpCount := 0
 		if spec.family == iptablesFamilyIPv6 {
 			icmpCount = len(essentialICMPv6Types)
 		}
-		perFamily := 3 + icmpCount // est, dns, icmpv6 x N, drop
+		perFamily := 4 + icmpCount // est, dns x 2, icmpv6 x N, drop
 		group := rules[offset : offset+perFamily]
 		offset += perFamily
-		est, dnsRule, drop := group[0], group[1], group[perFamily-1]
-		for _, r := range []iptablesRule{est, dnsRule, drop} {
+		est, dnsCt, dnsDst, drop := group[0], group[1], group[2], group[perFamily-1]
+		for _, r := range []iptablesRule{est, dnsCt, dnsDst, drop} {
 			if r.table != "filter" || r.chain != cwEgressChainName {
 				t.Errorf("%s: table=%q chain=%q, want filter/%s", spec.family, r.table, r.chain, cwEgressChainName)
 			}
@@ -374,21 +374,33 @@ func TestBuildCWEgressGuardRulesGolden(t *testing.T) {
 		if !reflect.DeepEqual(est.args, wantEst) {
 			t.Errorf("%s established return = %v, want %v", spec.family, est.args, wantEst)
 		}
-		// DNS carve-out is destination-scoped to the cluster DNS IP so a cw
-		// pod cannot reach an un-scoped external resolver in plaintext.
-		wantDNS := []string{
+		// The carve-out keeps the cluster resolver as the only non-TCP
+		// destination a cw pod can reach. It is written against both the
+		// connection's original destination and the packet's: this chain runs
+		// after kube-proxy's DNAT, where only the former survives, and on an
+		// untracked flow only the latter matches.
+		wantCt := []string{
+			"-m", "set", "--match-set", spec.setName, "src",
+			"-p", "udp", "--dport", "53",
+			"-m", "conntrack", "--ctorigdst", spec.dnsIP,
+			"-j", "RETURN",
+		}
+		if !reflect.DeepEqual(dnsCt.args, wantCt) {
+			t.Errorf("%s dns query (original dest) = %v, want %v", spec.family, dnsCt.args, wantCt)
+		}
+		wantDst := []string{
 			"-m", "set", "--match-set", spec.setName, "src",
 			"-p", "udp", "--dport", "53",
 			"-d", spec.dnsIP,
 			"-j", "RETURN",
 		}
-		if !reflect.DeepEqual(dnsRule.args, wantDNS) {
-			t.Errorf("%s dns query = %v, want %v", spec.family, dnsRule.args, wantDNS)
+		if !reflect.DeepEqual(dnsDst.args, wantDst) {
+			t.Errorf("%s dns query (packet dest) = %v, want %v", spec.family, dnsDst.args, wantDst)
 		}
 		// ICMPv6 allow rules (v6 only) must cover every essential type.
 		if spec.family == iptablesFamilyIPv6 {
 			for ti, wantType := range essentialICMPv6Types {
-				r := group[2+ti]
+				r := group[3+ti]
 				want := []string{
 					"-m", "set", "--match-set", spec.setName, "src",
 					"-p", "ipv6-icmp", "--icmpv6-type", strconv.Itoa(wantType),
@@ -850,9 +862,10 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 			icmpv6Count++
 		case strings.Contains(r.label, "dns"):
 			dnsCount++
-			// The DNS carve-out must be destination-scoped to the cluster DNS.
-			if !slices.Contains(r.args, "-d") {
-				t.Errorf("egress dns rule lacks a destination match: %v", r.args)
+			// Every carve-out row carries the destination scope in one form
+			// or the other; a row with neither would admit UDP/53 to anywhere.
+			if !slices.Contains(r.args, "--ctorigdst") && !slices.Contains(r.args, "-d") {
+				t.Errorf("egress dns rule carries no destination scope: %v", r.args)
 			}
 		}
 	}
@@ -862,8 +875,8 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 	if icmpv6Count != len(essentialICMPv6Types) {
 		t.Errorf("compose icmpv6 allow rules = %d, want %d", icmpv6Count, len(essentialICMPv6Types))
 	}
-	if dnsCount != 1 { // one IPv4 cluster-DNS destination
-		t.Errorf("compose dns rules = %d, want 1", dnsCount)
+	if dnsCount != 2 { // one IPv4 cluster-DNS destination, two scopes
+		t.Errorf("compose dns rules = %d, want 2", dnsCount)
 	}
 
 	// The egress FORWARD jump must sit in the jump set alongside the inbound

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -135,6 +135,7 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 		return fmt.Errorf("--log-level: %w", err)
 	}
 	slog.SetDefault(logger)
+	warnUnlessClusterDNSResolves(logger, cfg.clusterDNSIPs, resolvConfPath)
 	if err := initIptablesClients(); err != nil {
 		return err
 	}
@@ -493,6 +494,52 @@ func composeIptablesSyncRules(outboundPort, uid int, excludeUIDs []uint32, cwPas
 	rules = append(rules, buildCWEgressGuardRules(dnsIPsByFamily)...)
 	jumps := append(jumpRules(), cwJumpRule(), cwEgressJumpRule())
 	return rules, jumps
+}
+
+// resolvConfPath is the resolver configuration kubelet writes for this pod.
+// The ratls-mesh DaemonSet runs hostNetwork with dnsPolicy
+// ClusterFirstWithHostNet, so it names the servers every pod on this node
+// resolves against — which is what the carve-out has to name to be reachable.
+const resolvConfPath = "/etc/resolv.conf"
+
+// warnUnlessClusterDNSResolves reports each configured DNS server that this
+// node's own pod resolver does not name.
+//
+// The carve-out stays operator-declared: resolv.conf is read to contradict a
+// wrong value, never to supply one, so a resolver the node was pointed at
+// cannot widen a fail-closed egress guard. A cw pod whose queries go somewhere
+// the carve-out does not name loses DNS with nothing in the guard to say so,
+// and the shipped default is the c8s node image's, which no other
+// distribution shares.
+func warnUnlessClusterDNSResolves(logger *slog.Logger, configured []string, path string) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		logger.Warn("cannot check the cluster DNS carve-out against this node's resolver", "path", path, "error", err)
+		return
+	}
+	nameservers := map[string]bool{}
+	var listed []string
+	for _, line := range strings.Split(string(b), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != "nameserver" {
+			continue
+		}
+		if ip := net.ParseIP(fields[1]); ip != nil {
+			nameservers[ip.String()] = true
+			listed = append(listed, ip.String())
+		}
+	}
+	if len(nameservers) == 0 {
+		return
+	}
+	for _, raw := range configured {
+		ip := net.ParseIP(raw)
+		if ip == nil || nameservers[ip.String()] {
+			continue
+		}
+		logger.Warn("cluster DNS carve-out names a server this node's pods do not resolve against; confidential-workload pods will lose DNS unless --cluster-dns-ip is corrected",
+			"configured", ip.String(), "node_resolvers", listed)
+	}
 }
 
 // clusterDNSIPsByFamily validates each cluster DNS IP and groups it under its

--- a/test/e2e/mesh-cw-enforcement.sh
+++ b/test/e2e/mesh-cw-enforcement.sh
@@ -5,7 +5,8 @@
 # chart tests cannot: a dial to a cw pod IP is actually intercepted and
 # wrapped (the mesh inbound counter moves on the workload's node), the
 # FORWARD drop actually fires on this cluster's CNI for Service-VIP and
-# excluded-namespace traffic, and the drop counter records it. The inbound
+# excluded-namespace traffic, the drop counter records it, and the egress
+# guard's DNS carve-out is written so it can match in that chain at all. The inbound
 # connection counter is the wrap signal; no packet capture (tcpdump on CVM
 # node images is flaky and adds nothing the counters don't prove).
 #
@@ -19,6 +20,8 @@
 #   EXCLUDED_NS     mesh-excluded source namespace (default kube-system)
 #   MESH_HEALTH_PORT     ratls-mesh health/metrics port (chart
 #                        ratlsMesh.ports.health; default 15021)
+#   MESH_NS              namespace the chart is installed in (default
+#                        c8s-system), read for the ratls-mesh DaemonSet
 #   METRIC_WAIT_SECONDS  how long to wait for a counter to move; also the
 #                        abort budget for a baseline that never gets a
 #                        successful scrape (default 75; raise it above ~2x
@@ -30,6 +33,7 @@ set -euo pipefail
 client_image="${CLIENT_IMAGE:-curlimages/curl:8.8.0}"
 excluded_ns="${EXCLUDED_NS:-kube-system}"
 health_port="${MESH_HEALTH_PORT:-15021}"
+mesh_ns="${MESH_NS:-c8s-system}"
 metric_wait="${METRIC_WAIT_SECONDS:-75}"
 
 ns="mesh-cw-check-$$"
@@ -209,4 +213,54 @@ echo "ok: excluded-namespace source blocked (curl exit 28 = timeout from DROP)"
 await_metric_above "$excluded_node_ip" "$drops" "$base_excluded_drops" \
   "cw inbound drop counter on $excluded_node moved: the guard blocked the excluded source, not a coincidence"
 
-echo "PASS: workload path mesh-wrapped; VIP and excluded-source plaintext bypasses fail closed"
+# --- egress guard: the DNS carve-out is scoped where it can match -----------
+
+# The guard chain hangs off FORWARD, downstream of kube-proxy's Service DNAT,
+# so a carve-out written against the packet's destination reads a CoreDNS pod
+# IP and never fires — every cw pod then loses DNS while still reaching
+# Running, which is why this is asserted against the chain the node actually
+# runs rather than against the pod's health. Read on the workload's node, in
+# the sidecar that programs it.
+mesh_pod=$(kubectl get pods -n "$mesh_ns" -l app=c8s-ratls-mesh \
+  --field-selector="spec.nodeName=$cw_node" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+[ -n "$mesh_pod" ] || fail "no ratls-mesh pod on $cw_node in namespace $mesh_ns (set MESH_NS)"
+
+egress_chain=$(kubectl exec -n "$mesh_ns" "$mesh_pod" -c iptables-sync -- \
+  iptables -L RATLS-MESH-CW-EGRESS -n -v -x 2>/dev/null) \
+  || fail "RATLS-MESH-CW-EGRESS not readable on $cw_node; is the cw egress guard installed?"
+
+dns_rows=$(awk '/udp/ && /dpt:53/' <<<"$egress_chain")
+[ -n "$dns_rows" ] || fail "RATLS-MESH-CW-EGRESS carries no UDP/53 carve-out on $cw_node; cw pods cannot resolve:
+$egress_chain"
+
+# The chain runs downstream of kube-proxy's Service DNAT, so a carve-out
+# written only against the packet's destination cannot fire; the row that
+# names the connection's original destination is the one that does.
+grep -q 'ctorigdst' <<<"$dns_rows" || fail "no UDP/53 carve-out is scoped to the connection's original destination, so kube-proxy's DNAT puts the carve-out out of reach and every cw DNS query hits the drop below it:
+$dns_rows"
+
+# The address has to be the resolver this cluster's pods actually use;
+# scoping to any other is indistinguishable from having no carve-out.
+cluster_dns=$(kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
+if [ -n "$cluster_dns" ]; then
+  grep -q "$cluster_dns" <<<"$dns_rows" || fail "the UDP/53 carve-out names no address matching this cluster's DNS ClusterIP $cluster_dns; set ratlsMesh.clusterDNSIP:
+$dns_rows"
+fi
+
+# A RETURN below the drop is a RETURN that never runs.
+drop_line=$(awk '/DROP/ && /!tcp/ {print NR; exit}' <<<"$egress_chain")
+dns_line=$(awk '/udp/ && /dpt:53/ {print NR; exit}' <<<"$egress_chain")
+if [ -n "$drop_line" ] && [ -n "$dns_line" ] && [ "$dns_line" -gt "$drop_line" ]; then
+  fail "the UDP/53 carve-out is ordered below the non-TCP drop, so it is unreachable:
+$egress_chain"
+fi
+echo "ok: cw egress DNS carve-out is scoped to $cluster_dns and ordered above the drop"
+
+# Membership is what the guard keys on. An empty set is enforcement that is not
+# running, and reads identically to a guard that is simply not being exercised.
+cw_members=$(kubectl exec -n "$mesh_ns" "$mesh_pod" -c iptables-sync -- \
+  ipset list RATLS-MESH-CW-PODS 2>/dev/null | awk '/^Number of entries:/ {print $NF}')
+[ "${cw_members:-0}" -gt 0 ] || fail "ipset RATLS-MESH-CW-PODS on $cw_node holds no members while $cw_ns/$cw_pod is Running; the guard is not enforcing on any cw pod"
+echo "ok: cw ipset on $cw_node holds $cw_members member(s)"
+
+echo "PASS: workload path mesh-wrapped; VIP and excluded-source plaintext bypasses fail closed; egress DNS carve-out matchable"

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -153,7 +153,13 @@ log "Writing the allowlist floor"
 store_digests > "$WORKDIR/floor.tsv"
 [ -s "$WORKDIR/floor.tsv" ] || fail "containerd store scan came back empty"
 grep -q "docker.io/library/$WORKLOAD_IMAGE" "$WORKDIR/floor.tsv" || fail "workload image missing from the store scan"
-python3 - "$WORKDIR/floor.tsv" "$WORKDIR/values.yaml" "docker.io/$CURL_IMAGE" <<'PYEOF'
+# The cw egress guard scopes its DNS carve-out to this address, and the chart
+# default is the c8s node image's, which no other distribution shares — kind's
+# is 10.96.0.10. Read it off the cluster, as an operator must.
+CLUSTER_DNS_IP="$(kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}')"
+[ -n "$CLUSTER_DNS_IP" ] || fail "could not read the kube-dns ClusterIP"
+
+python3 - "$WORKDIR/floor.tsv" "$WORKDIR/values.yaml" "docker.io/$CURL_IMAGE" "$CLUSTER_DNS_IP" <<'PYEOF'
 import sys, yaml
 floor = {}
 for line in open(sys.argv[1]):
@@ -162,7 +168,10 @@ for line in open(sys.argv[1]):
 # Kept out of the floor on purpose: the admission test's unseen digest.
 floor = {d: r for d, r in floor.items() if r != sys.argv[3]}
 with open(sys.argv[2], "w") as f:
-    yaml.safe_dump({"nriImagePolicy": {"bootstrapAllowlist": {"digests": floor}}}, f)
+    yaml.safe_dump({
+        "nriImagePolicy": {"bootstrapAllowlist": {"digests": floor}},
+        "ratlsMesh": {"clusterDNSIP": sys.argv[4]},
+    }, f)
 print(f"floor: {len(floor)} digests")
 PYEOF
 
@@ -490,6 +499,28 @@ kubectl wait --for=condition=Ready pod/it-mesh-client --timeout=120s || fail "me
 CLIENT_IP="$(kubectl get pod it-mesh-client -o jsonpath='{.status.podIP}')"
 await_ipset RATLS-MESH-LOCAL-PODS "$CLIENT_IP"
 await_ipset RATLS-MESH-CW-PODS "$POD_IP"
+
+# The egress guard drops every non-TCP packet a cw pod sends, carving out
+# UDP/53 to the cluster resolver. The carve-out sits in a chain downstream of
+# kube-proxy's Service DNAT, so a query arrives there addressed to a CoreDNS
+# pod and a rule written against the packet's destination cannot fire — the
+# pod stays Running and every name it resolves fails. Assert resolution, not
+# health.
+KUBERNETES_IP="$(kubectl -n default get svc kubernetes -o jsonpath='{.spec.clusterIP}')"
+resolved="$(kubectl -n demo exec "$POD" -c app -- timeout 15 nslookup kubernetes.default.svc.cluster.local 2>&1)" \
+    || fail "cw pod cannot resolve a cluster name; the egress guard's DNS carve-out is unreachable in its chain:
+$resolved"
+echo "$resolved" | grep -q "$KUBERNETES_IP" \
+    || fail "cw pod's resolver answered without the kubernetes ClusterIP $KUBERNETES_IP: $resolved"
+pass "cw pod resolves cluster DNS through the egress guard's carve-out"
+
+# The carve-out names one resolver. Widening it to any UDP/53 destination
+# would pass the check above and hand every cw pod a plaintext channel to an
+# arbitrary host, so the scope is asserted directly.
+if kubectl -n demo exec "$POD" -c app -- timeout 8 nslookup example.com 192.0.2.53 >/dev/null 2>&1; then
+    fail "cw pod reached an off-cluster resolver on UDP/53; the carve-out must name the cluster DNS server only"
+fi
+pass "cw pod cannot reach an unnamed resolver on UDP/53"
 
 inbound='^ratls_mesh_connections_total.*direction="inbound"'
 base_inbound="$(mesh_metric "$inbound")"


### PR DESCRIPTION
The fail-closed cw egress guard drops every non-TCP packet from a
confidential-workload pod and carves out UDP/53 to the cluster DNS
server. The carve-out never matched. Measured on a live cluster with the
correct ClusterIP configured: the DNS RETURN rule sat at 0 packets while
the trailing DROP counted up, and any cw pod that resolved a name failed
while still reaching Running, so the symptom named neither DNS nor the
guard.

RATLS-MESH-CW-EGRESS hangs off filter/FORWARD, which kube-proxy's
nat/PREROUTING DNAT precedes. By the time a query reaches the guard its
destination is a CoreDNS pod IP, so `-d <ClusterIP>` matches nothing.
The carve-out is now emitted twice per server: once against the
connection's original destination, which survives the DNAT, and once
against the packet's, which is what fires where the flow is untracked or
the dataplane translates the Service outside netfilter. Both carry the
same destination scope, so whichever matches admits the same traffic and
neither widens the guard. Keeping both is deliberate — replacing `-d`
outright would trade this outage for the same outage on any dataplane
that does not hand netfilter a conntrack entry, and this chain already
documents that class of dataplane for its established-TCP RETURN. The
NOTE at the rule builder asking someone to confirm the DNAT ordering on
a live cluster is answered and gone.

The shipped default is independently wrong. 10.53.0.10 is the c8s node
guest image's cluster-dns; stock RKE2 is 10.43.0.10 and kubeadm is
10.96.0.10, so on any other cluster the value names an address no pod
resolves against — which is why the operator who found and fixed that
saw no change, with the DNAT bug underneath. The value stays
operator-declared: deriving it from the node would let a resolver the
node was pointed at widen the one hole in a fail-closed egress guard,
and the guard's whole point is that the destination is declared, not
discovered. Instead iptables-sync reads its own pod resolv.conf at
startup and warns, naming both the configured server and the ones this
node's pods actually use, when they disagree. resolv.conf contradicts a
wrong value; it never supplies one.

The in-guest guard had the same defect in a different form: its DNS
carve-out was tagged IPv4 unconditionally while the non-TCP drop below
it is family-agnostic, so an IPv6 cluster DNS lost the guest's own name
resolution. The family now follows the address. The guest's `-d` match
is correct there and stays — it runs no kube-proxy, so nothing rewrites
the destination before the OUTPUT chain.

TestBuildCWEgressGuardRulesGolden and
TestComposeIptablesSyncRulesAssemblesFullGuard both passed while the
carve-out matched nothing, because they assert rule shape and nothing
else can be asserted about a rule without a kernel. The real regression
test is in test/integration/cluster/run.sh, which runs in CI on a kind
cluster with real kube-proxy, real CoreDNS and a real cw pod: it now
resolves a cluster name from inside that pod and requires the answer to
carry the kubernetes ClusterIP, then requires a query aimed at an
off-cluster resolver to fail, so widening the carve-out cannot pass in
place of fixing it. That harness installed with the chart default until
now, which is a second reason it would have caught this; it reads the
kube-dns ClusterIP off the cluster, as an operator must.
test/e2e/mesh-cw-enforcement.sh gains the node-side shape checks that
need a real chain: a carve-out scoped to the connection's original
destination, naming this cluster's DNS ClusterIP, ordered above the
drop.
