### PR TITLE
fix(e2e): select the image manifest by the whole measurement tuple

### DIFF
--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -427,7 +427,11 @@ jobs:
           esac
           # shellcheck disable=SC2086  # deliberate split: cands is a word list
           cands="$(printf '%s\n' ${cands} | sed 's/-cdi//' | awk 'NF && !seen[$0]++')"
-          cands="$cands rke2-tdx-dev"
+          # No blind fallback to rke2-tdx-dev: it floats independently of the
+          # pinned image, and the dev variant is a serial-root-autologin build
+          # that is never shipped. Pin it through imageTag if it is genuinely
+          # under test, so the choice is recorded in the CM.
+          [ -n "$cands" ] || { echo "::error::cannot derive a manifest tag from image '$image'. Set 'imageTag' in $REFS_CM to the oras tag published beside it"; exit 1; }
           got_mrtd=""; oras_ref=""
           for t in $cands; do
             d=$(crane manifest "$repo:$t" 2>/dev/null | jq -r '.layers[]|select(.annotations["org.opencontainers.image.title"]=="manifest.json")|.digest') || true
@@ -444,7 +448,7 @@ jobs:
           done
           # Fail closed: without a manifest from the booted build there is
           # nothing to pin the gate to.
-          [ -n "$got_mrtd" ] || { echo "::error::no oras artifact among [$cands] publishes a manifest.json whose mrtd+rtmr1+rtmr2 matches the build this CVM booted. Set 'imageTag' in $REFS_CM to the image's tag if it is not a rke2-tdx-dev build"; exit 1; }
+          [ -n "$got_mrtd" ] || { echo "::error::no oras artifact among [$cands] publishes a manifest.json whose mrtd+rtmr1+rtmr2 matches the build this CVM booted. Set 'imageTag' in $REFS_CM to the oras tag published beside the pinned image"; exit 1; }
           echo "manifest from $oras_ref (MRTD $got_mrtd)"
           c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --image-manifest /tmp/image-manifest.json --out /tmp/guest.kubeconfig --timeout 180s
           [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -402,35 +402,49 @@ jobs:
           # artifact that sits beside the CDI image the CVM boots.
           #
           # The CM's 'image' may be a tag OR a digest (digest-pinning the boot
-          # ref is the stronger position), and a digest has no sibling name to
-          # derive, so candidates are tried in order and the MRTD comparison
-          # below picks the right one. That check is the real test anyway: it
-          # proves the manifest describes the build this CVM booted, which a
-          # name match never could.
+          # ref is the stronger position). A digest carries no name, so resolve
+          # it back to the sibling tag that points at it; without that the only
+          # candidate left is the floating dev tag, which moves independently of
+          # the pinned image.
+          #
+          # Candidates are matched on the whole mrtd+rtmr1+rtmr2 tuple. MRTD
+          # alone does not identify a build: two builds sharing a firmware and
+          # memory layout have the same MRTD while their kernels, and so their
+          # RTMR[1], differ. Matching on MRTD accepted such a manifest and the
+          # run then failed inside get-kubeconfig on an RTMR[1] mismatch.
           repo="${image%%@*}"; repo="${repo%%:*}"
           cands="${imageTag:-}"
           case "$image" in
-            *@*) : ;;                                  # digest: no name to strip
-            *-cdi) cands="$cands ${image#*:}" ;;       # tag: strip the -cdi suffix
+            *@*)
+              # Digest: find the -cdi tag resolving to it, and take its sibling.
+              want="${image#*@}"
+              for t in $(crane ls "$repo" 2>/dev/null | grep -E -- '-cdi(-[0-9a-f]+)?$'); do
+                [ "$(crane digest "$repo:$t" 2>/dev/null)" = "$want" ] || continue
+                cands="$cands $t"; break
+              done
+              ;;
+            *-cdi*) cands="$cands ${image#*:}" ;;      # tag: strip the -cdi suffix
           esac
           # shellcheck disable=SC2086  # deliberate split: cands is a word list
-          cands="$(printf '%s\n' ${cands} | sed 's/-cdi$//' | awk 'NF && !seen[$0]++')"
-          [ -n "$cands" ] || cands=rke2-tdx-dev
+          cands="$(printf '%s\n' ${cands} | sed 's/-cdi//' | awk 'NF && !seen[$0]++')"
+          cands="$cands rke2-tdx-dev"
           got_mrtd=""; oras_ref=""
           for t in $cands; do
             d=$(crane manifest "$repo:$t" 2>/dev/null | jq -r '.layers[]|select(.annotations["org.opencontainers.image.title"]=="manifest.json")|.digest') || true
             [ -n "$d" ] || { echo "  $t: no manifest.json layer"; continue; }
             crane blob "$repo@$d" > /tmp/candidate-manifest.json 2>/dev/null || continue
             m=$(jq -r '.tdx.mrtd // empty' /tmp/candidate-manifest.json)
-            if [ "$m" = "$mrtd" ]; then
+            m1=$(jq -r '.tdx.rtmr1 // empty' /tmp/candidate-manifest.json)
+            m2=$(jq -r '.tdx.rtmr2 // empty' /tmp/candidate-manifest.json)
+            if [ "$m" = "$mrtd" ] && [ "$m1" = "$rtmr1" ] && [ "$m2" = "$rtmr2" ]; then
               cp /tmp/candidate-manifest.json /tmp/image-manifest.json
               got_mrtd="$m"; oras_ref="$repo:$t"; break
             fi
-            echo "  $t: MRTD $m != $mrtd"
+            echo "  $t: tuple mismatch (mrtd ${m:0:16}/${mrtd:0:16} rtmr1 ${m1:0:16}/${rtmr1:0:16} rtmr2 ${m2:0:16}/${rtmr2:0:16})"
           done
           # Fail closed: without a manifest from the booted build there is
           # nothing to pin the gate to.
-          [ -n "$got_mrtd" ] || { echo "::error::no oras artifact among [$cands] publishes a manifest.json whose MRTD is $mrtd (the build this CVM booted). Set 'imageTag' in $REFS_CM to the image's tag if it is not a rke2-tdx-dev build"; exit 1; }
+          [ -n "$got_mrtd" ] || { echo "::error::no oras artifact among [$cands] publishes a manifest.json whose mrtd+rtmr1+rtmr2 matches the build this CVM booted. Set 'imageTag' in $REFS_CM to the image's tag if it is not a rke2-tdx-dev build"; exit 1; }
           echo "manifest from $oras_ref (MRTD $got_mrtd)"
           c8s get-kubeconfig --node "$GUEST_IP" --operator-key /tmp/op.key --image-manifest /tmp/image-manifest.json --out /tmp/guest.kubeconfig --timeout 180s
           [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }


### PR DESCRIPTION
## Review Focus Areas (required)

| File / Area | Focus | Why |
|-------------|-------|-----|
| `.github/workflows/tdx-metal-e2e.yml` | Critical | Selects the manifest the attestation gate is pinned to; also removes a fallback to a never-ship debug image |

## What Changed

Candidate manifests are matched on the whole `mrtd+rtmr1+rtmr2` tuple instead of MRTD alone; a digest-pinned image resolves back to the sibling tag that points at it; and the blind fallback to the floating `rke2-tdx-dev` tag is removed in favour of failing closed.

## Why

`confidential-e2e` fails in `get an attested, operator-key-bound kubeconfig (RA-TLS)`, after reporting the manifest as successfully resolved:

```
manifest from ghcr.io/confidential-dot-ai/node-guest-base:rke2-tdx-dev (MRTD 9309eaae...)
attestation gate: RTMR[1] mismatch (guest kernel):
  node reports 61f723e81c52432a091e01243134c8e7bf85101a0fb0a39f...
  expected     485f550e0a0f6b7a4dc8151ae5aee3d502928bedc740eb00...
```

Two defects compound.

**MRTD does not identify a build.** The refs CM pins the image the CVM boots, which resolves to `rke2-tdx-cdi-47c8522`. Its manifest and the one under the floating `rke2-tdx-dev` tag have the **same MRTD** and **different RTMR[1]**:

| tag | MRTD | RTMR[1] | build |
|---|---|---|---|
| `rke2-tdx-47c8522` (booted) | `9309eaae…` | `61f723e8…` | 2026-08-19T05:54:04Z |
| `rke2-tdx-dev` (selected) | `9309eaae…` | `485f550e…` | 2026-08-18T18:16:20Z |

MRTD covers firmware and initial memory layout; RTMR[1] covers the guest kernel. Two builds sharing the former while differing in the latter is exactly the case a pin is a three-register tuple to catch, and matching on one register let the wrong manifest through. The existing comment asserted the opposite ("the MRTD comparison below picks the right one... which a name match never could"), which is what made this hard to see.

**A digest pin derived no candidate.** The CM pins by digest (`image: ...@sha256:f4a53c45…`), the stronger position. The `*-cdi` strip only fired for tags, so the digest case fell through to `cands=rke2-tdx-dev`. The fix scans `crane ls` for the `-cdi` tag resolving to that digest and takes its sibling.

**The dev-tag fallback is removed rather than kept behind the derived candidate.** `rke2-tdx-dev` floats independently of the pinned image, and per `c8s-image-publish.yml` the dev variant is a *"serial root autologin, different measurement. Never ship."* build. A fallback that can pin the attestation gate to a root-shell image is the wrong default even when the tuple check makes a match unlikely. The step now fails closed and names `imageTag` as the fix, so testing a dev build is recorded in the CM instead of reached by accident.

Verified against the live registry: both a digest pin and a `-cdi` tag pin resolve to `rke2-tdx-47c8522`, and the tuple match selects it. Under the old logic the same inputs select `rke2-tdx-dev`.

Failing run for reference: [32536370585](https://github.com/confidential-dot-ai/c8s/actions/runs/32536370585). That dispatch also confirms the separate `c8sRef` staleness is real but not sufficient on its own — passing a post-#399 ref cleared the earlier `missing "mrtd"` parse failure and surfaced this one.

## Design Doc

N/A

## Checklist

- [x] New dependencies justified (if any) — none
- [x] Tests verify invariants, not just output format — the invariant is "the manifest describes the build this CVM booted"; MRTD-only matching asserted a weaker property that two live builds already violate
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: reproducible build maintained — n/a, CI-only
- [x] For crypto code: constant-time, zeroization, audited libraries only — n/a
