### PR TITLE
feat(measurements): template the config down to every component

### DIFF
--- a/cmd/c8s/operator.go
+++ b/cmd/c8s/operator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/controller"
 	"github.com/confidential-dot-ai/c8s/internal/webhook"
 )
@@ -43,6 +44,13 @@ Pod-to-pod mTLS is handled by the node-level ratls-mesh DaemonSet, not
 by this command.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateOperatorPlatform(operatorHardwarePlatform, kataEnforce); err != nil {
+			return err
+		}
+		// The injected sidecars and the measured initdata document carry a
+		// flat digest list, so a config is flattened into the same fields.
+		if _, err := cmdsutil.LoadMeasurementsConfig(cdsMeasurementsConfig,
+			"--measurements-config", "--cds-measurements", "--cds-rtmrs",
+			&cdsMeasurements, &cdsRTMRs); err != nil {
 			return err
 		}
 		return controller.Run(cmd.Context(), controller.Options{
@@ -86,6 +94,7 @@ var (
 	cdsURL                  string
 	attestationApiURL       string
 	cdsMeasurements         []string
+	cdsMeasurementsConfig   string
 	cdsRTMRs                []string
 	webhookConfigName       string
 	webhookServiceName      string
@@ -115,6 +124,7 @@ func init() {
 	operatorCmd.Flags().StringVar(&cdsURL, "cds-url", "", "CDS Service URL the injected get-cert containers POST to")
 	operatorCmd.Flags().StringVar(&attestationApiURL, "attestation-api-url", "", "attestation-api endpoint (empty = no verification)")
 	operatorCmd.Flags().StringSliceVar(&cdsMeasurements, "cds-measurements", nil, "SHA-384 hex launch measurement(s) the injected secret fetcher requires CDS to present (repeatable; empty pins none)")
+	operatorCmd.Flags().StringVar(&cdsMeasurementsConfig, "measurements-config", "", "path to a measurements config listing the VM images this cluster runs. Any listed image may serve as CDS; the injected sidecars carry the digests flat. Cannot be combined with --cds-measurements or --cds-rtmrs")
 	operatorCmd.Flags().StringSliceVar(&cdsRTMRs, "cds-rtmrs", nil, "TDX RTMR pin(s) <index>=<sha384-hex> the injected sidecars additionally hold CDS to (repeatable; ignored for SNP evidence, empty pins no registers)")
 	operatorCmd.Flags().StringSliceVar(&excludeNamespaces, "exclude-namespaces", nil, "extra namespaces the startup reinject sweep skips (mirrors webhook.extraExcluded)")
 	operatorCmd.Flags().StringVar(&webhookConfigName, "webhook-config-name", "", "MutatingWebhookConfiguration to patch caBundle (empty = skip)")

--- a/internal/cmds/allowlistproxy/cmd.go
+++ b/internal/cmds/allowlistproxy/cmd.go
@@ -30,14 +30,15 @@ const (
 )
 
 type config struct {
-	host              string
-	port              int
-	cdsURL            string
-	cdsMeasurements   []string
-	cdsRTMRs          []string
-	attestationAPIURL string
-	requestTimeout    time.Duration
-	readHeaderTimeout time.Duration
+	measurementsConfig string
+	host               string
+	port               int
+	cdsURL             string
+	cdsMeasurements    []string
+	cdsRTMRs           []string
+	attestationAPIURL  string
+	requestTimeout     time.Duration
+	readHeaderTimeout  time.Duration
 }
 
 // NewCmd returns the internal allowlist-proxy subcommand used by the tls-lb
@@ -59,6 +60,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.cdsURL, "cds-url", "", "CDS base URL (must use https/RA-TLS)")
 	f.StringSliceVar(&cfg.cdsMeasurements, "cds-measurements", nil, "allowed CDS SHA-384 launch measurement(s), repeatable/comma-separated; empty accepts any attested CDS (unsafe)")
 	f.StringSliceVar(&cfg.cdsRTMRs, "cds-rtmrs", nil, "TDX RTMR pin(s) <index>=<sha384-hex> CDS must additionally satisfy, repeatable/comma-separated; ignored when CDS presents SNP evidence (empty pins no registers)")
+	f.StringVar(&cfg.measurementsConfig, "measurements-config", "", "path to a measurements config listing the VM images this cluster runs, each matched as a whole image. Any listed image may serve as CDS. Cannot be combined with --cds-measurements or --cds-rtmrs")
 	f.StringVar(&cfg.attestationAPIURL, "attestation-api-url", "", "attestation-api URL used to verify CDS evidence")
 	f.DurationVar(&cfg.requestTimeout, "request-timeout", defaultRequestTimeout, "timeout for one request to CDS")
 	f.DurationVar(&cfg.readHeaderTimeout, "read-header-timeout", defaultReadHeaderTimeout, "HTTP request-header timeout")
@@ -127,6 +129,13 @@ func newHandler(cfg config, logger *slog.Logger) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Resolve before the flat fields are read: they feed the pin below.
+	pinned, err := cmdsutil.LoadMeasurementsConfig(cfg.measurementsConfig,
+		"--measurements-config", "--cds-measurements", "--cds-rtmrs",
+		&cfg.cdsMeasurements, &cfg.cdsRTMRs)
+	if err != nil {
+		return nil, err
+	}
 	measurements, err := ratls.ParseHexMeasurementsList(cfg.cdsMeasurements)
 	if err != nil {
 		return nil, fmt.Errorf("--cds-measurements: %w", err)
@@ -138,7 +147,7 @@ func newHandler(cfg config, logger *slog.Logger) (http.Handler, error) {
 	if err != nil {
 		return nil, fmt.Errorf("--cds-rtmrs: %w", err)
 	}
-	httpClient, err := ratls.NewVerifyingHTTPClient(ratls.Pins{Measurements: measurements, RTMRs: rtmrs}, cfg.attestationAPIURL)
+	httpClient, err := ratls.NewVerifyingHTTPClient(ratls.Pins{Measurements: measurements, RTMRs: rtmrs, Entries: pinned.Entries}, cfg.attestationAPIURL)
 	if err != nil {
 		return nil, fmt.Errorf("CDS RA-TLS client: %w", err)
 	}

--- a/internal/cmds/cmdsutil/measurementsconfig.go
+++ b/internal/cmds/cmdsutil/measurementsconfig.go
@@ -1,0 +1,59 @@
+package cmdsutil
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+)
+
+// LoadMeasurementsConfig loads a measurements config and fills the flat flag
+// slices from it, so a gate that can only express a digest list keeps pinning
+// exactly what it pins today. The returned reference values carry the whole
+// tuples, for the gates that can match them.
+//
+// digests and rtmrs are the command's own flag slices: non-empty means the
+// operator set both forms, which is refused rather than merged.
+func LoadMeasurementsConfig(path, configFlag, digestFlag, rtmrFlag string, digests, rtmrs *[]string) (measurements.ReferenceValues, error) {
+	if path == "" {
+		return measurements.ReferenceValues{}, nil
+	}
+	for _, f := range []struct {
+		name string
+		set  bool
+	}{{digestFlag, len(*digests) > 0}, {rtmrFlag, len(*rtmrs) > 0}} {
+		if f.set {
+			return measurements.ReferenceValues{}, fmt.Errorf("%s cannot be combined with %s", configFlag, f.name)
+		}
+	}
+	set, err := measurements.Load(path)
+	if err != nil {
+		return measurements.ReferenceValues{}, fmt.Errorf("%s: %w", configFlag, err)
+	}
+
+	*digests = set.HexDigests()
+	common, uniform := set.CommonRTMRs()
+	if !uniform {
+		// A single register set cannot express per-image tuples; say so
+		// rather than appearing to pin them.
+		slog.Warn("measurements config pins different registers per image; the flat pins are digest-only",
+			"flag", configFlag, "images", len(set.Entries))
+	}
+	pins := make([]string, 0, len(common))
+	for _, idx := range sortedIndices(common) {
+		pins = append(pins, fmt.Sprintf("%d=%x", idx, common[idx]))
+	}
+	*rtmrs = pins
+	slog.Info("measurements config loaded", "flag", configFlag, "tee", set.TEE, "images", len(set.Entries))
+	return set, nil
+}
+
+func sortedIndices(m map[int][]byte) []int {
+	out := make([]int, 0, len(m))
+	for i := range m {
+		out = append(out, i)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/cmds/cmdsutil/measurementsconfig_test.go
+++ b/internal/cmds/cmdsutil/measurementsconfig_test.go
@@ -1,0 +1,126 @@
+package cmdsutil
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+const (
+	utilDigestA = "aa11000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	utilDigestB = "bb22000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	utilReg1    = "111100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	utilReg2    = "222200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func writeConfig(t *testing.T, doc string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "measurements.json")
+	if err := os.WriteFile(path, []byte(doc), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The commands that can only carry a digest list read these fields, so the
+// loader must fill them or the gate would accept any attested peer.
+func TestLoadMeasurementsConfigFillsFlatFields(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"a","mrtd":"00`+utilDigestA+`","rtmr":[null,"`+utilReg1+`","`+utilReg2+`"]},
+		{"name":"b","mrtd":"00`+utilDigestB+`","rtmr":[null,"`+utilReg1+`","`+utilReg2+`"]}]}`)
+
+	var digests, rtmrs []string
+	set, err := LoadMeasurementsConfig(path, "--measurements-config", "--cds-measurements", "--cds-rtmrs", &digests, &rtmrs)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(set.Entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(set.Entries))
+	}
+	if len(digests) != 2 {
+		t.Fatalf("digests = %v, want both images", digests)
+	}
+	if !slices.Contains(rtmrs, "1="+utilReg1) || !slices.Contains(rtmrs, "2="+utilReg2) {
+		t.Errorf("rtmrs = %v, want the shared register pins", rtmrs)
+	}
+}
+
+// Images that disagree on registers cannot share one flat set; the digests
+// must still pin and the entries must keep their tuples.
+func TestLoadMeasurementsConfigDropsDivergentRTMRs(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"a","mrtd":"00`+utilDigestA+`","rtmr":[null,"`+utilReg1+`"]},
+		{"name":"b","mrtd":"00`+utilDigestB+`","rtmr":[null,"`+utilReg2+`"]}]}`)
+
+	var digests, rtmrs []string
+	set, err := LoadMeasurementsConfig(path, "--measurements-config", "--cds-measurements", "--cds-rtmrs", &digests, &rtmrs)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(rtmrs) != 0 {
+		t.Errorf("rtmrs = %v, want none: the images disagree", rtmrs)
+	}
+	if len(digests) != 2 {
+		t.Errorf("digests = %v, want both images still pinned", digests)
+	}
+	for _, e := range set.Entries {
+		if len(e.RTMRs) == 0 {
+			t.Errorf("entry %s lost its register pins", e.Name)
+		}
+	}
+}
+
+func TestLoadMeasurementsConfigRejectsMixedFlags(t *testing.T) {
+	path := writeConfig(t, `{"schema_version":"1","tee":"sev-snp","measurements":[{"name":"a","measurement":"00`+utilDigestA+`"}]}`)
+
+	for _, tc := range []struct {
+		name             string
+		digests, rtmrs   []string
+		wantFlagInErrMsg string
+	}{
+		{"with digests", []string{"00" + utilDigestB}, nil, "--cds-measurements"},
+		{"with rtmrs", nil, []string{"1=" + utilReg1}, "--cds-rtmrs"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			digests, rtmrs := tc.digests, tc.rtmrs
+			_, err := LoadMeasurementsConfig(path, "--measurements-config", "--cds-measurements", "--cds-rtmrs", &digests, &rtmrs)
+			if err == nil {
+				t.Fatal("accepted a mixed configuration")
+			}
+			if !strings.Contains(err.Error(), tc.wantFlagInErrMsg) {
+				t.Errorf("error %q does not name %s", err, tc.wantFlagInErrMsg)
+			}
+		})
+	}
+}
+
+func TestLoadMeasurementsConfigFailsClosed(t *testing.T) {
+	var digests, rtmrs []string
+	_, err := LoadMeasurementsConfig(filepath.Join(t.TempDir(), "absent.json"),
+		"--measurements-config", "--cds-measurements", "--cds-rtmrs", &digests, &rtmrs)
+	if err == nil {
+		t.Fatal("a missing config loaded as no pinning")
+	}
+	if len(digests) != 0 {
+		t.Errorf("digests populated from a failed load: %v", digests)
+	}
+}
+
+// An unset config leaves the flat flags exactly as the operator passed them.
+func TestLoadMeasurementsConfigUnsetLeavesFlagsAlone(t *testing.T) {
+	digests := []string{"00" + utilDigestA}
+	rtmrs := []string{"1=" + utilReg1}
+
+	set, err := LoadMeasurementsConfig("", "--measurements-config", "--cds-measurements", "--cds-rtmrs", &digests, &rtmrs)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !set.Empty() {
+		t.Error("an unset config produced reference values")
+	}
+	if len(digests) != 1 || len(rtmrs) != 1 {
+		t.Errorf("flat flags mutated: %v / %v", digests, rtmrs)
+	}
+}

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -137,6 +137,11 @@ spec:
         app.kubernetes.io/component: cds
       annotations:
         confidential.ai/trust-root-mode: "inMemory"
+        {{- if .Values.cds.measurementsConfig }}
+        # Pins live in a ConfigMap, which no longer changes the pod template on
+        # its own: without this a tightened pin would not roll the pod.
+        checksum/measurements-config: {{ .Values.cds.measurementsConfig | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.kata.enabled }}
       # Run the trust root inside a confidential VM. Its mesh CA and EAR signing
@@ -218,11 +223,15 @@ spec:
             {{- if .Values.cds.cnPattern }}
             - --allowed-cn-pattern={{ .Values.cds.cnPattern }}
             {{- end }}
+            {{- if .Values.cds.measurementsConfig }}
+            - --measurements-config=/etc/c8s-measurements/cds.json
+            {{- else }}
             {{- with .Values.cds.measurements }}
             - --measurements={{ join "," . }}
             {{- end }}
             {{- with .Values.cds.rtmrs }}
             - --rtmrs={{ join "," . }}
+            {{- end }}
             {{- end }}
             {{- with .Values.cds.sandboxInventoryCIDRs }}
             - --sandbox-inventory-cidr={{ join "," . }}
@@ -312,6 +321,11 @@ spec:
               mountPath: /etc/cds-operator-keys
               readOnly: true
             {{- end }}
+            {{- if .Values.cds.measurementsConfig }}
+            - name: measurements-config
+              mountPath: /etc/c8s-measurements
+              readOnly: true
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -343,6 +357,11 @@ spec:
         - name: operator-keys
           configMap:
             name: {{ include "c8s.cdsName" . }}-operator-keys
+        {{- end }}
+        {{- if .Values.cds.measurementsConfig }}
+        - name: measurements-config
+          configMap:
+            name: {{ include "c8s.fullname" . }}-measurements
         {{- end }}
 ---
 apiVersion: v1

--- a/internal/helmchart/c8s/templates/measurements-config.yaml
+++ b/internal/helmchart/c8s/templates/measurements-config.yaml
@@ -1,0 +1,35 @@
+{{- /*
+The measurements config: the VM images this cluster runs, each pinned as a
+whole image. Shared by every component that verifies one — cds, ratls-mesh,
+tls-lb's allowlist-proxy and the operator — so it lives in its own ConfigMap
+rather than beside a single component's own material.
+
+Public policy, not secret: these are the digests a verifier compares evidence
+against.
+*/ -}}
+{{- $cds := .Values.cds.measurementsConfig | default "" }}
+{{- $mesh := .Values.ratlsMesh.measurementsConfig | default "" }}
+{{- if or $cds $mesh }}
+{{- range $name, $doc := dict "cds.measurementsConfig" $cds "ratlsMesh.measurementsConfig" $mesh }}
+{{- if $doc }}
+{{- if not (hasPrefix "{" (trim $doc)) }}
+{{- fail (printf "%s must be the JSON content of the measurements config, not a file path — use `c8s install --measurements-config <file>`, `c8s render-values --measurements-config <file>`, or helm --set-file %s=<file>" $name $name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "c8s.fullname" . }}-measurements
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "c8s.commonLabels" . | indent 4 }}
+data:
+  {{- if $cds }}
+  cds.json: {{ $cds | quote }}
+  {{- end }}
+  {{- if $mesh }}
+  ratls-mesh.json: {{ $mesh | quote }}
+  {{- end }}
+---
+{{- end }}

--- a/internal/helmchart/c8s/templates/operator.yaml
+++ b/internal/helmchart/c8s/templates/operator.yaml
@@ -22,9 +22,16 @@ spec:
         app.kubernetes.io/name: c8s-operator
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: operator
-      {{- with .Values.operator.podAnnotations }}
+      {{- if or .Values.operator.podAnnotations .Values.cds.measurementsConfig }}
       annotations:
+        {{- if .Values.cds.measurementsConfig }}
+        # A ConfigMap edit alone does not change the pod template, so without
+        # this a tightened pin would not roll the operator.
+        checksum/measurements-config: {{ .Values.cds.measurementsConfig | sha256sum }}
+        {{- end }}
+        {{- with .Values.operator.podAnnotations }}
 {{ toYaml . | indent 8 }}
+        {{- end }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "c8s.operatorName" . }}
@@ -54,11 +61,15 @@ spec:
             {{- /* The same measurements CDS is pinned to elsewhere: the
                    injected secret fetcher verifies CDS before handing it a
                    sandbox token and taking a value back. */}}
+            {{- if .Values.cds.measurementsConfig }}
+            - --measurements-config=/etc/c8s-measurements/cds.json
+            {{- else }}
             {{- range .Values.cds.measurements }}
             - --cds-measurements={{ . }}
             {{- end }}
             {{- range .Values.cds.rtmrs }}
             - --cds-rtmrs={{ . }}
+            {{- end }}
             {{- end }}
             {{- range .Values.webhook.extraExcluded }}
             - --exclude-namespaces={{ . }}
@@ -111,9 +122,19 @@ spec:
             # this emptyDir rather than the immutable image.
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.cds.measurementsConfig }}
+            - name: measurements-config
+              mountPath: /etc/c8s-measurements
+              readOnly: true
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if .Values.cds.measurementsConfig }}
+        - name: measurements-config
+          configMap:
+            name: {{ include "c8s.fullname" . }}-measurements
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -53,6 +53,11 @@ spec:
       labels:
         {{- include "ratls-mesh.selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if .Values.ratlsMesh.measurementsConfig }}
+        # A ConfigMap edit alone does not change the pod template, so without
+        # this a tightened pin would not roll the DaemonSet.
+        checksum/measurements-config: {{ .Values.ratlsMesh.measurementsConfig | sha256sum }}
+        {{- end }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.ratlsMesh.ports.health | quote }}
         prometheus.io/path: "/metrics"
@@ -83,6 +88,11 @@ spec:
         - operator: "Exists"
           effect: "NoSchedule"
       volumes:
+        {{- if .Values.ratlsMesh.measurementsConfig }}
+        - name: measurements-config
+          configMap:
+            name: {{ include "c8s.fullname" . }}-measurements
+        {{- end }}
         - name: xtables-lock
           hostPath:
             path: {{ .Values.ratlsMesh.xtablesLockPath }}
@@ -230,6 +240,11 @@ spec:
             - name: tmp
               mountPath: /tmp
             {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
+            {{- if .Values.ratlsMesh.measurementsConfig }}
+            - name: measurements-config
+              mountPath: /etc/c8s-measurements
+              readOnly: true
+            {{- end }}
           args:
             - --platform
             - {{ .Values.ratlsMesh.platform | quote }}
@@ -255,6 +270,10 @@ spec:
             - --rotation-timeout
             - {{ .Values.ratlsMesh.rotationTimeout | quote }}
             {{- end }}
+            {{- if .Values.ratlsMesh.measurementsConfig }}
+            - --measurements-config
+            - /etc/c8s-measurements/ratls-mesh.json
+            {{- else }}
             {{- if .Values.ratlsMesh.measurements }}
             - --measurements
             - {{ .Values.ratlsMesh.measurements | join "," | quote }}
@@ -262,6 +281,7 @@ spec:
             {{- with .Values.ratlsMesh.rtmrs }}
             - --rtmrs
             - {{ join "," . | quote }}
+            {{- end }}
             {{- end }}
             {{- if gt (int .Values.ratlsMesh.maxConns) 0 }}
             - --max-conns
@@ -288,6 +308,7 @@ spec:
             - {{ printf "ratls-mesh.%s.svc" .Release.Namespace | quote }}
             - --ca-poll-interval
             - {{ .Values.ratlsMesh.cds.caPollInterval | quote }}
+            {{- if not .Values.ratlsMesh.measurementsConfig }}
             {{- with .Values.cds.measurements }}
             - --cds-measurements
             - {{ join "," . | quote }}
@@ -295,6 +316,7 @@ spec:
             {{- with .Values.cds.rtmrs }}
             - --cds-rtmrs
             - {{ join "," . | quote }}
+            {{- end }}
             {{- end }}
             {{- end }}
           env:

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -67,6 +67,11 @@ spec:
         {{- include "tls-lb.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/nginx-config: {{ include (print $.Template.BasePath "/tls-lb-configmap.yaml") . | sha256sum }}
+        {{- if .Values.cds.measurementsConfig }}
+        # A ConfigMap edit alone does not change the pod template, so without
+        # this a tightened pin would not roll the load balancer.
+        checksum/measurements-config: {{ .Values.cds.measurementsConfig | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.kata.enabled }}
       # Chart-managed mesh component: the webhook excludes the release
@@ -294,11 +299,15 @@ spec:
             - --port={{ include "c8s.int" .Values.tlsLb.allowlist.proxyPort }}
             - --cds-url={{ include "c8s.cdsURL" . }}
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
+            {{- if .Values.cds.measurementsConfig }}
+            - --measurements-config=/etc/c8s-measurements/cds.json
+            {{- else }}
             {{- with .Values.cds.measurements }}
             - --cds-measurements={{ join "," . }}
             {{- end }}
             {{- with .Values.cds.rtmrs }}
             - --cds-rtmrs={{ join "," . }}
+            {{- end }}
             {{- end }}
           {{- with (include "c8s.attestationApiHostIPEnv" .) }}
           # cvmMode=node: the proxy verifies CDS through the node-baked
@@ -306,9 +315,16 @@ spec:
           env:
             {{- . | nindent 12 }}
           {{- end }}
-          {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
+          {{- if or (eq (include "c8s.attestationApiHostSocket" .) "true") .Values.cds.measurementsConfig }}
           volumeMounts:
+            {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
             {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.cds.measurementsConfig }}
+            - name: measurements-config
+              mountPath: /etc/c8s-measurements
+              readOnly: true
+            {{- end }}
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -327,6 +343,11 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 1Mi
+        {{- if .Values.cds.measurementsConfig }}
+        - name: measurements-config
+          configMap:
+            name: {{ include "c8s.fullname" . }}-measurements
+        {{- end }}
         {{- if .Values.tlsLb.publicTLS.secretName }}
         - name: public-tls
           secret:


### PR DESCRIPTION
A measurements config now reaches the components that verify one. The flat values install also emits stay in place, so the consumers that read a plain digest list keep pinning what they always did.

- --measurements-config on operator and allowlist-proxy, through one loader in cmdsutil: refuses the flat flags alongside it, fails closed on an unreadable file, and fills the flat fields it replaces.
- allowlist-proxy matches whole images; the operator flattens, because the injected sidecars and the measured initdata carry a flat digest list.
- New release-scoped ConfigMap holds the document, mounted read-only into cds, ratls-mesh, tls-lb and the operator.
- Each template renders the config flag XOR the flat args: a component handed both refuses to start.
- The NRI plugin and CDS handoff keep reading the flat values, so nothing they pin changes.
- checksum/measurements-config on the four pods — a ConfigMap edit alone does not change a pod template, so a tightened pin would otherwise not roll.
- Rejects a file path where the JSON content belongs, as cds.operatorKeys already does.