### PR TITLE
feat(secrets): pin the CDS mesh CA on an operator secret write

### DIFF
--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -171,12 +171,30 @@ an operator:
 
 ```sh
 c8s secrets put /tenant-a/hf-token --url "$CDS" --measurements "$M" \
-  --operator-key operator.key < token.txt
+  --mesh-ca mesh-ca.pem --operator-key operator.key < token.txt
 ```
 
 The value is read from stdin or `--from-file`, and the bytes are stored exactly
 as read — a trailing newline is part of the value. The byte count is printed to
 confirm which one was sent.
+
+### Naming the CDS you are writing to
+
+`--mesh-ca` takes the CA bundle you hold out of band, the same anchor
+`c8s verify --mesh-ca` takes. Before the write, the CLI reads the mesh CA CDS
+serves at `GET /ca` over the attested connection and refuses unless it is one
+you pinned.
+
+`--measurements` alone does not cover this. It proves the peer is an attested
+build at a pinned launch measurement — but every confidential pod boots the
+same guest image, so that measurement is a property of the shape, not of the
+role. The mesh CA key is generated per CDS, so it is what tells your CDS from
+another one at the same measurement, and it is the anchor your workloads
+already trust.
+
+The write is refused with no `--mesh-ca`. `--force` writes without the check
+and says so on stderr; it governs the CA check only, and is unrelated to
+`--overwrite`, which governs replacing a value already at the path.
 
 ```
 PUT /secrets/<store path>   {"value": "<base64>", "overwrite": <bool>}

--- a/internal/cmds/secrets/meshca.go
+++ b/internal/cmds/secrets/meshca.go
@@ -1,0 +1,118 @@
+package secrets
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+// errMeshCARequired is the refusal an operator gets for a write that names no
+// mesh CA. RA-TLS proves the peer is a TEE running a pinned build; under
+// pod-as-CVM every confidential pod boots the same guest image, so a launch
+// measurement does not distinguish CDS from anything else at that shape. The
+// mesh CA key is what does: it is generated per CDS, and it is the anchor
+// `c8s verify --mesh-ca` and every workload already hold.
+var errMeshCARequired = fmt.Errorf(
+	"refusing to write a secret to a CDS whose mesh CA is not pinned: --measurements proves the peer is an attested build, " +
+		"but every confidential pod boots that same build, so it does not prove the peer is your CDS. " +
+		"Pass --mesh-ca <bundle.pem> (the anchor you pass to 'c8s verify --mesh-ca'), or --force to write without it")
+
+// verifyMeshCA fails unless every certificate CDS serves at GET /ca is present
+// in the operator's pinned bundle.
+//
+// INVARIANT: the fetch travels the attested channel the write itself uses, so
+// the bytes compared are the ones that CDS — not the host — served.
+func (c client) verifyMeshCA(ctx context.Context, bundlePath string) error {
+	pinned, err := pinnedCerts(bundlePath)
+	if err != nil {
+		return err
+	}
+	served, err := c.fetchCA(ctx)
+	if err != nil {
+		return err
+	}
+	if len(served) == 0 {
+		return fmt.Errorf("cds served no certificate at /ca, so its mesh CA cannot be checked against --mesh-ca")
+	}
+	for _, der := range served {
+		if !pinned[string(der)] {
+			return fmt.Errorf(
+				"the CDS at %s serves a mesh CA that is not in --mesh-ca %s: this is not the CDS that issued your workloads' certificates, "+
+					"and a secret written here would be released to whatever it admits", c.baseURL, bundlePath)
+		}
+	}
+	return nil
+}
+
+// pinnedCerts reads the operator's bundle into a set keyed by raw DER. Identity
+// is compared on the encoded certificate, not on a parsed field, so nothing in
+// the comparison depends on how a certificate is interpreted.
+func pinnedCerts(path string) (map[string]bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --mesh-ca: %w", err)
+	}
+	certs, err := parseCertsPEM(raw)
+	if err != nil {
+		return nil, fmt.Errorf("--mesh-ca %s: %w", path, err)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("--mesh-ca %s contains no PEM certificates", path)
+	}
+	out := make(map[string]bool, len(certs))
+	for _, der := range certs {
+		out[string(der)] = true
+	}
+	return out, nil
+}
+
+// fetchCA reads CDS's mesh CA chain over the attested channel.
+func (c client) fetchCA(ctx context.Context) ([][]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/ca", nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch the CDS mesh CA: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cds returned %d for /ca, so its mesh CA cannot be checked against --mesh-ca", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read the CDS mesh CA: %w", err)
+	}
+	certs, err := parseCertsPEM(raw)
+	if err != nil {
+		return nil, fmt.Errorf("cds /ca: %w", err)
+	}
+	return certs, nil
+}
+
+// parseCertsPEM decodes every CERTIFICATE block in raw, returning their DER.
+// A block that does not parse as a certificate is an error rather than a skip:
+// a bundle half of which was understood is not a bundle an operator pinned.
+func parseCertsPEM(raw []byte) ([][]byte, error) {
+	var out [][]byte
+	for rest := raw; len(rest) > 0; {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		if _, err := x509.ParseCertificate(block.Bytes); err != nil {
+			return nil, fmt.Errorf("PEM CERTIFICATE block does not parse: %w", err)
+		}
+		out = append(out, block.Bytes)
+	}
+	return out, nil
+}

--- a/internal/cmds/secrets/meshca_test.go
+++ b/internal/cmds/secrets/meshca_test.go
@@ -116,14 +116,23 @@ func ratlsServingCert(t *testing.T) tls.Certificate {
 // caDER. Returns the fake and its https URL.
 func newAttestedCDS(t *testing.T, caDER []byte) (*fakeCDS, string) {
 	t.Helper()
+	var body []byte
+	if caDER != nil {
+		body = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	}
+	return newAttestedCDSServingCA(t, http.StatusOK, body)
+}
+
+// newAttestedCDSServingCA is newAttestedCDS with the /ca response written out
+// verbatim, for the answers a well-behaved CDS never gives.
+func newAttestedCDSServingCA(t *testing.T, status int, body []byte) (*fakeCDS, string) {
+	t.Helper()
 	f := &fakeCDS{values: map[string]intsecrets.Origin{}}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ca", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/x-pem-file")
-		if caDER == nil {
-			return
-		}
-		_ = pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
 	})
 	mux.HandleFunc("/", f.serve)
 	srv := httptest.NewUnstartedServer(mux)
@@ -302,5 +311,135 @@ func TestPutPlaintextInsecureSkipsTheGate(t *testing.T) {
 	}
 	if len(f.seen) != 1 {
 		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}
+
+// An answer that is not a served CA must fail the write rather than be read as
+// one. Each of these is a distinct refusal, and none of them may fall through
+// to a comparison against a set the CLI never actually received.
+func TestPutRefusesAnUnusableCAResponse(t *testing.T) {
+	good := meshCA(t, "cds-m")
+	bundle := writePEM(t, "mesh-ca.pem", good)
+	key := writeOperatorKey(t)
+
+	tests := []struct {
+		name   string
+		status int
+		body   []byte
+		want   string
+	}{
+		{
+			// A CDS that does not route /ca (an LB pointed elsewhere, or a
+			// build without the route) must not read as "no CA to object to".
+			name:   "not found",
+			status: http.StatusNotFound,
+			body:   []byte("no such route\n"),
+			want:   "returned 404",
+		},
+		{
+			name:   "server error",
+			status: http.StatusInternalServerError,
+			body:   []byte("boom\n"),
+			want:   "returned 500",
+		},
+		{
+			// Truncated DER inside a well-formed PEM frame: the block decodes,
+			// the certificate does not. Skipping it would leave the served set
+			// empty and the comparison vacuous.
+			name:   "certificate does not parse",
+			status: http.StatusOK,
+			body:   pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: good[:len(good)/2]}),
+			want:   "does not parse",
+		},
+		{
+			// PEM that carries no certificate at all.
+			name:   "no certificate block",
+			status: http.StatusOK,
+			body:   pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not a key")}),
+			want:   "served no certificate",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, url := newAttestedCDSServingCA(t, tc.status, tc.body)
+			_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+				"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle)
+			if err == nil {
+				t.Fatal("the write was accepted")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("err = %v, want it to name %q", err, tc.want)
+			}
+			if len(f.seen) != 0 {
+				t.Fatalf("the refused write still sent %d request(s)", len(f.seen))
+			}
+		})
+	}
+}
+
+// A CDS whose /ca is unreachable fails the write. The gate has no "could not
+// check, so proceed" branch: an unanswered /ca is the same refusal as a wrong
+// one.
+func TestPutRefusesWhenTheCAIsUnreachable(t *testing.T) {
+	_, url := newAttestedCDS(t, meshCA(t, "cds-m"))
+	bundle := writePEM(t, "mesh-ca.pem", meshCA(t, "cds-m"))
+	key := writeOperatorKey(t)
+
+	// A port with nothing behind it: the URL parses and the scheme is https,
+	// so the gate runs and the fetch is what fails.
+	dead := strings.Replace(url, url[strings.LastIndex(url, ":")+1:], "1", 1)
+	_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", dead,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle)
+	if err == nil {
+		t.Fatal("a write to an unreachable CDS was accepted")
+	}
+}
+
+// A bundle carrying a non-certificate PEM block alongside the CA is still a
+// usable bundle: the extra block is skipped, and the CA in it still matches.
+// Operators paste these out of files that hold more than one kind of object.
+func TestPutIgnoresNonCertificateBlocksInTheBundle(t *testing.T) {
+	ca := meshCA(t, "cds-m")
+	f, url := newAttestedCDS(t, ca)
+	var buf bytes.Buffer
+	if err := pem.Encode(&buf, &pem.Block{Type: "PRIVATE KEY", Bytes: []byte("ignored")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: ca}); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "mixed.pem")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key := writeOperatorKey(t)
+
+	if _, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", path); err != nil {
+		t.Fatalf("a bundle with a non-certificate block was refused: %v", err)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}
+
+// A bundle whose certificate does not parse fails the write. Pinning against a
+// set the CLI could not fully read is not pinning.
+func TestPutRefusesABundleWithAnUnparseableCertificate(t *testing.T) {
+	ca := meshCA(t, "cds-m")
+	_, url := newAttestedCDS(t, ca)
+	path := filepath.Join(t.TempDir(), "truncated.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca[:len(ca)/2]}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key := writeOperatorKey(t)
+
+	_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", path)
+	if err == nil {
+		t.Fatal("an unparseable bundle was accepted")
+	}
+	if !strings.Contains(err.Error(), "--mesh-ca") || !strings.Contains(err.Error(), "does not parse") {
+		t.Fatalf("err = %v", err)
 	}
 }

--- a/internal/cmds/secrets/meshca_test.go
+++ b/internal/cmds/secrets/meshca_test.go
@@ -1,0 +1,306 @@
+package secrets
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// testMeasurement is a syntactically valid SHA-384 launch measurement. Its
+// value is irrelevant: the injected verifier approves, so what these tests
+// exercise is the mesh-CA gate that runs after a pinned measurement passes.
+const testMeasurement = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// meshCA mints a self-signed CA certificate standing in for one CDS's mesh CA.
+// Two calls produce two distinct CAs — the CDS_M / CDS_N split this gate exists
+// to detect.
+func meshCA(t *testing.T, cn string) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return der
+}
+
+func writePEM(t *testing.T, name string, ders ...[]byte) string {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, der := range ders {
+		if err := pem.Encode(&buf, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// ratlsServingCert mints the self-signed RA-TLS serving cert a direct CDS
+// presents, so the CLI reaches the write over the same attested path it uses in
+// production rather than over plaintext.
+func ratlsServingCert(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	embedded, err := json.Marshal(types.AttestationEvidence{
+		Platform: string(types.PlatformAzSnp),
+		Evidence: json.RawMessage(`{"hcl_report":"fake"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	att := &ratls.Attestation{TEEType: ratls.TEETypeSEVSNP, Report: embedded}
+	ext, err := att.MarshalExtension()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:    big.NewInt(2),
+		Subject:         pkix.Name{CommonName: "cds"},
+		NotBefore:       time.Now().Add(-time.Hour),
+		NotAfter:        time.Now().Add(time.Hour),
+		DNSNames:        []string{"localhost"},
+		ExtraExtensions: []pkix.Extension{ext},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
+}
+
+// newAttestedCDS serves the secrets API over RA-TLS, answering GET /ca with
+// caDER. Returns the fake and its https URL.
+func newAttestedCDS(t *testing.T, caDER []byte) (*fakeCDS, string) {
+	t.Helper()
+	f := &fakeCDS{values: map[string]intsecrets.Origin{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ca", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-pem-file")
+		if caDER == nil {
+			return
+		}
+		_ = pem.Encode(w, &pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	})
+	mux.HandleFunc("/", f.serve)
+	srv := httptest.NewUnstartedServer(mux)
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{ratlsServingCert(t)}}
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+	return f, srv.URL
+}
+
+// runAttested drives the CLI with an attestation verifier that approves, so the
+// only thing under test is the mesh-CA gate.
+func runAttested(t *testing.T, stdin string, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	approve := func(context.Context, string, json.RawMessage, localverify.Params) (*teetypes.VerificationResult, error) {
+		match := true
+		return &teetypes.VerificationResult{SignatureValid: true, ReportDataMatch: &match}, nil
+	}
+	cmd := newCmd(approve)
+	var out, errb bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errb)
+	cmd.SetIn(strings.NewReader(stdin))
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errb.String(), err
+}
+
+// A measurement pin proves the peer is an attested build; every confidential
+// pod boots that build, so the write is refused until the operator names the
+// mesh CA that distinguishes their CDS from anything else at the same shape.
+func TestPutRefusesWithoutMeshCA(t *testing.T) {
+	f, url := newAttestedCDS(t, meshCA(t, "cds-m"))
+	key := writeOperatorKey(t)
+
+	_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key)
+	if err == nil {
+		t.Fatal("a write with no --mesh-ca was accepted")
+	}
+	if !strings.Contains(err.Error(), "--mesh-ca") {
+		t.Fatalf("refusal does not name --mesh-ca: %v", err)
+	}
+	if len(f.seen) != 0 {
+		t.Fatalf("the refused write still sent %d request(s)", len(f.seen))
+	}
+}
+
+// The gate is an identity check on the CA key, so a CDS serving a CA the
+// operator never pinned is refused even though its attestation is valid — the
+// CDS_N case, where a genuine TEE at the same measurement is not your CDS.
+func TestPutRefusesAnotherCDSsMeshCA(t *testing.T) {
+	f, url := newAttestedCDS(t, meshCA(t, "cds-n"))
+	bundle := writePEM(t, "mesh-ca.pem", meshCA(t, "cds-m"))
+	key := writeOperatorKey(t)
+
+	_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle)
+	if err == nil {
+		t.Fatal("a write to a CDS serving an unpinned mesh CA was accepted")
+	}
+	if !strings.Contains(err.Error(), "not in --mesh-ca") {
+		t.Fatalf("refusal does not name the mismatch: %v", err)
+	}
+	if len(f.seen) != 0 {
+		t.Fatalf("the refused write still sent %d request(s)", len(f.seen))
+	}
+}
+
+// The matching CA is the whole point: the write proceeds and the secret lands.
+func TestPutAcceptsThePinnedMeshCA(t *testing.T) {
+	ca := meshCA(t, "cds-m")
+	f, url := newAttestedCDS(t, ca)
+	bundle := writePEM(t, "mesh-ca.pem", ca)
+	key := writeOperatorKey(t)
+
+	out, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle)
+	if err != nil {
+		t.Fatalf("put against the pinned CDS: %v", err)
+	}
+	if !strings.Contains(out, "+ /tenant-a/db (new)") {
+		t.Fatalf("output = %q", out)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}
+
+// A bundle carrying several CAs (rotation) admits a CDS serving any one of
+// them, and still refuses one serving a CA outside the bundle.
+func TestPutAcceptsAnyCAInTheBundle(t *testing.T) {
+	old, current := meshCA(t, "cds-old"), meshCA(t, "cds-current")
+	bundle := writePEM(t, "mesh-ca.pem", old, current)
+	key := writeOperatorKey(t)
+
+	for _, ca := range [][]byte{old, current} {
+		_, url := newAttestedCDS(t, ca)
+		if _, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+			"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle); err != nil {
+			t.Fatalf("a CA in the bundle was refused: %v", err)
+		}
+	}
+	_, url := newAttestedCDS(t, meshCA(t, "cds-n"))
+	if _, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle); err == nil {
+		t.Fatal("a CA outside the bundle was accepted")
+	}
+}
+
+// --force is the documented escape hatch. It writes, and it says on stderr that
+// it skipped the check, so the bypass is visible in an operator's transcript.
+func TestPutForceSkipsTheCheckLoudly(t *testing.T) {
+	f, url := newAttestedCDS(t, meshCA(t, "cds-n"))
+	key := writeOperatorKey(t)
+
+	_, errOut, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--force")
+	if err != nil {
+		t.Fatalf("--force did not write: %v", err)
+	}
+	if !strings.Contains(errOut, "--force") || !strings.Contains(errOut, "without checking the CDS mesh CA") {
+		t.Fatalf("--force wrote without announcing the skipped check: %q", errOut)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}
+
+// CDS answering /ca with nothing must not read as a match: an empty served set
+// would vacuously satisfy a subset check.
+func TestPutRefusesEmptyServedCA(t *testing.T) {
+	_, url := newAttestedCDS(t, nil)
+	bundle := writePEM(t, "mesh-ca.pem", meshCA(t, "cds-m"))
+	key := writeOperatorKey(t)
+
+	_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+		"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", bundle)
+	if err == nil {
+		t.Fatal("a CDS serving no CA was accepted")
+	}
+	if !strings.Contains(err.Error(), "served no certificate") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// An unreadable or certificate-free bundle fails the write rather than
+// degrading to no check.
+func TestPutRefusesUnusableBundle(t *testing.T) {
+	_, url := newAttestedCDS(t, meshCA(t, "cds-m"))
+	key := writeOperatorKey(t)
+	empty := filepath.Join(t.TempDir(), "empty.pem")
+	if err := os.WriteFile(empty, []byte("not pem\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, path := range map[string]string{
+		"absent":   filepath.Join(t.TempDir(), "nope.pem"),
+		"no certs": empty,
+	} {
+		_, _, err := runAttested(t, "hunter2", "put", "/tenant-a/db", "--url", url,
+			"--measurements", testMeasurement, "--operator-key", key, "--mesh-ca", path)
+		if err == nil {
+			t.Fatalf("%s bundle was accepted", name)
+		}
+	}
+}
+
+// The dev path is exempt for the same reason it is exempt from the measurement
+// pin: --insecure has already said nothing about the peer is authenticated.
+func TestPutPlaintextInsecureSkipsTheGate(t *testing.T) {
+	f, url := newFakeCDS(t)
+	key := writeOperatorKey(t)
+
+	if _, _, err := run(t, "hunter2", "put", "/tenant-a/db", "--url", url, "--insecure", "--operator-key", key); err != nil {
+		t.Fatalf("plaintext dev write refused: %v", err)
+	}
+	if len(f.seen) != 1 {
+		t.Fatalf("sent %d requests, want 1", len(f.seen))
+	}
+}

--- a/internal/cmds/secrets/put.go
+++ b/internal/cmds/secrets/put.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -16,6 +17,8 @@ func newPutCmd(o *options) *cobra.Command {
 		fromFile  string
 		overwrite bool
 		dryRun    bool
+		meshCA    string
+		force     bool
 	)
 	cmd := &cobra.Command{
 		Use:   "put <path>",
@@ -26,6 +29,9 @@ newline; the byte count is printed so you can confirm which bytes were sent.
 
 A path that already holds a value needs --overwrite, and the value it holds is
 named before it is replaced.
+
+The write names the CDS it trusts with --mesh-ca: the mesh CA CDS serves must be
+one you pinned, or the secret is refused. --force writes without that check.
 
 A workload reads its secret into a file once, at startup. Replacing a value
 reaches a running pod when that pod next restarts.`,
@@ -48,11 +54,15 @@ reaches a running pod when that pod next restarts.`,
 				return nil
 			}
 
-			signer, err := o.Signer()
+			c, err := o.client(cmd.Context())
 			if err != nil {
 				return err
 			}
-			c, err := o.client(cmd.Context())
+			if err := gateOnMeshCA(cmd, c, o.URL, meshCA, force); err != nil {
+				return err
+			}
+
+			signer, err := o.Signer()
 			if err != nil {
 				return err
 			}
@@ -90,7 +100,28 @@ reaches a running pod when that pod next restarts.`,
 	cmd.Flags().StringVar(&fromFile, "from-file", "", "read the value from this file instead of stdin")
 	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "replace a value already at the path")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "print the intended change without calling CDS")
+	cmd.Flags().StringVar(&meshCA, "mesh-ca", "", "PEM bundle of the mesh CA this CDS must serve; the same anchor 'c8s verify --mesh-ca' takes. Required unless --force")
+	cmd.Flags().BoolVar(&force, "force", false, "write the secret without checking the CDS mesh CA against --mesh-ca. Unrelated to --overwrite, which governs replacing an existing value")
 	return cmd
+}
+
+// gateOnMeshCA refuses a write whose CDS is not pinned to an operator-held mesh
+// CA. A plaintext endpoint is exempt for the same reason it is exempt from the
+// measurement pin: --insecure has already announced that nothing about the peer
+// is authenticated, and /ca fetched over it would be the host's answer anyway.
+func gateOnMeshCA(cmd *cobra.Command, c client, rawURL, meshCA string, force bool) error {
+	if u, err := url.Parse(rawURL); err == nil && u.Scheme == "http" {
+		return nil
+	}
+	if force {
+		fmt.Fprintln(cmd.ErrOrStderr(),
+			"warning: --force: writing this secret without checking the CDS mesh CA. An attested peer at this address that is not your CDS receives the value.")
+		return nil
+	}
+	if meshCA == "" {
+		return errMeshCARequired
+	}
+	return c.verifyMeshCA(cmd.Context(), meshCA)
 }
 
 // describe names a stored value by what put it there, for the line an operator


### PR DESCRIPTION
`c8s secrets put` required `--measurements`, which proves the peer is an attested build at a pinned launch measurement. Under pod-as-CVM that does not identify CDS: every confidential pod boots the same `kata-guest-base`, so the measurement is a function of the guest image and vCPU shape and carries no role. A second CDS at the same shape satisfies the pin.

`cdsconn.go` already says this in its own words:

> RA-TLS proves the peer is *a* TEE, not that it is the CDS this operator meant

`requirePinnedEndpoint` closed the empty-pin case. This closes the case where the pin is set and still does not distinguish one CDS from another. An operator writing to the wrong one hands over the secret *and* an operator token bound to that request.

## What identifies CDS

The mesh CA key. It is generated per CDS, it is the anchor `c8s verify --mesh-ca` already takes, and it is what every workload in the mesh already trusts. That makes it the property the meshes actually partition on: a CDS the operator did not provision has a different CA, and its leaves fail the chain check at every client holding the operator's bundle.

`put` now reads the CA CDS serves at `GET /ca` over the attested connection and refuses unless every certificate served is in the pinned bundle. Comparison is on raw DER, so nothing depends on how a certificate is interpreted. The fetch precedes minting the operator token, so a refused write never signs one.

## Flags

- `--mesh-ca <bundle.pem>` — required. Same anchor as `c8s verify --mesh-ca`.
- `--force` — writes without the check, and says so on stderr.

**`--force` governs the CA check only.** It is unrelated to `--overwrite`, which governs replacing a value already at the path. The two sitting next to each other is a footgun worth a second opinion — `--insecure-skip-mesh-ca` would not be confusable. Say the word and I'll rename it.

A plaintext `http://` endpoint is exempt, matching `requirePinnedEndpoint`: `--insecure` has already announced that nothing about the peer is authenticated, and `/ca` fetched over it would be the host's answer anyway.

## Tests

`meshca_test.go` drives the CLI end to end against an RA-TLS fake CDS over TLS, so the gate runs on the same attested path production uses: refusal with no `--mesh-ca`; refusal when CDS serves a CA outside the bundle (the CDS_M/CDS_N case); acceptance on a match; a multi-CA bundle admitting either during rotation while still refusing a third; `--force` writing and announcing it; an empty `/ca` response refused rather than vacuously satisfying the subset check; an absent or certificate-free bundle failing the write rather than degrading to no check; and the plaintext dev path still writing.

Mutation-checked: dropping the gate call fails six of them, and treating an empty served set as a match fails the one that covers it.

## Scope

`secrets put` only, as asked. `c8s secrets explain`, `c8s allowlist` and `c8s volume create` mint the same operator token against the same unidentified CDS through the shared `cdsconn.Signer()`, and want the same gate — deliberately left out of this PR since adding the flag to `cdsconn.BindFlags` changes every one of those commands' interfaces at once.

## Verification

`make lint`, `go build ./...`, `go test ./...` — clean apart from three pre-existing `internal/cmds/ratlsmesh` failures that fail identically on `main` in this container (no primary-interface IPv6).
