### PR TITLE
install: pin the kata guest artifact to the component image tag

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -884,6 +884,23 @@ func valuesFilesSetDistro(files []string) (bool, error) {
 	return false, nil
 }
 
+// valuesFilesSetGuestImageTag reports whether any -f values file names the
+// kata-guest-base tag itself. That file then owns the guest axis, and the
+// install leaves it alone — the same "a -f that actually sets the key owns it"
+// rule valuesFilesSetDistro applies to the containerd layout.
+func valuesFilesSetGuestImageTag(files []string) (bool, error) {
+	for _, f := range files {
+		tree, err := decodeValuesFile(f)
+		if err != nil {
+			return false, err
+		}
+		if v, err := stringAtPath(tree, "kata.guestImage.tag"); err == nil && v != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // valuesFilesSetMeasurements reports whether any -f values file pins a CDS
 // launch measurement. cds.measurements is the one the injected get-cert reads,
 // so it alone decides whether a pod-mode install is pinned; ratlsMesh.measurements
@@ -1722,7 +1739,18 @@ func validateDebugFlag(cvmMode string, debug bool) error {
 // rejects --debug outside --cvm-mode=pod before args are built; everything here still
 // keys on kata so a call-order change cannot emit a debug value for a non-kata
 // install.
-func appendKataInstallArgs(helmArgs []string, cvmMode string, debug bool) []string {
+//
+// guestTag pins the kata-guest-base artifact to the same tag the component
+// images resolve at.
+//
+// INVARIANT: the guest's baked bootstrap allowlist admits the component digests
+// this install resolves. The seed is fixed when the guest is built, so it names
+// the components of exactly one commit; letting the two axes resolve from
+// different tags admits a guest whose seed predates the components, and
+// policy-monitor then SIGKILLs the injected get-cert — the install never
+// converges and says only "Broken pipe". Empty leaves the chart default, which
+// is what a -f file owning kata.guestImage.tag wants.
+func appendKataInstallArgs(helmArgs []string, cvmMode string, debug bool, guestTag string) []string {
 	if !cvmModeIsPod(cvmMode) {
 		return helmArgs
 	}
@@ -1734,6 +1762,11 @@ func appendKataInstallArgs(helmArgs []string, cvmMode string, debug bool) []stri
 	)
 	if debug {
 		helmArgs = append(helmArgs, "--set", "kata.guestImage.debug=true")
+	}
+	if guestTag != "" {
+		// --set-string for the same reason component tags use it: an all-digit
+		// or zero-padded tag would otherwise be int-coerced.
+		helmArgs = append(helmArgs, "--set-string", "kata.guestImage.tag="+guestTag)
 	}
 	return helmArgs
 }

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -246,7 +246,7 @@ func TestBuildInstallHelmArgsOrdering(t *testing.T) {
 
 func TestAppendKataInstallArgsNonPodModeIsNoOp(t *testing.T) {
 	for _, mode := range []string{"node", "gke", "aks", ""} {
-		got := appendKataInstallArgs([]string{"upgrade"}, mode, false)
+		got := appendKataInstallArgs([]string{"upgrade"}, mode, false, "")
 		assertArgsEqual(t, got, []string{"upgrade"})
 	}
 }
@@ -257,7 +257,7 @@ func TestAppendKataInstallArgsPodModeIsEnforcing(t *testing.T) {
 	// image (the chart's enforce_host_components validation rejects them left
 	// on). Enforcement itself (webhook injection + ValidatingAdmissionPolicy)
 	// is keyed on kata.enabled in the chart — no separate value.
-	got := appendKataInstallArgs([]string{"upgrade"}, "pod", false)
+	got := appendKataInstallArgs([]string{"upgrade"}, "pod", false, "")
 	assertArgsEqual(t, got, []string{
 		"upgrade",
 		"--set", "kata.enabled=true",
@@ -270,7 +270,7 @@ func TestAppendKataInstallArgsPodModeIsEnforcing(t *testing.T) {
 func TestAppendKataInstallArgsDebugSelectsDebugGuestImage(t *testing.T) {
 	// --cvm-mode=pod --debug keeps the enforcing shape and additionally points
 	// the puller at the -debug guest image (host log/exec streams allowed).
-	got := appendKataInstallArgs([]string{"upgrade"}, "pod", true)
+	got := appendKataInstallArgs([]string{"upgrade"}, "pod", true, "")
 	assertArgsEqual(t, got, []string{
 		"upgrade",
 		"--set", "kata.enabled=true",
@@ -281,11 +281,35 @@ func TestAppendKataInstallArgsDebugSelectsDebugGuestImage(t *testing.T) {
 	})
 }
 
+func TestAppendKataInstallArgsPinsGuestImageTagToTheComponentTag(t *testing.T) {
+	// The guest's baked allowlist seed names the components of the commit it was
+	// built from, so a guest resolved from a different tag than the components
+	// admits neither: policy-monitor SIGKILLs the injected get-cert and the
+	// install never converges. --set-string, so an all-digit tag is not coerced.
+	got := appendKataInstallArgs([]string{"upgrade"}, "pod", true, "v0.1.10")
+	assertArgsEqual(t, got, []string{
+		"upgrade",
+		"--set", "kata.enabled=true",
+		"--set", "ratlsMesh.enabled=false",
+		"--set", "attestationApi.enabled=false",
+		"--set", "nriImagePolicy.enabled=false",
+		"--set", "kata.guestImage.debug=true",
+		"--set-string", "kata.guestImage.tag=v0.1.10",
+	})
+}
+
+func TestAppendKataInstallArgsGuestImageTagNonPodModeIsNoOp(t *testing.T) {
+	// The guest axis exists only under --cvm-mode=pod; a non-pod install must
+	// not emit a guest tag even if one reaches the builder.
+	got := appendKataInstallArgs([]string{"upgrade"}, "node", false, "v0.1.10")
+	assertArgsEqual(t, got, []string{"upgrade"})
+}
+
 func TestAppendKataInstallArgsDebugNonPodModeIsNoOp(t *testing.T) {
 	// RunE rejects --debug outside --cvm-mode=pod before args are built; the
 	// builder still keys everything on the pod mode so a call-order change
 	// cannot silently emit a debug guest image for a non-pod install.
-	got := appendKataInstallArgs([]string{"upgrade"}, "node", true)
+	got := appendKataInstallArgs([]string{"upgrade"}, "node", true, "")
 	assertArgsEqual(t, got, []string{"upgrade"})
 }
 
@@ -2015,4 +2039,50 @@ func TestReportExemptedImages(t *testing.T) {
 	if buf.Len() != 0 {
 		t.Errorf("nothing exempted must print nothing, got:\n%s", buf.String())
 	}
+}
+
+// A -f file that names kata.guestImage.tag owns the guest axis; the install
+// must not overwrite it with the component tag (the computed values file is
+// applied last and would otherwise win).
+func TestValuesFilesSetGuestImageTag(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	pinned := write("pinned.yaml", "kata:\n  guestImage:\n    tag: v0.1.10\n")
+	other := write("other.yaml", "kata:\n  guestImage:\n    debug: true\n")
+	empty := write("empty.yaml", "{}\n")
+
+	for _, tc := range []struct {
+		name  string
+		files []string
+		want  bool
+	}{
+		{"no files", nil, false},
+		{"unrelated keys only", []string{other, empty}, false},
+		{"tag pinned", []string{pinned}, true},
+		{"tag pinned in a later file", []string{other, pinned}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := valuesFilesSetGuestImageTag(tc.files)
+			if err != nil {
+				t.Fatalf("valuesFilesSetGuestImageTag: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("valuesFilesSetGuestImageTag = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	// An unreadable -f must surface, not read as "operator did not pin it" —
+	// that would silently re-float the guest axis the install is pinning.
+	t.Run("unreadable file errors", func(t *testing.T) {
+		if _, err := valuesFilesSetGuestImageTag([]string{filepath.Join(dir, "absent.yaml")}); err == nil {
+			t.Fatal("missing values file: want error, got nil")
+		}
+	})
 }

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -184,7 +184,22 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, c
 	if err != nil {
 		return nil, err
 	}
-	setArgs = appendKataInstallArgs(setArgs, installCvmMode, installKataDebug)
+	// The guest artifact and the component images are one identity: the guest's
+	// baked allowlist seed names the components of the commit it was built from
+	// (see appendKataInstallArgs). A -f file that names kata.guestImage.tag owns
+	// the axis and is left alone; installValues is empty for render-values,
+	// which registers no -f flag.
+	guestTag := ""
+	if cvmModeIsPod(installCvmMode) {
+		pinnedInValues, err := valuesFilesSetGuestImageTag(installValues)
+		if err != nil {
+			return nil, err
+		}
+		if !pinnedInValues {
+			guestTag = imageTag
+		}
+	}
+	setArgs = appendKataInstallArgs(setArgs, installCvmMode, installKataDebug, guestTag)
 	// installValues is empty for render-values, which registers no -f flag, so
 	// the hosted-lane default always applies there.
 	setArgs, err = appendExemptNamespacesInstallArgs(setArgs, installCvmMode, installValues)

--- a/cmd/c8s/render_values_test.go
+++ b/cmd/c8s/render_values_test.go
@@ -523,3 +523,75 @@ func TestCoerceTypedVsString(t *testing.T) {
 		}
 	}
 }
+
+// The guest axis is pinned to the component tag under --cvm-mode=pod, and a -f
+// file that names kata.guestImage.tag owns it instead. An unreadable -f must
+// abort the render rather than fall through to the pinning branch, which would
+// overwrite a tag the operator did set.
+func TestBuildValueArgsGuestImageTagPinning(t *testing.T) {
+	prev := installResolveDigests
+	installResolveDigests = false
+	defer func() { installResolveDigests = prev }()
+	prevValues := installValues
+	defer func() { installValues = prevValues }()
+
+	dir := t.TempDir()
+	pinned := filepath.Join(dir, "pinned.yaml")
+	if err := os.WriteFile(pinned, []byte("kata:\n  guestImage:\n    tag: v9.9.9\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	newCmd := func(mode string) *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().String(flagCvmMode, mode, "")
+		return cmd
+	}
+
+	t.Run("pod mode pins the guest to the component tag", func(t *testing.T) {
+		setCvmModeForTest(t, "pod")
+		installValues = nil
+		args, err := buildValueArgs(context.Background(), newCmd("pod"), "", nil, "v0.1.10", "", appendResolvedDigestArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.Contains(args, "kata.guestImage.tag=v0.1.10") {
+			t.Fatalf("pod mode should pin the guest tag to the component tag, got %v", args)
+		}
+	})
+
+	t.Run("a -f that sets the tag owns the axis", func(t *testing.T) {
+		setCvmModeForTest(t, "pod")
+		installValues = []string{pinned}
+		args, err := buildValueArgs(context.Background(), newCmd("pod"), "", nil, "v0.1.10", "", appendResolvedDigestArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if slices.ContainsFunc(args, func(a string) bool {
+			return strings.HasPrefix(a, "kata.guestImage.tag=")
+		}) {
+			t.Fatalf("a -f owning kata.guestImage.tag must not be overwritten, got %v", args)
+		}
+	})
+
+	t.Run("node mode emits no guest tag", func(t *testing.T) {
+		setCvmModeForTest(t, "node")
+		installValues = nil
+		args, err := buildValueArgs(context.Background(), newCmd("node"), "", nil, "v0.1.10", "", appendResolvedDigestArgs)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if slices.ContainsFunc(args, func(a string) bool {
+			return strings.HasPrefix(a, "kata.guestImage.tag=")
+		}) {
+			t.Fatalf("non-pod mode has no guest axis, got %v", args)
+		}
+	})
+
+	t.Run("an unreadable -f aborts the render", func(t *testing.T) {
+		setCvmModeForTest(t, "pod")
+		installValues = []string{filepath.Join(dir, "absent.yaml")}
+		if _, err := buildValueArgs(context.Background(), newCmd("pod"), "", nil, "v0.1.10", "", appendResolvedDigestArgs); err == nil {
+			t.Fatal("unreadable values file: want error, got nil")
+		}
+	})
+}

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -52,10 +52,12 @@ rke2). An install with `-f` values owns the distro instead: set
 doesn't fit — a mixed cluster cannot be detected and always needs that, plus
 nodeSelectors to partition the install.
 
-The kata-image-puller is on by default under `--cvm-mode=pod`. A
-single-node / local build can switch it off, and pin the guest image tag,
-through a `-f` values file (`kata.guestImage.enabled=false` /
-`kata.guestImage.tag=<tag>`) — there is no dedicated CLI flag for these.
+The kata-image-puller is on by default under `--cvm-mode=pod`, and the install
+pins `kata.guestImage.tag` to the tag it resolves the component images at — the
+guest's baked allowlist seed admits only the components of the commit the guest
+was built from. A `-f` values file can switch the puller off or own the tag
+itself (`kata.guestImage.enabled=false` / `kata.guestImage.tag=<tag>`); a file
+that sets the tag wins. There is no dedicated CLI flag for these.
 
 `--cvm-mode=pod --debug` points the puller at the `<tag>-debug` guest image —
 identical except the baked guest policy allows host log/exec streams, so

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -407,8 +407,10 @@ the image as `<short-sha>` and `main`. When the parent run created a stable
 release tag on that exact revision, the same build also receives the matching
 `vX.Y.Z` alias. A manual dispatch can publish a branch-scoped alias.
 
-Operators select the artifact tag by setting `kata.guestImage.tag` in a values
-file (`c8s install --cvm-mode=pod -f values.yaml`). The
+`c8s install --cvm-mode=pod` sets `kata.guestImage.tag` to the tag it resolves
+the component images at, so both axes name one commit. Operators override it by
+setting `kata.guestImage.tag` in a values file
+(`c8s install --cvm-mode=pod -f values.yaml`), which then owns the axis. The
 `c8s-kata-image-puller` DaemonSet picks that up and pulls accordingly —
 see "How it's consumed in-cluster" in
 [`kata-guest-base/README.md`](../kata-guest-base/README.md).

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -521,11 +521,10 @@ kata:
     ## Default true: under --cvm-mode=pod the puller fetches the published artifact.
     enabled: true
     repository: ghcr.io/confidential-dot-ai
-    ## Default tracks the same floating tag c8s itself falls back to for
-    ## non-release builds (see cmd/c8s/install.go fallbackImageTag). Release
-    ## installs SHOULD override this to a specific `<short-sha>`
-    ## digest-stand-in: the bootstrap allowlist binds to floating :main
-    ## digests, and the puller has no `digest:` field yet.
+    ## `c8s install --cvm-mode=pod` overwrites this with the tag it resolves the
+    ## component images at: the guest's baked allowlist seed admits only the
+    ## components of the commit the guest was built from. Set it here to own the
+    ## axis instead. The puller has no `digest:` field, so this is a tag.
     tag: main
     ## Use the `<tag>-debug` guest image variant, published in lockstep with
     ## every locked tag (.github/workflows/kata-guest-base.yml). Same build,


### PR DESCRIPTION
Under --cvm-mode=pod the guest artifact and the component images were two independent axes. --image-tag resolved the components; kata.guestImage.tag kept the chart default `main`. A release-stamped CLI therefore pinned its components to vX.Y.Z and still staged its guest from a floating tag.

That is not a cosmetic split. The guest's baked bootstrap allowlist seed is fixed when the guest is built, so it names the components of exactly one commit. When the two axes resolve to different commits, policy-monitor inside the guest denies and SIGKILLs the injected get-cert container, whose image is not in the seed. The install never converges and the only host-side symptom is

  createContainer failed: rpc error: code = Internal desc = Broken pipe (os error 32)

with tls-lb in Init:CrashLoopBackOff and no diagnostic naming the cause. The guest cannot recover on its own either: release-namespace pods are excluded by the webhook's namespaceSelector, so they receive no init-data document and the CDS allowlist refresh that would deliver the correct digests stays disabled.

This was hit on bare metal on 2026-08-20: `kata-guest-base:main-debug` pointed at the 5210d0d build while the component `:main` tags pointed at 64ed995, after two concurrent guest builds both pushed the floating tag and the older commit's build finished last.

buildValueArgs now derives the guest tag from the same resolveImageTag() the components use, so both axes name one commit by construction. A -f values file that sets kata.guestImage.tag still owns the axis — the same rule valuesFilesSetDistro applies to the containerd layout — so the documented override, and the escape hatch tagCouplingHint points at, keep working.

Verified on bare-metal SEV-SNP: `--image-tag v0.1.10` with no guest tag in any values file renders kata.guestImage.tag=v0.1.10, the puller stages v0.1.10-debug (c8s_ref 042a744441b6), the components resolve to the three digests in that guest's seed, the release converges first try, and CDS logs a launch digest byte-identical to `c8s kata measure` run offline against the v0.1.10 artifact.

This does not address the publish race that let the floating guest tag regress; that is a separate fix in the kata-guest-base workflow.