### PR TITLE
fix(node-guest-image): GPU label must survive node re-registration

### DIFF
--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh
@@ -1,15 +1,18 @@
 #!/bin/sh
-# Label this node when an NVIDIA GPU is actually attached.
+# Label this node when an NVIDIA GPU is attached, so the baked
+# nvidia-device-plugin DaemonSet (which selects on the label) schedules only
+# where a GPU exists. On a GPU-less node the plugin's cdi-annotations strategy
+# hard-fails generating a CDI spec with no driver and crashloops forever.
 #
-# Every published node image carries the GPU userspace and the baked
-# nvidia-device-plugin DaemonSet, but GPU presence is a launch-time choice.
-# The DaemonSet selects on this label; without it the plugin lands on
-# GPU-less nodes where FAIL_ON_INIT_ERROR cannot save it — the
-# cdi-annotations strategy hard-fails generating a CDI spec with no driver
-# loaded, and the pod crashloops forever.
+# The label goes on kubelet's --node-labels (via kubelet-arg), NOT rke2's
+# node-label: rke2 node-label is applied only at first node registration, so a
+# re-join under an existing node name (any agent relaunch) would silently drop
+# it. kubelet re-asserts --node-labels on every start, so the label survives.
+# confidential.ai/ is a non-reserved prefix, so NodeRestriction lets the
+# kubelet self-set it.
 #
-# Detection is PCI presence, not /dev/nvidia*: the device nodes only exist
-# once the driver has loaded, and this runs before rke2 starts.
+# Detection is PCI presence, not /dev/nvidia*: the device nodes only exist once
+# the driver has loaded, and this runs before rke2 starts.
 set -eu
 
 FRAGMENT=/etc/rancher/rke2/config.yaml.d/20-gpu-node-label.yaml
@@ -21,7 +24,9 @@ for vendor in /sys/bus/pci/devices/*/vendor; do
     [ -e "$vendor" ] || continue
     if [ "$(cat "$vendor")" = "0x10de" ]; then
         mkdir -p /etc/rancher/rke2/config.yaml.d
-        printf 'node-label+:\n  - "confidential.ai/gpu=true"\n' > "$FRAGMENT"
+        # kubelet-arg+ appends to the base config's kubelet-arg list rather
+        # than replacing it.
+        printf 'kubelet-arg+:\n  - "node-labels=confidential.ai/gpu=true"\n' > "$FRAGMENT"
         exit 0
     fi
 done


### PR DESCRIPTION
## Bug

#472 writes the GPU node label as an rke2 `node-label+` config fragment. rke2/k3s apply `node-label` **only at first node registration** — on any re-registration under an existing node name, the labels are not re-asserted. Every agent relaunch re-registers, so the `confidential.ai/gpu=true` label silently vanishes even though the fragment is still on disk. The nvidia-device-plugin DaemonSet (which nodeSelects on that label) then never schedules, and the node stops advertising `nvidia.com/gpu`.

Observed live on a B200 node-CVM: after its kubelet re-joined following a stale-node-record cleanup, the node came up with no `confidential.ai/gpu` label and the device plugin at 0 desired. Hand-applying the label immediately brought the plugin to 1/1 and `nvidia.com/gpu: 1` allocatable — confirming the mechanism is right but the persistence is not.

## Fix

Write the label through kubelet's `--node-labels` (via `kubelet-arg+`) instead of rke2's registration-time `node-label`. The kubelet re-asserts `--node-labels` on **every** start, so the label survives a re-join. `confidential.ai/` is a non-reserved prefix, so NodeRestriction lets the kubelet self-set it — and this works on agents, which have no admin kubeconfig to label themselves out-of-band. `kubelet-arg+` appends to the base config's kubelet-arg list rather than replacing it.

Detection, clean-slate-on-relaunch, and the before-rke2 ordering are unchanged.

## Validation

shellcheck clean; fragment is valid YAML and uses the `+` list-merge key. The end-to-end persistence check (relaunch the GPU agent, confirm the label + `nvidia.com/gpu` come back without manual intervention) is pending a free GPU node — the pair was torn down mid-test by concurrent work.