### PR TITLE
fix(install): report kata pods the scheduler never placed instead of healing past them

### DIFF
--- a/cmd/c8s/install_heal.go
+++ b/cmd/c8s/install_heal.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
 // runHelmWithKataHeal runs `helm upgrade --install --wait ...` and, on
@@ -22,6 +24,9 @@ import (
 // --cvm-mode=pod (kata is the only shape that produces this state) and
 // --wait (nothing to heal without a rollout deadline). Non-kata failures and
 // second-attempt failures surface unchanged.
+//
+// A pod the scheduler never placed is reported instead: it has no sandbox, so
+// the retry would just re-wait on a pod that still cannot schedule.
 func runHelmWithKataHeal(ctx context.Context, stdout, stderr io.Writer, helmArgs []string, namespace string, kata, wait bool) error {
 	fmt.Fprintf(stdout, "+ helm %s\n", strings.Join(helmArgs, " "))
 	if err := runCommand(ctx, stdout, stderr, "helm", helmArgs); err == nil {
@@ -31,13 +36,18 @@ func runHelmWithKataHeal(ctx context.Context, stdout, stderr io.Writer, helmArgs
 	} else if !looksLikeRolloutTimeout(err) {
 		return fmt.Errorf("helm install failed: %w", err)
 	}
-	stuck, err := stuckKataPods(ctx, namespace)
+	stuck, unscheduled, err := triageKataPods(ctx, namespace)
 	if err != nil {
 		fmt.Fprintf(stderr, "helm install failed and heal-check failed: %v\n", err)
 		return fmt.Errorf("helm install failed: %w", err)
 	}
+	// helm --wait gates on the whole release, so a retry that leaves an
+	// unplaced pod behind spends the full deadline again.
+	if len(unscheduled) > 0 {
+		return fmt.Errorf("helm install failed: %s", unscheduledPodReport(namespace, unscheduled))
+	}
 	if len(stuck) == 0 {
-		return fmt.Errorf("helm install failed (no stuck c8s-system kata pods found; nothing to heal)")
+		return fmt.Errorf("helm install failed (no c8s-system kata pod is stuck at sandbox creation; nothing to heal)")
 	}
 	fmt.Fprintf(stdout, "+ helm rollout timed out on %d stuck kata pod(s): %s. Force-deleting and retrying once.\n",
 		len(stuck), strings.Join(stuck, ", "))
@@ -84,16 +94,13 @@ func looksLikeRolloutTimeout(err error) bool {
 	return true
 }
 
-// stuckKataPods returns the names of pods in namespace whose spec pins a
-// kata RuntimeClass and that have been sitting in a pre-Running state long
-// enough that a kata-agent race is the plausible cause. The threshold
-// deliberately matches the manual-heal experience: 90s is well past a
-// healthy sandbox start (single-digit seconds on a warm host, up to ~30s on
-// a cold one) and well before an operator would notice by tailing pods.
-func stuckKataPods(ctx context.Context, namespace string) ([]string, error) {
+// triageKataPods splits the namespace's kata-RuntimeClass pods into ones
+// placed on a node and pre-Running past stuckPodMinAge (a force-delete drops
+// the wedged sandbox) and ones the scheduler never placed (no sandbox exists).
+func triageKataPods(ctx context.Context, namespace string) (stuck, unscheduled []string, err error) {
 	out, err := exec.CommandContext(ctx, "kubectl", "get", "pods", "-n", namespace, "-o", "json").Output()
 	if err != nil {
-		return nil, fmt.Errorf("kubectl get pods -n %s: %w", namespace, err)
+		return nil, nil, fmt.Errorf("kubectl get pods -n %s: %w", namespace, err)
 	}
 	var list struct {
 		Items []struct {
@@ -103,6 +110,7 @@ func stuckKataPods(ctx context.Context, namespace string) ([]string, error) {
 				DeletionTimestamp time.Time `json:"deletionTimestamp"`
 			} `json:"metadata"`
 			Spec struct {
+				NodeName         string `json:"nodeName"`
 				RuntimeClassName string `json:"runtimeClassName"`
 			} `json:"spec"`
 			Status struct {
@@ -114,12 +122,20 @@ func stuckKataPods(ctx context.Context, namespace string) ([]string, error) {
 		} `json:"items"`
 	}
 	if err := json.Unmarshal(out, &list); err != nil {
-		return nil, fmt.Errorf("parse kubectl get pods output: %w", err)
+		return nil, nil, fmt.Errorf("parse kubectl get pods output: %w", err)
 	}
-	var stuck []string
 	now := time.Now()
 	for _, p := range list.Items {
 		if !strings.HasPrefix(p.Spec.RuntimeClassName, "kata-") {
+			continue
+		}
+		// A pod mid-shutdown will be replaced by the Deployment controller
+		// — don't fight it.
+		if !p.Metadata.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if p.Spec.NodeName == "" {
+			unscheduled = append(unscheduled, p.Metadata.Name)
 			continue
 		}
 		// Already Running with a Ready container is progressing, not stuck.
@@ -133,17 +149,27 @@ func stuckKataPods(ctx context.Context, namespace string) ([]string, error) {
 		if anyReady {
 			continue
 		}
-		// A pod mid-shutdown will be replaced by the Deployment controller
-		// — don't fight it.
-		if !p.Metadata.DeletionTimestamp.IsZero() {
-			continue
-		}
 		if now.Sub(p.Metadata.CreationTimestamp) < stuckPodMinAge {
 			continue
 		}
 		stuck = append(stuck, p.Metadata.Name)
 	}
-	return stuck, nil
+	return stuck, unscheduled, nil
+}
+
+const kataImagePullerSelector = "app.kubernetes.io/component=kata-image-puller"
+
+func unscheduledPodReport(namespace string, pods []string) string {
+	return fmt.Sprintf(`%d kata pod(s) never scheduled, so there is no sandbox to heal: %s
+Confidential pods require the node label %s=true, set by the operator once a node's kata-image-puller is Ready.
+  kubectl -n %s describe pod %s
+  kubectl get nodes -L %s
+  kubectl -n %s get pods -l %s -o wide`,
+		len(pods), strings.Join(pods, ", "),
+		webhook.GuestReadyNodeLabel,
+		namespace, pods[0],
+		webhook.GuestReadyNodeLabel,
+		namespace, kataImagePullerSelector)
 }
 
 // stuckPodMinAge is the lower bound before a pre-Running kata pod counts as

--- a/cmd/c8s/install_heal_test.go
+++ b/cmd/c8s/install_heal_test.go
@@ -8,11 +8,13 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
-// The heal returns the specific pod names it will delete: kata-RC pods that
-// have been sitting pre-Running long enough to be stuck, and nothing else.
-func TestStuckKataPods_Filters(t *testing.T) {
+// The heal returns the specific pod names it will delete: kata-RC pods placed
+// on a node and sitting pre-Running long enough to be stuck, and nothing else.
+func TestTriageKataPods_Filters(t *testing.T) {
 	old := stuckPodMinAge
 	stuckPodMinAge = 30 * time.Second
 	t.Cleanup(func() { stuckPodMinAge = old })
@@ -20,46 +22,138 @@ func TestStuckKataPods_Filters(t *testing.T) {
 	list := podList{Items: []pod{
 		{ // stuck kata pod — the case we want to heal
 			Metadata: podMeta{Name: "cds-stuck", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
-			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-snp"},
 			Status:   podStatus{Phase: "Pending"},
 		},
 		{ // running fine — do not disturb
 			Metadata: podMeta{Name: "cds-running", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
-			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-snp"},
 			Status:   podStatus{Phase: "Running", ContainerStatuses: []podContainerStatus{{Ready: true}}},
 		},
 		{ // non-kata — not in the failure mode we heal
 			Metadata: podMeta{Name: "operator", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
-			Spec:     podSpec{RuntimeClassName: ""},
+			Spec:     podSpec{NodeName: "node-1", RuntimeClassName: ""},
 			Status:   podStatus{Phase: "Pending"},
 		},
 		{ // too young — normal sandbox creation, do not race it
 			Metadata: podMeta{Name: "cds-fresh", CreationTimestamp: time.Now().Add(-5 * time.Second)},
-			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-snp"},
 			Status:   podStatus{Phase: "Pending"},
 		},
 		{ // already being deleted — let the Deployment controller handle it
 			Metadata: podMeta{Name: "cds-terminating", CreationTimestamp: time.Now().Add(-2 * time.Minute), DeletionTimestamp: time.Now().Add(-10 * time.Second)},
-			Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+			Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-snp"},
+			Status:   podStatus{Phase: "Pending"},
+		},
+		{ // never placed — no sandbox to drop, so report rather than delete
+			Metadata: podMeta{Name: "tls-lb-unscheduled", CreationTimestamp: time.Now().Add(-2 * time.Minute)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-tdx"},
+			Status:   podStatus{Phase: "Pending"},
+		},
+		{ // never placed and mid-shutdown — the controller replaces it
+			Metadata: podMeta{Name: "cds-unscheduled-terminating", CreationTimestamp: time.Now().Add(-2 * time.Minute), DeletionTimestamp: time.Now().Add(-10 * time.Second)},
+			Spec:     podSpec{RuntimeClassName: "kata-qemu-tdx"},
 			Status:   podStatus{Phase: "Pending"},
 		},
 	}}
-	got, err := runStuckKataPodsWithFakeKubectl(t, list)
+	stuck, unscheduled, err := runTriageKataPodsWithFakeKubectl(t, list)
 	if err != nil {
-		t.Fatalf("stuckKataPods: %v", err)
+		t.Fatalf("triageKataPods: %v", err)
 	}
-	want := []string{"cds-stuck"}
-	if !equalStringSlice(got, want) {
-		t.Fatalf("stuck = %v, want %v", got, want)
+	if want := []string{"cds-stuck"}; !equalStringSlice(stuck, want) {
+		t.Fatalf("stuck = %v, want %v", stuck, want)
+	}
+	if want := []string{"tls-lb-unscheduled"}; !equalStringSlice(unscheduled, want) {
+		t.Fatalf("unscheduled = %v, want %v", unscheduled, want)
 	}
 }
 
-// runStuckKataPodsWithFakeKubectl runs the production stuckKataPods against a
-// fake `kubectl` on PATH that returns the given pod list — the same shape the
-// real one emits with `-o json`. Keeps the exec path in the test rather than
-// splitting the parser out into a private helper the production code would
-// then have to route around.
-func runStuckKataPodsWithFakeKubectl(t *testing.T, list podList) ([]string, error) {
+// An unplaced pod must not cost a second rollout deadline: helm runs once,
+// nothing is deleted, and the returned error names the label and the
+// component that sets it. The mixed case carries a genuinely stuck pod too —
+// helm --wait re-waits on the whole release, so healing it would still burn
+// the deadline on the pod that cannot schedule.
+func TestRunHelmWithKataHeal_UnscheduledPodsReportedNotDeleted(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		items []pod
+	}{
+		{"unscheduled only", []pod{unscheduledPod("c8s-cds-689668b59-89hw8")}},
+		{"stuck and unscheduled", []pod{
+			unscheduledPod("c8s-cds-689668b59-89hw8"),
+			{
+				Metadata: podMeta{Name: "c8s-tls-lb-stuck", CreationTimestamp: time.Now().Add(-1 * time.Minute)},
+				Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-tdx"},
+				Status:   podStatus{Phase: "Pending"},
+			},
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			old := stuckPodMinAge
+			stuckPodMinAge = 100 * time.Millisecond
+			t.Cleanup(func() { stuckPodMinAge = old })
+
+			stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+			shimDir := t.TempDir()
+
+			counterPath := filepath.Join(t.TempDir(), "helm-calls")
+			os.WriteFile(counterPath, []byte("0"), 0o644)
+			writeShim(t, shimDir, "helm", `#!/bin/sh
+n=$(cat `+counterPath+`)
+echo $((n+1)) > `+counterPath+`
+echo "Error: UPGRADE FAILED: ... context deadline exceeded" >&2
+exit 1
+`)
+
+			body, _ := json.Marshal(podList{Items: tc.items})
+			fixture := filepath.Join(t.TempDir(), "pods.json")
+			os.WriteFile(fixture, body, 0o644)
+			// A delete records its argv rather than failing, so the assertion
+			// below fails on the deletion itself and not on its exit code.
+			deleteLog := filepath.Join(t.TempDir(), "deleted")
+			writeShim(t, shimDir, "kubectl", `#!/bin/sh
+case "$1" in
+  get) exec cat `+fixture+` ;;
+  delete) echo "$@" >> `+deleteLog+`; exit 0 ;;
+  *) exit 9 ;;
+esac
+`)
+			t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			err := runHelmWithKataHeal(context.Background(), stdout, stderr, []string{"upgrade", "--install"}, "c8s-system", true, true)
+			if err == nil {
+				t.Fatal("want an error when a kata pod never scheduled")
+			}
+			if got := readCounter(t, counterPath); got != "1" {
+				t.Fatalf("helm should have run once, saw %s calls", got)
+			}
+			if b, readErr := os.ReadFile(deleteLog); readErr == nil {
+				t.Fatalf("nothing should have been deleted, got: %s", b)
+			}
+			if !bytesContainsAll([]byte(err.Error()),
+				[]byte("c8s-cds-689668b59-89hw8"),
+				[]byte(webhook.GuestReadyNodeLabel),
+				[]byte("kata-image-puller")) {
+				t.Fatalf("report missing from the returned error:\n%s", err.Error())
+			}
+		})
+	}
+}
+
+func unscheduledPod(name string) pod {
+	return pod{
+		Metadata: podMeta{Name: name, CreationTimestamp: time.Now().Add(-1 * time.Minute)},
+		Spec:     podSpec{RuntimeClassName: "kata-qemu-tdx"},
+		Status:   podStatus{Phase: "Pending"},
+	}
+}
+
+// runTriageKataPodsWithFakeKubectl runs the production triageKataPods against
+// a fake `kubectl` on PATH that returns the given pod list — the same shape
+// the real one emits with `-o json`. Keeps the exec path in the test rather
+// than splitting the parser out into a private helper the production code
+// would then have to route around.
+func runTriageKataPodsWithFakeKubectl(t *testing.T, list podList) (stuck, unscheduled []string, err error) {
 	t.Helper()
 	body, err := json.Marshal(list)
 	if err != nil {
@@ -69,7 +163,7 @@ func runStuckKataPodsWithFakeKubectl(t *testing.T, list podList) ([]string, erro
 	if err := os.WriteFile(fixture, body, 0o644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	// Shim kubectl to `cat` our fixture: stuckKataPods runs `kubectl get
+	// Shim kubectl to `cat` our fixture: triageKataPods runs `kubectl get
 	// pods -n <ns> -o json`, whose only real dependency is stdout.
 	shimDir := t.TempDir()
 	shim := filepath.Join(shimDir, "kubectl")
@@ -78,7 +172,7 @@ func runStuckKataPodsWithFakeKubectl(t *testing.T, list podList) ([]string, erro
 		t.Fatalf("write kubectl shim: %v", err)
 	}
 	t.Setenv("PATH", shimDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	return stuckKataPods(context.Background(), "c8s-system")
+	return triageKataPods(context.Background(), "c8s-system")
 }
 
 // Helm succeeded: no kubectl calls, no heal message, nil error.
@@ -129,7 +223,7 @@ echo "helm ok"
 
 	list := podList{Items: []pod{{
 		Metadata: podMeta{Name: "c8s-cds-stuck", CreationTimestamp: time.Now().Add(-1 * time.Minute)},
-		Spec:     podSpec{RuntimeClassName: "kata-qemu-snp"},
+		Spec:     podSpec{NodeName: "node-1", RuntimeClassName: "kata-qemu-snp"},
 		Status:   podStatus{Phase: "Pending"},
 	}}}
 	body, _ := json.Marshal(list)
@@ -196,8 +290,10 @@ type podMeta struct {
 	DeletionTimestamp time.Time `json:"deletionTimestamp,omitempty"`
 }
 type podSpec struct {
+	NodeName         string `json:"nodeName,omitempty"`
 	RuntimeClassName string `json:"runtimeClassName"`
 }
+
 type podStatus struct {
 	Phase             string               `json:"phase"`
 	ContainerStatuses []podContainerStatus `json:"containerStatuses"`


### PR DESCRIPTION
Closes the install half of the pod-CVM wedge: `c8s install --cvm-mode pod --hardware-platform tdx --single-node --wait` timed out twice — 10m, then another 10m on the heal retry — with `c8s-cds` and `c8s-tls-lb` Pending on

```
FailedScheduling: 0/1 nodes are available: 1 node(s) didn't match Pod's node affinity/selector
```

## Why it was undiagnosable

The unmet term is `confidential.ai/kata-guest-ready`, which `c8s.kataGuestReadyAffinity` renders onto both. Nothing in the failure output names that label, and its setter is not where you would look: `KataGuestReadyReconciler` runs inside the **operator Deployment**, mirroring per-node `kata-image-puller` readiness. Dumping every DaemonSet podspec — the obvious next step — finds no reference to the key and reads as "nothing sets this label".

## Why the retry was wasted

`stuckKataPods` selected every kata-RuntimeClass pod that was not Ready and older than 90s. That fits an unschedulable pod exactly as well as the wedged-sandbox pod the heal exists for: `runtimeClassName` is set at creation, an unplaced pod has no `containerStatuses`, and it is well past 90s. Both Pending pods were force-deleted and `helm --wait` re-ran; the replacements were Pending for the same reason.

## Fix

Triage on `spec.nodeName`:

- **placed** — has a sandbox a force-delete drops. Heals as before.
- **unplaced** — has none, so deleting only yields another pod that cannot schedule. Reported, retry skipped.

The retry is skipped whenever any pod is unplaced, including alongside a genuinely stuck one: `helm --wait` gates on the whole release, so that retry cannot converge either.

The report is the returned error rather than a stderr aside, because the CLI prints the returned error last and `nothing to heal` would otherwise be the final line:

```
helm install failed: 1 kata pod(s) never scheduled, so there is no sandbox to heal: c8s-cds-689668b59-89hw8
Confidential pods require the node label confidential.ai/kata-guest-ready=true, set by the operator once a node's kata-image-puller is Ready.
  kubectl -n c8s-system describe pod c8s-cds-689668b59-89hw8
  kubectl get nodes -L confidential.ai/kata-guest-ready
  kubectl -n c8s-system get pods -l app.kubernetes.io/component=kata-image-puller -o wide
```

`describe pod` also covers the taint and resource causes of an unplaced pod, so the report does not have to guess which one applies.

## What is deliberately unchanged

The affinity stays, and the alternative key floated in the report is the wrong one. `katacontainers.io/kata-runtime` means kata-deploy installed the runtime; it says nothing about the measured c8s guest being staged on that node. Gating cds on it — or hand-labelling the node — would let it boot on the stock kata guest, outside the measurement the platform's trust rests on.

## Tests

`TestTriageKataPods_Filters` covers both buckets and the terminating/young/non-kata exclusions. `TestRunHelmWithKataHeal_UnscheduledPodsReportedNotDeleted` runs unscheduled-only and mixed stuck+unscheduled, asserting helm runs once, the kubectl shim records no delete, and the report is in the returned error. Both were mutation-checked: removing the short-circuit or the `nodeName` triage fails them.