### PR TITLE
fix(ci): stop the coverage gate failing on measurement noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,9 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: base-total.txt
-          key: coverage-total-${{ github.sha }}
+          # -v2: entries below carry a one-decimal total, which the gate no
+          # longer compares against.
+          key: coverage-total-v2-${{ github.sha }}
 
       - name: Restore baseline total
         if: github.event_name == 'pull_request'
@@ -295,7 +297,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: base-total.txt
-          key: coverage-total-${{ github.event.pull_request.base.sha }}
+          key: coverage-total-v2-${{ github.event.pull_request.base.sha }}
 
       # Fallback when the base commit's total is not cached (e.g. cache
       # evicted, or main's coverage run predates this workflow).
@@ -319,9 +321,18 @@ jobs:
           head=$(./scripts/coverage-gate.sh total head.out)
           base=$(cat base-total.txt)
           echo "total coverage: base=${base}% head=${head}%"
+          # Tests exercising retries, timeouts and concurrent paths cover
+          # slightly different statements run to run, so the total wanders.
+          # Across 18 consecutive PR runs it moved within a ~0.2pp band, in
+          # both directions, including on PRs touching no Go at all: below
+          # that, the gate fails on noise. 0.25 is the smallest value clearing
+          # the band, and it is a real blind spot, roughly 80 statements on
+          # this tree. Shrinking it means making the measurement deterministic
+          # (fake clocks, seeded RNG in the offending packages), not lowering
+          # the number, which only restores the false failures.
           awk -v h="$head" -v b="$base" 'BEGIN {
-            if (h + 0.05 < b) {
-              printf "coverage gate: total coverage decreased (%.1f%% -> %.1f%%)\n", b, h
+            if (h + 0.25 < b) {
+              printf "coverage gate: total coverage decreased (%.2f%% -> %.2f%%)\n", b, h
               exit 1
             }
           }'

--- a/scripts/coverage-gate.sh
+++ b/scripts/coverage-gate.sh
@@ -3,7 +3,7 @@
 #
 # Usage:
 #   scripts/coverage-gate.sh run [profile]        run tests, write coverage profile
-#   scripts/coverage-gate.sh total <profile>      print total coverage (e.g. "67.9")
+#   scripts/coverage-gate.sh total <profile>      print total coverage (e.g. "67.94")
 #
 # The profile is produced with -coverpkg=./... so packages without their own
 # test files are still measured (a brand-new untested package counts as 0%,
@@ -28,7 +28,9 @@ percent() { # per-package coverage table from a coverprofile: "<pct> <stmts> <pk
         T+=stmts[k]; if (covered[k]) C+=stmts[k];
       }
       for (p in tot) printf "%.1f %d %s\n", 100*cov[p]/tot[p], tot[p], p;
-      printf "%.1f %d TOTAL\n", (T ? 100*C/T : 0), T;
+      # Two decimals: the gate compares this against a tolerance, and at one
+      # decimal the smallest representable drop already exceeded it.
+      printf "%.2f %d TOTAL\n", (T ? 100*C/T : 0), T;
     }' "$1"
 }
 


### PR DESCRIPTION
## Review Focus Areas (required)

| File / Area | Focus | Why |
|-------------|-------|-----|
| `.github/workflows/ci.yml` | Standard | Loosens a merge gate: the tolerance change is the reviewable decision |
| `scripts/coverage-gate.sh` | Light | Output precision only |

## What Changed

The total is emitted at two decimals instead of one, and the non-decreasing check compares against a 0.25pp tolerance instead of 0.05. The baseline cache key is bumped to `-v2`, since existing entries hold one-decimal totals.

## Why

Two defects, one of them making the tolerance dead code.

**The tolerance never applied.** `coverage-gate.sh total` rounds to one decimal (`printf "%.1f"`), so the smallest representable non-zero drop is 0.1. The gate's epsilon was 0.05, half the rounding quantum. Any drop that survived rounding was already ≥ 0.1 and failed; anything smaller was invisible. The 0.05 read as slack but provided none.

**Coverage is not deterministic here.** Tests exercising retries, timeouts and concurrent paths cover slightly different statements run to run. Sampling the `total coverage:` line from 18 consecutive PR runs, the total wanders in a ~0.2pp band **in both directions**:

```
32503313978  base=90.0% head=90.0%
32463644004  base=90.0% head=89.9%   <- failed
32430680441  base=89.9% head=90.0%   <- "increased"
32417730984  base=90.0% head=89.9%   <- failed
32406054362  base=89.9% head=89.8%   <- failed
32415982785  base=89.9% head=90.0%   <- "increased"
```

Three of those failures are noise. Run 32463644004 is the clearest case: that PR (#467) changes **one shell file and zero Go files**, so base and head measured an identical Go tree and still differed by 0.1pp. It is also not a stale cached baseline — the job's step list shows `Checkout base branch` and `Measure base coverage` both ran, so both numbers came from the same job, same runner, same command.

0.25 is the smallest tolerance clearing the observed band. Verified against the sampled data: every noise case above passes, `90.00 -> 89.74` still fails, `90.00 -> 89.75` passes.

**The tolerance is a real blind spot, not free.** At ~33k statements, 0.25pp is roughly 80 statements that can go uncovered without tripping the gate. That is the honest cost of a nondeterministic measurement. The way to shrink it is to make the measurement deterministic — fake clocks and seeded RNG in the packages that wander — not to lower the number, which only restores the false failures. Noted in the comment so the next person doesn't "tighten" it back into flakiness.

## Design Doc

N/A

## Checklist

- [x] New dependencies justified (if any) — none
- [x] Tests verify invariants, not just output format — the gate's invariant is "coverage did not regress"; it previously fired on measurement noise, testing the sampler rather than the tree
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: reproducible build maintained — n/a, CI-only
- [x] For crypto code: constant-time, zeroization, audited libraries only — n/a
