### PR TITLE
test(ratls-mesh): serve pre-bound listeners instead of probing free ports

### DIFF
--- a/internal/cmds/ratlsmesh/health.go
+++ b/internal/cmds/ratlsmesh/health.go
@@ -106,16 +106,21 @@ func (h *healthServer) handleReady(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("ready\n"))
 }
 
-func (h *healthServer) serve(ctx context.Context, addr string) error {
+// serve binds addr, or adopts the pre-bound ln when non-nil, and serves
+// until ctx is cancelled.
+func (h *healthServer) serve(ctx context.Context, addr string, ln net.Listener) error {
 	srv := &http.Server{
 		Handler:      h.mux,
 		ReadTimeout:  durOrDefault(h.readTimeout, 5*time.Second),
 		WriteTimeout: durOrDefault(h.writeTimeout, 10*time.Second),
 		IdleTimeout:  60 * time.Second,
 	}
-	ln, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
+	if ln == nil {
+		var err error
+		ln, err = net.Listen("tcp", addr)
+		if err != nil {
+			return err
+		}
 	}
 	go func() {
 		<-ctx.Done()

--- a/internal/cmds/ratlsmesh/health_test.go
+++ b/internal/cmds/ratlsmesh/health_test.go
@@ -198,10 +198,11 @@ func TestHealthReadyGatesOnCertUsable(t *testing.T) {
 func TestHealthServerServe(t *testing.T) {
 	h := newHealthServer(testMetrics(), nil, nil, 10, time.Second, time.Second)
 	h.ready.Store(true)
-	port := freePort(t)
+	ln := bindLoopback(t)
+	port := listenerPort(ln)
 	ctx, cancel := context.WithCancel(context.Background())
 	errCh := make(chan error, 1)
-	go func() { errCh <- h.serve(ctx, fmt.Sprintf("127.0.0.1:%d", port)) }()
+	go func() { errCh <- h.serve(ctx, ln.Addr().String(), ln) }()
 
 	assertEventually(t, 5*time.Second, func() bool {
 		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/live", port))
@@ -223,12 +224,12 @@ func TestHealthServerServe(t *testing.T) {
 	}
 
 	// A second serve on an already-bound port errors immediately.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	held, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
-	if err := h.serve(context.Background(), ln.Addr().String()); err == nil {
+	defer held.Close()
+	if err := h.serve(context.Background(), held.Addr().String(), nil); err == nil {
 		t.Fatal("serve on a bound port should error")
 	}
 }

--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -433,7 +433,7 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 	}
 
 	go func() {
-		if err := health.serve(ctx, fmt.Sprintf(":%d", inGuestHealthPort)); err != nil {
+		if err := health.serve(ctx, fmt.Sprintf(":%d", inGuestHealthPort), nil); err != nil {
 			logger.Error("health server error", "error", err)
 		}
 	}()

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -79,6 +80,14 @@ func newRatlsMeshCommand() *cobra.Command {
 	return cmd
 }
 
+// proxyListeners are served instead of binding the matching *Port fields;
+// tests pre-bind them.
+type proxyListeners struct {
+	outbound net.Listener
+	inbound  net.Listener
+	health   net.Listener
+}
+
 type proxyConfig struct {
 	platform                  string
 	attestationApiURL         string
@@ -96,6 +105,7 @@ type proxyConfig struct {
 	maxConns                  int
 	maxConnsPerSource         int
 	healthPort                int
+	listeners                 proxyListeners
 	measurements              string
 	certTTL                   time.Duration
 	rotationTimeout           time.Duration
@@ -321,6 +331,8 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 	proxy := &Proxy{
 		outboundAddr:      fmt.Sprintf(":%d", c.outboundPort),
 		inboundAddr:       fmt.Sprintf(":%d", c.inboundPort),
+		outboundLn:        c.listeners.outbound,
+		inboundLn:         c.listeners.inbound,
 		serverTLS:         serverTLS,
 		clientTLS:         clientTLS,
 		nodeIP:            c.nodeIP,
@@ -364,7 +376,7 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 
 	// Start health/metrics server.
 	go func() {
-		if err := health.serve(ctx, fmt.Sprintf(":%d", c.healthPort)); err != nil {
+		if err := health.serve(ctx, fmt.Sprintf(":%d", c.healthPort), c.listeners.health); err != nil {
 			logger.Error("health server error", "error", err)
 		}
 	}()

--- a/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
+++ b/internal/cmds/ratlsmesh/main_run_lifecycle_test.go
@@ -130,6 +130,7 @@ func TestRunProxyMeasurementLengthMessage(t *testing.T) {
 	t.Setenv("NODE_IP", "")
 	stubKubeClientset(t, k8sfake.NewSimpleClientset(), nil)
 	cfg := defaultTestProxyConfig(t)
+	bindProxyPorts(t, cfg)
 	cfg.logLevel = "error"
 	cfg.localCIDRBootTimeout = time.Millisecond
 	cfg.nodeIP = "127.0.0.1"
@@ -155,9 +156,7 @@ func TestRunProxySelfSignedReadiness(t *testing.T) {
 	cfg.platform = "sev-snp"
 	cfg.nodeIP = nodeIP
 	cfg.attestationApiURL = attest.URL
-	cfg.outboundPort = freePort(t)
-	cfg.inboundPort = freePort(t)
-	cfg.healthPort = freePort(t)
+	bindProxyPorts(t, cfg)
 	cfg.rotationTimeout = 5 * time.Second
 	cfg.metricsUpdateInterval = 10 * time.Millisecond
 	cfg.localCIDRBootTimeout = time.Millisecond
@@ -292,9 +291,7 @@ func TestRunProxyCDSModeDegraded(t *testing.T) {
 	cfg.platform = "sev-snp"
 	cfg.nodeIP = nodeIP
 	cfg.attestationApiURL = "http://127.0.0.1:1" // refused: warm-up failure is non-fatal
-	cfg.outboundPort = freePort(t)
-	cfg.inboundPort = freePort(t)
-	cfg.healthPort = freePort(t)
+	bindProxyPorts(t, cfg)
 	cfg.certMode = "cds"
 	cfg.cdsURL = cds.URL
 	cfg.cdsMeasurements = "" // deliberately unset: must warn

--- a/internal/cmds/ratlsmesh/main_run_test.go
+++ b/internal/cmds/ratlsmesh/main_run_test.go
@@ -54,15 +54,32 @@ func stubKubeClientset(t *testing.T, cs kubernetes.Interface, err error) {
 	t.Cleanup(func() { newKubeClientset = old })
 }
 
-func freePort(t *testing.T) int {
+// bindLoopback returns a held-open loopback listener for the code under test
+// to adopt.
+func bindLoopback(t *testing.T) net.Listener {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}
-	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
-	return port
+	t.Cleanup(func() { ln.Close() }) // ignored error once the server adopts ln
+	return ln
+}
+
+func listenerPort(ln net.Listener) int {
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// bindProxyPorts hands runProxy pre-bound listeners and points the matching
+// port fields at them.
+func bindProxyPorts(t *testing.T, cfg *proxyConfig) {
+	t.Helper()
+	cfg.listeners.outbound = bindLoopback(t)
+	cfg.listeners.inbound = bindLoopback(t)
+	cfg.listeners.health = bindLoopback(t)
+	cfg.outboundPort = listenerPort(cfg.listeners.outbound)
+	cfg.inboundPort = listenerPort(cfg.listeners.inbound)
+	cfg.healthPort = listenerPort(cfg.listeners.health)
 }
 
 // writeSelfSignedCertPEM writes a throwaway self-signed certificate to a
@@ -173,6 +190,8 @@ func TestRunProxyConfigErrors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := defaultTestProxyConfig(t)
+			// A case that slips past validation binds ephemeral ports, not the fixed defaults.
+			bindProxyPorts(t, cfg)
 			cfg.logLevel = "error"
 			cfg.localCIDRBootTimeout = time.Millisecond
 			tt.mutate(cfg)
@@ -279,9 +298,7 @@ func TestRunProxyFullLifecycle(t *testing.T) {
 	cfg.platform = "sev-snp"
 	cfg.nodeIP = nodeIP
 	cfg.attestationApiURL = "http://127.0.0.1:1" // refused instantly; warm-up failure is non-fatal
-	cfg.outboundPort = freePort(t)
-	cfg.inboundPort = freePort(t)
-	cfg.healthPort = freePort(t)
+	bindProxyPorts(t, cfg)
 	cfg.certDNSSAN = "mesh.example"
 	cfg.measurements = strings.Repeat("ab", 48)
 	cfg.cdsMeasurements = strings.Repeat("cd", 48)

--- a/internal/cmds/ratlsmesh/proxy.go
+++ b/internal/cmds/ratlsmesh/proxy.go
@@ -38,15 +38,19 @@ type Resolver interface {
 type Proxy struct {
 	outboundAddr string
 	inboundAddr  string
-	serverTLS    *tls.Config
-	clientTLS    *tls.Config
-	nodeIP       string
-	inboundPort  int
-	resolver     Resolver
-	origDstFunc  func(net.Conn) (string, error)
-	logger       *slog.Logger
-	metrics      *metrics
-	accessLog    bool
+	// outboundLn/inboundLn, when non-nil, are served instead of binding the
+	// Addr strings; tests hand over pre-bound listeners.
+	outboundLn  net.Listener
+	inboundLn   net.Listener
+	serverTLS   *tls.Config
+	clientTLS   *tls.Config
+	nodeIP      string
+	inboundPort int
+	resolver    Resolver
+	origDstFunc func(net.Conn) (string, error)
+	logger      *slog.Logger
+	metrics     *metrics
+	accessLog   bool
 
 	dialTimeout       time.Duration
 	tlsDialTimeout    time.Duration
@@ -154,13 +158,13 @@ func (p *Proxy) Run(ctx context.Context) error {
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		if err := p.serve(ctx, p.outboundAddr, nil, p.handleOutbound, outReady, &p.metrics.acceptConsecutiveOutbound); err != nil {
+		if err := p.serve(ctx, p.outboundAddr, p.outboundLn, nil, p.handleOutbound, outReady, &p.metrics.acceptConsecutiveOutbound); err != nil {
 			errCh <- fmt.Errorf("outbound: %w", err)
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		if err := p.serve(ctx, p.inboundAddr, p.serverTLS, p.handleInbound, inReady, &p.metrics.acceptConsecutiveInbound); err != nil {
+		if err := p.serve(ctx, p.inboundAddr, p.inboundLn, p.serverTLS, p.handleInbound, inReady, &p.metrics.acceptConsecutiveInbound); err != nil {
 			errCh <- fmt.Errorf("inbound: %w", err)
 		}
 	}()
@@ -203,15 +207,19 @@ func (p *Proxy) Run(ctx context.Context) error {
 	}
 }
 
-// serve is the generic listen/accept loop. If tlsCfg is non-nil the listener
-// is wrapped with TLS. The ready channel is closed once the listener is bound.
+// serve is the generic listen/accept loop. ln, when non-nil, is served
+// instead of binding addr. If tlsCfg is non-nil the listener is wrapped with
+// TLS. The ready channel is closed once the listener is acquired.
 // consecutiveErrors is an atomic counter exposed as a metric for readiness gating.
-func (p *Proxy) serve(ctx context.Context, addr string, tlsCfg *tls.Config, handler func(context.Context, net.Conn), ready chan<- struct{}, consecutiveErrors *atomic.Int64) error {
-	ln, err := (&net.ListenConfig{
-		KeepAlive: durOrDefault(p.keepAlive, 30*time.Second),
-	}).Listen(ctx, "tcp", addr)
-	if err != nil {
-		return fmt.Errorf("listen %s: %w", addr, err)
+func (p *Proxy) serve(ctx context.Context, addr string, ln net.Listener, tlsCfg *tls.Config, handler func(context.Context, net.Conn), ready chan<- struct{}, consecutiveErrors *atomic.Int64) error {
+	if ln == nil {
+		var err error
+		ln, err = (&net.ListenConfig{
+			KeepAlive: durOrDefault(p.keepAlive, 30*time.Second),
+		}).Listen(ctx, "tcp", addr)
+		if err != nil {
+			return fmt.Errorf("listen %s: %w", addr, err)
+		}
 	}
 	if tlsCfg != nil {
 		ln = tls.NewListener(ln, tlsCfg)
@@ -230,7 +238,7 @@ func (p *Proxy) serve(ctx context.Context, addr string, tlsCfg *tls.Config, hand
 			}
 			n := consecutiveErrors.Add(1)
 			p.metrics.acceptErrors.Inc()
-			p.logger.Warn("accept error", "addr", addr, "error", err, "consecutive", n)
+			p.logger.Warn("accept error", "addr", ln.Addr(), "error", err, "consecutive", n)
 
 			// Exponential backoff: 5ms, 10ms, 20ms, … capped at 640ms.
 			backoff := 5 * time.Millisecond

--- a/internal/cmds/ratlsmesh/proxy_serve_test.go
+++ b/internal/cmds/ratlsmesh/proxy_serve_test.go
@@ -215,13 +215,12 @@ func TestInboundHeaderAtSizeLimitAccepted(t *testing.T) {
 // log must classify it as tls_error and the handshake histogram must not
 // record a bogus zero-duration sample.
 func TestOutboundDialFailureClassifiedAsTLSError(t *testing.T) {
-	deadPort := freePort(t)
 	m := testMetrics()
 	var logBuf syncBuffer
 	_, clientTLS := testTLSConfigs(t)
 	p := &Proxy{
 		nodeIP:      "1.1.1.1",
-		inboundPort: deadPort,
+		inboundPort: 1, // refused: nothing listens on port 1
 		clientTLS:   clientTLS,
 		resolver:    &fixedRemoteResolver{nodeIP: "127.0.0.1"},
 		origDstFunc: func(net.Conn) (string, error) { return "10.244.1.5:8080", nil },
@@ -283,14 +282,18 @@ func startProxyRun(t *testing.T, mutate func(*Proxy)) *proxyRunFixture {
 	t.Helper()
 	backend := startBackend(t, "run-e2e")
 	serverTLS, clientTLS := testTLSConfigs(t)
-	outPort := freePort(t)
-	inPort := freePort(t)
+	outLn := bindLoopback(t)
+	inLn := bindLoopback(t)
+	outPort := listenerPort(outLn)
+	inPort := listenerPort(inLn)
 	logBuf := &syncBuffer{}
 	ready := make(chan struct{})
 
 	p := &Proxy{
-		outboundAddr: fmt.Sprintf("127.0.0.1:%d", outPort),
-		inboundAddr:  fmt.Sprintf("127.0.0.1:%d", inPort),
+		outboundAddr: outLn.Addr().String(),
+		inboundAddr:  inLn.Addr().String(),
+		outboundLn:   outLn,
+		inboundLn:    inLn,
 		serverTLS:    serverTLS,
 		clientTLS:    clientTLS,
 		nodeIP:       "127.0.0.1",
@@ -548,20 +551,22 @@ func TestServeConnectionLimits(t *testing.T) {
 			releaseHold := func() { holdOnce.Do(func() { close(hold) }) }
 			defer releaseHold()
 
-			outPort := freePort(t)
-			inPort := freePort(t)
+			outLn := bindLoopback(t)
+			inLn := bindLoopback(t)
 			var sem chan struct{}
 			if tc.sem > 0 {
 				sem = make(chan struct{}, tc.sem)
 			}
 			ready := make(chan struct{})
 			p := &Proxy{
-				outboundAddr: fmt.Sprintf("127.0.0.1:%d", outPort),
-				inboundAddr:  fmt.Sprintf("127.0.0.1:%d", inPort),
+				outboundAddr: outLn.Addr().String(),
+				inboundAddr:  inLn.Addr().String(),
+				outboundLn:   outLn,
+				inboundLn:    inLn,
 				serverTLS:    serverTLS,
 				clientTLS:    clientTLS,
 				nodeIP:       "127.0.0.1",
-				inboundPort:  inPort,
+				inboundPort:  listenerPort(inLn),
 				resolver:     &staticResolver{nodeIP: "127.0.0.1"},
 				origDstFunc: func(net.Conn) (string, error) {
 					<-hold

--- a/internal/cmds/ratlsmesh/proxy_test.go
+++ b/internal/cmds/ratlsmesh/proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1007,6 +1008,33 @@ func TestReadinessOnShutdown(t *testing.T) {
 
 	if health.ready.Load() {
 		t.Fatal("health.ready should be false after shutdown")
+	}
+}
+
+// A held port makes the outbound bind fail; Run must return the listen
+// error instead of dropping it.
+func TestRunReturnsListenError(t *testing.T) {
+	held := bindLoopback(t)
+	p := &Proxy{
+		outboundAddr: held.Addr().String(),
+		inboundAddr:  "127.0.0.1:0",
+		logger:       testLogger(),
+		metrics:      testMetrics(),
+		drainTimeout: time.Millisecond,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.Run(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "outbound: listen") {
+			t.Fatalf("Run() = %v, want the outbound listen error", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Run did not stop after cancel")
 	}
 }
 


### PR DESCRIPTION
`freePort` probed `127.0.0.1:0`, closed the listener, and handed the port to the proxy and health servers to bind a moment later. Under `go test ./...` — package binaries running concurrently on one host — a neighbor could claim the port in between; the bind failed with "address already in use" and the test hung until its readiness timeout. On the coverage gate this aborts `scripts/coverage-gate.sh` before the comparison runs, so an unrelated PR reports as a coverage regression.

The proxy and health servers now adopt a listener the test already holds, so the port is bound continuously from probe to serve and the window is gone rather than narrowed. Production is untouched: the new fields and parameter are nil on every production path, which keeps the old bind behavior byte-for-byte. Tests bind the loopback listeners up front and point the config's port fields at them, so a server that ignores its listener fails deterministically against the port the test still holds. The runProxy tests also stop exposing their listeners on every interface — loopback only now.

`TestOutboundDialFailureClassifiedAsTLSError` wants the opposite guarantee — a refused dial — so it dials port 1 like the other refused-endpoint tests, and `freePort` is deleted rather than left around as a trap.

Verification: old code, 8 concurrent package binaries × 3 runs of the affected tests: 2 of 24 failed with the issue's bind error. New code under the same stress: 0 of 24. `go test -race` on the package and full `go test ./...` pass. `TestRunReturnsListenError` adds coverage for serve's bind-error branch, which had none.

Follow-up, not in this PR: identical `freePort` copies in `internal/cmds/cds` and `internal/cmds/cdsattest`.
