### PR TITLE
fix(getkubeconfig): retry while cred-release is not yet listening

### DIFF
--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -77,6 +77,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.TLSServerName, "tls-server-name", "c8s-cvm", "kubeconfig tls-server-name — pins apiserver cert verification to this SAN (the image bakes it into tls-san) instead of the dialed IP. Empty to omit")
 	f.StringVar(&cfg.OutPath, "out", "", "output kubeconfig path (required)")
 	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
+	f.DurationVar(&cfg.ReleaseWait, "release-wait", 2*time.Minute, "how long to keep retrying while cred-release is not yet listening (it comes up after attest); 0 fails on the first refused dial")
 	cmd.MarkFlagsMutuallyExclusive("node", "vmi")
 	return cmd
 }

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -5,8 +5,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"github.com/confidential-dot-ai/c8s/internal/cmds/credrelease"
 	"os"
+	"syscall"
 	"time"
 )
 
@@ -44,6 +47,8 @@ type Config struct {
 	OutPath string
 	// Timeout bounds each network step.
 	Timeout time.Duration
+	// ReleaseWait bounds retries while cred-release is not yet listening.
+	ReleaseWait time.Duration
 }
 
 // Run executes the client flow: attest + RTMR[3] gate, then CSR -> cred-release
@@ -90,9 +95,25 @@ func Run(ctx context.Context, cfg Config) error {
 	//    cert key AND satisfy the same full measured-identity policy as the
 	//    attest gate, so the host can't MITM the channel.
 	httpClient := newRATLSClient(cfg, exp)
-	relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
-	defer cancel2()
-	resp, err := requestCredential(relCtx, httpClient, cfg.ReleaseBaseURL, keyPEM, csrPEM)
+	// cred-release starts listening well after attest answers (it waits on
+	// the node's own boot chain), so a refused dial right after the attest
+	// gate is boot ordering, not failure. Retry exactly that, bounded.
+	var resp *credrelease.ReleaseResponse
+	releaseDeadline := time.Now().Add(cfg.ReleaseWait)
+	for {
+		relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
+		resp, err = requestCredential(relCtx, httpClient, cfg.ReleaseBaseURL, keyPEM, csrPEM)
+		cancel2()
+		if err == nil || !errors.Is(err, syscall.ECONNREFUSED) || !time.Now().Before(releaseDeadline) {
+			break
+		}
+		fmt.Fprintln(os.Stderr, "cred-release not listening yet; retrying")
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("credential release: %w", ctx.Err())
+		case <-time.After(5 * time.Second):
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("credential release: %w", err)
 	}


### PR DESCRIPTION
running `c8s get-kubeconfig` right after a launch's attest gate passes fails with:

```
credential release: release request: Post "https://<node>:8443/release-credential": dial tcp <node>:8443: connect: connection refused
```

cred-release comes up 1–2 minutes after attest:8400 answers, so this is boot ordering, not a failure — but the operator has to hand-loop the command. this retries exactly `ECONNREFUSED` (everything else — auth failures, policy mismatches, refused-by-verifier — still fails fast), bounded by a new `--release-wait` (default 2m, 0 disables). the operator JWT is re-minted per attempt so its body binding stays fresh.