### PR TITLE
fix(kata): give the image-puller probe a timeout it can meet

### DIFF
--- a/internal/controller/kataguestready_controller.go
+++ b/internal/controller/kataguestready_controller.go
@@ -16,9 +16,12 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
-const kataImagePullerComponent = "kata-image-puller"
+// KataImagePullerComponent and ComponentLabel select the puller pods whose
+// readiness this controller mirrors. The chart must render the same pair onto
+// the puller pod template (asserted in internal/helmchart/chart_test.go).
+const KataImagePullerComponent = "kata-image-puller"
 
-const componentLabel = "app.kubernetes.io/component"
+const ComponentLabel = "app.kubernetes.io/component"
 
 // KataGuestReadyReconciler maintains webhook.GuestReadyNodeLabel from the
 // node's kata-image-puller readiness, which already re-validates the drop-in
@@ -79,7 +82,7 @@ func (r *KataGuestReadyReconciler) pullerReadyOn(ctx context.Context, node strin
 	var pods corev1.PodList
 	if err := r.List(ctx, &pods,
 		client.InNamespace(r.Namespace),
-		client.MatchingLabels{componentLabel: kataImagePullerComponent},
+		client.MatchingLabels{ComponentLabel: KataImagePullerComponent},
 	); err != nil {
 		return false, fmt.Errorf("list kata-image-puller pods: %w", err)
 	}
@@ -120,6 +123,6 @@ func pullerPodToNode(_ context.Context, obj client.Object) []ctrl.Request {
 func pullerPodPredicate(namespace string) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		return obj.GetNamespace() == namespace &&
-			obj.GetLabels()[componentLabel] == kataImagePullerComponent
+			obj.GetLabels()[ComponentLabel] == KataImagePullerComponent
 	})
 }

--- a/internal/controller/kataguestready_controller_test.go
+++ b/internal/controller/kataguestready_controller_test.go
@@ -33,7 +33,7 @@ func pullerPod(name, node string, ready bool) *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: testReleaseNS,
-			Labels:    map[string]string{componentLabel: kataImagePullerComponent},
+			Labels:    map[string]string{ComponentLabel: KataImagePullerComponent},
 		},
 		Spec: corev1.PodSpec{NodeName: node},
 		Status: corev1.PodStatus{
@@ -156,7 +156,7 @@ func TestPullerPodPredicate(t *testing.T) {
 		t.Fatal("predicate rejected a puller pod in the release namespace")
 	}
 	other := pullerPod("p", "n1", true)
-	other.Labels[componentLabel] = "cds"
+	other.Labels[ComponentLabel] = "cds"
 	if p.Create(event.CreateEvent{Object: other}) {
 		t.Fatal("predicate accepted a non-puller pod")
 	}

--- a/internal/helmchart/c8s/templates/kata-image-puller-nvidia.yaml
+++ b/internal/helmchart/c8s/templates/kata-image-puller-nvidia.yaml
@@ -95,6 +95,7 @@ spec:
                 - /bin/sh
                 - /scripts/pull-and-configure.sh
                 - check
+            timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 30
           volumeMounts:

--- a/internal/helmchart/c8s/templates/kata-image-puller.yaml
+++ b/internal/helmchart/c8s/templates/kata-image-puller.yaml
@@ -150,6 +150,10 @@ spec:
                 - /bin/sh
                 - /scripts/pull-and-configure.sh
                 - check
+            # The check stats the pulled artifacts and the wrapper across the
+            # /host bind mount; kubelet's 1s default would fail it on a loaded
+            # node and drop the guest-ready label off a healthy one.
+            timeoutSeconds: 5
             periodSeconds: 10
             failureThreshold: 30
           volumeMounts:

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/controller"
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -4459,6 +4460,40 @@ func TestChartKataPinnedPodsCarryInstanceLabel(t *testing.T) {
 	slices.Sort(pinned)
 	if want := []string{"c8s-cds", "c8s-tls-lb"}; !reflect.DeepEqual(pinned, want) {
 		t.Errorf("kata-pinned workloads = %v, want %v", pinned, want)
+	}
+}
+
+// Contract with KataGuestReadyReconciler (internal/controller): it lists the
+// puller pods by this label pair and mirrors their readiness into
+// webhook.GuestReadyNodeLabel. If the rendered label drifts, the list matches
+// nothing, the label is never set, and every confidential pod stays Pending.
+func TestChartKataImagePullerCarriesControllerSelector(t *testing.T) {
+	out, err := helmTemplateKata(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	ds := renderedDaemonSet(t, out, "c8s-kata-deploy-image-puller")
+	if got := ds.Spec.Template.Labels[controller.ComponentLabel]; got != controller.KataImagePullerComponent {
+		t.Fatalf("puller pod template: %s = %q, want %q", controller.ComponentLabel, got, controller.KataImagePullerComponent)
+	}
+}
+
+// The check stats the pulled artifacts across the /host bind mount, so
+// kubelet's 1s default probe timeout would drop the guest-ready label off a
+// healthy node under load.
+func TestChartKataImagePullerProbeTimeout(t *testing.T) {
+	out, err := helmTemplateKata(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	for _, ds := range []string{"c8s-kata-deploy-image-puller", "c8s-kata-deploy-image-puller-nvidia"} {
+		probe := renderedDaemonSetContainer(t, out, ds, "reconcile").ReadinessProbe
+		if probe == nil || probe.Exec == nil {
+			t.Fatalf("%s: want an exec readiness probe, got %+v", ds, probe)
+		}
+		if probe.TimeoutSeconds != 5 {
+			t.Errorf("%s: readiness timeoutSeconds = %d, want 5", ds, probe.TimeoutSeconds)
+		}
 	}
 }
 


### PR DESCRIPTION
Second half of the pod-CVM wedge, from the other end: why `confidential.ai/kata-guest-ready` can be absent (or flap) on a node whose puller is Running.

## Probe timeout

The puller's readiness probe is the **sole** input to that label — `KataGuestReadyReconciler` mirrors per-node puller readiness into it, and cds and tls-lb carry a required nodeAffinity on it. The probe set `periodSeconds` and `failureThreshold` but no `timeoutSeconds`, so it inherited kubelet's **1s default** while `pull-and-configure.sh check` re-derives the drop-in fingerprint with a `sed` over kata-deploy's TOML and stats five artifacts across the `/host` bind mount.

On a single-node host running the control plane, kata and nydus together, that can exceed a second. The probe then fails on a node that is correctly reconciled, the controller **removes** the label, and confidential pods stop being schedulable — recovered on the next tick, so it presents as flapping rather than as a probe problem.

**The probe never downloads.** `check` exits at `pull-and-configure.sh:141`, before the `mkdir -p` and `oras pull` at 144/156, so 5s bounds local filesystem work only — never the multi-GB artifact fetch. That runs in the container's main process (`while true; do sh pull-and-configure.sh; sleep 30; done`), which kubelet does not time out: a failing readiness probe just holds the pod NotReady until the pull lands. The deadline that applies to the pull is `helm --wait --timeout=10m`, not this.

Both pullers now allow 5s. This is the chart's existing convention, not a new judgement: `attest-proxy` already pins 5s and `chart_test.go` asserts it, with the comment *"Kubelet's 1s default probe timeout would flap the healthcheck's 3s internal budget."* These two were the only exec probes in the chart without it.

## Chart-to-controller selector

The component label pair the reconciler lists puller pods by lived as unexported constants in `internal/controller` and as independent literals in the chart, with no test across the two. A drift there yields an empty list, a label that is never set, and confidential pods Pending forever with nothing naming the cause — the same end state as the bug above, reached a different way.

`ComponentLabel` / `KataImagePullerComponent` are exported and the rendered pod template is asserted against them, following the `TestChartKataPinnedPodsCarryInstanceLabel` precedent for the uninstall guard.

## Scope

Not claimed as *the* root cause of the reported install — that needs the puller's logs from the affected host, and `check` has several other permanent-failure modes (notably a missing `configuration-qemu-tdx.toml` if kata-deploy has not finished). This removes one real way the label can be wrong on a healthy node, and pins the selector that would otherwise fail silently. #458 makes the failure point at those logs.

## Tests

`TestChartKataImagePullerProbeTimeout` (both pullers) and `TestChartKataImagePullerCarriesControllerSelector`. Mutation-checked: stripping `timeoutSeconds` or drifting the component label fails them.
