### PR TITLE
kernel: drop IP_VS from the node-image fragments (confos#66 round 1)

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -440,6 +440,22 @@ jobs:
             confidential-os-builder/output/${{ env.VARIANT }}/roothash
           if-no-files-found: error
 
+      - name: Upload resolved kernel snapshot (gate)
+        # The lineage lockfile these inputs resolve to, so a fragment PR can
+        # commit it without a local Linux builder (confos#66;
+        # kernel-snapshot.yml is the kata lineage's equivalent). One cell —
+        # the snapshot is per-KERNEL_FLAVOR, not per-platform or per-leg. A
+        # cache-restored copy is equally valid: the exact key hashes the
+        # fragments, so the cached snapshot was resolved from these same
+        # inputs (by a sibling leg or an earlier run of them).
+        if: inputs.gate == true && matrix.platform == 'tdx' && inputs.leg != 'b'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kernel-snapshot-${{ github.run_id }}
+          path: c8s/node-guest-image/kernel/config-x86_64-${{ inputs.dev && 'c8s-dev' || 'c8s' }}.snapshot
+          if-no-files-found: error
+          retention-days: 7
+
       - name: Check whether the rootfs changed
         if: inputs.gate != true
         # Skip the multi-GB push when the roothash matches what's published.

--- a/node-guest-image/kernel/c8s-dev.config
+++ b/node-guest-image/kernel/c8s-dev.config
@@ -200,13 +200,8 @@ CONFIG_NETFILTER_XT_TARGET_MARK=y
 CONFIG_NETFILTER_XT_MATCH_SOCKET=y
 CONFIG_NETFILTER_XT_TARGET_TPROXY=y
 
-# --- kube-proxy IPVS mode ------------------------------------------------
-
-CONFIG_IP_VS=y
-CONFIG_IP_VS_NFCT=y
-CONFIG_IP_VS_RR=y
-CONFIG_IP_VS_WRR=y
-CONFIG_IP_VS_SH=y
+# NOT added: IP_VS* — kube-proxy is disabled (disable-kube-proxy: true) in
+# favor of Cilium kubeProxyReplacement, so no IPVS service path exists.
 
 # ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
 # glue that lets iptables rules reference a set via `-m set --match-set` —

--- a/node-guest-image/kernel/c8s.config
+++ b/node-guest-image/kernel/c8s.config
@@ -192,13 +192,8 @@ CONFIG_NETFILTER_XT_TARGET_MARK=y
 CONFIG_NETFILTER_XT_MATCH_SOCKET=y
 CONFIG_NETFILTER_XT_TARGET_TPROXY=y
 
-# --- kube-proxy IPVS mode ------------------------------------------------
-
-CONFIG_IP_VS=y
-CONFIG_IP_VS_NFCT=y
-CONFIG_IP_VS_RR=y
-CONFIG_IP_VS_WRR=y
-CONFIG_IP_VS_SH=y
+# NOT added: IP_VS* — kube-proxy is disabled (disable-kube-proxy: true) in
+# favor of Cilium kubeProxyReplacement, so no IPVS service path exists.
 
 # ipsets — IP_SET is the ipset core; NETFILTER_XT_SET is the separate xtables
 # glue that lets iptables rules reference a set via `-m set --match-set` —

--- a/node-guest-image/kernel/config-x86_64-c8s.snapshot
+++ b/node-guest-image/kernel/config-x86_64-c8s.snapshot
@@ -1321,7 +1321,6 @@ CONFIG_NETFILTER_XT_MATCH_CONNTRACK=y
 # CONFIG_NETFILTER_XT_MATCH_HL is not set
 # CONFIG_NETFILTER_XT_MATCH_IPCOMP is not set
 # CONFIG_NETFILTER_XT_MATCH_IPRANGE is not set
-# CONFIG_NETFILTER_XT_MATCH_IPVS is not set
 # CONFIG_NETFILTER_XT_MATCH_L2TP is not set
 # CONFIG_NETFILTER_XT_MATCH_LENGTH is not set
 # CONFIG_NETFILTER_XT_MATCH_LIMIT is not set
@@ -1366,52 +1365,7 @@ CONFIG_IP_SET_HASH_NET=y
 # CONFIG_IP_SET_HASH_NETPORT is not set
 # CONFIG_IP_SET_HASH_NETIFACE is not set
 # CONFIG_IP_SET_LIST_SET is not set
-CONFIG_IP_VS=y
-# CONFIG_IP_VS_IPV6 is not set
-# CONFIG_IP_VS_DEBUG is not set
-CONFIG_IP_VS_TAB_BITS=12
-
-#
-# IPVS transport protocol load balancing support
-#
-# CONFIG_IP_VS_PROTO_TCP is not set
-# CONFIG_IP_VS_PROTO_UDP is not set
-# CONFIG_IP_VS_PROTO_ESP is not set
-# CONFIG_IP_VS_PROTO_AH is not set
-# CONFIG_IP_VS_PROTO_SCTP is not set
-
-#
-# IPVS scheduler
-#
-CONFIG_IP_VS_RR=y
-CONFIG_IP_VS_WRR=y
-# CONFIG_IP_VS_LC is not set
-# CONFIG_IP_VS_WLC is not set
-# CONFIG_IP_VS_FO is not set
-# CONFIG_IP_VS_OVF is not set
-# CONFIG_IP_VS_LBLC is not set
-# CONFIG_IP_VS_LBLCR is not set
-# CONFIG_IP_VS_DH is not set
-CONFIG_IP_VS_SH=y
-# CONFIG_IP_VS_MH is not set
-# CONFIG_IP_VS_SED is not set
-# CONFIG_IP_VS_NQ is not set
-# CONFIG_IP_VS_TWOS is not set
-
-#
-# IPVS SH scheduler
-#
-CONFIG_IP_VS_SH_TAB_BITS=8
-
-#
-# IPVS MH scheduler
-#
-CONFIG_IP_VS_MH_TAB_INDEX=12
-
-#
-# IPVS application helper
-#
-CONFIG_IP_VS_NFCT=y
+# CONFIG_IP_VS is not set
 
 #
 # IP: Netfilter Configuration


### PR DESCRIPTION
Round 1 of confos#66 item 3 (trim dead kernel-config surface), in the issue's suggested order: IP_VS alone first, so a boot regression names its own cause.

## Why IP_VS is dead in this lineage

`node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml` sets `disable-kube-proxy: true`, and the Cilium override runs `kubeProxyReplacement: true` with `bpf.masquerade: true` — service routing never touches IPVS. The reason is the *lineage*, not c8s generally: c8s also runs where kube-proxy exists (kind integration lane, GKE), but this kernel only ships in the node image. A `NOT added:` comment now marks the deliberate absence in both fragments.

## Snapshot lockfile

The first commit adds a gate-mode artifact upload of the lineage lockfile to `c8s-image.yml` (one cell — the snapshot is per-KERNEL_FLAVOR, not per-platform/leg): the gate legs regenerate it inside the kernel cache anyway, and publishing it lets fragment PRs commit the refreshed snapshot without a local Linux builder.

The committed `config-x86_64-c8s.snapshot` **is** that artifact from this PR's own gate run (32604636187, sha256 `70893fa5…`), and the follow-up gate run on the final head reproduced it byte-identically (run 32605251532). The delta is exactly the expected collapse: the whole resolved IP_VS block (18 symbols/values) → `# CONFIG_IP_VS is not set`, plus `# CONFIG_NETFILTER_XT_MATCH_IPVS is not set` disappearing with its vanished dependency. Nothing else moves.

## Measurement + runtime gate

This is a deliberate measurement roll (MRTD/RTMR1/RTMR2 shift). Per confos#66, greps can't prove Cilium/containerd/RKE2 never probe these symbols at runtime, so the runtime gate runs **immediately after merge**, on the image the main build publishes (gate builds don't publish, and a branch dispatch would repoint shared tags): boot on TDX hardware (cross-host tdx-host-1 ↔ b200 pair), both inner nodes Ready, Cilium converged, mesh workload reachable, measurements re-pinned. A boot regression reverts this PR — launches are digest/measurement-pinned, so a bad floating tag can't reach running infrastructure in the interim.

FUSE_FS + SQUASHFS follow in a separate round once this one verifies clean.