### PR TITLE
fix(node-guest-image): schedule the device plugin only on GPU nodes

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/gpu-node-label.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/gpu-node-label.service
@@ -1,0 +1,14 @@
+# Label GPU nodes before rke2 registers them, so the baked
+# nvidia-device-plugin DaemonSet only schedules where a GPU exists.
+[Unit]
+Description=Label the node when an NVIDIA GPU is attached
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/gpu-node-label.sh
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -17,6 +17,9 @@ enable models-disk.service
 # to CDS. Ordered before rke2 so the file exists when containerd launches the
 # baked plugin.
 enable nri-node-ip.service
+# Label GPU launches before rke2 registers the node; the baked
+# nvidia-device-plugin DaemonSet selects on the label.
+enable gpu-node-label.service
 # Role dispatch + the role-gated rke2 pair.
 enable rke2-role.service
 enable rke2-server.service

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Label this node when an NVIDIA GPU is actually attached.
+#
+# Every published node image carries the GPU userspace and the baked
+# nvidia-device-plugin DaemonSet, but GPU presence is a launch-time choice.
+# The DaemonSet selects on this label; without it the plugin lands on
+# GPU-less nodes where FAIL_ON_INIT_ERROR cannot save it — the
+# cdi-annotations strategy hard-fails generating a CDI spec with no driver
+# loaded, and the pod crashloops forever.
+#
+# Detection is PCI presence, not /dev/nvidia*: the device nodes only exist
+# once the driver has loaded, and this runs before rke2 starts.
+set -eu
+
+FRAGMENT=/etc/rancher/rke2/config.yaml.d/20-gpu-node-label.yaml
+
+# Clean slate: a relaunch without the GPU must not inherit the label.
+rm -f "$FRAGMENT"
+
+for vendor in /sys/bus/pci/devices/*/vendor; do
+    [ -e "$vendor" ] || continue
+    if [ "$(cat "$vendor")" = "0x10de" ]; then
+        mkdir -p /etc/rancher/rke2/config.yaml.d
+        printf 'node-label+:\n  - "confidential.ai/gpu=true"\n' > "$FRAGMENT"
+        exit 0
+    fi
+done
+exit 0

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/nvidia-device-plugin.yaml
@@ -37,6 +37,12 @@ spec:
       labels:
         app.kubernetes.io/name: nvidia-device-plugin
     spec:
+      # Set by gpu-node-label.service only when an NVIDIA function is on the
+      # PCI bus: FAIL_ON_INIT_ERROR cannot rescue a GPU-less node — the
+      # cdi-annotations strategy still hard-fails CDI spec generation with no
+      # driver, and the pod crashloops.
+      nodeSelector:
+        confidential.ai/gpu: "true"
       priorityClassName: system-node-critical
       tolerations:
         - operator: Exists


### PR DESCRIPTION
on GPU-less node-CVMs the baked nvidia-device-plugin crashloops forever (observed: 15 restarts/hour on a 2-node tdx pair, both nodes). `FAIL_ON_INIT_ERROR=false` survives NVML init, but `DEVICE_LIST_STRATEGY=cdi-annotations` then hard-fails generating a CDI spec with no driver loaded:

```
E ... error starting plugins: ... failed to get CDI spec: failed to construct device spec generators: failed to initialize NVML: Driver Not Loaded
```

every published image composes the gpu profiles, so this can't be a build-variant split — GPU presence is a launch-time property. this adds `gpu-node-label.service` (oneshot, ordered before rke2, preset-enabled): when an NVIDIA function is on the PCI bus it writes a `node-label+` rke2 config fragment (`confidential.ai/gpu=true`), cleaned first on every boot so a relaunch without the GPU sheds the label; the DaemonSet gains a matching nodeSelector. detection is PCI vendor, not /dev/nvidia*, because the unit runs before the driver loads.