### PR TITLE
test(integration): let the excluded-namespace mesh assertion prove protection

### DIFF
--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -598,17 +598,36 @@ case "$rc" in
         ;;
 esac
 
-# A mesh-excluded namespace (kube-system) is not intercepted; its direct dial
-# to the cw pod IP falls through to the FORWARD guard.
+# A mesh-excluded namespace (kube-system) is not intercepted on egress; its
+# direct dial to the cw pod IP is left to the node's inbound chains.
 kubectl run it-mesh-excl -n kube-system --restart=Never --image="$CURL_IMAGE" --command -- sleep 600 >/dev/null
 kubectl wait --for=condition=Ready pod/it-mesh-excl -n kube-system --timeout=120s \
     || fail "excluded-namespace client pod not Ready"
-out="$(kubectl exec -n kube-system it-mesh-excl -- sh -c "curl -s -o /dev/null --max-time 5 http://$POD_IP:80/; echo rc=\$?" || true)"
+# This dial crosses the same nat PREROUTING chains as the VIP case, so it has
+# the same two secure outcomes and the same one insecure outcome. Which of the
+# two secure ones happens is a property of rule ordering, not of the client's
+# namespace, so demanding rc=28 alone fails on a wrapped hop and passes a
+# plaintext one unnoticed (rc=0 proves only "not dropped"). Require the
+# matching counter instead.
+base_drops_excl="$(mesh_metric "$drops")"
+base_inbound_excl="$(mesh_metric "$inbound")"
+out="$(kubectl exec -n kube-system it-mesh-excl -- sh -c "curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://$POD_IP:80/; echo rc=\$?" || true)"
 rc="$(echo "$out" | grep -o 'rc=[0-9]*' | cut -d= -f2)"
-# rc=0 is the insecure outcome, not a slow one: the dial completed, so the cw
-# guard admitted an unmeshed source.
-[ "$rc" = "28" ] || fail "excluded-namespace dial reached the cw workload in plaintext: want curl rc=28 (DROP timeout), got rc=$rc"
-pass "excluded-namespace plaintext bypass dropped by the cw inbound guard"
+case "$rc" in
+    28)
+        await_metric_above "$drops" "${base_drops_excl:-0}" "cw inbound drop counter"
+        pass "excluded-namespace plaintext bypass dropped by the cw inbound guard (counter moved)"
+        ;;
+    0)
+        echo "$out" | grep -q "^200" || fail "excluded-namespace dial rc=0 but no 200: $out"
+        await_metric_above "$inbound" "${base_inbound_excl:-0}" \
+            "excluded-namespace dial returned 200 but the mesh recorded no inbound connection, so the hop reached the cw workload outside the mesh — in plaintext"
+        pass "excluded-namespace dial wrapped by the mesh (inbound counter moved; rule-ordering variant)"
+        ;;
+    *)
+        fail "excluded-namespace bypass to the cw workload: want rc=28 (dropped) or rc=0 (wrapped), got rc=$rc"
+        ;;
+esac
 
 log "tls-lb front door"
 kubectl -n "$NS" exec deploy/c8s-tls-lb -c nginx -- cat /tls/ca.pem > "$WORKDIR/mesh-ca.pem" \


### PR DESCRIPTION
## Review Focus Areas (required)

| File / Area | Focus | Why |
|-------------|-------|-----|
| `test/integration/cluster/run.sh` | Critical | Mesh trust-boundary assertion: decides whether a plaintext hop to a confidential workload fails the run |

## What Changed

The excluded-namespace mesh assertion accepted only `curl rc=28`. It now accepts rc=28 or rc=0 and requires the matching counter to move (`ratls_mesh_iptables_cw_inbound_drops_total` for dropped, `ratls_mesh_connections_total{direction="inbound"}` for wrapped), failing only when neither does. The dial also captures `%{http_code}`, which the previous form discarded.

## Why

Closes confidential-dot-ai/c8s-workspace#170.

The dial from `kube-system` crosses the same `nat PREROUTING` chains as the Service-VIP case two blocks above, so it has the same two secure outcomes. Which one occurs is a property of rule ordering, not of the client's namespace: mesh-first drops (rc=28), kube-proxy-first wraps the hop (rc=0, inbound counter moves). The VIP case documents exactly this and accepts both; the excluded-namespace case demanded one.

That made it wrong in both directions. It failed a run where the hop was securely wrapped, which is the flake observed on #267 ([run 32399548471](https://github.com/confidential-dot-ai/c8s/actions/runs/32399548471/job/96524191314), passing on an identical rerun). More importantly it checked no counter at all, so it could only ever prove "not dropped" — a genuine plaintext bypass and a benign wrapped hop both produce rc=0, and the assertion passed both. The flake was the visible symptom of an assertion that could not distinguish the secure outcome from the insecure one.

The comment above the block also asserted that rc=0 is the insecure outcome, which the evidence disproves; it now describes both secure paths.

Worth confirming separately, and not settled here: whether an unmeshed-namespace dial should be interceptable at all. If interception is meant to be scoped to meshed namespaces, then rc=0-with-inbound-counter is a `ratlsmesh` rule-scoping finding rather than a benign variant, and this test should reject it — for a reason it would then state and check. That question is tracked on the issue.

## Design Doc

N/A

## Checklist

- [x] New dependencies justified (if any) — none
- [x] Tests verify invariants, not just output format — the point of the change: the assertion now checks the invariant (traffic was dropped or wrapped, never plaintext) instead of a single return code that proved neither
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: reproducible build maintained — n/a, test-only
- [x] For crypto code: constant-time, zeroization, audited libraries only — n/a
