### PR TITLE
fix(ci): rebuild the kernel when its toolchain cache is gone

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -268,6 +268,13 @@ jobs:
             c8s/node-guest-image/kernel/config-x86_64-*.snapshot
           key: ${{ runner.os }}-kernel-v3-${{ env.KERNEL_FLAVOR }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf','confidential-os-builder/mkosi/kernel-builder/mkosi.sandbox/**','c8s/node-guest-image/kernel/c8s.config','c8s/node-guest-image/kernel/c8s-dev.config','confidential-os-builder/kernel/required.config','confidential-os-builder/kernel/hardening.config','confidential-os-builder/kernel/confidential.config','c8s/node-guest-image/kernel/config-x86_64-*.snapshot','confidential-os-builder/kernel/randstruct.seed','confidential-os-builder/kernel/version','c8s/node-guest-image/build','c8s/node-guest-image/module-signing.crt') }}
 
+      - name: Rebuild the kernel when its toolchain is gone
+        # confos kernel short-circuits on the manifest before it ensures the
+        # tools tree that confos-fetch-gpu compiles the modules in; dropping
+        # the manifest takes the full path, which rebuilds both.
+        if: steps.tools-tree.outputs.cache-hit != 'true'
+        run: rm -f confidential-os-builder/output/kernel/manifest.json
+
       - name: Cache base image tools
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:


### PR DESCRIPTION
Since 2026-08-20 19:08 UTC every main image build has failed at GPU staging:

  confos-fetch-gpu: kernel-builder tools tree
  mkosi/kernel-builder/mkosi.output/image missing — run 'confos kernel' first.

The kernel step's outputs live in three independently evictable caches. This repo sits over the 10 GB Actions cache limit (10.7 GB across 178 entries), and GitHub evicted Linux-tools-v2-* and Linux-gpu-staged-rke2-* while keeping Linux-kernel-v3-rke2-*. `confos kernel` returns on a manifest hit before Step 0a ensures the tools tree, so that combination leaves confos-fetch-gpu with no toolchain to compile the NVIDIA modules in, and the failed job skips the success-gated saves that would repopulate either cache — the state is stable, not transient.

Dropping the manifest when the toolchain cache missed takes the full kernel path, which rebuilds the tools tree and re-banks both caches. It also keeps the modules and the kernel on one toolchain: a tools tree rebuilt by itself can pull newer packages than the cached kernel was compiled with.

Upstream follow-up: confos's own advice ("run 'confos kernel' first") is unactionable, since that command short-circuits before ensuring the tree.