### PR TITLE
fix(ratls-mesh): keep one ipset failure from freezing the guard's membership

### DIFF
--- a/internal/cmds/ratlsmesh/iptables_metrics.go
+++ b/internal/cmds/ratlsmesh/iptables_metrics.go
@@ -24,6 +24,7 @@ type iptablesMetricsSnapshot struct {
 	JumpPositionViolations  int64 `json:"jump_position_violations"`
 	JumpPositionCheckErrors int64 `json:"jump_position_check_errors"`
 	IPSetOverflows          int64 `json:"ipset_overflows"`
+	IPSetSyncFailures       int64 `json:"ipset_sync_failures"`
 	CWInboundDrops          int64 `json:"cw_inbound_drops"`
 	CWPassthroughReturns    int64 `json:"cw_passthrough_returns"`
 	// Membership is what the guard and the interception rules key on, so a set
@@ -59,6 +60,7 @@ func currentIptablesMetricsSnapshot() iptablesMetricsSnapshot {
 		JumpPositionViolations:  iptablesJumpPositionViolations(),
 		JumpPositionCheckErrors: iptablesJumpPositionCheckErrors(),
 		IPSetOverflows:          iptablesIPSetOverflows(),
+		IPSetSyncFailures:       iptablesIPSetSyncFailures(),
 		CWInboundDrops:          iptablesCWInboundDrops(),
 		CWPassthroughReturns:    iptablesCWPassthroughReturns(),
 		PodIPSetMembers:         podIPSetMemberCount(),

--- a/internal/cmds/ratlsmesh/metrics.go
+++ b/internal/cmds/ratlsmesh/metrics.go
@@ -45,6 +45,7 @@ type metrics struct {
 	iptablesJumpViolations       prometheus.Gauge
 	iptablesJumpCheckErrors      prometheus.Gauge
 	iptablesIPSetOverflows       prometheus.Gauge
+	iptablesIPSetSyncFailures    prometheus.Gauge
 	iptablesPodIPSetMembers      prometheus.Gauge
 	iptablesCWIPSetMembers       prometheus.Gauge
 	iptablesCWIPSetShrinks       prometheus.Gauge
@@ -138,6 +139,10 @@ func newMetrics() *metrics {
 		Name: "ratls_mesh_iptables_ipset_overflow_total",
 		Help: "Sidecar-reported reconcile cycles where pod count exceeded --ipset-maxelem.",
 	})
+	m.iptablesIPSetSyncFailures = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "ratls_mesh_iptables_ipset_sync_failures_total",
+		Help: "Sidecar-reported ipset writes that failed. A set keeps its previous contents, so enforcement runs against a stale membership until the next cycle succeeds.",
+	})
 	m.iptablesPodIPSetMembers = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "ratls_mesh_iptables_pod_ipset_members",
 		Help: "Sidecar-reported pod IPs in the interception ipset (v4+v6). Interception is membership-driven, so a drop means those pods stopped being redirected through the proxy.",
@@ -229,6 +234,7 @@ func newMetrics() *metrics {
 		m.iptablesJumpViolations,
 		m.iptablesJumpCheckErrors,
 		m.iptablesIPSetOverflows,
+		m.iptablesIPSetSyncFailures,
 		m.iptablesPodIPSetMembers,
 		m.iptablesCWIPSetMembers,
 		m.iptablesCWIPSetShrinks,
@@ -364,6 +370,7 @@ func (m *metrics) refreshIptablesMetrics(path string) error {
 	m.iptablesJumpViolations.Set(float64(snap.JumpPositionViolations))
 	m.iptablesJumpCheckErrors.Set(float64(snap.JumpPositionCheckErrors))
 	m.iptablesIPSetOverflows.Set(float64(snap.IPSetOverflows))
+	m.iptablesIPSetSyncFailures.Set(float64(snap.IPSetSyncFailures))
 	m.iptablesPodIPSetMembers.Set(float64(snap.PodIPSetMembers))
 	m.iptablesCWIPSetMembers.Set(float64(snap.CWIPSetMembers))
 	m.iptablesCWIPSetShrinks.Set(float64(snap.CWIPSetShrinks))

--- a/internal/cmds/ratlsmesh/netfilter_fake_test.go
+++ b/internal/cmds/ratlsmesh/netfilter_fake_test.go
@@ -14,8 +14,10 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 )
 
 // fakeIptablesScript emulates iptables/ip6tables closely enough for
@@ -945,5 +947,64 @@ func TestPublishIptablesMetricsWarnsOnlyOnWriteFailure(t *testing.T) {
 	publishIptablesMetrics(slog.New(slog.NewJSONHandler(&failBuf, nil)))
 	if !hasMsg(decodeLogRecords(failBuf.String()), "write iptables metrics file failed") {
 		t.Errorf("failed write did not warn: %s", failBuf.String())
+	}
+}
+
+// cwPodStore is a pod cache holding one confidential workload, which is what
+// the guard sets are computed from.
+func cwPodStore(t *testing.T) cache.Store {
+	t.Helper()
+	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
+	if err := store.Add(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "serving",
+			Namespace: "demo",
+			Labels:    map[string]string{labelConfidentialWorkload: "vllm"},
+		},
+		Status: corev1.PodStatus{HostIP: "10.0.0.1", PodIP: "10.244.0.9"},
+	}); err != nil {
+		t.Fatalf("seed pod store: %v", err)
+	}
+	return store
+}
+
+// Membership is what the guard matches on, so a set left at a previous cycle's
+// contents is enforcement that has stopped covering pods created since — and
+// the cw sets, which the fail-closed guard keys on, used to be written last and
+// abandoned whenever an earlier set failed.
+func TestReconcilePodIPSetsWritesGuardSetsFirst(t *testing.T) {
+	nf := installFakeNetfilter(t)
+	if _, err := reconcilePodIPSets(cwPodStore(t), []string{"10.0.0.1"}, nil, 100, testLogger()); err != nil {
+		t.Fatalf("reconcilePodIPSets: %v", err)
+	}
+	script := nf.read("restore_scripts")
+	cwAt := strings.Index(script, cwPodIPSetName4)
+	podAt := strings.Index(script, podIPSetName4)
+	if cwAt < 0 || podAt < 0 {
+		t.Fatalf("both sets must be written; script:\n%s", script)
+	}
+	if cwAt > podAt {
+		t.Errorf("the guard's own set is written after the interception sets, so an earlier failure costs it its write:\n%s", script)
+	}
+}
+
+func TestReconcilePodIPSetsAttemptsEverySetWhenOneFails(t *testing.T) {
+	nf := installFakeNetfilter(t)
+	nf.set("ipset_restore_fail", "ipset v7.15: Kernel error received: Invalid argument")
+	before := iptablesIPSetSyncFailures()
+
+	_, err := reconcilePodIPSets(cwPodStore(t), []string{"10.0.0.1"}, nil, 100, testLogger())
+	if err == nil {
+		t.Fatal("a failing ipset write must surface")
+	}
+	// Abandoning the remaining sets is what froze membership behind a single
+	// warning; every set gets its own attempt and its own error.
+	for _, label := range []string{"IPv4 cw pod ipset", "IPv6 cw pod ipset", "IPv4 pod ipset", "local IPv4 pod ipset"} {
+		if !strings.Contains(err.Error(), label) {
+			t.Errorf("the %s was never attempted after an earlier set failed: %v", label, err)
+		}
+	}
+	if got := iptablesIPSetSyncFailures() - before; got != 6 {
+		t.Errorf("sync failures counted %d, want one per managed set (6)", got)
 	}
 }

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -36,6 +36,15 @@ func iptablesIPSetOverflows() int64 {
 	return ipsetOverflows.Load()
 }
 
+// ipsetSyncFailures counts individual set writes that failed. A set that keeps
+// its previous contents is enforcement running against a stale membership,
+// which no other counter distinguishes from a quiet cluster.
+var ipsetSyncFailures atomic.Int64
+
+func iptablesIPSetSyncFailures() int64 {
+	return ipsetSyncFailures.Load()
+}
+
 // Membership levels for the last reconcile, plus a count of reconciles that
 // shrank the cw set. Absence from these sets is what silently removes
 // interception and the cw guard, so it has to be visible: a gauge alone cannot
@@ -310,18 +319,30 @@ func reconcilePodIPSets(store cache.Store, nodeIPs []string, excludedSourceNames
 		ipsetOverflows.Add(1)
 		publishIptablesMetrics(logger)
 	}
+	// INVARIANT: the guard sets are written first, and one set's failure never
+	// costs another its write. Membership is what the fail-closed guard and the
+	// interception rules match on, so a set left at a previous cycle's contents
+	// stops covering pods created since — plaintext reaches a cw pod, and the
+	// only signal is a warning. Ordering puts the cw sets, which the guard
+	// keys on, ahead of the sets that only decide interception.
 	specs := []ipSetSpec{
+		{cwPodIPSetName4, "inet", sets.cwIPv4, "IPv4 cw pod ipset"},
+		{cwPodIPSetName6, "inet6", sets.cwIPv6, "IPv6 cw pod ipset"},
 		{podIPSetName4, "inet", sets.allIPv4, "IPv4 pod ipset"},
 		{podIPSetName6, "inet6", sets.allIPv6, "IPv6 pod ipset"},
 		{localPodIPSetName4, "inet", sets.localIPv4, "local IPv4 pod ipset"},
 		{localPodIPSetName6, "inet6", sets.localIPv6, "local IPv6 pod ipset"},
-		{cwPodIPSetName4, "inet", sets.cwIPv4, "IPv4 cw pod ipset"},
-		{cwPodIPSetName6, "inet6", sets.cwIPv6, "IPv6 cw pod ipset"},
 	}
+	var errs []error
 	for _, spec := range specs {
 		if err := replaceIPSetMembers(logger, spec.name, spec.family, spec.members, ipsetMaxElem); err != nil {
-			return nil, fmt.Errorf("sync %s: %w", spec.label, err)
+			ipsetSyncFailures.Add(1)
+			errs = append(errs, fmt.Errorf("sync %s: %w", spec.label, err))
 		}
+	}
+	if len(errs) > 0 {
+		publishIptablesMetrics(logger)
+		return nil, errors.Join(errs...)
 	}
 	recordIPSetMembership(logger, len(sets.allIPv4)+len(sets.allIPv6), len(sets.cwIPv4)+len(sets.cwIPv6))
 	logger.Debug("pod ipsets reconciled", "ipv4", len(sets.allIPv4), "ipv6", len(sets.allIPv6), "local_ipv4", len(sets.localIPv4), "local_ipv6", len(sets.localIPv6), "cw_ipv4", len(sets.cwIPv4), "cw_ipv6", len(sets.cwIPv6))

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -60,6 +60,27 @@ diagnostics() {
     kubectl get pods -A -o wide 2>&1 || true
     kubectl -n "$NS" logs deploy/c8s-cds --tail=40 2>&1 || true
     kubectl -n "$NS" logs deploy/c8s-operator --tail=40 2>&1 || true
+    mesh_diagnostics
+}
+
+# The mesh assertions are counter and membership claims, and neither survives
+# into the log otherwise: a failed one leaves no way to tell a stale ipset from
+# a rule that never fired from a workload reached in plaintext.
+mesh_diagnostics() {
+    local pod
+    pod="$(kubectl -n "$NS" get pod -l app=c8s-ratls-mesh -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+    [ -n "$pod" ] || return 0
+    echo "--- ratls-mesh counters ---"
+    kubectl -n "$NS" exec "$pod" -c iptables-sync -- \
+        sh -c 'cat /tmp/ratls-iptables-metrics.json' 2>&1 || true
+    echo "--- cw guard chains and ipsets ---"
+    for chain in RATLS-MESH-CW RATLS-MESH-CW-EGRESS; do
+        kubectl -n "$NS" exec "$pod" -c iptables-sync -- iptables -L "$chain" -n -v -x 2>&1 || true
+    done
+    kubectl -n "$NS" exec "$pod" -c iptables-sync -- iptables -L FORWARD -n --line-numbers 2>&1 | head -12 || true
+    for set in RATLS-MESH-CW-PODS RATLS-MESH-PODS RATLS-MESH-LOCAL-PODS; do
+        kubectl -n "$NS" exec "$pod" -c iptables-sync -- ipset list "$set" 2>&1 | head -20 || true
+    done
 }
 
 cleanup() {
@@ -568,7 +589,8 @@ case "$rc" in
         ;;
     0)
         echo "$out" | grep -q "^200" || fail "VIP dial rc=0 but no 200: $out"
-        await_metric_above "$inbound" "${base_inbound_vip:-0}" "mesh inbound counter (VIP hop wrapped)"
+        await_metric_above "$inbound" "${base_inbound_vip:-0}" \
+            "VIP dial returned 200 but the mesh recorded no inbound connection, so the hop reached the cw workload outside the mesh — in plaintext"
         pass "Service-VIP dial wrapped by the mesh (inbound counter moved; rule-ordering variant)"
         ;;
     *)
@@ -583,7 +605,9 @@ kubectl wait --for=condition=Ready pod/it-mesh-excl -n kube-system --timeout=120
     || fail "excluded-namespace client pod not Ready"
 out="$(kubectl exec -n kube-system it-mesh-excl -- sh -c "curl -s -o /dev/null --max-time 5 http://$POD_IP:80/; echo rc=\$?" || true)"
 rc="$(echo "$out" | grep -o 'rc=[0-9]*' | cut -d= -f2)"
-[ "$rc" = "28" ] || fail "excluded-namespace bypass to the cw workload: want curl rc=28 (DROP timeout), got rc=$rc"
+# rc=0 is the insecure outcome, not a slow one: the dial completed, so the cw
+# guard admitted an unmeshed source.
+[ "$rc" = "28" ] || fail "excluded-namespace dial reached the cw workload in plaintext: want curl rc=28 (DROP timeout), got rc=$rc"
 pass "excluded-namespace plaintext bypass dropped by the cw inbound guard"
 
 log "tls-lb front door"


### PR DESCRIPTION
Two CI runs of the same tree reached a confidential workload in plaintext: once from a mesh-excluded namespace past the cw inbound guard, once via a Service VIP that returned 200 while the mesh recorded no inbound connection. Both are the harness catching the insecure outcome it documents, not flakiness — I called it flaky first and was wrong.

- `reconcilePodIPSets` wrote the sets in a fixed order and returned on the first failure, with the cw sets last. A transient failure on any earlier set left the guard's own membership at the previous cycle's contents, behind one warning. Guard sets go first now, and every set gets its own attempt.
- ipset write failures are counted and exported, so a stale set is visible instead of inferred.
- The cluster harness dumps mesh counters, guard chains and ipsets on failure, and its mesh assertions now say that failing means plaintext reached the workload.

This is a real defect on the path that failed, not a proven cause: those runs predate the counters that would show it.