### PR TITLE
ci(c8s-image): snapshot-pin host build deps via confos bin/host-deps

### DIFF
--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -77,8 +77,7 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  # TODO(confos#111): before merge, repoint at the confos main merge commit.
-  CONFOS_REF: ${{ inputs.confos_ref || '5f560211f78213cb5d880f5fe410a1686264203b' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
+  CONFOS_REF: ${{ inputs.confos_ref || 'fd4427c0a401238f3430d05d9ba775ec0691d523' }} # pin: main — snapshot-pinned host build deps (confos#111, confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
   ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
 
 jobs:

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -78,7 +78,7 @@ env:
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
   # TODO(confos#111): before merge, repoint at the confos main merge commit.
-  CONFOS_REF: ${{ inputs.confos_ref || '0039c27ae329ab88117b06a8f6b7045475895e82' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
+  CONFOS_REF: ${{ inputs.confos_ref || '5f560211f78213cb5d880f5fe410a1686264203b' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
   ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
 
 jobs:

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -78,7 +78,7 @@ env:
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
   # TODO(confos#111): before merge, repoint at the confos main merge commit.
-  CONFOS_REF: ${{ inputs.confos_ref || '8109fcd8544f34b350a1ef4d334bb4e21c126c33' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
+  CONFOS_REF: ${{ inputs.confos_ref || '0039c27ae329ab88117b06a8f6b7045475895e82' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
   ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
 
 jobs:
@@ -184,46 +184,32 @@ jobs:
           ref: 84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
       - name: Restore build-dep debs
-        # Keyed on the runner-image release and the host-deps pin: the
-        # resolved deb set is a function of confos's committed snapshot
-        # timestamp and the preinstalled package state. Warm runs never touch
-        # the apt mirror, whose degradation has taken out gate legs repeatedly.
+        # Keyed on the runner-image release and the host-deps pin (script +
+        # the base mkosi.sources it reads): the resolved deb set is a
+        # function of confos's committed snapshot and the preinstalled
+        # package state. Warm runs never touch the apt mirror, whose
+        # degradation has taken out gate legs repeatedly.
         id: apt-debs
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps') }}
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
         # base ovmf is for the SNP path.
         # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
-        # iasl (DSDT) and clang (bindgen) shape measured bytes: cold runs
-        # install through confos's bin/host-deps (snapshot-pinned, fail-closed
-        # on live-mirror fetches, confos#36), which moves the dep closure to
-        # the snapshot's versions — hence --allow-downgrades on the warm
-        # reinstall too. Warm runs stay fully offline: apt sources are nulled,
-        # so a deb set that no longer resolves fails instead of drifting.
+        # iasl (DSDT) and clang (bindgen) shape measured bytes: host-deps
+        # installs them snapshot-pinned, fail-closed on live-mirror fetches
+        # (confos#36); with a warm apt-debs it reinstalls fully offline.
         # Bounded: a dead mirror connection otherwise hangs until the job's
         # 3h limit.
         timeout-minutes: 10
         run: |
           set -euo pipefail
-          if compgen -G "apt-debs/*.deb" >/dev/null; then
-            sudo DEBIAN_FRONTEND=noninteractive apt-get \
-              -o Dir::Etc::sourcelist=/dev/null \
-              -o Dir::Etc::sourceparts=/dev/null \
-              -o Dpkg::Options::=--force-confdef \
-              -o Dpkg::Options::=--force-confold \
-              install -y --allow-downgrades ./apt-debs/*.deb
-          else
-            confidential-os-builder/bin/host-deps \
-              systemd-container ovmf cpio acpica-tools \
-              libclang-dev clang libtss2-dev
-            mkdir -p apt-debs
-            sudo cp /var/cache/apt/archives/*.deb apt-debs/
-            sudo chown -R "$(id -u):$(id -g)" apt-debs
-          fi
+          confidential-os-builder/bin/host-deps --cache-dir apt-debs \
+            systemd-container ovmf cpio acpica-tools \
+            libclang-dev clang libtss2-dev
           # The exact host set, for auditing a published measurement's toolchain.
           { echo "### host build-dep debs"; find apt-debs -maxdepth 1 -name '*.deb' -printf '- %f\n' | sort; } >> "$GITHUB_STEP_SUMMARY"
 
@@ -233,7 +219,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps') }}
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache staged GPU tree

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -77,7 +77,8 @@ env:
   # the image's TDX measurement, so it's a reviewed PR + a --measurements
   # refresh. Must be on confos origin/main. The confos_ref dispatch input
   # overrides it for A/B measurement checks.
-  CONFOS_REF: ${{ inputs.confos_ref || 'cf544e9fa9f035dc17f87d5e92ec9732ae247660' }} # pin: v0.4.3 — SNP operator-key initrd arm (confos#106), per-lineage snapshot lockfiles (confos#105), attest-gpu serves SNP (confos#102/#103); one deliberate measurement roll
+  # TODO(confos#111): before merge, repoint at the confos main merge commit.
+  CONFOS_REF: ${{ inputs.confos_ref || '8109fcd8544f34b350a1ef4d334bb4e21c126c33' }} # pin: PR confos#111 head — snapshot-pinned host build deps (confos#36); rolls the SNP measurement once (OVMF 2ubuntu0.9 -> snapshot 2ubuntu0.8)
   ATTESTATION_RS_REF: "4c81fc55060723ce212a2ce5e8fcc49b294c6fb4" # pin: main 2026-08-06 (#80) — bump = new origin/main SHA + --measurements refresh in the same PR
 
 jobs:
@@ -183,40 +184,47 @@ jobs:
           ref: 84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
       - name: Restore build-dep debs
-        # Keyed per runner-image release: installing a fixed deb set is only
-        # valid against the preinstalled package state it was resolved for.
-        # Warm runs never touch the apt mirror, whose degradation has taken
-        # out gate legs repeatedly.
+        # Keyed on the runner-image release and the host-deps pin: the
+        # resolved deb set is a function of confos's committed snapshot
+        # timestamp and the preinstalled package state. Warm runs never touch
+        # the apt mirror, whose degradation has taken out gate legs repeatedly.
         id: apt-debs
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps') }}
 
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
         # base ovmf is for the SNP path.
         # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
+        # iasl (DSDT) and clang (bindgen) shape measured bytes: cold runs
+        # install through confos's bin/host-deps (snapshot-pinned, fail-closed
+        # on live-mirror fetches, confos#36), which moves the dep closure to
+        # the snapshot's versions — hence --allow-downgrades on the warm
+        # reinstall too. Warm runs stay fully offline: apt sources are nulled,
+        # so a deb set that no longer resolves fails instead of drifting.
         # Bounded: a dead mirror connection otherwise hangs until the job's
         # 3h limit.
         timeout-minutes: 10
         run: |
           set -euo pipefail
           if compgen -G "apt-debs/*.deb" >/dev/null; then
-            sudo apt-get install -y ./apt-debs/*.deb
+            sudo DEBIAN_FRONTEND=noninteractive apt-get \
+              -o Dir::Etc::sourcelist=/dev/null \
+              -o Dir::Etc::sourceparts=/dev/null \
+              -o Dpkg::Options::=--force-confdef \
+              -o Dpkg::Options::=--force-confold \
+              install -y --allow-downgrades ./apt-debs/*.deb
           else
-            sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
-            sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
-              --download-only \
+            confidential-os-builder/bin/host-deps \
               systemd-container ovmf cpio acpica-tools \
               libclang-dev clang libtss2-dev
             mkdir -p apt-debs
             sudo cp /var/cache/apt/archives/*.deb apt-debs/
             sudo chown -R "$(id -u):$(id -g)" apt-debs
-            sudo apt-get install -y ./apt-debs/*.deb
           fi
-          # iasl (DSDT) and clang (bindgen) shape measured bytes; record the
-          # exact host set until these ride a snapshot mirror (confos#36).
+          # The exact host set, for auditing a published measurement's toolchain.
           { echo "### host build-dep debs"; find apt-debs -maxdepth 1 -name '*.deb' -printf '- %f\n' | sort; } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save build-dep debs
@@ -225,7 +233,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}
+          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps') }}
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache staged GPU tree

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -167,6 +167,11 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
         with:
+          # Pinned: rustc compiles attestation-api, whose bytes ship in the
+          # measured rootfs — "stable" drifts between legs across a Rust
+          # release (a c8s#392 divergence candidate). Bumping this can move
+          # measurements.
+          toolchain: "1.98.0"
           # Both cargo workspaces this job compiles; the default "." caches neither.
           cache-workspaces: |
             attestation-rs

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -182,6 +182,12 @@ jobs:
         with:
           ref: 84af20892b61c8e177e391f997ded8b4cb5514f2 # v26
 
+      - name: Compute runner-image cache term
+        # ImageOS/ImageVersion are runner-process env vars, not workflow env
+        # context — ${{ env.ImageOS }} silently renders empty in a key.
+        id: image
+        run: echo "key=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
       - name: Restore build-dep debs
         # Keyed on the runner-image release and the host-deps pin (script +
         # the base mkosi.sources it reads): the resolved deb set is a
@@ -192,7 +198,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+          key: apt-debs-${{ steps.image.outputs.key }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       - name: Install build deps
         # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
@@ -218,7 +224,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: apt-debs
-          key: apt-debs-${{ env.ImageOS }}-${{ env.ImageVersion }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+          key: apt-debs-${{ steps.image.outputs.key }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       # Caches: confos c8s.yml's keys/paths, scoped to the confos checkout dir.
       - name: Cache staged GPU tree

--- a/.github/workflows/image-repro-debug.yml
+++ b/.github/workflows/image-repro-debug.yml
@@ -54,6 +54,10 @@ jobs:
 
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
+        with:
+          # Keep in lockstep with c8s-image.yml: rustc shapes the measured
+          # attestation-api bytes the A/B builds compare.
+          toolchain: "1.98.0"
 
       - name: Setup uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1

--- a/.github/workflows/image-repro-debug.yml
+++ b/.github/workflows/image-repro-debug.yml
@@ -64,11 +64,13 @@ jobs:
           ref: ${{ steps.pins.outputs.mkosi }}
 
       - name: Install build deps
-        timeout-minutes: 5
+        # Same snapshot-pinned toolchain as c8s-image (confos#36): the A/B
+        # verdicts only describe the real pipeline if the host debs match.
+        timeout-minutes: 10
         run: |
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 update -y
-          sudo apt-get -o Acquire::http::Timeout=30 -o Acquire::Retries=3 install -y \
-            systemd-container ovmf cpio acpica-tools libclang-dev clang libtss2-dev
+          confidential-os-builder/bin/host-deps \
+            systemd-container ovmf cpio acpica-tools \
+            libclang-dev clang libtss2-dev
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1


### PR DESCRIPTION
## Problem

Closes the c8s half of confos#36: `iasl` (DSDT) and `clang`/`libclang-dev` (bindgen for attestation-api) shape measured bytes, but the apt-debs cache only froze them per runner-image release — a rotation refreshed the set unreviewed from the live archive. A freeze, not a pin. The Rust toolchain had the same hole: `rustc` compiles attestation-api (measured rootfs bytes) and "stable" drifts between gate legs across a Rust release — this PR's own gate run updated the machine from 1.97.1 to 1.98.0 mid-run, which is the exact divergence signature of #392 (base image differs, kernel/initrd identical).

## Fix

- Host debs install through confos's `bin/host-deps` (confos#111, merged): snapshot.ubuntu.com at the base image's committed pin, apt confined to a snapshot-only source list above priority 1000, transcript scanned fail-closed, manifest-validated deb cache (warm runs fully offline; any mismatch — pin bump, runner rotation, tampering — falls back to a cold snapshot install).
- `CONFOS_REF` bumped to the confos#111 merge commit `fd4427c` — a deliberate measurement roll (published OVMF moves from live 2024.02-2ubuntu0.9 to the snapshot's 2ubuntu0.8).
- Rust toolchain pinned to 1.98.0 (today's stable, so the pin itself moves nothing) in `c8s-image.yml` and `image-repro-debug.yml`; the repro harness also installs the same pinned host debs, so its A/B verdicts describe the real pipeline.
- Cache keys carry the host-deps script + the mkosi.sources pin it reads, with the runner-image term computed at runtime (`env.ImageOS` renders empty in workflow expressions — confos#112).

## Verified

- confos side: post-merge `base.yml` cold run made 42 snapshot fetches and zero live-mirror fetches (ovmf 2024.02-2ubuntu0.8); the dispatched second run hit the deb cache and reinstalled fully offline with zero network fetches.
- Container e2e of every cache path: warm offline, pin-bump/tamper/cross-release fallback to cold, foreign-deb exclusion, dev-machine live apt lists preserved.
- This PR's A/B gate (build-a/build-b × snp/tdx) validates the new measurement tuple's reproducibility on the final head. (One earlier leg failed on a transient cdn.kernel.org HTTP/2 error, unrelated.)

## After merge

- The first published manifest carries the new `mrtd`/`rtmr1`/`rtmr2` tuple: update the metal-e2e refs ConfigMap on the TDX host or `tdx-metal-e2e` fails its tuple match.
- Watch whether #392's ~10% divergence rate drops to zero — the clang/libclang and rustc drift classes this PR removes are the leading candidates for it.
- `kata-guest-base.yml` still installs host debs raw and carries its own CONFOS_REF; same treatment is a separate PR/roll.