### PR TITLE
test(e2e): scriptified e2e tests

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -211,7 +211,6 @@ jobs:
               enabled: false
           EOF
           )
-          CW=$(base64 -w0 c8s/samples/nginx-confidential-pod.yaml)
 
           # RENDER GATE: fail chart validation HERE (30s) not in the CVM (20min).
           # Both substitutions are throwaway stand-ins so `helm template` has
@@ -257,22 +256,14 @@ jobs:
             say FAIL_HELM
             exit 0
           fi
+          export PATH="/var/lib/rancher/rke2/bin:\$PATH"
+          E2E=\$(echo /tmp/c8s-*/test/e2e)
           CDSOK=0
-          for i in \$(seq 1 45); do
-            PODS=\$(\$K -n c8s-system get pods --no-headers 2>&1)
-            printf '%s\n' "\$PODS" | sed 's/^/@@POD /;s/\$/@@/'
-            CDS=\$(printf '%s\n' "\$PODS" | grep '^c8s-cds-' | head -1)
-            echo "@@CDSR \$i: \${CDS:-nopod}@@"
-            printf '%s' "\$CDS" | grep -qE ' 1/1 +Running' && { CDSOK=1; say CDS_READY; break; }
-            printf '%s\n' "\$PODS" | grep -q 'ImagePullBackOff' && IPB=\$((\${IPB:-0}+1)) || IPB=0
-            [ "\$IPB" -ge 5 ] && { \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'; say FAIL_IMAGEPULL; exit 0; }
-            sleep 12
-          done
-          # consumption proof: a cw workload must RUN with the CDS-issued cert injected.
-          # Under MEAS_ENFORCED that cert is only issued if the node attests the pinned
-          # measurement — so this IS the enforcement test, not a separate assertion.
-          WOK=0; COK=0
+          if bash "\$E2E/components-ready.sh" c8s-cds; then CDSOK=1; say CDS_READY; fi
+          \$K -n c8s-system get pods --no-headers 2>&1 | sed 's/^/@@POD /;s/\$/@@/'
+          WOK=0
           if [ "\$CDSOK" != "1" ]; then
+            \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'
             \$K -n c8s-system logs deploy/c8s-cds --tail=15 2>&1 | sed 's/^/@@CDSLOG /;s/\$/@@/'
             \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
           fi
@@ -294,26 +285,16 @@ jobs:
               sleep 5
             done
             [ "\$NRIOK" = "1" ] || say WARN_NRI_NOT_READY
-            printf %s '$CW' | base64 -d | \$K apply -f - 2>&1 | sed 's/^/@@CWAPPLY /;s/\$/@@/'
-            for i in \$(seq 1 60); do
-              DP=\$(\$K -n default get deploy demo-nginx --no-headers 2>&1)
-              echo "@@CWDEP \$i: \$DP@@"
-              printf '%s' "\$DP" | grep -qE ' 1/1 ' && { WOK=1; say WORKLOAD_OK; break; }
-              sleep 10
-            done
-            IC=\$(\$K -n default get pods -l app=demo-nginx -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null)
-            echo "@@CWCONTAINERS \${IC:-none}@@"
-            printf '%s' "\$IC" | grep -q 'c8s-cert' && { COK=1; say CERT_INJECTED; }
-            if [ "\$WOK" = "1" ] && [ "\$COK" = "1" ]; then
-              # Live-cluster e2e suites from the merge-under-test's own source.
-              # A suite failure fails the lane (FAIL_ marker -> no PAYLOAD_OK).
-              export PATH="/var/lib/rancher/rke2/bin:\$PATH"
-              E2E=\$(echo /tmp/c8s-*/test/e2e)
-              FAILED=""
-              bash "\$E2E/cw-label-policy.sh" && say E2E_CW_LABEL_OK || FAILED="\$FAILED cw-label-policy"
-              bash "\$E2E/ca-handoff.sh" && say E2E_CA_HANDOFF_OK || FAILED="\$FAILED ca-handoff"
-              if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
-            fi
+            # Live-cluster e2e suites from the merge-under-test's own source.
+            # A suite failure fails the lane (FAIL_ marker -> no PAYLOAD_OK).
+            # Only markers reach the run log, so a suite's own stdout lands in
+            # the guest-console artifact; the diagnostics below stay inline.
+            FAILED=""
+            # Under MEAS_ENFORCED the cert is only issued if the node attests the pinned measurement, so this is the enforcement test.
+            bash "\$E2E/cw-workload.sh" && { WOK=1; say WORKLOAD_OK; } || FAILED="\$FAILED cw-workload"
+            bash "\$E2E/cw-label-policy.sh" && say E2E_CW_LABEL_OK || FAILED="\$FAILED cw-label-policy"
+            bash "\$E2E/ca-handoff.sh" && say E2E_CA_HANDOFF_OK || FAILED="\$FAILED ca-handoff"
+            if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
             if [ "\$WOK" != "1" ]; then
               \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
               \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -509,43 +509,27 @@ jobs:
         run: |
           set -euo pipefail
           export KUBECONFIG=/tmp/guest.kubeconfig
-          # awk, not a regex backreference: `$2 !~ /^([0-9]+)\/\1$/` looks right
-          # and is not (awk has no backreferences), so it silently only ever
-          # matches 1/1 and calls every sidecar-bearing pod not-ready.
-          for i in $(seq 1 40); do
-            NOTREADY=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | awk '{split($2,a,"/"); if (a[1]!=a[2] || $3!="Running") n++} END {print n+0}')
-            TOTAL=$(kubectl -n c8s-system get pods --no-headers 2>/dev/null | wc -l)
-            [ "$TOTAL" -gt 0 ] && [ "$NOTREADY" -eq 0 ] && { echo "all $TOTAL components Running"; break; }
-            sleep 15
-          done
-          kubectl -n c8s-system get pods --no-headers
-          [ "${NOTREADY:-1}" -eq 0 ] || { echo "::error::components did not converge"; kubectl -n c8s-system describe pods | tail -40; exit 1; }
+          bash /tmp/c8s-src/test/e2e/components-ready.sh
 
-      - name: NEGATIVE, the baked floor must deny a non-allowlisted image
-        # The product's core guarantee, asserted rather than worked around.
-        # Uses the `default` namespace deliberately: the node image bakes a
-        # restricted PSA default and exempts `default` for smoke pods, so a
-        # denial here is unambiguously the IMAGE floor, not PodSecurity.
+      - name: assert the image floor denies, then opens to a signed write
+        # tls-lb fronts /allowlist on hostPort 443, and node mode puts CDS in
+        # the node CVM, so the endpoint pins to the node MRTD.
         run: |
           set -euo pipefail
           export KUBECONFIG=/tmp/guest.kubeconfig
-          kubectl -n default delete pod denied --ignore-not-found >/dev/null 2>&1 || true
-          kubectl -n default run denied --image=busybox:1.36 --restart=Never --command -- sleep 300
-          for i in $(seq 1 24); do
-            R=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null || true)
-            [ -n "$R" ] && [ "$R" != ContainerCreating ] && break
-            sleep 5
-          done
-          MSG=$(kubectl -n default get pod denied -o jsonpath='{.status.containerStatuses[0].state.waiting.message}' 2>/dev/null || true)
-          echo "reason=$R"
-          echo "message=$MSG"
-          echo "$MSG" | grep -q 'image not in allowlist' || {
-            echo "::error title=SECURITY REGRESSION::the baked NRI floor did NOT deny a non-allowlisted image (reason=$R). The product's fail-closed admission guarantee is not holding on this image."
-            kubectl -n default describe pod denied | tail -20
-            exit 1
-          }
-          echo "OK: floor denied busybox:1.36 at container creation"
-          kubectl -n default delete pod denied --wait=false >/dev/null 2>&1 || true
+          export C8S_ALLOWLIST_URL="https://$GUEST_IP:443"
+          export C8S_MEASUREMENTS="$mrtd"
+          export C8S_OPERATOR_KEY=/tmp/op.key
+          bash /tmp/c8s-src/test/e2e/allowlist-enforcement.sh
+
+      - name: assert a confidential workload runs with an injected cert
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          export C8S_ALLOWLIST_URL="https://$GUEST_IP:443"
+          export C8S_MEASUREMENTS="$mrtd"
+          export C8S_OPERATOR_KEY=/tmp/op.key
+          bash /tmp/c8s-src/test/e2e/cw-workload.sh
 
       - name: summary
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-ca-handoff test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -186,6 +186,26 @@ test-e2e-mesh-cw-enforcement:
 # Also runs post-merge in the snp-metal-e2e lane's in-guest payload.
 test-e2e-ca-handoff:
 	./test/e2e/ca-handoff.sh
+
+# Live-cluster check that image admission is fail-closed and that a signed
+# allowlist write opens it. Needs kubectl pointed at a cluster with c8s
+# installed, plus C8S_ALLOWLIST_URL, C8S_MEASUREMENTS and C8S_OPERATOR_KEY.
+# Also runs post-merge in the tdx-metal-e2e lane.
+test-e2e-allowlist-enforcement:
+	./test/e2e/allowlist-enforcement.sh
+
+# Live-cluster check that every c8s-system pod is Running and Ready. Needs
+# kubectl pointed at a cluster with c8s installed. Also runs post-merge in
+# the tdx-metal-e2e lane.
+test-e2e-components-ready:
+	./test/e2e/components-ready.sh
+
+# Live-cluster check that the sample confidential workload runs with the
+# injected c8s-cert sidecar. Needs kubectl pointed at a cluster with c8s
+# installed; under a fail-closed floor also C8S_OPERATOR_KEY,
+# C8S_ALLOWLIST_URL and C8S_MEASUREMENTS. Runs post-merge in both metal lanes.
+test-e2e-cw-workload:
+	./test/e2e/cw-workload.sh
 
 # Parse + decision tests for the baked kata-agent policy. The guest evaluates
 # it with regorus, which reads Rego v0 plus the future keywords, so the checks

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -8,7 +8,7 @@ covers and why the kind harness is shaped the way it is.
 | --- | --- | --- | --- |
 | docker-compose | `make test-integration` | Integration | get-cert's RA-TLS flow against mock CDS + mock attestation-api, nginx serving the issued leaf |
 | kind cluster | `make test-integration-cluster` | Integration (cluster) | the full node-mode control plane and workload path (below) |
-| live-cluster scripts | `test/e2e/*.sh` | snp/tdx-metal-e2e | cw-label policy, mesh enforcement, CA handoff on real TEEs |
+| live-cluster scripts | `test/e2e/*.sh` | snp/tdx-metal-e2e | cw-label policy, mesh enforcement, CA handoff, allowlist enforcement, control-plane convergence on real TEEs |
 
 ## The kind harness
 

--- a/test/e2e/allowlist-enforcement.sh
+++ b/test/e2e/allowlist-enforcement.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Live-cluster check that image admission is fail-closed and that a signed
+# allowlist write opens it: a non-allowlisted image is denied at container
+# creation, and the same image runs once its digest is on the floor.
+#
+# Needs kubectl pointed at a cluster with c8s installed, `c8s` and `crane` on
+# PATH, and:
+#   C8S_ALLOWLIST_URL  RA-TLS tls-lb or direct CDS base URL
+#   C8S_MEASUREMENTS   launch measurement pinning that endpoint
+#   C8S_OPERATOR_KEY   path to the operator EC key PEM pinned on CDS
+set -euo pipefail
+. "$(dirname "$0")/lib.sh"
+
+: "${C8S_ALLOWLIST_URL:?names the RA-TLS CDS or tls-lb endpoint}"
+: "${C8S_MEASUREMENTS:?pins the launch measurement of that endpoint}"
+: "${C8S_OPERATOR_KEY:?path to the operator EC key PEM}"
+
+# `default` is exempt from the node image's restricted PSA default, so a denial
+# here is the image floor and not PodSecurity.
+ns=default
+pod=allowlist-probe
+image=busybox:1.36
+
+al() { c8s allowlist "$@" --url "$C8S_ALLOWLIST_URL" --measurements "$C8S_MEASUREMENTS"; }
+
+probe() {
+  kubectl -n "$ns" run "$pod" --image="$image" --restart=Never --command -- sleep 300 >/dev/null
+}
+
+digest=""
+cleanup() {
+  kubectl -n "$ns" delete pod "$pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  [ -n "$digest" ] && al remove "$digest" >/dev/null 2>&1
+  return 0
+}
+trap cleanup EXIT
+
+digest=$(c8s allowlist inspect-image "$image" | awk '$1 == "digest:" { print $2 }')
+[ -n "$digest" ] || fail "no digest resolved for $image"
+
+probe
+denied=""
+for _ in $(seq 1 60); do
+  msg=$(kubectl -n "$ns" get pod "$pod" \
+    -o jsonpath='{.status.containerStatuses[0].state.waiting.message}' 2>/dev/null || true)
+  case "$msg" in *"image not in allowlist"*) denied=1; break ;; esac
+  sleep 2
+done
+if [ -z "$denied" ]; then
+  kubectl -n "$ns" describe pod "$pod" | tail -20
+  fail "SECURITY REGRESSION: $image was admitted without being allowlisted;" \
+       "the image floor is not fail-closed (waiting message: ${msg:-none})"
+fi
+echo "ok: $image denied at container creation"
+
+al add "$digest" "$image" >/dev/null || fail "signed floor write rejected for $digest"
+echo "ok: signed floor write accepted"
+
+# Recreated rather than waited out: the plugin re-pulls every 5s, while
+# kubelet's CreateContainerError backoff reaches minutes.
+kubectl -n "$ns" delete pod "$pod" --wait=true --timeout=60s >/dev/null
+probe
+if ! kubectl -n "$ns" wait --for=condition=Ready "pod/$pod" --timeout=120s >/dev/null; then
+  kubectl -n "$ns" describe pod "$pod" | tail -20
+  fail "$image still blocked after its digest was allowlisted"
+fi
+echo "ok: allowlisted image admitted"
+
+echo "PASS: image floor is fail-closed and a signed write opens it"

--- a/test/e2e/components-ready.sh
+++ b/test/e2e/components-ready.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Live-cluster check that the c8s control plane converged: pods in c8s-system
+# are Running with every container Ready.
+#
+# With no arguments every pod must be ready. Name-prefix arguments narrow it to
+# those components, for installs that deliberately leave others out.
+#
+# Needs kubectl pointed at a cluster with c8s installed.
+set -euo pipefail
+. "$(dirname "$0")/lib.sh"
+
+ns=c8s-system
+
+select_pods() {
+  if [ "$#" -eq 0 ]; then cat; return 0; fi
+  local pat="" p
+  for p in "$@"; do pat="${pat:+$pat|}^$p"; done
+  grep -E "$pat" || true
+}
+
+# awk, not a regex backreference: `$2 !~ /^([0-9]+)\/\1$/` looks right and is
+# not (awk has no backreferences), so it silently only ever matches 1/1 and
+# calls every sidecar-bearing pod not-ready.
+count_notready() {
+  awk 'NF {split($2,a,"/"); if (a[1]!=a[2] || $3!="Running") n++} END {print n+0}'
+}
+
+converged=""
+backoff=0
+for _ in $(seq 1 40); do
+  listing=$(kubectl -n "$ns" get pods --no-headers 2>/dev/null | select_pods "$@" || true)
+  total=$(printf '%s\n' "$listing" | awk 'NF' | wc -l)
+  n=$(printf '%s\n' "$listing" | count_notready)
+  if [ "$total" -gt 0 ] && [ "$n" -eq 0 ]; then converged=1; break; fi
+  # A pull that is still backing off after a minute does not recover inside
+  # the window; fail now rather than spending the whole timeout on it.
+  case "$listing" in
+    *ImagePullBackOff*) backoff=$((backoff + 1)) ;;
+    *) backoff=0 ;;
+  esac
+  if [ "$backoff" -ge 5 ]; then
+    kubectl -n "$ns" get events --sort-by=.lastTimestamp 2>/dev/null | grep -i pull | tail -6 || true
+    fail "image pulls are backing off; components cannot converge"
+  fi
+  sleep 15
+done
+
+printf '%s\n' "${listing:-}"
+if [ -z "$converged" ]; then
+  kubectl -n "$ns" describe pods | tail -40
+  fail "c8s components did not converge (${n:-?} of ${total:-0} not ready)"
+fi
+
+echo "PASS: all $total c8s components Running"

--- a/test/e2e/cw-workload.sh
+++ b/test/e2e/cw-workload.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Live-cluster check that a confidential workload runs bound to CDS: the sample
+# cw deployment reaches Ready and carries the injected c8s-cert sidecar.
+#
+# Needs kubectl pointed at a cluster with c8s installed. Under a fail-closed
+# image floor the workload digest must be admitted first: set C8S_OPERATOR_KEY
+# with C8S_ALLOWLIST_URL and C8S_MEASUREMENTS and this adds it. An audit-mode
+# floor admits it without them.
+set -euo pipefail
+. "$(dirname "$0")/lib.sh"
+
+manifest="$(dirname "$0")/../../samples/nginx-confidential-pod.yaml"
+[ -f "$manifest" ] || fail "sample manifest not found at $manifest"
+
+ns=default
+deploy=demo-nginx
+
+# A failed workload is left standing for the caller to diagnose.
+cleanup() {
+  local rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  kubectl -n "$ns" delete -f "$manifest" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+image=$(grep -oE '[[:graph:]]+@sha256:[0-9a-f]{64}' "$manifest" | head -1)
+[ -n "$image" ] || fail "no digest-pinned image in $manifest"
+
+if [ -n "${C8S_OPERATOR_KEY:-}" ]; then
+  : "${C8S_ALLOWLIST_URL:?needed alongside C8S_OPERATOR_KEY}"
+  : "${C8S_MEASUREMENTS:?needed alongside C8S_OPERATOR_KEY}"
+  c8s allowlist add "${image#*@}" "$image" \
+    --url "$C8S_ALLOWLIST_URL" --measurements "$C8S_MEASUREMENTS" >/dev/null \
+    || fail "signed floor write rejected for the workload digest"
+  echo "ok: workload digest admitted"
+fi
+
+kubectl apply -f "$manifest" >/dev/null
+
+ready=""
+for _ in $(seq 1 60); do
+  have=$(kubectl -n "$ns" get deploy "$deploy" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)
+  if [ "${have:-0}" -ge 1 ]; then ready=1; break; fi
+  sleep 10
+done
+if [ -z "$ready" ]; then
+  kubectl -n "$ns" describe pods -l "app=$deploy" | tail -30
+  fail "$deploy never became Ready"
+fi
+echo "ok: $deploy Ready"
+
+names=$(kubectl -n "$ns" get pods -l "app=$deploy" \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null || true)
+case "$names" in
+  *c8s-cert*) ;;
+  *) fail "the webhook did not inject the c8s-cert sidecar (init containers: ${names:-none})" ;;
+esac
+echo "ok: c8s-cert sidecar injected"
+
+echo "PASS: confidential workload runs with a CDS-issued cert"


### PR DESCRIPTION
- added some additional checks on TDX
- tripwire for SEV-SNP until `c8s kubeconfig` works there