### PR TITLE
fix(volumed): sweep stale volume mappings, and stop the hook lying about them

### DIFF
--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -162,7 +162,11 @@ removing it under a live volume strands the mappings on the node, where they
 keep the backing disk open against the next install. Scale those workloads to
 zero first — volumed tears the volumes down — or pass --force. Whatever is
 still mapped when the release goes is reaped by the chart's volumed pre-delete
-hook, which runs on every node before the daemon is removed.
+hook, which runs on every node before the daemon is removed. That hook can only
+close a mapping nothing is using: a live consumer keeps the device open through
+its own mount namespace, which the hook's host-side unmount does not reach, so
+under --force the hook fails on those and names them. Whatever it leaves is
+swept by volumed the next time it starts.
 
 Left in place by default: the ConfidentialWorkload CRD (helm never deletes
 crds/; --delete-crds removes it ALONG WITH EVERY ConfidentialWorkload object)
@@ -223,13 +227,16 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH.`,
 
 		// volumed goes with the release and is the only component that unmaps
 		// a pod's volume devices, so the teardown order is load-bearing.
-		if boolAtPath(values, "volumed.enabled") && !uninstallForce {
+		if boolAtPath(values, "volumed.enabled") {
 			pods, err := listVolumePods(ctx)
 			if err != nil {
 				return err
 			}
 			if len(pods) > 0 {
-				return volumePodsRunningError(pods)
+				if !uninstallForce {
+					return volumePodsRunningError(pods)
+				}
+				fmt.Fprintf(os.Stdout, "%s\n", forcedVolumePodsWarning(pods))
 			}
 		}
 
@@ -533,7 +540,15 @@ func filterVolumePods(lines []string) []string {
 // volumePodsRunningError is the volume guard's refusal: it names the pods and
 // the ordering that avoids the leak.
 func volumePodsRunningError(pods []string) error {
-	return fmt.Errorf("pods are still holding c8s encrypted volumes, and volumed is the only thing that unmaps them:\n  %s\nscale those workloads to zero first (volumed then tears the volumes down), or pass --force to uninstall anyway and leave the device-mapper stack on the node",
+	return fmt.Errorf("pods are still holding c8s encrypted volumes, and volumed is the only thing that unmaps them:\n  %s\nscale those workloads to zero first (volumed then tears the volumes down), or pass --force to uninstall with those mappings still open",
+		strings.Join(pods, "\n  "))
+}
+
+// forcedVolumePodsWarning is what --force buys: the uninstall proceeds, and the
+// mappings these pods hold stay open on their nodes, because the pre-delete
+// hook cannot close a device a live mount namespace still references.
+func forcedVolumePodsWarning(pods []string) string {
+	return fmt.Sprintf("! --force: these pods still hold c8s encrypted volumes:\n  %s\nthe volumed pre-delete hook will fail to close their dm-crypt/dm-verity mappings, which then hold the backing disks open. Delete these pods and re-run the uninstall to leave the nodes clean; otherwise volumed sweeps the residue the next time it starts, so a reinstall clears it",
 		strings.Join(pods, "\n  "))
 }
 
@@ -818,7 +833,7 @@ func init() {
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
 	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep the kata host artifacts (/opt/kata, containerd drop-in, kata-guest-base image, RKE2 prep template, node labels) off every kata node via a short-lived privileged DaemonSet. Skipped automatically when the release was installed without --cvm-mode=pod")
 	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the kata host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry kata artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
-	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (their mounts go with the pre-delete hook that reaps the node's device-mapper stack)")
+	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it)")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteNamespace, "delete-namespace", false, "also delete the release namespace (and everything left in it, e.g. an operator-created image pull Secret)")
 	rootCmd.AddCommand(uninstallCmd)

--- a/cmd/c8s/uninstall_exec_test.go
+++ b/cmd/c8s/uninstall_exec_test.go
@@ -497,12 +497,23 @@ func TestUninstallRefusesWhileVolumePodsRun(t *testing.T) {
 		mustNotContainPrefix(t, s.f.calls(t), "helm uninstall")
 	})
 
-	t.Run("--force proceeds", func(t *testing.T) {
+	t.Run("--force proceeds, having still asked which pods hold volumes", func(t *testing.T) {
 		s := newUninstallStubs(t, values, holding, false)
 		if err := runC8s(t, "uninstall", "--force"); err != nil {
 			t.Fatalf("uninstall --force: %v", err)
 		}
 		mustContainLine(t, s.f.calls(t), "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+		// The pre-delete hook cannot close what these pods hold, so --force has
+		// to name them here; a failed hook's logs go with the release.
+		var listed bool
+		for _, c := range s.f.calls(t) {
+			if strings.HasPrefix(c, "kubectl get pods --all-namespaces") {
+				listed = true
+			}
+		}
+		if !listed {
+			t.Errorf("--force skipped the volume-pod listing, so the mappings it strands are never named; calls: %v", s.f.calls(t))
+		}
 	})
 
 	t.Run("pod listing failure surfaces", func(t *testing.T) {

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -527,3 +527,20 @@ func TestFilterVolumePodsKeepsOnlyLivePodsHoldingVolumes(t *testing.T) {
 		t.Errorf("filterVolumePods = %v, want %v", got, want)
 	}
 }
+
+// --force does not make the leak clean, and the text has to say so: the
+// operator's only other chance to learn it is a hook log that goes with the
+// release.
+func TestForcedVolumePodsWarning(t *testing.T) {
+	got := forcedVolumePodsWarning([]string{"default/inference-0", "tenant-a/rag-1"})
+	for _, want := range []string{
+		"default/inference-0",
+		"tenant-a/rag-1",
+		"re-run the uninstall",
+		"volumed sweeps",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("warning does not carry %q:\n%s", want, got)
+		}
+	}
+}

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -137,6 +137,15 @@ The serial is a **selector, not a trust input**. The host chooses it and answers
 the query per read. Pointing a pod at the wrong device fails closed: the wrong
 key produces noise, and verity refuses it.
 
+### Replacing an image
+
+`attach` hands LIO the file, and the kernel resolves the path once. Replace an
+image with **`detach` → overwrite → `attach`**, never in place: a `kubectl cp`,
+or any `mv` into position, leaves a new file at the path while the device keeps
+serving the one the attach opened. `md5sum` on the node then matches the source
+while every read from the pod fails, because they are reading different files.
+`attach` refuses an already-attached volume and says so.
+
 Because the device is on one node, the pod must be scheduled there; `create`
 emits the matching `nodeSelector`.
 
@@ -258,6 +267,36 @@ it — so the sandbox would have to arrive as an inventory-signed token bound to
 nonce the daemon issued, because such a token is otherwise transferable between
 pods. The kata shape does not need this: moving the daemon inside the guest
 removes the second caller instead of authenticating it.
+
+## Uninstalling, and what is left behind
+
+`c8s uninstall` refuses while a pod holds a volume, because volumed is the only
+thing that unmaps one. Scale those workloads to zero and let volumed tear the
+volumes down before uninstalling.
+
+`--force` proceeds and names the pods it is proceeding past. Their mappings
+stay: the chart's pre-delete hook unmounts on the host, but a running consumer
+holds the device open through its own mount namespace, so the close fails and
+the hook says which names it could not close. A mapping left open holds the
+backing disk open, so a volume it covers cannot be reopened.
+
+Nothing needs a shell on the node to clear it. volumed sweeps the c8s mappings
+it finds at startup, so **reinstalling c8s reaps whatever an uninstall left** —
+and the kernel refuses to close a mapping something still has mounted, so the
+sweep cannot take a volume from a workload that is still using it. A mapping
+still held after a reinstall means a pod is still holding it: delete the pod
+and volumed's reaper closes it within a sweep interval.
+
+Rebooting or replacing the node clears them too — device-mapper state does not
+survive a reboot.
+
+**A leftover LIO backstore is not that.** `c8s volume attach` is operator-driven
+and outside the release lifecycle, so uninstall leaves it alone by design; a
+node that has had volumes attached still lists them afterwards. The two look
+alike on the node and are told apart by what lists them: a leaked mapping shows
+in `dmsetup ls` as a `c8s-crypt-`/`c8s-verity-` pair, an attached backstore in
+`/sys/kernel/config/target/core/fileio_0/`. Remove the second with
+`c8s volume detach <name>`.
 
 ## What this defends
 

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -56,6 +56,9 @@ func (o *recordingOps) MountRO(_ context.Context, _ string, target *os.File) err
 
 func (o *recordingOps) Unmount(context.Context, string) error { return nil }
 
+// This path never sweeps: the daemon under test is already serving.
+func (o *recordingOps) ListMappings(context.Context) ([]string, error) { return nil, nil }
+
 // fixedIdentity stands in for the kernel peer-credential lookup, which needs a
 // real pod cgroup. Everything downstream of it is the production path.
 type fixedIdentity struct{ pod volumed.PodCgroup }

--- a/internal/cmds/volume/attach.go
+++ b/internal/cmds/volume/attach.go
@@ -92,7 +92,12 @@ func (a Attacher) Attach(ctx context.Context, name, image string) (serial string
 
 	store := a.backstore(name)
 	if _, err := os.Stat(store); err == nil {
-		return "", fmt.Errorf("volume: %q is already attached; detach it first", name)
+		// The kernel opened the image once, at the attach that built this
+		// backstore, and serves that file for as long as the backstore lives.
+		// Replacing the image at the same path since then — kubectl cp, or any
+		// mv into place — left the device on the old file, where hashing the
+		// path confirms bytes nothing is reading.
+		return "", fmt.Errorf("volume: %q is already attached, and the device serves the file that attach opened rather than whatever is at its path now; detach it first, then attach again", name)
 	}
 
 	var undo []func()
@@ -345,7 +350,11 @@ Hyper-V exposes no virtio bus, and a cloud disk's serial is the provider's, so
 this drives LIO's loopback target to build a local SCSI disk instead.
 
 The image is ciphertext and this does not read it. Pointing a pod at the wrong
-device fails closed — the key will not decrypt it, and verity will refuse it.`,
+device fails closed — the key will not decrypt it, and verity will refuse it.
+
+The device serves the file this command opens, not the path. Replace an image
+by 'detach', overwrite, then 'attach' again: writing a new file over the path
+of an attached image leaves the device on the old one.`,
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmds/volume/attach_test.go
+++ b/internal/cmds/volume/attach_test.go
@@ -121,8 +121,16 @@ func TestAttachRefusesAnAlreadyAttachedVolume(t *testing.T) {
 	if _, err := a.Attach(context.Background(), "weights", img); err != nil {
 		t.Fatalf("first attach: %v", err)
 	}
-	if _, err := a.Attach(context.Background(), "weights", img); err == nil {
+	_, err := a.Attach(context.Background(), "weights", img)
+	if err == nil {
 		t.Fatal("attached the same volume twice")
+	}
+	// The kernel resolves fd_dev_name once. An operator who replaced the image
+	// in place is here because the device is serving the file the first attach
+	// opened, so the refusal has to say that rather than just "already
+	// attached" — hashing the path confirms bytes nothing is reading.
+	if !strings.Contains(err.Error(), "the file that attach opened") {
+		t.Errorf("refusal does not say the device is bound to the file, not the path: %v", err)
 	}
 }
 

--- a/internal/cmds/volumed/cmd.go
+++ b/internal/cmds/volumed/cmd.go
@@ -120,6 +120,12 @@ func runNode(ctx context.Context, cfg config) error {
 	}
 	defer l.Close()
 
+	// Mappings an earlier volumed left behind hold the backing disk open, so a
+	// volume they cover cannot be reopened until they go. Sweep before serving.
+	if closed, stuck := opener.SweepStale(ctx); closed > 0 || len(stuck) > 0 {
+		slog.Info("swept mappings left by an earlier volumed", "closed", closed, "still_in_use", stuck)
+	}
+
 	reaper := &Reaper{
 		Opener:   opener,
 		Liveness: CgroupLiveness{Root: cfg.cgroupRoot},

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -43,6 +44,8 @@ type DeviceOps interface {
 	// by teardown that handle is long closed.
 	MountRO(ctx context.Context, source string, target *os.File) error
 	Unmount(ctx context.Context, target string) error
+	// ListMappings names the device-mapper targets published on this node.
+	ListMappings(ctx context.Context) ([]string, error)
 }
 
 // ErrNotAuthorized is returned when a caller presents the wrong key for a
@@ -173,13 +176,13 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 		return nil, err
 	}
 
-	cryptMapper := mapperName("crypt", req.Pod.UID, req.Name)
+	cryptMapper := mapperName(cryptKind, req.Pod.UID, req.Name)
 	if err := o.Ops.CryptOpen(ctx, req.Device, cryptMapper, key); err != nil {
 		return fail(fmt.Errorf("volumed: open dm-crypt: %w", err))
 	}
 	undo = append(undo, func(ctx context.Context) { _ = o.Ops.CryptClose(ctx, cryptMapper) })
 
-	verityMapper := mapperName("verity", req.Pod.UID, req.Name)
+	verityMapper := mapperName(verityKind, req.Pod.UID, req.Name)
 	if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, req.Blob.Verity); err != nil {
 		return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
 	}
@@ -245,6 +248,45 @@ func (o *Opener) teardown(ctx context.Context, m *mount) {
 	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
 }
 
+// SweepStale closes the c8s mappings left on this node by an earlier volumed,
+// and reports how many it closed and which it could not.
+//
+// Nothing else on a node can reap these: they outlive the release that made
+// them, and until they are closed they hold the backing disk open, so the next
+// install cannot reopen it. This runs once, before the daemon serves, which is
+// what makes the residue self-healing rather than permanent.
+//
+// INVARIANT: the kernel is the liveness check. A mapping something still has
+// mounted refuses to close, so a workload's volume cannot be pulled out from
+// under it — including one whose pod outlived the volumed that opened it. That
+// is stronger than inferring liveness here, which would be a decision this
+// process has no state to make.
+func (o *Opener) SweepStale(ctx context.Context) (closed int, stuck []string) {
+	mappings, err := o.Ops.ListMappings(ctx)
+	if err != nil {
+		return 0, []string{fmt.Sprintf("unreadable %s: %v", mapperDir, err)}
+	}
+	// verity is stacked on crypt and holds it open, so it goes first.
+	for _, kind := range []string{verityKind, cryptKind} {
+		prefix := "c8s-" + kind + "-"
+		for _, name := range mappings {
+			if !strings.HasPrefix(name, prefix) {
+				continue
+			}
+			close := o.Ops.VerityClose
+			if kind == cryptKind {
+				close = o.Ops.CryptClose
+			}
+			if err := close(ctx, name); err != nil {
+				stuck = append(stuck, name)
+				continue
+			}
+			closed++
+		}
+	}
+	return closed, stuck
+}
+
 // Pods returns the distinct pods holding a volume, so teardown can ask which of
 // them still exist.
 func (o *Opener) Pods() []PodCgroup {
@@ -290,6 +332,13 @@ func mountKey(podUID, name string) string { return podUID + "/" + name }
 
 // mapperName is scoped by pod so two pods opening the same volume get their own
 // mappings, and one pod's teardown cannot remove another's.
+// The two halves of a volume's device stack, and the mapper-name prefixes
+// SweepStale matches on.
+const (
+	cryptKind  = "crypt"
+	verityKind = "verity"
+)
+
 func mapperName(kind, podUID, name string) string {
 	return fmt.Sprintf("c8s-%s-%s-%s", kind, podUID, name)
 }

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -110,6 +111,30 @@ func (f *fakeOps) VerityClose(ctx context.Context, mapper string) error {
 	defer f.mu.Unlock()
 	delete(f.verityOpen, mapper)
 	return nil
+}
+
+// ListMappings answers from what is open, the way /dev/mapper does: a mapping
+// is listed until something closes it.
+func (f *fakeOps) ListMappings(ctx context.Context) ([]string, error) {
+	if err := f.ctxErr(ctx); err != nil {
+		return nil, err
+	}
+	if err := f.record("ListMappings"); err != nil {
+		return nil, err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var out []string
+	for name := range f.cryptOpen {
+		out = append(out, name)
+	}
+	for name := range f.verityOpen {
+		out = append(out, name)
+	}
+	// /dev/mapper carries every consumer's targets, not only ours.
+	out = append(out, "control", "rootvg-swap")
+	sort.Strings(out)
+	return out, nil
 }
 
 func (f *fakeOps) MountRO(ctx context.Context, _ string, target *os.File) error {
@@ -489,5 +514,79 @@ func TestOpenUnwindsAfterTheCallerContextIsCancelled(t *testing.T) {
 	}
 	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
 		t.Errorf("leaked crypt=%d verity=%d mounts=%d after a cancelled open", c, v, m)
+	}
+}
+
+// A volume stack outlives the volumed that opened it: the mappings are kernel
+// state, and nothing else on a node reaps them. Until they go they hold the
+// backing disk open, so the next install cannot reopen the volume.
+func TestSweepStaleClosesMappingsLeftByAnEarlierVolumed(t *testing.T) {
+	ops := newOps()
+	ops.cryptOpen["c8s-crypt-podA-weights"] = true
+	ops.verityOpen["c8s-verity-podA-weights"] = true
+
+	o := testOpener(t, ops)
+	closed, stuck := o.SweepStale(context.Background())
+	if closed != 2 {
+		t.Errorf("closed %d mappings, want the crypt and verity pair", closed)
+	}
+	if len(stuck) != 0 {
+		t.Errorf("reported %v as still in use", stuck)
+	}
+	if len(ops.cryptOpen) != 0 || len(ops.verityOpen) != 0 {
+		t.Errorf("mappings survived the sweep: crypt=%v verity=%v", ops.cryptOpen, ops.verityOpen)
+	}
+	// verity is stacked on crypt and holds it open, so closing crypt first
+	// would fail against a real device-mapper.
+	var verityAt, cryptAt = -1, -1
+	for i, c := range ops.calls {
+		switch c {
+		case "VerityClose":
+			verityAt = i
+		case "CryptClose":
+			cryptAt = i
+		}
+	}
+	if verityAt < 0 || cryptAt < 0 || verityAt > cryptAt {
+		t.Errorf("verity must close before the crypt device under it; calls: %v", ops.calls)
+	}
+}
+
+// The sweep runs before this process has any state, so the kernel is what
+// decides: a mapping something still has mounted refuses to close, and a
+// workload's volume is not pulled out from under it.
+func TestSweepStaleLeavesAMappingStillInUse(t *testing.T) {
+	ops := newOps()
+	ops.cryptOpen["c8s-crypt-podA-weights"] = true
+	ops.verityOpen["c8s-verity-podA-weights"] = true
+	ops.failOn = "VerityClose"
+
+	o := testOpener(t, ops)
+	closed, stuck := o.SweepStale(context.Background())
+	if closed != 1 {
+		t.Errorf("closed %d, want only the crypt mapping", closed)
+	}
+	if len(stuck) != 1 || stuck[0] != "c8s-verity-podA-weights" {
+		t.Errorf("stuck = %v, want the verity mapping that refused", stuck)
+	}
+	if !ops.verityOpen["c8s-verity-podA-weights"] {
+		t.Error("a mapping that refused to close was reported as gone")
+	}
+}
+
+// Sweeping by name prefix keeps it to volumes this platform opened; the node's
+// other device-mapper targets are not ours to close.
+func TestSweepStaleTouchesOnlyC8sMappings(t *testing.T) {
+	ops := newOps()
+	ops.cryptOpen["luks-tenant-disk"] = true
+	ops.verityOpen["c8s-verity-podA-weights"] = true
+
+	o := testOpener(t, ops)
+	closed, _ := o.SweepStale(context.Background())
+	if closed != 1 {
+		t.Errorf("closed %d, want only the c8s mapping", closed)
+	}
+	if !ops.cryptOpen["luks-tenant-disk"] {
+		t.Error("closed a device-mapper target this platform did not open")
 	}
 }

--- a/internal/cmds/volumed/systemops.go
+++ b/internal/cmds/volumed/systemops.go
@@ -91,6 +91,20 @@ func (SystemOps) MountRO(_ context.Context, source string, target *os.File) erro
 
 // Unmount detaches the mount. MNT_DETACH so a mount still busy is removed from
 // the tree rather than left for kubelet to trip over while tearing the pod down.
+// ListMappings names what device-mapper has published, which is the only
+// record of a volume stack that outlives the process that opened it.
+func (SystemOps) ListMappings(_ context.Context) ([]string, error) {
+	entries, err := os.ReadDir(mapperDir)
+	if err != nil {
+		return nil, fmt.Errorf("volumed: read %s: %w", mapperDir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names, nil
+}
+
 func (SystemOps) Unmount(_ context.Context, target string) error {
 	if err := unix.Unmount(target, unix.MNT_DETACH); !unmounted(err) {
 		return fmt.Errorf("unmount %s: %w", target, err)

--- a/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
+++ b/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
@@ -2,15 +2,26 @@
 #
 # Removes the device-mapper stack volumed opened for the pods on this node:
 # unmount each c8s volume, then close the dm-verity and dm-crypt mappings
-# behind it. volumed is the only component that reaps those, so once the
-# release is gone nothing on the node can — the mappings keep the backing disk
-# open and the next install fails to reopen it ("already mapped or mounted").
-# Idempotent: a node with nothing open exits clean.
+# behind it. The mappings keep the backing disk open, so a volume they cover
+# cannot be reopened while they are there. Anything this hook cannot close is
+# swept by volumed the next time it starts.
+# Idempotent: a node with nothing open exits clean. A mapping that will not
+# close exits non-zero — the alternative is an uninstall that reports success
+# and leaves state no later run can reach.
 #
 # Names come from internal/cmds/volumed/open.go (mapperName): the mappings are
 # c8s-crypt-<pod-uid>-<volume> and c8s-verity-<pod-uid>-<volume>, and the
 # verity device is the mount source.
 set -eu
+
+# Retry budget for a close. Sized to ride out kubelet's asynchronous unmount
+# while staying far inside helm's hook timeout.
+CLOSE_ATTEMPTS=5
+CLOSE_RETRY_SECONDS=2
+
+# Prefixed onto the host paths below so the shipped bytes can be run against a
+# fixture tree. The hook sets nothing and the prefix is empty.
+root="${C8S_TEARDOWN_ROOT:-}"
 
 echo "==> volumed teardown starting"
 
@@ -23,7 +34,7 @@ while read -r source target _; do
   case "$source" in
   /dev/mapper/c8s-verity-*) targets="$targets $target" ;;
   esac
-done </proc/mounts
+done <"$root/proc/mounts"
 
 for target in $targets; do
   if umount "$target"; then
@@ -36,19 +47,43 @@ done
 # 2. Close the mappings, verity before crypt: verity is stacked on the crypt
 #    device and holds it open.
 closed=0
-for dev in /dev/mapper/c8s-verity-* /dev/mapper/c8s-crypt-*; do
+stuck=""
+for dev in "$root"/dev/mapper/c8s-verity-* "$root"/dev/mapper/c8s-crypt-*; do
   [ -e "$dev" ] || continue
-  name=${dev#/dev/mapper/}
+  name=${dev##*/}
   close=veritysetup
   case "$name" in
   c8s-crypt-*) close=cryptsetup ;;
   esac
-  if "$close" close "$name"; then
-    closed=$((closed + 1))
-    echo "closed $name"
-  else
-    echo "WARNING: $close close $name failed" >&2
-  fi
+  # kubelet tears the consumer's mount down asynchronously, so a device that
+  # reads busy on the first try is often free a moment later.
+  attempt=1
+  while :; do
+    if "$close" close "$name"; then
+      closed=$((closed + 1))
+      echo "closed $name"
+      break
+    fi
+    if [ "$attempt" -ge "$CLOSE_ATTEMPTS" ]; then
+      stuck="$stuck $name"
+      break
+    fi
+    attempt=$((attempt + 1))
+    sleep "$CLOSE_RETRY_SECONDS"
+  done
 done
 
 echo "==> volumed teardown finished: $closed mapping(s) closed"
+
+if [ -n "$stuck" ]; then
+  # The host unmount above does not clear a consumer pod's own mount namespace,
+  # so a volume still in use stays busy here. Exiting 0 would hand helm a
+  # healthy hook and delete volumed, after which nothing on the node reaps
+  # these and the next install cannot reopen the disk.
+  echo "ERROR: still open after ${CLOSE_ATTEMPTS} attempts:$stuck" >&2
+  echo "       something is still using these volumes; the host-side unmount does not" >&2
+  echo "       release a consumer pod's own mount namespace. Delete the pods holding" >&2
+  echo "       them and re-run the uninstall; volumed sweeps whatever is left when it" >&2
+  echo "       next starts, so a reinstall clears them too." >&2
+  exit 1
+fi

--- a/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
@@ -1,9 +1,15 @@
 {{- if .Values.volumed.enabled }}
 {{- /*
   Pre-delete DaemonSet that reaps the device-mapper stack volumed opened on
-  each node (files/scripts/volumed-teardown.sh). Helm waits for it to be Ready
-  before deleting the release, so the reap happens while the mounts are still
-  reachable — and it runs for any chart consumer, not only `c8s uninstall`.
+  each node (files/scripts/volumed-teardown.sh). It runs before the release is
+  deleted, so the reap happens while the mounts are still reachable — and it
+  runs for any chart consumer, not only `c8s uninstall`.
+
+  The script exits non-zero when a mapping will not close, which helm 4 waits
+  for and turns into a failed uninstall. Helm 3 waits only until the DaemonSet
+  object exists, so there the failure is in the hook pod rather than in helm's
+  exit code; `c8s uninstall` names the pods that cause it before it starts.
+  hook-delete-policy keeps a failed hook's pods for exactly that reason.
 
   Same privilege shape as the volumed DaemonSet it cleans up after: unmounting
   another pod's directory and closing a dm target needs it.

--- a/internal/helmchart/volumed_teardown_script_test.go
+++ b/internal/helmchart/volumed_teardown_script_test.go
@@ -1,0 +1,213 @@
+//go:build !c8s_node
+
+package helmchart
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The teardown script is the pre-delete hook's whole body and had no test that
+// ran it: the chart tests only grep the rendered args for the command names.
+// That is how a swallowed close failure shipped, so these run the shipped bytes
+// against a fixture tree.
+
+const teardownScriptPath = "c8s/files/scripts/volumed-teardown.sh"
+
+type teardownFixture struct {
+	root   string
+	script string
+	log    string
+}
+
+// newTeardownFixture lays out $root/proc/mounts and $root/dev/mapper for the
+// named mappings, and stubs every host tool the script calls onto PATH. Each
+// stub logs its argv; closeBody is spliced into veritysetup and cryptsetup so a
+// case can decide which closes succeed.
+func newTeardownFixture(t *testing.T, mappings []string, mounted []string, closeBody string) *teardownFixture {
+	t.Helper()
+	dir := t.TempDir()
+	f := &teardownFixture{
+		root:   filepath.Join(dir, "root"),
+		script: filepath.Join(dir, "teardown.sh"),
+		log:    filepath.Join(dir, "calls.log"),
+	}
+
+	body, err := ChartFS.ReadFile(teardownScriptPath)
+	if err != nil {
+		t.Fatalf("read %s from the chart: %v", teardownScriptPath, err)
+	}
+	if err := os.WriteFile(f.script, body, 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	mapper := filepath.Join(f.root, "dev", "mapper")
+	if err := os.MkdirAll(mapper, 0o755); err != nil {
+		t.Fatalf("mkdir mapper: %v", err)
+	}
+	for _, name := range mappings {
+		if err := os.WriteFile(filepath.Join(mapper, name), nil, 0o644); err != nil {
+			t.Fatalf("create mapping %s: %v", name, err)
+		}
+	}
+	proc := filepath.Join(f.root, "proc")
+	if err := os.MkdirAll(proc, 0o755); err != nil {
+		t.Fatalf("mkdir proc: %v", err)
+	}
+	var mounts strings.Builder
+	// One unrelated line so the source filter is exercised, not just the shape.
+	mounts.WriteString("/dev/sda1 / ext4 rw 0 0\n")
+	for i, name := range mounted {
+		mounts.WriteString("/dev/mapper/" + name + " /var/lib/kubelet/pods/p" + string(rune('a'+i)) + "/vol ext4 ro 0 0\n")
+	}
+	if err := os.WriteFile(filepath.Join(proc, "mounts"), []byte(mounts.String()), 0o644); err != nil {
+		t.Fatalf("write mounts: %v", err)
+	}
+
+	binDir := filepath.Join(dir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	stub := func(name, extra string) {
+		script := "#!/bin/sh\nprintf '%s\\n' \"" + name + " $*\" >> '" + f.log + "'\n" + extra + "\nexit 0\n"
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatalf("write %s stub: %v", name, err)
+		}
+	}
+	stub("umount", "")
+	// A no-op sleep keeps the retry budget free: the delay is the script's, not
+	// the test's.
+	stub("sleep", "")
+	stub("veritysetup", closeBody)
+	stub("cryptsetup", closeBody)
+	t.Setenv("PATH", binDir+":/bin:/usr/bin")
+	return f
+}
+
+// run executes the script and returns its combined output and exit code.
+func (f *teardownFixture) run(t *testing.T) (string, int) {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", f.script)
+	cmd.Env = append(os.Environ(), "C8S_TEARDOWN_ROOT="+f.root)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run teardown: %v", err)
+	}
+	return string(out), code
+}
+
+func (f *teardownFixture) calls(t *testing.T) []string {
+	t.Helper()
+	data, err := os.ReadFile(f.log)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func TestVolumedTeardownClosesCleanly(t *testing.T) {
+	f := newTeardownFixture(t,
+		[]string{"c8s-verity-podA-data", "c8s-crypt-podA-data"},
+		[]string{"c8s-verity-podA-data"},
+		"")
+	out, code := f.run(t)
+	if code != 0 {
+		t.Fatalf("exit %d on a node whose mappings all close; output:\n%s", code, out)
+	}
+	if !strings.Contains(out, "2 mapping(s) closed") {
+		t.Errorf("did not report both closes:\n%s", out)
+	}
+	calls := f.calls(t)
+	var verityAt, cryptAt = -1, -1
+	for i, c := range calls {
+		switch {
+		case strings.HasPrefix(c, "veritysetup close"):
+			verityAt = i
+		case strings.HasPrefix(c, "cryptsetup close"):
+			cryptAt = i
+		}
+	}
+	if verityAt < 0 || cryptAt < 0 {
+		t.Fatalf("both closes must be attempted; calls: %v", calls)
+	}
+	// verity is stacked on crypt and holds it open, so the order is load-bearing.
+	if verityAt > cryptAt {
+		t.Errorf("crypt closed before the verity device stacked on it; calls: %v", calls)
+	}
+	if !strings.Contains(strings.Join(calls, "\n"), "umount /var/lib/kubelet/pods/pa/vol") {
+		t.Errorf("the mounted verity device was not unmounted; calls: %v", calls)
+	}
+}
+
+func TestVolumedTeardownIsIdempotentOnAnEmptyNode(t *testing.T) {
+	f := newTeardownFixture(t, nil, nil, "")
+	out, code := f.run(t)
+	if code != 0 {
+		t.Fatalf("exit %d with nothing open; output:\n%s", code, out)
+	}
+	if !strings.Contains(out, "0 mapping(s) closed") {
+		t.Errorf("expected a clean no-op:\n%s", out)
+	}
+	for _, c := range f.calls(t) {
+		if strings.Contains(c, "close") {
+			t.Errorf("closed something on an empty node: %q", c)
+		}
+	}
+}
+
+// The reported defect: the close sits inside an `if`, so `set -eu` never fires,
+// the script warns and exits 0, helm sees a healthy hook and deletes the
+// release — after which volumed is gone and nothing on the node can reap these.
+func TestVolumedTeardownFailsWhenAMappingStaysOpen(t *testing.T) {
+	f := newTeardownFixture(t,
+		[]string{"c8s-verity-podA-data", "c8s-crypt-podA-data"},
+		[]string{"c8s-verity-podA-data"},
+		`case "$1 $2" in "close c8s-verity-podA-data") exit 1 ;; esac`)
+	out, code := f.run(t)
+	if code == 0 {
+		t.Fatalf("exit 0 while a mapping stayed open; a leaking uninstall must not report success:\n%s", out)
+	}
+	if !strings.Contains(out, "c8s-verity-podA-data") {
+		t.Errorf("failure does not name the mapping that stayed open:\n%s", out)
+	}
+	if !strings.Contains(out, "re-run the uninstall") {
+		t.Errorf("failure does not say how to get the node clean:\n%s", out)
+	}
+}
+
+// A device busy on the first try is often free once kubelet finishes tearing
+// the consumer's mount down, so the close is retried before it is called stuck.
+func TestVolumedTeardownRetriesABusyClose(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "attempts")
+	f := newTeardownFixture(t,
+		[]string{"c8s-crypt-podA-data"},
+		nil,
+		`n=$(cat '`+marker+`' 2>/dev/null || echo 0); n=$((n + 1)); echo "$n" > '`+marker+`'
+if [ "$n" -lt 3 ]; then exit 1; fi`)
+	out, code := f.run(t)
+	if code != 0 {
+		t.Fatalf("exit %d though the close succeeded on the third attempt; output:\n%s", code, out)
+	}
+	if !strings.Contains(out, "1 mapping(s) closed") {
+		t.Errorf("retry did not report the eventual close:\n%s", out)
+	}
+	attempts := 0
+	for _, c := range f.calls(t) {
+		if strings.HasPrefix(c, "cryptsetup close") {
+			attempts++
+		}
+	}
+	if attempts != 3 {
+		t.Errorf("close attempted %d times, want 3 (retry stops as soon as it succeeds)", attempts)
+	}
+}


### PR DESCRIPTION
An uninstall with a pod still holding a volume unmounted the volume, failed to
close the dm-crypt/dm-verity pair behind it, and exited 0. The close sat inside
an `if`, so `set -eu` never fired — helm saw a healthy hook and deleted the
release. volumed went with it, and nothing on the node reaped the mappings, so
they held the backing disk open against every later install.

## Changes

- **volumed sweeps c8s mappings at startup.** Residue now clears on the next
  install, with no shell on the node — which matters because operators are not
  expected to have one. The kernel is the liveness check: a mapping something
  still has mounted refuses to close, so a live workload cannot lose its volume
  to the sweep, including one that outlived the volumed that opened it.
- **The pre-delete hook retries each close, then fails.** It exits non-zero
  naming what stayed open instead of warning and reporting success.
- **`c8s uninstall` lists volume-holding pods under `--force` too**, and names
  the ones whose mappings the hook will not be able to close.
- **`attach` says what the device is bound to.** The kernel resolves the image
  path once, so replacing an image in place leaves the device serving the old
  file while a hash of the path matches the new one. The refusal for an
  already-attached volume says so; `docs/volumes.md` documents
  detach → overwrite → attach.

## Review notes

- **`--force` still only bypasses the guard.** Making it delete the pods was
  considered and dropped: it gates the kata check as well, so one flag would
  mean "proceed anyway" there and "delete tenant workloads cluster-wide" here —
  off an annotation pod authors write, and a Deployment would recreate the pod
  before the hook ran anyway.
- **The hook's exit code is not load-bearing on helm 3.** It waits only until
  the DaemonSet object exists; helm 4 waits on hook readiness and fails the
  uninstall. The chart comment claiming otherwise is corrected. `c8s uninstall`
  covers the gap from the CLI side, which is why the `--force` listing matters.
- **The sweep is node-shape only.** The guest shape has no reaper and its
  volumes die with the VM.
- Adds the first test that executes an embedded chart script, against a fixture
  tree with the host tools stubbed. The chart tests only ever grepped the
  rendered argv, which is how a swallowed failure shipped.

## Verification

Unit and chart tests only — no cluster run. The reported case is reproduced at
the script level (a close that never succeeds must exit non-zero and name the
mapping); the sweep is covered against the fake device-mapper, including the
busy case and a non-c8s target it must not touch.
