### PR TITLE
feat(measurements): pin whole VM images from a measurements config

### DIFF
--- a/cmd/c8s/measurements.go
+++ b/cmd/c8s/measurements.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/measurements"
+
+func init() {
+	rootCmd.AddCommand(measurements.NewCmd())
+}

--- a/docs/kata-launch-measurement.md
+++ b/docs/kata-launch-measurement.md
@@ -40,7 +40,7 @@ differ. Measured on a live SNP cluster:
 when it is set (see [`secrets.md`](secrets.md), "When it is served"). So pod
 mode needs the *set* of per-shape digests, and until now the only way to learn
 one was to boot a pod, let attestation fail, and read the
-`measurement not in allowlist` warning out of the CDS log. `c8s install
+`measurement does not match any reference value` warning out of the CDS log. `c8s install
 --cvm-mode=pod --measurements` takes the digests this tool produces
 (`cmd/c8s/install.go`); under `--cvm-mode=node/gke/aks` the same flag takes the
 node image's `manifest.json` value instead.
@@ -252,8 +252,8 @@ $ sudo script -qec "/opt/kata/bin/kata-runtime exec $SID" /dev/null
 
 The response's `evidence.quote` is a base64 TDX quote; its `MRTD` is what
 `c8s kata measure --platform tdx` must reproduce. CDS also logs refused
-measurements verbatim (`measurement not in allowlist`) if the allow-list is
-already pinned.
+measurements verbatim (`measurement does not match any reference value`) if
+the reference values are already pinned.
 
 ### TDX limitations
 

--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/secrets"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -47,7 +48,7 @@ type AttestHandler struct {
 	// verification + signing. Zero = no timeout.
 	RequestTimeout time.Duration
 
-	// Measurements is the flat allowlist of SHA-384 launch digests permitted
+	// Measurements is the flat set of SHA-384 launch digests permitted
 	// to obtain a signed leaf. Empty = no measurement pinning.
 	Measurements map[string]bool
 
@@ -58,6 +59,10 @@ type AttestHandler struct {
 	// SNP evidence is unaffected (kernel-hashes folds the guest image into
 	// its launch digest). Empty = no RTMR pinning.
 	RTMRs map[int][]byte
+
+	// Entries pins whole images. When set it replaces Measurements and RTMRs,
+	// so a digest from one image cannot be paired with another's registers.
+	Entries []measurements.Entry
 
 	// Policy enforces SAN/CN constraints on the CSR before signing. Without
 	// this, an attestation-passing workload could mint a leaf for any
@@ -201,18 +206,26 @@ func (h AttestHandler) HandleAttest(w http.ResponseWriter, r *http.Request) {
 	// measurement is admitted, so the digest a leaf was issued against is the
 	// only record of what actually attested.
 	launchDigest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest)
-	if len(h.Measurements) > 0 {
-		if !h.Measurements[launchDigest] {
-			slog.Warn("measurement not in allowlist", "launch_digest", launchDigest, "remote_addr", r.RemoteAddr)
+	if len(h.Entries) > 0 {
+		if err := attestationclient.EnforceEntries(verifyResp, h.Entries, req.Evidence.Platform); err != nil {
+			slog.Warn("no pinned image matches this evidence", "launch_digest", launchDigest, "error", err, "remote_addr", r.RemoteAddr)
 			attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
 			return
 		}
-	}
-	if attestationclient.TDXPlatform(req.Evidence.Platform) {
-		if err := attestationclient.EnforceRTMRs(verifyResp, h.RTMRs); err != nil {
-			slog.Warn("RTMR pin not satisfied", "launch_digest", launchDigest, "error", err, "remote_addr", r.RemoteAddr)
-			attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "TDX runtime measurement registers not allowed")
-			return
+	} else {
+		if len(h.Measurements) > 0 {
+			if !h.Measurements[launchDigest] {
+				slog.Warn("measurement does not match any reference value", "launch_digest", launchDigest, "remote_addr", r.RemoteAddr)
+				attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
+				return
+			}
+		}
+		if attestationclient.TDXPlatform(req.Evidence.Platform) {
+			if err := attestationclient.EnforceRTMRs(verifyResp, h.RTMRs); err != nil {
+				slog.Warn("RTMR pin not satisfied", "launch_digest", launchDigest, "error", err, "remote_addr", r.RemoteAddr)
+				attestation.WriteError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "TDX runtime measurement registers not allowed")
+				return
+			}
 		}
 	}
 

--- a/internal/cmds/cds/attest_test.go
+++ b/internal/cmds/cds/attest_test.go
@@ -959,7 +959,7 @@ func TestAttest_MeasurementDenialRecordsPeer(t *testing.T) {
 		t.Fatalf("status: got %d, want 403", w.Code)
 	}
 	logs := buf.String()
-	if !strings.Contains(logs, "measurement not in allowlist") {
+	if !strings.Contains(logs, "measurement does not match any reference value") {
 		t.Fatalf("no denial record: %s", logs)
 	}
 	if !strings.Contains(logs, "remote_addr") {

--- a/internal/cmds/cds/cmd.go
+++ b/internal/cmds/cds/cmd.go
@@ -48,7 +48,8 @@ func NewCmd() *cobra.Command {
 	flags.StringVar(&cfg.caCommonName, "ca-common-name", issuer.DefaultCACommonName, "common name for the in-memory generated mesh CA")
 	flags.DurationVar(&cfg.caCertValidity, "ca-cert-validity", 8760*time.Hour, "validity period of the in-memory mesh CA certificate")
 	flags.StringSliceVar(&cfg.measurements, "measurements", nil, "SHA-384 hex launch measurements allowed to call /attest (empty = no pinning, UNSAFE)")
-	flags.StringSliceVar(&cfg.rtmrs, "rtmrs", nil, "TDX RTMR pins <index>=<sha384-hex> required of TDX callers on /attest and /attest-key (repeatable; RTMR[1] pins the guest kernel, RTMR[2] the command line carrying the dm-verity root hash). SNP evidence is unaffected. Empty = no RTMR pinning: on TDX the measurement allowlist then covers TDVF firmware only, UNSAFE")
+	flags.StringVar(&cfg.measurementsConfig, "measurements-config", "", "path to a measurements config pinning the VM images allowed to call /attest, each matched as a whole image. Cannot be combined with --measurements or --rtmrs")
+	flags.StringSliceVar(&cfg.rtmrs, "rtmrs", nil, "TDX RTMR pins <index>=<sha384-hex> required of TDX callers on /attest and /attest-key (repeatable; RTMR[1] pins the guest kernel, RTMR[2] the command line carrying the dm-verity root hash). SNP evidence is unaffected. Empty = no RTMR pinning: on TDX the reference values then cover TDVF firmware only, UNSAFE")
 
 	flags.StringVar(&cfg.earIssuerName, "ear-issuer", "cds", "")
 	flags.StringVar(&cfg.expectedIssuer, "expected-issuer", "", "EAR JWT issuer claim required on /sign-csr (empty disables)")
@@ -132,6 +133,7 @@ type config struct {
 	caCommonName        string
 	caCertValidity      time.Duration
 	measurements        []string
+	measurementsConfig  string
 	rtmrs               []string
 	earIssuerName       string
 	expectedIssuer      string

--- a/internal/cmds/cds/measurementsconfig.go
+++ b/internal/cmds/cds/measurementsconfig.go
@@ -1,0 +1,59 @@
+package cds
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// resolveMeasurementsConfig loads --measurements-config and fills the flat
+// lists from it, so every gate that can only express a digest list keeps
+// pinning exactly what it pins today. The returned reference values carry the
+// whole tuples, for the gates that can match them.
+func resolveMeasurementsConfig(cfg *config) (measurements.ReferenceValues, error) {
+	if cfg.measurementsConfig == "" {
+		return measurements.ReferenceValues{}, nil
+	}
+	if len(cfg.measurements) > 0 || len(cfg.rtmrs) > 0 {
+		return measurements.ReferenceValues{}, fmt.Errorf("--measurements-config cannot be combined with --measurements or --rtmrs")
+	}
+	set, err := measurements.Load(cfg.measurementsConfig)
+	if err != nil {
+		return measurements.ReferenceValues{}, err
+	}
+	// Reference values for the other platform would refuse every peer at
+	// runtime. An empty platform is validateConfig's error to report.
+	if platform := ratls.NormalizePlatform(cfg.ratlsPlatform); platform != "" && platform != set.TEE {
+		return measurements.ReferenceValues{}, fmt.Errorf(
+			"--measurements-config declares tee %q but --ratls-platform is %q", set.TEE, platform)
+	}
+	cfg.measurements = set.HexDigests()
+
+	common, uniform := set.CommonRTMRs()
+	if !uniform {
+		// Gates keyed on a single register set cannot express per-image
+		// tuples; say so rather than appearing to pin them.
+		slog.Warn("measurements config pins different registers per image: /attest matches whole images, but gates that take one register set (/attest-key) are digest-only",
+			"images", len(set.Entries))
+	}
+	for _, idx := range sortedIndices(common) {
+		cfg.rtmrs = append(cfg.rtmrs, fmt.Sprintf("%d=%x", idx, common[idx]))
+	}
+	if _, err := ratls.ParseRTMRPins(cfg.rtmrs); err != nil {
+		return measurements.ReferenceValues{}, fmt.Errorf("--measurements-config: %w", err)
+	}
+	slog.Info("measurements config loaded", "tee", set.TEE, "images", len(set.Entries))
+	return set, nil
+}
+
+func sortedIndices(m map[int][]byte) []int {
+	out := make([]int, 0, len(m))
+	for i := range m {
+		out = append(out, i)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/cmds/cds/measurementsconfig_test.go
+++ b/internal/cmds/cds/measurementsconfig_test.go
@@ -1,0 +1,176 @@
+package cds
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, doc string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "measurements.json")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const (
+	cfgDigestA = "aa11000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	cfgDigestB = "bb22000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	cfgReg1    = "111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	cfgReg2    = "222200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+
+// The gates that can only read the flat list must still see a pin, or a
+// config-mode start would silently unpin /sign-csr, /secrets and handoff.
+func TestResolveMeasurementsConfigFillsFlatLists(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"sev-snp","measurements":[
+		{"name":"a","measurement":"00`+cfgDigestA+`"},
+		{"name":"b","measurement":"00`+cfgDigestB+`"}]}`)
+
+	cfg := config{measurementsConfig: path}
+	set, err := resolveMeasurementsConfig(&cfg)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(set.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(set.Entries))
+	}
+	if len(cfg.measurements) != 2 {
+		t.Fatalf("flat measurements = %v, want 2 digests", cfg.measurements)
+	}
+	if refs := parseReferenceDigests(cfg.measurements); len(refs) != 2 {
+		t.Errorf("reference digests = %v, want both images", refs)
+	}
+}
+
+// RTMR pins shared by every image can be carried by the flat list; the gates
+// that take one register set then keep enforcing them.
+func TestResolveMeasurementsConfigCarriesCommonRTMRs(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"a","mrtd":"00`+cfgDigestA+`","rtmr":[null,"`+cfgReg1+`","`+cfgReg2+`"]},
+		{"name":"b","mrtd":"00`+cfgDigestB+`","rtmr":[null,"`+cfgReg1+`","`+cfgReg2+`"]}]}`)
+
+	cfg := config{measurementsConfig: path}
+	if _, err := resolveMeasurementsConfig(&cfg); err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(cfg.rtmrs) != 2 {
+		t.Fatalf("flat rtmrs = %v, want 2 pins", cfg.rtmrs)
+	}
+	for _, want := range []string{"1=" + cfgReg1, "2=" + cfgReg2} {
+		if !containsPin(cfg.rtmrs, want) {
+			t.Errorf("rtmrs %v missing %s", cfg.rtmrs, want)
+		}
+	}
+}
+
+// Images with different registers cannot be flattened onto one register set.
+// The digests must still pin, and the tuples stay available for /attest.
+func TestResolveMeasurementsConfigDropsDivergentRTMRs(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"a","mrtd":"00`+cfgDigestA+`","rtmr":[null,"`+cfgReg1+`"]},
+		{"name":"b","mrtd":"00`+cfgDigestB+`","rtmr":[null,"`+cfgReg2+`"]}]}`)
+
+	cfg := config{measurementsConfig: path}
+	set, err := resolveMeasurementsConfig(&cfg)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(cfg.rtmrs) != 0 {
+		t.Errorf("flat rtmrs = %v, want none: the images disagree", cfg.rtmrs)
+	}
+	if len(cfg.measurements) != 2 {
+		t.Errorf("flat measurements = %v, want both digests", cfg.measurements)
+	}
+	for _, e := range set.Entries {
+		if len(e.RTMRs) == 0 {
+			t.Errorf("entry %s lost its register pins", e.Name)
+		}
+	}
+}
+
+func TestResolveMeasurementsConfigRejectsMixedFlags(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"sev-snp","measurements":[{"name":"a","measurement":"00`+cfgDigestA+`"}]}`)
+
+	for _, tc := range []struct {
+		name string
+		cfg  config
+	}{
+		{"with --measurements", config{measurementsConfig: path, measurements: []string{"00" + cfgDigestB}}},
+		{"with --rtmrs", config{measurementsConfig: path, rtmrs: []string{"1=" + cfgReg1}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveMeasurementsConfig(&tc.cfg)
+			if err == nil {
+				t.Fatal("accepted a mixed configuration")
+			}
+			if !strings.Contains(err.Error(), "cannot be combined") {
+				t.Errorf("error %q does not explain the conflict", err)
+			}
+		})
+	}
+}
+
+// A config for the other platform refuses every peer at runtime, so it has to
+// stop startup instead.
+func TestResolveMeasurementsConfigRejectsPlatformMismatch(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[{"name":"a","mrtd":"00`+cfgDigestA+`"}]}`)
+
+	cfg := config{measurementsConfig: path, ratlsPlatform: "sev-snp"}
+	_, err := resolveMeasurementsConfig(&cfg)
+	if err == nil {
+		t.Fatal("accepted tdx reference values on an sev-snp platform")
+	}
+	for _, want := range []string{"tdx", "sev-snp"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+	if len(cfg.measurements) != 0 {
+		t.Errorf("flat measurements populated despite the mismatch: %v", cfg.measurements)
+	}
+}
+
+// The aliases the platform flag accepts must compare equal to the spelling the
+// document uses.
+func TestResolveMeasurementsConfigAcceptsPlatformAliases(t *testing.T) {
+	snp := writeConfig(t, `{"schema_version":"1","tee":"sev-snp","measurements":[{"name":"a","measurement":"00`+cfgDigestA+`"}]}`)
+	tdx := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[{"name":"a","mrtd":"00`+cfgDigestA+`"}]}`)
+
+	for _, tc := range []struct{ platform, path string }{
+		{"snp", snp}, {"az-snp", snp}, {"gcp-snp", snp}, {"sev-snp", snp},
+		{"tdx", tdx}, {"az-tdx", tdx}, {"gcp-tdx", tdx},
+		{"", snp}, // validateConfig reports a missing platform, not this check
+	} {
+		t.Run(tc.platform, func(t *testing.T) {
+			cfg := config{measurementsConfig: tc.path, ratlsPlatform: tc.platform}
+			if _, err := resolveMeasurementsConfig(&cfg); err != nil {
+				t.Fatalf("rejected platform %q: %v", tc.platform, err)
+			}
+		})
+	}
+}
+
+// A named config that cannot be read must stop startup, never degrade to no
+// pinning.
+func TestResolveMeasurementsConfigFailsClosed(t *testing.T) {
+	cfg := config{measurementsConfig: filepath.Join(t.TempDir(), "absent.json")}
+	if _, err := resolveMeasurementsConfig(&cfg); err == nil {
+		t.Fatal("a missing config started unpinned")
+	}
+	if len(cfg.measurements) != 0 {
+		t.Errorf("flat measurements populated from a failed load: %v", cfg.measurements)
+	}
+}
+
+func containsPin(pins []string, want string) bool {
+	for _, p := range pins {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cmds/cds/routes_test.go
+++ b/internal/cmds/cds/routes_test.go
@@ -490,7 +490,7 @@ func TestReadinessFn(t *testing.T) {
 	}
 }
 
-func TestParseMeasurementAllowlist(t *testing.T) {
+func TestParseReferenceDigests(t *testing.T) {
 	cases := []struct {
 		name    string
 		input   []string
@@ -503,7 +503,7 @@ func TestParseMeasurementAllowlist(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseMeasurementAllowlist(tc.input)
+			got := parseReferenceDigests(tc.input)
 			if len(got) != tc.wantLen {
 				t.Errorf("len: got %d, want %d (map=%v)", len(got), tc.wantLen, got)
 			}

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -50,6 +50,12 @@ func run(cfg config) error {
 	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", cfg.attestationApiURL); err != nil {
 		return err
 	}
+	// Resolve before validateConfig: the handoff and secrets predicates read
+	// the flat lists, so a config-mode start must fill them first.
+	pinned, err := resolveMeasurementsConfig(&cfg)
+	if err != nil {
+		return err
+	}
 	if err := validateConfig(cfg); err != nil {
 		return err
 	}
@@ -133,7 +139,7 @@ func run(cfg config) error {
 	)
 	caChainPEM := certutil.EncodeCertPEM(mesh.Cert.Raw)
 
-	measurements := parseMeasurementAllowlist(cfg.measurements)
+	measurements := parseReferenceDigests(cfg.measurements)
 	if len(measurements) == 0 {
 		slog.Warn("--measurements empty: /attest accepts any TEE measurement. UNSAFE outside development.")
 	} else {
@@ -325,6 +331,7 @@ func run(cfg config) error {
 			RequestTimeout:    cfg.requestTimeout,
 			Measurements:      measurements,
 			RTMRs:             rtmrPins,
+			Entries:           pinned.Entries,
 			SANValidation:     cfg.sanValidation,
 			Policy:            policy,
 			AllowlistStore:    &allowlistStore,
@@ -433,7 +440,7 @@ func run(cfg config) error {
 // validated against cds's own rotator/issuer name, and the signer EAR is minted
 // by cds's earIssuer — no external service to dial for it.
 func buildHandoffHandler(ctx context.Context, cfg config, mesh *issuer.CA, allowlistStore *allowlist.Store, operatorKeysHash string, keyProvider issuer.KeyProvider, earIssuer ear.Issuer, asClient attestationclient.Client) (*issuer.HandoffHandler, error) {
-	handoffMeasurements := parseMeasurementAllowlist(cfg.handoffMeasurements)
+	handoffMeasurements := parseReferenceDigests(cfg.handoffMeasurements)
 	if len(handoffMeasurements) == 0 {
 		slog.Info("/handoff disabled: set --handoff-measurements to enable mesh CA handoff to peer replicas")
 		return nil, nil
@@ -690,7 +697,7 @@ func measurementDigests(allowed map[string]bool) ([][]byte, error) {
 	return out, nil
 }
 
-func parseMeasurementAllowlist(raw []string) map[string]bool {
+func parseReferenceDigests(raw []string) map[string]bool {
 	if len(raw) == 0 {
 		return nil
 	}

--- a/internal/cmds/measurements/cmd.go
+++ b/internal/cmds/measurements/cmd.go
@@ -1,0 +1,42 @@
+// Package measurements implements the `c8s measurements` command group:
+// deriving a measurements config from built images, and checking one.
+package measurements
+
+import (
+	"fmt"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/spf13/cobra"
+)
+
+// NewCmd returns the `c8s measurements` command group.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "measurements",
+		Short: "Work with measurements config files",
+		Long: "A measurements config pins the VM images a cluster accepts. Each entry is one\n" +
+			"image, matched as a whole: a launch digest together with the runtime registers\n" +
+			"measured from the same build.",
+	}
+	cmd.AddCommand(newDeriveCmd(), newLintCmd())
+	return cmd
+}
+
+func newLintCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint <measurements.json>",
+		Short: "Check a measurements config for problems",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			set, err := measurements.Load(args[0])
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "ok: %s, %d image(s)\n", set.TEE, len(set.Entries))
+			for _, e := range set.Entries {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s: %d register pin(s)\n", e.Name, len(e.RTMRs))
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cmds/measurements/derive.go
+++ b/internal/cmds/measurements/derive.go
@@ -1,0 +1,181 @@
+package measurements
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/spf13/cobra"
+)
+
+// manifestSchemaVersion is the confos manifest this command reads. confos
+// rejects other versions rather than migrating, so pin the same one.
+const manifestSchemaVersion = 3
+
+type manifestHeader struct {
+	Version int `json:"version"`
+	Build   struct {
+		Platform string `json:"platform"`
+	} `json:"build"`
+}
+
+func newDeriveCmd() *cobra.Command {
+	var tee, out string
+
+	cmd := &cobra.Command{
+		Use:   "derive <image-dir|manifest.json>...",
+		Short: "Derive a measurements config from confidential-os-builder images",
+		Long: "Reads the manifest.json of each built image and writes a measurements config\n" +
+			"pinning them. An SNP image contributes one entry per vCPU variant; a TDX image\n" +
+			"contributes its MRTD with RTMR[1] and RTMR[2].",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			set, err := derive(args, tee)
+			if err != nil {
+				return err
+			}
+			doc, err := measurements.Format(set)
+			if err != nil {
+				return err
+			}
+			// Round-trip so derive can only emit what every component loads.
+			if _, err := measurements.Parse(doc); err != nil {
+				return fmt.Errorf("derived config is not valid: %w", err)
+			}
+			if out == "" {
+				_, err := cmd.OutOrStdout().Write(doc)
+				return err
+			}
+			return os.WriteFile(out, doc, 0o644)
+		},
+	}
+	cmd.Flags().StringVar(&tee, "tee", "", "platform to derive for (sev-snp or tdx); required when an image is built for both")
+	cmd.Flags().StringVar(&out, "out", "", "write to this path instead of stdout")
+	return cmd
+}
+
+func derive(inputs []string, tee string) (measurements.ReferenceValues, error) {
+	if tee != "" && tee != measurements.TEESNP && tee != measurements.TEETDX {
+		return measurements.ReferenceValues{}, fmt.Errorf("--tee %q, want %q or %q", tee, measurements.TEESNP, measurements.TEETDX)
+	}
+	var set measurements.ReferenceValues
+	for _, in := range inputs {
+		path, name, err := resolveManifest(in)
+		if err != nil {
+			return measurements.ReferenceValues{}, err
+		}
+		platform, err := manifestPlatform(path, tee)
+		if err != nil {
+			return measurements.ReferenceValues{}, err
+		}
+		if set.TEE == "" {
+			set.TEE = platform
+		}
+		// One file describes one platform: a cluster mixing SNP and TDX
+		// images is not supported.
+		if platform != set.TEE {
+			return measurements.ReferenceValues{}, fmt.Errorf("%s is %s but an earlier input is %s; derive one config per platform", path, platform, set.TEE)
+		}
+		entries, err := entriesFor(path, name, platform)
+		if err != nil {
+			return measurements.ReferenceValues{}, err
+		}
+		fmt.Fprintf(os.Stderr, "%s: %d %s entr%s from %s\n", name, len(entries), platform, plural(len(entries)), path)
+		set.Entries = append(set.Entries, entries...)
+	}
+	return set, nil
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// resolveManifest accepts a build output directory or the manifest itself and
+// names the entry after the directory the image was built into.
+func resolveManifest(in string) (path, name string, err error) {
+	info, err := os.Stat(in)
+	if err != nil {
+		return "", "", fmt.Errorf("read image: %w", err)
+	}
+	path = in
+	if info.IsDir() {
+		path = filepath.Join(in, "manifest.json")
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", "", err
+	}
+	return path, filepath.Base(filepath.Dir(abs)), nil
+}
+
+func manifestPlatform(path, tee string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read image manifest: %w", err)
+	}
+	var h manifestHeader
+	if err := json.Unmarshal(data, &h); err != nil {
+		return "", fmt.Errorf("image manifest %s is not a JSON object: %w", path, err)
+	}
+	if h.Version != manifestSchemaVersion {
+		return "", fmt.Errorf("image manifest %s is schema version %d, want %d — rebuild with the current confos", path, h.Version, manifestSchemaVersion)
+	}
+	switch h.Build.Platform {
+	case "snp":
+		return measurements.TEESNP, nil
+	case "tdx":
+		return measurements.TEETDX, nil
+	case "multi":
+		if tee == "" {
+			return "", fmt.Errorf("image manifest %s is built for both platforms; pass --tee %s or --tee %s", path, measurements.TEESNP, measurements.TEETDX)
+		}
+		return tee, nil
+	default:
+		return "", fmt.Errorf("image manifest %s has platform %q, want snp, tdx or multi", path, h.Build.Platform)
+	}
+}
+
+func entriesFor(path, name, platform string) ([]measurements.Entry, error) {
+	if platform == measurements.TEESNP {
+		pins, err := runtimemeasure.LoadSNPImageManifest(path)
+		if err != nil {
+			return nil, err
+		}
+		smps := make([]int, 0, len(pins.BySMP))
+		for smp := range pins.BySMP {
+			smps = append(smps, smp)
+		}
+		sort.Ints(smps)
+		out := make([]measurements.Entry, 0, len(smps))
+		for _, smp := range smps {
+			d := pins.BySMP[smp]
+			out = append(out, measurements.Entry{
+				Name:   fmt.Sprintf("%s-smp%d", name, smp),
+				Digest: append([]byte(nil), d[:]...),
+			})
+		}
+		return out, nil
+	}
+
+	pins, err := runtimemeasure.LoadImageManifest(path)
+	if err != nil {
+		return nil, err
+	}
+	// RTMR[0] varies with the VM shape and RTMR[3] is extended at runtime, so
+	// an image pins only RTMR[1] and RTMR[2].
+	return []measurements.Entry{{
+		Name:   name,
+		Digest: append([]byte(nil), pins.MRTD[:]...),
+		RTMRs: map[int][]byte{
+			1: append([]byte(nil), pins.RTMR1[:]...),
+			2: append([]byte(nil), pins.RTMR2[:]...),
+		},
+	}}, nil
+}

--- a/internal/cmds/measurements/derive_test.go
+++ b/internal/cmds/measurements/derive_test.go
@@ -1,0 +1,318 @@
+package measurements
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+)
+
+const (
+	snpFixture = "../../../pkg/runtimemeasure/testdata/confos-snp-manifest.json"
+	tdxFixture = "../../../pkg/runtimemeasure/testdata/confos-tdx-manifest.json"
+)
+
+// stageImage copies a build manifest into a directory named like a build
+// output, since the entry name comes from that directory.
+func stageImage(t *testing.T, fixture, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// An SNP image contributes one entry per vCPU variant, because the vCPU count
+// is part of the launch measurement.
+func TestDeriveSNPEntryPerVariant(t *testing.T) {
+	dir := stageImage(t, snpFixture, "c8s-worker")
+
+	set, err := derive([]string{dir}, "")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if set.TEE != measurements.TEESNP {
+		t.Errorf("tee = %q, want %q", set.TEE, measurements.TEESNP)
+	}
+	if len(set.Entries) != 4 {
+		t.Fatalf("got %d entries, want one per snp_variants entry", len(set.Entries))
+	}
+	for _, want := range []string{"c8s-worker-smp2", "c8s-worker-smp4", "c8s-worker-smp8", "c8s-worker-smp16"} {
+		if !hasEntry(set.Entries, want) {
+			t.Errorf("no entry named %q; got %v", want, names(set.Entries))
+		}
+	}
+	for _, e := range set.Entries {
+		if len(e.RTMRs) != 0 {
+			t.Errorf("SNP entry %s carries RTMR pins", e.Name)
+		}
+	}
+}
+
+// A TDX image pins MRTD with RTMR[1] and RTMR[2]; RTMR[0] varies with the VM
+// shape and RTMR[3] is extended at runtime.
+func TestDeriveTDXPinsTheTuple(t *testing.T) {
+	dir := stageImage(t, tdxFixture, "c8s-broker")
+
+	set, err := derive([]string{dir}, "")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if set.TEE != measurements.TEETDX {
+		t.Errorf("tee = %q, want %q", set.TEE, measurements.TEETDX)
+	}
+	if len(set.Entries) != 1 {
+		t.Fatalf("got %d entries, want 1", len(set.Entries))
+	}
+	e := set.Entries[0]
+	if e.Name != "c8s-broker" {
+		t.Errorf("name = %q, want the image directory name", e.Name)
+	}
+	if _, pinned := e.RTMRs[0]; pinned {
+		t.Error("RTMR[0] pinned: it varies with vCPU and memory shape")
+	}
+	if _, pinned := e.RTMRs[3]; pinned {
+		t.Error("RTMR[3] pinned: it is extended by in-guest software")
+	}
+	for _, idx := range []int{1, 2} {
+		if len(e.RTMRs[idx]) != measurements.DigestSize {
+			t.Errorf("RTMR[%d] = %d bytes, want %d", idx, len(e.RTMRs[idx]), measurements.DigestSize)
+		}
+	}
+}
+
+// Whatever derive emits must load everywhere, so it round-trips through the
+// same parser every component uses.
+func TestDeriveOutputParses(t *testing.T) {
+	for _, tc := range []struct{ name, fixture string }{
+		{"snp", snpFixture},
+		{"tdx", tdxFixture},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			set, err := derive([]string{stageImage(t, tc.fixture, "img")}, "")
+			if err != nil {
+				t.Fatalf("derive: %v", err)
+			}
+			doc, err := measurements.Format(set)
+			if err != nil {
+				t.Fatalf("format: %v", err)
+			}
+			reparsed, err := measurements.Parse(doc)
+			if err != nil {
+				t.Fatalf("derived config does not parse: %v\n%s", err, doc)
+			}
+			if len(reparsed.Entries) != len(set.Entries) || reparsed.TEE != set.TEE {
+				t.Errorf("round trip changed the config: %d/%s vs %d/%s",
+					len(reparsed.Entries), reparsed.TEE, len(set.Entries), set.TEE)
+			}
+		})
+	}
+}
+
+// Merging images of different platforms would produce a config no cluster can
+// use, since one file describes one platform.
+func TestDeriveRefusesMixedPlatforms(t *testing.T) {
+	snp := stageImage(t, snpFixture, "worker")
+	tdx := stageImage(t, tdxFixture, "broker")
+
+	if _, err := derive([]string{snp, tdx}, ""); err == nil {
+		t.Fatal("merged an SNP and a TDX image into one config")
+	}
+}
+
+func TestDeriveMergesImagesOfOnePlatform(t *testing.T) {
+	a := stageImage(t, tdxFixture, "leader")
+	b := stageImage(t, tdxFixture, "worker")
+
+	set, err := derive([]string{a, b}, "")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if len(set.Entries) != 2 {
+		t.Fatalf("got %d entries, want one per image", len(set.Entries))
+	}
+	if !hasEntry(set.Entries, "leader") || !hasEntry(set.Entries, "worker") {
+		t.Errorf("entries = %v, want both image names", names(set.Entries))
+	}
+}
+
+// A manifest built for both platforms carries two sets of values, so the
+// caller has to say which one the cluster runs.
+func TestDeriveMultiPlatformNeedsTEE(t *testing.T) {
+	dir := stageImage(t, snpFixture, "img")
+	patchManifest(t, dir, func(m map[string]any) {
+		m["build"].(map[string]any)["platform"] = "multi"
+	})
+
+	_, err := derive([]string{dir}, "")
+	if err == nil {
+		t.Fatal("derived from a multi-platform manifest without --tee")
+	}
+	if !strings.Contains(err.Error(), "--tee") {
+		t.Errorf("error %q does not name the flag that resolves it", err)
+	}
+	if _, err := derive([]string{dir}, measurements.TEESNP); err != nil {
+		t.Fatalf("--tee did not resolve the ambiguity: %v", err)
+	}
+}
+
+// confos rejects manifests of another schema version rather than migrating
+// them; reading one anyway would pin fields that may have moved.
+func TestDeriveRejectsOtherSchemaVersion(t *testing.T) {
+	dir := stageImage(t, snpFixture, "img")
+	patchManifest(t, dir, func(m map[string]any) { m["version"] = 2 })
+
+	_, err := derive([]string{dir}, "")
+	if err == nil {
+		t.Fatal("derived from a version 2 manifest")
+	}
+	if !strings.Contains(err.Error(), "version") {
+		t.Errorf("error %q does not mention the schema version", err)
+	}
+}
+
+func TestDeriveRejectsBadInput(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent")
+	if _, err := derive([]string{missing}, ""); err == nil {
+		t.Error("accepted a path that does not exist")
+	}
+	if _, err := derive([]string{stageImage(t, snpFixture, "img")}, "sev"); err == nil {
+		t.Error("accepted an unknown --tee value")
+	}
+}
+
+// A manifest path is accepted directly, and names the entry after the
+// directory holding it.
+func TestDeriveAcceptsManifestPath(t *testing.T) {
+	dir := stageImage(t, tdxFixture, "direct")
+
+	set, err := derive([]string{filepath.Join(dir, "manifest.json")}, "")
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if set.Entries[0].Name != "direct" {
+		t.Errorf("name = %q, want %q", set.Entries[0].Name, "direct")
+	}
+}
+
+func TestLintReportsAProblem(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.json")
+	bad := filepath.Join(dir, "bad.json")
+
+	set, err := derive([]string{stageImage(t, tdxFixture, "img")}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := measurements.Format(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(good, doc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bad, []byte(`{"schema_version":"1","tee":"tdx","measurements":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newLintCmd()
+	cmd.SetOut(new(strings.Builder))
+	cmd.SetArgs([]string{good})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("lint rejected a derived config: %v", err)
+	}
+
+	cmd = newLintCmd()
+	cmd.SetOut(new(strings.Builder))
+	cmd.SetArgs([]string{bad})
+	if err := cmd.Execute(); err == nil {
+		t.Error("lint accepted a config pinning no image")
+	}
+}
+
+func TestDeriveCmdWritesTheOutFile(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "measurements.json")
+
+	cmd := newDeriveCmd()
+	cmd.SetOut(new(strings.Builder))
+	cmd.SetArgs([]string{"--out", out, stageImage(t, snpFixture, "img")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if _, err := measurements.Load(out); err != nil {
+		t.Fatalf("written config does not load: %v", err)
+	}
+}
+
+func patchManifest(t *testing.T, dir string, edit func(map[string]any)) {
+	t.Helper()
+	path := filepath.Join(dir, "manifest.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	edit(m)
+	patched, err := json.Marshal(m)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, patched, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func hasEntry(entries []measurements.Entry, name string) bool {
+	for _, e := range entries {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func names(entries []measurements.Entry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Name)
+	}
+	return out
+}
+
+// With no --out the config goes to stdout, so it can be piped.
+func TestDeriveCmdWritesStdout(t *testing.T) {
+	var out strings.Builder
+	cmd := newDeriveCmd()
+	cmd.SetOut(&out)
+	cmd.SetArgs([]string{stageImage(t, tdxFixture, "img")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	if _, err := measurements.Parse([]byte(out.String())); err != nil {
+		t.Fatalf("stdout is not a loadable config: %v\n%s", err, out.String())
+	}
+}
+
+func TestDeriveCmdReportsBadInput(t *testing.T) {
+	cmd := newDeriveCmd()
+	cmd.SetOut(new(strings.Builder))
+	cmd.SetErr(new(strings.Builder))
+	cmd.SetArgs([]string{filepath.Join(t.TempDir(), "absent")})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("derive accepted a path that does not exist")
+	}
+}

--- a/pkg/attestationclient/entries.go
+++ b/pkg/attestationclient/entries.go
@@ -1,0 +1,72 @@
+package attestationclient
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// EnforceEntries accepts evidence matching one reference image whole: its
+// launch digest AND, on TDX, every register that image pins. A digest from one
+// build with registers from another matches nothing, which is what pinning the
+// two separately could not express.
+//
+// RTMRs are checked only for TDX-shaped evidence, as elsewhere: SNP folds the
+// guest image into its launch digest and reports no registers.
+func EnforceEntries(resp types.VerifyResponse, entries []measurements.Entry, platform string) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	digest, err := launchDigest(resp)
+	if err != nil {
+		return err
+	}
+
+	var reported [4]string
+	checkRTMRs := TDXPlatform(platform)
+	if checkRTMRs {
+		if reported, err = reportedRTMRs(resp); err != nil {
+			return err
+		}
+	}
+
+	var lastErr error
+	for _, e := range entries {
+		if !bytes.Equal(digest, e.Digest) {
+			continue
+		}
+		if !checkRTMRs || len(e.RTMRs) == 0 {
+			return nil
+		}
+		if err := enforceRTMRsAgainst(reported, e.RTMRs); err != nil {
+			lastErr = fmt.Errorf("%s: %w", e.Name, err)
+			continue
+		}
+		return nil
+	}
+	if lastErr != nil {
+		return lastErr
+	}
+	return fmt.Errorf("%w: no pinned image has this launch measurement", ErrMeasurementNotAllowed)
+}
+
+// launchDigest validates the reported digest. A missing digest is a refusal:
+// entries always pin, so there is nothing it could legitimately match.
+func launchDigest(resp types.VerifyResponse) ([]byte, error) {
+	raw := strings.ToLower(strings.TrimSpace(resp.Result.Claims.LaunchDigest))
+	if raw == "" {
+		return nil, fmt.Errorf("%w: launch measurement missing", ErrMeasurementNotAllowed)
+	}
+	digest, err := hex.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: launch digest is not hex: %w", ErrInvalidLaunchDigest, err)
+	}
+	if len(digest) != launchMeasurementSize {
+		return nil, fmt.Errorf("%w: launch digest is %d bytes, expected %d", ErrInvalidLaunchDigest, len(digest), launchMeasurementSize)
+	}
+	return digest, nil
+}

--- a/pkg/attestationclient/entries_test.go
+++ b/pkg/attestationclient/entries_test.go
@@ -1,0 +1,161 @@
+package attestationclient
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	digestA = "aa11" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	digestB = "bb22" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	regA1   = "1111" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	regA2   = "2222" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	regB1   = "3333" + "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func evidence(t *testing.T, digest string, rtmrs map[string]string) types.VerifyResponse {
+	t.Helper()
+	var resp types.VerifyResponse
+	resp.Result.Claims.LaunchDigest = digest
+	if rtmrs != nil {
+		raw, err := json.Marshal(rtmrs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Result.Claims.PlatformData = raw
+	}
+	return resp
+}
+
+func entryTDX(t *testing.T, name, digest string, r1, r2 string) measurements.Entry {
+	t.Helper()
+	e := measurements.Entry{Name: name, Digest: mustHex(t, digest), RTMRs: map[int][]byte{}}
+	if r1 != "" {
+		e.RTMRs[1] = mustHex(t, r1)
+	}
+	if r2 != "" {
+		e.RTMRs[2] = mustHex(t, r2)
+	}
+	return e
+}
+
+// The bug this feature exists for: image A's MRTD with image B's registers.
+// Pinning the two separately accepts it; one tuple per image does not.
+func TestEnforceEntriesRejectsCrossedTuple(t *testing.T) {
+	entries := []measurements.Entry{
+		entryTDX(t, "image-a", digestA, regA1, regA2),
+		entryTDX(t, "image-b", digestB, regB1, ""),
+	}
+	crossed := evidence(t, digestA, map[string]string{"rtmr_1": regB1, "rtmr_2": regA2})
+	if err := EnforceEntries(crossed, entries, string(types.PlatformTdx)); err == nil {
+		t.Fatal("accepted image A's digest with image B's RTMR[1]")
+	}
+
+	matched := evidence(t, digestA, map[string]string{"rtmr_1": regA1, "rtmr_2": regA2})
+	if err := EnforceEntries(matched, entries, string(types.PlatformTdx)); err != nil {
+		t.Fatalf("rejected a whole matching image: %v", err)
+	}
+	second := evidence(t, digestB, map[string]string{"rtmr_1": regB1})
+	if err := EnforceEntries(second, entries, string(types.PlatformTdx)); err != nil {
+		t.Fatalf("rejected the second pinned image: %v", err)
+	}
+}
+
+func TestEnforceEntriesRefusals(t *testing.T) {
+	entries := []measurements.Entry{entryTDX(t, "image-a", digestA, regA1, "")}
+	tdx := string(types.PlatformTdx)
+
+	tests := []struct {
+		name string
+		resp types.VerifyResponse
+		want error
+	}{
+		{"unpinned digest", evidence(t, digestB, map[string]string{"rtmr_1": regA1}), ErrMeasurementNotAllowed},
+		{"missing digest", evidence(t, "", map[string]string{"rtmr_1": regA1}), ErrMeasurementNotAllowed},
+		{"malformed digest", evidence(t, "zz"+digestA[2:], nil), ErrInvalidLaunchDigest},
+		{"short digest", evidence(t, "aa11", nil), ErrInvalidLaunchDigest},
+		{"pinned register not reported", evidence(t, digestA, map[string]string{"rtmr_2": regA2}), ErrRTMRNotAllowed},
+		{"register mismatch", evidence(t, digestA, map[string]string{"rtmr_1": regB1}), ErrRTMRNotAllowed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := EnforceEntries(tc.resp, entries, tdx)
+			if err == nil {
+				t.Fatal("accepted")
+			}
+			if !errors.Is(err, tc.want) {
+				t.Errorf("error %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+// SNP folds the guest image into its launch digest and reports no registers,
+// so entry RTMRs must not be enforced against it.
+func TestEnforceEntriesIgnoresRTMRsOnSNP(t *testing.T) {
+	entries := []measurements.Entry{entryTDX(t, "image-a", digestA, regA1, regA2)}
+	resp := evidence(t, digestA, nil)
+	if err := EnforceEntries(resp, entries, string(types.PlatformSnp)); err != nil {
+		t.Fatalf("enforced TDX registers against SNP evidence: %v", err)
+	}
+}
+
+func TestEnforceEntriesEmptyIsNoGate(t *testing.T) {
+	if err := EnforceEntries(evidence(t, digestA, nil), nil, string(types.PlatformTdx)); err != nil {
+		t.Fatalf("empty entry set gated: %v", err)
+	}
+}
+
+func TestEnforceEntriesAcceptsUppercaseClaim(t *testing.T) {
+	entries := []measurements.Entry{{Name: "a", Digest: mustHex(t, digestA)}}
+	resp := evidence(t, strings.ToUpper(digestA), nil)
+	if err := EnforceEntries(resp, entries, string(types.PlatformSnp)); err != nil {
+		t.Fatalf("rejected an uppercase claim the legacy path accepts: %v", err)
+	}
+}
+
+// Converted flat flags must decide exactly as the flat path does: a digest
+// from the list AND the one pinned register set.
+func TestEnforceEntriesMatchesFlatFlagSemantics(t *testing.T) {
+	digests := [][]byte{mustHex(t, digestA), mustHex(t, digestB)}
+	rtmrs := map[int][]byte{1: mustHex(t, regA1)}
+	set := measurements.FromFlags(digests, rtmrs)
+	tdx := string(types.PlatformTdx)
+
+	cases := []struct {
+		name string
+		resp types.VerifyResponse
+	}{
+		{"first digest, pinned register", evidence(t, digestA, map[string]string{"rtmr_1": regA1})},
+		{"second digest, pinned register", evidence(t, digestB, map[string]string{"rtmr_1": regA1})},
+		{"first digest, wrong register", evidence(t, digestA, map[string]string{"rtmr_1": regB1})},
+		{"unpinned digest", evidence(t, "cc33"+digestA[4:], map[string]string{"rtmr_1": regA1})},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			legacy := enforceLaunchMeasurement(tc.resp, [][]byte{digests[0], digests[1]})
+			if legacy == nil {
+				legacy = EnforceRTMRs(tc.resp, rtmrs)
+			}
+			entries := EnforceEntries(tc.resp, set.Entries, tdx)
+			if (legacy == nil) != (entries == nil) {
+				t.Errorf("legacy err=%v but entries err=%v", legacy, entries)
+			}
+		})
+	}
+}

--- a/pkg/attestationclient/live_snp_test.go
+++ b/pkg/attestationclient/live_snp_test.go
@@ -1,0 +1,73 @@
+package attestationclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// TestLiveSNPEntryEnforcement drives the real verification path against real
+// SEV-SNP evidence: a config pinning the booted image is admitted, and one
+// pinning any other image is refused. Set C8S_LIVE_ATTESTATION_URL to the
+// attestation-api of a running CVM and C8S_LIVE_EVIDENCE to its evidence.
+func TestLiveSNPEntryEnforcement(t *testing.T) {
+	apiURL := os.Getenv("C8S_LIVE_ATTESTATION_URL")
+	evidencePath := os.Getenv("C8S_LIVE_EVIDENCE")
+	if apiURL == "" || evidencePath == "" {
+		t.Skip("set C8S_LIVE_ATTESTATION_URL and C8S_LIVE_EVIDENCE to run against a live CVM")
+	}
+
+	raw, err := os.ReadFile(evidencePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var evidence types.AttestationEvidence
+	if err := json.Unmarshal(raw, &evidence); err != nil {
+		t.Fatal(err)
+	}
+
+	configPath := os.Getenv("C8S_LIVE_CONFIG")
+	if configPath == "" {
+		t.Fatal("set C8S_LIVE_CONFIG to the measurements config pinning the booted image")
+	}
+	pinned, err := measurements.Load(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client := attestationclient.NewClient(apiURL)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// The evidence was requested with an all-zero REPORTDATA.
+	var policy attestationclient.EvidencePolicy
+	policy.Entries = pinned.Entries
+
+	if _, err := client.VerifyEvidence(ctx, evidence, policy); err != nil {
+		t.Fatalf("rejected the image it was booted from: %v", err)
+	}
+
+	// Flip one byte of every pinned digest: same shape, different image.
+	wrong := make([]measurements.Entry, 0, len(pinned.Entries))
+	for _, e := range pinned.Entries {
+		d := append([]byte(nil), e.Digest...)
+		d[0] ^= 0xff
+		wrong = append(wrong, measurements.Entry{Name: e.Name, Digest: d, RTMRs: e.RTMRs})
+	}
+	policy.Entries = wrong
+	_, err = client.VerifyEvidence(ctx, evidence, policy)
+	if err == nil {
+		t.Fatal("admitted a guest whose launch measurement is not pinned")
+	}
+	if !errors.Is(err, attestationclient.ErrMeasurementNotAllowed) {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+	t.Logf("unpinned image refused: %v", err)
+}

--- a/pkg/attestationclient/verify.go
+++ b/pkg/attestationclient/verify.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -26,7 +27,7 @@ var (
 	ErrReportDataMismatch = errors.New("attestationclient: REPORTDATA mismatch in attestation evidence")
 
 	// ErrMeasurementNotAllowed: the verified launch measurement is absent or
-	// not in the caller's allowed set while an allowed set is pinned.
+	// does not match any of the caller's reference values while some are pinned.
 	ErrMeasurementNotAllowed = errors.New("attestationclient: launch measurement not allowed")
 
 	// ErrInvalidLaunchDigest: the /verify response carried a launch digest
@@ -99,6 +100,11 @@ type EvidencePolicy struct {
 	// only: the attestation-api's TDX verifier has no minimum-TCB parameter.
 	MinTcb *types.MinTcb
 
+	// Entries pins whole images — a launch digest together with the registers
+	// measured from the same build. When set it replaces Measurements and
+	// RTMRs, so a digest from one image cannot be paired with another's.
+	Entries []measurements.Entry
+
 	// Measurements is the set of acceptable launch measurements; empty
 	// accepts any (callers are expected to warn). The attestation-api
 	// normalizes both the SNP LAUNCH_DIGEST and the TDX MRTD into
@@ -122,7 +128,7 @@ type EvidencePolicy struct {
 
 // VerifyEvidence verifies an attestation evidence envelope against policy via
 // /verify, enforcing the verdict ([Client.VerifyEnforced]) plus the launch
-// measurement allowlist. Platforms without verification rules here fail
+// measurement reference values. Platforms without verification rules here fail
 // closed with [ErrUnsupportedPlatform] rather than being approved under
 // another platform's rules.
 func (c Client) VerifyEvidence(ctx context.Context, evidence types.AttestationEvidence, policy EvidencePolicy) (types.VerifyResponse, error) {
@@ -149,11 +155,27 @@ func (c Client) verifySNPEvidence(ctx context.Context, evidence types.Attestatio
 	if err != nil {
 		return types.VerifyResponse{}, err
 	}
-	if err := enforceLaunchMeasurement(resp, policy.Measurements); err != nil {
+	if err := enforcePins(resp, policy, evidence.Platform); err != nil {
 		return types.VerifyResponse{}, err
 	}
 
 	return resp, nil
+}
+
+// enforcePins applies whichever pin form the caller configured. Entries are
+// matched whole; the flat pair keeps its own path so an operator who set only
+// it sees exactly the decisions it always made.
+func enforcePins(resp types.VerifyResponse, policy EvidencePolicy, platform string) error {
+	if len(policy.Entries) > 0 {
+		return EnforceEntries(resp, policy.Entries, platform)
+	}
+	if err := enforceLaunchMeasurement(resp, policy.Measurements); err != nil {
+		return err
+	}
+	if TDXPlatform(platform) {
+		return EnforceRTMRs(resp, policy.RTMRs)
+	}
+	return nil
 }
 
 func (c Client) verifyTDXEvidence(ctx context.Context, evidence types.AttestationEvidence, policy EvidencePolicy) (types.VerifyResponse, error) {
@@ -174,10 +196,7 @@ func (c Client) verifyTDXEvidence(ctx context.Context, evidence types.Attestatio
 	if err != nil {
 		return types.VerifyResponse{}, err
 	}
-	if err := enforceLaunchMeasurement(resp, policy.Measurements); err != nil {
-		return types.VerifyResponse{}, err
-	}
-	if err := EnforceRTMRs(resp, policy.RTMRs); err != nil {
+	if err := enforcePins(resp, policy, evidence.Platform); err != nil {
 		return types.VerifyResponse{}, err
 	}
 	return resp, nil
@@ -200,6 +219,16 @@ func EnforceRTMRs(resp types.VerifyResponse, pinned map[int][]byte) error {
 	if len(pinned) == 0 {
 		return nil
 	}
+	reported, err := reportedRTMRs(resp)
+	if err != nil {
+		return err
+	}
+	return enforceRTMRsAgainst(reported, pinned)
+}
+
+// reportedRTMRs reads the registers the verifier reported. Shared with the
+// entry matcher so the two cannot disagree about what evidence carries.
+func reportedRTMRs(resp types.VerifyResponse) ([4]string, error) {
 	var platform struct {
 		RTMR0 string `json:"rtmr_0"`
 		RTMR1 string `json:"rtmr_1"`
@@ -208,11 +237,13 @@ func EnforceRTMRs(resp types.VerifyResponse, pinned map[int][]byte) error {
 	}
 	if len(resp.Result.Claims.PlatformData) > 0 {
 		if err := json.Unmarshal(resp.Result.Claims.PlatformData, &platform); err != nil {
-			return fmt.Errorf("%w: platform data unreadable: %w", ErrRTMRNotAllowed, err)
+			return [4]string{}, fmt.Errorf("%w: platform data unreadable: %w", ErrRTMRNotAllowed, err)
 		}
 	}
-	reported := [4]string{platform.RTMR0, platform.RTMR1, platform.RTMR2, platform.RTMR3}
+	return [4]string{platform.RTMR0, platform.RTMR1, platform.RTMR2, platform.RTMR3}, nil
+}
 
+func enforceRTMRsAgainst(reported [4]string, pinned map[int][]byte) error {
 	for _, idx := range sortedRTMRIndices(pinned) {
 		want := pinned[idx]
 		if idx < 0 || idx >= len(reported) {
@@ -246,7 +277,7 @@ func sortedRTMRIndices(pinned map[int][]byte) []int {
 }
 
 // enforceLaunchMeasurement validates the verifier's normalized launch digest
-// and, when allowed is non-empty, requires it to match the caller's allowlist.
+// and, when allowed is non-empty, requires it to match a caller reference value.
 // For SNP the digest is LAUNCH_DIGEST; for TDX it is MRTD. Both are SHA-384.
 func enforceLaunchMeasurement(resp types.VerifyResponse, allowed [][]byte) error {
 	digest := resp.Result.Claims.LaunchDigest
@@ -265,7 +296,7 @@ func enforceLaunchMeasurement(resp types.VerifyResponse, allowed [][]byte) error
 		return fmt.Errorf("%w: launch digest is %d bytes, expected %d", ErrInvalidLaunchDigest, len(measurement), launchMeasurementSize)
 	}
 	if len(allowed) > 0 && !MeasurementAllowed(measurement, allowed) {
-		return fmt.Errorf("%w: launch measurement not in allowed set", ErrMeasurementNotAllowed)
+		return fmt.Errorf("%w: launch measurement does not match any reference value", ErrMeasurementNotAllowed)
 	}
 	return nil
 }
@@ -282,7 +313,7 @@ func verifyRequest(evidence types.AttestationEvidence, reportData []byte, allowD
 }
 
 // MeasurementAllowed reports whether measurement byte-equals one of the
-// allowed launch digests (an empty allowed set means "no pin" and is handled
+// reference launch digests (an empty set means "no pin" and is handled
 // by callers).
 func MeasurementAllowed(measurement []byte, allowed [][]byte) bool {
 	for _, m := range allowed {

--- a/pkg/measurements/measurements.go
+++ b/pkg/measurements/measurements.go
@@ -1,0 +1,421 @@
+// Package measurements is the schema for a measurements config file: the set
+// of VM images a cluster accepts, each pinned as one atomic tuple. A launch
+// digest and its RTMRs only mean anything together — two images built against
+// the same TDVF firmware share an MRTD — so an entry is matched whole or not
+// at all, and the flat flag forms convert into entries rather than being
+// enforced alongside them.
+package measurements
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	// SchemaVersion1 is the only schema version this package accepts.
+	SchemaVersion1 = "1"
+
+	// TEESNP and TEETDX are the platforms a file may declare. One file
+	// describes one platform: a cluster mixing SNP and TDX images is not
+	// supported.
+	TEESNP = "sev-snp"
+	TEETDX = "tdx"
+
+	// DigestSize is the SHA-384 width of every pinned register.
+	DigestSize = 48
+
+	// MaxRTMRs is the number of TDX runtime measurement registers.
+	MaxRTMRs = 4
+)
+
+// Entry is one accepted VM image.
+type Entry struct {
+	// Name identifies the image in diagnostics and on accept. It carries no
+	// matching semantics.
+	Name string
+
+	// Digest is the SNP LAUNCH_DIGEST or the TDX MRTD.
+	Digest []byte
+
+	// RTMRs pins TDX runtime measurement registers by index. An absent index
+	// is unchecked; an all-zero value pins the register to zero.
+	RTMRs map[int][]byte
+}
+
+// ReferenceValues is what a verifier compares evidence against: the images an
+// inbound gate accepts. Gates that cannot express a tuple flatten these back
+// to the flat shapes, so none is left reading a form the operator did not set.
+type ReferenceValues struct {
+	// TEE is the declared platform.
+	TEE string
+
+	// Entries are the accepted images. Empty means the set pins nothing.
+	Entries []Entry
+}
+
+// Empty reports whether the set pins nothing, i.e. accepts any attested peer.
+func (s ReferenceValues) Empty() bool { return len(s.Entries) == 0 }
+
+// Digests returns every reference launch digest, for gates that match on
+// the digest alone.
+func (s ReferenceValues) Digests() [][]byte {
+	out := make([][]byte, 0, len(s.Entries))
+	for _, e := range s.Entries {
+		out = append(out, e.Digest)
+	}
+	return out
+}
+
+// DigestSet returns the pinned digests as lowercase hex, for gates that hold
+// them as a string set.
+func (s ReferenceValues) DigestSet() map[string]bool {
+	out := make(map[string]bool, len(s.Entries))
+	for _, e := range s.Entries {
+		out[hex.EncodeToString(e.Digest)] = true
+	}
+	return out
+}
+
+// CommonRTMRs returns the RTMR pins shared by every entry, and whether the
+// entries agree. Gates that cannot express per-entry tuples take this; when
+// ok is false they must say so rather than silently dropping the pins.
+func (s ReferenceValues) CommonRTMRs() (map[int][]byte, bool) {
+	if len(s.Entries) == 0 {
+		return nil, true
+	}
+	first := s.Entries[0].RTMRs
+	for _, e := range s.Entries[1:] {
+		if !sameRTMRs(first, e.RTMRs) {
+			return nil, false
+		}
+	}
+	return first, true
+}
+
+func sameRTMRs(a, b map[int][]byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for idx, want := range a {
+		got, ok := b[idx]
+		if !ok || !bytes.Equal(got, want) {
+			return false
+		}
+	}
+	return true
+}
+
+// HexDigests returns the pinned digests as lowercase hex, for the flag and
+// values shapes that carry a plain list.
+func (s ReferenceValues) HexDigests() []string {
+	out := make([]string, 0, len(s.Entries))
+	for _, e := range s.Entries {
+		out = append(out, hex.EncodeToString(e.Digest))
+	}
+	return out
+}
+
+// FromFlags converts the legacy flat pins into entries: every digest carries
+// the same RTMR map, which is what the flat form enforced. Registers pinned
+// without any digest have no entry form and stay on the flat path.
+func FromFlags(digests [][]byte, rtmrs map[int][]byte) ReferenceValues {
+	entries := make([]Entry, 0, len(digests))
+	for _, d := range digests {
+		// Each entry owns its map: callers mutate policy pins in place.
+		own := make(map[int][]byte, len(rtmrs))
+		for i, v := range rtmrs {
+			own[i] = v
+		}
+		if len(own) == 0 {
+			own = nil
+		}
+		entries = append(entries, Entry{Digest: d, RTMRs: own})
+	}
+	return ReferenceValues{Entries: entries}
+}
+
+// Load reads and validates a measurements config file. A missing or malformed
+// file is an error, never an empty policy: the caller asked for pinning.
+func Load(path string) (ReferenceValues, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ReferenceValues{}, fmt.Errorf("read measurements config: %w", err)
+	}
+	s, err := Parse(data)
+	if err != nil {
+		return ReferenceValues{}, fmt.Errorf("measurements config %s: %w", path, err)
+	}
+	return s, nil
+}
+
+// Format renders a set as a measurements config document. The result is
+// re-parsed by the caller, so a set that formats is a set that loads.
+func Format(s ReferenceValues) ([]byte, error) {
+	f := wire{SchemaVersion: SchemaVersion1, TEE: s.TEE}
+	for _, e := range s.Entries {
+		we := wireEntry{Name: e.Name}
+		d := hex.EncodeToString(e.Digest)
+		switch s.TEE {
+		case TEESNP:
+			we.Measurement = &d
+		case TEETDX:
+			we.MRTD = &d
+			if len(e.RTMRs) > 0 {
+				we.RTMR = make([]*string, MaxRTMRs)
+				for idx, v := range e.RTMRs {
+					h := hex.EncodeToString(v)
+					we.RTMR[idx] = &h
+				}
+			}
+		default:
+			return nil, fmt.Errorf("tee %q, want %q or %q", s.TEE, TEESNP, TEETDX)
+		}
+		f.Measurements = append(f.Measurements, we)
+	}
+	out, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode measurements config: %w", err)
+	}
+	return append(out, '\n'), nil
+}
+
+// wire mirrors the file exactly; validation happens against these fields so an
+// absent value stays distinguishable from an empty one.
+type wire struct {
+	SchemaVersion string      `json:"schema_version"`
+	TEE           string      `json:"tee"`
+	Measurements  []wireEntry `json:"measurements"`
+}
+
+type wireEntry struct {
+	Name        string    `json:"name"`
+	Measurement *string   `json:"measurement,omitempty"`
+	MRTD        *string   `json:"mrtd,omitempty"`
+	RTMR        []*string `json:"rtmr,omitempty"`
+}
+
+// Parse validates a measurements config document. Parsing and linting are the
+// same strictness, so a file that lints clean is the file every component
+// loads.
+func Parse(data []byte) (ReferenceValues, error) {
+	if err := rejectDuplicateKeys(data); err != nil {
+		return ReferenceValues{}, err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var f wire
+	if err := dec.Decode(&f); err != nil {
+		return ReferenceValues{}, fmt.Errorf("decode: %w", err)
+	}
+	if dec.More() {
+		return ReferenceValues{}, fmt.Errorf("trailing data after the JSON object")
+	}
+	return f.validate()
+}
+
+func (f wire) validate() (ReferenceValues, error) {
+	if f.SchemaVersion != SchemaVersion1 {
+		return ReferenceValues{}, fmt.Errorf("schema_version %q, want %q", f.SchemaVersion, SchemaVersion1)
+	}
+	if f.TEE != TEESNP && f.TEE != TEETDX {
+		return ReferenceValues{}, fmt.Errorf("tee %q, want %q or %q", f.TEE, TEESNP, TEETDX)
+	}
+	// An empty list would pin nothing while reading as a pinned config;
+	// omitting the flag is how an operator asks for no pinning.
+	if len(f.Measurements) == 0 {
+		return ReferenceValues{}, fmt.Errorf("measurements is empty: a config file must pin at least one image")
+	}
+
+	set := ReferenceValues{TEE: f.TEE, Entries: make([]Entry, 0, len(f.Measurements))}
+	names := make(map[string]bool, len(f.Measurements))
+	tuples := make(map[string]int, len(f.Measurements))
+	for i, we := range f.Measurements {
+		e, err := we.validate(f.TEE, i)
+		if err != nil {
+			return ReferenceValues{}, err
+		}
+		if names[e.Name] {
+			return ReferenceValues{}, fmt.Errorf("measurements[%d]: duplicate name %q", i, e.Name)
+		}
+		names[e.Name] = true
+		key := tupleKey(e)
+		if prev, dup := tuples[key]; dup {
+			return ReferenceValues{}, fmt.Errorf("measurements[%d] pins the same tuple as measurements[%d]", i, prev)
+		}
+		tuples[key] = i
+		set.Entries = append(set.Entries, e)
+	}
+	return set, nil
+}
+
+func (we wireEntry) validate(tee string, i int) (Entry, error) {
+	at := fmt.Sprintf("measurements[%d]", i)
+	if strings.TrimSpace(we.Name) == "" {
+		return Entry{}, fmt.Errorf("%s: name is required", at)
+	}
+	e := Entry{Name: we.Name}
+
+	switch tee {
+	case TEESNP:
+		if we.MRTD != nil || we.RTMR != nil {
+			return Entry{}, fmt.Errorf("%s: mrtd and rtmr are tdx fields, but tee is %q", at, TEESNP)
+		}
+		if we.Measurement == nil {
+			return Entry{}, fmt.Errorf("%s: measurement is required", at)
+		}
+		d, err := decodeRegister(*we.Measurement)
+		if err != nil {
+			return Entry{}, fmt.Errorf("%s.measurement: %w", at, err)
+		}
+		e.Digest = d
+	case TEETDX:
+		if we.Measurement != nil {
+			return Entry{}, fmt.Errorf("%s: measurement is a sev-snp field, but tee is %q", at, TEETDX)
+		}
+		if we.MRTD == nil {
+			return Entry{}, fmt.Errorf("%s: mrtd is required", at)
+		}
+		d, err := decodeRegister(*we.MRTD)
+		if err != nil {
+			return Entry{}, fmt.Errorf("%s.mrtd: %w", at, err)
+		}
+		e.Digest = d
+		rtmrs, err := decodeRTMRs(we.RTMR, at)
+		if err != nil {
+			return Entry{}, err
+		}
+		e.RTMRs = rtmrs
+	}
+	return e, nil
+}
+
+func decodeRTMRs(raw []*string, at string) (map[int][]byte, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if len(raw) > MaxRTMRs {
+		return nil, fmt.Errorf("%s.rtmr has %d entries, want at most %d", at, len(raw), MaxRTMRs)
+	}
+	out := make(map[int][]byte, len(raw))
+	for idx, v := range raw {
+		if v == nil {
+			continue
+		}
+		// RTMR[0] mixes the TD HOB and VMM ACPI tables, so it varies with the
+		// VM shape and can never be pinned to a stable value.
+		if idx == 0 {
+			return nil, fmt.Errorf("%s.rtmr[0]: must be null — RTMR[0] varies with vCPU and memory shape", at)
+		}
+		if *v == "" {
+			out[idx] = make([]byte, DigestSize)
+			continue
+		}
+		d, err := decodeRegister(*v)
+		if err != nil {
+			return nil, fmt.Errorf("%s.rtmr[%d]: %w", at, idx, err)
+		}
+		out[idx] = d
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+// decodeRegister requires lowercase hex of exactly one register width.
+// Uppercase is rejected rather than folded so one register has one spelling.
+func decodeRegister(s string) ([]byte, error) {
+	if s != strings.ToLower(s) {
+		return nil, fmt.Errorf("%q is not lowercase hex", s)
+	}
+	if len(s) != hex.EncodedLen(DigestSize) {
+		return nil, fmt.Errorf("is %d hex chars, want %d", len(s), hex.EncodedLen(DigestSize))
+	}
+	d, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, fmt.Errorf("is not hex: %w", err)
+	}
+	return d, nil
+}
+
+func tupleKey(e Entry) string {
+	var b strings.Builder
+	b.WriteString(hex.EncodeToString(e.Digest))
+	idx := make([]int, 0, len(e.RTMRs))
+	for i := range e.RTMRs {
+		idx = append(idx, i)
+	}
+	sort.Ints(idx)
+	for _, i := range idx {
+		fmt.Fprintf(&b, "|%d=%s", i, hex.EncodeToString(e.RTMRs[i]))
+	}
+	return b.String()
+}
+
+// rejectDuplicateKeys fails a document that names any key twice. encoding/json
+// keeps the last occurrence silently, so without this the value a reviewer
+// reads and the value a gate loads could differ. The schema is two levels, so
+// the document and each entry are scanned directly.
+func rejectDuplicateKeys(data []byte) error {
+	if key, err := duplicateKey(data); err != nil || key != "" {
+		if err != nil {
+			return err
+		}
+		return fmt.Errorf("duplicate key %q", key)
+	}
+	// Tolerant: a document whose shape is wrong is Parse's error to report.
+	var doc struct {
+		Measurements []json.RawMessage `json:"measurements"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return nil
+	}
+	for i, entry := range doc.Measurements {
+		key, err := duplicateKey(entry)
+		if err != nil {
+			return err
+		}
+		if key != "" {
+			return fmt.Errorf("duplicate key %q in measurements[%d]", key, i)
+		}
+	}
+	return nil
+}
+
+// duplicateKey returns the first key obj names twice, or "" if it names none
+// twice or is not an object.
+func duplicateKey(obj []byte) (string, error) {
+	dec := json.NewDecoder(bytes.NewReader(obj))
+	tok, err := dec.Token()
+	if err != nil {
+		return "", nil
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return "", nil
+	}
+	seen := make(map[string]bool)
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return "", fmt.Errorf("not valid JSON: %w", err)
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return "", fmt.Errorf("not valid JSON: object key is %T", keyTok)
+		}
+		if seen[key] {
+			return key, nil
+		}
+		seen[key] = true
+		var value json.RawMessage
+		if err := dec.Decode(&value); err != nil {
+			return "", fmt.Errorf("not valid JSON: %w", err)
+		}
+	}
+	return "", nil
+}

--- a/pkg/measurements/measurements_test.go
+++ b/pkg/measurements/measurements_test.go
@@ -1,0 +1,259 @@
+package measurements
+
+import (
+	"bytes"
+	"encoding/hex"
+	"strings"
+	"testing"
+)
+
+const (
+	d1 = "c1e0a7000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009"
+	d2 = "9f2c1a000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003"
+	r1 = "77df02000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
+	r2 = "3e90ac000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005"
+)
+
+func snpFile(entries string) string {
+	return `{"schema_version":"1","tee":"sev-snp","measurements":[` + entries + `]}`
+}
+
+func tdxFile(entries string) string {
+	return `{"schema_version":"1","tee":"tdx","measurements":[` + entries + `]}`
+}
+
+func TestParseValidSNP(t *testing.T) {
+	set, err := Parse([]byte(snpFile(
+		`{"name":"worker-smp2","measurement":"` + d1 + `"},` +
+			`{"name":"worker-smp4","measurement":"` + d2 + `"}`)))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if set.TEE != TEESNP {
+		t.Errorf("TEE = %q, want %q", set.TEE, TEESNP)
+	}
+	if len(set.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(set.Entries))
+	}
+	if got := hex.EncodeToString(set.Entries[0].Digest); got != d1 {
+		t.Errorf("digest = %s, want %s", got, d1)
+	}
+	if set.Entries[0].RTMRs != nil {
+		t.Errorf("SNP entry carries RTMRs: %v", set.Entries[0].RTMRs)
+	}
+	if set.Empty() {
+		t.Error("Empty() = true for a populated set")
+	}
+}
+
+// An empty rtmr slot pins the register to all zeros; a null slot leaves it
+// unchecked. The two must not collapse into each other.
+func TestParseTDXRTMRSlots(t *testing.T) {
+	set, err := Parse([]byte(tdxFile(
+		`{"name":"worker","mrtd":"` + d1 + `","rtmr":[null,"` + r1 + `",null,""]}`)))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	got := set.Entries[0].RTMRs
+	if _, pinned := got[0]; pinned {
+		t.Error("rtmr[0] pinned from a null slot")
+	}
+	if _, pinned := got[2]; pinned {
+		t.Error("rtmr[2] pinned from a null slot")
+	}
+	if want, _ := hex.DecodeString(r1); !bytes.Equal(got[1], want) {
+		t.Errorf("rtmr[1] = %x, want %s", got[1], r1)
+	}
+	if !bytes.Equal(got[3], make([]byte, DigestSize)) {
+		t.Errorf("rtmr[3] = %x, want %d zero bytes", got[3], DigestSize)
+	}
+}
+
+func TestParseRejects(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  string
+		want string
+	}{
+		{"wrong schema version", `{"schema_version":"2","tee":"tdx","measurements":[{"name":"a","mrtd":"` + d1 + `"}]}`, "schema_version"},
+		{"missing schema version", `{"tee":"tdx","measurements":[{"name":"a","mrtd":"` + d1 + `"}]}`, "schema_version"},
+		{"unknown tee", `{"schema_version":"1","tee":"sev","measurements":[{"name":"a","mrtd":"` + d1 + `"}]}`, "tee"},
+		{"empty measurements", `{"schema_version":"1","tee":"tdx","measurements":[]}`, "empty"},
+		{"missing measurements", `{"schema_version":"1","tee":"tdx"}`, "empty"},
+		{"unknown field", snpFile(`{"name":"a","measurement":"` + d1 + `","host_data":"ab"}`), "host_data"},
+		{"unknown top-level field", `{"schema_version":"1","tee":"tdx","extra":1,"measurements":[{"name":"a","mrtd":"` + d1 + `"}]}`, "extra"},
+		{"duplicate top-level key", `{"schema_version":"1","tee":"tdx","tee":"sev-snp","measurements":[{"name":"a","mrtd":"` + d1 + `"}]}`, "duplicate key"},
+		{"duplicate key inside an entry", tdxFile(`{"name":"a","mrtd":"` + d1 + `","mrtd":"` + d2 + `"}`), "duplicate key"},
+		{"uppercase hex", snpFile(`{"name":"a","measurement":"` + strings.ToUpper(d1) + `"}`), "lowercase"},
+		{"short digest", snpFile(`{"name":"a","measurement":"c1e0a7"}`), "hex chars"},
+		{"non-hex digest", snpFile(`{"name":"a","measurement":"` + strings.Repeat("z", 96) + `"}`), "not hex"},
+		{"missing name", snpFile(`{"measurement":"` + d1 + `"}`), "name is required"},
+		{"blank name", snpFile(`{"name":"  ","measurement":"` + d1 + `"}`), "name is required"},
+		{"missing measurement", snpFile(`{"name":"a"}`), "measurement is required"},
+		{"missing mrtd", tdxFile(`{"name":"a"}`), "mrtd is required"},
+		{"snp entry with mrtd", snpFile(`{"name":"a","measurement":"` + d1 + `","mrtd":"` + d2 + `"}`), "tdx fields"},
+		{"snp entry with rtmr", snpFile(`{"name":"a","measurement":"` + d1 + `","rtmr":[null,"` + r1 + `"]}`), "tdx fields"},
+		{"tdx entry with measurement", tdxFile(`{"name":"a","mrtd":"` + d1 + `","measurement":"` + d2 + `"}`), "sev-snp field"},
+		{"pinned rtmr0", tdxFile(`{"name":"a","mrtd":"` + d1 + `","rtmr":["` + r1 + `"]}`), "rtmr[0]"},
+		{"zero-pinned rtmr0", tdxFile(`{"name":"a","mrtd":"` + d1 + `","rtmr":[""]}`), "rtmr[0]"},
+		{"too many rtmrs", tdxFile(`{"name":"a","mrtd":"` + d1 + `","rtmr":[null,"` + r1 + `","` + r2 + `","` + r1 + `","` + r2 + `"]}`), "at most"},
+		{"duplicate name", snpFile(`{"name":"a","measurement":"` + d1 + `"},{"name":"a","measurement":"` + d2 + `"}`), "duplicate name"},
+		{"duplicate tuple", snpFile(`{"name":"a","measurement":"` + d1 + `"},{"name":"b","measurement":"` + d1 + `"}`), "same tuple"},
+		{"not an object", `[]`, "decode"},
+		{"trailing data", snpFile(`{"name":"a","measurement":"`+d1+`"}`) + `{}`, "trailing data"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.doc))
+			if err == nil {
+				t.Fatalf("Parse accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// Two entries differing only in RTMRs are distinct images, not a duplicate.
+func TestParseAllowsSameMRTDDifferentRTMRs(t *testing.T) {
+	if _, err := Parse([]byte(tdxFile(
+		`{"name":"a","mrtd":"` + d1 + `","rtmr":[null,"` + r1 + `"]},` +
+			`{"name":"b","mrtd":"` + d1 + `","rtmr":[null,"` + r2 + `"]}`))); err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+}
+
+// The flat flags enforced "digest in the list AND the one RTMR set". The
+// converted entries must say exactly that.
+func TestFromFlagsMatchesFlatSemantics(t *testing.T) {
+	b1, _ := hex.DecodeString(d1)
+	b2, _ := hex.DecodeString(d2)
+	pins, _ := hex.DecodeString(r1)
+	rtmrs := map[int][]byte{1: pins}
+
+	set := FromFlags([][]byte{b1, b2}, rtmrs)
+	if len(set.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(set.Entries))
+	}
+	for i, e := range set.Entries {
+		if !bytes.Equal(e.RTMRs[1], pins) {
+			t.Errorf("entry %d does not carry the shared RTMR pin", i)
+		}
+	}
+	common, ok := set.CommonRTMRs()
+	if !ok || !bytes.Equal(common[1], pins) {
+		t.Errorf("CommonRTMRs = %v, %v; want the shared pin", common, ok)
+	}
+}
+
+// --rtmrs without --measurements has no entry form; it stays on the flat
+// path, so the converted set must report itself as pinning nothing rather
+// than claiming a digest gate the operator never configured.
+func TestFromFlagsRTMRsWithoutDigests(t *testing.T) {
+	pins, _ := hex.DecodeString(r1)
+	set := FromFlags(nil, map[int][]byte{1: pins})
+	if len(set.Entries) != 0 {
+		t.Errorf("got %d entries, want 0", len(set.Entries))
+	}
+	if !set.Empty() {
+		t.Error("Empty() = false for a set with no entries")
+	}
+	if len(set.DigestSet()) != 0 {
+		t.Error("DigestSet() is non-empty for a set with no entries")
+	}
+}
+
+// Entries must not share one RTMR map: consumers assign to policy pins.
+func TestFromFlagsEntriesOwnTheirRTMRs(t *testing.T) {
+	b1, _ := hex.DecodeString(d1)
+	b2, _ := hex.DecodeString(d2)
+	pins, _ := hex.DecodeString(r1)
+	set := FromFlags([][]byte{b1, b2}, map[int][]byte{1: pins})
+
+	set.Entries[0].RTMRs[2] = make([]byte, DigestSize)
+	if _, leaked := set.Entries[1].RTMRs[2]; leaked {
+		t.Error("mutating one entry's RTMRs changed another's")
+	}
+}
+
+func TestEmptySet(t *testing.T) {
+	if !(ReferenceValues{}).Empty() {
+		t.Error("zero ReferenceValues is not Empty()")
+	}
+	if !FromFlags(nil, nil).Empty() {
+		t.Error("FromFlags(nil, nil) is not Empty()")
+	}
+}
+
+// A gate that cannot express per-entry tuples must be able to tell that the
+// entries disagree, rather than silently taking the first.
+func TestCommonRTMRsDisagree(t *testing.T) {
+	set, err := Parse([]byte(tdxFile(
+		`{"name":"a","mrtd":"` + d1 + `","rtmr":[null,"` + r1 + `"]},` +
+			`{"name":"b","mrtd":"` + d2 + `","rtmr":[null,"` + r2 + `"]}`)))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, ok := set.CommonRTMRs(); ok {
+		t.Error("CommonRTMRs reported agreement across differing entries")
+	}
+}
+
+func TestDigestAccessors(t *testing.T) {
+	set, err := Parse([]byte(snpFile(
+		`{"name":"a","measurement":"` + d1 + `"},{"name":"b","measurement":"` + d2 + `"}`)))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if got := len(set.Digests()); got != 2 {
+		t.Errorf("Digests() len = %d, want 2", got)
+	}
+	ds := set.DigestSet()
+	if !ds[d1] || !ds[d2] {
+		t.Errorf("DigestSet() = %v, want both digests", ds)
+	}
+}
+
+func FuzzParse(f *testing.F) {
+	f.Add(snpFile(`{"name":"a","measurement":"` + d1 + `"}`))
+	f.Add(tdxFile(`{"name":"a","mrtd":"` + d1 + `","rtmr":[null,"` + r1 + `","` + r2 + `",""]}`))
+	f.Fuzz(func(t *testing.T, doc string) {
+		set, err := Parse([]byte(doc))
+		if err != nil {
+			return
+		}
+		// Anything that parses must be usable as a policy without panicking
+		// and must actually pin something.
+		if set.Empty() {
+			t.Fatalf("accepted a document that pins nothing: %q", doc)
+		}
+		for _, e := range set.Entries {
+			if len(e.Digest) != DigestSize {
+				t.Fatalf("accepted a %d-byte digest", len(e.Digest))
+			}
+			for idx, v := range e.RTMRs {
+				if idx == 0 {
+					t.Fatalf("accepted a pin on RTMR[0]")
+				}
+				if len(v) != DigestSize {
+					t.Fatalf("accepted a %d-byte RTMR pin", len(v))
+				}
+			}
+		}
+		set.CommonRTMRs()
+		set.DigestSet()
+	})
+}
+
+// Format must refuse a set whose platform it cannot render, rather than
+// emitting a document that would not load.
+func TestFormatRejectsUnknownTEE(t *testing.T) {
+	_, err := Format(ReferenceValues{TEE: "sev", Entries: []Entry{{Name: "a", Digest: make([]byte, DigestSize)}}})
+	if err == nil {
+		t.Fatal("formatted a set with an unknown tee")
+	}
+	if !strings.Contains(err.Error(), "tee") {
+		t.Errorf("error %q does not name the field", err)
+	}
+}

--- a/pkg/ratls/cdsclient/client.go
+++ b/pkg/ratls/cdsclient/client.go
@@ -137,7 +137,7 @@ func NewClient(cfg *Config) *Client {
 //  2. Call CDS (authenticate -> attest) over RA-TLS to get a signed certificate
 //     chain. Authenticity of the response is provided by the RA-TLS handshake
 //     (the underlying http.Client's TLSClientConfig verifies CDS's peer cert
-//     against the configured measurement allowlist).
+//     against the configured reference values).
 //  3. Return key + leaf cert + authenticated CA bundle from the signed response
 func (c *Client) RequestCert(ctx context.Context) (*ecdsa.PrivateKey, []byte, []byte, error) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/pkg/ratls/client.go
+++ b/pkg/ratls/client.go
@@ -10,7 +10,7 @@ import (
 
 // NewVerifyingHTTPClient returns an http.Client whose TLS handshake
 // verifies the peer's RA-TLS attestation extension against the supplied
-// pins (launch-measurement allowlist plus any TDX RTMR pins). Zero pins
+// pins (launch-measurement reference values plus any TDX RTMR pins). Zero pins
 // falls back to TOFU on the attestation extension — UNSAFE outside
 // development; the caller is expected to warn.
 //

--- a/pkg/ratls/errors.go
+++ b/pkg/ratls/errors.go
@@ -21,7 +21,7 @@ var (
 	ErrSignatureInvalid = errors.New("ratls: hardware signature verification failed")
 
 	// ErrPolicyViolation indicates that the verified launch measurement is not
-	// in the [VerifyPolicy] allowlist. Debug and minimum-TCB policy are
+	// in the [VerifyPolicy] reference values. Debug and minimum-TCB policy are
 	// enforced by the attestation-api; those rejections surface as the
 	// attestation-api error or [ErrSignatureInvalid], not this sentinel.
 	ErrPolicyViolation = errors.New("ratls: attestation policy check failed")

--- a/pkg/ratls/measurements.go
+++ b/pkg/ratls/measurements.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Pins is the peer-identity pin set an in-cluster RA-TLS verifier enforces:
-// the launch-measurement allowlist and, for TDX peers, the runtime
+// the launch-measurement reference values and, for TDX peers, the runtime
 // measurement registers. The zero value pins nothing (accept any attested
 // TEE — development only; callers warn).
 type Pins struct {

--- a/pkg/ratls/verify.go
+++ b/pkg/ratls/verify.go
@@ -308,7 +308,7 @@ func unpackSNPMinTcb(packed uint64) types.MinTcb {
 
 // verifyEnvelopeOnline forwards the envelope to the attestation-api enforced
 // verifier ([attestationclient.Client.VerifyEvidence] — verdict gate,
-// platform-specific REPORTDATA wire form, measurement allowlist) and maps its
+// platform-specific REPORTDATA wire form, measurement reference values) and maps its
 // verdicts onto this package's sentinels.
 func verifyEnvelopeOnline(evidence *types.AttestationEvidence, policy *VerifyPolicy, expectedReportData [64]byte) (*VerifyResult, error) {
 	timeout := policy.AttestationVerifyTimeout

--- a/pkg/runtimemeasure/manifest.go
+++ b/pkg/runtimemeasure/manifest.go
@@ -98,30 +98,31 @@ func rejectDuplicateRegisters(data []byte, scope string) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	tok, err := dec.Token()
 	if err != nil {
-		return nil // not a JSON object; Unmarshal already reported the shape
+		return fmt.Errorf("manifest is not valid JSON: %w", err)
 	}
 	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
-		return nil
+		return fmt.Errorf("manifest is not a JSON object")
 	}
 	seen := make(map[string]bool, 3)
+	var scoped []json.RawMessage
 	for dec.More() {
 		keyTok, err := dec.Token()
 		if err != nil {
-			return nil
+			return fmt.Errorf("manifest is not valid JSON: %w", err)
 		}
 		key, ok := keyTok.(string)
 		if !ok {
-			return nil
+			return fmt.Errorf("manifest is not valid JSON: object key is %T", keyTok)
 		}
 		// Decode consumes the whole value, nested objects and arrays included,
 		// so the loop only ever sees top-level keys.
 		var value json.RawMessage
 		if err := dec.Decode(&value); err != nil {
-			return nil
+			return fmt.Errorf("manifest is not valid JSON: %w", err)
 		}
 		if scope != "" {
 			if key == scope {
-				return rejectDuplicateRegisters(value, "")
+				scoped = append(scoped, value)
 			}
 			continue
 		}
@@ -131,6 +132,16 @@ func rejectDuplicateRegisters(data []byte, scope string) error {
 				return fmt.Errorf("duplicate %q key — a register may be named only once, since JSON parsing would silently keep the last value", key)
 			}
 			seen[key] = true
+		}
+	}
+	// Every occurrence must be collected before recursing: Unmarshal keeps the
+	// last, so checking only the first would inspect bytes the pin never loads.
+	if scope != "" {
+		if len(scoped) > 1 {
+			return fmt.Errorf("duplicate %q key — a register object may be named only once, since JSON parsing would silently keep the last value", scope)
+		}
+		if len(scoped) == 1 {
+			return rejectDuplicateRegisters(scoped[0], "")
 		}
 	}
 	return nil

--- a/pkg/runtimemeasure/manifest_dupscope_test.go
+++ b/pkg/runtimemeasure/manifest_dupscope_test.go
@@ -1,0 +1,40 @@
+package runtimemeasure
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A repeated "tdx" object must fail the load. encoding/json keeps the last
+// occurrence, so a check that stopped at the first would validate registers
+// the pin never loads.
+func TestLoadImageManifestRejectsDuplicateTDXObject(t *testing.T) {
+	published := strings.Repeat("a", 96)
+	attacker := strings.Repeat("b", 96)
+	doc := `{"tdx":{"mrtd":"` + published + `","rtmr1":"` + published + `","rtmr2":"` + published + `"},` +
+		`"tdx":{"mrtd":"` + attacker + `","rtmr1":"` + attacker + `","rtmr2":"` + attacker + `"}}`
+
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	pins, err := LoadImageManifest(path)
+	if err == nil {
+		t.Fatalf("loaded a manifest with two tdx objects: %x", pins.MRTD)
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("error %q does not report a duplicate", err)
+	}
+}
+
+func TestLoadImageManifestRejectsMalformedJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "manifest.json")
+	if err := os.WriteFile(path, []byte(`[]`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadImageManifest(path); err == nil {
+		t.Fatal("loaded a JSON array as an image manifest")
+	}
+}

--- a/test/e2e/ca-handoff.sh
+++ b/test/e2e/ca-handoff.sh
@@ -237,7 +237,7 @@ phase=$(run_probe "$bad_pod" "$bad_meas" 30)
 bad_logs=$(kubectl logs "$bad_pod" -n "$cds_ns" 2>/dev/null || true)
 printf '%s\n' "$bad_logs"
 [ "$phase" = Failed ] || fail "probe with a wrong --measurements pin was not refused (phase=${phase:-unknown}; logs above)"
-grep -q "launch measurement not in allowed set" <<<"$bad_logs" \
+grep -q "launch measurement does not match any reference value" <<<"$bad_logs" \
   || fail "refused probe's log names no measurement mismatch (see above)"
 echo "ok: wrong --measurements pin refused (log names the measurement mismatch)"
 

--- a/test/mock-cds/main.go
+++ b/test/mock-cds/main.go
@@ -220,7 +220,7 @@ func handleAttest(store *challengeStore, verifier attestationclient.Client) http
 			return
 		}
 		if digest := strings.ToLower(verifyResp.Result.Claims.LaunchDigest); digest != mockLaunchDigest {
-			slog.Warn("measurement not in allowlist", "launch_digest", digest, "remote_addr", r.RemoteAddr)
+			slog.Warn("measurement does not match any reference value", "launch_digest", digest, "remote_addr", r.RemoteAddr)
 			writeError(w, http.StatusForbidden, types.ErrorCodeMeasurementDenied, "launch measurement not allowed")
 			return
 		}


### PR DESCRIPTION
A cluster can now accept more than one VM image. Each entry pins one image as a tuple — launch digest plus, on TDX, the registers measured from that same build — so a digest from one image can no longer be paired with another's registers.

- New --measurements-config on c8s cds, mutually exclusive with --measurements/--rtmrs.
- c8s measurements derive|lint builds and checks one from confidential-os-builder images.
- The config fills the flat lists it replaces, so gates that read only a digest list keep pinning exactly what they pin today.
- cds only so far; ratls-mesh, install and the chart wiring follow.
- fixed a bug where duplicate measurements could be passed to the runtime measurement