### PR TITLE
fix(ratls-mesh): drop the DNS carve-out's destination scope

### DIFF
--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -822,18 +822,15 @@ theater), and CDS and tls-lb run in their own kata CVMs.
   Guests bake `C8S_MESH_INBOUND_PASSTHROUGH=tcp:8443` so the CDS/tls-lb
   front doors can accept certless external clients — inbound :8443 is
   unmeshed in every guest.
-- **Cluster DNS carve-out is a shared invariant.** The egress guards scope
-  UDP/53 to the cluster DNS server. The host takes it from the chart
-  (`ratlsMesh.clusterDNSIP` → `--cluster-dns-ip`); the guest reads
-  `C8S_CLUSTER_DNS_IP` baked in kata-guest-base. Set both to the same value
-  or one side drops the other's DNS; the c8s default is 10.53.0.10 on both,
-  which is the c8s node image's `cluster-dns` — stock RKE2 uses 10.43.0.10
-  and kubeadm 10.96.0.10, so a cluster off that image must set it. The host
-  logs a warning naming the mismatch when the configured server is not one
-  its own pod resolver lists. The host guard hangs off `FORWARD`, downstream
-  of kube-proxy's Service DNAT, so it carves out both the packet's
-  destination and the connection's original one — whichever survives on the
-  cluster's dataplane.
+- **DNS.** The egress guards carve out UDP/53 to any destination, on the
+  host and in the guest alike. A resolver sits outside the guest's trust
+  boundary whatever its address, so its answers are untrusted input: they
+  select which endpoint a workload dials, and the RA-TLS handshake at that
+  endpoint is what authenticates the peer. A host that swaps, forges or
+  drops a DNS answer redirects or denies a connection it cannot read, which
+  it can do at the network layer regardless. The carve-out is scoped to the
+  cw pod ipset and to UDP/53; every other non-TCP from a cw pod still
+  drops.
 
 ## Which certificate is used where
 

--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -48,7 +48,6 @@ const (
 	envPlatform              = "C8S_PLATFORM"
 	envPodIP                 = "C8S_POD_IP"
 	envInboundPassthrough    = "C8S_MESH_INBOUND_PASSTHROUGH"
-	envClusterDNSIP          = "C8S_CLUSTER_DNS_IP"
 )
 
 // defaultInGuestAttestationServiceURL is the loopback URL the in-guest
@@ -74,10 +73,6 @@ type inGuestConfig struct {
 	meshMeasurements      string
 	podIP                 string
 	inboundPassthrough    string
-	// clusterDNSIP is the cluster DNS (CoreDNS) server IP the in-guest egress
-	// guard's DNS carve-out is scoped to; set via C8S_CLUSTER_DNS_IP and must
-	// match the host's --cluster-dns-ip.
-	clusterDNSIP string
 
 	// Parsed from inboundPassthrough by validate().
 	inboundPassthroughPorts []int
@@ -99,7 +94,6 @@ func defaultInGuestConfig() inGuestConfig {
 	return inGuestConfig{
 		platform:           "sev-snp",
 		logLevel:           "info",
-		clusterDNSIP:       clusterDNSClusterIP,
 		certTTL:            24 * time.Hour,
 		rotationTimeout:    30 * time.Second,
 		dialTimeout:        5 * time.Second,
@@ -136,11 +130,6 @@ func loadInGuestConfig(env func(string) string) inGuestConfig {
 	c.meshMeasurements = env(envMeshMeasurements)
 	c.podIP = env(envPodIP)
 	c.inboundPassthrough = env(envInboundPassthrough)
-	if v := env(envClusterDNSIP); v != "" {
-		c.clusterDNSIP = v
-	} else {
-		c.clusterDNSIP = clusterDNSClusterIP
-	}
 	return c
 }
 
@@ -165,9 +154,6 @@ func (c *inGuestConfig) validate() error {
 		return fmt.Errorf("%s: %w", envInboundPassthrough, err)
 	}
 	c.inboundPassthroughPorts = ports
-	if net.ParseIP(c.clusterDNSIP) == nil {
-		return fmt.Errorf("%s %q is not a valid IP address", envClusterDNSIP, c.clusterDNSIP)
-	}
 	return validateConfig(c.attestationServiceURL, inGuestOutboundPort, inGuestInboundPort, inGuestHealthPort, c.certTTL)
 }
 
@@ -291,7 +277,7 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 	// Install iptables redirects first. A failure here is non-recoverable:
 	// the proxy would otherwise come up but the workload's traffic would
 	// silently bypass the mesh — a worse failure mode than crashing.
-	if err := setupInGuestIptables(logger, podIP, c.inboundPassthroughPorts, c.clusterDNSIP); err != nil {
+	if err := setupInGuestIptables(logger, podIP, c.inboundPassthroughPorts); err != nil {
 		return fmt.Errorf("in-guest iptables setup: %w", err)
 	}
 
@@ -715,12 +701,12 @@ same end state.`,
 // Returns an error on the first failure; the caller exits non-zero.
 // Idempotent: installIptablesRules flushes the managed chains first so
 // a crash-restart does not double-install rules.
-func setupInGuestIptables(logger *slog.Logger, podIP string, inboundPassthroughPorts []int, clusterDNSIP string) error {
+func setupInGuestIptables(logger *slog.Logger, podIP string, inboundPassthroughPorts []int) error {
 	if err := initIptablesClients(); err != nil {
 		return err
 	}
 	rules := buildInGuestIptablesRules(inGuestOutboundPort, inGuestInboundPort, inGuestHealthPort, inboundPassthroughPorts)
-	rules = append(rules, buildInGuestFailClosedRules(clusterDNSIP)...)
+	rules = append(rules, buildInGuestFailClosedRules()...)
 	jumps := jumpRules()
 	jumps = append(jumps, guestFilterJumps()...)
 	logger.Info("installing in-guest iptables redirects",
@@ -858,18 +844,14 @@ func buildInGuestIptablesRules(outboundPort, inboundPort, healthPort int, inboun
 // non-TCP the NAT redirects do not carry: the mesh terminates TCP only, so
 // these rules make the guest fail closed on the UDP/ICMP/SCTP that would
 // otherwise egress or enter plaintext. The exemptions are loopback (intra-VM
-// IPC), UDP/53 to the cluster DNS server (host and the DNS reply), TCP
-// ESTABLISHED/RELATED replies on INPUT, and the ICMPv6 types IPv6 needs. The
-// guest enforces this locally so it does not depend on an external node.
-func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
-	// The guest runs no kube-proxy, so its nat table holds only the mesh's own
-	// TCP redirects and a query still carries the DNS server address on OUTPUT.
-	// The carve-out is installed in the client that owns that address; the
-	// drop below is family-agnostic, so tagging it wrong drops the guest's DNS.
-	dnsFamily := iptablesFamilyIPv4
-	if ip := net.ParseIP(dnsServerIP); ip != nil && ip.To4() == nil {
-		dnsFamily = iptablesFamilyIPv6
-	}
+// IPC), UDP/53 (the query and its reply), TCP ESTABLISHED/RELATED replies on
+// INPUT, and the ICMPv6 types IPv6 needs. The guest enforces this locally so
+// it does not depend on an external node.
+//
+// The UDP/53 carve-out names no destination. A resolver is outside the guest's
+// trust boundary whatever its address, so an answer is untrusted input that
+// authenticated peers do not rely on; see docs/ratls.md, "DNS".
+func buildInGuestFailClosedRules() []iptablesRule {
 	rules := []iptablesRule{
 		iptablesRule{
 			table: "filter", chain: guestFilterOutputChain,
@@ -878,9 +860,8 @@ func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
 		},
 		iptablesRule{
 			table: "filter", chain: guestFilterOutputChain,
-			label:  "in-guest-output-return-dns",
-			family: dnsFamily,
-			args:   []string{"-p", "udp", "--dport", "53", "-d", dnsServerIP, "-j", "RETURN"},
+			label: "in-guest-output-return-dns",
+			args:  []string{"-p", "udp", "--dport", "53", "-j", "RETURN"},
 		},
 	}
 	// In-guest chains are installed per family; tag the ICMPv6 Allows so they
@@ -911,9 +892,8 @@ func buildInGuestFailClosedRules(dnsServerIP string) []iptablesRule {
 		},
 		iptablesRule{
 			table: "filter", chain: guestFilterInputChain,
-			label:  "in-guest-input-return-dns-reply",
-			family: dnsFamily,
-			args:   []string{"-p", "udp", "--sport", "53", "-s", dnsServerIP, "-j", "RETURN"},
+			label: "in-guest-input-return-dns-reply",
+			args:  []string{"-p", "udp", "--sport", "53", "-j", "RETURN"},
 		},
 	)
 	for _, t := range essentialICMPv6Types {

--- a/internal/cmds/ratlsmesh/in_guest_linux_test.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux_test.go
@@ -37,7 +37,6 @@ func TestLoadInGuestConfigPopulatesFromEnv(t *testing.T) {
 		envCDSMeasurements:       "aa,bb",
 		envMeshMeasurements:      "cc",
 		envPodIP:                 "10.0.0.5",
-		envClusterDNSIP:          "fd53::a",
 	}
 	c := loadInGuestConfig(func(k string) string { return envs[k] })
 	if c.workloadID != "alice" {
@@ -55,9 +54,6 @@ func TestLoadInGuestConfigPopulatesFromEnv(t *testing.T) {
 	if c.podIP != "10.0.0.5" {
 		t.Errorf("podIP = %q", c.podIP)
 	}
-	if c.clusterDNSIP != "fd53::a" {
-		t.Errorf("clusterDNSIP = %q, want the env override", c.clusterDNSIP)
-	}
 }
 
 func TestInGuestConfigValidate(t *testing.T) {
@@ -72,20 +68,8 @@ func TestInGuestConfigValidate(t *testing.T) {
 				workloadID:            "alice",
 				cdsURL:                "https://cds:8443",
 				attestationServiceURL: "http://127.0.0.1:8400",
-				clusterDNSIP:          clusterDNSClusterIP,
 				certTTL:               24 * time.Hour,
 			},
-		},
-		{
-			name: "bad cluster DNS IP",
-			cfg: inGuestConfig{
-				workloadID:            "alice",
-				cdsURL:                "https://cds:8443",
-				attestationServiceURL: "http://127.0.0.1:8400",
-				clusterDNSIP:          "not-an-ip",
-				certTTL:               24 * time.Hour,
-			},
-			wantErr: envClusterDNSIP,
 		},
 		{
 			name: "missing workload id",
@@ -280,12 +264,11 @@ func containsArg(args []string, want string) bool {
 }
 
 // The in-guest filter fail-closed rules drop non-TCP the NAT redirects do
-// not carry, exempting loopback (intra-VM IPC), UDP/53 restricted to the
-// cluster DNS server, and the ICMPv6 types IPv6 needs. The guest enforces
-// this locally so it does not depend on an external node.
+// not carry, exempting loopback (intra-VM IPC), UDP/53 to any destination,
+// and the ICMPv6 types IPv6 needs. The guest enforces this locally so it does
+// not depend on an external node.
 func TestBuildInGuestFailClosedRulesGolden(t *testing.T) {
-	const dnsIP = "10.53.0.10"
-	rules := buildInGuestFailClosedRules(dnsIP)
+	rules := buildInGuestFailClosedRules()
 	// OUTPUT: lo return, dns return, 14 icmpv6 returns, drop = 17.
 	// INPUT: established, lo, dns reply, 14 icmpv6 returns, drop = 18.
 	if len(rules) != 17+18 {
@@ -294,18 +277,17 @@ func TestBuildInGuestFailClosedRulesGolden(t *testing.T) {
 	out := rules[0:17]
 	in := rules[17:35]
 
-	// OUTPUT order: loopback, DNS (family ipv4, -d), icmpv6 (ipv6), drop.
+	// OUTPUT order: loopback, DNS (both families), icmpv6 (ipv6), drop.
 	if out[0].chain != guestFilterOutputChain || out[0].table != "filter" {
 		t.Errorf("OUTPUT[0]: got %s/%s, want filter/%s", out[0].table, out[0].chain, guestFilterOutputChain)
 	}
 	assertContains(t, "out lo", out[0].args, "-o", "lo")
 	assertContains(t, "out lo", out[0].args, "-j", "RETURN")
-	if out[1].family != iptablesFamilyIPv4 {
-		t.Errorf("OUTPUT dns rule family=%q, want ipv4 (ClusterIP is v4)", out[1].family)
+	if out[1].family != iptablesFamilyAll {
+		t.Errorf("OUTPUT dns rule family=%q, want both families", out[1].family)
 	}
 	assertContains(t, "out dns", out[1].args, "-p", "udp")
 	assertContains(t, "out dns", out[1].args, "--dport", "53")
-	assertContains(t, "out dns", out[1].args, "-d", dnsIP)
 	assertContains(t, "out dns", out[1].args, "-j", "RETURN")
 	for ti, want := range essentialICMPv6Types {
 		r := out[2+ti]
@@ -318,7 +300,7 @@ func TestBuildInGuestFailClosedRulesGolden(t *testing.T) {
 	}
 	assertNontcpDrop(t, "OUTPUT", out[len(out)-1])
 
-	// INPUT order: established, loopback, dns reply (ipv4, -s), icmpv6, drop.
+	// INPUT order: established, loopback, dns reply (both families), icmpv6, drop.
 	if in[0].chain != guestFilterInputChain || in[0].table != "filter" {
 		t.Errorf("INPUT[0]: got %s/%s, want filter/%s", in[0].table, in[0].chain, guestFilterInputChain)
 	}
@@ -327,12 +309,11 @@ func TestBuildInGuestFailClosedRulesGolden(t *testing.T) {
 	assertContains(t, "in est", in[0].args, "-j", "RETURN")
 	assertContains(t, "in lo", in[1].args, "-i", "lo")
 	assertContains(t, "in lo", in[1].args, "-j", "RETURN")
-	if in[2].family != iptablesFamilyIPv4 {
-		t.Errorf("INPUT dns reply rule family=%q, want ipv4", in[2].family)
+	if in[2].family != iptablesFamilyAll {
+		t.Errorf("INPUT dns reply rule family=%q, want both families", in[2].family)
 	}
 	assertContains(t, "in dns reply", in[2].args, "-p", "udp")
 	assertContains(t, "in dns reply", in[2].args, "--sport", "53")
-	assertContains(t, "in dns reply", in[2].args, "-s", dnsIP)
 	assertContains(t, "in dns reply", in[2].args, "-j", "RETURN")
 	for ti, want := range essentialICMPv6Types {
 		r := in[3+ti]
@@ -643,31 +624,28 @@ func TestRunInGuestConfigErrors(t *testing.T) {
 	})
 }
 
-// The guest's non-TCP drop is family-agnostic while the DNS carve-out is
-// installed in one client, so an IPv6 cluster DNS whose carve-out is tagged
-// IPv4 loses the guest's own name resolution.
-func TestBuildInGuestFailClosedRulesTagsDNSByFamily(t *testing.T) {
-	dnsRules := func(t *testing.T, dnsIP string) []iptablesRule {
-		t.Helper()
-		var got []iptablesRule
-		for _, r := range buildInGuestFailClosedRules(dnsIP) {
-			if strings.Contains(r.label, "dns") {
-				got = append(got, r)
+// The guest carve-out names no resolver address and is installed in both
+// clients, so it holds on a cluster whose DNS sits at any address and in
+// either family. A destination or source scope here would drop the guest's
+// own name resolution wherever the resolver does not match.
+func TestBuildInGuestFailClosedRulesDNSNamesNoAddress(t *testing.T) {
+	var dns []iptablesRule
+	for _, r := range buildInGuestFailClosedRules() {
+		if strings.Contains(r.label, "dns") {
+			dns = append(dns, r)
+		}
+	}
+	if len(dns) != 2 {
+		t.Fatalf("got %d dns rules, want the OUTPUT query and the INPUT reply", len(dns))
+	}
+	for _, r := range dns {
+		if r.family != iptablesFamilyAll {
+			t.Errorf("%s family = %q, want both families", r.label, r.family)
+		}
+		for _, scope := range []string{"-d", "-s", "--ctorigdst"} {
+			if slices.Contains(r.args, scope) {
+				t.Errorf("%s is scoped by %s (%v); the carve-out must name no address", r.label, scope, r.args)
 			}
-		}
-		if len(got) != 2 {
-			t.Fatalf("%s: got %d dns rules, want the OUTPUT query and the INPUT reply", dnsIP, len(got))
-		}
-		return got
-	}
-	for _, r := range dnsRules(t, "10.53.0.10") {
-		if r.family != iptablesFamilyIPv4 {
-			t.Errorf("%s family = %q, want ipv4", r.label, r.family)
-		}
-	}
-	for _, r := range dnsRules(t, "fd00::10") {
-		if r.family != iptablesFamilyIPv6 {
-			t.Errorf("%s family = %q, want ipv6", r.label, r.family)
 		}
 	}
 }

--- a/internal/cmds/ratlsmesh/iptables.go
+++ b/internal/cmds/ratlsmesh/iptables.go
@@ -62,14 +62,6 @@ var managedIPSetNames = []string{
 	cwPodIPSetName4, cwPodIPSetName6,
 }
 
-// clusterDNSClusterIP is the cluster DNS Service ClusterIP the DNS carve-out
-// is destination-scoped to. The c8s node guest image sets cluster-dns
-// 10.53.0.10 (rke2 config.yaml); stock RKE2 uses 10.43.0.10 and kubeadm
-// 10.96.0.10, so a cluster off the c8s node image needs --cluster-dns-ip.
-// The scope makes the cluster resolver the only non-TCP destination a cw pod
-// can reach; queries it forwards upstream are the resolver's to police.
-const clusterDNSClusterIP = "10.53.0.10"
-
 // essentialICMPv6Types are the ICMPv6 types IPv6 needs to operate (RFC 4890):
 // 1-4 error/PMTU reporting, 128/129 echo, 130-132 Multicast Listener, 133-137
 // NDP (RS/RA/NS/NA) and redirect. The fail-closed egress guards RETURN these
@@ -437,22 +429,14 @@ func buildCWGuardRules(passthrough []cwPassthrough) []iptablesRule {
 // buildCWEgressGuardRules computes the filter-table rules that fail closed
 // on egress from confidential-workload pods: the mesh redirects TCP only, so
 // these rules drop every non-TCP from a cw pod, exempting established TCP
-// replies, UDP/53 queries to the cluster DNS server(s), and the ICMPv6 types
-// IPv6 needs. dnsIPs maps each family to the cluster DNS server IP(s) the DNS
-// carve-out is restricted to. TCP egress never reaches this chain: pod-
-// destination TCP is intercepted in PREROUTING and non-pod TCP is out of
-// scope here.
+// replies, UDP/53 queries, and the ICMPv6 types IPv6 needs. TCP egress never
+// reaches this chain: pod-destination TCP is intercepted in PREROUTING and
+// non-pod TCP is out of scope here.
 //
-// INVARIANT: the DNS carve-out is emitted twice per server, once against the
-// packet's destination and once against the connection's original one. This
-// chain hangs off FORWARD, which kube-proxy's nat/PREROUTING DNAT precedes: by
-// then a query to the DNS ClusterIP carries a CoreDNS pod IP and -d matches
-// nothing, while the conntrack original tuple still holds the ClusterIP. Where
-// the flow is untracked, or the dataplane translates the Service outside
-// netfilter, the reverse holds and -d is the row that fires. Both carry the
-// same destination scope, so whichever matches admits the same traffic: the
-// only non-TCP destination a cw pod may reach is the named resolver.
-func buildCWEgressGuardRules(dnsIPs map[iptablesFamily][]string) []iptablesRule {
+// The UDP/53 carve-out names no destination. A resolver is outside the guest's
+// trust boundary whatever its address, so an answer is untrusted input that
+// authenticated peers do not rely on; see docs/ratls.md, "DNS".
+func buildCWEgressGuardRules() []iptablesRule {
 	var rules []iptablesRule
 	for _, spec := range []struct {
 		family  iptablesFamily
@@ -473,24 +457,17 @@ func buildCWEgressGuardRules(dnsIPs map[iptablesFamily][]string) []iptablesRule 
 				"-j", "RETURN",
 			},
 		})
-		for _, ip := range dnsIPs[spec.family] {
-			for _, scope := range [][]string{
-				{"-m", "conntrack", "--ctorigdst", ip},
-				{"-d", ip},
-			} {
-				rules = append(rules, iptablesRule{
-					table:  "filter",
-					chain:  cwEgressChainName,
-					label:  "cw-egress-dns-query",
-					family: spec.family,
-					args: slices.Concat(
-						[]string{"-m", "set", "--match-set", spec.setName, "src", "-p", "udp", "--dport", "53"},
-						scope,
-						[]string{"-j", "RETURN"},
-					),
-				})
-			}
-		}
+		rules = append(rules, iptablesRule{
+			table:  "filter",
+			chain:  cwEgressChainName,
+			label:  "cw-egress-dns-query",
+			family: spec.family,
+			args: []string{
+				"-m", "set", "--match-set", spec.setName, "src",
+				"-p", "udp", "--dport", "53",
+				"-j", "RETURN",
+			},
+		})
 		if spec.family == iptablesFamilyIPv6 {
 			for _, t := range essentialICMPv6Types {
 				rules = append(rules, iptablesRule{

--- a/internal/cmds/ratlsmesh/iptables_sync_run_test.go
+++ b/internal/cmds/ratlsmesh/iptables_sync_run_test.go
@@ -3,12 +3,8 @@
 package ratlsmesh
 
 import (
-	"bytes"
 	"context"
-	"log/slog"
 	"net"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -48,7 +44,6 @@ func defaultTestSyncConfig() *iptablesSyncConfig {
 		watchdogPeriod:          2 * time.Second,
 		ipsetMaxElem:            defaultIPSetMaxElem,
 		cwInboundPassthrough:    formatCWPassthrough(defaultCWPassthrough),
-		clusterDNSIPs:           []string{clusterDNSClusterIP},
 		logLevel:                "error",
 	}
 }
@@ -220,22 +215,6 @@ func TestSelectMissingFamilyNodeIPsRejectsAggregate(t *testing.T) {
 	}
 }
 
-func TestClusterDNSIPsByFamily(t *testing.T) {
-	byFam, err := clusterDNSIPsByFamily([]string{"10.53.0.10", "fd00::10"})
-	if err != nil {
-		t.Fatalf("clusterDNSIPsByFamily: %v", err)
-	}
-	if got := byFam[iptablesFamilyIPv4]; len(got) != 1 || got[0] != "10.53.0.10" {
-		t.Errorf("v4 group = %v, want [10.53.0.10]", got)
-	}
-	if got := byFam[iptablesFamilyIPv6]; len(got) != 1 || got[0] != "fd00::10" {
-		t.Errorf("v6 group = %v, want [fd00::10]", got)
-	}
-	if _, err := clusterDNSIPsByFamily([]string{"not-an-ip"}); err == nil {
-		t.Error("malformed IP: want an error so the egress carve-out fails closed")
-	}
-}
-
 // A link-local-only family presence is not a host address: the selector must
 // skip it and report the family as genuinely absent (single-stack), not error.
 func TestSelectMissingFamilyNodeIPsSkipsLinkLocal(t *testing.T) {
@@ -267,48 +246,5 @@ func TestDiscoverMissingFamilyNodeIPsRealHostSmoke(t *testing.T) {
 	}
 	if _, ok := got[iptablesFamilyIPv4]; ok {
 		t.Errorf("discover returned IPv4 %q even though it was provided", got[iptablesFamilyIPv4])
-	}
-}
-
-// The shipped carve-out default is the c8s node image's cluster-dns, so on any
-// other distribution it names a server no pod resolves against — a cluster-wide
-// cw DNS outage whose only symptom is a drop counter. resolv.conf is read to
-// contradict a wrong value, never to supply one.
-func TestWarnUnlessClusterDNSResolves(t *testing.T) {
-	write := func(t *testing.T, body string) string {
-		t.Helper()
-		path := filepath.Join(t.TempDir(), "resolv.conf")
-		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-			t.Fatalf("write resolv.conf: %v", err)
-		}
-		return path
-	}
-	warnings := func(t *testing.T, configured []string, path string) string {
-		t.Helper()
-		var buf bytes.Buffer
-		warnUnlessClusterDNSResolves(slog.New(slog.NewJSONHandler(&buf, nil)), configured, path)
-		return buf.String()
-	}
-
-	pod := write(t, "search demo.svc.cluster.local svc.cluster.local\nnameserver 10.43.0.10\n")
-	if got := warnings(t, []string{"10.53.0.10"}, pod); !strings.Contains(got, "10.53.0.10") {
-		t.Errorf("a carve-out naming a server the node does not resolve against went unreported: %q", got)
-	}
-	if got := warnings(t, []string{"10.43.0.10"}, pod); got != "" {
-		t.Errorf("matching server warned anyway: %q", got)
-	}
-
-	// Dual-stack: each configured server is judged on its own.
-	dual := write(t, "nameserver 10.43.0.10\nnameserver fd00::a\n")
-	if got := warnings(t, []string{"10.43.0.10", "fd00::a"}, dual); got != "" {
-		t.Errorf("both configured servers are listed, yet one warned: %q", got)
-	}
-
-	// A resolv.conf with nothing to compare against says nothing either way.
-	if got := warnings(t, []string{"10.53.0.10"}, write(t, "search cluster.local\n")); got != "" {
-		t.Errorf("nameserver-less resolv.conf produced a mismatch claim: %q", got)
-	}
-	if got := warnings(t, []string{"10.53.0.10"}, filepath.Join(t.TempDir(), "absent")); !strings.Contains(got, "cannot check") {
-		t.Errorf("unreadable resolv.conf went unreported: %q", got)
 	}
 }

--- a/internal/cmds/ratlsmesh/iptables_test.go
+++ b/internal/cmds/ratlsmesh/iptables_test.go
@@ -322,36 +322,31 @@ func TestBuildCWGuardRulesEmptyPassthroughIsStrict(t *testing.T) {
 }
 
 // The egress guard drops non-TCP from cw pod source IPs (the mesh carries
-// TCP only), exempting established TCP replies, DNS queries restricted to the
-// cluster DNS server(s), and the ICMPv6 types IPv6 needs. Golden test
-// asserting the exact rules for both families.
+// TCP only), exempting established TCP replies, UDP/53 queries to any
+// destination, and the ICMPv6 types IPv6 needs. Golden test asserting the
+// exact rules for both families.
 func TestBuildCWEgressGuardRulesGolden(t *testing.T) {
-	dns := map[iptablesFamily][]string{
-		iptablesFamilyIPv4: {"10.53.0.10"},
-		iptablesFamilyIPv6: {"fd00::10"},
-	}
-	rules := buildCWEgressGuardRules(dns)
+	rules := buildCWEgressGuardRules()
 	specs := []struct {
 		family  iptablesFamily
 		setName string
-		dnsIP   string
 	}{
-		{iptablesFamilyIPv4, cwPodIPSetName4, "10.53.0.10"},
-		{iptablesFamilyIPv6, cwPodIPSetName6, "fd00::10"},
+		{iptablesFamilyIPv4, cwPodIPSetName4},
+		{iptablesFamilyIPv6, cwPodIPSetName6},
 	}
-	// Per family: established RETURN, 2 DNS RETURNs (one per destination
-	// scope), [14 ICMPv6 RETURN for v6], nontcp DROP. v4 = 5, v6 = 5 + 14.
+	// Per family: established RETURN, DNS RETURN, [14 ICMPv6 RETURN for v6],
+	// nontcp DROP. v4 = 3, v6 = 3 + 14.
 	var offset int
 	for _, spec := range specs {
 		icmpCount := 0
 		if spec.family == iptablesFamilyIPv6 {
 			icmpCount = len(essentialICMPv6Types)
 		}
-		perFamily := 4 + icmpCount // est, dns x 2, icmpv6 x N, drop
+		perFamily := 3 + icmpCount // est, dns, icmpv6 x N, drop
 		group := rules[offset : offset+perFamily]
 		offset += perFamily
-		est, dnsCt, dnsDst, drop := group[0], group[1], group[2], group[perFamily-1]
-		for _, r := range []iptablesRule{est, dnsCt, dnsDst, drop} {
+		est, dns, drop := group[0], group[1], group[perFamily-1]
+		for _, r := range []iptablesRule{est, dns, drop} {
 			if r.table != "filter" || r.chain != cwEgressChainName {
 				t.Errorf("%s: table=%q chain=%q, want filter/%s", spec.family, r.table, r.chain, cwEgressChainName)
 			}
@@ -374,33 +369,20 @@ func TestBuildCWEgressGuardRulesGolden(t *testing.T) {
 		if !reflect.DeepEqual(est.args, wantEst) {
 			t.Errorf("%s established return = %v, want %v", spec.family, est.args, wantEst)
 		}
-		// The carve-out keeps the cluster resolver as the only non-TCP
-		// destination a cw pod can reach. It is written against both the
-		// connection's original destination and the packet's: this chain runs
-		// after kube-proxy's DNAT, where only the former survives, and on an
-		// untracked flow only the latter matches.
-		wantCt := []string{
+		// The carve-out names no destination, so it survives kube-proxy's
+		// Service DNAT and holds whatever address the cluster resolver has.
+		wantDNS := []string{
 			"-m", "set", "--match-set", spec.setName, "src",
 			"-p", "udp", "--dport", "53",
-			"-m", "conntrack", "--ctorigdst", spec.dnsIP,
 			"-j", "RETURN",
 		}
-		if !reflect.DeepEqual(dnsCt.args, wantCt) {
-			t.Errorf("%s dns query (original dest) = %v, want %v", spec.family, dnsCt.args, wantCt)
-		}
-		wantDst := []string{
-			"-m", "set", "--match-set", spec.setName, "src",
-			"-p", "udp", "--dport", "53",
-			"-d", spec.dnsIP,
-			"-j", "RETURN",
-		}
-		if !reflect.DeepEqual(dnsDst.args, wantDst) {
-			t.Errorf("%s dns query (packet dest) = %v, want %v", spec.family, dnsDst.args, wantDst)
+		if !reflect.DeepEqual(dns.args, wantDNS) {
+			t.Errorf("%s dns query = %v, want %v", spec.family, dns.args, wantDNS)
 		}
 		// ICMPv6 allow rules (v6 only) must cover every essential type.
 		if spec.family == iptablesFamilyIPv6 {
 			for ti, wantType := range essentialICMPv6Types {
-				r := group[3+ti]
+				r := group[2+ti]
 				want := []string{
 					"-m", "set", "--match-set", spec.setName, "src",
 					"-p", "ipv6-icmp", "--icmpv6-type", strconv.Itoa(wantType),
@@ -430,7 +412,7 @@ func TestBuildCWEgressGuardRulesGolden(t *testing.T) {
 // PREROUTING before FORWARD), so a TCP packet's protocol column never equals
 // "tcp" at the point the drop is evaluated. The rule uses `! -p tcp`.
 func TestBuildCWEgressGuardRulesDoesNotDropTCP(t *testing.T) {
-	rules := buildCWEgressGuardRules(map[iptablesFamily][]string{iptablesFamilyIPv4: {clusterDNSClusterIP}})
+	rules := buildCWEgressGuardRules()
 	for _, r := range rules {
 		if !strings.Contains(r.label, "drop") {
 			continue
@@ -452,7 +434,7 @@ func TestBuildCWEgressGuardRulesDoesNotDropTCP(t *testing.T) {
 // non-TCP flows are still dropped (SEC-4). A guard built without this would
 // let arbitrary established UDP pass the host FORWARD guard.
 func TestBuildCWEgressGuardEstablishedReturnIsTCPOnly(t *testing.T) {
-	rules := buildCWEgressGuardRules(map[iptablesFamily][]string{iptablesFamilyIPv4: {clusterDNSClusterIP}})
+	rules := buildCWEgressGuardRules()
 	for _, r := range rules {
 		if !strings.Contains(r.label, "established") {
 			continue
@@ -838,7 +820,6 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 		iptablesFamilyIPv4: "10.0.0.1",
 		iptablesFamilyIPv6: "fd00::10",
 	}
-	dnsIPs := map[iptablesFamily][]string{iptablesFamilyIPv4: {clusterDNSClusterIP}}
 	exclude, err := parseExcludeUIDs("0")
 	if err != nil {
 		t.Fatalf("parseExcludeUIDs: %v", err)
@@ -847,10 +828,10 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parseCWPassthrough: %v", err)
 	}
-	rules, jumps := composeIptablesSyncRules(15001, defaultProxyUID, exclude, cwPassthrough, nodeIPs, dnsIPs)
+	rules, jumps := composeIptablesSyncRules(15001, defaultProxyUID, exclude, cwPassthrough, nodeIPs)
 
-	// The egress guard rules (both families, incl. ICMPv6 and dest-scoped
-	// DNS) must be present.
+	// The egress guard rules (both families, incl. ICMPv6 and the DNS
+	// carve-out) must be present.
 	var egressCount, icmpv6Count, dnsCount int
 	for _, r := range rules {
 		if r.chain != cwEgressChainName {
@@ -862,10 +843,13 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 			icmpv6Count++
 		case strings.Contains(r.label, "dns"):
 			dnsCount++
-			// Every carve-out row carries the destination scope in one form
-			// or the other; a row with neither would admit UDP/53 to anywhere.
-			if !slices.Contains(r.args, "--ctorigdst") && !slices.Contains(r.args, "-d") {
-				t.Errorf("egress dns rule carries no destination scope: %v", r.args)
+			// A destination scope here is the regression this removed: it
+			// silently drops every cw DNS query on a cluster whose resolver
+			// sits at another address.
+			for _, scope := range []string{"--ctorigdst", "-d"} {
+				if slices.Contains(r.args, scope) {
+					t.Errorf("egress dns rule is scoped by %s: %v", scope, r.args)
+				}
 			}
 		}
 	}
@@ -875,8 +859,8 @@ func TestComposeIptablesSyncRulesAssemblesFullGuard(t *testing.T) {
 	if icmpv6Count != len(essentialICMPv6Types) {
 		t.Errorf("compose icmpv6 allow rules = %d, want %d", icmpv6Count, len(essentialICMPv6Types))
 	}
-	if dnsCount != 2 { // one IPv4 cluster-DNS destination, two scopes
-		t.Errorf("compose dns rules = %d, want 2", dnsCount)
+	if dnsCount != 2 { // one carve-out per family
+		t.Errorf("compose dns rules = %d, want one per family", dnsCount)
 	}
 
 	// The egress FORWARD jump must sit in the jump set alongside the inbound

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -539,7 +539,6 @@ type iptablesSyncConfig struct {
 	excludeUIDs             string
 	excludeSourceNamespaces string
 	nodeIPs                 []string
-	clusterDNSIPs           []string
 	resyncPeriod            time.Duration
 	watchdogPeriod          time.Duration
 	ipsetMaxElem            int
@@ -566,7 +565,6 @@ func newIptablesSyncCommand() *cobra.Command {
 	fs.StringVar(&cfg.excludeUIDs, "exclude-uids", "0", "comma-separated UIDs to skip (e.g. root=0 so kubelet/containerd can reach registries)")
 	fs.StringVar(&cfg.excludeSourceNamespaces, "exclude-source-namespaces", defaultMeshExcludedSourceNamespacesCSV(), "comma-separated local source namespaces excluded from transparent mesh interception")
 	fs.StringSliceVar(&cfg.nodeIPs, "node-ip", nil, "local node IP(s); repeat or comma-separate for dual-stack (one per family). Defaults to NODE_IP env. Each address must be a non-loopback, non-unspecified IP bound to a local interface.")
-	fs.StringSliceVar(&cfg.clusterDNSIPs, "cluster-dns-ip", []string{clusterDNSClusterIP}, "cluster DNS (CoreDNS) server IP(s) the egress DNS carve-out is restricted to (c8s default 10.53.0.10). Set the same IP in the guest C8S_CLUSTER_DNS_IP and verify the carve-out on a live cluster (post-DNAT).")
 	fs.DurationVar(&cfg.resyncPeriod, "resync-period", 30*time.Second, "periodic full ipset reconciliation interval")
 	fs.DurationVar(&cfg.watchdogPeriod, "watchdog-period", 2*time.Second, "interval at which the base-chain jump rules are re-asserted at position 1 (bounds the race window against kube-proxy reinserting KUBE-SERVICES)")
 	fs.IntVar(&cfg.ipsetMaxElem, "ipset-maxelem", defaultIPSetMaxElem, "maximum members per managed ipset")

--- a/internal/cmds/ratlsmesh/netfilter_fake_test.go
+++ b/internal/cmds/ratlsmesh/netfilter_fake_test.go
@@ -670,11 +670,11 @@ func TestCleanupPodIPSetsForNamesWarnsOnDestroyFailure(t *testing.T) {
 // carve-out for the cluster DNS server.
 func TestSetupInGuestIptablesInstallsFailClosed(t *testing.T) {
 	nf := installFakeNetfilter(t)
-	if err := setupInGuestIptables(slog.New(slog.DiscardHandler), "10.0.0.5", nil, clusterDNSClusterIP); err != nil {
+	if err := setupInGuestIptables(slog.New(slog.DiscardHandler), "10.0.0.5", nil); err != nil {
 		t.Fatalf("setupInGuestIptables: %v", err)
 	}
-	if len(callsContaining(nf.calls(), "iptables ", clusterDNSClusterIP)) == 0 {
-		t.Errorf("no rule references the cluster DNS IP %s", clusterDNSClusterIP)
+	if len(callsContaining(nf.calls(), "iptables ", "--dport 53")) == 0 {
+		t.Error("no in-guest rule carves out UDP/53; the guest cannot resolve")
 	}
 }
 

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -124,19 +124,12 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 	if err != nil {
 		return err
 	}
-	// Validate the cluster DNS IPs and split them per family. The egress DNS
-	// carve-out is restricted to these, so a cw pod cannot reach an un-scoped
-	// external resolver over plaintext UDP/53.
-	dnsIPsByFamily, err := clusterDNSIPsByFamily(cfg.clusterDNSIPs)
-	if err != nil {
-		return err
-	}
 	// The cw inbound and egress guards are always installed. Inbound posture
 	// is the passthrough allowlist; the egress guard drops non-TCP from cw
 	// pods, with the DNS carve-out and ICMPv6 essentials as the only
 	// exceptions.
 	rules, jumps := composeIptablesSyncRules(
-		cfg.outboundPort, cfg.uid, excludeUIDs, cwPassthrough, nodeIPsByFamily, dnsIPsByFamily,
+		cfg.outboundPort, cfg.uid, excludeUIDs, cwPassthrough, nodeIPsByFamily,
 	)
 
 	logger, err := certutil.NewJSONLogger(cfg.logLevel)
@@ -144,7 +137,6 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 		return fmt.Errorf("--log-level: %w", err)
 	}
 	slog.SetDefault(logger)
-	warnUnlessClusterDNSResolves(logger, cfg.clusterDNSIPs, resolvConfPath)
 	if err := initIptablesClients(); err != nil {
 		return err
 	}
@@ -509,79 +501,12 @@ func parseNodeIPs(raw []string) (map[iptablesFamily]string, error) {
 // cycle. It is a pure function over already-validated inputs so the rule/jump
 // composition is unit-testable without a live kube; a rule dropped here is
 // caught the same way a rule-shaped regression is.
-func composeIptablesSyncRules(outboundPort, uid int, excludeUIDs []uint32, cwPassthrough []cwPassthrough, nodeIPsByFamily map[iptablesFamily]string, dnsIPsByFamily map[iptablesFamily][]string) ([]iptablesRule, []iptablesRule) {
+func composeIptablesSyncRules(outboundPort, uid int, excludeUIDs []uint32, cwPassthrough []cwPassthrough, nodeIPsByFamily map[iptablesFamily]string) ([]iptablesRule, []iptablesRule) {
 	rules := buildPodIPSetRules(outboundPort, uid, excludeUIDs, nodeIPsByFamily)
 	rules = append(rules, buildCWGuardRules(cwPassthrough)...)
-	rules = append(rules, buildCWEgressGuardRules(dnsIPsByFamily)...)
+	rules = append(rules, buildCWEgressGuardRules()...)
 	jumps := append(jumpRules(), cwJumpRule(), cwEgressJumpRule())
 	return rules, jumps
-}
-
-// resolvConfPath is the resolver configuration kubelet writes for this pod.
-// The ratls-mesh DaemonSet runs hostNetwork with dnsPolicy
-// ClusterFirstWithHostNet, so it names the servers every pod on this node
-// resolves against — which is what the carve-out has to name to be reachable.
-const resolvConfPath = "/etc/resolv.conf"
-
-// warnUnlessClusterDNSResolves reports each configured DNS server that this
-// node's own pod resolver does not name.
-//
-// The carve-out stays operator-declared: resolv.conf is read to contradict a
-// wrong value, never to supply one, so a resolver the node was pointed at
-// cannot widen a fail-closed egress guard. A cw pod whose queries go somewhere
-// the carve-out does not name loses DNS with nothing in the guard to say so,
-// and the shipped default is the c8s node image's, which no other
-// distribution shares.
-func warnUnlessClusterDNSResolves(logger *slog.Logger, configured []string, path string) {
-	b, err := os.ReadFile(path)
-	if err != nil {
-		logger.Warn("cannot check the cluster DNS carve-out against this node's resolver", "path", path, "error", err)
-		return
-	}
-	nameservers := map[string]bool{}
-	var listed []string
-	for _, line := range strings.Split(string(b), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 2 || fields[0] != "nameserver" {
-			continue
-		}
-		if ip := net.ParseIP(fields[1]); ip != nil {
-			nameservers[ip.String()] = true
-			listed = append(listed, ip.String())
-		}
-	}
-	if len(nameservers) == 0 {
-		return
-	}
-	for _, raw := range configured {
-		ip := net.ParseIP(raw)
-		if ip == nil || nameservers[ip.String()] {
-			continue
-		}
-		logger.Warn("cluster DNS carve-out names a server this node's pods do not resolve against; confidential-workload pods will lose DNS unless --cluster-dns-ip is corrected",
-			"configured", ip.String(), "node_resolvers", listed)
-	}
-}
-
-// clusterDNSIPsByFamily validates each cluster DNS IP and groups it under its
-// address family. A malformed value fails the sync so the egress carve-out
-// never silently degrades to an un-scoped allow-all.
-func clusterDNSIPsByFamily(ips []string) (map[iptablesFamily][]string, error) {
-	out := map[iptablesFamily][]string{}
-	for _, raw := range ips {
-		ip := net.ParseIP(raw)
-		if ip == nil {
-			return out, fmt.Errorf("--cluster-dns-ip %q is not a valid IP address", raw)
-		}
-		var fam iptablesFamily
-		if ip.To4() != nil {
-			fam = iptablesFamilyIPv4
-		} else {
-			fam = iptablesFamilyIPv6
-		}
-		out[fam] = append(out[fam], ip.String())
-	}
-	return out, nil
 }
 
 // ifaceAddrSet groups the addresses bound to one interface.

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -173,8 +173,6 @@ spec:
             - {{ $excludeSourceNamespaces | quote }}
             - --node-ip
             - $(NODE_IP)
-            - --cluster-dns-ip
-            - {{ .Values.ratlsMesh.clusterDNSIP | quote }}
             - --resync-period
             - {{ .Values.ratlsMesh.iptablesSync.resyncPeriod | quote }}
             - --watchdog-period

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -710,12 +710,6 @@ ratlsMesh:
       - protocol: tcp
         sourcePort: 53
 
-  # Cluster DNS (CoreDNS) Service ClusterIP the egress guards' DNS carve-out
-  # is destination-scoped to. Defaults to the c8s node image's cluster-dns
-  # (10.53.0.10). Override if the cluster uses a different IP, and set the
-  # same value in the guest's C8S_CLUSTER_DNS_IP.
-  clusterDNSIP: "10.53.0.10"
-
   # Certificate settings
   certMode: cds  # self-signed | cds
   certTtl: "4h"

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7418,10 +7418,11 @@ func TestChartDaemonSetPreStopKeepsGuard(t *testing.T) {
 	}
 }
 
-// The fail-closed egress guards scope their DNS carve-out to the cluster DNS
-// server; the daemonset must pass that ClusterIP to iptables-sync so the
-// carve-out is not silently scoped to a different address.
-func TestChartIptablesSyncCarriesClusterDNS(t *testing.T) {
+// The fail-closed egress guards carve out UDP/53 to any destination, so the
+// daemonset names no resolver address. A reintroduced --cluster-dns-ip would
+// scope the carve-out to one address again and silently drop every cw DNS
+// query on a cluster whose resolver sits elsewhere.
+func TestChartIptablesSyncNamesNoClusterDNS(t *testing.T) {
 	out, err := helmTemplate(t)
 	if err != nil {
 		t.Fatalf("helm template: %v\n%s", err, out)
@@ -7437,17 +7438,10 @@ func TestChartIptablesSyncCarriesClusterDNS(t *testing.T) {
 	if len(flags) == 0 {
 		t.Fatal("iptables-sync container command not found")
 	}
-	var saw bool
-	for i := 0; i+1 < len(flags); i++ {
-		if flags[i] == "--cluster-dns-ip" {
-			saw = true
-			if flags[i+1] != "10.53.0.10" {
-				t.Errorf("--cluster-dns-ip = %q, want c8s default 10.53.0.10", flags[i+1])
-			}
+	for _, f := range flags {
+		if f == "--cluster-dns-ip" {
+			t.Errorf("iptables-sync carries --cluster-dns-ip; the carve-out must name no address: %v", flags)
 		}
-	}
-	if !saw {
-		t.Error("iptables-sync command does not carry --cluster-dns-ip")
 	}
 }
 

--- a/test/e2e/mesh-cw-enforcement.sh
+++ b/test/e2e/mesh-cw-enforcement.sh
@@ -215,12 +215,9 @@ await_metric_above "$excluded_node_ip" "$drops" "$base_excluded_drops" \
 
 # --- egress guard: the DNS carve-out is scoped where it can match -----------
 
-# The guard chain hangs off FORWARD, downstream of kube-proxy's Service DNAT,
-# so a carve-out written against the packet's destination reads a CoreDNS pod
-# IP and never fires — every cw pod then loses DNS while still reaching
-# Running, which is why this is asserted against the chain the node actually
-# runs rather than against the pod's health. Read on the workload's node, in
-# the sidecar that programs it.
+# A cw pod that loses DNS still reaches Running, so this is asserted against
+# the chain the node actually runs rather than against the pod's health. Read
+# on the workload's node, in the sidecar that programs it.
 mesh_pod=$(kubectl get pods -n "$mesh_ns" -l app=c8s-ratls-mesh \
   --field-selector="spec.nodeName=$cw_node" -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
 [ -n "$mesh_pod" ] || fail "no ratls-mesh pod on $cw_node in namespace $mesh_ns (set MESH_NS)"
@@ -233,19 +230,15 @@ dns_rows=$(awk '/udp/ && /dpt:53/' <<<"$egress_chain")
 [ -n "$dns_rows" ] || fail "RATLS-MESH-CW-EGRESS carries no UDP/53 carve-out on $cw_node; cw pods cannot resolve:
 $egress_chain"
 
-# The chain runs downstream of kube-proxy's Service DNAT, so a carve-out
-# written only against the packet's destination cannot fire; the row that
-# names the connection's original destination is the one that does.
-grep -q 'ctorigdst' <<<"$dns_rows" || fail "no UDP/53 carve-out is scoped to the connection's original destination, so kube-proxy's DNAT puts the carve-out out of reach and every cw DNS query hits the drop below it:
-$dns_rows"
-
-# The address has to be the resolver this cluster's pods actually use;
-# scoping to any other is indistinguishable from having no carve-out.
-cluster_dns=$(kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
-if [ -n "$cluster_dns" ]; then
-  grep -q "$cluster_dns" <<<"$dns_rows" || fail "the UDP/53 carve-out names no address matching this cluster's DNS ClusterIP $cluster_dns; set ratlsMesh.clusterDNSIP:
-$dns_rows"
-fi
+# The carve-out names no destination, so it survives kube-proxy's Service DNAT
+# and holds whatever address this cluster's resolver has. A row naming one is
+# the regression this replaced: where the resolver sits elsewhere it puts the
+# carve-out out of reach and every cw DNS query hits the drop below.
+# In `iptables -L -n -v -x` the destination column is field 9; unscoped reads
+# 0.0.0.0/0. A conntrack scope shows as an extra match instead of a column.
+scoped=$(awk '$9 != "0.0.0.0/0" || /ctorigdst/' <<<"$dns_rows")
+[ -z "$scoped" ] || fail "the UDP/53 carve-out is destination-scoped; it must name no address:
+$scoped"
 
 # A RETURN below the drop is a RETURN that never runs.
 drop_line=$(awk '/DROP/ && /!tcp/ {print NR; exit}' <<<"$egress_chain")

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -174,13 +174,7 @@ log "Writing the allowlist floor"
 store_digests > "$WORKDIR/floor.tsv"
 [ -s "$WORKDIR/floor.tsv" ] || fail "containerd store scan came back empty"
 grep -q "docker.io/library/$WORKLOAD_IMAGE" "$WORKDIR/floor.tsv" || fail "workload image missing from the store scan"
-# The cw egress guard scopes its DNS carve-out to this address, and the chart
-# default is the c8s node image's, which no other distribution shares — kind's
-# is 10.96.0.10. Read it off the cluster, as an operator must.
-CLUSTER_DNS_IP="$(kubectl -n kube-system get svc kube-dns -o jsonpath='{.spec.clusterIP}')"
-[ -n "$CLUSTER_DNS_IP" ] || fail "could not read the kube-dns ClusterIP"
-
-python3 - "$WORKDIR/floor.tsv" "$WORKDIR/values.yaml" "docker.io/$CURL_IMAGE" "$CLUSTER_DNS_IP" <<'PYEOF'
+python3 - "$WORKDIR/floor.tsv" "$WORKDIR/values.yaml" "docker.io/$CURL_IMAGE" <<'PYEOF'
 import sys, yaml
 floor = {}
 for line in open(sys.argv[1]):
@@ -191,7 +185,6 @@ floor = {d: r for d, r in floor.items() if r != sys.argv[3]}
 with open(sys.argv[2], "w") as f:
     yaml.safe_dump({
         "nriImagePolicy": {"bootstrapAllowlist": {"digests": floor}},
-        "ratlsMesh": {"clusterDNSIP": sys.argv[4]},
     }, f)
 print(f"floor: {len(floor)} digests")
 PYEOF


### PR DESCRIPTION
The fail-closed cw egress guards scoped their UDP/53 carve-out to a configured resolver address, defaulting to the c8s node image's `10.53.0.10`. On any cluster whose resolver sits elsewhere — stock RKE2 `10.43.0.10`, kubeadm and kind `10.96.0.10` — the carve-out named an address no pod queries, so every `confidential.ai/cw` pod lost DNS while `c8s install` exited 0. Keeping it correct needed the address plumbed through the chart, a host flag, and a guest env var that nothing in the tree ever wrote.

## Why the scope goes rather than gets fixed

A resolver is outside the guest's trust boundary whatever its address, so its answers are untrusted input either way. What a DNS answer does is select which endpoint a workload dials; the RA-TLS handshake at that endpoint is what authenticates the peer. A host that swaps, forges or drops an answer redirects or denies a connection it cannot read — which it can do at the network layer regardless of what the carve-out names.

So the scope was buying no confidentiality or integrity, and was costing a cluster-wide DNS outage whose only symptom was a drop counter.

## What changes

The carve-out names UDP/53 and no address, on the host guard and in the guest. Everything else the guard drops still drops — it stays scoped to the cw pod ipset, and every other non-TCP from a cw pod hits the `DROP` below it.

Removed: `ratlsMesh.clusterDNSIP`, `--cluster-dns-ip`, `C8S_CLUSTER_DNS_IP`, `clusterDNSIPsByFamily`, and `warnUnlessClusterDNSResolves` — the resolv.conf mismatch warning that existed only to diagnose the misconfigured address.

The inbound guard's `defaultCWPassthrough` (sport 53 → ephemeral dport range) is untouched: it is not address-scoped and was not part of this failure.

## Tests

`TestBuildCWEgressGuardRulesGolden` and `TestBuildInGuestFailClosedRulesGolden` assert the new rule shape exactly. `TestBuildInGuestFailClosedRulesDNSNamesNoAddress` and the compose-level check assert the inverse invariant — that no carve-out row carries `-d`, `-s` or `--ctorigdst` — so a reintroduced destination scope fails rather than silently shipping. `TestChartIptablesSyncNamesNoClusterDNS` does the same at the chart layer.

`TestClusterDNSIPsByFamily` and `TestWarnUnlessClusterDNSResolves` are removed with the code they covered.

The e2e mesh assertion and the integration lane both drop their by-hand ClusterIP lookup; the e2e now fails if a destination-scoped row reappears.

## Supersedes #464

That PR fixed the address by deriving it from the cluster at install time. This removes the thing that needed deriving. #464 should be closed if this lands.

## Verification

`make lint`, `go build ./...`, `go test ./...` — clean apart from three pre-existing failures in `internal/cmds/ratlsmesh` (`TestRunIptablesSyncValidationErrors`, `TestDiscoverMissingFamilyNodeIPsRealHostSmoke`, `TestRunIptablesSyncHappyPath`) that fail identically on `main` in this container, which has no primary-interface IPv6.

Not run: the live-cluster e2e and integration lanes.
