### PR TITLE
feat(volumes): mutable encrypted volumes alongside immutable ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
   inventory, or from the in-guest `policy-monitor` under pod-as-CVM.
 
 - **Encrypted volumes.** Data too large to be a secret — model weights, in
-  practice — encrypted at rest on host-visible storage (erofs, dm-verity,
-  dm-crypt) and opened only inside the TEE. The key travels as a secret
+  practice — encrypted at rest on host-visible storage (dm-crypt) and opened
+  only inside the TEE. Immutable volumes verify every read (erofs, dm-verity);
+  mutable volumes are writable ext4. The key travels as a secret
   through the release path above, so possession of the volume implies nothing
   without attestation. On node-as-CVM the `volumed` node agent ships
   disabled — `c8s install --volumes` deploys it; under pod-as-CVM `volumed`

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -69,9 +69,11 @@ anchors nothing. It is also a fingerprint naming which model a volume holds, and
 A mutable blob carries the key and its mode, nothing else:
 
 ```json
-{ "type": "c8s.volume/v1",
+{
+  "type": "c8s.volume/v1",
   "key": "<base64, 64 bytes>",
-  "mutable": true }
+  "mutable": true
+}
 ```
 
 There is no integrity anchor to carry — a volume the host can rewrite has
@@ -105,7 +107,8 @@ c8s volume create --mutable \
   --path /tenant-a/volumes/datasets \
   --escrow-out ./datasets.escrow.json \
   --node node-1 \
-  --url https://cds.example --measurements-file ./m.txt \
+  --url https://cds.example \
+  --measurements-file ./m.txt \
   --operator-key ./operator.key
 ```
 
@@ -113,10 +116,14 @@ or empty, for scratch space the workload fills itself:
 
 ```sh
 c8s volume create --mutable \
-  --name scratch --size 50Gi \
-  --out ./scratch.img --path /tenant-a/volumes/scratch \
-  --escrow-out ./scratch.escrow.json --node node-1 \
-  --url https://cds.example --measurements-file ./m.txt \
+  --name scratch \
+  --size 50Gi \
+  --out ./scratch.img \
+  --path /tenant-a/volumes/scratch \
+  --escrow-out ./scratch.escrow.json \
+  --node node-1 \
+  --url https://cds.example \
+  --measurements-file ./m.txt \
   --operator-key ./operator.key
 ```
 
@@ -237,7 +244,9 @@ Each entry is `NAME=/store/path`. `NAME` selects the node's device by its
 the volume dir — above, `/models/weights`. It must be a DNS-1123 label of at
 most 12 characters, because the serial holds no more. The annotation is the
 same for both modes; whether the plaintext is writable comes from the volume's
-key blob, not from the pod.
+key blob, not from the pod. Flipping the mode in a blob gets nothing: an
+immutable image is erofs and fails to mount as ext4, and a mutable image has
+no hash tree for verity to anchor.
 
 The webhook injects a `c8s-volume` sidecar and, per volume, an `emptyDir` with
 `mountPropagation: HostToContainer`. The sidecar fetches the key over the
@@ -417,6 +426,9 @@ of scope by decision, not by oversight.
   `c8s cds verify --operator-keys`, and running it continuously is a
   precondition for trusting a volume.
 - **Access patterns are visible.** Which sectors are read, and when, leaks
-  structure.
+  structure. AES-XTS is deterministic, so for a mutable volume the host can
+  also tell when a sector returns to a value it has seen before — the standard
+  FDE trade-off (BitLocker and FileVault share it), with no IV space per
+  sector write to do better with.
 - **Availability.** The host can withhold or destroy the device.
 - **Whatever the workload does with the plaintext** once it has it.

--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -20,13 +20,17 @@ already has. Treat volume keys accordingly.
 
 ## The artifact
 
-An image built by `c8s volume create`, in three layers:
+An image built by `c8s volume create`, in two modes. Immutable is the default:
+the workload reads, and every read is verified. Mutable (`--mutable`) is for
+data the workload must write — the same encryption with no verification layer,
+because dm-verity cannot cover a writable device. The accepted trade-off: the
+host can flip bits or roll the volume back, and nothing detects it.
 
-| | |
-|---|---|
-| filesystem | erofs, read-only by construction |
-| integrity | dm-verity, hash tree appended to the filesystem |
-| confidentiality | plain dm-crypt, `aes-xts-plain64`, 512-bit key, 512-byte sectors |
+| | immutable (default) | mutable (`--mutable`) |
+|---|---|---|
+| filesystem | erofs, read-only by construction | ext4, read-write |
+| integrity | dm-verity, hash tree appended to the filesystem | none |
+| confidentiality | plain dm-crypt, `aes-xts-plain64`, 512-bit key, 512-byte sectors | same |
 
 **There is no LUKS header.** A LUKS2 header is on-disk metadata whose integrity
 is an unkeyed checksum the host can recompute, and it is parsed as root inside
@@ -35,10 +39,10 @@ parameter comes from the key blob, which only ever travels over the attested
 channel. What a header would buy — rotating the key via keyslots — is not real
 against a host that keeps a copy of the old header and can restore it.
 
-**The hash tree is inside the encryption.** A hash tree is a fingerprint of the
-plaintext, so leaving it in the clear would let the host identify what a volume
-holds. Keeping it inside also means the root hash commits to the data rather
-than to one encryption of it.
+**The hash tree is inside the encryption** (immutable volumes). A hash tree is
+a fingerprint of the plaintext, so leaving it in the clear would let the host
+identify what a volume holds. Keeping it inside also means the root hash
+commits to the data rather than to one encryption of it.
 
 **Sector size is 512.** For `aes-xts-plain64` the tweak is the sector index, but
 at a larger sector size dm-crypt's numbering depends on `iv_large_sectors` — and
@@ -62,7 +66,21 @@ entry because it is the integrity anchor, and an anchor the host can edit
 anchors nothing. It is also a fingerprint naming which model a volume holds, and
 `GET /allowlist` is unauthenticated.
 
+A mutable blob carries the key and its mode, nothing else:
+
+```json
+{ "type": "c8s.volume/v1",
+  "key": "<base64, 64 bytes>",
+  "mutable": true }
+```
+
+There is no integrity anchor to carry — a volume the host can rewrite has
+nothing for an anchor to commit to. The mode and the tree are one invariant: a
+blob carrying both or neither is refused rather than disambiguated.
+
 ## Creating a volume
+
+Immutable, the default — package a directory:
 
 ```sh
 c8s volume create \
@@ -76,9 +94,42 @@ c8s volume create \
   --operator-key ./operator.key
 ```
 
-It packages the directory, formats the hash tree, generates a key, encrypts, and
-`PUT`s the blob. It prints the annotations, the `nodeSelector`, and the
-allowlist grant to apply; it does not modify any workload.
+Mutable — preloaded from a directory, sized up front:
+
+```sh
+c8s volume create --mutable \
+  --name datasets \
+  --source ./imagenet \
+  --size 200Gi \
+  --out ./datasets.img \
+  --path /tenant-a/volumes/datasets \
+  --escrow-out ./datasets.escrow.json \
+  --node node-1 \
+  --url https://cds.example --measurements-file ./m.txt \
+  --operator-key ./operator.key
+```
+
+or empty, for scratch space the workload fills itself:
+
+```sh
+c8s volume create --mutable \
+  --name scratch --size 50Gi \
+  --out ./scratch.img --path /tenant-a/volumes/scratch \
+  --escrow-out ./scratch.escrow.json --node node-1 \
+  --url https://cds.example --measurements-file ./m.txt \
+  --operator-key ./operator.key
+```
+
+`--size` takes a byte count or a quantity like `50Gi`. Omitted with a
+`--source`, it is inferred — the tree's bytes plus a block per entry, grown by
+half — and printed, so you can see what was chosen and pin it on the next run.
+It is rejected without `--mutable`: an immutable image sizes itself to its
+contents. Every byte of the image is encrypted at creation, free space
+included, so a `--size 200Gi` build writes a 200Gi file.
+
+Each form packages its input, generates a key, encrypts, and `PUT`s the blob.
+It prints the annotations, the `nodeSelector`, and the allowlist grant to
+apply; it does not modify any workload.
 
 The key is generated per volume and never taken from you. AES-XTS is
 deterministic, so re-encrypting a changed directory under a reused key would
@@ -89,9 +140,9 @@ serial, `VIRTIO_BLK_ID_BYTES` is 20, and `c8s-vol-` takes eight; a thirteenth
 character is silently dropped, so two volumes would be indistinguishable to the
 node.
 
-Creation needs `mkfs.erofs` and `veritysetup` on the machine running it. It does
-**not** need root, a loop device, or `cryptsetup`: the encryption is done in
-process.
+Creation needs `mkfs.erofs` and `veritysetup` on the machine running it —
+`mkfs.ext4` instead for a mutable volume. It does **not** need root, a loop
+device, or `cryptsetup`: the encryption is done in process.
 
 ### Keep the escrow file
 
@@ -135,7 +186,7 @@ where they are.
 
 The serial is a **selector, not a trust input**. The host chooses it and answers
 the query per read. Pointing a pod at the wrong device fails closed: the wrong
-key produces noise, and verity refuses it.
+key produces noise — verity refuses it, or nothing will mount it.
 
 ### Replacing an image
 
@@ -145,6 +196,11 @@ or any `mv` into position, leaves a new file at the path while the device keeps
 serving the one the attach opened. `md5sum` on the node then matches the source
 while every read from the pod fails, because they are reading different files.
 `attach` refuses an already-attached volume and says so.
+
+Replacing a mutable volume's image discards what was on it: the new image is a
+fresh filesystem, and the old contents exist only in the old ciphertext. Update
+a mutable volume by writing through the mounted volume, not by rebuilding under
+it.
 
 Because the device is on one node, the pod must be scheduled there; `create`
 emits the matching `nodeSelector`.
@@ -162,8 +218,8 @@ Release is gated on the workload entry's `secrets` grant, exactly as in
 volume beneath it, and the annotation naming which volume to open is
 host-written. `create` prints an exact-path grant for this reason.
 
-`read` only. A volume is mounted read-only, so a write grant says nothing about
-whether a workload may see the plaintext.
+`read` only. Writability is a property of the volume, not the grant: a write
+grant says nothing about whether a workload may see the plaintext.
 
 ## Consuming a volume
 
@@ -179,13 +235,23 @@ annotations:
 Each entry is `NAME=/store/path`. `NAME` selects the node's device by its
 `c8s-vol-<NAME>` serial and names the directory the plaintext appears in under
 the volume dir — above, `/models/weights`. It must be a DNS-1123 label of at
-most 12 characters, because the serial holds no more.
+most 12 characters, because the serial holds no more. The annotation is the
+same for both modes; whether the plaintext is writable comes from the volume's
+key blob, not from the pod.
 
-The webhook injects a `c8s-volume` sidecar and, per volume, an `emptyDir`
-mounted read-only with `mountPropagation: HostToContainer`. The sidecar fetches
-the key over the attested `/secrets` flow and posts `{name, blob}` to
-`c8s volumed`, which opens the device and mounts it read-only into that pod's
-`emptyDir`.
+The webhook injects a `c8s-volume` sidecar and, per volume, an `emptyDir` with
+`mountPropagation: HostToContainer`. The sidecar fetches the key over the
+attested `/secrets` flow and posts `{name, blob}` to `c8s volumed`, which opens
+the device and mounts it into that pod's `emptyDir` — read-only erofs for an
+immutable volume, read-write ext4 for a mutable one.
+
+**One writer per device.** Two read-write mounts of one device corrupt the
+filesystem, so the daemon refuses to open a device that already has a mutable
+mount (or to open mutable one that has any mount) and the sidecar surfaces the
+refusal. Schedule mutable consumers so only one pod opens a device at a time:
+one replica, or a `Recreate` strategy — a rolling update of a single-device
+workload briefly runs two pods against it. Immutable volumes share a device
+freely, as they always have.
 
 Where volumed runs, and how the sidecar reaches it, depends on the shape:
 
@@ -210,11 +276,14 @@ rather than mounts is one marked `encryption_key=ephemeral`, which CDH formats
 under a key the guest generates — so direct-volume assignment is not usable; the
 qemu wrapper
 (`kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh`) attaches this pod's
-volume devices to its VM instead, read-only and with the serial preserved. Which
-volumes it attaches comes from the pod's annotation — a selector, not a trust
-input, on the same reasoning as the serial: attaching another tenant's device
-hands the guest ciphertext the host already holds, and it still cannot be opened
-without the key CDS releases against the grant.
+volume devices to its VM instead, with the serial preserved. Which volumes it
+attaches comes from the pod's annotation — a selector, not a trust input, on
+the same reasoning as the serial: attaching another tenant's device hands the
+guest ciphertext the host already holds, and it still cannot be opened without
+the key CDS releases against the grant. Devices reach the VM writable — the
+host cannot tell a mutable volume from an immutable one, since the mode lives
+in the key blob it never sees — so an immutable volume's writes are refused in
+the guest, at its dm-crypt mapping.
 
 What decides whether a mount happens, in order:
 
@@ -224,11 +293,12 @@ What decides whether a mount happens, in order:
 2. The daemon mounts into **the calling pod's directory and no other**. The pod
    comes from the caller's cgroup via kernel peer credentials; the request has no
    field naming it, and the mount target is built from the resolved UID.
-3. The device opens only if the key is right and the verity root hash matches.
+3. The device opens only if the key is right — and, for an immutable volume,
+   the verity root hash matches.
 
-A request naming a volume already open under that pod must present the same key
-and root hash. Without that the volume *name* — a label in a host-written
-annotation — would be the credential.
+A request naming a volume already open under that pod must present the same
+key, mode, and root hash. Without that the volume *name* — a label in a
+host-written annotation — would be the credential.
 
 The volume appears **after the workload starts**, because release is gated on
 the whole container set having been admitted. A consumer must wait for it rather
@@ -294,11 +364,13 @@ survive a reboot.
 and outside the release lifecycle, so uninstall leaves it alone by design; a
 node that has had volumes attached still lists them afterwards. The two look
 alike on the node and are told apart by what lists them: a leaked mapping shows
-in `dmsetup ls` as a `c8s-crypt-`/`c8s-verity-` pair, an attached backstore in
+in `dmsetup ls` as `c8s-crypt-`/`c8s-verity-` names, an attached backstore in
 `/sys/kernel/config/target/core/fileio_0/`. Remove the second with
 `c8s volume detach <name>`.
 
 ## What this defends
+
+An immutable volume:
 
 | Threat | |
 |---|---|
@@ -312,12 +384,28 @@ in `dmsetup ls` as a `c8s-crypt-`/`c8s-verity-` pair, an attached backstore in
 Tamper detection is **lazy**: `veritysetup open` checks the top of the tree, and
 a modified data block surfaces as an I/O error when it is read, not at open.
 
+A mutable volume:
+
+| Threat | |
+|---|---|
+| Host reads the volume at rest | prevented — AES-XTS, key never leaves the TEE |
+| Host tampers with the ciphertext | **not detected** — a flipped bit returns wrong data, a failed mount, or a read-only remount |
+| Host rolls the volume back | **not detected** — an earlier state is indistinguishable from the current one |
+| Host swaps in a different device | fails closed — wrong key decrypts to noise that will not mount |
+| A pod outside the grant reads it | refused — no grant, no key |
+| An allowlisted but different workload reads it | refused — whole-entry match |
+
+Per-sector authentication (AEAD) would restore tamper and rollback detection
+for mutable volumes and is planned for a future release; for now they are out
+of scope by decision, not by oversight.
+
 ### What it does not
 
 - **Any pod on the node can open a volume whose blob it holds.** The daemon
   authorizes on possession, not entitlement — see [Possession of the blob is the
   authorization](#possession-of-the-blob-is-the-authorization). The blob still
-  only comes from CDS, and only to a pod the grant covers.
+  only comes from CDS, and only to a pod the grant covers. For a mutable
+  volume, opening means writing too.
 - **Anyone with pod create or exec RBAC in the workload's namespace can read a
   mounted volume.** Under `--cvm-mode=node` the control plane runs inside the
   node CVM, so this is not a capability the host has — but it is a Kubernetes

--- a/internal/cmds/getvolume/cmd.go
+++ b/internal/cmds/getvolume/cmd.go
@@ -17,8 +17,8 @@ func NewCmd() *cobra.Command {
 		Use:   "get-volume",
 		Short: "Fetch this pod's volume keys from CDS and have the node open them",
 		Long: `get-volume fetches the key for each encrypted volume a workload is granted
-and hands it to the node agent, which opens the device and mounts it read-only
-into this pod.
+and hands it to the node agent, which opens the device and mounts it into this
+pod — read-only for an immutable volume, read-write for a mutable one.
 
 It authenticates with the pod's CDS-issued certificate and a sandbox token
 redeemed from the node's admission inventory, and CDS releases only when the

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -24,9 +24,16 @@ type recordingOps struct {
 	mounted []string
 	key     []byte
 	verity  volume.Verity
+	mounts  []recordedMount
 }
 
-func (o *recordingOps) CryptOpen(_ context.Context, device, mapper string, key []byte) error {
+// recordedMount is what one Mount was asked to do.
+type recordedMount struct {
+	fsType   string
+	readOnly bool
+}
+
+func (o *recordingOps) CryptOpen(_ context.Context, device, mapper string, key []byte, readOnly bool) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.calls = append(o.calls, "CryptOpen "+device+" "+mapper)
@@ -46,11 +53,12 @@ func (o *recordingOps) VerityOpen(_ context.Context, _, mapper string, v volume.
 
 func (o *recordingOps) VerityClose(context.Context, string) error { return nil }
 
-func (o *recordingOps) MountRO(_ context.Context, _ string, target *os.File) error {
+func (o *recordingOps) Mount(_ context.Context, _ string, target *os.File, fsType string, readOnly bool) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.calls = append(o.calls, "MountRO")
+	o.calls = append(o.calls, "Mount")
 	o.mounted = append(o.mounted, target.Name())
+	o.mounts = append(o.mounts, recordedMount{fsType: fsType, readOnly: readOnly})
 	return nil
 }
 
@@ -126,7 +134,7 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 	want := []string{
 		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + e2ePodUID + "-weights",
 		"VerityOpen c8s-verity-" + e2ePodUID + "-weights",
-		"MountRO",
+		"Mount",
 	}
 	for i, w := range want {
 		if i >= len(ops.calls) || ops.calls[i] != w {
@@ -144,6 +152,9 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 	}
 	if ops.verity.RootHash != testBlob(t).Verity.RootHash {
 		t.Error("the verity anchor did not come from the blob")
+	}
+	if len(ops.mounts) != 1 || ops.mounts[0].fsType != "erofs" || !ops.mounts[0].readOnly {
+		t.Errorf("mount = %+v, want read-only erofs", ops.mounts)
 	}
 
 	// It landed in this pod's own emptyDir for this volume, and nowhere else.
@@ -205,6 +216,43 @@ func TestSidecarReportsADaemonRefusal(t *testing.T) {
 	daemon, daemonBase := daemonClient(cfg)
 	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err == nil {
 		t.Fatal("a refused open was reported as success")
+	}
+}
+
+// A mutable blob travels the same delivery path and skips verity: the daemon
+// mounts the crypt device itself, writable ext4.
+func TestSidecarOpensAMutableVolumeEndToEnd(t *testing.T) {
+	endpoint := startInventory(t)
+	_, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testMutableBlobJSON(t)}},
+	})
+
+	socketDir := t.TempDir()
+	ops := startDaemon(t, socketDir)
+
+	cfg := flowConfig(t, url)
+	cfg.SocketDir = socketDir
+	daemon, daemonBase := daemonClient(cfg)
+	if err := openAllWith(context.Background(), cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ops.mu.Lock()
+	defer ops.mu.Unlock()
+	want := []string{
+		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + e2ePodUID + "-weights",
+		"Mount",
+	}
+	if len(ops.calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", ops.calls, want)
+	}
+	for i, w := range want {
+		if ops.calls[i] != w {
+			t.Fatalf("calls = %v, want %v", ops.calls, want)
+		}
+	}
+	if len(ops.mounts) != 1 || ops.mounts[0].fsType != "ext4" || ops.mounts[0].readOnly {
+		t.Errorf("mount = %+v, want writable ext4", ops.mounts)
 	}
 }
 
@@ -288,7 +336,7 @@ func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
 	want := []string{
 		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + volumed.GuestPodUID + "-weights",
 		"VerityOpen c8s-verity-" + volumed.GuestPodUID + "-weights",
-		"MountRO",
+		"Mount",
 	}
 	for i, w := range want {
 		if i >= len(ops.calls) || ops.calls[i] != w {

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -53,10 +53,18 @@ func (o *recordingOps) VerityOpen(_ context.Context, _, mapper string, v volume.
 
 func (o *recordingOps) VerityClose(context.Context, string) error { return nil }
 
-func (o *recordingOps) Mount(_ context.Context, _ string, target *os.File, fsType string, readOnly bool) error {
+func (o *recordingOps) MountRO(_ context.Context, _ string, target *os.File, fsType string) error {
+	return o.recordMount("MountRO", target, fsType, true)
+}
+
+func (o *recordingOps) MountRW(_ context.Context, _ string, target *os.File, fsType string) error {
+	return o.recordMount("MountRW", target, fsType, false)
+}
+
+func (o *recordingOps) recordMount(op string, target *os.File, fsType string, readOnly bool) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.calls = append(o.calls, "Mount")
+	o.calls = append(o.calls, op)
 	o.mounted = append(o.mounted, target.Name())
 	o.mounts = append(o.mounts, recordedMount{fsType: fsType, readOnly: readOnly})
 	return nil
@@ -134,7 +142,7 @@ func TestSidecarOpensAVolumeEndToEnd(t *testing.T) {
 	want := []string{
 		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + e2ePodUID + "-weights",
 		"VerityOpen c8s-verity-" + e2ePodUID + "-weights",
-		"Mount",
+		"MountRO",
 	}
 	for i, w := range want {
 		if i >= len(ops.calls) || ops.calls[i] != w {
@@ -241,7 +249,7 @@ func TestSidecarOpensAMutableVolumeEndToEnd(t *testing.T) {
 	defer ops.mu.Unlock()
 	want := []string{
 		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + e2ePodUID + "-weights",
-		"Mount",
+		"MountRW",
 	}
 	if len(ops.calls) != len(want) {
 		t.Fatalf("calls = %v, want %v", ops.calls, want)
@@ -336,7 +344,7 @@ func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
 	want := []string{
 		"CryptOpen /dev/disk/by-id/virtio-c8s-vol-weights c8s-crypt-" + volumed.GuestPodUID + "-weights",
 		"VerityOpen c8s-verity-" + volumed.GuestPodUID + "-weights",
-		"Mount",
+		"MountRO",
 	}
 	for i, w := range want {
 		if i >= len(ops.calls) || ops.calls[i] != w {

--- a/internal/cmds/getvolume/flow_test.go
+++ b/internal/cmds/getvolume/flow_test.go
@@ -143,6 +143,23 @@ func testBlobJSON(t *testing.T) []byte {
 	return raw
 }
 
+func testMutableBlobJSON(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, volume.KeyBytes)
+	for i := range key {
+		key[i] = byte(i)
+	}
+	blob, err := volume.NewMutableBlob(key)
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	raw, err := json.Marshal(blob)
+	if err != nil {
+		t.Fatalf("marshal blob: %v", err)
+	}
+	return raw
+}
+
 func flowConfig(t *testing.T, url string) config {
 	t.Helper()
 	return config{

--- a/internal/cmds/volume/attach.go
+++ b/internal/cmds/volume/attach.go
@@ -299,9 +299,9 @@ func loopbackWWN(name string) string {
 
 // checkImage resolves the image and returns its size.
 //
-// A size that is not a whole number of verity blocks is a truncated or
-// corrupted copy. Attaching it would defer the failure to a verity error on
-// first read, which says nothing about what went wrong.
+// A size that is not a whole number of image blocks is a truncated or
+// corrupted copy. Attaching it would defer the failure to a read error deep
+// inside a consumer, which says nothing about what went wrong.
 func checkImage(image string) (string, int64, error) {
 	abs, err := filepath.Abs(image)
 	if err != nil {
@@ -315,9 +315,9 @@ func checkImage(image string) (string, int64, error) {
 		return "", 0, fmt.Errorf("volume: %s is not a regular file", abs)
 	}
 	size := fi.Size()
-	if size == 0 || size%VerityBlockSize != 0 {
+	if size == 0 || size%ImageBlockSize != 0 {
 		return "", 0, fmt.Errorf("volume: %s is %d bytes, not a whole number of %d-byte blocks; truncated copy?",
-			abs, size, VerityBlockSize)
+			abs, size, ImageBlockSize)
 	}
 	return abs, size, nil
 }
@@ -350,7 +350,7 @@ Hyper-V exposes no virtio bus, and a cloud disk's serial is the provider's, so
 this drives LIO's loopback target to build a local SCSI disk instead.
 
 The image is ciphertext and this does not read it. Pointing a pod at the wrong
-device fails closed — the key will not decrypt it, and verity will refuse it.
+device fails closed — the key will not decrypt it to anything that mounts.
 
 The device serves the file this command opens, not the path. Replace an image
 by 'detach', overwrite, then 'attach' again: writing a new file over the path

--- a/internal/cmds/volume/blob.go
+++ b/internal/cmds/volume/blob.go
@@ -1,13 +1,12 @@
 // Package volume implements the `c8s volume` operator CLI: building an
-// encrypted, integrity-protected block image and putting its key into the CDS
-// secret store.
+// encrypted block image and putting its key into the CDS secret store.
 //
-// The image is plain dm-crypt with a dm-verity tree inside it. There is
-// deliberately no LUKS header: a LUKS2 header is on-disk metadata whose only
-// integrity is an unkeyed checksum the host can recompute, and it is parsed as
-// root inside the TEE on every open. Plain dm-crypt has no on-disk metadata at
-// all, so every parameter comes from the key blob, which travels over the
-// attested channel.
+// The image is plain dm-crypt — erofs with a dm-verity tree inside it for an
+// immutable volume, writable ext4 for a mutable one. There is deliberately no
+// LUKS header: a LUKS2 header is on-disk metadata whose only integrity is an
+// unkeyed checksum the host can recompute, and it is parsed as root inside the
+// TEE on every open. Plain dm-crypt has no on-disk metadata at all, so every
+// parameter comes from the key blob, which travels over the attested channel.
 package volume
 
 import (
@@ -34,13 +33,19 @@ const KeyBytes = 64
 const verityHashBytes = 32
 
 // Blob is what the store holds for one volume: everything needed to open it,
-// and nothing that could be taken from anywhere else. The verity root hash
-// rides here rather than in an annotation or the allowlist entry because it is
-// the integrity anchor; an anchor the host can edit anchors nothing.
+// and nothing that could be taken from anywhere else.
+//
+// Two shapes, and exactly two. An immutable volume (erofs under dm-verity)
+// carries Verity: the root hash rides here rather than in an annotation or the
+// allowlist entry because it is the integrity anchor, and an anchor the host
+// can edit anchors nothing. A mutable volume (ext4 over writable dm-crypt) has
+// no integrity anchor to carry — by design, the host can flip bits — so it
+// carries only the key, and Mutable says the opener must not expect a tree.
 type Blob struct {
-	Type   string `json:"type"`
-	Key    string `json:"key"`
-	Verity Verity `json:"verity"`
+	Type    string  `json:"type"`
+	Key     string  `json:"key"`
+	Mutable bool    `json:"mutable,omitempty"`
+	Verity  *Verity `json:"verity,omitempty"`
 }
 
 // Verity is the geometry needed to open the hash tree without reading a
@@ -57,7 +62,8 @@ type Verity struct {
 	HashOffset uint64 `json:"hash_offset"`
 }
 
-// NewBlob builds a blob from a freshly generated key and the verity output.
+// NewBlob builds an immutable blob from a freshly generated key and the verity
+// output.
 func NewBlob(key []byte, v Verity) (Blob, error) {
 	if len(key) != KeyBytes {
 		return Blob{}, fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
@@ -65,7 +71,23 @@ func NewBlob(key []byte, v Verity) (Blob, error) {
 	b := Blob{
 		Type:   BlobType,
 		Key:    base64.StdEncoding.EncodeToString(key),
-		Verity: v,
+		Verity: &v,
+	}
+	if err := b.Validate(); err != nil {
+		return Blob{}, err
+	}
+	return b, nil
+}
+
+// NewMutableBlob builds a blob for a writable volume: key only, no tree.
+func NewMutableBlob(key []byte) (Blob, error) {
+	if len(key) != KeyBytes {
+		return Blob{}, fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	b := Blob{
+		Type:    BlobType,
+		Key:     base64.StdEncoding.EncodeToString(key),
+		Mutable: true,
 	}
 	if err := b.Validate(); err != nil {
 		return Blob{}, err
@@ -102,6 +124,19 @@ func (b Blob) Validate() error {
 	}
 	if len(key) != KeyBytes {
 		return fmt.Errorf("volume: key is %d bytes, want %d", len(key), KeyBytes)
+	}
+	// The mode and the tree are one invariant: mutable has no verity to check,
+	// immutable cannot open without it. A blob carrying both is refused rather
+	// than disambiguated, because which of the two the author meant is
+	// unknowable here.
+	if b.Mutable {
+		if b.Verity != nil {
+			return fmt.Errorf("volume: mutable blob must not carry verity geometry")
+		}
+		return nil
+	}
+	if b.Verity == nil {
+		return fmt.Errorf("volume: immutable blob carries no verity geometry")
 	}
 	if err := validateHex("root_hash", b.Verity.RootHash, verityHashBytes); err != nil {
 		return err

--- a/internal/cmds/volume/blob_test.go
+++ b/internal/cmds/volume/blob_test.go
@@ -39,7 +39,7 @@ func TestBlobRoundTrips(t *testing.T) {
 	if len(key) != KeyBytes {
 		t.Fatalf("key is %d bytes, want %d", len(key), KeyBytes)
 	}
-	if got.Verity != validVerity() {
+	if got.Verity == nil || *got.Verity != validVerity() {
 		t.Fatalf("verity: got %+v, want %+v", got.Verity, validVerity())
 	}
 }
@@ -110,5 +110,73 @@ func TestDecodeKeyFailsOnCorruptKey(t *testing.T) {
 	b.Key = "not base64"
 	if _, err := b.DecodeKey(); err == nil {
 		t.Fatal("accepted a non-base64 key")
+	}
+}
+
+func TestMutableBlobRoundTrips(t *testing.T) {
+	b, err := NewMutableBlob(testKey())
+	if err != nil {
+		t.Fatalf("new mutable blob: %v", err)
+	}
+	raw, err := b.Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// A mutable blob carries nothing but the key: there is no tree to
+	// describe, and a "verity" key left in the JSON would invite a reader to
+	// expect one.
+	if strings.Contains(string(raw), "verity") {
+		t.Fatalf("mutable blob names verity: %s", raw)
+	}
+	got, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Mutable || got.Verity != nil {
+		t.Fatalf("decoded %+v, want mutable with no verity", got)
+	}
+}
+
+// A pre-mutable blob — type, key, verity — decodes as immutable: escrow files
+// written before this field existed must keep opening their volumes.
+func TestBlobWithoutMutableFieldDecodesImmutable(t *testing.T) {
+	raw, err := validBlob(t).Marshal()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(raw), "mutable") {
+		t.Fatalf("immutable blob names mutable: %s", raw)
+	}
+	got, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Mutable {
+		t.Fatal("a blob without the field decoded as mutable")
+	}
+}
+
+// The mode and the tree are one invariant: both present or both absent is a
+// blob whose author's intent is unknowable, refused rather than disambiguated.
+func TestValidateRejectsModeAndTreeMismatch(t *testing.T) {
+	both := validBlob(t)
+	both.Mutable = true
+	if err := both.Validate(); err == nil {
+		t.Error("accepted mutable with verity geometry")
+	}
+
+	neither, err := NewMutableBlob(testKey())
+	if err != nil {
+		t.Fatalf("new mutable blob: %v", err)
+	}
+	neither.Mutable = false
+	if err := neither.Validate(); err == nil {
+		t.Error("accepted immutable without verity geometry")
+	}
+}
+
+func TestNewMutableBlobRejectsWrongKeyLength(t *testing.T) {
+	if _, err := NewMutableBlob(make([]byte, 32)); err == nil {
+		t.Fatal("accepted a 32-byte key")
 	}
 }

--- a/internal/cmds/volume/cmd.go
+++ b/internal/cmds/volume/cmd.go
@@ -31,11 +31,13 @@ func newCmd(verify localverify.VerifyFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "volume",
 		Short: "Build encrypted volumes and store their keys in CDS",
-		Long: `Build a volume that only an attested workload can read.
+		Long: `Build a volume that only an attested workload can open.
 
 'create' packages a directory into an encrypted, integrity-protected image and
-puts its key into the CDS secret store. The image is ciphertext: copy it to the
-node by any means, including through the untrusted host.
+puts its key into the CDS secret store — or, with --mutable, builds a writable
+volume the workload can both read and write, without integrity protection. The
+image is ciphertext either way: copy it to the node by any means, including
+through the untrusted host.
 
 'attach' then presents that image to the node as a disk carrying the serial the
 volume is found by, and 'detach' removes it. Both run on the node, as root, and

--- a/internal/cmds/volume/cmd_test.go
+++ b/internal/cmds/volume/cmd_test.go
@@ -84,7 +84,7 @@ func TestPutBlobSendsTheBlobUnderTheOperatorToken(t *testing.T) {
 	if err != nil {
 		t.Fatalf("server received something that is not a key blob: %v", err)
 	}
-	if got.Key != testBlob(t).Key || got.Verity != validVerity() {
+	if got.Key != testBlob(t).Key || got.Verity == nil || *got.Verity != validVerity() {
 		t.Error("server received a different blob than was built")
 	}
 }

--- a/internal/cmds/volume/create.go
+++ b/internal/cmds/volume/create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
@@ -19,7 +20,10 @@ type createConfig struct {
 	path      string
 	escrowOut string
 	node      string
+	size      string
+	sizeBytes uint64
 	workDir   string
+	mutable   bool
 	dryRun    bool
 
 	// run executes the build tools. Not a flag: tests set it so the whole
@@ -32,8 +36,16 @@ func newCreateCmd(o *options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Build an encrypted volume and store its key",
-		Long: `Package --source into an encrypted image at --out and store its key at --path
-in the CDS secret store.
+		Long: `Build an encrypted image at --out and store its key at --path in the CDS
+secret store.
+
+By default the volume is immutable: --source is packaged into an erofs image
+with a dm-verity tree inside the encryption, and every read is checked against
+the root hash in the key blob.
+
+With --mutable the volume is a writable ext4 of --size bytes, preloaded from
+--source when one is given. A mutable volume has no integrity protection: the
+host can flip bits or roll it back, and c8s cannot detect that.
 
 The image is written as ciphertext and can travel by any means, including
 through the untrusted host. Attach it to the node as a raw block device whose
@@ -50,11 +62,13 @@ the volume is unopenable — keep it somewhere durable and access-controlled.`,
 	}
 	f := cmd.Flags()
 	f.StringVar(&cfg.name, "name", "", "volume name; forms the device serial c8s-vol-<name> (required, max 12 chars)")
-	f.StringVar(&cfg.source, "source", "", "directory whose contents become the volume (required)")
+	f.StringVar(&cfg.source, "source", "", "directory whose contents become the volume (required for immutable, optional preload for mutable)")
 	f.StringVar(&cfg.out, "out", "", "where to write the encrypted image; must not exist (required)")
 	f.StringVar(&cfg.path, "path", "", "secret-store path for the key, e.g. /tenant-a/volumes/weights (required)")
 	f.StringVar(&cfg.escrowOut, "escrow-out", "", "where to write the key blob you must keep (required)")
 	f.StringVar(&cfg.node, "node", "", "node holding the device; emitted as a nodeSelector on the printed annotations")
+	f.BoolVar(&cfg.mutable, "mutable", false, "build a writable ext4 volume instead of an immutable, verified one")
+	f.StringVar(&cfg.size, "size", "", "mutable filesystem size, e.g. 50Gi (default: inferred from --source; required without one)")
 	f.StringVar(&cfg.workDir, "work-dir", "", "directory for build intermediates (default: a temp dir); they are removed either way")
 	f.BoolVar(&cfg.dryRun, "dry-run", false, "build the image and write escrow, but do not call CDS")
 	return cmd
@@ -75,13 +89,26 @@ func runCreate(cmd *cobra.Command, o *options, cfg createConfig) error {
 	if err != nil {
 		return err
 	}
-	verity, err := Build(cmd.Context(), BuildConfig{
-		Source: cfg.source, Out: cfg.out, Key: key, WorkDir: cfg.workDir, Run: cfg.run,
-	})
-	if err != nil {
-		return err
+	var blob Blob
+	var size uint64
+	var verity Verity
+	if cfg.mutable {
+		size, err = BuildMutable(cmd.Context(), MutableBuildConfig{
+			Source: cfg.source, Out: cfg.out, Key: key, Size: cfg.sizeBytes, WorkDir: cfg.workDir, Run: cfg.run,
+		})
+		if err != nil {
+			return err
+		}
+		blob, err = NewMutableBlob(key)
+	} else {
+		verity, err = Build(cmd.Context(), BuildConfig{
+			Source: cfg.source, Out: cfg.out, Key: key, WorkDir: cfg.workDir, Run: cfg.run,
+		})
+		if err != nil {
+			return err
+		}
+		blob, err = NewBlob(key, verity)
 	}
-	blob, err := NewBlob(key, verity)
 	if err != nil {
 		return err
 	}
@@ -95,8 +122,8 @@ func runCreate(cmd *cobra.Command, o *options, cfg createConfig) error {
 
 	out := cmd.OutOrStdout()
 	if cfg.dryRun {
-		fmt.Fprintf(out, "built %s (%d data blocks); key escrowed to %s; CDS not called\n",
-			cfg.out, verity.DataBlocks, cfg.escrowOut)
+		fmt.Fprintf(out, "built %s (%s); key escrowed to %s; CDS not called\n",
+			cfg.out, buildSummary(cfg.mutable, size, verity), cfg.escrowOut)
 		return nil
 	}
 
@@ -112,7 +139,7 @@ func runCreate(cmd *cobra.Command, o *options, cfg createConfig) error {
 		return err
 	}
 
-	printResult(out, cfg, path, verity)
+	printResult(out, cfg, path, size, verity)
 	return nil
 }
 
@@ -120,12 +147,28 @@ func validateCreate(cfg *createConfig) (string, error) {
 	switch {
 	case cfg.name == "":
 		return "", fmt.Errorf("--name is required")
-	case cfg.source == "":
-		return "", fmt.Errorf("--source is required")
 	case cfg.out == "":
 		return "", fmt.Errorf("--out is required")
 	case cfg.escrowOut == "":
 		return "", fmt.Errorf("--escrow-out is required: it is the only copy of the key outside CDS")
+	}
+	if !cfg.mutable {
+		if cfg.source == "" {
+			return "", fmt.Errorf("--source is required for an immutable volume")
+		}
+		if cfg.size != "" {
+			return "", fmt.Errorf("--size is only valid with --mutable: an immutable image sizes itself to its contents")
+		}
+	}
+	if cfg.size != "" {
+		sizeBytes, err := parseSize(cfg.size)
+		if err != nil {
+			return "", err
+		}
+		cfg.sizeBytes = sizeBytes
+	}
+	if cfg.mutable && cfg.source == "" && cfg.size == "" {
+		return "", fmt.Errorf("--size is required for a mutable volume without --source")
 	}
 	if err := ValidVolumeName(cfg.name); err != nil {
 		return "", fmt.Errorf("--name: %w", err)
@@ -135,6 +178,19 @@ func validateCreate(cfg *createConfig) (string, error) {
 		return "", fmt.Errorf("--path: %w", err)
 	}
 	return path, nil
+}
+
+// parseSize reads --size as a byte count or a quantity like 50Gi.
+func parseSize(s string) (uint64, error) {
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0, fmt.Errorf("--size: %v (want a byte count or a quantity like 50Gi)", err)
+	}
+	v := q.Value()
+	if v <= 0 {
+		return 0, fmt.Errorf("--size must be positive")
+	}
+	return uint64(v), nil
 }
 
 // writeEscrow saves the blob, O_EXCL and 0600. It is the whole key: an operator
@@ -155,8 +211,20 @@ func writeEscrow(dest string, blob Blob) error {
 	return nil
 }
 
-func printResult(w io.Writer, cfg createConfig, path string, v Verity) {
-	fmt.Fprintf(w, "+ %s (%d data blocks)\n", cfg.out, v.DataBlocks)
+// buildSummary is the one-line description of what a build produced: a size
+// for mutable, a block count for immutable.
+func buildSummary(mutable bool, size uint64, v Verity) string {
+	if mutable {
+		return fmt.Sprintf("%s, mutable, read-write", resource.NewQuantity(int64(size), resource.BinarySI))
+	}
+	return fmt.Sprintf("%d data blocks", v.DataBlocks)
+}
+
+func printResult(w io.Writer, cfg createConfig, path string, size uint64, v Verity) {
+	fmt.Fprintf(w, "+ %s (%s)\n", cfg.out, buildSummary(cfg.mutable, size, v))
+	if cfg.mutable {
+		fmt.Fprintf(w, "  mutable volumes have no integrity protection: the host can flip bits or roll back undetected\n")
+	}
 	fmt.Fprintf(w, "+ key stored at %s\n", path)
 	fmt.Fprintf(w, "+ key escrowed to %s — keep it; a CDS restart needs it\n\n", cfg.escrowOut)
 

--- a/internal/cmds/volume/create_flow_test.go
+++ b/internal/cmds/volume/create_flow_test.go
@@ -177,7 +177,9 @@ func TestRunCreateStoresBlobAndPrintsGuidance(t *testing.T) {
 	if err != nil {
 		t.Fatalf("escrow blob: %v", err)
 	}
-	if stored.Key != escrowed.Key || stored.Verity != escrowed.Verity {
+	if stored.Key != escrowed.Key ||
+		(stored.Verity == nil) != (escrowed.Verity == nil) ||
+		(stored.Verity != nil && *stored.Verity != *escrowed.Verity) {
 		t.Fatal("the blob stored in CDS differs from the escrowed one")
 	}
 
@@ -237,5 +239,71 @@ func TestExecRunnerPinsEnvAndWrapsFailure(t *testing.T) {
 		t.Fatal("a failing tool reported success")
 	} else if !strings.Contains(err.Error(), "boom") {
 		t.Errorf("error drops the tool's output: %v", err)
+	}
+}
+
+// A mutable dry run builds the ext4 image, escrows a key-only blob, and never
+// reaches CDS — the same escrow-then-store ordering the immutable path holds.
+func TestRunCreateMutableDryRunBuildsAndEscrows(t *testing.T) {
+	f := newFlowFixture(t)
+	fake := newFake()
+	cfg := f.config(fake)
+	cfg.dryRun = true
+	cfg.mutable = true
+	cfg.sizeBytes = 20 << 20
+
+	cmd, out := captureCmd()
+	if err := runCreate(cmd, &options{}, cfg); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	img, err := os.ReadFile(f.out)
+	if err != nil {
+		t.Fatalf("image not written: %v", err)
+	}
+	if len(img) != 20<<20 {
+		t.Errorf("image is %d bytes, want %d", len(img), 20<<20)
+	}
+	raw, err := os.ReadFile(f.escrow)
+	if err != nil {
+		t.Fatalf("escrow not written: %v", err)
+	}
+	blob, err := DecodeBlob(raw)
+	if err != nil {
+		t.Fatalf("escrow is not a key blob: %v", err)
+	}
+	if !blob.Mutable || blob.Verity != nil {
+		t.Fatalf("escrow blob = %+v, want mutable with no verity", blob)
+	}
+
+	// The escrowed key must decrypt the image, or the escrow recovers nothing.
+	key, err := blob.DecodeKey()
+	if err != nil {
+		t.Fatalf("escrow key: %v", err)
+	}
+	var plain bytes.Buffer
+	if err := Decrypt(&plain, bytes.NewReader(img), key); err != nil {
+		t.Fatalf("decrypt with escrowed key: %v", err)
+	}
+	if !bytes.Equal(plain.Bytes(), make([]byte, 20<<20)) {
+		t.Fatal("escrowed key does not decrypt the image it was written alongside")
+	}
+	if !strings.Contains(out.String(), "mutable") {
+		t.Errorf("output does not name the volume mutable: %s", out.String())
+	}
+}
+
+// The mutable path must warn on the artifact itself: the operator is giving up
+// tamper detection by choosing it.
+func TestPrintResultWarnsThatMutableHasNoIntegrity(t *testing.T) {
+	var out bytes.Buffer
+	printResult(&out, createConfig{
+		name: "scratch", out: "/tmp/vol.img", escrowOut: "/tmp/escrow.json", mutable: true,
+	}, "/tenant-a/volumes/scratch", 50<<30, Verity{})
+	got := out.String()
+	for _, want := range []string{"50Gi", "no integrity protection"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
 	}
 }

--- a/internal/cmds/volume/create_test.go
+++ b/internal/cmds/volume/create_test.go
@@ -150,7 +150,7 @@ func TestPrintResultNamesSerialAnnotationAndExactGrant(t *testing.T) {
 	var out bytes.Buffer
 	printResult(&out, createConfig{
 		name: "weights", out: "/tmp/vol.img", escrowOut: "/tmp/escrow.json", node: "node-1",
-	}, "/tenant-a/volumes/weights", Verity{DataBlocks: 4})
+	}, "/tenant-a/volumes/weights", 0, Verity{DataBlocks: 4})
 	got := out.String()
 	for _, want := range []string{
 		"c8s-vol-weights",
@@ -195,5 +195,83 @@ func TestWriteEscrowReportsAnUnwritableDestination(t *testing.T) {
 	}
 	if err := writeEscrow(filepath.Join(t.TempDir(), "missing-dir", "escrow.json"), blob); err == nil {
 		t.Fatal("accepted a path whose directory does not exist")
+	}
+}
+
+// runCreateArgs drives the command through cobra with exactly the given flags,
+// for validation tests that need source-less invocations. A rejected
+// invocation must fail before any build runs, so no tool fakes are needed.
+func runCreateArgs(dir string, extra ...string) error {
+	o := &options{}
+	cmd := newCreateCmd(o)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs(append([]string{
+		"--name=weights",
+		"--out=" + filepath.Join(dir, "vol.img"),
+		"--path=/tenant-a/volumes/weights",
+		"--escrow-out=" + filepath.Join(dir, "escrow.json"),
+		"--dry-run",
+	}, extra...))
+	return cmd.Execute()
+}
+
+func TestCreateImmutableRequiresSource(t *testing.T) {
+	dir := t.TempDir()
+	err := runCreateArgs(dir)
+	if err == nil || !strings.Contains(err.Error(), "--source is required") {
+		t.Fatalf("got %v, want a --source error", err)
+	}
+}
+
+// An immutable image sizes itself to what it packs; a size would say nothing.
+func TestCreateRejectsSizeWithoutMutable(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	err := runCreateArgs(dir, "--source="+src, "--size=50Gi")
+	if err == nil || !strings.Contains(err.Error(), "--size is only valid with --mutable") {
+		t.Fatalf("got %v, want a --size/--mutable error", err)
+	}
+}
+
+// A mutable volume with no source has nothing to be sized from.
+func TestCreateMutableWithoutSourceOrSizeIsRejected(t *testing.T) {
+	dir := t.TempDir()
+	err := runCreateArgs(dir, "--mutable")
+	if err == nil || !strings.Contains(err.Error(), "--size is required") {
+		t.Fatalf("got %v, want a --size error", err)
+	}
+}
+
+func TestCreateRejectsBadSize(t *testing.T) {
+	dir := t.TempDir()
+	for _, size := range []string{"bogus", "-5", "0"} {
+		if err := runCreateArgs(dir, "--mutable", "--size="+size); err == nil {
+			t.Errorf("size %q: accepted", size)
+		}
+	}
+}
+
+func TestParseSize(t *testing.T) {
+	for input, want := range map[string]uint64{
+		"50Gi":        50 << 30,
+		"512Mi":       512 << 20,
+		"10G":         10_000_000_000,
+		"10737418240": 10 << 30,
+	} {
+		got, err := parseSize(input)
+		if err != nil {
+			t.Errorf("%q: %v", input, err)
+		} else if got != want {
+			t.Errorf("%q = %d, want %d", input, got, want)
+		}
+	}
+	for _, input := range []string{"", "bogus", "-5", "0", "1.5.2"} {
+		if _, err := parseSize(input); err == nil {
+			t.Errorf("%q: accepted", input)
+		}
 	}
 }

--- a/internal/cmds/volume/image.go
+++ b/internal/cmds/volume/image.go
@@ -289,7 +289,9 @@ func treeSize(source string) (dataBytes, entries uint64, err error) {
 	return dataBytes, entries, nil
 }
 
-func alignUp(n, unit uint64) uint64 { return (n + unit - 1) / unit * unit }
+func alignUp(n, unit uint64) uint64 {
+	return (n + unit - 1) / unit * unit
+}
 
 // erofsArgs pins the inputs that would otherwise vary per build, so the same
 // source directory yields the same image and therefore the same root hash.

--- a/internal/cmds/volume/image.go
+++ b/internal/cmds/volume/image.go
@@ -18,6 +18,15 @@ import (
 // directory from sharing a hash tree.
 const saltBytes = 32
 
+// ImageBlockSize is the unit every built image is a whole number of: ext4's
+// block size for a mutable volume, dm-verity's for an immutable one. Same
+// value, two reasons — attach checks copies against it.
+const ImageBlockSize = 4096
+
+// minMutableBytes floors a mutable volume: below it ext4's own metadata leaves
+// no room to write anything.
+const minMutableBytes = 16 << 20
+
 // Runner executes one build tool. It exists so the orchestration is testable
 // without erofs-utils and cryptsetup on the machine running the tests.
 type Runner func(ctx context.Context, name string, args ...string) ([]byte, error)
@@ -130,6 +139,158 @@ func Build(ctx context.Context, cfg BuildConfig) (Verity, error) {
 	return v, nil
 }
 
+// MutableBuildConfig describes one writable image build.
+type MutableBuildConfig struct {
+	// Source, when set, is the directory preloaded into the filesystem.
+	Source string
+	// Out is where the encrypted image is written. It must not already exist.
+	Out string
+	// Key is the XTS key; GenerateKey supplies it.
+	Key []byte
+	// Size is the filesystem size in bytes. Zero infers it from Source, which
+	// is then required.
+	Size uint64
+	// WorkDir holds the intermediate plaintext image, as in BuildConfig.
+	WorkDir string
+	// Run executes the build tools; nil uses execRunner.
+	Run Runner
+}
+
+// BuildMutable builds a writable ext4 image of Size bytes — preloaded from
+// Source when one is given — and encrypts it to Out, returning the size
+// actually built so an inferred Size is reported back to the operator.
+//
+// Every sector is encrypted, free space included: a sector left unwritten
+// would read back as the XTS decryption of zeros rather than the plaintext
+// zeros the filesystem expects, so the image must hold real ciphertext end to
+// end.
+func BuildMutable(ctx context.Context, cfg MutableBuildConfig) (uint64, error) {
+	run := cfg.Run
+	if run == nil {
+		run = execRunner
+	}
+	if len(cfg.Key) != KeyBytes {
+		return 0, fmt.Errorf("volume: key is %d bytes, want %d", len(cfg.Key), KeyBytes)
+	}
+	size := cfg.Size
+	var inodes uint64
+	if cfg.Source != "" {
+		if err := checkSource(cfg.Source); err != nil {
+			return 0, err
+		}
+		dataBytes, entries, err := treeSize(cfg.Source)
+		if err != nil {
+			return 0, err
+		}
+		if size == 0 {
+			size = inferSize(dataBytes, entries)
+		}
+		inodes = inferInodes(size, entries)
+	}
+	if size == 0 {
+		return 0, fmt.Errorf("volume: a mutable volume without --source needs --size")
+	}
+	size = alignUp(size, ImageBlockSize)
+	if size < minMutableBytes {
+		return 0, fmt.Errorf("volume: mutable volume size %d is below the %d MiB minimum",
+			size, minMutableBytes>>20)
+	}
+
+	// O_EXCL on the output, as in Build.
+	out, err := os.OpenFile(cfg.Out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("volume: create %s: %w", cfg.Out, err)
+	}
+	defer out.Close()
+
+	work, cleanup, err := workDir(cfg.WorkDir)
+	if err != nil {
+		return 0, err
+	}
+	defer cleanup()
+
+	dataPath := filepath.Join(work, "data.ext4")
+	// The plaintext image is removed on the way out, as in Build.
+	defer func() { os.Remove(dataPath) }()
+
+	data, err := os.OpenFile(dataPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("volume: create intermediate image: %w", err)
+	}
+	if err := data.Truncate(int64(size)); err != nil {
+		data.Close()
+		return 0, fmt.Errorf("volume: size intermediate image: %w", err)
+	}
+	if err := data.Close(); err != nil {
+		return 0, fmt.Errorf("volume: close intermediate image: %w", err)
+	}
+
+	if _, err := run(ctx, "mkfs.ext4", ext4Args(dataPath, cfg.Source, inodes)...); err != nil {
+		return 0, err
+	}
+	if err := encryptFile(out, cfg.Key, dataPath); err != nil {
+		return 0, err
+	}
+	return size, nil
+}
+
+// ext4Args builds a 4K-block ext4 with no root-reserved blocks, preloading
+// source when given. Reserved blocks exist to keep a host's root user able to
+// write; a volume whose whole content is tenant data gets nothing from them.
+// -e remount-ro matches the platform rootfs: a filesystem error degrades the
+// mount to read-only rather than letting corruption spread — on a volume with
+// no integrity layer, the most likely cause is a host flipping bits.
+// Ownership and modes from the source are preserved, as on the immutable path.
+func ext4Args(dest, source string, inodes uint64) []string {
+	args := []string{"-q", "-F", "-b", fmt.Sprint(ImageBlockSize), "-m", "0", "-e", "remount-ro"}
+	if inodes > 0 {
+		args = append(args, "-N", fmt.Sprint(inodes))
+	}
+	if source != "" {
+		args = append(args, "-d", source)
+	}
+	return append(args, dest)
+}
+
+// inferSize estimates what a source tree needs: its bytes plus a block per
+// entry, grown by half so the volume is not born full, floored and rounded to
+// whole mebibytes.
+func inferSize(dataBytes, entries uint64) uint64 {
+	need := (dataBytes + entries*ImageBlockSize) * 3 / 2
+	return alignUp(max(need, minMutableBytes), 4<<20)
+}
+
+// inferInodes raises the inode count when the source tree's entries outnumber
+// what the default ratio gives the image, so a tree of small files does not
+// run mkfs out of inodes while blocks remain. Zero keeps the default.
+func inferInodes(size, entries uint64) uint64 {
+	const defaultInodeRatio = 16384
+	if inodes := entries * 2; inodes > size/defaultInodeRatio {
+		return inodes
+	}
+	return 0
+}
+
+// treeSize totals a source tree's bytes and entries, the inputs to inferSize.
+func treeSize(source string) (dataBytes, entries uint64, err error) {
+	err = filepath.Walk(source, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		entries++
+		if info.Mode().IsRegular() {
+			dataBytes += uint64(info.Size())
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, 0, fmt.Errorf("volume: measure --source: %w", err)
+	}
+	return dataBytes, entries, nil
+}
+
+func alignUp(n, unit uint64) uint64 { return (n + unit - 1) / unit * unit }
+
 // erofsArgs pins the inputs that would otherwise vary per build, so the same
 // source directory yields the same image and therefore the same root hash.
 //
@@ -176,6 +337,16 @@ func parseRootHash(veritysetupOutput []byte) (string, error) {
 		return "", fmt.Errorf("volume: veritysetup root hash is %d hex chars, want %d", len(root), verityHashBytes*2)
 	}
 	return root, nil
+}
+
+// encryptFile encrypts one whole file to out.
+func encryptFile(out io.Writer, key []byte, path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("volume: open intermediate image: %w", err)
+	}
+	defer f.Close()
+	return Encrypt(out, f, key)
 }
 
 // encryptConcat encrypts data followed by tree as one stream, so sector indices

--- a/internal/cmds/volume/image_test.go
+++ b/internal/cmds/volume/image_test.go
@@ -42,6 +42,10 @@ func (f *fakeTools) run(_ context.Context, name string, args ...string) ([]byte,
 			return nil, err
 		}
 		return []byte("VERITY header information\nRoot hash:      " + f.rootHash + "\n"), nil
+	case "mkfs.ext4":
+		// argv is [...flags, dest]; the caller already sized dest. The fake
+		// leaves it zeroed, which is valid plaintext to encrypt.
+		return nil, nil
 	}
 	return nil, errors.New("unexpected tool " + name)
 }
@@ -317,5 +321,199 @@ func TestBuildFailsWhenErofsFails(t *testing.T) {
 		Source: src, Out: filepath.Join(dir, "v.img"), Key: testKey(), Run: f.run,
 	}); err == nil {
 		t.Fatal("build succeeded despite mkfs.erofs failing")
+	}
+}
+
+func mkfsExt4Call(t *testing.T, f *fakeTools) string {
+	t.Helper()
+	for _, c := range f.calls {
+		if c[0] == "mkfs.ext4" {
+			return strings.Join(c, " ")
+		}
+	}
+	t.Fatal("mkfs.ext4 was never invoked")
+	return ""
+}
+
+func TestBuildMutableProducesSizedDecryptableImage(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "vol.img")
+	key := testKey()
+	f := newFake()
+	const size = 20 << 20
+
+	got, err := BuildMutable(t.Context(), MutableBuildConfig{Out: out, Key: key, Size: size, Run: f.run})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if got != size {
+		t.Fatalf("size = %d, want %d", got, size)
+	}
+	ct, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read image: %v", err)
+	}
+	if len(ct) != size {
+		t.Fatalf("image is %d bytes, want %d", len(ct), size)
+	}
+
+	// Every sector is real ciphertext, free space included: the whole image
+	// must decrypt, to the zeroed plaintext the fake left behind.
+	var plain bytes.Buffer
+	if err := Decrypt(&plain, bytes.NewReader(ct), key); err != nil {
+		t.Fatalf("decrypt: %v", err)
+	}
+	if !bytes.Equal(plain.Bytes(), make([]byte, size)) {
+		t.Fatal("decrypted image is not the zeroed filesystem the build wrote")
+	}
+
+	argv := mkfsExt4Call(t, f)
+	for _, want := range []string{"-b 4096", "-m 0", "-e remount-ro"} {
+		if !strings.Contains(argv, want) {
+			t.Errorf("mkfs.ext4 argv missing %q: %s", want, argv)
+		}
+	}
+	if strings.Contains(argv, " -d ") {
+		t.Errorf("mkfs.ext4 preloads without a source: %s", argv)
+	}
+}
+
+// A source with no size is sized from the tree, grown and rounded, and the
+// size actually built is handed back so the operator sees it.
+func TestBuildMutableInfersSizeFromSource(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	const payload = 3 << 20
+	if err := os.WriteFile(filepath.Join(src, "weights.bin"), make([]byte, payload), 0o600); err != nil {
+		t.Fatalf("seed src: %v", err)
+	}
+	f := newFake()
+
+	got, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), Run: f.run,
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// The walk counts the directory itself as an entry.
+	if want := inferSize(payload, 2); got != want {
+		t.Fatalf("size = %d, want the inferred %d", got, want)
+	}
+	if argv := mkfsExt4Call(t, f); !strings.Contains(argv, " -d "+src) {
+		t.Errorf("mkfs.ext4 argv does not preload the source: %s", argv)
+	}
+}
+
+// An explicit size is used as given (rounded up to a whole block), with the
+// source preloaded.
+func TestBuildMutableHonorsAnExplicitSize(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	f := newFake()
+
+	got, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), Size: 100<<20 + 1, Run: f.run,
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if want := uint64(100<<20 + ImageBlockSize); got != want {
+		t.Fatalf("size = %d, want %d (rounded to a whole block)", got, want)
+	}
+}
+
+func TestBuildMutableRejectsBadInvocations(t *testing.T) {
+	dir := t.TempDir()
+	f := newFake()
+
+	// No source and no size: there is nothing to size from.
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Out: filepath.Join(dir, "a.img"), Key: testKey(), Run: f.run,
+	}); err == nil || !strings.Contains(err.Error(), "--size") {
+		t.Errorf("got %v, want a --size error", err)
+	}
+
+	// Below the floor ext4's own metadata leaves nothing to write into.
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Out: filepath.Join(dir, "b.img"), Key: testKey(), Size: 4 << 20, Run: f.run,
+	}); err == nil {
+		t.Error("accepted a size below the minimum")
+	}
+
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Out: filepath.Join(dir, "c.img"), Key: make([]byte, 32), Size: 20 << 20, Run: f.run,
+	}); err == nil {
+		t.Error("accepted a 32-byte key")
+	}
+
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Source: filepath.Join(dir, "nope"), Out: filepath.Join(dir, "d.img"), Key: testKey(), Run: f.run,
+	}); err == nil {
+		t.Error("accepted a source directory that does not exist")
+	}
+}
+
+// The plaintext image is what the whole design protects, on this path too:
+// it must not survive the build, including when the caller supplied the work
+// directory.
+func TestBuildMutableRemovesPlaintextIntermediates(t *testing.T) {
+	dir := t.TempDir()
+	work := filepath.Join(dir, "work")
+	f := newFake()
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Out: filepath.Join(dir, "vol.img"), Key: testKey(), Size: 20 << 20, WorkDir: work, Run: f.run,
+	}); err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	entries, err := os.ReadDir(work)
+	if err != nil {
+		t.Fatalf("read work dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("work dir still holds %d file(s); the plaintext image survived the build", len(entries))
+	}
+}
+
+func TestBuildMutableRefusesToOverwriteExistingImage(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "vol.img")
+	if err := os.WriteFile(out, []byte("existing"), 0o600); err != nil {
+		t.Fatalf("seed out: %v", err)
+	}
+	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
+		Out: out, Key: testKey(), Size: 20 << 20, Run: newFake().run,
+	}); err == nil {
+		t.Fatal("build overwrote an existing image")
+	}
+}
+
+func TestInferSize(t *testing.T) {
+	// A tiny tree gets the floor, grown nowhere.
+	if got := inferSize(100, 3); got != minMutableBytes {
+		t.Errorf("inferSize(100, 3) = %d, want the %d-byte floor", got, minMutableBytes)
+	}
+	// Otherwise: bytes plus a block per entry, grown by half, rounded to
+	// whole mebibytes.
+	got := inferSize(32<<20, 1)
+	want := alignUp((32<<20+ImageBlockSize)*3/2, 4<<20)
+	if got != want {
+		t.Errorf("inferSize(32MiB, 1) = %d, want %d", got, want)
+	}
+}
+
+func TestInferInodes(t *testing.T) {
+	// Few entries on a large image: the default ratio suffices.
+	if got := inferInodes(1<<30, 10); got != 0 {
+		t.Errorf("inferInodes(1GiB, 10) = %d, want the default", got)
+	}
+	// A tree of small files outnumbers it.
+	if got := inferInodes(1<<30, 100000); got != 200000 {
+		t.Errorf("inferInodes(1GiB, 100000) = %d, want 200000", got)
 	}
 }

--- a/internal/cmds/volumed/cmd.go
+++ b/internal/cmds/volumed/cmd.go
@@ -57,8 +57,9 @@ func NewCmd() *cobra.Command {
 		Long: `volumed opens an encrypted volume for a pod.
 
 An injected sidecar fetches the volume's key from CDS over the attested secrets
-flow and hands it to this daemon, which opens dm-crypt and dm-verity and mounts
-the result read-only into that pod and no other.
+flow and hands it to this daemon, which opens the device and mounts the result
+into that pod and no other — read-only under dm-verity for an immutable volume,
+read-write ext4 for a mutable one.
 
 It runs in one of two shapes. On node-CVM it is a privileged node daemon: it
 resolves the calling pod from kernel peer credentials and mounts into that pod's

--- a/internal/cmds/volumed/modes.go
+++ b/internal/cmds/volumed/modes.go
@@ -1,0 +1,59 @@
+package volumed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
+)
+
+// A volumeMode is how one mode builds the device stack above the dm-crypt
+// mapping: an immutable volume stacks dm-verity and mounts erofs read-only,
+// a mutable one mounts the crypt device itself, writable ext4.
+type volumeMode interface {
+	// open builds the layers above cryptMapper and returns what to mount.
+	open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob) (mountSpec, error)
+	// close unwinds what open built — a no-op for a mode with no layers.
+	close(ctx context.Context, ops DeviceOps, podUID, name string)
+}
+
+// mountSpec is where a stack's top is mounted and how.
+type mountSpec struct {
+	source   string
+	fsType   string
+	readOnly bool
+}
+
+// modeFor selects the stack a mode builds.
+func modeFor(mutable bool) volumeMode {
+	if mutable {
+		return mutableMode{}
+	}
+	return immutableMode{}
+}
+
+// immutableMode stacks dm-verity over the crypt mapping and mounts the
+// verified device, read-only erofs.
+type immutableMode struct{}
+
+func (immutableMode) open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob) (mountSpec, error) {
+	verityMapper := mapperName(verityKind, podUID, name)
+	if err := ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, *b.Verity); err != nil {
+		return mountSpec{}, fmt.Errorf("volumed: open dm-verity: %w", err)
+	}
+	return mountSpec{source: devPath(verityMapper), fsType: fsTypeErofs, readOnly: true}, nil
+}
+
+func (immutableMode) close(ctx context.Context, ops DeviceOps, podUID, name string) {
+	_ = ops.VerityClose(ctx, mapperName(verityKind, podUID, name))
+}
+
+// mutableMode mounts the crypt device itself, writable ext4: there is no
+// integrity layer to build or unwind.
+type mutableMode struct{}
+
+func (mutableMode) open(_ context.Context, _ DeviceOps, _, _, cryptMapper string, _ volume.Blob) (mountSpec, error) {
+	return mountSpec{source: devPath(cryptMapper), fsType: fsTypeExt4, readOnly: false}, nil
+}
+
+func (mutableMode) close(context.Context, DeviceOps, string, string) {}

--- a/internal/cmds/volumed/modes.go
+++ b/internal/cmds/volumed/modes.go
@@ -3,25 +3,20 @@ package volumed
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 )
 
 // A volumeMode is how one mode builds the device stack above the dm-crypt
-// mapping: an immutable volume stacks dm-verity and mounts erofs read-only,
-// a mutable one mounts the crypt device itself, writable ext4.
+// mapping and mounts its top: an immutable volume stacks dm-verity and mounts
+// the verified erofs read-only, a mutable one mounts the crypt device itself,
+// writable ext4.
 type volumeMode interface {
-	// open builds the layers above cryptMapper and returns what to mount.
-	open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob) (mountSpec, error)
-	// close unwinds what open built — a no-op for a mode with no layers.
-	close(ctx context.Context, ops DeviceOps, podUID, name string)
-}
-
-// mountSpec is where a stack's top is mounted and how.
-type mountSpec struct {
-	source   string
-	fsType   string
-	readOnly bool
+	// open builds the layers above cryptMapper and mounts the top at target.
+	open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob, target *os.File) error
+	// close unwinds what open built, mount included.
+	close(ctx context.Context, ops DeviceOps, podUID, name, target string)
 }
 
 // modeFor selects the stack a mode builds.
@@ -36,15 +31,20 @@ func modeFor(mutable bool) volumeMode {
 // verified device, read-only erofs.
 type immutableMode struct{}
 
-func (immutableMode) open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob) (mountSpec, error) {
+func (immutableMode) open(ctx context.Context, ops DeviceOps, podUID, name, cryptMapper string, b volume.Blob, target *os.File) error {
 	verityMapper := mapperName(verityKind, podUID, name)
 	if err := ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, *b.Verity); err != nil {
-		return mountSpec{}, fmt.Errorf("volumed: open dm-verity: %w", err)
+		return fmt.Errorf("volumed: open dm-verity: %w", err)
 	}
-	return mountSpec{source: devPath(verityMapper), fsType: fsTypeErofs, readOnly: true}, nil
+	if err := ops.MountRO(ctx, devPath(verityMapper), target, fsTypeErofs); err != nil {
+		_ = ops.VerityClose(ctx, verityMapper)
+		return fmt.Errorf("volumed: mount: %w", err)
+	}
+	return nil
 }
 
-func (immutableMode) close(ctx context.Context, ops DeviceOps, podUID, name string) {
+func (immutableMode) close(ctx context.Context, ops DeviceOps, podUID, name, target string) {
+	_ = ops.Unmount(ctx, target)
 	_ = ops.VerityClose(ctx, mapperName(verityKind, podUID, name))
 }
 
@@ -52,8 +52,13 @@ func (immutableMode) close(ctx context.Context, ops DeviceOps, podUID, name stri
 // integrity layer to build or unwind.
 type mutableMode struct{}
 
-func (mutableMode) open(_ context.Context, _ DeviceOps, _, _, cryptMapper string, _ volume.Blob) (mountSpec, error) {
-	return mountSpec{source: devPath(cryptMapper), fsType: fsTypeExt4, readOnly: false}, nil
+func (mutableMode) open(ctx context.Context, ops DeviceOps, _, _, cryptMapper string, _ volume.Blob, target *os.File) error {
+	if err := ops.MountRW(ctx, devPath(cryptMapper), target, fsTypeExt4); err != nil {
+		return fmt.Errorf("volumed: mount: %w", err)
+	}
+	return nil
 }
 
-func (mutableMode) close(context.Context, DeviceOps, string, string) {}
+func (mutableMode) close(ctx context.Context, ops DeviceOps, _, _, target string) {
+	_ = ops.Unmount(ctx, target)
+}

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -83,7 +83,6 @@ type mount struct {
 	device     string
 	mutable    bool
 	cryptDev   string
-	verityDev  string
 	target     string
 }
 
@@ -98,6 +97,9 @@ type Opener struct {
 
 	mu     sync.Mutex
 	mounts map[string]*mount
+	// opening tracks in-flight opens by device, so a concurrent open is judged
+	// against one that has not landed in mounts yet.
+	opening map[string]bool
 }
 
 // DefaultMaxMounts bounds live volumes when MaxMounts is unset.
@@ -129,6 +131,7 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 	o.mu.Lock()
 	if o.mounts == nil {
 		o.mounts = map[string]*mount{}
+		o.opening = map[string]bool{}
 	}
 	if existing, ok := o.mounts[mountKey(req.Pod.UID, req.Name)]; ok {
 		o.mu.Unlock()
@@ -145,7 +148,16 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 		o.mu.Unlock()
 		return ErrVolumeInUse
 	}
+	// Reserve the device for the open's duration, so a conflicting open racing
+	// this one is judged against it rather than against a mounts map it has
+	// not landed in yet.
+	o.opening[req.Device] = req.Blob.Mutable
 	o.mu.Unlock()
+	defer func() {
+		o.mu.Lock()
+		delete(o.opening, req.Device)
+		o.mu.Unlock()
+	}()
 
 	m, err := o.open(ctx, req, key, commitment)
 	if err != nil {
@@ -153,22 +165,17 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 	}
 
 	// A concurrent identical request may have won the race; keep one mapping
-	// and tear the loser down outside the lock. The device check repeats here:
-	// a conflicting open may have landed while this one ran.
+	// and tear the loser down outside the lock.
 	o.mu.Lock()
 	existing, lost := o.mounts[mountKey(req.Pod.UID, req.Name)]
-	conflict := !lost && o.deviceConflict(req.Device, req.Blob.Mutable)
-	if !lost && !conflict {
+	if !lost {
 		o.mounts[mountKey(req.Pod.UID, req.Name)] = m
 	}
 	o.mu.Unlock()
-	if !lost && !conflict {
+	if !lost {
 		return nil
 	}
 	o.teardown(ctx, m)
-	if conflict {
-		return ErrVolumeInUse
-	}
 	if subtle.ConstantTimeCompare(existing.commitment[:], commitment[:]) != 1 {
 		return ErrNotAuthorized
 	}
@@ -176,8 +183,11 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 }
 
 // deviceConflict reports whether opening device in mode mutable conflicts with
-// a live mount. Caller holds mu.
+// a live mount or an in-flight open. Caller holds mu.
 func (o *Opener) deviceConflict(device string, mutable bool) bool {
+	if m, inFlight := o.opening[device]; inFlight && (m || mutable) {
+		return true
+	}
 	for _, m := range o.mounts {
 		if m.device == device && (m.mutable || mutable) {
 			return true
@@ -212,23 +222,14 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 	}
 	undo = append(undo, func(ctx context.Context) { _ = o.Ops.CryptClose(ctx, cryptMapper) })
 
-	// The stack's top and the mount flags are the mode's: an immutable volume
-	// mounts the verified device, read-only erofs; a mutable one mounts the
-	// crypt device itself, writable ext4.
-	source := devPath(cryptMapper)
-	fsType, readOnly := fsTypeExt4, false
-	verityMapper := ""
-	if !req.Blob.Mutable {
-		verityMapper = mapperName(verityKind, req.Pod.UID, req.Name)
-		if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, *req.Blob.Verity); err != nil {
-			return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
-		}
-		undo = append(undo, func(ctx context.Context) { _ = o.Ops.VerityClose(ctx, verityMapper) })
-		source = devPath(verityMapper)
-		fsType, readOnly = fsTypeErofs, true
+	mode := modeFor(req.Blob.Mutable)
+	spec, err := mode.open(ctx, o.Ops, req.Pod.UID, req.Name, cryptMapper, req.Blob)
+	if err != nil {
+		return fail(err)
 	}
+	undo = append(undo, func(ctx context.Context) { mode.close(ctx, o.Ops, req.Pod.UID, req.Name) })
 
-	if err := o.Ops.Mount(ctx, source, target, fsType, readOnly); err != nil {
+	if err := o.Ops.Mount(ctx, spec.source, target, spec.fsType, spec.readOnly); err != nil {
 		return fail(fmt.Errorf("volumed: mount: %w", err))
 	}
 
@@ -239,7 +240,6 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 		device:     req.Device,
 		mutable:    req.Blob.Mutable,
 		cryptDev:   cryptMapper,
-		verityDev:  verityMapper,
 		target:     target.Name(),
 	}, nil
 }
@@ -286,10 +286,7 @@ func (o *Opener) teardown(ctx context.Context, m *mount) {
 	cleanup, cancel := cleanupContext(ctx)
 	defer cancel()
 	_ = o.Ops.Unmount(cleanup, m.target)
-	// A mutable mount has no verity layer.
-	if m.verityDev != "" {
-		_ = o.Ops.VerityClose(cleanup, m.verityDev)
-	}
+	modeFor(m.mutable).close(cleanup, o.Ops, m.pod.UID, m.name)
 	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
 }
 

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -38,11 +38,12 @@ type DeviceOps interface {
 	CryptClose(ctx context.Context, mapper string) error
 	VerityOpen(ctx context.Context, dataDev, mapper string, v volume.Verity) error
 	VerityClose(ctx context.Context, mapper string) error
-	// Mount takes the resolved target as an open handle rather than a path:
-	// the implementation mounts through /proc/self/fd so nothing can be swapped
-	// between resolving the target and using it. Unmount takes a path, because
-	// by teardown that handle is long closed.
-	Mount(ctx context.Context, source string, target *os.File, fsType string, readOnly bool) error
+	// MountRO and MountRW take the resolved target as an open handle rather
+	// than a path: the implementation mounts through /proc/self/fd so nothing
+	// can be swapped between resolving the target and using it. Unmount takes
+	// a path, because by teardown that handle is long closed.
+	MountRO(ctx context.Context, source string, target *os.File, fsType string) error
+	MountRW(ctx context.Context, source string, target *os.File, fsType string) error
 	Unmount(ctx context.Context, target string) error
 	// ListMappings names the device-mapper targets published on this node.
 	ListMappings(ctx context.Context) ([]string, error)
@@ -223,15 +224,10 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 	undo = append(undo, func(ctx context.Context) { _ = o.Ops.CryptClose(ctx, cryptMapper) })
 
 	mode := modeFor(req.Blob.Mutable)
-	spec, err := mode.open(ctx, o.Ops, req.Pod.UID, req.Name, cryptMapper, req.Blob)
-	if err != nil {
+	if err := mode.open(ctx, o.Ops, req.Pod.UID, req.Name, cryptMapper, req.Blob, target); err != nil {
 		return fail(err)
 	}
-	undo = append(undo, func(ctx context.Context) { mode.close(ctx, o.Ops, req.Pod.UID, req.Name) })
-
-	if err := o.Ops.Mount(ctx, spec.source, target, spec.fsType, spec.readOnly); err != nil {
-		return fail(fmt.Errorf("volumed: mount: %w", err))
-	}
+	undo = append(undo, func(ctx context.Context) { mode.close(ctx, o.Ops, req.Pod.UID, req.Name, target.Name()) })
 
 	return &mount{
 		pod:        req.Pod,
@@ -285,8 +281,7 @@ func (o *Opener) ClosePod(ctx context.Context, podUID string) int {
 func (o *Opener) teardown(ctx context.Context, m *mount) {
 	cleanup, cancel := cleanupContext(ctx)
 	defer cancel()
-	_ = o.Ops.Unmount(cleanup, m.target)
-	modeFor(m.mutable).close(cleanup, o.Ops, m.pod.UID, m.name)
+	modeFor(m.mutable).close(cleanup, o.Ops, m.pod.UID, m.name, m.target)
 	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
 }
 

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -34,15 +34,15 @@ func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
 // Each Open has a matching Close, and the orchestration calls Close for every
 // step it completed when a later one fails.
 type DeviceOps interface {
-	CryptOpen(ctx context.Context, device, mapper string, key []byte) error
+	CryptOpen(ctx context.Context, device, mapper string, key []byte, readOnly bool) error
 	CryptClose(ctx context.Context, mapper string) error
 	VerityOpen(ctx context.Context, dataDev, mapper string, v volume.Verity) error
 	VerityClose(ctx context.Context, mapper string) error
-	// MountRO takes the resolved target as an open handle rather than a path:
+	// Mount takes the resolved target as an open handle rather than a path:
 	// the implementation mounts through /proc/self/fd so nothing can be swapped
 	// between resolving the target and using it. Unmount takes a path, because
 	// by teardown that handle is long closed.
-	MountRO(ctx context.Context, source string, target *os.File) error
+	Mount(ctx context.Context, source string, target *os.File, fsType string, readOnly bool) error
 	Unmount(ctx context.Context, target string) error
 	// ListMappings names the device-mapper targets published on this node.
 	ListMappings(ctx context.Context) ([]string, error)
@@ -56,6 +56,13 @@ var ErrNotAuthorized = errors.New("volumed: not authorized for this volume")
 // devices and a mount, and every cw pod can reach the socket.
 var ErrTooManyMounts = errors.New("volumed: too many open volumes on this node")
 
+// ErrVolumeInUse reports an open that conflicts with a live mount of the same
+// device. Two read-write mounts of one device corrupt the filesystem, and a
+// read-write mount under read-only readers corrupts what they read, so a
+// device shared with any mount refuses a mutable open, and one shared with a
+// mutable mount refuses every open.
+var ErrVolumeInUse = errors.New("volumed: volume device is already in use")
+
 // Request is one open, after the caller has been resolved.
 type Request struct {
 	// Pod is the calling pod, as the kernel placed it. Its cgroup path is held
@@ -67,11 +74,14 @@ type Request struct {
 }
 
 // mount is a live volume. The commitment is what a second caller must reproduce
-// to be handed the same mapping.
+// to be handed the same mapping. The device and mode are kept so an open that
+// would mount the same device unsafely is refused (see ErrVolumeInUse).
 type mount struct {
 	pod        PodCgroup
 	name       string
 	commitment [sha256.Size]byte
+	device     string
+	mutable    bool
 	cryptDev   string
 	verityDev  string
 	target     string
@@ -93,13 +103,13 @@ type Opener struct {
 // DefaultMaxMounts bounds live volumes when MaxMounts is unset.
 const DefaultMaxMounts = 64
 
-// Open makes the volume readable at the calling pod's mount target, and is
+// Open makes the volume available at the calling pod's mount target, and is
 // idempotent for a caller repeating an identical request — which a restarted
 // sidecar does, since kubelet restarts it for the pod's life.
 //
-// A request naming a volume already open must present the same key and root
-// hash. Without that check the volume *name* would be the credential, and a
-// name is a label in a host-written annotation: any pod reaching the socket
+// A request naming a volume already open must present the same key, mode, and
+// root hash. Without that check the volume *name* would be the credential, and
+// a name is a label in a host-written annotation: any pod reaching the socket
 // would be handed the plaintext once one entitled pod had opened it.
 func (o *Opener) Open(ctx context.Context, req Request) error {
 	key, err := req.Blob.DecodeKey()
@@ -114,7 +124,7 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 		return fmt.Errorf("volumed: volume name %q is not a dns-1123 label", req.Name)
 	}
 
-	commitment := commitmentFor(key, req.Blob.Verity.RootHash)
+	commitment := commitmentFor(key, req.Blob)
 
 	o.mu.Lock()
 	if o.mounts == nil {
@@ -131,6 +141,10 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 		o.mu.Unlock()
 		return ErrTooManyMounts
 	}
+	if o.deviceConflict(req.Device, req.Blob.Mutable) {
+		o.mu.Unlock()
+		return ErrVolumeInUse
+	}
 	o.mu.Unlock()
 
 	m, err := o.open(ctx, req, key, commitment)
@@ -139,21 +153,37 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 	}
 
 	// A concurrent identical request may have won the race; keep one mapping
-	// and tear the loser down outside the lock.
+	// and tear the loser down outside the lock. The device check repeats here:
+	// a conflicting open may have landed while this one ran.
 	o.mu.Lock()
 	existing, lost := o.mounts[mountKey(req.Pod.UID, req.Name)]
-	if !lost {
+	conflict := !lost && o.deviceConflict(req.Device, req.Blob.Mutable)
+	if !lost && !conflict {
 		o.mounts[mountKey(req.Pod.UID, req.Name)] = m
 	}
 	o.mu.Unlock()
-	if !lost {
+	if !lost && !conflict {
 		return nil
 	}
 	o.teardown(ctx, m)
+	if conflict {
+		return ErrVolumeInUse
+	}
 	if subtle.ConstantTimeCompare(existing.commitment[:], commitment[:]) != 1 {
 		return ErrNotAuthorized
 	}
 	return nil
+}
+
+// deviceConflict reports whether opening device in mode mutable conflicts with
+// a live mount. Caller holds mu.
+func (o *Opener) deviceConflict(device string, mutable bool) bool {
+	for _, m := range o.mounts {
+		if m.device == device && (m.mutable || mutable) {
+			return true
+		}
+	}
+	return false
 }
 
 // open runs the privileged steps, undoing everything it completed if a later
@@ -177,18 +207,28 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 	}
 
 	cryptMapper := mapperName(cryptKind, req.Pod.UID, req.Name)
-	if err := o.Ops.CryptOpen(ctx, req.Device, cryptMapper, key); err != nil {
+	if err := o.Ops.CryptOpen(ctx, req.Device, cryptMapper, key, !req.Blob.Mutable); err != nil {
 		return fail(fmt.Errorf("volumed: open dm-crypt: %w", err))
 	}
 	undo = append(undo, func(ctx context.Context) { _ = o.Ops.CryptClose(ctx, cryptMapper) })
 
-	verityMapper := mapperName(verityKind, req.Pod.UID, req.Name)
-	if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, req.Blob.Verity); err != nil {
-		return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
+	// The stack's top and the mount flags are the mode's: an immutable volume
+	// mounts the verified device, read-only erofs; a mutable one mounts the
+	// crypt device itself, writable ext4.
+	source := devPath(cryptMapper)
+	fsType, readOnly := fsTypeExt4, false
+	verityMapper := ""
+	if !req.Blob.Mutable {
+		verityMapper = mapperName(verityKind, req.Pod.UID, req.Name)
+		if err := o.Ops.VerityOpen(ctx, devPath(cryptMapper), verityMapper, *req.Blob.Verity); err != nil {
+			return fail(fmt.Errorf("volumed: open dm-verity: %w", err))
+		}
+		undo = append(undo, func(ctx context.Context) { _ = o.Ops.VerityClose(ctx, verityMapper) })
+		source = devPath(verityMapper)
+		fsType, readOnly = fsTypeErofs, true
 	}
-	undo = append(undo, func(ctx context.Context) { _ = o.Ops.VerityClose(ctx, verityMapper) })
 
-	if err := o.Ops.MountRO(ctx, devPath(verityMapper), target); err != nil {
+	if err := o.Ops.Mount(ctx, source, target, fsType, readOnly); err != nil {
 		return fail(fmt.Errorf("volumed: mount: %w", err))
 	}
 
@@ -196,6 +236,8 @@ func (o *Opener) open(ctx context.Context, req Request, key []byte, commitment [
 		pod:        req.Pod,
 		name:       req.Name,
 		commitment: commitment,
+		device:     req.Device,
+		mutable:    req.Blob.Mutable,
 		cryptDev:   cryptMapper,
 		verityDev:  verityMapper,
 		target:     target.Name(),
@@ -244,7 +286,10 @@ func (o *Opener) teardown(ctx context.Context, m *mount) {
 	cleanup, cancel := cleanupContext(ctx)
 	defer cancel()
 	_ = o.Ops.Unmount(cleanup, m.target)
-	_ = o.Ops.VerityClose(cleanup, m.verityDev)
+	// A mutable mount has no verity layer.
+	if m.verityDev != "" {
+		_ = o.Ops.VerityClose(cleanup, m.verityDev)
+	}
 	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
 }
 
@@ -318,11 +363,18 @@ func (o *Opener) maxMounts() int {
 	return DefaultMaxMounts
 }
 
-// commitmentFor binds a mapping to the exact key and root hash that opened it.
-func commitmentFor(key []byte, rootHash string) [sha256.Size]byte {
+// commitmentFor binds a mapping to the exact key and mode that opened it — and,
+// for an immutable volume, the root hash. Without the mode a caller holding the
+// key could be handed a writable mapping by presenting an immutable request, or
+// the reverse.
+func commitmentFor(key []byte, b volume.Blob) [sha256.Size]byte {
 	h := sha256.New()
 	h.Write(key)
-	h.Write([]byte(rootHash))
+	if b.Mutable {
+		h.Write([]byte("mutable"))
+	} else {
+		h.Write([]byte(b.Verity.RootHash))
+	}
 	var out [sha256.Size]byte
 	copy(out[:], h.Sum(nil))
 	return out

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -150,11 +150,19 @@ func (f *fakeOps) ListMappings(ctx context.Context) ([]string, error) {
 	return out, nil
 }
 
-func (f *fakeOps) Mount(ctx context.Context, source string, target *os.File, fsType string, readOnly bool) error {
+func (f *fakeOps) MountRO(ctx context.Context, source string, target *os.File, fsType string) error {
+	return f.mount(ctx, "MountRO", source, target, fsType, true)
+}
+
+func (f *fakeOps) MountRW(ctx context.Context, source string, target *os.File, fsType string) error {
+	return f.mount(ctx, "MountRW", source, target, fsType, false)
+}
+
+func (f *fakeOps) mount(ctx context.Context, op, source string, target *os.File, fsType string, readOnly bool) error {
 	if err := f.ctxErr(ctx); err != nil {
 		return err
 	}
-	if err := f.record("Mount"); err != nil {
+	if err := f.record(op); err != nil {
 		return err
 	}
 	f.mu.Lock()
@@ -239,7 +247,7 @@ func TestOpenRunsTheStepsInOrder(t *testing.T) {
 	if err := o.Open(t.Context(), testRequest(t)); err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
 		t.Fatalf("sequence = %q", got)
 	}
 	if o.Len() != 1 {
@@ -263,7 +271,7 @@ func TestOpenUnwindsEveryCompletedStepOnFailure(t *testing.T) {
 	for _, tc := range []struct{ failOn, wantSeq string }{
 		{"CryptOpen", "CryptOpen"},
 		{"VerityOpen", "CryptOpen,VerityOpen,CryptClose"},
-		{"Mount", "CryptOpen,VerityOpen,Mount,VerityClose,CryptClose"},
+		{"MountRO", "CryptOpen,VerityOpen,MountRO,VerityClose,CryptClose"},
 	} {
 		ops := newOps()
 		ops.failOn = tc.failOn
@@ -297,7 +305,7 @@ func TestOpenIsIdempotentForAnIdenticalRequest(t *testing.T) {
 	if err := o.Open(t.Context(), req); err != nil {
 		t.Fatalf("repeat open: %v", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
 		t.Fatalf("repeat re-ran privileged steps: %q", got)
 	}
 	if o.Len() != 1 {
@@ -326,7 +334,7 @@ func TestOpenRefusesAWrongKeyForAnOpenVolume(t *testing.T) {
 	if err := o.Open(t.Context(), other); !errors.Is(err, ErrNotAuthorized) {
 		t.Fatalf("got %v, want ErrNotAuthorized", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
 		t.Fatalf("a refused caller reached the privileged steps: %q", got)
 	}
 }
@@ -348,7 +356,7 @@ func TestOpenMutableMountsTheCryptDeviceWritable(t *testing.T) {
 	if err := o.Open(t.Context(), testMutableRequest(t)); err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,Mount" {
+	if got := ops.sequence(); got != "CryptOpen,MountRW" {
 		t.Fatalf("sequence = %q, want no verity step", got)
 	}
 	m := ops.mounts[0]

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -21,10 +21,21 @@ type fakeOps struct {
 
 	cryptOpen, verityOpen, mounted map[string]bool
 
+	// cryptRO records the read-only flag each crypt mapping was opened with,
+	// and mounts the (fsType, readOnly) of each Mount call.
+	cryptRO map[string]bool
+	mounts  []mountCall
+
 	// honorCtx makes every op fail once its context is done.
 	honorCtx bool
 	// afterCryptOpen fires once the first privileged step has landed.
 	afterCryptOpen func()
+}
+
+// mountCall records what one Mount was asked to do.
+type mountCall struct {
+	source, fsType string
+	readOnly       bool
 }
 
 func newOps() *fakeOps {
@@ -32,6 +43,7 @@ func newOps() *fakeOps {
 		cryptOpen:  map[string]bool{},
 		verityOpen: map[string]bool{},
 		mounted:    map[string]bool{},
+		cryptRO:    map[string]bool{},
 	}
 }
 
@@ -55,7 +67,7 @@ func (f *fakeOps) record(op string) error {
 	return nil
 }
 
-func (f *fakeOps) CryptOpen(ctx context.Context, _, mapper string, key []byte) error {
+func (f *fakeOps) CryptOpen(ctx context.Context, _, mapper string, key []byte, readOnly bool) error {
 	if len(key) != volume.KeyBytes {
 		return errors.New("wrong key length")
 	}
@@ -68,6 +80,7 @@ func (f *fakeOps) CryptOpen(ctx context.Context, _, mapper string, key []byte) e
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cryptOpen[mapper] = true
+	f.cryptRO[mapper] = readOnly
 	if f.afterCryptOpen != nil {
 		f.afterCryptOpen()
 	}
@@ -137,11 +150,11 @@ func (f *fakeOps) ListMappings(ctx context.Context) ([]string, error) {
 	return out, nil
 }
 
-func (f *fakeOps) MountRO(ctx context.Context, _ string, target *os.File) error {
+func (f *fakeOps) Mount(ctx context.Context, source string, target *os.File, fsType string, readOnly bool) error {
 	if err := f.ctxErr(ctx); err != nil {
 		return err
 	}
-	if err := f.record("MountRO"); err != nil {
+	if err := f.record("Mount"); err != nil {
 		return err
 	}
 	f.mu.Lock()
@@ -149,6 +162,7 @@ func (f *fakeOps) MountRO(ctx context.Context, _ string, target *os.File) error 
 	// The kernel resolves /proc/self/fd/N to the directory it names, so the
 	// mount lands at the real path — which is what teardown unmounts.
 	f.mounted[target.Name()] = true
+	f.mounts = append(f.mounts, mountCall{source: source, fsType: fsType, readOnly: readOnly})
 	return nil
 }
 
@@ -225,11 +239,21 @@ func TestOpenRunsTheStepsInOrder(t *testing.T) {
 	if err := o.Open(t.Context(), testRequest(t)); err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
 		t.Fatalf("sequence = %q", got)
 	}
 	if o.Len() != 1 {
 		t.Fatalf("opener holds %d mounts, want 1", o.Len())
+	}
+	m := ops.mounts[0]
+	if m.fsType != fsTypeErofs || !m.readOnly {
+		t.Errorf("mount = %+v, want read-only erofs", m)
+	}
+	if !strings.HasSuffix(m.source, "c8s-verity-"+testPodUID+"-weights") {
+		t.Errorf("mount source = %q, want the verity device", m.source)
+	}
+	if !ops.cryptRO["c8s-crypt-"+testPodUID+"-weights"] {
+		t.Error("immutable volume's crypt mapping was not opened read-only")
 	}
 }
 
@@ -239,7 +263,7 @@ func TestOpenUnwindsEveryCompletedStepOnFailure(t *testing.T) {
 	for _, tc := range []struct{ failOn, wantSeq string }{
 		{"CryptOpen", "CryptOpen"},
 		{"VerityOpen", "CryptOpen,VerityOpen,CryptClose"},
-		{"MountRO", "CryptOpen,VerityOpen,MountRO,VerityClose,CryptClose"},
+		{"Mount", "CryptOpen,VerityOpen,Mount,VerityClose,CryptClose"},
 	} {
 		ops := newOps()
 		ops.failOn = tc.failOn
@@ -273,7 +297,7 @@ func TestOpenIsIdempotentForAnIdenticalRequest(t *testing.T) {
 	if err := o.Open(t.Context(), req); err != nil {
 		t.Fatalf("repeat open: %v", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
 		t.Fatalf("repeat re-ran privileged steps: %q", got)
 	}
 	if o.Len() != 1 {
@@ -293,7 +317,7 @@ func TestOpenRefusesAWrongKeyForAnOpenVolume(t *testing.T) {
 
 	other := testRequest(t)
 	wrong := make([]byte, volume.KeyBytes)
-	blob, err := volume.NewBlob(wrong, other.Blob.Verity)
+	blob, err := volume.NewBlob(wrong, *other.Blob.Verity)
 	if err != nil {
 		t.Fatalf("blob: %v", err)
 	}
@@ -302,8 +326,192 @@ func TestOpenRefusesAWrongKeyForAnOpenVolume(t *testing.T) {
 	if err := o.Open(t.Context(), other); !errors.Is(err, ErrNotAuthorized) {
 		t.Fatalf("got %v, want ErrNotAuthorized", err)
 	}
-	if got := ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+	if got := ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
 		t.Fatalf("a refused caller reached the privileged steps: %q", got)
+	}
+}
+
+func testMutableRequest(t *testing.T) Request {
+	t.Helper()
+	blob, err := volume.NewMutableBlob(volumeKey())
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	return Request{Pod: testPod(testPodUID), Name: "weights", Device: "/dev/disk/by-id/virtio-c8s-vol-weights", Blob: blob}
+}
+
+// A mutable volume mounts the crypt device itself, writable ext4 — there is no
+// verity layer to open.
+func TestOpenMutableMountsTheCryptDeviceWritable(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	if err := o.Open(t.Context(), testMutableRequest(t)); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if got := ops.sequence(); got != "CryptOpen,Mount" {
+		t.Fatalf("sequence = %q, want no verity step", got)
+	}
+	m := ops.mounts[0]
+	if m.fsType != fsTypeExt4 || m.readOnly {
+		t.Errorf("mount = %+v, want writable ext4", m)
+	}
+	if !strings.HasSuffix(m.source, "c8s-crypt-"+testPodUID+"-weights") {
+		t.Errorf("mount source = %q, want the crypt device", m.source)
+	}
+	if ops.cryptRO["c8s-crypt-"+testPodUID+"-weights"] {
+		t.Error("mutable volume's crypt mapping was opened read-only")
+	}
+}
+
+// Close on a mutable mount must not touch a verity layer that never existed.
+func TestCloseMutableSkipsVerity(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	req := testMutableRequest(t)
+	if err := o.Open(t.Context(), req); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	o.Close(t.Context(), req.Pod.UID, req.Name)
+	if got := ops.sequence(); !strings.HasSuffix(got, "Unmount,CryptClose") {
+		t.Fatalf("teardown order = %q", got)
+	}
+	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("leaked crypt=%d verity=%d mounts=%d", c, v, m)
+	}
+}
+
+// The mode is part of the commitment: the same key presented in the other mode
+// is a different volume, not a repeat request.
+func TestOpenRefusesAModeFlipOnAnOpenVolume(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := o.Open(t.Context(), testMutableRequest(t)); !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("immutable then mutable: got %v, want ErrNotAuthorized", err)
+	}
+
+	ops2 := newOps()
+	o2 := testOpener(t, ops2)
+	if err := o2.Open(t.Context(), testMutableRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	if err := o2.Open(t.Context(), testRequest(t)); !errors.Is(err, ErrNotAuthorized) {
+		t.Fatalf("mutable then immutable: got %v, want ErrNotAuthorized", err)
+	}
+}
+
+// conflictTree builds the kubelet volume dirs for two pods, each able to hold
+// weights, and the first able to hold datasets too.
+func conflictTree(t *testing.T) (root, otherUID string) {
+	t.Helper()
+	root, base := kubeletTree(t)
+	for _, n := range []string{"weights", "datasets"} {
+		if err := os.Mkdir(filepath.Join(base, KubeVolumeName(n)), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", n, err)
+		}
+	}
+	otherUID = "99999999-8888-7777-6666-555555555555"
+	otherBase := filepath.Join(root, "pods", otherUID, emptyDirSubdir)
+	if err := os.MkdirAll(filepath.Join(otherBase, KubeVolumeName("weights")), 0o755); err != nil {
+		t.Fatalf("mkdir other pod: %v", err)
+	}
+	return root, otherUID
+}
+
+// Two writable mounts of one device corrupt the filesystem, and a writable
+// mount under read-only readers corrupts what they read: if either side is
+// mutable, one device backs one mount. This is the double-mount a rolling
+// update of a single-device workload would otherwise hit.
+func TestMutableOpenIsExclusivePerDevice(t *testing.T) {
+	root, otherUID := conflictTree(t)
+	ops := newOps()
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
+
+	if err := o.Open(t.Context(), testMutableRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+
+	// Same pod, different name, same device.
+	samePod := testMutableRequest(t)
+	samePod.Name = "datasets"
+	if err := o.Open(t.Context(), samePod); !errors.Is(err, ErrVolumeInUse) {
+		t.Errorf("second mutable open, same pod: got %v, want ErrVolumeInUse", err)
+	}
+
+	// Another pod, same device.
+	otherPod := testMutableRequest(t)
+	otherPod.Pod = testPod(otherUID)
+	if err := o.Open(t.Context(), otherPod); !errors.Is(err, ErrVolumeInUse) {
+		t.Errorf("second mutable open, other pod: got %v, want ErrVolumeInUse", err)
+	}
+
+	// A read-only open of the same device is refused too.
+	ro := testRequest(t)
+	ro.Pod = testPod(otherUID)
+	if err := o.Open(t.Context(), ro); !errors.Is(err, ErrVolumeInUse) {
+		t.Errorf("immutable open over a mutable one: got %v, want ErrVolumeInUse", err)
+	}
+	if o.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want only the first", o.Len())
+	}
+}
+
+// The mirror image: a device held mutable refuses every later open, whichever
+// mode the later one asks for.
+func TestImmutableOpenRefusesAMutableHolderOfTheSameDevice(t *testing.T) {
+	root, otherUID := conflictTree(t)
+	ops := newOps()
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
+
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	mutable := testMutableRequest(t)
+	mutable.Pod = testPod(otherUID)
+	if err := o.Open(t.Context(), mutable); !errors.Is(err, ErrVolumeInUse) {
+		t.Fatalf("got %v, want ErrVolumeInUse", err)
+	}
+}
+
+// Read-only mounts of one device share it as they always have.
+func TestImmutableOpensShareADevice(t *testing.T) {
+	root, otherUID := conflictTree(t)
+	ops := newOps()
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
+
+	if err := o.Open(t.Context(), testRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	other := testRequest(t)
+	other.Pod = testPod(otherUID)
+	if err := o.Open(t.Context(), other); err != nil {
+		t.Fatalf("second immutable open: %v", err)
+	}
+	if o.Len() != 2 {
+		t.Fatalf("opener holds %d mounts, want 2", o.Len())
+	}
+}
+
+// Exclusivity is per device, not per daemon: two mutable volumes on distinct
+// devices open side by side.
+func TestMutableOpensOnDistinctDevicesCoexist(t *testing.T) {
+	root, _ := conflictTree(t)
+	ops := newOps()
+	o := &Opener{Ops: ops, Targets: KubeletTargets{Root: root}}
+
+	if err := o.Open(t.Context(), testMutableRequest(t)); err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	second := testMutableRequest(t)
+	second.Name = "datasets"
+	second.Device = "/dev/disk/by-id/virtio-c8s-vol-datasets"
+	if err := o.Open(t.Context(), second); err != nil {
+		t.Fatalf("second open: %v", err)
+	}
+	if o.Len() != 2 {
+		t.Fatalf("opener holds %d mounts, want 2", o.Len())
 	}
 }
 
@@ -318,7 +526,7 @@ func TestOpenRefusesADifferentRootHashForAnOpenVolume(t *testing.T) {
 	}
 
 	other := testRequest(t)
-	v := other.Blob.Verity
+	v := *other.Blob.Verity
 	v.RootHash = strings.Repeat("cd", 32)
 	blob, err := volume.NewBlob(volumeKey(), v)
 	if err != nil {
@@ -471,15 +679,31 @@ func TestMapperNamesAreScopedPerPod(t *testing.T) {
 	}
 }
 
-func TestCommitmentCoversKeyAndRootHash(t *testing.T) {
+func TestCommitmentCoversKeyModeAndRootHash(t *testing.T) {
 	key := volumeKey()
-	base := commitmentFor(key, "aa")
-	if commitmentFor(key, "bb") == base {
+	withHash := func(h string) volume.Blob {
+		b, err := volume.NewBlob(key, volume.Verity{
+			RootHash: h, Salt: "cd", DataBlocks: 4, HashOffset: 4 * volume.VerityBlockSize,
+		})
+		if err != nil {
+			t.Fatalf("blob: %v", err)
+		}
+		return b
+	}
+	base := commitmentFor(key, withHash(strings.Repeat("aa", 32)))
+	if commitmentFor(key, withHash(strings.Repeat("bb", 32))) == base {
 		t.Error("commitment ignores the root hash")
 	}
 	other := make([]byte, volume.KeyBytes)
-	if commitmentFor(other, "aa") == base {
+	if commitmentFor(other, withHash(strings.Repeat("aa", 32))) == base {
 		t.Error("commitment ignores the key")
+	}
+	mutable, err := volume.NewMutableBlob(key)
+	if err != nil {
+		t.Fatalf("mutable blob: %v", err)
+	}
+	if commitmentFor(key, mutable) == base {
+		t.Error("commitment ignores the mode")
 	}
 }
 

--- a/internal/cmds/volumed/server.go
+++ b/internal/cmds/volumed/server.go
@@ -165,6 +165,8 @@ func (s *Server) handleOpen(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "not authorized for this volume", http.StatusForbidden)
 	case errors.Is(err, ErrTooManyMounts):
 		http.Error(w, "too many open volumes on this node", http.StatusInsufficientStorage)
+	case errors.Is(err, ErrVolumeInUse):
+		http.Error(w, "volume device is already in use", http.StatusConflict)
 	default:
 		// Forward the underlying cause, not just a generic 500: the caller is
 		// the in-pod get-volume sidecar over a node-local socket, same tenant

--- a/internal/cmds/volumed/server_test.go
+++ b/internal/cmds/volumed/server_test.go
@@ -207,7 +207,7 @@ func TestServerIsIdempotentForARepeatedRequest(t *testing.T) {
 	if f.opener.Len() != 1 {
 		t.Fatalf("opener holds %d mounts, want 1", f.opener.Len())
 	}
-	if got := f.ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
+	if got := f.ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
 		t.Fatalf("repeats re-ran privileged steps: %q", got)
 	}
 }

--- a/internal/cmds/volumed/server_test.go
+++ b/internal/cmds/volumed/server_test.go
@@ -27,12 +27,18 @@ func (f fakeIdentity) Resolve(workloadclaims.Peer) (PodCgroup, error) {
 }
 
 type fakeDevices struct {
-	err error
+	// device, when set, is answered for every name — two names resolving to
+	// one disk, which is what a device-conflict test needs.
+	device string
+	err    error
 }
 
 func (f fakeDevices) Device(name string) (string, error) {
 	if f.err != nil {
 		return "", f.err
+	}
+	if f.device != "" {
+		return f.device, nil
 	}
 	return "/dev/disk/by-id/virtio-c8s-vol-" + name, nil
 }
@@ -133,7 +139,7 @@ func TestServerRefusesAWrongKeyForAnOpenVolume(t *testing.T) {
 	}
 
 	body := openBody(t)
-	blob, err := volume.NewBlob(make([]byte, volume.KeyBytes), body.Blob.Verity)
+	blob, err := volume.NewBlob(make([]byte, volume.KeyBytes), *body.Blob.Verity)
 	if err != nil {
 		t.Fatalf("blob: %v", err)
 	}
@@ -201,9 +207,48 @@ func TestServerIsIdempotentForARepeatedRequest(t *testing.T) {
 	if f.opener.Len() != 1 {
 		t.Fatalf("opener holds %d mounts, want 1", f.opener.Len())
 	}
-	if got := f.ops.sequence(); got != "CryptOpen,VerityOpen,MountRO" {
+	if got := f.ops.sequence(); got != "CryptOpen,VerityOpen,Mount" {
 		t.Fatalf("repeats re-ran privileged steps: %q", got)
 	}
+}
+
+// A second open of a device already held answers 409: the workload backing
+// off and being rescheduled is the recovery, not a retry.
+func TestServerReportsAConflictingOpen(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity())
+	f.srv.Devices = fakeDevices{device: "/dev/vdb"}
+	body := openBody(t)
+	blob, err := volume.NewMutableBlob(mustKey(t, body))
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	body.Blob = blob
+	if got := f.post(t, body).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("first open: status %d", got)
+	}
+
+	// Same device, another name, same mutable key: one device, one mount.
+	other := openBody(t)
+	otherBlob, err := volume.NewMutableBlob(mustKey(t, other))
+	if err != nil {
+		t.Fatalf("blob: %v", err)
+	}
+	other.Name = "datasets"
+	other.Blob = otherBlob
+	if got := f.post(t, other).StatusCode; got != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", got, http.StatusConflict)
+	}
+}
+
+// mustKey decodes the key out of a test body so a re-moded blob opens the same
+// volume.
+func mustKey(t *testing.T, body OpenRequest) []byte {
+	t.Helper()
+	key, err := body.Blob.DecodeKey()
+	if err != nil {
+		t.Fatalf("key: %v", err)
+	}
+	return key
 }
 
 // The node cap answers differently from a refusal: a caller turned away here

--- a/internal/cmds/volumed/systemops.go
+++ b/internal/cmds/volumed/systemops.go
@@ -84,24 +84,32 @@ func (s SystemOps) VerityClose(ctx context.Context, mapper string) error {
 	return s.run(ctx, "veritysetup", nil, "close", mapper)
 }
 
-// Mount mounts the opened device at the target handle.
+// The hardening every volume mount gets, with and without the read-only flag
+// an immutable volume adds.
+const (
+	mountROFlags uintptr = unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC
+	mountRWFlags uintptr = unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC
+)
+
+// MountRO mounts the opened device read-only at the target handle; MountRW
+// mounts it writable.
 //
 // The syscall is made directly rather than through mount(8): the target is an
 // open handle, and passing /proc/self/fd to a subprocess would reopen it by
 // path in a process that does not hold it.
-func (SystemOps) Mount(_ context.Context, source string, target *os.File, fsType string, readOnly bool) error {
-	if err := unix.Mount(source, ProcPath(target), fsType, mountFlags(readOnly), ""); err != nil {
+func (SystemOps) MountRO(_ context.Context, source string, target *os.File, fsType string) error {
+	return doMount(source, target, fsType, mountROFlags)
+}
+
+func (SystemOps) MountRW(_ context.Context, source string, target *os.File, fsType string) error {
+	return doMount(source, target, fsType, mountRWFlags)
+}
+
+func doMount(source string, target *os.File, fsType string, flags uintptr) error {
+	if err := unix.Mount(source, ProcPath(target), fsType, flags, ""); err != nil {
 		return fmt.Errorf("mount %s at %s: %w", source, target.Name(), err)
 	}
 	return nil
-}
-
-func mountFlags(readOnly bool) uintptr {
-	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
-	if readOnly {
-		flags |= unix.MS_RDONLY
-	}
-	return flags
 }
 
 // Unmount detaches the mount. MNT_DETACH so a mount still busy is removed from

--- a/internal/cmds/volumed/systemops.go
+++ b/internal/cmds/volumed/systemops.go
@@ -15,11 +15,14 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 )
 
-// fsType is the filesystem inside every volume. `c8s volume create` always
-// builds erofs, so this is an invariant rather than a choice the caller makes —
-// and a filesystem type read from the request would be a host-chosen argument
-// to mount(2).
-const fsType = "erofs"
+// The only two filesystems a volume can hold: erofs under dm-verity for an
+// immutable volume, writable ext4 for a mutable one. The opener picks from the
+// validated blob's mode — a filesystem type read from the request would be a
+// host-chosen argument to mount(2).
+const (
+	fsTypeErofs = "erofs"
+	fsTypeExt4  = "ext4"
+)
 
 // keyFD is where the key file lands in the child. exec.Cmd.ExtraFiles starts at
 // 3, and cryptsetup opens it by path.
@@ -40,19 +43,24 @@ type SystemOps struct {
 //
 // Plain, not LUKS: there is no header on the device, so every parameter comes
 // from the key blob and none from bytes the host can rewrite.
-func (s SystemOps) CryptOpen(ctx context.Context, device, mapper string, key []byte) error {
+//
+// An immutable volume's mapping must be read-only at the device layer, not
+// only at the mount: a writable mapping lets anything on the node write
+// plaintext through it, producing ciphertext under the real key on
+// host-visible storage. A mutable volume's is the writable one by design.
+func (s SystemOps) CryptOpen(ctx context.Context, device, mapper string, key []byte, readOnly bool) error {
 	keyFile, err := keyMemfd(key)
 	if err != nil {
 		return err
 	}
 	defer keyFile.Close()
 
-	if err := s.run(ctx, "cryptsetup", []*os.File{keyFile}, cryptOpenArgs(device, mapper)...); err != nil {
+	if err := s.run(ctx, "cryptsetup", []*os.File{keyFile}, cryptOpenArgs(device, mapper, readOnly)...); err != nil {
 		return err
 	}
-	// The mapping must be read-only at the device layer, not only at the mount:
-	// a writable mapping lets anything on the node write plaintext through it,
-	// producing ciphertext under the real key on host-visible storage.
+	if !readOnly {
+		return nil
+	}
 	if err := assertReadOnly(mapperDir, mapper); err != nil {
 		_ = s.CryptClose(ctx, mapper)
 		return err
@@ -76,17 +84,24 @@ func (s SystemOps) VerityClose(ctx context.Context, mapper string) error {
 	return s.run(ctx, "veritysetup", nil, "close", mapper)
 }
 
-// MountRO mounts the verified device at the target handle.
+// Mount mounts the opened device at the target handle.
 //
 // The syscall is made directly rather than through mount(8): the target is an
 // open handle, and passing /proc/self/fd to a subprocess would reopen it by
 // path in a process that does not hold it.
-func (SystemOps) MountRO(_ context.Context, source string, target *os.File) error {
-	const flags = unix.MS_RDONLY | unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC
-	if err := unix.Mount(source, ProcPath(target), fsType, flags, ""); err != nil {
+func (SystemOps) Mount(_ context.Context, source string, target *os.File, fsType string, readOnly bool) error {
+	if err := unix.Mount(source, ProcPath(target), fsType, mountFlags(readOnly), ""); err != nil {
 		return fmt.Errorf("mount %s at %s: %w", source, target.Name(), err)
 	}
 	return nil
+}
+
+func mountFlags(readOnly bool) uintptr {
+	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	if readOnly {
+		flags |= unix.MS_RDONLY
+	}
+	return flags
 }
 
 // Unmount detaches the mount. MNT_DETACH so a mount still busy is removed from
@@ -130,8 +145,8 @@ func unmounted(err error) bool {
 //   - --sector-size 512 matches what wrote the image. For aes-xts-plain64 the
 //     tweak is the sector index, and at a larger sector size the numbering
 //     depends on iv_large_sectors.
-func cryptOpenArgs(device, mapper string) []string {
-	return []string{
+func cryptOpenArgs(device, mapper string, readOnly bool) []string {
+	args := []string{
 		"open",
 		"--type", "plain",
 		"--hash", "plain",
@@ -140,10 +155,11 @@ func cryptOpenArgs(device, mapper string) []string {
 		"--cipher", "aes-xts-plain64",
 		"--key-size", strconv.Itoa(volume.KeyBytes * 8),
 		"--sector-size", strconv.Itoa(volume.SectorSize),
-		"--readonly",
-		"--batch-mode",
-		device, mapper,
 	}
+	if readOnly {
+		args = append(args, "--readonly")
+	}
+	return append(args, "--batch-mode", device, mapper)
 }
 
 // verityOpenArgs builds the verity open with no superblock.

--- a/internal/cmds/volumed/systemops_test.go
+++ b/internal/cmds/volumed/systemops_test.go
@@ -103,17 +103,15 @@ func TestCryptOpenMutableOmitsReadOnly(t *testing.T) {
 }
 
 func TestMountFlags(t *testing.T) {
-	ro := mountFlags(true)
-	if ro&unix.MS_RDONLY == 0 {
+	if mountROFlags&unix.MS_RDONLY == 0 {
 		t.Error("read-only mount without MS_RDONLY")
 	}
-	rw := mountFlags(false)
-	if rw&unix.MS_RDONLY != 0 {
+	if mountRWFlags&unix.MS_RDONLY != 0 {
 		t.Error("writable mount carries MS_RDONLY")
 	}
 	for _, flag := range []uintptr{unix.MS_NOSUID, unix.MS_NODEV, unix.MS_NOEXEC} {
-		if rw&flag == 0 || ro&flag == 0 {
-			t.Errorf("hardening flag %d missing (rw=%d ro=%d)", flag, rw, ro)
+		if mountRWFlags&flag == 0 || mountROFlags&flag == 0 {
+			t.Errorf("hardening flag %d missing (rw=%d ro=%d)", flag, mountRWFlags, mountROFlags)
 		}
 	}
 }

--- a/internal/cmds/volumed/systemops_test.go
+++ b/internal/cmds/volumed/systemops_test.go
@@ -37,7 +37,7 @@ func hasFlag(args []string, flag string) bool {
 // the image was written with and the key it is opened with would differ, and
 // the volume would decrypt to noise with nothing to say why.
 func TestCryptOpenUsesTheKeyBytesDirectly(t *testing.T) {
-	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x")
+	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x", true)
 	if got := argsAfter(args, "--hash"); got != "plain" {
 		t.Fatalf("--hash = %q, want plain", got)
 	}
@@ -49,7 +49,7 @@ func TestCryptOpenUsesTheKeyBytesDirectly(t *testing.T) {
 // The tweak is the sector index; at a larger sector size dm-crypt's numbering
 // depends on iv_large_sectors, so this must match what wrote the image.
 func TestCryptOpenMatchesTheWriterCipherAndSectorSize(t *testing.T) {
-	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x")
+	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x", true)
 	if got := argsAfter(args, "--cipher"); got != "aes-xts-plain64" {
 		t.Errorf("--cipher = %q", got)
 	}
@@ -65,7 +65,7 @@ func TestCryptOpenMatchesTheWriterCipherAndSectorSize(t *testing.T) {
 }
 
 func TestCryptOpenIsReadOnlyAndTakesTheKeyByFD(t *testing.T) {
-	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x")
+	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x", true)
 	if !hasFlag(args, "--readonly") {
 		t.Error("mapping is not opened read-only")
 	}
@@ -81,6 +81,40 @@ func TestCryptOpenIsReadOnlyAndTakesTheKeyByFD(t *testing.T) {
 	}
 	if args[len(args)-2] != "/dev/vdb" || args[len(args)-1] != "c8s-crypt-x" {
 		t.Errorf("device and mapper are not the trailing positionals: %v", args[len(args)-2:])
+	}
+}
+
+// A mutable volume's mapping is the writable one by design: no --readonly,
+// and no read-only assertion to fail it afterwards.
+func TestCryptOpenMutableOmitsReadOnly(t *testing.T) {
+	args := cryptOpenArgs("/dev/vdb", "c8s-crypt-x", false)
+	if hasFlag(args, "--readonly") {
+		t.Error("a writable mapping carries --readonly")
+	}
+	if args[len(args)-3] != "--batch-mode" || args[len(args)-2] != "/dev/vdb" || args[len(args)-1] != "c8s-crypt-x" {
+		t.Errorf("batch-mode, device and mapper are not the trailing arguments: %v", args[len(args)-3:])
+	}
+
+	r := &fakeRunner{}
+	err := SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-absent", make([]byte, volume.KeyBytes), false)
+	if err != nil {
+		t.Fatalf("a writable open ran the read-only assertion: %v", err)
+	}
+}
+
+func TestMountFlags(t *testing.T) {
+	ro := mountFlags(true)
+	if ro&unix.MS_RDONLY == 0 {
+		t.Error("read-only mount without MS_RDONLY")
+	}
+	rw := mountFlags(false)
+	if rw&unix.MS_RDONLY != 0 {
+		t.Error("writable mount carries MS_RDONLY")
+	}
+	for _, flag := range []uintptr{unix.MS_NOSUID, unix.MS_NODEV, unix.MS_NOEXEC} {
+		if rw&flag == 0 || ro&flag == 0 {
+			t.Errorf("hardening flag %d missing (rw=%d ro=%d)", flag, rw, ro)
+		}
 	}
 }
 
@@ -279,7 +313,7 @@ func TestCryptOpenPassesTheKeyOutOfBand(t *testing.T) {
 	key := make([]byte, volume.KeyBytes)
 	// assertReadOnly fails here: there is no real mapping to inspect. The open
 	// itself is what this covers.
-	_ = SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-x", key)
+	_ = SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-x", key, true)
 
 	if len(r.calls) == 0 {
 		t.Fatal("cryptsetup was never invoked")
@@ -296,7 +330,7 @@ func TestCryptOpenPassesTheKeyOutOfBand(t *testing.T) {
 // for the caller to mount.
 func TestCryptOpenClosesAMappingItCannotVerify(t *testing.T) {
 	r := &fakeRunner{}
-	err := SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-absent", make([]byte, volume.KeyBytes))
+	err := SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-absent", make([]byte, volume.KeyBytes), true)
 	if err == nil {
 		t.Fatal("an unverifiable mapping was accepted")
 	}
@@ -307,7 +341,7 @@ func TestCryptOpenClosesAMappingItCannotVerify(t *testing.T) {
 
 func TestCryptOpenReportsAFailedTool(t *testing.T) {
 	r := &fakeRunner{failOn: "open"}
-	err := SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-x", make([]byte, volume.KeyBytes))
+	err := SystemOps{Run: r.run}.CryptOpen(context.Background(), "/dev/vdb", "c8s-crypt-x", make([]byte, volume.KeyBytes), true)
 	if err == nil || !strings.Contains(err.Error(), "tool said no") {
 		t.Fatalf("got %v, want the tool's output", err)
 	}

--- a/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
+++ b/internal/helmchart/c8s/files/scripts/kata-qemu-scratch-wrapper.sh
@@ -19,8 +19,10 @@
 # a selector and not a trust input: naming another tenant's device attaches
 # ciphertext the host already holds, and the guest still cannot open it without
 # the key CDS releases against the allowlist grant (docs/volumes.md, "The serial
-# is a selector, not a trust input"). Volume devices are attached read-only, so
-# a guest cannot write ciphertext back over one.
+# is a selector, not a trust input"). Devices are attached read-write: a mutable
+# volume exists to be written, and the host cannot tell one from immutable —
+# the mode lives in the key blob, which the host never sees. An immutable
+# volume's writes are refused in the guest, at its dm-crypt mapping.
 #
 # PRODUCTION NOTE: still a prototype. The clean version attaches the disks from
 # the kata runtime (or a CDI device) rather than wrapping qemu. Tunables via env:
@@ -169,7 +171,7 @@ while IFS= read -r vol; do
     [ -n "$vol" ] || continue
     if dev="$(device_for "$vol")"; then
         volume_args+=(
-            -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
+            -drive "file=$dev,format=raw,if=none,id=confaivol$n,cache=none"
             -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol"
         )
         n=$((n + 1))

--- a/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
+++ b/internal/helmchart/c8s/files/scripts/volumed-teardown.sh
@@ -10,8 +10,9 @@
 # and leaves state no later run can reach.
 #
 # Names come from internal/cmds/volumed/open.go (mapperName): the mappings are
-# c8s-crypt-<pod-uid>-<volume> and c8s-verity-<pod-uid>-<volume>, and the
-# verity device is the mount source.
+# c8s-crypt-<pod-uid>-<volume> and c8s-verity-<pod-uid>-<volume>. The mount
+# source is the verity device for an immutable volume, the crypt device itself
+# for a mutable one.
 set -eu
 
 # Retry budget for a close. Sized to ride out kubelet's asynchronous unmount
@@ -25,14 +26,14 @@ root="${C8S_TEARDOWN_ROOT:-}"
 
 echo "==> volumed teardown starting"
 
-# 1. Unmount what the verity devices back. /proc/mounts names the source
-#    device, which holds even after kubelet has renamed the pod directory.
-#    Collect the targets before unmounting any: /proc/mounts is generated as
-#    it is read, so unmounting mid-scan would shift the rest of the file.
+# 1. Unmount what the c8s devices back. /proc/mounts names the source device,
+#    which holds even after kubelet has renamed the pod directory. Collect the
+#    targets before unmounting any: /proc/mounts is generated as it is read, so
+#    unmounting mid-scan would shift the rest of the file.
 targets=""
 while read -r source target _; do
   case "$source" in
-  /dev/mapper/c8s-verity-*) targets="$targets $target" ;;
+  /dev/mapper/c8s-verity-* | /dev/mapper/c8s-crypt-*) targets="$targets $target" ;;
   esac
 done <"$root/proc/mounts"
 

--- a/internal/helmchart/volumed_teardown_script_test.go
+++ b/internal/helmchart/volumed_teardown_script_test.go
@@ -148,6 +148,27 @@ func TestVolumedTeardownClosesCleanly(t *testing.T) {
 	}
 }
 
+// A mutable volume's mount source is the crypt device itself — there is no
+// verity layer — so the unmount scan must match it too, or uninstall leaves
+// the mapping holding the backing disk open.
+func TestVolumedTeardownUnmountsAMutableMount(t *testing.T) {
+	f := newTeardownFixture(t,
+		[]string{"c8s-crypt-podA-data"},
+		[]string{"c8s-crypt-podA-data"},
+		"")
+	out, code := f.run(t)
+	if code != 0 {
+		t.Fatalf("exit %d on a node whose mappings all close; output:\n%s", code, out)
+	}
+	calls := strings.Join(f.calls(t), "\n")
+	if !strings.Contains(calls, "umount /var/lib/kubelet/pods/pa/vol") {
+		t.Errorf("the mounted crypt device was not unmounted; calls: %v", calls)
+	}
+	if !strings.Contains(calls, "cryptsetup close c8s-crypt-podA-data") {
+		t.Errorf("the crypt mapping was not closed; calls: %v", calls)
+	}
+}
+
 func TestVolumedTeardownIsIdempotentOnAnEmptyNode(t *testing.T) {
 	f := newTeardownFixture(t, nil, nil, "")
 	out, code := f.run(t)

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -1038,9 +1038,9 @@ func mutatePod(pod *corev1.Pod, inj *injection, cfg Config) {
 			remountAll(pod, corev1.VolumeMount{
 				Name:      volume.KubeVolumeName(name),
 				MountPath: filepath.Join(effective.Volumes.Dir, name),
-				ReadOnly:  true,
-				// The node agent makes the mount outside this pod; without
-				// propagation the container keeps seeing the empty directory.
+				// Writability is the daemon's mount flags: read-only for an
+				// immutable volume, read-write for a mutable one. A container-
+				// side ReadOnly would not narrow a propagated mount anyway.
 				MountPropagation: &hostToContainer,
 			})
 		}

--- a/internal/webhook/pod_mutator_volumes_test.go
+++ b/internal/webhook/pod_mutator_volumes_test.go
@@ -64,10 +64,12 @@ func TestVolumeFetcherIsANativeSidecarAfterTheCertContainers(t *testing.T) {
 	}
 }
 
-// The plaintext is read-only to the workload, and the node agent makes the
-// mount from outside the pod — without HostToContainer the container keeps
-// seeing the empty directory it started with.
-func TestVolumeMountIsReadOnlyAndPropagated(t *testing.T) {
+// The node agent makes the mount from outside the pod — without
+// HostToContainer the container keeps seeing the empty directory it started
+// with. The container's own mount is not read-only: writability is the
+// daemon's mount flags (ro for immutable, rw for mutable), and a container-side
+// flag would not narrow a propagated mount anyway.
+func TestVolumeMountIsPropagated(t *testing.T) {
 	pod := podWithApp()
 	mutateWithVolumes(t, pod, []string{"weights=/tenant-a/volumes/weights"}, "")
 
@@ -76,8 +78,8 @@ func TestVolumeMountIsReadOnlyAndPropagated(t *testing.T) {
 	if m == nil {
 		t.Fatalf("app has no volume mount; mounts = %v", mountNames(app))
 	}
-	if !m.ReadOnly {
-		t.Error("the workload may write the decrypted volume")
+	if m.ReadOnly {
+		t.Error("a read-only container mount would hide a mutable volume's writability")
 	}
 	if m.MountPropagation == nil || *m.MountPropagation != corev1.MountPropagationHostToContainer {
 		t.Errorf("propagation = %v, want HostToContainer", m.MountPropagation)
@@ -145,8 +147,8 @@ func TestPreDeclaredVolumeAndMountAreOverwritten(t *testing.T) {
 	if m.MountPath != "/run/c8s/volumes/weights" {
 		t.Errorf("mount path = %q, want the webhook's own", m.MountPath)
 	}
-	if !m.ReadOnly {
-		t.Error("a pre-declared writable mount survived")
+	if m.ReadOnly {
+		t.Error("a pre-declared read-only mount survived")
 	}
 	if m.MountPropagation == nil || *m.MountPropagation != corev1.MountPropagationHostToContainer {
 		t.Error("a pre-declared unpropagated mount survived")

--- a/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
+++ b/kata-guest-base/scripts/kata-qemu-scratch-wrapper.sh
@@ -19,8 +19,10 @@
 # a selector and not a trust input: naming another tenant's device attaches
 # ciphertext the host already holds, and the guest still cannot open it without
 # the key CDS releases against the allowlist grant (docs/volumes.md, "The serial
-# is a selector, not a trust input"). Volume devices are attached read-only, so
-# a guest cannot write ciphertext back over one.
+# is a selector, not a trust input"). Devices are attached read-write: a mutable
+# volume exists to be written, and the host cannot tell one from immutable —
+# the mode lives in the key blob, which the host never sees. An immutable
+# volume's writes are refused in the guest, at its dm-crypt mapping.
 #
 # PRODUCTION NOTE: still a prototype. The clean version attaches the disks from
 # the kata runtime (or a CDI device) rather than wrapping qemu. Tunables via env:
@@ -169,7 +171,7 @@ while IFS= read -r vol; do
     [ -n "$vol" ] || continue
     if dev="$(device_for "$vol")"; then
         volume_args+=(
-            -drive "file=$dev,format=raw,if=none,id=confaivol$n,readonly=on,cache=none"
+            -drive "file=$dev,format=raw,if=none,id=confaivol$n,cache=none"
             -device "virtio-blk-pci,drive=confaivol$n,serial=$SERIAL_PREFIX$vol"
         )
         n=$((n + 1))


### PR DESCRIPTION
c8s volumes have been immutable after creation: erofs under dm-verity inside plain dm-crypt. Some workloads need to write — scratch space, datasets they update, checkpoints. This adds a mutable mode that keeps the same encryption and release path and drops the verification layer, which cannot cover a writable device.

`c8s volume create --mutable` builds a writable ext4 of --size bytes (preloaded from --source when given; --size inferred from the source otherwise, or required without one). The default stays immutable.

- The key blob carries the mode: "mutable": true with no verity geometry, and Validate refuses a blob with both or neither. Old escrow blobs decode as immutable; old daemons reject the new field and fail closed.
- volumed reads the mode from the validated blob: writable dm-crypt, no verity mapping, ext4 mounted rw. Immutable is unchanged. The open-idempotency commitment covers key+mode+root hash, so a mode flip on an open volume is not authorized.
- One writer per device: two rw mounts of one device corrupt the filesystem (a rolling update hits this on a single-device workload), so a device with a live mount refuses a mutable open, and one with a mutable mount refuses every open — 409 at the daemon.
- mkfs.ext4 -e remount-ro: an fs error degrades the mount read-only rather than spreading corruption; on a no-integrity volume the likely cause is the host flipping bits.
- The webhook no longer pins the container mount read-only (writability is the daemon's mount flags) and the kata qemu wrapper attaches devices read-write — the host cannot know the mode, since it lives in the key blob it never sees; immutable enforcement is the guest's dm-crypt --readonly either way.
- The uninstall teardown hook unmounts c8s-crypt-* sources too, not only c8s-verity-*.

Accepted and documented: a mutable volume has no integrity — bit flips and rollbacks are undetected. Per-sector authentication (AEAD) is future work. No resize, re-encryption, or mode conversion.