### PR TITLE
fix(policy-monitor): retry a self-report refusal the missing network caused

### DIFF
--- a/internal/cmds/policymonitor/initdata.go
+++ b/internal/cmds/policymonitor/initdata.go
@@ -25,7 +25,7 @@ var errNoInitData = errors.New("policy-monitor: no init-data document")
 // The attester or the verifier did not answer; a later read may.
 var errAttestUnavailable = errors.New("policy-monitor: attestation service unavailable")
 
-// The verifier refused this guest's report, which every retry reproduces.
+// The verifier refused this guest's report.
 var errAttestVerdict = errors.New("policy-monitor: self-report refused")
 
 // The verified report carries no usable init-data anchor to compare the
@@ -114,6 +114,12 @@ var (
 	initDataWaitInterval = 2 * time.Second
 )
 
+// A refusal is re-tried this many times before it counts as a verdict.
+// INVARIANT: initDataVerdictRetries * initDataWaitInterval stays under
+// refreshSettleBudget, so a real refusal still lands inside the wait a
+// would-be deny makes. TestVerdictRetriesFitTheDenyWait pins the two.
+const initDataVerdictRetries = 5
+
 // A digest mismatch is re-read this many times, this far apart, before it counts
 // as a verdict. Covers a document caught mid-write without letting a genuinely
 // uncommitted one hold the guest off its seed for the whole budget.
@@ -133,6 +139,11 @@ const (
 //
 // Waiting is bounded and every outcome still falls back to the baked seed, so
 // a guest whose host delivers no document behaves exactly as before.
+//
+// The verifier fetches AMD KDS collateral to judge an SNP report, and the pod
+// network arrives from a unit ordered behind this one (see
+// resolveSandboxDigestsHostLate), so the first self-reports run without a
+// resolver: a refusal counts as a verdict only after initDataVerdictRetries.
 func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Config) {
 	if cfg.CDSMeasurements != "" {
 		return
@@ -140,6 +151,7 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 	deadline := time.Now().Add(initDataWaitBudget)
 	var lastErr error
 	settling := 0
+	verdicts := 0
 	for {
 		measurements, err := resolveInitDataMeasurements(ctx, cfg)
 		switch {
@@ -155,8 +167,8 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 			logger.Warn("init-data carries no CDS measurements; allowlist refresh will stay disabled",
 				"key", initdata.KeyCDSMeasurements)
 			return
-		case errors.Is(err, errAttestVerdict):
-			logger.Error("self-report refused by the verifier", "error", err)
+		case errors.Is(err, errAttestVerdict) && verdicts >= initDataVerdictRetries:
+			logger.Error("self-report refused by the verifier", "error", err, "attempts", verdicts+1)
 			return
 		case errors.Is(err, errNoHostDataAnchor):
 			logger.Warn("verified report carries no 32-byte init-data anchor", "error", err)
@@ -165,7 +177,10 @@ func awaitInitDataMeasurements(ctx context.Context, logger *slog.Logger, cfg *Co
 		lastErr = err
 
 		wait := initDataWaitInterval
-		if errors.Is(err, errNoInitData) || errors.Is(err, errAttestUnavailable) {
+		if errors.Is(err, errAttestVerdict) {
+			verdicts++
+			settling = 0
+		} else if errors.Is(err, errNoInitData) || errors.Is(err, errAttestUnavailable) {
 			settling = 0
 		} else {
 			// kata-agent writes the document in place, so a read that lands

--- a/internal/cmds/policymonitor/initdata_test.go
+++ b/internal/cmds/policymonitor/initdata_test.go
@@ -629,13 +629,12 @@ func TestAwaitInitDataMeasurementsStopsOnUncommittedDocument(t *testing.T) {
 	}
 }
 
-// A refused report is terminal and reaches the operator at Error: the wait
-// stops at the first refusal rather than spending the budget on retries that
-// reproduce it.
+// A refusal that keeps reproducing is terminal and reaches the operator at
+// Error. The budget is two orders of magnitude past the retries so that the
+// bound, not the deadline, is what the call count measures.
 func TestAwaitInitDataMeasurementsStopsOnRefusedReport(t *testing.T) {
 	writeInitData(t, testDocument(t, "aabb"))
-	// A budget that would dominate the test if the refusal were retried.
-	shortInitDataWait(t, time.Minute, 10*time.Second)
+	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
 
 	v := newScriptedVerifier(t, http.StatusUnprocessableEntity, -1)
 	cfg := &Config{AttestationServiceURL: v.url}
@@ -646,14 +645,49 @@ func TestAwaitInitDataMeasurementsStopsOnRefusedReport(t *testing.T) {
 	if cfg.CDSMeasurements != "" {
 		t.Fatalf("CDSMeasurements = %q, want empty so refresh fails closed onto the baked seed", cfg.CDSMeasurements)
 	}
-	if n := v.verifyCalls(); n != 1 {
-		t.Fatalf("verify attempts = %d, want 1: a refusal must not be retried", n)
+	if n, want := v.verifyCalls(), initDataVerdictRetries+1; n != want {
+		t.Fatalf("verify attempts = %d, want %d: the refusal must be bounded", n, want)
 	}
-	if elapsed := time.Since(start); elapsed > 5*time.Second {
-		t.Fatalf("refusal took %s; it must not consume the wait budget", elapsed)
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("refusal took %s; the bound must stop it, not the wait budget", elapsed)
 	}
 	if got := rec.levelOf(t, "refused"); got != slog.LevelError {
 		t.Fatalf("refusal logged at %v, want Error", got)
+	}
+}
+
+// The bug this fixes: policy-monitor self-reports at READY=1, before kata-agent
+// has installed the pod network, so the verifier's VCEK fetch has no resolver
+// and it answers about itself rather than about the evidence. Taking that as a
+// verdict left the guest frozen on its baked seed for the life of the pod, so
+// no operator allowlist entry ever reached it.
+func TestAwaitInitDataMeasurementsOutlastsARefusalTheNetworkCaused(t *testing.T) {
+	raw := testDocument(t, "aabb,ccdd")
+	writeInitData(t, raw)
+	digest := initdata.Digest(raw)
+	shortInitDataWait(t, 5*time.Second, 10*time.Millisecond)
+
+	// Refused while the route is missing, answered once it appears.
+	v := newScriptedVerifier(t, http.StatusUnprocessableEntity, 2)
+	v.attester.SetVerdict(hostDataVerdict(digest[:]))
+
+	cfg := &Config{AttestationServiceURL: v.url}
+	awaitInitDataMeasurements(context.Background(), quietLogger(), cfg)
+
+	if cfg.CDSMeasurements != "aabb,ccdd" {
+		t.Fatalf("CDSMeasurements = %q, want the wait to outlast a refusal the missing network caused", cfg.CDSMeasurements)
+	}
+	if n := v.verifyCalls(); n != 3 {
+		t.Fatalf("verify calls = %d, want 3: two refusals then the answer", n)
+	}
+}
+
+// A refusal is retried, so it delays the refresh posture a would-be deny waits
+// on (monitor.go, refreshState.awaitSettled). The retries have to fit inside
+// that wait or the deny stops seeing a settled answer.
+func TestVerdictRetriesFitTheDenyWait(t *testing.T) {
+	if spent := initDataVerdictRetries * initDataWaitInterval; spent >= refreshSettleBudget {
+		t.Fatalf("verdict retries spend %s, which is not inside refreshSettleBudget %s", spent, refreshSettleBudget)
 	}
 }
 


### PR DESCRIPTION
## The bug

Under `--cvm-mode=pod`, no operator-added allowlist entry ever reaches a kata guest. `c8s allowlist workload apply` succeeds, CDS serves the entry, and the pod is still refused in-guest with `image not allowlisted`. The guest enforces only the ~4 digests baked into `kata-guest-base`, for the life of the pod. It fails 100% of the time, and it fails closed.

`awaitInitDataMeasurements` runs from a goroutine that starts at `READY=1`. Its self-report needs the verifier to fetch VCEK collateral from AMD KDS, so it needs DNS and egress — but kata-agent installs the pod network from a unit systemd orders *behind* this one. That ordering is already documented in this package: `resolveSandboxDigestsHostLate` exists precisely because "the route appears shortly after READY=1", and it retries around it. The self-report did not.

attestation-api answers 4xx for its own inability to reach KDS, `classifyVerifyError` maps that to `errAttestVerdict`, and the wait returned on the first one — abandoning the 90 s budget it had just reserved. `cfg.CDSMeasurements` stays empty, `runAllowlistRefresh` disables itself with `reasonNoMeasurements`, and the guest is frozen on its seed.

From a workload guest's journal, the fix is visible four lines below the bug — `advertise-host inference` hits the same missing network, retries, and recovers on attempt 4:

```
21:28:05  ERROR self-report refused by the verifier   error="… API error (422) … kdsintf.amd.com/vcek/…"
21:28:05  ERROR allowlist refresh disabled; enforcement frozen at the baked seed
21:28:05  WARN  advertise-host inference failed; retrying  attempt=1
          error="… lookup c8s-cds.c8s-system.svc on [::1]:53: connection refused"
21:28:11  INFO  advertise-host inference recovered  attempt=4  host=10.42.0.71
```

## The change

A refusal is re-tried `initDataVerdictRetries` (5) times at `initDataWaitInterval`, and only then taken as a verdict.

Nothing else moves. 422 still classifies as a verdict, the digest-mismatch tamper path keeps its own separate 3 x 100 ms settle grace, `verifiedSelfHostData` is untouched, and every exhausted path still leaves `CDSMeasurements` empty and falls back to the baked seed.

## Timing, since this is the part worth arguing about

A genuine bad-evidence verdict now settles in ~10 s of sleeps rather than ~0 s. That is deliberate and it is bounded on both sides:

- 10 s covers the six-second gap measured on hardware.
- 10 s is inside the 20 s `refreshSettleBudget` a would-be deny waits on (`monitor.go` → `refreshState.awaitSettled`), so a real refusal still settles before the deny path stops waiting for it. `TestVerdictRetriesFitTheDenyWait` pins that relationship rather than leaving it as prose.
- The deny path can only get *slower*, never more permissive: `awaitSettled` reports nothing, and the decision after it is the same `m.admits(rc)` against an additive allowlist.
- A slow verifier produces `errAttestUnavailable` (deadline exceeded), not `errAttestVerdict`, so `initDataTimeout` does not multiply through the retry count.

The verifier is inside the TCB (`127.0.0.1:8400`), so the host cannot mint a verdict at all; its only lever here is egress to KDS, which is the bug rather than a new capability.

## Why this and not the network gate

The obvious alternative is to gate the self-report on network readiness by reusing `resolveSandboxDigestsHostLate`. Rejected: it is a no-op exactly when `SandboxDigestsAdvertiseHost` is set explicitly (that path short-circuits inference), prepending a 90 s wait would overrun the 110 s `signerSettleBudget` that bounds the serial chain — and decisively, it still permanently disables refresh if the verifier blips *after* the network is up.

## Relationship to attestation-rs#84

**Merged.** That PR is the correct fix: a verifier that cannot reach its CA should answer 502, not 4xx, and c8s's `refusesEvidence` already treats 5xx as retryable — so with it, this same loop retries for the full 90 s budget with no c8s change at all.

This PR is still worth having, and merging #84 does not change that. The verifier this call reaches is not the host-side DaemonSet whose digest is pinned in `values.yaml` — it is the `attestation-api` binary baked into kata-guest-base and served on loopback (`kata-guest-base/scripts/fetch.sh`; `values.yaml`: *"in-guest attestation-service is baked into kata-guest-base on loopback"*). So the 502 fix reaches a guest only with a guest-image rebuild, which moves the SNP launch digest every operator has pinned and re-verified. This half needs no rebuild, so it is what makes guests in the field today recover.

Two follow-ups actually deliver #84 into c8s, neither in this PR: bumping `attestationApi.pinnedDigest` (host-side, once an image is published), and a kata-guest-base rebuild with the measurement re-pin that implies (guest-side).

## Tests

- **New:** `TestAwaitInitDataMeasurementsOutlastsARefusalTheNetworkCaused` — refused while the route is missing, answered once it appears, `CDSMeasurements` populated. Verified to fail against the old behaviour.
- **New:** `TestVerdictRetriesFitTheDenyWait` — the budget invariant above.
- **Changed:** `TestAwaitInitDataMeasurementsStopsOnRefusedReport` pinned the old behaviour ("a refusal must not be retried") and now pins the bound. Its budget/interval move to 5 s / 10 ms so the count measures the bound rather than racing the deadline.
- **Unchanged and still passing:** the `TestClassifyVerifyError` rows including 422 → verdict, `TestVerifiedSelfHostDataRejectsAStatusRefusal`, and the tamper path (`StopsOnUncommittedDocument`), which routes through `settling` and not `verdicts`.

`go test ./internal/cmds/policymonitor/... -count=2`, `make lint` and `golangci-lint` clean.

## Acceptance criteria I cannot claim

The reported criteria 1–3 (a non-seed `busybox` pod runs to completion; the guest journal shows measurements taken; CDS logs a `GET /allowlist` from a guest) are bare-metal e2e observations. Neither PR can demonstrate them in CI — they want re-running on hardware before this is called done.

## Noticed while here, not changed

`applyInitDataMeasurements` has no production caller — only tests. It is now a second, divergent copy of this policy ("one read, so every failure is final"). Worth deleting separately.
