### PR TITLE
fix(nri-image-policy): do not read a slow CDS as a shutdown request

### DIFF
--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -185,7 +185,13 @@ func Run(args []string) error {
 		})
 		if err != nil {
 			switch {
-			case errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded):
+			// INVARIANT: shutdown is read off the parent context, never off
+			// the error chain. pullInitial gives every attempt its own
+			// deadline, so a merely slow CDS returns an error wrapping
+			// context.DeadlineExceeded that is indistinguishable from a
+			// SIGTERM by inspection — and taking that branch parks the
+			// process on pluginErrCh forever, never ready and never pulling.
+			case ctx.Err() != nil:
 				logger.Info("shutdown before plugin became ready")
 				if perr := <-pluginErrCh; perr != nil {
 					logger.Error("plugin error during shutdown", "error", perr)

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -314,6 +314,70 @@ logging:
 	}
 }
 
+// A CDS that is merely slow must not be read as a shutdown request. Every
+// initial-pull attempt carries its own deadline, so exhausting the retries
+// against an unresponsive endpoint returns an error wrapping
+// context.DeadlineExceeded while the process context is still live. Treating
+// that as SIGTERM parked the process on the plugin error channel: never ready,
+// never pulling again, and only a containerd restart cleared it. Run must take
+// the fail-soft path instead and surface the plugin's own failure.
+func TestRun_SlowCDSDuringInitialPullIsNotShutdown(t *testing.T) {
+	t.Setenv("NRI_PLUGIN_NAME", "")
+	origDelay, origRetries := allowlistApiInitialDelay, allowlistApiMaxRetries
+	allowlistApiInitialDelay = 5 * time.Millisecond
+	allowlistApiMaxRetries = 1
+	defer func() {
+		allowlistApiInitialDelay, allowlistApiMaxRetries = origDelay, origRetries
+	}()
+
+	// Both endpoints accept and then hang, so an attempt expires on its own
+	// deadline instead of being refused: connection-refused is a plain error
+	// and would never have reached the branch under test.
+	blocked := make(chan struct{})
+	defer close(blocked)
+	stalledAttestation := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		select {
+		case <-blocked:
+		case <-r.Context().Done():
+		}
+	}))
+	defer stalledAttestation.Close()
+	stalledCDS := stalledListener(t, blocked)
+
+	dir := t.TempDir()
+	cfgYAML := fmt.Sprintf(`
+plugin:
+  health_addr: unix://%s/health.sock
+containerd:
+  socket: %s/ctr.sock
+allowlist:
+  always_allow:
+    "%s": image-a
+  pull:
+    url: https://%s/
+    attestation_api_url: %s
+    cds_measurements: ["%s"]
+    interval: 30s
+    timeout: 300ms
+policy:
+  mode: fail-closed
+  enforce_existing: false
+logging:
+  level: error
+`, dir, dir, pushDigestA, stalledCDS, stalledAttestation.URL, strings.Repeat("ab", 48))
+
+	// The NRI socket does not exist here, so registration fails and that
+	// failure is what Run must report. A nil return means Run classified the
+	// stalled pull as a shutdown and swallowed it.
+	err := runWithDeadline(t, 20*time.Second, []string{"-config", writeConfigYAML(t, cfgYAML)})
+	if err == nil {
+		t.Fatal("Run returned nil: a stalled initial pull was misread as shutdown")
+	}
+	if !strings.HasPrefix(err.Error(), "plugin: ") {
+		t.Fatalf("err = %v, want the NRI plugin run failure", err)
+	}
+}
+
 // --- allowlistPullHTTPClient ------------------------------------------------
 
 func TestAllowlistPullHTTPClient_ValidMeasurements(t *testing.T) {
@@ -605,4 +669,29 @@ func TestAllowlistPullHTTPClient_InvalidMeasurements(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid CDS measurements")
 	}
+}
+
+// stalledListener accepts TCP connections and holds them open without ever
+// speaking, so a client dialing it hangs until its own deadline fires. It
+// returns the host:port to dial.
+func stalledListener(t *testing.T, done <-chan struct{}) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				<-done
+				_ = conn.Close()
+			}()
+		}
+	}()
+	return ln.Addr().String()
 }

--- a/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
@@ -146,7 +146,9 @@ fi
 
 # NRI does not respawn pre-registered plugins on exit. Binary, config, or
 # containerd registration changes therefore require a restart. Shims survive.
+restarted_containerd=0
 if [ "$containerd_changed" = "1" ] || [ "$binary_changed" = "1" ] || [ "$config_changed" = "1" ]; then
+  restarted_containerd=1
   echo "restarting containerd (detached via systemd-run): $RESTART_COMMAND"
   # The restart tears down this pod's own containerd shim. Running it in this
   # pod's process tree (nsenter ... sh -c) means it is killed together with the
@@ -162,20 +164,36 @@ if [ "$containerd_changed" = "1" ] || [ "$binary_changed" = "1" ] || [ "$config_
     sh -c "$RESTART_COMMAND"
 fi
 
-i=0
-# Sized against the worker plugin's initial CDS pull (allowlistApi* consts in
-# internal/cmds/nri-image-policy/main.go): 4 backoff sleeps (2+4+8+16s) plus
-# per-attempt fetch timeouts before it goes Ready on the floor.
-until curl --unix-socket "/host{{ include "nri-image-policy.hostHealthSocket" $root }}" --silent --fail \
-    --max-time 2 http://localhost/healthz >/dev/null 2>&1; do
-  i=$((i + 1))
-  if [ "$i" -gt 120 ]; then
-    echo "ERROR: plugin not healthy after 120s" >&2
+# The plugin goes ready once its initial CDS pull settles: 4 backoff sleeps
+# (2+4+8+16s) plus per-attempt fetch timeouts (allowlistApi* consts in
+# internal/cmds/nri-image-policy/main.go). A containerd restart adds the
+# runtime's own recovery, and on a sole control-plane node that takes the
+# apiserver down with it, so the budget is wider when we restarted it.
+budget=120
+if [ "$restarted_containerd" = "1" ]; then
+  budget=300
+fi
+# A wall-clock deadline, so the number in the failure message is the time that
+# actually passed: each miss costs the curl timeout as well as the sleep.
+deadline=$(($(date +%s) + budget))
+
+health_socket="/host{{ include "nri-image-policy.hostHealthSocket" $root }}"
+until health=$(curl --unix-socket "$health_socket" --silent --fail --max-time 2 \
+    --write-out ' [http %{http_code}]' http://localhost/healthz 2>&1); do
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    # Re-read without --fail so the body and status come back rather than
+    # being discarded: the plugin says why it is not ready, and curl exit 7
+    # (nothing listening on the socket) is a different fault entirely.
+    rc=0
+    last=$(curl --unix-socket "$health_socket" --silent --max-time 2 \
+      --write-out ' [http %{http_code}]' http://localhost/healthz 2>&1) || rc=$?
+    echo "ERROR: plugin not healthy after ${budget}s; last /healthz: ${last:-<no response>} (curl exit $rc)" >&2
+    echo "       the plugin runs under containerd, so its log is the journal of the unit restarted by: $RESTART_COMMAND" >&2
     exit 1
   fi
   sleep 1
 done
-echo "==> nri-image-policy installer finished; plugin healthy"
+echo "==> nri-image-policy installer finished; plugin healthy: $health"
 {{- end }}
 
 {{/*


### PR DESCRIPTION
An install run left the plugin alive and serving NRI while `/healthz`
returned `503 not ready` for over twenty minutes, with the allowlist
pull abandoned entirely — the attestation-api served one request and
then nothing. A manual `c8s allowlist list` from the same node against
the same endpoint and pinned measurement returned instantly, so CDS, the
NodePort, the RA-TLS chain and the attestation-api were all healthy.
Because containerd owns the plugin process, deleting the DaemonSet pod
replaced nothing; the stale process survived to restart 3 unchanged and
only `systemctl restart rke2-server` cleared it. Helm meanwhile failed
the release on the installer's health poll.

Run classified the initial pull's failure by walking the error chain for
context.Canceled or context.DeadlineExceeded and treating either as
SIGTERM. pullInitial gives every attempt its own deadline, and net/http
reports its own client timeouts as DeadlineExceeded, so a CDS that is
merely slow produces exactly that shape while the process context is
still live. Taking the shutdown branch then blocks on pluginErrCh, which
only ever receives when plugin.Run returns — and the NRI stub was
healthy, so nothing was ever sent. SetReady is never called, the pull
loop is never started, and the one log line is INFO "shutdown before
plugin became ready".

Shutdown is now read off the parent context. pullInitial returns
ctx.Err() unwrapped on real cancellation, so ctx.Err() != nil is the
signal, and a per-attempt deadline falls through to the fail-soft branch
that already exists for it: warn, serve the bootstrap floor, go ready,
and let runPullLoop keep retrying. That is the intended posture — the
alternative is a plugin that blocks container creation node-wide because
one fetch was slow. It also means a slow CDS now reaches
RunDeferredCheck with a floor-only store, which under the default
enforceExisting stops running containers the floor does not carry. That
is not new — any non-timeout CDS failure has always taken this branch —
but it is now reachable from a timeout, and gating the retroactive check
on a store that has actually been refreshed is worth doing separately.

The installer's timeout message reported only that the plugin was not
healthy, discarding the response that would have said why. It now
re-reads /healthz without --fail so the body, HTTP status and curl exit
code reach the operator, and points at the runtime's journal since that
is where a containerd-launched plugin logs. The budget was sized against
the plugin's CDS backoff rather than against a containerd restart that
on a sole control-plane node takes the apiserver with it, so it is wider
when this run restarted containerd — and it is now a wall-clock deadline
rather than a loop counter, which counted iterations costing between one
and three seconds each and reported the number as seconds.

TestRun_SlowCDSDuringInitialPullIsNotShutdown covers the branch, which
had no test: both the CDS and attestation endpoints accept and hang, so
attempts expire on their own deadline rather than being refused —
connection-refused is a plain error and never reached the misclassifying
branch, which is why the neighbouring 5xx-serving fake could not catch
this. It asserts Run surfaces the NRI registration failure; a nil return
means the stalled pull was swallowed as shutdown. Verified failing
before the change and passing after, and it runs under runWithDeadline
so a regression fails rather than hangs. Removing the DeadlineExceeded
arm leaves the shutdown arm itself untested; it now needs a cancelled
parent context, which is not worth a test of its own.
