### PR TITLE
test(node-guest-image): guard the GPU label mechanism (#486)

### DIFF
--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -135,6 +135,15 @@ jobs:
             -manifest "$manifests/local-path-storage.yaml" \
             -manifest "$manifests/nvidia-device-plugin.yaml"
 
+  gpu-label:
+    name: gpu-node-label logic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run the gpu-node-label unit test
+        run: make test-node-guest-image-gpu-label
+
   rke2-role:
     name: rke2-role dispatch (script)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -141,6 +141,10 @@ test-integration-cluster:
 # mounts, writes /run/confos) — sudo on a disposable box.
 test-node-guest-image-role:
 	./node-guest-image/tests/rke2-role-test.sh
+
+# GPU-node label logic (root-free unit test; fakes the PCI tree).
+test-node-guest-image-gpu-label:
+	./node-guest-image/tests/gpu-node-label-test.sh
 
 # Role-gated unit wiring under real systemd in a privileged container.
 # Needs only docker.

--- a/node-guest-image/tests/gpu-node-label-test.sh
+++ b/node-guest-image/tests/gpu-node-label-test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Unit test for gpu-node-label.sh: the GPU-presence detection and, crucially,
+# that it writes the label as a kubelet-arg (re-asserted every kubelet start)
+# rather than an rke2 node-label (applied only at first registration, so it
+# would silently vanish on any agent re-join). Root-free: fakes the PCI sysfs
+# tree and the rke2 config dir under a temp root.
+set -u
+
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$TESTS_DIR/lib.sh"
+SCRIPT=${GPU_LABEL_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh"}
+[[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
+
+# negation wrapper: ok runs "$@" directly, so a bare ! is not a command.
+not() { ! "$@"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+FRAGMENT="$WORK/etc/rancher/rke2/config.yaml.d/20-gpu-node-label.yaml"
+
+# Run the production script verbatim with its two absolute paths rebased into
+# $WORK — no edits to logic, only the roots it reads/writes.
+run_label() {
+    sed -e "s|/etc/rancher/rke2|$WORK/etc/rancher/rke2|g" \
+        -e "s|/sys/bus/pci/devices|$WORK/sys/bus/pci/devices|g" \
+        "$SCRIPT" | bash
+}
+set_vendor() { # set_vendor HEXID
+    rm -rf "$WORK/sys/bus/pci/devices"
+    mkdir -p "$WORK/sys/bus/pci/devices/0000:0b:00.0"
+    printf '%s' "$1" > "$WORK/sys/bus/pci/devices/0000:0b:00.0/vendor"
+}
+
+CASE="nvidia present"
+set_vendor 0x10de
+run_label
+ok "emits a fragment" test -f "$FRAGMENT"
+ok "labels via kubelet-arg, not rke2 node-label" grep -q '^kubelet-arg+:' "$FRAGMENT"
+ok "does NOT use node-label (the register-only key #486 replaced)" not grep -q 'node-label+:' "$FRAGMENT"
+ok "sets the gpu label value" grep -q 'node-labels=confidential.ai/gpu=true' "$FRAGMENT"
+
+CASE="non-nvidia device"
+set_vendor 0x8086
+run_label
+ok "writes no fragment for a non-GPU device" not test -f "$FRAGMENT"
+
+CASE="relaunch without gpu clears a stale label"
+set_vendor 0x10de; run_label
+ok "fragment present after a GPU boot" test -f "$FRAGMENT"
+set_vendor 0x8086; run_label
+ok "stale fragment removed when the GPU is gone" not test -f "$FRAGMENT"
+
+summarize "gpu-node-label"


### PR DESCRIPTION
Follow-up to #486 — adds the regression test that fix was missing (it merged with an empty-GPU-node validation gap).

Root-free unit test for `gpu-node-label.sh`:
- GPU present (PCI vendor 0x10de) → emits the fragment
- non-GPU device → no fragment
- relaunch without a GPU → stale fragment removed
- **the #486 property**: the label is written via `kubelet-arg+` (kubelet re-asserts `--node-labels` every start, so it survives a node re-registration) and explicitly NOT via rke2 `node-label+` (applied only at first registration — the original bug)

Fakes the PCI sysfs tree and the rke2 config dir under a temp root, so it needs no root and no hardware. New `make test-node-guest-image-gpu-label` target, wired into `node-guest-image-lint.yml`. Runs the production script verbatim (only its two absolute paths rebased into the sandbox).

The live end-to-end proof (relaunch a GPU agent, confirm the label + `nvidia.com/gpu` return automatically) is still worth doing once a GPU node is free — but the mechanism the fix depends on is now guarded in CI regardless.