### PR TITLE
fix(ci): compare the measurement against the image the VM booted

### DIFF
--- a/.github/workflows/snp-measure-smp.yml
+++ b/.github/workflows/snp-measure-smp.yml
@@ -41,7 +41,6 @@ jobs:
     env:
       NS: confai-images
       REFS_CM: base-image-refs
-      IMAGE: ghcr.io/confidential-dot-ai/node-guest-base:rke2-snp-dev
       VM: cvm-meas-${{ github.run_id }}-${{ github.run_attempt }}
       CORES: ${{ inputs.cores }}
       MEMORY: 8Gi
@@ -85,8 +84,17 @@ jobs:
           [ -n "$ROOTPVC" ] || { echo "::error::$REFS_CM missing rootPvc"; exit 1; }
           PAT=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.igvmFilePattern}')
           [ -n "$PAT" ] || { echo "::error::$REFS_CM has no igvmFilePattern, so it cannot serve a per-count IGVM"; exit 1; }
-          echo "ROOTPVC=$ROOTPVC" >> "$GITHUB_ENV"
-          echo "IGVMFILE=${PAT//\{cores\}/$CORES}" >> "$GITHUB_ENV"
+          # The digest to compare against must come from the image this VM
+          # boots, not a hardcoded ref: a measurement from one image tells you
+          # nothing about another image's published digest.
+          IMG=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.image}')
+          [ -n "$IMG" ] || { echo "::error::$REFS_CM has no 'image' key, so the published digest cannot be located"; exit 1; }
+          {
+            echo "ROOTPVC=$ROOTPVC"
+            echo "IGVMFILE=${PAT//\{cores\}/$CORES}"
+            echo "IMAGE=$IMG"
+          } >> "$GITHUB_ENV"
+          echo "booting $IMG (per $REFS_CM)"
 
       - name: boot the CVM
         run: |
@@ -207,8 +215,10 @@ jobs:
         run: |
           set -euo pipefail
           M='${{ steps.capture.outputs.measurement }}'
+          repo="${IMAGE%%@*}"; repo="${repo%%:*}"
           d=$(crane manifest "$IMAGE" | jq -r '.layers[]|select(.annotations["org.opencontainers.image.title"]=="manifest.json")|.digest')
-          PUB=$(crane blob "${IMAGE%%:*}@${d}" | jq -r --argjson c "$CORES" '.snp_variants[]|select(.smp==$c)|.measurement.snp_launch_digest')
+          [ -n "$d" ] || { echo "::error::$IMAGE publishes no manifest.json layer, so there is no digest to compare against"; exit 1; }
+          PUB=$(crane blob "${repo}@${d}" | jq -r --argjson c "$CORES" '.snp_variants[]|select(.smp==$c)|.measurement.snp_launch_digest')
           {
             echo "### SNP launch measurement — smp${CORES}"
             echo
@@ -216,6 +226,7 @@ jobs:
             echo "|---|---|"
             echo "| hardware | \`${M}\` |"
             echo "| manifest | \`${PUB:-(no variant for smp$CORES)}\` |"
+            echo "| image | \`${IMAGE}\` |"
             echo
             if [ "$M" = "$PUB" ]; then
               echo "**MATCH** — the published digest for smp${CORES} is what the hardware produces."


### PR DESCRIPTION
## Problem

The first green run of `snp-measure-smp`
([32397819660](https://github.com/confidential-dot-ai/c8s/actions/runs/32397819660))
reported a mismatch:

```
hardware (smp8): d43313c5d66a5ada315a0d2ea385ad9b97f0451920f14e23053983d6360125f7e0ce1bad5038eecf4bb5b4354f9d1d3c
manifest (smp8): 5312c29afd5fb80f5b2d89b9af1acd0440b4274a8251aab72c1aba888525aec91687a3cd7795966f32ebdbf81f045dd8
```

That mismatch is **this lane's bug, not a bad published digest.** The job boots
whatever `base-image-refs` pins (rootfs `cpu-image-rootdisk-…`, the `base-cpu`
flavor) but compared against a hardcoded
`IMAGE=ghcr.io/…/node-guest-base:rke2-snp-dev`. Two different images: one
image's hardware measurement says nothing about another's published digest, so
the comparison could only ever mismatch.

I introduced the hardcoded ref in #438 and read past it when interpreting the
result — I called the digest wrong before checking which image had booted.

## Fix

Read `image` from the same refs CM the boot uses, so the measurement and the
digest describe one build. Also handle a digest ref when locating the
`manifest.json` layer (the same form that broke `tdx-metal-e2e` in #423), and
name the compared image in the job summary so a future mismatch can be read
without digging through the log.

## What the run did establish

Everything except the comparison. The network path works end to end on real
hardware: VM booted `guest-smp8.igvm`, VMI address `10.42.0.33`,
attestation-api answered `{"status":"ok","platform":"snp"}`, quote fetched,
`c8s verify` parsed it, and a genuine smp8 guest produced
`d43313c5…`.

So the smp8 question is still open — the measurement is real, it just has not
been compared against the right reference yet. The next dispatch does that.
