### PR TITLE
ci(e2e): warn when the pinned c8s ref no longer matches the pinned image

### DIFF
--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -207,6 +207,40 @@ jobs:
             echo "c8sRef=${{ inputs.c8s_ref }}" >> "$GITHUB_ENV"
           fi
 
+      - name: preflight, the pinned ref still matches the pinned image
+        # c8sRef and image are separate CM fields, so they can drift apart with
+        # nothing to notice: a stale c8sRef built a CLI three days older than
+        # the image and failed the lane on a manifest the CLI could not parse.
+        #
+        # The image's own -cdi tags carry the c8s ref its components were baked
+        # from (c8s-image.yml passes the same SHORT_SHA to both). Reproducible
+        # builds mean one digest can hold SEVERAL such tags -- commits touching
+        # no image input produce a byte-identical image -- so agreement is
+        # "c8sRef is among them", never "equals the first one found".
+        #
+        # Advisory: an operator may deliberately pair a newer CLI with an older
+        # image, and only the baked floor can say whether that is denied.
+        continue-on-error: true
+        if: inputs.c8s_ref == ''
+        run: |
+          set -euo pipefail
+          repo="${image%%@*}"; repo="${repo%%:*}"
+          case "$image" in
+            *@*) want="${image#*@}" ;;
+            *)   want="$(crane digest "$image" 2>/dev/null || true)" ;;
+          esac
+          [ -n "$want" ] || { echo "could not resolve '$image' to a digest; skipping"; exit 0; }
+          matched=0; tagged=""
+          for t in $(crane ls "$repo" 2>/dev/null | grep -E '^rke2-tdx-cdi-[0-9a-f]{7,}$'); do
+            [ "$(crane digest "$repo:$t" 2>/dev/null)" = "$want" ] || continue
+            r="${t#rke2-tdx-cdi-}"
+            tagged="${tagged:+$tagged }$r"
+            [ "$r" = "$c8sRef" ] && matched=1
+          done
+          [ -n "$tagged" ] || { echo "no sha-suffixed tag points at the pinned image; nothing to compare"; exit 0; }
+          [ "$matched" = 1 ] && { echo "c8sRef '$c8sRef' matches the pinned image's build ref"; exit 0; }
+          echo "::warning title=stale c8sRef::the CM pins c8sRef='$c8sRef' but its image was built from [$tagged]. The CLI under test is not the one shipped in this image; re-seed c8sRef unless the pairing is deliberate"
+
       - name: preflight, TDX device capacity
         # KubeVirt's socket device-plugin probes the QGS socket ONLY at
         # virt-handler startup and never re-checks. After a host reboot or a


### PR DESCRIPTION
## Review Focus Areas (required)

| File / Area | Focus | Why |
|-------------|-------|-----|
| `.github/workflows/tdx-metal-e2e.yml` | Standard | Advisory preflight; cannot fail the lane, but its warning is what a future operator will act on |

## What Changed

A preflight step compares the refs CM's `c8sRef` against the c8s ref carried by the pinned image's own `-cdi` tags, and warns when they disagree. Advisory (`continue-on-error`), and skipped when an explicit `c8s_ref` input is supplied.

## Why

`c8sRef` and `image` are separate fields of the same ConfigMap, and nothing checks they came from the same build. They drifted: `c8sRef` stayed at `47c8522` while the loader fix the lane needed landed hours later, and the run failed with

```
--image-manifest: image manifest /tmp/image-manifest.json: missing "mrtd"
```

which is a manifest-parse error, not a version-pairing error. The actual cause — a CLI three days older than the image — was several inferential steps away from the symptom, and stayed unnoticed for three days.

The pairing itself is real and documented on the `c8s_ref` input: the node image bakes an admission floor from the components of *its* build ref, so a mismatched CLI can get its own components denied. This makes the existing constraint observable instead of implicit.

## Why membership, not equality

The image's `-cdi` tags carry the c8s ref its components were baked from: `c8s-image.yml` computes `SHORT_SHA="${C8S_REF_INPUT:-${HEAD_SHA::7}}"` and uses it both to bake the components and to suffix the tags, on the automatic and manual-rebuild paths alike.

But the mapping is many-to-one. Reproducible builds mean commits touching no image input produce a byte-identical image, which the registry dedupes to one digest under several tags:

```
sha256:883c3ee9… → rke2-tdx-cdi-{508ae73, b1efc08, 3c75ae0}
```

Those three commits differ in Go code, so they build different CLIs. Any of them is a legitimate pairing for that image, so the check asks whether `c8sRef` is *among* the tags, never whether it equals the first one found.

This is also why the ref is not simply derived from the image and the field dropped: a digest cannot say which of three refs the operator meant, and guessing would look authoritative while being arbitrary.

## Why advisory

Pairing a newer CLI with an older image is a legitimate thing to test, and only the baked floor can say whether the result is denied. A hard failure would block that; the warning names the condition and leaves the decision with the operator. The step is skipped entirely when `c8s_ref` is passed explicitly, since the existing version-pairing warning already covers that path.

## Verification

Logic exercised against live registry data for the four cases that matter:

| case | `c8sRef` | image's tags | result |
|---|---|---|---|
| the drift that caused the outage | `3b4b855` | `47c8522` | warns |
| correctly paired | `47c8522` | `47c8522` | passes |
| multi-tag digest, ref is a member | `b1efc08` | `508ae73 b1efc08 3c75ae0` | passes |
| multi-tag digest, ref is not | `deadbee` | `508ae73 b1efc08 3c75ae0` | warns |

`actionlint` reports the same 14 pre-existing shellcheck findings as `main`; no new ones.

## Design Doc

N/A

## Checklist

- [x] New dependencies justified (if any) — none; `crane` is already installed by the lane
- [x] Tests verify invariants, not just output format — the invariant is "the CLI under test is the one this image shipped"; previously nothing asserted it
- [x] No secrets in code, logs, or error messages
- [x] For TEE code: reproducible build maintained — n/a, CI-only
- [x] For crypto code: constant-time, zeroization, audited libraries only — n/a
