### PR TITLE
fix(uninstall): sweep the host state the release leaves behind (NRI plugin, mesh netfilter, nydus unit, guest-image loops)

### DIFF
--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -23,9 +23,11 @@
 # fail-closed image admission until reimage — so the NRI and template steps
 # below are skipped when the baked-only nri-node-ip.service unit exists.
 #
-# Failure policy: containerd config removal, the runtime restart, and the
-# guest-dir deletions are fatal — the CLI keeps the failed DaemonSet so its
-# logs survive.
+# Fatal vs warn: containerd config removal, the runtime restart, and the
+# guest-dir steps fail the sweep (the CLI then keeps the DaemonSet so its
+# logs survive). Per-object netfilter failures warn and
+# continue; a host with no iptables at all fails the sweep at the end, after
+# every other step ran.
 #
 # Env (all required unless noted; set by `c8s uninstall` from the release's
 # computed values):
@@ -66,6 +68,7 @@ assert_safe_guest_dir() {
 CONTAINERD_DIR="/host${HOST_CONTAINERD_DIR}"
 NRI_CONTAINERD_DIR_HOST="/host${NRI_CONTAINERD_DIR}"
 config_changed=0
+sweep_failed=0
 
 baked_node=0
 if [ -f /host/etc/systemd/system/nri-node-ip.service ]; then
@@ -222,4 +225,72 @@ if [ "$baked_node" = "0" ]; then
   esac
 fi
 
+# 6. RATLS-MESH netfilter state. The mesh's preStop removes only the traffic
+#    interception (--keep-guard keeps the fail-closed filter chains and their
+#    ipsets by design), and a mesh pod that never ran preStop leaves
+#    everything — including the OUTPUT redirect that sends host-originated
+#    pod traffic to a dead proxy port. Names are the mesh's fixed contract
+#    (internal/cmds/ratlsmesh/iptables.go; pinned by a Go test). Both address
+#    families; jumps before chains, chains before ipsets (a referenced object
+#    cannot be deleted). Prefers the nft frontend the mesh always wrote.
+# shellcheck disable=SC2016
+mesh_cleanup_script='
+set -u
+ipt4=""
+ipt6=""
+for b in iptables-nft iptables; do
+  if command -v "$b" >/dev/null 2>&1; then ipt4="$b"; break; fi
+done
+for b in ip6tables-nft ip6tables; do
+  if command -v "$b" >/dev/null 2>&1; then ipt6="$b"; break; fi
+done
+if [ -z "$ipt4" ] && [ -z "$ipt6" ]; then
+  echo "ERROR: no iptables/ip6tables on this host — cannot sweep RATLS-MESH netfilter state" >&2
+  exit 1
+fi
+
+clean_family() {
+  B="$1"
+  while "$B" -t nat -D OUTPUT -j RATLS-MESH 2>/dev/null; do :; done
+  while "$B" -t nat -D PREROUTING -j RATLS-MESH-PREROUTING 2>/dev/null; do :; done
+  while "$B" -t filter -D FORWARD -j RATLS-MESH-CW 2>/dev/null; do :; done
+  while "$B" -t filter -D FORWARD -j RATLS-MESH-CW-EGRESS 2>/dev/null; do :; done
+  for spec in nat:RATLS-MESH nat:RATLS-MESH-PREROUTING filter:RATLS-MESH-CW filter:RATLS-MESH-CW-EGRESS filter:RATLS-MESH-GUEST-IN filter:RATLS-MESH-GUEST-OUT
+  do
+    t=${spec%%:*}
+    c=${spec#*:}
+    if "$B" -t "$t" -L "$c" -n >/dev/null 2>&1; then
+      if "$B" -t "$t" -F "$c" && "$B" -t "$t" -X "$c"; then
+        echo "$B $t chain removed: $c"
+      else
+        echo "warning: could not remove $B $t chain $c" >&2
+      fi
+    fi
+  done
+}
+[ -z "$ipt4" ] || clean_family "$ipt4"
+[ -z "$ipt6" ] || clean_family "$ipt6"
+
+if command -v ipset >/dev/null 2>&1; then
+  for s in RATLS-MESH-PODS RATLS-MESH-PODS6 RATLS-MESH-LOCAL-PODS RATLS-MESH-LOCAL-PODS6 RATLS-MESH-CW-PODS RATLS-MESH-CW-PODS6
+  do
+    for n in "$s" "$s-TMP"; do
+      ipset destroy "$n" 2>/dev/null && echo "ipset removed: $n" || true
+    done
+  done
+else
+  echo "warning: no ipset on this host — any RATLS-MESH-* ipsets are left in place" >&2
+fi
+exit 0
+'
+
+if ! nsenter -t 1 -m -u -i -n -p -- sh -c "$mesh_cleanup_script"; then
+  echo "ERROR: RATLS-MESH netfilter sweep failed — stale chains redirect host-originated pod traffic to a dead port" >&2
+  sweep_failed=1
+fi
+
+if [ "$sweep_failed" = "1" ]; then
+  echo "==> c8s host sweep finished WITH FAILURES (see above)" >&2
+  exit 1
+fi
 echo "==> c8s host sweep finished"

--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -195,7 +195,85 @@ rm -f /host/usr/local/bin/containerd-shim-kata-*-v2
 
 # 6. The guest image dirs (multi-GB; nothing else cleans them up). Presence-
 #    gated: a non-kata release never wrote these, so an absent custom path is
-#    a no-op while an existing unsafe one still fails closed.
+#    a no-op while an existing unsafe one still fails closed. Before each rm,
+#    unmount the mounts of loop devices bound to files under the dir (wherever
+#    the mountpoint lives), detach those loops, and unmount anything mounted
+#    at or beneath the dir — otherwise the rm unlinks files a loop still pins
+#    and the space is never reclaimed. Runs host-side: loop backing_file
+#    paths render against the reader's mount namespace.
+# shellcheck disable=SC2016
+detach_guest_dir_script='
+set -u
+dir="$GUEST_DIR"
+fail=0
+
+for bf in /sys/block/loop*/loop/backing_file; do
+  [ -f "$bf" ] || continue
+  backing=$(cat "$bf" 2>/dev/null) || continue
+  case "$backing" in
+    "$dir"/*) ;;
+    *) continue ;;
+  esac
+  lo=${bf#/sys/block/}
+  lo=${lo%%/*}
+  dev="/dev/$lo"
+  # Unmount this device (and its partitions) wherever it is mounted: losetup
+  # -d on a mounted loop reports success but only defers via autoclear.
+  mps=$(
+    while read -r src mp _; do
+      case "$src" in
+        "$dev" | "$dev"p[0-9]*) echo "$mp" ;;
+      esac
+    done < /proc/self/mounts | sort -r
+  )
+  echo "$mps" | while read -r mp; do
+    [ -n "$mp" ] || continue
+    umount "$mp" 2>/dev/null && echo "unmounted: $mp" || echo "warning: umount failed: $mp ($dev)" >&2
+  done
+  if losetup -d "$dev" 2>/dev/null; then
+    echo "loop device detached: $dev ($backing)"
+  else
+    echo "warning: could not detach $dev ($backing)" >&2
+  fi
+done
+
+# Anything mounted at or beneath the dir itself: rm -rf crosses mountpoints,
+# so a mount left behind would redirect the delete outside the validated
+# tree. Any source, not just the loops above.
+mps=$(
+  while read -r _ mp _; do
+    case "$mp" in
+      "$dir" | "$dir"/*) echo "$mp" ;;
+    esac
+  done < /proc/self/mounts | sort -r
+)
+echo "$mps" | while read -r mp; do
+  [ -n "$mp" ] || continue
+  umount "$mp" 2>/dev/null && echo "unmounted: $mp" || echo "warning: umount failed: $mp" >&2
+done
+
+while read -r _ mp _; do
+  case "$mp" in
+    "$dir" | "$dir"/*) echo "still mounted: $mp" >&2; fail=1 ;;
+  esac
+done < /proc/self/mounts
+for bf in /sys/block/loop*/loop/backing_file; do
+  [ -f "$bf" ] || continue
+  backing=$(cat "$bf" 2>/dev/null) || continue
+  lo=${bf#/sys/block/}
+  lo=${lo%%/*}
+  case "$backing" in
+    "$dir"/*" (deleted)")
+      # Already unlinked; the loop pins space until reboot and cannot be
+      # detached (losetup -d answers ENOENT). Nothing left to protect.
+      echo "note: /dev/$lo holds an already-deleted file; space frees on reboot" ;;
+    "$dir"/*) echo "still bound: /dev/$lo ($backing)" >&2; fail=1 ;;
+  esac
+done
+
+[ "$fail" = "0" ]
+'
+
 sweep_guest_dir() {
   dir="${1%/}"
   if [ ! -d "/host${dir}" ]; then
@@ -203,8 +281,13 @@ sweep_guest_dir() {
     return 0
   fi
   assert_safe_guest_dir "$dir"
-  rm -rf "/host${dir}"
-  echo "guest image dir removed: ${dir}"
+  if GUEST_DIR="$dir" nsenter -t 1 -m -- sh -c "$detach_guest_dir_script"; then
+    rm -rf "/host${dir}"
+    echo "guest image dir removed: ${dir}"
+  else
+    echo "ERROR: ${dir} is still pinned (see above); leaving it in place" >&2
+    sweep_failed=1
+  fi
 }
 
 sweep_guest_dir "${GUEST_IMAGE_DIR}"

--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -1,33 +1,52 @@
-# c8s kata host sweep — run by `c8s uninstall` as a privileged init container
-# on every node kata-deploy targeted (a short-lived kubectl-applied DaemonSet;
-# see cmd/c8s/uninstall.go).
+# shellcheck shell=sh
+# c8s host sweep — run by `c8s uninstall` as a privileged init container on
+# every linux node (a short-lived kubectl-applied DaemonSet; see
+# cmd/c8s/uninstall.go).
 #
-# `helm uninstall` already drives the supported kata cleanup: deleting the
-# kata-deploy DaemonSet runs `kata-deploy cleanup` in its preStop hook, which
-# removes /opt/kata, deregisters the containerd drop-in, restarts the runtime,
-# and unlabels the node. That hook is best-effort — it is bounded by the pod's
-# termination grace period, and the runtime restart it triggers can kill the
-# pod mid-cleanup — and it knows nothing about the c8s-side artifacts (the
-# pulled kata-guest-base image, the RKE2 containerd-prep template). This sweep
-# is the idempotent last word: it removes whatever is still present and
-# restarts the runtime only if it had to deregister kata itself.
+# `helm uninstall` already drives the supported cleanup: the kata-deploy
+# preStop removes /opt/kata and deregisters the runtime, the chart's
+# pre-delete hooks remove the NRI plugin and volumed mappings, and the mesh's
+# preStop strips its traffic interception. Every one of those is best-effort:
+# hooks need a release healthy enough to run them, a preStop is bounded by
+# the pod's termination grace period (and the runtime restart it triggers can
+# kill the pod mid-cleanup), the mesh preStop deliberately keeps its
+# fail-closed guard, and none of them knows about the c8s-side artifacts
+# (pulled guest images, the RKE2 containerd-prep template). This sweep is the
+# idempotent last word and runs on every uninstall, whatever the release's
+# shape: leftovers may come from a previous install of a different shape,
+# which this release's values cannot see.
 #
-# Env (all required; set by `c8s uninstall` from the release's computed
-# values):
-#   HOST_CONTAINERD_DIR    — host containerd config directory (distro-specific)
-#   GUEST_IMAGE_DIR        — host dir the kata-image-puller pulled kata-guest-base
+# Baked node image exception: on the c8s node image the NRI plugin, its floor
+# config, the containerd drop-in, and the managed RKE2 containerd template
+# are baked into the measured image at the same paths the chart uses. They
+# are node-image state, not release state — deleting them strips the node's
+# fail-closed image admission until reimage — so the NRI and template steps
+# below are skipped when the baked-only nri-node-ip.service unit exists.
+#
+# Failure policy: containerd config removal, the runtime restart, and the
+# guest-dir deletions are fatal — the CLI keeps the failed DaemonSet so its
+# logs survive.
+#
+# Env (all required unless noted; set by `c8s uninstall` from the release's
+# computed values):
+#   HOST_CONTAINERD_DIR    — host containerd config directory (kata.distro)
+#   GUEST_IMAGE_DIR        — dir the kata-image-puller pulled kata-guest-base
 #                            into (kata.guestImage.hostPath)
-#   GUEST_IMAGE_DIR_NVIDIA — host dir the GPU puller pulled the <tag>-nvidia
-#                            guest image into (kata.gpu.guestImage.hostPath).
-#                            GPU ships with every --kata install, so this is
-#                            set for any kata release; empty only for a
-#                            pre-GPU release (no kata.gpu block)
+#   GUEST_IMAGE_DIR_NVIDIA — GPU guest image dir (kata.gpu.guestImage.hostPath);
+#                            empty only for a pre-GPU release = skip
 #   RKE2_PREP              — "true" when the install ran the RKE2 containerd-prep
 #                            initContainer whose template/lock this sweep owns
-#   RESTART_COMMAND        — host runtime restart, run via nsenter into PID 1
+#   RESTART_COMMAND        — host runtime restart, run detached via systemd-run
+#   NRI_CONTAINERD_DIR     — containerd config dir the NRI installer targeted
+#                            (nriImagePolicy.distro)
+#   NRI_PLUGIN_DIR         — NRI plugin directory (nriImagePolicy.hostPaths.pluginDir)
+#   NRI_PLUGIN_FILENAME    — plugin filename inside it (nriImagePolicy.pluginFilename)
+#   NRI_CONFIG_DIR         — plugin config dir (nriImagePolicy.hostPaths.configDir)
+#   NRI_RUNTIME_DIR        — plugin runtime dir (nriImagePolicy.hostPaths.runtimeDir)
+#   NRI_CACHE_DIR          — plugin cache dir (nriImagePolicy.hostPaths.cacheDir)
 set -eu
 
-echo "==> c8s kata sweep starting"
+echo "==> c8s host sweep starting"
 
 # Independent guard mirroring cmd/c8s/uninstall.go's validateSweepPath: the
 # GUEST_IMAGE_DIR* values come from Helm release values and are deleted with
@@ -45,14 +64,27 @@ assert_safe_guest_dir() {
 }
 
 CONTAINERD_DIR="/host${HOST_CONTAINERD_DIR}"
+NRI_CONTAINERD_DIR_HOST="/host${NRI_CONTAINERD_DIR}"
 config_changed=0
+
+baked_node=0
+if [ -f /host/etc/systemd/system/nri-node-ip.service ]; then
+  baked_node=1
+  echo "c8s node image detected — the baked NRI stack and managed containerd template are image state; leaving them"
+fi
+
+# == Phase 1: containerd configuration =======================================
+# Everything that needs a runtime restart is removed first, the restart runs
+# once (phase 2), and only then are host artifacts deleted (phase 3): with
+# the registration gone, no interruption can leave the fail-closed NRI
+# validator requiring a plugin whose binary is already deleted.
 
 # 1. kata-deploy's containerd runtime drop-in. Still present only when the
 #    preStop cleanup was cut short — remove it from whichever schema-versioned
 #    drop-in dir it landed in; the restart below deregisters the runtimes.
 #    The `imports` line referencing the drop-in dir is left alone: with no
 #    matching files the glob is inert, kata-deploy owns that edit on k8s, and
-#    on RKE2 the next config regen drops it once the managed template (step 4)
+#    on RKE2 the next config regen drops it once the managed template (step 3)
 #    is gone.
 for d in config-v3.toml.d config.toml.d; do
   for n in kata-deploy.toml zz-c8s-kata-annotations.toml; do
@@ -64,9 +96,73 @@ for d in config-v3.toml.d config.toml.d; do
     fi
   done
 done
-[ "$config_changed" = "1" ] || echo "containerd drop-in already absent"
 
-# 2. The kata-static payload (runtime, shim, QEMU/CLH, guest kernel + images)
+# 2. The NRI image-policy's containerd registration: the standalone drop-in
+#    (rke2), or the sentinel-delimited block in config.toml (k8s patch mode).
+#    Mirrors the chart's files/scripts/uninstall.sh.
+if [ "$baked_node" = "0" ]; then
+  for d in config-v3.toml.d config.toml.d; do
+    f="${NRI_CONTAINERD_DIR_HOST}/${d}/nri-image-policy.toml"
+    if [ -f "$f" ]; then
+      rm -f "$f"
+      config_changed=1
+      echo "containerd drop-in removed: $f"
+    fi
+  done
+  MARK_BEGIN='# BEGIN c8s-nri-image-policy (managed)'
+  MARK_END='# END c8s-nri-image-policy (managed)'
+  main_config="${NRI_CONTAINERD_DIR_HOST}/config.toml"
+  if [ -f "$main_config" ] && grep -qF "$MARK_BEGIN" "$main_config"; then
+    awk -v b="$MARK_BEGIN" -v e="$MARK_END" '
+      $0==b { skip=1; next }
+      $0==e { skip=0; next }
+      !skip { print }
+    ' "$main_config" > "$main_config.tmp"
+    mv -f "$main_config.tmp" "$main_config"
+    echo "containerd config block removed from $main_config"
+    config_changed=1
+  fi
+fi
+
+# 3. RKE2 containerd-prep leftovers: the sentinel-marked managed template
+#    (which would re-add the drop-in import on every RKE2 config regen) and
+#    the prep lock file. Only a sentinel-marked template is removed — an
+#    operator-owned template is never touched, and a legacy pre-sentinel
+#    template is left for the prep's own next-install self-repair rather than
+#    deleted on content guesswork. On a baked node image the template is
+#    image state (same sentinel by design) and stays.
+if [ "${RKE2_PREP}" = "true" ]; then
+  if [ "$baked_node" = "0" ]; then
+    SENTINEL='c8s-containerd-prep:managed-template'
+    for t in config-v3.toml.tmpl config.toml.tmpl; do
+      f="${CONTAINERD_DIR}/${t}"
+      [ -f "$f" ] || continue
+      if grep -qF "$SENTINEL" "$f"; then
+        rm -f "$f"
+        echo "managed containerd template removed: $f"
+      else
+        echo "leaving ${t}: not the c8s-managed template"
+      fi
+    done
+  fi
+  rm -f "${CONTAINERD_DIR}/.c8s-containerd-prep.lock"
+fi
+
+# == Phase 2: one runtime restart ============================================
+# Detached via systemd-run: restarting rke2/containerd kills this pod's own
+# shim, and a restart in the pod's process tree dies with it mid-restart,
+# which on a sole control-plane node can wedge the rke2 bootstrap.
+if [ "$config_changed" = "1" ]; then
+  echo "restarting containerd (detached via systemd-run): ${RESTART_COMMAND}"
+  # shellcheck disable=SC2086
+  nsenter -t 1 -m -u -i -n -p -- \
+    systemd-run --collect --description="c8s host sweep containerd restart" \
+    sh -c "${RESTART_COMMAND}"
+fi
+
+# == Phase 3: host artifacts =================================================
+
+# 5. The kata-static payload (runtime, shim, QEMU/CLH, guest kernel + images)
 #    and the per-shim symlinks kata-deploy installs beside it. /opt/kata also
 #    carries the image-puller's <cfg>.upstream snapshot, so that goes too.
 if [ -d /host/opt/kata ]; then
@@ -77,57 +173,53 @@ else
 fi
 rm -f /host/usr/local/bin/containerd-shim-kata-*-v2
 
-# 3. The kata-guest-base artifact the image-puller pulled (hardened kernel +
-#    dm-verity rootfs, multi-GB). Nothing else cleans this up — kata-deploy
-#    never knew about it, and the puller has no uninstall path.
-assert_safe_guest_dir "${GUEST_IMAGE_DIR}"
-if [ -d "/host${GUEST_IMAGE_DIR}" ]; then
-  rm -rf "/host${GUEST_IMAGE_DIR}"
-  echo "guest image dir removed: ${GUEST_IMAGE_DIR}"
-else
-  echo "guest image dir already absent: ${GUEST_IMAGE_DIR}"
-fi
+# 4. The guest image dirs (multi-GB; nothing else cleans them up). Presence-
+#    gated: a non-kata release never wrote these, so an absent custom path is
+#    a no-op while an existing unsafe one still fails closed.
+sweep_guest_dir() {
+  dir="${1%/}"
+  if [ ! -d "/host${dir}" ]; then
+    echo "guest image dir already absent: ${dir}"
+    return 0
+  fi
+  assert_safe_guest_dir "$dir"
+  rm -rf "/host${dir}"
+  echo "guest image dir removed: ${dir}"
+}
 
-# 3b. The confidential-GPU guest image the nvidia puller pulled into its own
-#     dir (see GUEST_IMAGE_DIR_NVIDIA above; empty -> step skipped).
+sweep_guest_dir "${GUEST_IMAGE_DIR}"
 GUEST_IMAGE_DIR_NVIDIA="${GUEST_IMAGE_DIR_NVIDIA:-}"
 if [ -n "${GUEST_IMAGE_DIR_NVIDIA}" ]; then
-  assert_safe_guest_dir "${GUEST_IMAGE_DIR_NVIDIA}"
-  if [ -d "/host${GUEST_IMAGE_DIR_NVIDIA}" ]; then
-    rm -rf "/host${GUEST_IMAGE_DIR_NVIDIA}"
-    echo "nvidia guest image dir removed: ${GUEST_IMAGE_DIR_NVIDIA}"
-  else
-    echo "nvidia guest image dir already absent: ${GUEST_IMAGE_DIR_NVIDIA}"
-  fi
+  sweep_guest_dir "${GUEST_IMAGE_DIR_NVIDIA}"
 fi
 
-# 4. RKE2 containerd-prep leftovers: the sentinel-marked managed template
-#    (which would re-add the drop-in import on every RKE2 config regen) and
-#    the prep lock file. Only a sentinel-marked template is removed — an
-#    operator-owned template is never touched, and a legacy pre-sentinel
-#    template is left for the prep's own next-install self-repair rather than
-#    deleted on content guesswork.
-if [ "${RKE2_PREP}" = "true" ]; then
-  SENTINEL='c8s-containerd-prep:managed-template'
-  for t in config-v3.toml.tmpl config.toml.tmpl; do
-    f="${CONTAINERD_DIR}/${t}"
-    [ -f "$f" ] || continue
-    if grep -qF "$SENTINEL" "$f"; then
-      rm -f "$f"
-      echo "managed containerd template removed: $f"
-    else
-      echo "leaving ${t}: not the c8s-managed template"
+# 5. The NRI plugin's host artifacts: the binary, its boot config, the health
+#    socket dir, and the allowlist cache. The rm -rf targets must carry the
+#    plugin's own directory name — the values come from the release and a
+#    bare parent dir (/var/run, /var/lib) is never deleted.
+if [ "$baked_node" = "0" ]; then
+  plugin_glob_dir="/host${NRI_PLUGIN_DIR}"
+  if [ -d "$plugin_glob_dir" ]; then
+    exact="${plugin_glob_dir}/${NRI_PLUGIN_FILENAME}"
+    if [ -f "$exact" ]; then
+      rm -f "$exact"
+      echo "NRI plugin removed: $exact"
     fi
-  done
-  rm -f "${CONTAINERD_DIR}/.c8s-containerd-prep.lock"
+    for f in "$plugin_glob_dir"/*-nri-image-policy; do
+      [ -f "$f" ] || continue
+      rm -f "$f"
+      echo "NRI plugin removed: $f"
+    done
+  fi
+  rm -f "/host${NRI_CONFIG_DIR}/image-policy.yaml"
+  case "$NRI_RUNTIME_DIR" in
+    */nri-image-policy) rm -rf "/host${NRI_RUNTIME_DIR}" ;;
+    *) [ ! -e "/host${NRI_RUNTIME_DIR}" ] || echo "leaving NRI runtime dir with a custom name: ${NRI_RUNTIME_DIR}" ;;
+  esac
+  case "$NRI_CACHE_DIR" in
+    */nri-image-policy) rm -rf "/host${NRI_CACHE_DIR}" ;;
+    *) [ ! -e "/host${NRI_CACHE_DIR}" ] || echo "leaving NRI cache dir with a custom name: ${NRI_CACHE_DIR}" ;;
+  esac
 fi
 
-# 5. Restart the runtime only if step 1 deregistered kata. On the clean
-#    preStop path the restart already happened, and a second restart would
-#    blip the node for nothing.
-if [ "$config_changed" = "1" ]; then
-  echo "restarting containerd: ${RESTART_COMMAND}"
-  nsenter -t 1 -m -u -i -n -p -- sh -c "${RESTART_COMMAND}"
-fi
-
-echo "==> c8s kata sweep finished"
+echo "==> c8s host sweep finished"

--- a/cmd/c8s/kata-sweep.sh
+++ b/cmd/c8s/kata-sweep.sh
@@ -23,9 +23,9 @@
 # fail-closed image admission until reimage — so the NRI and template steps
 # below are skipped when the baked-only nri-node-ip.service unit exists.
 #
-# Fatal vs warn: containerd config removal, the runtime restart, and the
-# guest-dir steps fail the sweep (the CLI then keeps the DaemonSet so its
-# logs survive). Per-object netfilter failures warn and
+# Fatal vs warn: containerd config removal, the runtime restart, the nydus
+# unit, and the guest-dir steps fail the sweep (the CLI then keeps the
+# DaemonSet so its logs survive). Per-object netfilter failures warn and
 # continue; a host with no iptables at all fails the sweep at the end, after
 # every other step ran.
 #
@@ -165,6 +165,23 @@ fi
 
 # == Phase 3: host artifacts =================================================
 
+# 4. nydus-for-kata-tee: kata-deploy's EXPERIMENTAL_SETUP_SNAPSHOTTER
+#    installs this host unit; its own cleanup removes it only when the
+#    preStop completes. Stop it while its binary under /opt/kata still
+#    exists. /var/lib/nydus-for-kata-tee stays on purpose: containerd's
+#    meta.db keeps nydus snapshot records, and wiping the backend behind
+#    them makes the next install's pulls fail with "target snapshot already
+#    exists" (see kata-deploy's uninstall_nydus_snapshotter).
+NYDUS_UNIT=/host/etc/systemd/system/nydus-for-kata-tee.service
+if [ -f "$NYDUS_UNIT" ]; then
+  nsenter -t 1 -m -u -i -n -p -- systemctl disable --now nydus-for-kata-tee.service
+  rm -f "$NYDUS_UNIT"
+  nsenter -t 1 -m -u -i -n -p -- systemctl daemon-reload
+  echo "nydus-for-kata-tee.service removed"
+else
+  echo "nydus-for-kata-tee.service already absent"
+fi
+
 # 5. The kata-static payload (runtime, shim, QEMU/CLH, guest kernel + images)
 #    and the per-shim symlinks kata-deploy installs beside it. /opt/kata also
 #    carries the image-puller's <cfg>.upstream snapshot, so that goes too.
@@ -176,7 +193,7 @@ else
 fi
 rm -f /host/usr/local/bin/containerd-shim-kata-*-v2
 
-# 4. The guest image dirs (multi-GB; nothing else cleans them up). Presence-
+# 6. The guest image dirs (multi-GB; nothing else cleans them up). Presence-
 #    gated: a non-kata release never wrote these, so an absent custom path is
 #    a no-op while an existing unsafe one still fails closed.
 sweep_guest_dir() {
@@ -196,7 +213,7 @@ if [ -n "${GUEST_IMAGE_DIR_NVIDIA}" ]; then
   sweep_guest_dir "${GUEST_IMAGE_DIR_NVIDIA}"
 fi
 
-# 5. The NRI plugin's host artifacts: the binary, its boot config, the health
+# 7. The NRI plugin's host artifacts: the binary, its boot config, the health
 #    socket dir, and the allowlist cache. The rm -rf targets must carry the
 #    plugin's own directory name — the values come from the release and a
 #    bare parent dir (/var/run, /var/lib) is never deleted.
@@ -225,7 +242,7 @@ if [ "$baked_node" = "0" ]; then
   esac
 fi
 
-# 6. RATLS-MESH netfilter state. The mesh's preStop removes only the traffic
+# 8. RATLS-MESH netfilter state. The mesh's preStop removes only the traffic
 #    interception (--keep-guard keeps the fail-closed filter chains and their
 #    ipsets by design), and a mesh pod that never ran preStop leaves
 #    everything — including the OUTPUT redirect that sends host-originated

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -153,6 +153,10 @@ install's containerd-prep uses — and removes, idempotently:
     base-chain jumps in iptables and ip6tables, and the RATLS-MESH-* ipsets
     (the mesh's own preStop deliberately keeps the fail-closed guard, so this
     survives every healthy uninstall too)
+  - the nydus-for-kata-tee systemd unit kata-deploy installs (its data dir
+    /var/lib/nydus-for-kata-tee is preserved on purpose: containerd's
+    meta.db keeps nydus snapshot records, and wiping the backend behind them
+    breaks the next install's pulls)
   - /opt/kata (the kata-static payload) and the containerd-shim-kata-*
     symlinks
   - kata-deploy's containerd runtime drop-in, restarting containerd/RKE2
@@ -947,7 +951,7 @@ func init() {
 	uninstallCmd.Flags().StringVar(&uninstallNamespace, "namespace", "c8s-system", "namespace the release was installed into")
 	uninstallCmd.Flags().StringVar(&uninstallRelease, "release", "c8s", "Helm release name")
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
-	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, ratls-mesh netfilter state, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
+	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, ratls-mesh netfilter state, nydus unit, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
 	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry c8s artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
 	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it)")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -28,10 +28,10 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
 
-// kataSweepScript reverses the kata host install on a single node. Kept as a
-// standalone POSIX-shell file (like the chart's files/scripts/*) so it gets
-// shellcheck; it runs as the init container of the sweep DaemonSet built in
-// kataSweepDaemonSet.
+// kataSweepScript sweeps c8s host state off a single node (see the script
+// header for the full inventory). Kept as a standalone POSIX-shell file (like
+// the chart's files/scripts/*) so it gets shellcheck; it runs as the init
+// container of the sweep DaemonSet built in kataSweepDaemonSet.
 //
 //go:embed kata-sweep.sh
 var kataSweepScript string
@@ -90,14 +90,14 @@ const kataRuntimeNodeLabel = "katacontainers.io/kata-runtime"
 // by c8s and is not c8s's to strip.
 const snpCapabilityNodeLabel = "confidential.ai/sev-snp"
 
-// kataUninstallConfig is the slice of the release's computed values the kata
-// host sweep needs. It is read from `helm get values --all` BEFORE the
-// release is deleted — afterwards the -f/--set overrides from install time
-// (custom guestImage.hostPath, distro, nodeSelector) are unrecoverable.
+// kataUninstallConfig is the slice of the release's computed values the host
+// sweep needs. It is read from `helm get values --all` BEFORE the release is
+// deleted — afterwards the -f/--set overrides from install time (custom
+// guestImage.hostPath, distro, nriImagePolicy.hostPaths) are unrecoverable.
 type kataUninstallConfig struct {
 	Enabled             bool
 	Distro              string
-	ContainerdConfigDir string // resolved absolute host dir
+	ContainerdConfigDir string // resolved absolute host dir (kata.distro)
 	GuestImageHostPath  string
 	// GuestImageNvidiaHostPath is the GPU guest-image dir (kata.gpu.guestImage.hostPath).
 	// The GPU stack ships with every kata install, so it is set for any kata
@@ -105,7 +105,16 @@ type kataUninstallConfig struct {
 	// sweep skips it.
 	GuestImageNvidiaHostPath string
 	SweepImage               string
-	NodeSelector             map[string]string
+	// NRI image-policy host paths (nriImagePolicy.*): where the chart's
+	// installer DaemonSet wrote the plugin, or where the node image baked it.
+	// The sweep distinguishes the two via a baked-only marker on the host.
+	NriContainerdDir   string // resolved from nriImagePolicy.containerd.configDir/.distro
+	NriPluginDir       string
+	NriPluginFilename  string
+	NriConfigDir       string
+	NriRuntimeDir      string
+	NriCacheDir        string
+	ImagePullSecretRef []string // Secret names for the sweep pod's imagePullSecrets
 }
 
 var uninstallCmd = &cobra.Command{
@@ -121,33 +130,44 @@ plugin (pre-delete hook), and — best-effort — the kata runtime itself:
 deleting the kata-deploy DaemonSet runs 'kata-deploy cleanup' in its preStop
 hook on each node.
 
-The kata host sweep then nukes what that path cannot guarantee. The preStop
-hook is bounded by the pod's termination grace period (and the runtime
-restart it triggers can kill the pod mid-cleanup), and it knows nothing about
-the c8s-side artifacts. After the release is gone the sweep runs a
-short-lived privileged DaemonSet (the same digest-pinned busybox image the
-install's containerd-prep uses) on the nodes kata-deploy targeted and
-removes, idempotently:
+The host sweep then nukes what that path cannot guarantee. The preStop hook
+is bounded by the pod's termination grace period (and the runtime restart it
+triggers can kill the pod mid-cleanup), the pre-delete hooks only fire on a
+release healthy enough to run them, and none of them knows about the
+c8s-side artifacts. The sweep runs on every uninstall — not only kata
+releases — because the host state below is not confined to the release's own
+shape: a previous install on the same host may have had a different shape
+(node vs pod), and leftovers brick or degrade the next cluster. After the
+release is gone the sweep runs a short-lived privileged DaemonSet on every
+linux node — with the release's NRI plugin image where the fail-closed
+plugin is live (the sweep image must already be on the allowlist; the sweep
+is what removes the plugin), else the digest-pinned busybox image the
+install's containerd-prep uses — and removes, idempotently:
 
+  - the NRI image-policy host plugin: containerd registration (drop-in or
+    managed config block), the plugin binary, its config/cache/runtime dirs —
+    skipped entirely on c8s node images, where the whole stack is baked into
+    the measured image (detected via nri-node-ip.service) and is the image's
+    to keep, not the release's to delete
   - /opt/kata (the kata-static payload) and the containerd-shim-kata-*
     symlinks
   - kata-deploy's containerd runtime drop-in, restarting containerd/RKE2
-    only if the drop-in was still registered
+    (detached, via systemd-run) only if a drop-in was still registered
   - the pulled kata-guest-base artifact (kata.guestImage.hostPath, multi-GB —
     nothing else cleans this up), and the separate GPU guest image
     (kata.gpu.guestImage.hostPath)
-  - on RKE2: the c8s-managed containerd template and the containerd-prep lock
+  - on RKE2: the c8s-managed containerd template (skipped on c8s node images,
+    same baked-state rule) and the containerd-prep lock
   - the katacontainers.io/kata-runtime node labels and the
     confidential.ai/sev-snp capability labels the install's probe applied
     (via kubectl)
 
-Whether kata was installed — and which host paths, distro layout, and node
-set to sweep — is read from the release's computed values
-('helm get values --all') before the release is deleted, so -f overrides from
-install time are honored. For a release that is already gone (e.g. a previous
-bare 'helm uninstall' left the hosts dirty), pass --host-sweep-only: the helm
-step is skipped and the sweep uses the embedded chart's defaults plus the
-distro detected from the cluster.
+Which host paths and distro layout to sweep is read from the release's
+computed values ('helm get values --all') before the release is deleted, so
+-f overrides from install time are honored. For a release that is already
+gone (e.g. a previous bare 'helm uninstall' left the hosts dirty), pass
+--host-sweep-only: the helm step is skipped and the sweep uses the embedded
+chart's defaults plus the distro detected from the cluster.
 
 The uninstall refuses to proceed while pods with a kata RuntimeClass are
 still running — removing the runtime under a running confidential workload
@@ -206,10 +226,12 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH.`,
 				return err
 			}
 		}
-		// --host-sweep-only is an explicit "the hosts are dirty" claim, so it
-		// sweeps even when the release values say kata was off (the dirt may
-		// be from an earlier kata-enabled install of the same release name).
-		sweep := uninstallKataSweep && (cfg.Enabled || uninstallHostSweepOnly)
+		// The host sweep runs on every uninstall, whatever the release's
+		// shape: the artifacts it removes (NRI plugin, mesh netfilter state,
+		// kata payload, guest images) may be cross-shape leftovers the
+		// release's own values cannot see, and the chart's pre-delete hooks
+		// are only a healthy-release first line. --kata-sweep=false opts out.
+		sweep := uninstallKataSweep
 
 		// Deleting the kata-deploy DaemonSet removes the runtime from under
 		// any pod still using a kata RuntimeClass (its preStop cleanup runs
@@ -247,16 +269,14 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH.`,
 			hc.Stdout = os.Stdout
 			hc.Stderr = os.Stderr
 			if err := hc.Run(); err != nil {
-				return fmt.Errorf("helm uninstall failed: %w", err)
+				return fmt.Errorf("helm uninstall failed: %w — a wedged pre-delete hook blocks the sweep too; recover with 'helm uninstall --no-hooks %s --namespace %s' followed by 'c8s uninstall --host-sweep-only'", err, uninstallRelease, uninstallNamespace)
 			}
 		}
 
 		if sweep {
-			if err := runKataSweep(ctx, uninstallNamespace, uninstallRelease, cfg); err != nil {
+			if err := runKataSweep(ctx, uninstallNamespace, uninstallRelease, cfg, uninstallHostSweepOnly); err != nil {
 				return err
 			}
-		} else if uninstallKataSweep {
-			fmt.Fprintln(os.Stdout, "+ kata not enabled in the release values — host sweep skipped")
 		}
 
 		if uninstallDeleteCRDs {
@@ -349,6 +369,9 @@ func chartDefaultKataConfig(ctx context.Context) (kataUninstallConfig, error) {
 		return kataUninstallConfig{}, fmt.Errorf("embedded chart values carry no kata block")
 	}
 	kata["distro"] = distro
+	if nri, ok := nestedMap(tree, "nriImagePolicy"); ok {
+		nri["distro"] = distro
+	}
 
 	cfg, err := kataConfigFromValues(tree)
 	if err != nil {
@@ -379,7 +402,7 @@ func kataConfigFromValues(tree map[string]any) (kataUninstallConfig, error) {
 	cfg.Distro = distro
 
 	override, _ := kata["containerdConfigDir"].(string)
-	cfg.ContainerdConfigDir, err = kataContainerdDir(override, distro)
+	cfg.ContainerdConfigDir, err = containerdConfigDirFor(override, distro)
 	if err != nil {
 		return kataUninstallConfig{}, err
 	}
@@ -400,23 +423,71 @@ func kataConfigFromValues(tree map[string]any) (kataUninstallConfig, error) {
 		return kataUninstallConfig{}, err
 	}
 
-	if sel, ok := nestedMap(tree, "kata", "nodeSelector"); ok {
-		cfg.NodeSelector = make(map[string]string, len(sel))
-		for k, v := range sel {
-			s, ok := v.(string)
-			if !ok {
-				return kataUninstallConfig{}, fmt.Errorf("kata.nodeSelector[%q] is not a string (%T)", k, v)
-			}
-			cfg.NodeSelector[k] = s
-		}
-	}
+	cfg = nriConfigFromValues(tree, cfg)
+	cfg.ImagePullSecretRef = imagePullSecretNames(tree)
 	return cfg, nil
 }
 
-// kataContainerdDir resolves the host containerd config directory the sweep
-// targets — the same mapping as the chart's c8s.kataContainerdConfigDir
-// helper, so the sweep cleans exactly where the install wrote.
-func kataContainerdDir(override, distro string) (string, error) {
+// nriConfigFromValues fills the NRI image-policy host paths, defaulting to
+// the chart's values.yaml constants when a key is absent (an old or foreign
+// release). The containerd dir follows nriImagePolicy.*, not kata.*: the CLI
+// sets both distros together at install, but a -f release can diverge them,
+// and the NRI installer targeted its own.
+func nriConfigFromValues(tree map[string]any, cfg kataUninstallConfig) kataUninstallConfig {
+	cfg.NriPluginDir = stringOrDefault(tree, "nriImagePolicy.hostPaths.pluginDir", "/opt/nri/plugins")
+	cfg.NriPluginFilename = stringOrDefault(tree, "nriImagePolicy.pluginFilename", "10-nri-image-policy")
+	cfg.NriConfigDir = stringOrDefault(tree, "nriImagePolicy.hostPaths.configDir", "/etc/nri/conf.d")
+	cfg.NriRuntimeDir = stringOrDefault(tree, "nriImagePolicy.hostPaths.runtimeDir", "/var/run/nri-image-policy")
+	cfg.NriCacheDir = stringOrDefault(tree, "nriImagePolicy.hostPaths.cacheDir", "/var/lib/nri-image-policy")
+	distro := stringOrDefault(tree, "nriImagePolicy.distro", cfg.Distro)
+	override := stringOrDefault(tree, "nriImagePolicy.containerd.configDir", "")
+	dir, err := containerdConfigDirFor(override, distro)
+	if err != nil {
+		// An exotic NRI distro the mapping does not know: fall back to the
+		// kata-resolved dir rather than refuse the whole sweep.
+		dir = cfg.ContainerdConfigDir
+	}
+	cfg.NriContainerdDir = dir
+	return cfg
+}
+
+// stringOrDefault reads a dotted path from a decoded values tree, returning
+// fallback when the path is absent or not a string.
+func stringOrDefault(tree map[string]any, path, fallback string) string {
+	s, err := stringAtPath(tree, path)
+	if err != nil {
+		return fallback
+	}
+	return s
+}
+
+// imagePullSecretNames collects the chart-wide pull secret references
+// (imagePullSecret + imagePullSecrets[].name) so the sweep pod can pull its
+// image where the install needed credentials. Absent on a default release.
+func imagePullSecretNames(tree map[string]any) []string {
+	var names []string
+	if s, err := stringAtPath(tree, "imagePullSecret"); err == nil && s != "" {
+		names = append(names, s)
+	}
+	if list, ok := tree["imagePullSecrets"].([]any); ok {
+		for _, item := range list {
+			m, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			if name, ok := m["name"].(string); ok && name != "" && !slices.Contains(names, name) {
+				names = append(names, name)
+			}
+		}
+	}
+	return names
+}
+
+// containerdConfigDirFor resolves the host containerd config directory a
+// component targeted — the same mapping as the chart's helpers
+// (c8s.kataContainerdConfigDir, nri-image-policy.containerdConfigDir), so the
+// sweep cleans exactly where the install wrote.
+func containerdConfigDirFor(override, distro string) (string, error) {
 	if override != "" {
 		return override, nil
 	}
@@ -443,30 +514,48 @@ func kataRestartCommand(distro string) string {
 	return "systemctl restart containerd"
 }
 
-// sweepImageRef picks the image the sweep DaemonSet runs: the chart's
-// containerd-prep image (kata.containerdPrep.image). The sweep has the same
-// shape — pure POSIX shell, privileged, host root mounted — so it inherits
-// the same digest-pinned, already-vetted image instead of introducing a new
-// supply-chain entry. Digest wins over tag, mirroring the chart helper;
-// neither set is an error, never a silently-floating default.
+// sweepImageRef picks the image the sweep DaemonSet runs. On shapes where
+// the fail-closed NRI plugin is live on the host, the sweep pod's image must
+// already be on the allowlist — the sweep is what removes the plugin, so it
+// cannot ask for admission afterwards. The one image guaranteed admitted
+// there is the plugin's own (the installer DaemonSet ran it), so a release
+// that resolved nriImagePolicy.image sweeps with it (debian-based: sh,
+// coreutils, and util-linux's nsenter are all present). Everywhere else the
+// digest-pinned containerd-prep busybox is enough: no host NRI to consult,
+// or the baked node image whose floor already admits it. Digest wins over
+// tag, mirroring the chart helper; neither set on either image is an error,
+// never a silently-floating default.
 func sweepImageRef(tree map[string]any) (string, error) {
-	img, ok := nestedMap(tree, "kata", "containerdPrep", "image")
+	if ref, ok := imageRefAt(tree, "nriImagePolicy.image"); ok {
+		return ref, nil
+	}
+	if ref, ok := imageRefAt(tree, "kata.containerdPrep.image"); ok {
+		return ref, nil
+	}
+	return "", fmt.Errorf("neither nriImagePolicy.image nor kata.containerdPrep.image resolves to a pinned reference (digest or tag)")
+}
+
+// imageRefAt renders values image block <path> (repository + digest|tag) as
+// a pullable reference. ok=false when the block is missing, incomplete, or
+// carries neither digest nor tag.
+func imageRefAt(tree map[string]any, path string) (string, bool) {
+	img, ok := nestedMap(tree, strings.Split(path, ".")...)
 	if !ok {
-		return "", fmt.Errorf("values carry no kata.containerdPrep.image block")
+		return "", false
 	}
 	repo, _ := img["repository"].(string)
 	digest, _ := img["digest"].(string)
 	tag, _ := img["tag"].(string)
 	if repo == "" {
-		return "", fmt.Errorf("kata.containerdPrep.image.repository is unset")
+		return "", false
 	}
 	if digest != "" {
-		return repo + "@" + digest, nil
+		return repo + "@" + digest, true
 	}
 	if tag != "" {
-		return repo + ":" + tag, nil
+		return repo + ":" + tag, true
 	}
-	return "", fmt.Errorf("kata.containerdPrep.image has neither digest nor tag")
+	return "", false
 }
 
 // listKataPods returns "namespace/name (runtimeClass)" for every pod the guard
@@ -607,17 +696,22 @@ func validateSweepPath(field, p string, allowEmpty bool) error {
 	return nil
 }
 
-func runKataSweep(ctx context.Context, namespace, release string, cfg kataUninstallConfig) error {
+func runKataSweep(ctx context.Context, namespace, release string, cfg kataUninstallConfig, hostSweepOnly bool) error {
 	// The sweep launches a privileged DaemonSet that recursively deletes the
 	// guest-image dirs below the mounted host root. Validate those release-
 	// derived paths before doing anything destructive so a hostile/malformed
 	// value cannot turn the sweep into host destruction (defense in depth with
-	// the guard inside kata-sweep.sh).
-	if err := validateSweepPath("kata.guestImage.hostPath", cfg.GuestImageHostPath, false); err != nil {
-		return err
-	}
-	if err := validateSweepPath("kata.gpu.guestImage.hostPath", cfg.GuestImageNvidiaHostPath, true); err != nil {
-		return err
+	// the guard inside kata-sweep.sh). Only a kata release could have written
+	// those dirs, so only a kata release fails pre-flight on a bad one — for
+	// other shapes the script's own guard presence-gates the deletion instead
+	// of failing the whole uninstall over a dir c8s never wrote.
+	if cfg.Enabled || hostSweepOnly {
+		if err := validateSweepPath("kata.guestImage.hostPath", cfg.GuestImageHostPath, false); err != nil {
+			return err
+		}
+		if err := validateSweepPath("kata.gpu.guestImage.hostPath", cfg.GuestImageNvidiaHostPath, true); err != nil {
+			return err
+		}
 	}
 
 	// The kata-deploy preStop cleanup and the image-puller's reconcile loop
@@ -718,11 +812,12 @@ func waitPodsGone(ctx context.Context, namespace, selector string) error {
 	}
 }
 
-// kataSweepDaemonSet renders the sweep DaemonSet: same node set (linux +
-// kata.nodeSelector), tolerations, and privilege shape as the kata-deploy
-// DaemonSet it cleans up after, with kata-sweep.sh as an init container and a
-// pause container whose readiness lets `kubectl rollout status` double as
-// "every node finished sweeping".
+// kataSweepDaemonSet renders the sweep DaemonSet: every linux node (the
+// swept artifacts are not confined to kata-selected nodes — the NRI installer
+// and the mesh DaemonSets land on all of them — and a node can carry a
+// previous shape's leftovers), tolerating all taints, with kata-sweep.sh as
+// an init container and a pause container whose readiness lets `kubectl
+// rollout status` double as "every node finished sweeping".
 func kataSweepDaemonSet(release, namespace string, cfg kataUninstallConfig) *appsv1.DaemonSet {
 	labels := map[string]string{
 		"app.kubernetes.io/name":      "c8s-operator",
@@ -730,10 +825,11 @@ func kataSweepDaemonSet(release, namespace string, cfg kataUninstallConfig) *app
 		"app.kubernetes.io/component": "kata-sweep",
 	}
 	nodeSelector := map[string]string{"kubernetes.io/os": "linux"}
-	for k, v := range cfg.NodeSelector {
-		nodeSelector[k] = v
-	}
 	privileged := true
+	pullSecrets := make([]corev1.LocalObjectReference, 0, len(cfg.ImagePullSecretRef))
+	for _, n := range cfg.ImagePullSecretRef {
+		pullSecrets = append(pullSecrets, corev1.LocalObjectReference{Name: n})
+	}
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{APIVersion: "apps/v1", Kind: "DaemonSet"},
 		ObjectMeta: metav1.ObjectMeta{
@@ -746,10 +842,13 @@ func kataSweepDaemonSet(release, namespace string, cfg kataUninstallConfig) *app
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				Spec: corev1.PodSpec{
-					// hostPID: the sweep nsenters into PID 1 to restart the
-					// runtime when it deregisters a leftover drop-in.
+					// hostPID: the sweep nsenters into PID 1 for host binaries
+					// (systemctl, iptables, losetup) and the runtime restart.
 					HostPID:      true,
 					NodeSelector: nodeSelector,
+					// The install's pull secret, so the sweep image pulls on
+					// private-mirror clusters too (chart-wide values).
+					ImagePullSecrets: pullSecrets,
 					// Sweep everywhere kata-deploy installed — including
 					// control-plane and otherwise-tainted nodes (mirrors the
 					// install's one-shot posture).
@@ -767,6 +866,12 @@ func kataSweepDaemonSet(release, namespace string, cfg kataUninstallConfig) *app
 							{Name: "GUEST_IMAGE_DIR_NVIDIA", Value: cfg.GuestImageNvidiaHostPath},
 							{Name: "RKE2_PREP", Value: strconv.FormatBool(cfg.Distro == "rke2")},
 							{Name: "RESTART_COMMAND", Value: kataRestartCommand(cfg.Distro)},
+							{Name: "NRI_CONTAINERD_DIR", Value: cfg.NriContainerdDir},
+							{Name: "NRI_PLUGIN_DIR", Value: cfg.NriPluginDir},
+							{Name: "NRI_PLUGIN_FILENAME", Value: cfg.NriPluginFilename},
+							{Name: "NRI_CONFIG_DIR", Value: cfg.NriConfigDir},
+							{Name: "NRI_RUNTIME_DIR", Value: cfg.NriRuntimeDir},
+							{Name: "NRI_CACHE_DIR", Value: cfg.NriCacheDir},
 						},
 						// Privileged with the host root mounted — the same
 						// posture as kata-deploy: removing a runtime from a
@@ -831,8 +936,8 @@ func init() {
 	uninstallCmd.Flags().StringVar(&uninstallNamespace, "namespace", "c8s-system", "namespace the release was installed into")
 	uninstallCmd.Flags().StringVar(&uninstallRelease, "release", "c8s", "Helm release name")
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
-	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep the kata host artifacts (/opt/kata, containerd drop-in, kata-guest-base image, RKE2 prep template, node labels) off every kata node via a short-lived privileged DaemonSet. Skipped automatically when the release was installed without --cvm-mode=pod")
-	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the kata host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry kata artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
+	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
+	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry c8s artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
 	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it)")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteNamespace, "delete-namespace", false, "also delete the release namespace (and everything left in it, e.g. an operator-created image pull Secret)")

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -149,6 +149,10 @@ install's containerd-prep uses — and removes, idempotently:
     skipped entirely on c8s node images, where the whole stack is baked into
     the measured image (detected via nri-node-ip.service) and is the image's
     to keep, not the release's to delete
+  - the ratls-mesh netfilter state: the RATLS-MESH chains and their
+    base-chain jumps in iptables and ip6tables, and the RATLS-MESH-* ipsets
+    (the mesh's own preStop deliberately keeps the fail-closed guard, so this
+    survives every healthy uninstall too)
   - /opt/kata (the kata-static payload) and the containerd-shim-kata-*
     symlinks
   - kata-deploy's containerd runtime drop-in, restarting containerd/RKE2
@@ -726,6 +730,13 @@ func runKataSweep(ctx context.Context, namespace, release string, cfg kataUninst
 			return fmt.Errorf("waiting for %s pods to terminate: %w", component, err)
 		}
 	}
+	// Same for the mesh: it re-asserts its base-chain iptables jumps on a
+	// watchdog, so sweeping while a mesh pod still runs leaks the rules the
+	// sweep just deleted (helm --wait=false leaves pods terminating).
+	meshSelector := fmt.Sprintf("app.kubernetes.io/instance=%s,app.kubernetes.io/name=ratls-mesh", release)
+	if err := waitPodsGone(ctx, namespace, meshSelector); err != nil {
+		return fmt.Errorf("waiting for ratls-mesh pods to terminate: %w", err)
+	}
 
 	// The sweep pods are privileged; re-assert the namespace's privileged
 	// pod-security labels (idempotent — the install already set them, but on
@@ -936,7 +947,7 @@ func init() {
 	uninstallCmd.Flags().StringVar(&uninstallNamespace, "namespace", "c8s-system", "namespace the release was installed into")
 	uninstallCmd.Flags().StringVar(&uninstallRelease, "release", "c8s", "Helm release name")
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
-	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
+	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, ratls-mesh netfilter state, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
 	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry c8s artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
 	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it)")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")

--- a/cmd/c8s/uninstall.go
+++ b/cmd/c8s/uninstall.go
@@ -163,7 +163,9 @@ install's containerd-prep uses — and removes, idempotently:
     (detached, via systemd-run) only if a drop-in was still registered
   - the pulled kata-guest-base artifact (kata.guestImage.hostPath, multi-GB —
     nothing else cleans this up), and the separate GPU guest image
-    (kata.gpu.guestImage.hostPath)
+    (kata.gpu.guestImage.hostPath); loop devices still bound under those dirs
+    are unmounted and detached first, or the rm unlinks files the loops keep
+    pinning and the space is never reclaimed
   - on RKE2: the c8s-managed containerd template (skipped on c8s node images,
     same baked-state rule) and the containerd-prep lock
   - the katacontainers.io/kata-runtime node labels and the
@@ -953,7 +955,7 @@ func init() {
 	uninstallCmd.Flags().BoolVar(&uninstallWait, "wait", true, "wait for the release deletion to complete (helm --wait); the kata host sweep additionally waits for the kata pods to be gone either way")
 	uninstallCmd.Flags().BoolVar(&uninstallKataSweep, "kata-sweep", true, "after the release is deleted, sweep c8s host artifacts (NRI image-policy plugin, ratls-mesh netfilter state, nydus unit, /opt/kata, containerd drop-in, kata-guest-base images, RKE2 prep template, node labels) off every node via a short-lived privileged DaemonSet. Runs for every release shape — leftovers may come from a previous install's shape, not this release's")
 	uninstallCmd.Flags().BoolVar(&uninstallHostSweepOnly, "host-sweep-only", false, "skip the helm uninstall and only run the host sweep — for a cluster whose release is already gone (e.g. a previous bare 'helm uninstall') but whose nodes still carry c8s artifacts. Uses the chart defaults and the distro detected from the cluster when the release values are unavailable")
-	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it)")
+	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "uninstall even while pods with a kata RuntimeClass are running (they lose their runtime: kata VMs keep running unmanaged but cannot restart), or while pods hold c8s encrypted volumes (the pre-delete hook cannot close a mapping a live pod holds, and fails naming it). With pods left running, the sweep's loop detach and guest-image deletion also cut devices and images out from under live guests")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteCRDs, "delete-crds", false, "also delete the ConfidentialWorkload CRD — this deletes EVERY ConfidentialWorkload object in the cluster with it")
 	uninstallCmd.Flags().BoolVar(&uninstallDeleteNamespace, "delete-namespace", false, "also delete the release namespace (and everything left in it, e.g. an operator-created image pull Secret)")
 	rootCmd.AddCommand(uninstallCmd)

--- a/cmd/c8s/uninstall_exec_test.go
+++ b/cmd/c8s/uninstall_exec_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -154,18 +155,65 @@ func TestUninstallRejectsMalformedReleaseValues(t *testing.T) {
 	mustNotContainPrefix(t, s.f.calls(t), "helm uninstall")
 }
 
-func TestUninstallNonKataSkipsSweep(t *testing.T) {
+// A non-kata release still sweeps: the host state (NRI plugin, mesh
+// netfilter, guest-image leftovers) may be a previous shape's leftover the
+// release's own values cannot see.
+func TestUninstallNonKataStillSweeps(t *testing.T) {
 	values := kataReleaseValuesFile(t, false, "/var/lib/c8s/kata-images", "/var/lib/c8s/kata-images-nvidia")
 	s := newUninstallStubs(t, values, "", false)
 	if err := runC8s(t, "uninstall"); err != nil {
 		t.Fatalf("uninstall: %v", err)
 	}
 	calls := s.f.calls(t)
-	mustContainLine(t, calls, "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
-	// No sweep: nothing applied, nothing rolled out, nothing deleted.
-	mustNotContainPrefix(t, calls, "kubectl apply")
-	mustNotContainPrefix(t, calls, "kubectl rollout")
-	mustNotContainPrefix(t, calls, "kubectl delete")
+	hi := lineIndex(calls, "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+	ai := lineIndex(calls, "kubectl apply -f -")
+	ri := lineIndex(calls, "kubectl rollout status daemonset/c8s-kata-sweep -n c8s-system --timeout=5m")
+	di := lineIndex(calls, "kubectl delete daemonset c8s-kata-sweep -n c8s-system --ignore-not-found")
+	if hi < 0 || ai < hi || ri < ai || di < ri {
+		t.Fatalf("sweep order wrong (helm=%d apply=%d rollout=%d delete=%d):\n%s", hi, ai, ri, di, strings.Join(calls, "\n"))
+	}
+	// The sweep is parameterized from the non-kata release's values...
+	ds := appliedDaemonSet(t, s.applied)
+	env := map[string]string{}
+	for _, e := range ds.Spec.Template.Spec.InitContainers[0].Env {
+		env[e.Name] = e.Value
+	}
+	if env["GUEST_IMAGE_DIR"] != "/var/lib/c8s/kata-images" || env["GUEST_IMAGE_DIR_NVIDIA"] != "/var/lib/c8s/kata-images-nvidia" {
+		t.Errorf("sweep env guest dirs = %q / %q, want the release values", env["GUEST_IMAGE_DIR"], env["GUEST_IMAGE_DIR_NVIDIA"])
+	}
+	// ...and targets every linux node, not kata-selected ones.
+	wantSelector := map[string]string{"kubernetes.io/os": "linux"}
+	if !reflect.DeepEqual(ds.Spec.Template.Spec.NodeSelector, wantSelector) {
+		t.Errorf("nodeSelector = %v, want %v", ds.Spec.Template.Spec.NodeSelector, wantSelector)
+	}
+}
+
+// --kata-sweep=false opts every release shape out of the host sweep.
+func TestUninstallKataSweepFalseSkipsSweep(t *testing.T) {
+	for _, kataEnabled := range []bool{true, false} {
+		values := kataReleaseValuesFile(t, kataEnabled, "/var/lib/c8s/kata-images", "")
+		s := newUninstallStubs(t, values, "", false)
+		if err := runC8s(t, "uninstall", "--kata-sweep=false"); err != nil {
+			t.Fatalf("uninstall (kataEnabled=%v): %v", kataEnabled, err)
+		}
+		calls := s.f.calls(t)
+		mustContainLine(t, calls, "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+		mustNotContainPrefix(t, calls, "kubectl apply")
+		mustNotContainPrefix(t, calls, "kubectl rollout")
+	}
+}
+
+// The kata-pods guard stays gated on kata: a non-kata release sweeps even
+// with kata pods still running (nothing it removes is their runtime).
+func TestUninstallNonKataIgnoresRunningKataPods(t *testing.T) {
+	values := kataReleaseValuesFile(t, false, "/var/lib/c8s/kata-images", "")
+	running := `*runtimeClassName*) /usr/bin/printf 'default\tinference-0\tkata-qemu-snp\tinference\n' ;;
+`
+	s := newUninstallStubs(t, values, running, false)
+	if err := runC8s(t, "uninstall"); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
 }
 
 func TestUninstallRefusesWhileKataPodsRun(t *testing.T) {
@@ -273,6 +321,18 @@ func TestUninstallSweepRefusesUnsafeGuestImagePaths(t *testing.T) {
 		}
 		mustNotContainPrefix(t, s.f.calls(t), "kubectl apply")
 	})
+	// A non-kata release never wrote the guest dirs, so a hostile custom
+	// path in its values is not a pre-flight error: the sweep script's own
+	// guard presence-gates the deletion instead of failing the uninstall
+	// over a dir c8s never created.
+	t.Run("non-kata release with an unsafe guest path still sweeps", func(t *testing.T) {
+		values := kataReleaseValuesFile(t, false, "/opt/kata", "")
+		s := newUninstallStubs(t, values, "", false)
+		if err := runC8s(t, "uninstall"); err != nil {
+			t.Fatalf("uninstall: %v", err)
+		}
+		mustContainLine(t, s.f.calls(t), "kubectl apply -f -")
+	})
 }
 
 func TestUninstallSweepRolloutFailureKeepsDaemonSet(t *testing.T) {
@@ -317,7 +377,13 @@ func TestUninstallHelmUninstallFailure(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "helm uninstall failed") {
 		t.Fatalf("want the helm failure surfaced, got %v", err)
 	}
-	mustContainLine(t, s.f.calls(t), "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+	if !strings.Contains(err.Error(), "--no-hooks") {
+		t.Fatalf("want the recovery hint (--no-hooks + --host-sweep-only), got %v", err)
+	}
+	calls := s.f.calls(t)
+	mustContainLine(t, calls, "helm uninstall c8s --namespace c8s-system --wait --timeout=5m")
+	// A failed helm uninstall aborts before the sweep.
+	mustNotContainPrefix(t, calls, "kubectl apply")
 }
 
 func TestUninstallDeleteCRDsAndNamespace(t *testing.T) {
@@ -329,8 +395,16 @@ func TestUninstallDeleteCRDsAndNamespace(t *testing.T) {
 			t.Fatalf("uninstall: %v", err)
 		}
 		calls := s.f.calls(t)
-		mustContainLine(t, calls, "kubectl delete crd "+confidentialWorkloadCRD+" --ignore-not-found")
-		mustContainLine(t, calls, "kubectl delete namespace c8s-system --ignore-not-found")
+		ci := lineIndex(calls, "kubectl delete crd "+confidentialWorkloadCRD+" --ignore-not-found")
+		ni := lineIndex(calls, "kubectl delete namespace c8s-system --ignore-not-found")
+		if ci < 0 || ni < 0 {
+			t.Fatalf("want crd and namespace deletes, got:\n%s", strings.Join(calls, "\n"))
+		}
+		// The sweep finishes before the CRD/namespace deletes.
+		si := lineIndex(calls, "kubectl delete daemonset c8s-kata-sweep -n c8s-system --ignore-not-found")
+		if si < 0 || si > ci || si > ni {
+			t.Fatalf("sweep cleanup must precede the deletes (sweep=%d crd=%d ns=%d):\n%s", si, ci, ni, strings.Join(calls, "\n"))
+		}
 	})
 
 	t.Run("delete failure surfaces", func(t *testing.T) {

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -163,7 +163,7 @@ func TestKataPodsRunningErrorReportsSkippedChartPods(t *testing.T) {
 
 // The sweep must target exactly the directory the install wrote into — the
 // same mapping as the chart's c8s.kataContainerdConfigDir helper.
-func TestKataContainerdDir(t *testing.T) {
+func TestContainerdConfigDirFor(t *testing.T) {
 	tests := []struct {
 		name     string
 		override string
@@ -180,7 +180,7 @@ func TestKataContainerdDir(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := kataContainerdDir(tt.override, tt.distro)
+			got, err := containerdConfigDirFor(tt.override, tt.distro)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("err = %v, wantErr = %t", err, tt.wantErr)
 			}
@@ -222,8 +222,6 @@ kata:
   enabled: true
   distro: rke2
   containerdConfigDir: ""
-  nodeSelector:
-    confidential.ai/kata: "true"
   containerdPrep:
     image:
       repository: busybox
@@ -231,6 +229,8 @@ kata:
       digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
   guestImage:
     hostPath: /var/lib/c8s/kata-images
+nriImagePolicy:
+  distro: rke2
 `)
 	cfg, err := kataConfigFromValues(tree)
 	if err != nil {
@@ -242,10 +242,64 @@ kata:
 		ContainerdConfigDir: "/var/lib/rancher/rke2/agent/etc/containerd",
 		GuestImageHostPath:  "/var/lib/c8s/kata-images",
 		SweepImage:          "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028",
-		NodeSelector:        map[string]string{"confidential.ai/kata": "true"},
+		// The NRI containerd dir follows nriImagePolicy.distro; the host
+		// paths fall back to the chart defaults when absent.
+		NriContainerdDir:  "/var/lib/rancher/rke2/agent/etc/containerd",
+		NriPluginDir:      "/opt/nri/plugins",
+		NriPluginFilename: "10-nri-image-policy",
+		NriConfigDir:      "/etc/nri/conf.d",
+		NriRuntimeDir:     "/var/run/nri-image-policy",
+		NriCacheDir:       "/var/lib/nri-image-policy",
 	}
 	if !reflect.DeepEqual(cfg, want) {
 		t.Errorf("config = %+v, want %+v", cfg, want)
+	}
+}
+
+// A -f release can diverge the two distros; the NRI sweep must target the
+// NRI installer's containerd dir, not kata's.
+func TestNriConfigFromValuesDivergentDistro(t *testing.T) {
+	tree := chartValuesTree(t, `
+kata:
+  enabled: false
+  distro: rke2
+  guestImage:
+    hostPath: /var/lib/c8s/kata-images
+  containerdPrep:
+    image:
+      repository: busybox
+      digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
+nriImagePolicy:
+  distro: k8s
+  hostPaths:
+    pluginDir: /custom/nri/plugins
+`)
+	cfg, err := kataConfigFromValues(tree)
+	if err != nil {
+		t.Fatalf("kataConfigFromValues: %v", err)
+	}
+	if cfg.NriContainerdDir != "/etc/containerd" {
+		t.Errorf("NriContainerdDir = %q, want /etc/containerd (nriImagePolicy.distro)", cfg.NriContainerdDir)
+	}
+	if cfg.NriPluginDir != "/custom/nri/plugins" {
+		t.Errorf("NriPluginDir = %q, want the values override", cfg.NriPluginDir)
+	}
+}
+
+func TestImagePullSecretNames(t *testing.T) {
+	tree := chartValuesTree(t, `
+imagePullSecret: regcred
+imagePullSecrets:
+  - name: regcred
+  - name: mirrorcred
+`)
+	got := imagePullSecretNames(tree)
+	want := []string{"regcred", "mirrorcred"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("imagePullSecretNames = %v, want %v (uniq, secret first)", got, want)
+	}
+	if got := imagePullSecretNames(map[string]any{}); len(got) != 0 {
+		t.Errorf("imagePullSecretNames(empty) = %v, want none", got)
 	}
 }
 
@@ -387,6 +441,49 @@ kata:
 	}
 }
 
+// On a host running the fail-closed NRI plugin the sweep pod's image must
+// already be admitted; the plugin's own image is the one image guaranteed
+// on the allowlist (the installer ran it).
+func TestSweepImageRefPrefersNriImageOnNriReleases(t *testing.T) {
+	tree := chartValuesTree(t, `
+kata:
+  containerdPrep:
+    image:
+      repository: busybox
+      digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
+nriImagePolicy:
+  image:
+    repository: ghcr.io/confidential-dot-ai/nri-image-policy
+    digest: "sha256:aaa"
+`)
+	ref, err := sweepImageRef(tree)
+	if err != nil {
+		t.Fatalf("sweepImageRef: %v", err)
+	}
+	if ref != "ghcr.io/confidential-dot-ai/nri-image-policy@sha256:aaa" {
+		t.Errorf("sweepImageRef = %q, want the NRI plugin image", ref)
+	}
+	// Unpinned NRI image (a release that never resolved it) falls back to
+	// the containerd-prep busybox.
+	tree = chartValuesTree(t, `
+kata:
+  containerdPrep:
+    image:
+      repository: busybox
+      digest: "sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028"
+nriImagePolicy:
+  image:
+    repository: ghcr.io/confidential-dot-ai/nri-image-policy
+`)
+	ref, err = sweepImageRef(tree)
+	if err != nil {
+		t.Fatalf("sweepImageRef: %v", err)
+	}
+	if ref != "busybox@sha256:9532d8c39891ca2ecde4d30d7710e01fb739c87a8b9299685c63704296b16028" {
+		t.Errorf("sweepImageRef = %q, want the busybox fallback", ref)
+	}
+}
+
 func TestKataSweepDaemonSetShape(t *testing.T) {
 	cfg := kataUninstallConfig{
 		Enabled:                  true,
@@ -395,7 +492,13 @@ func TestKataSweepDaemonSetShape(t *testing.T) {
 		GuestImageHostPath:       "/var/lib/c8s/kata-images",
 		GuestImageNvidiaHostPath: "/var/lib/c8s/kata-images-nvidia",
 		SweepImage:               "busybox@sha256:abc",
-		NodeSelector:             map[string]string{"confidential.ai/kata": "true"},
+		NriContainerdDir:         "/var/lib/rancher/rke2/agent/etc/containerd",
+		NriPluginDir:             "/opt/nri/plugins",
+		NriPluginFilename:        "10-nri-image-policy",
+		NriConfigDir:             "/etc/nri/conf.d",
+		NriRuntimeDir:            "/var/run/nri-image-policy",
+		NriCacheDir:              "/var/lib/nri-image-policy",
+		ImagePullSecretRef:       []string{"regcred"},
 	}
 	ds := kataSweepDaemonSet("c8s", "c8s-system", cfg)
 
@@ -404,15 +507,18 @@ func TestKataSweepDaemonSetShape(t *testing.T) {
 	}
 
 	pod := ds.Spec.Template.Spec
-	// The sweep must reach every node kata-deploy installed on: the merged
-	// linux + kata.nodeSelector node set, tolerating all taints, with hostPID
-	// for the nsenter-driven runtime restart.
+	// The sweep must reach every linux node: the NRI installer and the mesh
+	// DaemonSets are not confined to kata-selected nodes, and a node can
+	// carry a previous shape's leftovers. All taints tolerated; hostPID for
+	// the nsenter-driven host work.
 	wantSelector := map[string]string{
-		"kubernetes.io/os":     "linux",
-		"confidential.ai/kata": "true",
+		"kubernetes.io/os": "linux",
 	}
 	if !reflect.DeepEqual(pod.NodeSelector, wantSelector) {
 		t.Errorf("nodeSelector = %v, want %v", pod.NodeSelector, wantSelector)
+	}
+	if len(pod.ImagePullSecrets) != 1 || pod.ImagePullSecrets[0].Name != "regcred" {
+		t.Errorf("imagePullSecrets = %v, want [regcred]", pod.ImagePullSecrets)
 	}
 	if len(pod.Tolerations) != 1 || pod.Tolerations[0].Operator != "Exists" {
 		t.Errorf("tolerations = %v, want a single operator:Exists", pod.Tolerations)
@@ -442,6 +548,12 @@ func TestKataSweepDaemonSetShape(t *testing.T) {
 		"GUEST_IMAGE_DIR_NVIDIA": "/var/lib/c8s/kata-images-nvidia",
 		"RKE2_PREP":              "true",
 		"RESTART_COMMAND":        kataRestartCommand("rke2"),
+		"NRI_CONTAINERD_DIR":     "/var/lib/rancher/rke2/agent/etc/containerd",
+		"NRI_PLUGIN_DIR":         "/opt/nri/plugins",
+		"NRI_PLUGIN_FILENAME":    "10-nri-image-policy",
+		"NRI_CONFIG_DIR":         "/etc/nri/conf.d",
+		"NRI_RUNTIME_DIR":        "/var/run/nri-image-policy",
+		"NRI_CACHE_DIR":          "/var/lib/nri-image-policy",
 	}
 	gotEnv := map[string]string{}
 	for _, e := range sweep.Env {
@@ -544,3 +656,4 @@ func TestForcedVolumePodsWarning(t *testing.T) {
 		}
 	}
 }
+

--- a/cmd/c8s/uninstall_test.go
+++ b/cmd/c8s/uninstall_test.go
@@ -657,3 +657,42 @@ func TestForcedVolumePodsWarning(t *testing.T) {
 	}
 }
 
+// TestKataSweepScriptMeshNetfilterNames pins the netfilter names the sweep
+// script removes to the mesh's fixed contract (internal/cmds/ratlsmesh:
+// jumpRules, managedChains, managedIPSetNames + the -TMP swap variants). The
+// two cleanup paths must not drift: a name added or renamed on the mesh side
+// must be added here too.
+func TestKataSweepScriptMeshNetfilterNames(t *testing.T) {
+	names := []string{
+		// Base-chain jumps (as "parent -j chain" in -D form).
+		"-D OUTPUT -j RATLS-MESH",
+		"-D PREROUTING -j RATLS-MESH-PREROUTING",
+		"-D FORWARD -j RATLS-MESH-CW",
+		"-D FORWARD -j RATLS-MESH-CW-EGRESS",
+		// Chains (as "table:chain" sweep specs).
+		"nat:RATLS-MESH",
+		"nat:RATLS-MESH-PREROUTING",
+		"filter:RATLS-MESH-CW",
+		"filter:RATLS-MESH-CW-EGRESS",
+		"filter:RATLS-MESH-GUEST-IN",
+		"filter:RATLS-MESH-GUEST-OUT",
+		// ipsets.
+		"RATLS-MESH-PODS",
+		"RATLS-MESH-PODS6",
+		"RATLS-MESH-LOCAL-PODS",
+		"RATLS-MESH-LOCAL-PODS6",
+		"RATLS-MESH-CW-PODS",
+		"RATLS-MESH-CW-PODS6",
+	}
+	for _, name := range names {
+		// Delimit the match so a suffixed sibling (RATLS-MESH-PODS6) cannot
+		// satisfy a missing shorter name (RATLS-MESH-PODS).
+		if !strings.Contains(kataSweepScript, name+" ") && !strings.Contains(kataSweepScript, name+"\n") {
+			t.Errorf("kata-sweep.sh does not sweep %q (mesh netfilter contract)", name)
+		}
+	}
+	// The -TMP swap variants are destroyed alongside each ipset.
+	if !strings.Contains(kataSweepScript, `"$s-TMP"`) {
+		t.Error("kata-sweep.sh does not destroy the -TMP ipset swap variants")
+	}
+}

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -323,16 +323,14 @@ sequenceDiagram
 kata-deploy separately runs `kata-deploy cleanup` on `preStop` to unwind the
 host runtime install.
 
-**`c8s uninstall`** wraps the helm step and adds the kata host sweep the
-preStop hook cannot guarantee: after the release is gone, a short-lived
-privileged DaemonSet removes whatever survived on each node — `/opt/kata`, the
-containerd runtime drop-in (restarting the runtime only if it was still
-registered), the pulled kata-guest-base artifact, the RKE2 containerd-prep
-template — plus the `katacontainers.io/kata-runtime` node labels. It refuses
+**`c8s uninstall`** wraps the helm step and adds the host sweep the preStop
+hook cannot guarantee: after the release is gone, a short-lived privileged
+DaemonSet removes whatever survived on each node, on every release shape
+(leftovers may come from a previous install of a different shape). It refuses
 to run under live kata pods (`--force` overrides), reads the release values
 before deletion so install-time `-f` overrides are honored, and
 `--host-sweep-only` recovers a cluster whose release a bare `helm uninstall`
-already deleted. See [`kata.md`](kata.md#uninstalling).
+already deleted. Full sweep inventory: [`kata.md`](kata.md#uninstalling).
 
 ---
 

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -432,6 +432,17 @@ it via `kata.guestImage.debug=true`; its launch measurement differs from
 the locked image, so locked-reference attestation rejects it. See "Debug
 variant" in [`kata-guest-base/README.md`](../kata-guest-base/README.md).
 
+## Host-side introspection of a staged image
+
+Loop-mounting the staged rootfs (e.g. to read the baked bootstrap allowlist)
+pins the file under `/var/lib/c8s/kata-images`; `c8s uninstall` detaches
+loops whose backing file is under the guest dirs, unmounting their mounts
+first, wherever the mountpoint lives. Mounts and loops on a *copy* outside
+`/var/lib/c8s` are yours to clean up: unmount before `losetup -d` (a mounted
+loop detaches silently via autoclear and reads as stuck), and match devices
+by backing path — never `losetup -D`, which takes every unused loop on the
+host.
+
 ## Puller DaemonSet
 
 `internal/helmchart/c8s/templates/kata-image-puller.yaml`. Per node, the

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -654,7 +654,9 @@ linux node, removing:
   systemd-run) only when a runtime drop-in was still registered;
 - the pulled kata-guest-base artifact (`kata.guestImage.hostPath`,
   multi-GB) — nothing else cleans this up; and the separate GPU guest image
-  (`kata.gpu.guestImage.hostPath`);
+  (`kata.gpu.guestImage.hostPath`). Loop devices still bound under those
+  dirs are unmounted and detached first; a dir that stays pinned is left in
+  place and fails the sweep rather than being unlinked under the loops;
 - on RKE2, the sentinel-marked containerd template the containerd-prep
   initContainer wrote (skipped on the c8s node image, same baked-state
   rule), and its lock file;

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -640,6 +640,11 @@ linux node, removing:
   the c8s node image, where the whole stack is baked into the measured image
   (detected via the baked-only `nri-node-ip.service`) — there it is the
   image's to keep, not the release's to delete;
+- the ratls-mesh netfilter state: the `RATLS-MESH` chains and their
+  base-chain jumps in `iptables` and `ip6tables`, and the `RATLS-MESH-*`
+  ipsets. The mesh's own preStop deliberately keeps the fail-closed guard,
+  so this state survives every healthy uninstall, and a stale `OUTPUT`
+  redirect blackholes host-originated pod traffic for non-root users;
 - `/opt/kata` and the `containerd-shim-kata-*` symlinks, if the preStop
   cleanup was cut short — restarting containerd/RKE2 (detached, via
   systemd-run) only when a runtime drop-in was still registered;

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -620,32 +620,44 @@ boundary is the per-pod SEV-SNP attestation of each `kata-qemu-snp` pod.
 
 ## Uninstalling
 
-`c8s uninstall` wraps `helm uninstall` and then sweeps the host-side kata
+`c8s uninstall` wraps `helm uninstall` and then sweeps the host-side
 artifacts off every node. The helm step deletes the kata-deploy DaemonSet,
 whose `preStop` hook runs `kata-deploy cleanup` (removes `/opt/kata`,
 deregisters the containerd drop-in, restarts the runtime, unlabels the
 node) — but that hook is best-effort: it is bounded by the pod's termination
 grace period, the runtime restart it triggers can kill the pod mid-cleanup,
 and it knows nothing about the c8s-side artifacts. The sweep is the
-idempotent last word. It reads the release's computed values before the
-release is deleted (so install-time `-f` overrides are honored), then runs a
-short-lived privileged DaemonSet (the same digest-pinned busybox image as the
-containerd-prep initContainer) on the nodes kata-deploy targeted, removing:
+idempotent last word, and it runs on every uninstall, whatever the release's
+shape: leftovers may come from a previous install of a *different* shape
+(node vs pod), which this release's values cannot see. It reads the release's
+computed values before the release is deleted (so install-time `-f` overrides
+are honored), then runs a short-lived privileged DaemonSet (the same
+digest-pinned busybox image as the containerd-prep initContainer) on every
+linux node, removing:
 
+- the NRI image-policy host plugin: its containerd registration (drop-in or
+  managed config block), binary, config, and state dirs. Skipped entirely on
+  the c8s node image, where the whole stack is baked into the measured image
+  (detected via the baked-only `nri-node-ip.service`) — there it is the
+  image's to keep, not the release's to delete;
 - `/opt/kata` and the `containerd-shim-kata-*` symlinks, if the preStop
-  cleanup was cut short — restarting containerd/RKE2 only when the runtime
-  drop-in was still registered;
+  cleanup was cut short — restarting containerd/RKE2 (detached, via
+  systemd-run) only when a runtime drop-in was still registered;
 - the pulled kata-guest-base artifact (`kata.guestImage.hostPath`,
   multi-GB) — nothing else cleans this up; and the separate GPU guest image
   (`kata.gpu.guestImage.hostPath`);
 - on RKE2, the sentinel-marked containerd template the containerd-prep
-  initContainer wrote, and its lock file;
+  initContainer wrote (skipped on the c8s node image, same baked-state
+  rule), and its lock file;
 - the `katacontainers.io/kata-runtime` node labels and the platform labels
   the install applied from `--hardware-platform`
   (`confidential.ai/sev-snp`, `confidential.ai/tdx`) — via
   kubectl. Only those exact default keys are removed — a custom
   `kata.snpNodeSelector` (an NFD or provisioning-owned label) was never
   applied by c8s and is left alone.
+
+The swept paths are cluster-global, so running two c8s releases in one
+cluster is unsupported: uninstalling either strips the other's host state.
 
 The RuntimeClass objects and the enforcement policy are deleted with the
 release. The uninstall refuses to run while pods with a kata RuntimeClass

--- a/docs/kata.md
+++ b/docs/kata.md
@@ -645,6 +645,10 @@ linux node, removing:
   ipsets. The mesh's own preStop deliberately keeps the fail-closed guard,
   so this state survives every healthy uninstall, and a stale `OUTPUT`
   redirect blackholes host-originated pod traffic for non-root users;
+- the `nydus-for-kata-tee` systemd unit kata-deploy installs. Its data dir
+  `/var/lib/nydus-for-kata-tee` is preserved on purpose: containerd's
+  meta.db keeps nydus snapshot records, and wiping the backend behind them
+  breaks the next install's pulls;
 - `/opt/kata` and the `containerd-shim-kata-*` symlinks, if the preStop
   cleanup was cut short — restarting containerd/RKE2 (detached, via
   systemd-run) only when a runtime drop-in was still registered;

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -206,14 +206,14 @@ webhook configuration, RuntimeClasses, and the enforcement policy). The
 release — a `failurePolicy: Fail` webhook cannot outlive the operator Service
 and block pod creation cluster-wide.
 
-For a `--cvm-mode=pod` install it then **sweeps the host-side kata artifacts** that the
-`kata-deploy` preStop cleanup cannot guarantee: a short-lived privileged
-DaemonSet removes `/opt/kata`, the containerd runtime drop-in (restarting the
-runtime only when the drop-in was still registered), the pulled
-`kata-guest-base` image, the RKE2 containerd-prep template, and the
-`katacontainers.io/kata-runtime` node labels. The sweep set and host paths are
-read from the release's computed values *before* deletion, so install-time `-f`
-overrides are honored; it is skipped automatically for a non-kata install.
+It then **sweeps the host-side artifacts** that the chart's hooks and the
+`kata-deploy` preStop cleanup cannot guarantee — on every release shape, since
+leftovers may come from a previous install of a different shape. The swept set
+(NRI image-policy plugin, kata payload and guest images, RKE2
+containerd-prep template, node labels) is in
+[`docs/kata.md`](kata.md#uninstalling). The host paths are read from the
+release's computed values *before* deletion, so install-time `-f` overrides are
+honored.
 
 Guardrails:
 
@@ -224,7 +224,7 @@ Guardrails:
   chart-managed pods (CDS and tls-lb pin a kata RuntimeClass) are excluded by
   release namespace + `app.kubernetes.io/instance`, and the refusal reports how
   many it skipped; see [`docs/kata.md`](kata.md#uninstalling).
-- `--host-sweep-only` runs only the kata sweep, for a cluster whose release a
+- `--host-sweep-only` runs only the host sweep, for a cluster whose release a
   bare `helm uninstall` already removed but whose nodes still carry artifacts;
   it uses the chart defaults and the distro detected from the cluster.
 - `--delete-crds` and `--delete-namespace` are **off by default** and

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -209,8 +209,8 @@ and block pod creation cluster-wide.
 It then **sweeps the host-side artifacts** that the chart's hooks and the
 `kata-deploy` preStop cleanup cannot guarantee — on every release shape, since
 leftovers may come from a previous install of a different shape. The swept set
-(NRI image-policy plugin, ratls-mesh netfilter state, kata payload and
-guest images, RKE2 containerd-prep template, node labels) is in
+(NRI image-policy plugin, ratls-mesh netfilter state, nydus unit, kata payload
+and guest images, RKE2 containerd-prep template, node labels) is in
 [`docs/kata.md`](kata.md#uninstalling). The host paths are read from the
 release's computed values *before* deletion, so install-time `-f` overrides are
 honored.

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -209,8 +209,8 @@ and block pod creation cluster-wide.
 It then **sweeps the host-side artifacts** that the chart's hooks and the
 `kata-deploy` preStop cleanup cannot guarantee — on every release shape, since
 leftovers may come from a previous install of a different shape. The swept set
-(NRI image-policy plugin, kata payload and guest images, RKE2
-containerd-prep template, node labels) is in
+(NRI image-policy plugin, ratls-mesh netfilter state, kata payload and
+guest images, RKE2 containerd-prep template, node labels) is in
 [`docs/kata.md`](kata.md#uninstalling). The host paths are read from the
 release's computed values *before* deletion, so install-time `-f` overrides are
 honored.

--- a/internal/cmds/ratlsmesh/iptables.go
+++ b/internal/cmds/ratlsmesh/iptables.go
@@ -53,6 +53,9 @@ const ipSetTmpSuffix = "-TMP"
 // managedIPSetNames is the single source of truth for the ipsets this process
 // owns. reconcileLiveSetMaxElem and runIptablesCleanup derive their name lists
 // (and the -TMP swap variants) from it, so adding a set is one edit here.
+// These names (and the chain/jump names below) are a fixed contract with the
+// uninstall host sweep (cmd/c8s/kata-sweep.sh), pinned there by
+// TestKataSweepScriptMeshNetfilterNames.
 var managedIPSetNames = []string{
 	podIPSetName4, podIPSetName6,
 	localPodIPSetName4, localPodIPSetName6,


### PR DESCRIPTION
## Summary

Found on the bare-metal SEV-SNP pod-as-CVM e2e (2026-08-20): `c8s uninstall` reported success while leaving host state that broke the next install. Four independent artifacts, one shared root cause — the only removers were the kata-gated host sweep and the chart's pre-delete hooks, and both are skippable (the sweep on `kata.enabled`, the hooks on a release healthy enough to run them; the NRI hook can also lose the race between its detached containerd restart and its own artifact deletion, so even a healthy release can orphan the plugin).

The host sweep now runs on **every** uninstall (`--kata-sweep=false` opts out) on **every linux node**, and covers, in four commits:

1. **NRI image-policy plugin** — containerd registration (drop-in, or the managed `config.toml` block on k8s distro), binary, config, and state dirs, sourced from `nriImagePolicy.*` values rather than `kata.*`. The script is reordered so all config removal precedes one detached (`systemd-run`) restart, which precedes artifact deletion: no interruption can leave the fail-closed `default_validator` requiring a plugin whose binary is already gone.
2. **ratls-mesh netfilter state** — the four base-chain jumps, six `RATLS-MESH` chains, and six ipsets (+`-TMP`), both address families, via the host's `iptables-nft`/`iptables` (the mesh has only ever written nft rules). The mesh's own preStop is always `--keep-guard`, so the guard state survived even healthy uninstalls. The CLI now waits for mesh pods to terminate before sweeping (the mesh re-asserts jumps on a watchdog). Names are pinned to `internal/cmds/ratlsmesh` by a test.
3. **`nydus-for-kata-tee.service`** — `disable --now`, unit removal, `daemon-reload`, ordered before the `/opt/kata` removal.
4. **Loop devices pinning guest images** — before each guest-dir `rm -rf`, the sweep unmounts the mounts of loops whose backing file is under the dir (wherever the mountpoint lives — a mounted loop only autoclear-defers `losetup -d`), detaches them (by backing path, never `losetup -D`), and unmounts anything mounted at or beneath the dir itself (which `rm -rf` would otherwise cross). A dir that stays pinned is left in place and fails the sweep rather than being unlinked under the loops. Loops on images outside `/var/lib/c8s` are untouched; `docs/kata-guest-base.md` gains the matching introspection teardown note.

## Two acceptance deviations to ratify

**T1: the sweep does not remove the NRI stack on c8s node images.** Those paths are baked into the measured node image (same paths, byte-identical by design — `node-guest-image/c8s/mkosi.*`): deleting them strips the node's fail-closed admission until reimage and breaks a later node-as-CVM install on the same node. The sweep skips the NRI steps (and the sentinel-marked containerd template, also baked) when the baked-only `nri-node-ip.service` unit exists. Consequence for the e2e accept criterion: on a baked node the plugin stays, and the fresh cluster reaches Ready when its RKE2 matches the baked floor. The round-5 bricking (`klipper-helm:v0.13.3-build20260727` denied) was the baked floor meeting a newer RKE2 than the image baked — that reproduces on a virgin node with no uninstall involved, so it's a node-image/floor-freshness issue, not an uninstall orphan; suggest a follow-up there.

**T3: `/var/lib/nydus-for-kata-tee` is preserved.** kata-deploy's own uninstaller deliberately keeps it: containerd's `meta.db` retains nydus snapshot records, and wiping the backend behind them makes the next install's pulls fail with `target snapshot already exists` (documented in `uninstall_nydus_snapshotter`). The dir is inert metadata (all confidential shims use nydus guest-pull, so layers never land on the host). The harness assertion should become: unit `not-found`, `/opt/kata` absent — drop the dir-absence check.

## Notes

- The sweep pod runs the release's **NRI plugin image** where it resolved (any
  `nriImagePolicy.enabled` shape): on hosts with the fail-closed plugin live,
  the sweep image must already be on the allowlist — the sweep is what removes
  the plugin, so it cannot ask for admission, and the plugin's own image is
  the one the installer already ran. Other shapes keep the digest-pinned
  containerd-prep busybox. (Found by the kind harness: its fail-closed
  admission test denied the sweep pod's busybox → `Init:CreateContainerError`.)

- Non-kata releases with a custom guest-image path outside `/var/lib/c8s` no longer fail pre-flight (the release never wrote the dir); the script presence-gates and still fails closed on an existing unsafe path.
- The sweep restarts containerd detached now (the chart's pattern) — the previous synchronous restart could die with the sweep pod mid-restart.
- Removing the mesh guard strips it from under any still-running cw pods on non-kata shapes; uninstall already removes the platform those pods' certs/policy depend on, so the guard is defined to go with it.
- Two c8s releases in one cluster were never supported; documented now — the swept state is cluster-global.
- Failed helm uninstall (e.g. a wedged pre-delete hook) now prints the recovery path: `helm uninstall --no-hooks` + `c8s uninstall --host-sweep-only`.
- CI: `cmd/c8s/kata-sweep.sh` should join the "Shellcheck release scripts" step in `actionlint.yml` — the one-line change is held back from this branch because the push token lacks the `workflow` scope. The script is shellcheck-clean locally (v0.10.0). Suggested diff:
  ```diff
             shellcheck \
               .github/scripts/calculate-release-version.sh \
  +            cmd/c8s/kata-sweep.sh \
               kata-guest-base/scripts/ci/publish-release-aliases.sh
  ```

## Test plan

- `go test ./...` green; new/updated tests cover: non-kata releases sweep (ordering, values plumbing, linux-only node selector), `--kata-sweep=false` on both shapes, non-kata releases ignore running kata pods, unsafe guest paths fail pre-flight only for kata releases, helm-uninstall failure aborts before the sweep and prints the recovery hint, the mesh netfilter names pin, NRI values plumbing (divergent distro, pull-secret merge).
- `shellcheck cmd/c8s/kata-sweep.sh` clean; `dash -n` clean.
- Smoke-tested the script against a fake host root with stubbed `nsenter`/`systemctl`/`iptables-nft`/`ipset`: full artifact removal with exactly one detached restart, foreign NRI plugins preserved, baked-marker skips the NRI stack and template while sweeping chart state, and a host with no iptables fails the sweep only after every other step completed.
- The kind cluster harness (`test/integration/cluster/run.sh`) runs install → `c8s uninstall` on a node-mode release with a live mesh, so CI exercises the sweep end-to-end.
- Bare-metal (the finding's harness): full install/uninstall cycle twice, plus the failed-release and cross-shape cases — checklist per finding: `/opt/nri/plugins` clean of `*-nri-image-policy`, zero `RATLS-MESH` in `iptables-save`/`ip6tables-save`/`ipset list`, nydus unit `not-found` with `/var/lib/nydus-for-kata-tee` **present**, no `(deleted)` loops under `/var/lib/c8s`, and the second install reaches Ready.
