### PR TITLE
feat(cds): bind multiple measurements to verification output

### DIFF
--- a/internal/cmds/cds/measurementsconfig.go
+++ b/internal/cmds/cds/measurementsconfig.go
@@ -1,6 +1,7 @@
 package cds
 
 import (
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -55,5 +56,27 @@ func sortedIndices(m map[int][]byte) []int {
 		out = append(out, i)
 	}
 	sort.Ints(out)
+	return out
+}
+
+// servedTEE names the platform the served document declares. The flat flags
+// carry no platform of their own, so it comes from the one CDS attests on.
+func servedTEE(ratlsPlatform string) string {
+	if ratls.NormalizePlatform(ratlsPlatform) == measurements.TEETDX {
+		return measurements.TEETDX
+	}
+	return measurements.TEESNP
+}
+
+// measurementBytes decodes the flat allowlist back into digests for the
+// served document. Entries that are not hex never reached a gate either.
+func measurementBytes(allowed map[string]bool) [][]byte {
+	out := make([][]byte, 0, len(allowed))
+	for m := range allowed {
+		if b, err := hex.DecodeString(m); err == nil {
+			out = append(out, b)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return string(out[i]) < string(out[j]) })
 	return out
 }

--- a/internal/cmds/cds/routes.go
+++ b/internal/cmds/cds/routes.go
@@ -26,6 +26,7 @@ type dependencies struct {
 	JWKSFunc          func() []byte
 	CACertPEM         []byte
 	OperatorKeysPEM   []byte                // pinned operator public keys; empty = /operator-keys 404s
+	MeasurementsDoc   []byte                // reference values being enforced, as served at /measurements
 	RateLimiter       *issuer.IPRateLimiter // per-source-IP limiter for attestation endpoints
 	ChallengeLimiter  *issuer.IPRateLimiter // /authenticate's own, so it cannot spend the map above
 	MaxRequestSize    int64                 // applied to write endpoints; must be > 0
@@ -95,6 +96,7 @@ func newRouter(deps dependencies) http.Handler {
 
 	r.Get("/ca", handleCA(deps.CACertPEM))
 	r.Get("/operator-keys", handleOperatorKeys(deps.OperatorKeysPEM))
+	r.Get("/measurements", handleMeasurements(deps.MeasurementsDoc))
 
 	return r
 }
@@ -150,6 +152,20 @@ func handleCA(caCertPEM []byte) http.HandlerFunc {
 // handleOperatorKeys serves the pinned operator public-key bundle (public
 // material, like /ca) so `c8s verify` can report which keys may mutate the
 // allowlist. 404 when allowlist writes are disabled (no pinned keys).
+// handleMeasurements serves the reference values this CDS is enforcing. An
+// empty set is served, not 404'd: "admitting any measurement" is the state a
+// verifier most needs to be told about.
+func handleMeasurements(doc []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if len(doc) == 0 {
+			http.Error(w, "measurements unavailable", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(doc)
+	}
+}
+
 func handleOperatorKeys(operatorKeysPEM []byte) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		if len(operatorKeysPEM) == 0 {

--- a/internal/cmds/cds/routes_test.go
+++ b/internal/cmds/cds/routes_test.go
@@ -5,8 +5,10 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -626,4 +628,50 @@ func newStubRouterWithHandoff(t *testing.T) http.Handler {
 		MaxRequestSize:   65536,
 	}
 	return newRouter(deps)
+}
+
+// /measurements must report what this CDS enforces, and must report an empty
+// set rather than hiding it: "admits any measurement" is the finding a
+// verifier most needs.
+func TestHandleMeasurements(t *testing.T) {
+	set, err := measurements.Parse([]byte(
+		`{"schema_version":"1","tee":"sev-snp","measurements":[{"name":"a","measurement":"` +
+			strings.Repeat("ab", 48) + `"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := measurements.Serve(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	handleMeasurements(doc)(w, httptest.NewRequest(http.MethodGet, "/measurements", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	served, err := measurements.ParseServed(w.Body.Bytes())
+	if err != nil {
+		t.Fatalf("served body does not parse: %v", err)
+	}
+	if len(served.Entries) != 1 || served.TEE != measurements.TEESNP {
+		t.Errorf("served set = %+v, want the one pinned image", served)
+	}
+
+	empty, err := measurements.Serve(measurements.ReferenceValues{TEE: measurements.TEESNP})
+	if err != nil {
+		t.Fatal(err)
+	}
+	w = httptest.NewRecorder()
+	handleMeasurements(empty)(w, httptest.NewRequest(http.MethodGet, "/measurements", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("empty set status = %d, want 200 (not a 404)", w.Code)
+	}
+	servedEmpty, err := measurements.ParseServed(w.Body.Bytes())
+	if err != nil {
+		t.Fatalf("empty served body does not parse: %v", err)
+	}
+	if len(servedEmpty.Entries) != 0 {
+		t.Errorf("empty set served %d entries", len(servedEmpty.Entries))
+	}
 }

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -30,6 +30,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/earsigner"
+	measurementspkg "github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -153,6 +154,19 @@ func run(cfg config) error {
 		slog.Info("TDX RTMR pinning enabled for /attest and /attest-key", "count", len(rtmrPins))
 	} else if len(measurements) > 0 {
 		slog.Warn("--rtmrs empty: on TDX the measurement allowlist pins TDVF firmware only (MRTD); the guest kernel and rootfs are not pinned. SNP is unaffected.")
+	}
+
+	// Served at /measurements so a verifier holding the operator's own file can
+	// detect a swapped config. Built from the enforced values, never re-read
+	// from disk: re-reading would attest the file rather than the policy.
+	served := pinned
+	if served.Empty() {
+		served = measurementspkg.FromFlags(measurementBytes(measurements), rtmrPins)
+	}
+	served.TEE = servedTEE(cfg.ratlsPlatform)
+	measurementsDoc, err := measurementspkg.Serve(served)
+	if err != nil {
+		return fmt.Errorf("render /measurements document: %w", err)
 	}
 
 	dnsPatterns, err := compilePatterns("--dns-san-pattern", cfg.dnsSANPatterns)
@@ -363,6 +377,7 @@ func run(cfg config) error {
 		JWKSFunc:          rotator.JWKSetJSON,
 		CACertPEM:         caChainPEM,
 		OperatorKeysPEM:   operatorKeysPEM,
+		MeasurementsDoc:   measurementsDoc,
 		RateLimiter:       rateLimiter,
 		ChallengeLimiter:  challengeLimiter,
 		MaxRequestSize:    cfg.maxRequestSize,

--- a/internal/cmds/verify/initdata_test.go
+++ b/internal/cmds/verify/initdata_test.go
@@ -24,7 +24,7 @@ var (
 // the verdict policies, then applyInitDataNote on the final verdict.
 func finalOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, plan *verifyPlan) Outcome {
 	oc := newOutcome(cfg, ev, result, nil, plan)
-	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{})
+	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	applyInitDataNote(&oc, result, plan)
 	return oc
 }
@@ -74,7 +74,7 @@ func TestVerifyEvidence_InitDataPinMatch(t *testing.T) {
 	plan := mustPlan(t, cfg)
 
 	var out, errOut bytes.Buffer
-	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 	if code != exitVerified {
 		t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
 	}
@@ -87,7 +87,7 @@ func TestVerifyEvidence_InitDataPinMatch(t *testing.T) {
 
 	jsonCfg := config{initDataHex: genoaInitDataPin, output: "json"}
 	var jout, jerr bytes.Buffer
-	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), genoaFileEvidence(t), nil, operatorKeysReport{}, &jout, &jerr); code != exitVerified {
+	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), genoaFileEvidence(t), nil, operatorKeysReport{}, measurementsReport{}, &jout, &jerr); code != exitVerified {
 		t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitVerified, jout.String(), jerr.String())
 	}
 	var parsed map[string]any
@@ -149,7 +149,7 @@ func TestVerifyEvidence_InitDataNoteAbsentOnFailedVerdict(t *testing.T) {
 			jsonCfg := tc.cfg
 			jsonCfg.output = "json"
 			var jout, jerr bytes.Buffer
-			if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), tc.ev(t), nil, opKeys, &jout, &jerr); code != exitFailed {
+			if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), tc.ev(t), nil, opKeys, measurementsReport{}, &jout, &jerr); code != exitFailed {
 				t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitFailed, jout.String(), jerr.String())
 			}
 			var parsed map[string]any
@@ -169,7 +169,7 @@ func TestVerifyEvidence_InitDataNoteAbsentOnFailedVerdict(t *testing.T) {
 			textCfg := tc.cfg
 			textCfg.output = "text"
 			var tout, terr bytes.Buffer
-			verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), tc.ev(t), nil, opKeys, &tout, &terr)
+			verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), tc.ev(t), nil, opKeys, measurementsReport{}, &tout, &terr)
 			if text := tout.String(); strings.Contains(text, "init-data:") || strings.Contains(text, "matches --init-data") {
 				t.Errorf("a failed verdict must render no init-data line:\n%s", text)
 			}
@@ -190,7 +190,7 @@ func TestVerifyEvidence_InitDataNoteRidesPartialVerdict(t *testing.T) {
 
 	jsonCfg := config{initDataHex: genoaInitDataPin, output: "json"}
 	var jout, jerr bytes.Buffer
-	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), makeEv(t), nil, operatorKeysReport{}, &jout, &jerr); code != exitPartial {
+	if code := verifyEvidence(context.Background(), jsonCfg, mustPlan(t, jsonCfg), makeEv(t), nil, operatorKeysReport{}, measurementsReport{}, &jout, &jerr); code != exitPartial {
 		t.Fatalf("json exit = %d, want %d; output:\n%s%s", code, exitPartial, jout.String(), jerr.String())
 	}
 	var parsed map[string]any
@@ -209,7 +209,7 @@ func TestVerifyEvidence_InitDataNoteRidesPartialVerdict(t *testing.T) {
 
 	textCfg := config{initDataHex: genoaInitDataPin, output: "text"}
 	var tout, terr bytes.Buffer
-	verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), makeEv(t), nil, operatorKeysReport{}, &tout, &terr)
+	verifyEvidence(context.Background(), textCfg, mustPlan(t, textCfg), makeEv(t), nil, operatorKeysReport{}, measurementsReport{}, &tout, &terr)
 	text := tout.String()
 	for _, want := range []string{"~ PARTIALLY VERIFIED", "init-data:    " + genoaInitDataPin, "matches --init-data"} {
 		if !strings.Contains(text, want) {
@@ -226,7 +226,7 @@ func TestVerifyEvidence_InitDataPinMismatchIsRefused(t *testing.T) {
 	plan := mustPlan(t, cfg)
 
 	var out, errOut bytes.Buffer
-	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 	if code != exitFailed {
 		t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitFailed, out.String(), errOut.String())
 	}
@@ -247,7 +247,7 @@ func TestVerifyEvidence_InitDataUnpinnedIsLabelled(t *testing.T) {
 	plan := mustPlan(t, config{})
 
 	var out, errOut bytes.Buffer
-	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	code := verifyEvidence(context.Background(), cfg, plan, genoaFileEvidence(t), nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 	if code != exitVerified {
 		t.Fatalf("exit = %d, want %d; output:\n%s", code, exitVerified, out.String())
 	}

--- a/internal/cmds/verify/localverify_test.go
+++ b/internal/cmds/verify/localverify_test.go
@@ -66,7 +66,7 @@ func TestVerifyEvidence_TimeoutBoundsCollateralFetch(t *testing.T) {
 	cfg := config{timeout: 50 * time.Millisecond, output: "text"}
 	var out, errOut bytes.Buffer
 	start := time.Now()
-	code := verifyEvidence(context.Background(), cfg, &verifyPlan{policy: &ratls.VerifyPolicy{}}, bareSnpEvidence(t), nil, operatorKeysReport{}, &out, &errOut)
+	code := verifyEvidence(context.Background(), cfg, &verifyPlan{policy: &ratls.VerifyPolicy{}}, bareSnpEvidence(t), nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 	if elapsed := time.Since(start); elapsed > 10*time.Second {
 		t.Fatalf("verifyEvidence took %v, want the 50ms timeout enforced", elapsed)
 	}

--- a/internal/cmds/verify/measurementsconfig.go
+++ b/internal/cmds/verify/measurementsconfig.go
@@ -1,0 +1,140 @@
+package verify
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+)
+
+// maxServedMeasurements bounds the served document. Reference values for a
+// realistic fleet are kilobytes; a larger body is a wrong endpoint, not a
+// bigger policy.
+const maxServedMeasurements = 1 << 20
+
+// measurementsReport is the cross-check section of the verdict: what the
+// attested target says it is enforcing, beside what the operator pinned.
+type measurementsReport struct {
+	served   measurements.ReferenceValues
+	fetched  bool
+	fetchErr error
+	note     string
+}
+
+// fetchServedMeasurements GETs <base>/measurements bound to the endpoint whose
+// attestation was just verified: the handshake requires the presented leaf's
+// SHA-256 to equal wantCertSHA256, so a different endpoint — or a MITM on this
+// second connection — cannot substitute its own set into the report.
+func fetchServedMeasurements(ctx context.Context, base, serverName, wantCertSHA256 string, timeout time.Duration) (measurements.ReferenceValues, error) {
+	if wantCertSHA256 == "" {
+		return measurements.ReferenceValues{}, fmt.Errorf("no attested serving certificate to bind the fetch to")
+	}
+	tlsCfg := &tls.Config{
+		InsecureSkipVerify: true, //nolint:gosec // trust comes from the attested-cert pin below, not PKI
+		ServerName:         serverName,
+		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+			if len(rawCerts) == 0 {
+				return fmt.Errorf("no peer certificate")
+			}
+			sum := sha256.Sum256(rawCerts[0])
+			if got := hex.EncodeToString(sum[:]); got != wantCertSHA256 {
+				return fmt.Errorf("serving cert changed between attestation and measurement fetch (got sha256 %s, attested %s)", got, wantCertSHA256)
+			}
+			return nil
+		},
+	}
+	client := &http.Client{
+		Timeout:   timeout,
+		Transport: &http.Transport{TLSClientConfig: tlsCfg},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/measurements", nil)
+	if err != nil {
+		return measurements.ReferenceValues{}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return measurements.ReferenceValues{}, fmt.Errorf("fetch /measurements: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return measurements.ReferenceValues{}, fmt.Errorf("/measurements not served: this target predates the endpoint, so its enforced set cannot be checked")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return measurements.ReferenceValues{}, fmt.Errorf("/measurements returned %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxServedMeasurements+1))
+	if err != nil {
+		return measurements.ReferenceValues{}, fmt.Errorf("read /measurements: %w", err)
+	}
+	if len(body) > maxServedMeasurements {
+		return measurements.ReferenceValues{}, fmt.Errorf("/measurements body exceeds %d bytes", maxServedMeasurements)
+	}
+	return measurements.ParseServed(body)
+}
+
+// checkServedMeasurements compares the served set against the operator's file.
+// Equality is exact in both directions: an entry the target pins and the file
+// does not is the substitution this check exists to catch, and one the file
+// pins and the target does not means the cluster is enforcing less than the
+// operator believes.
+func checkServedMeasurements(want measurements.ReferenceValues, report measurementsReport, fail func(string, ...any)) {
+	if report.fetchErr != nil {
+		fail("could not fetch /measurements to check it against --measurements-config: %v", report.fetchErr)
+		return
+	}
+	if !report.fetched {
+		fail("--measurements-config cannot be checked: %s", report.note)
+		return
+	}
+	if len(report.served.Entries) == 0 {
+		fail("the target serves an empty measurement set: it admits any TEE attestation, while --measurements-config pins %d image(s)", len(want.Entries))
+		return
+	}
+	if want.TEE != report.served.TEE {
+		fail("--measurements-config is for %q but the target enforces %q", want.TEE, report.served.TEE)
+		return
+	}
+	missing, extra := measurements.Diff(want, report.served)
+	for _, e := range extra {
+		fail("the target admits an image --measurements-config does not pin: %s (%x)", e.Name, e.Digest)
+	}
+	for _, e := range missing {
+		fail("--measurements-config pins an image the target does not admit: %s (%x)", e.Name, e.Digest)
+	}
+}
+
+// gatherMeasurements fetches the set the target reports enforcing. Like the
+// operator-key fetch it never fails the run here; a fetch error is recorded so
+// checkServedMeasurements can fail the verdict when --measurements-config
+// asked for the check, rather than letting an erroring endpoint dodge it.
+func gatherMeasurements(ctx context.Context, cfg config, ev *evidence) measurementsReport {
+	if cfg.measurementsConfig == "" {
+		return measurementsReport{}
+	}
+	if cfg.kind != "cds" {
+		return measurementsReport{note: "target kind is not cds (use --kind cds to enable)"}
+	}
+	if cfg.url == "" {
+		return measurementsReport{note: "not fetched (no target URL)"}
+	}
+	if ev.certSHA256 == "" {
+		return measurementsReport{note: "not fetched (no serving cert to bind to)"}
+	}
+	_, baseURL, err := normalizeTarget(cfg.url, defaultPort(cfg))
+	if err != nil {
+		return measurementsReport{note: "not fetched: " + err.Error()}
+	}
+	served, err := fetchServedMeasurements(ctx, baseURL, cfg.server, ev.certSHA256, cfg.timeout)
+	if err != nil {
+		return measurementsReport{note: "not fetched: " + err.Error(), fetchErr: err}
+	}
+	return measurementsReport{served: served, fetched: true}
+}

--- a/internal/cmds/verify/measurementsconfig_test.go
+++ b/internal/cmds/verify/measurementsconfig_test.go
@@ -1,0 +1,186 @@
+package verify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+)
+
+const (
+	mcDigestA = "aa11000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	mcDigestB = "bb22000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+)
+
+func mcSet(t *testing.T, entries string) measurements.ReferenceValues {
+	t.Helper()
+	s, err := measurements.ParseServed([]byte(`{"schema_version":"1","tee":"sev-snp","measurements":[` + entries + `]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+// collectFailures stands in for the verdict's fail sink.
+func collectFailures() (func(string, ...any), *[]string) {
+	var msgs []string
+	return func(format string, args ...any) { msgs = append(msgs, fmt.Sprintf(format, args...)) }, &msgs
+}
+
+func TestCheckServedMeasurementsExactMatch(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: want, fetched: true}, fail)
+	if len(*msgs) != 0 {
+		t.Errorf("identical sets reported a difference: %v", *msgs)
+	}
+}
+
+// An image the target admits and the operator did not pin is the substitution
+// this check exists to catch.
+func TestCheckServedMeasurementsReportsAnExtraImage(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+	served := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"},{"name":"rogue","measurement":"00`+mcDigestB+`"}`)
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: served, fetched: true}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "admits an image") {
+		t.Fatalf("extra entry not reported: %v", *msgs)
+	}
+	if !strings.Contains((*msgs)[0], "rogue") {
+		t.Errorf("failure does not name the offending image: %s", (*msgs)[0])
+	}
+}
+
+// The other direction means the cluster enforces less than the operator thinks.
+func TestCheckServedMeasurementsReportsAMissingImage(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"},{"name":"b","measurement":"00`+mcDigestB+`"}`)
+	served := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: served, fetched: true}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "does not admit") {
+		t.Fatalf("missing entry not reported: %v", *msgs)
+	}
+}
+
+// A target enforcing nothing is the loudest finding, not a quiet difference.
+func TestCheckServedMeasurementsReportsAnEmptySet(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: measurements.ReferenceValues{TEE: measurements.TEESNP}, fetched: true}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "empty measurement set") {
+		t.Fatalf("an unpinned target was not reported: %v", *msgs)
+	}
+}
+
+// Names carry no matching semantics, so the same pin under another name is
+// still the same pin.
+func TestCheckServedMeasurementsIgnoresNames(t *testing.T) {
+	want := mcSet(t, `{"name":"local-name","measurement":"00`+mcDigestA+`"}`)
+	served := mcSet(t, `{"name":"cluster-name","measurement":"00`+mcDigestA+`"}`)
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: served, fetched: true}, fail)
+	if len(*msgs) != 0 {
+		t.Errorf("differing names reported as a mismatch: %v", *msgs)
+	}
+}
+
+// Neither an unfetched check nor a failed fetch may pass silently.
+func TestCheckServedMeasurementsNeverPassesUnchecked(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+
+	fail, msgs := collectFailures()
+	checkServedMeasurements(want, measurementsReport{note: "target kind is not cds"}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "cannot be checked") {
+		t.Errorf("unfetched check did not fail: %v", *msgs)
+	}
+
+	fail, msgs = collectFailures()
+	checkServedMeasurements(want, measurementsReport{fetchErr: fmt.Errorf("connection refused")}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "could not fetch") {
+		t.Errorf("fetch error did not fail: %v", *msgs)
+	}
+}
+
+// A target on the other platform is a policy error, not a per-image diff.
+func TestCheckServedMeasurementsReportsPlatformMismatch(t *testing.T) {
+	want := mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`)
+	served, err := measurements.ParseServed([]byte(
+		`{"schema_version":"1","tee":"tdx","measurements":[{"name":"a","mrtd":"00` + mcDigestA + `"}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fail, msgs := collectFailures()
+
+	checkServedMeasurements(want, measurementsReport{served: served, fetched: true}, fail)
+	if len(*msgs) != 1 || !strings.Contains((*msgs)[0], "the target enforces") {
+		t.Fatalf("platform mismatch not reported: %v", *msgs)
+	}
+}
+
+// End to end over HTTPS: the fetch must read a real served document, and must
+// refuse a server whose certificate is not the one that was attested — that
+// binding is what stops a substituted endpoint answering for CDS.
+func TestFetchServedMeasurementsBindsToTheAttestedCert(t *testing.T) {
+	doc, err := measurements.Serve(mcSet(t, `{"name":"a","measurement":"00`+mcDigestA+`"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/measurements" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Write(doc)
+	}))
+	defer srv.Close()
+
+	leaf := srv.Certificate().Raw
+	sum := sha256.Sum256(leaf)
+	attested := hex.EncodeToString(sum[:])
+
+	got, err := fetchServedMeasurements(context.Background(), srv.URL, "example.com", attested, 10*time.Second)
+	if err != nil {
+		t.Fatalf("fetch over the attested cert failed: %v", err)
+	}
+	if len(got.Entries) != 1 || got.TEE != measurements.TEESNP {
+		t.Fatalf("served set = %+v, want the one pinned image", got)
+	}
+
+	// A different attested fingerprint must abort the handshake.
+	if _, err := fetchServedMeasurements(context.Background(), srv.URL, "example.com", strings.Repeat("00", 32), 10*time.Second); err == nil {
+		t.Error("fetch accepted a server that is not the attested target")
+	}
+
+	// No attested cert at all is refused rather than fetched unbound.
+	if _, err := fetchServedMeasurements(context.Background(), srv.URL, "example.com", "", 10*time.Second); err == nil {
+		t.Error("fetch proceeded with nothing to bind to")
+	}
+}
+
+// A target that does not serve the endpoint must be reported, never treated as
+// agreement.
+func TestFetchServedMeasurementsReportsAMissingEndpoint(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(http.NotFound))
+	defer srv.Close()
+	sum := sha256.Sum256(srv.Certificate().Raw)
+
+	_, err := fetchServedMeasurements(context.Background(), srv.URL, "example.com", hex.EncodeToString(sum[:]), 10*time.Second)
+	if err == nil {
+		t.Fatal("a 404 was not reported")
+	}
+	if !strings.Contains(err.Error(), "not served") {
+		t.Errorf("error %q does not explain the missing endpoint", err)
+	}
+}

--- a/internal/cmds/verify/partial_test.go
+++ b/internal/cmds/verify/partial_test.go
@@ -83,7 +83,7 @@ func snpVerifiedOutcome(t *testing.T, cfg config, ev *evidence) Outcome {
 		Claims:         teetypes.Claims{LaunchDigest: launch},
 	}
 	oc := newOutcome(cfg, ev, result, nil, plan)
-	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{})
+	applyVerdictPolicies(&oc, cfg, ev, nil, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	return oc
 }
 
@@ -144,7 +144,7 @@ func TestWebPKIFrontDoorIsPartialNotVerified(t *testing.T) {
 	// the door lie rides the failure instead of being buried by it.
 	verr := &securityError{err: errors.New("rejected")}
 	failed := newOutcome(config{}, ev, nil, verr, mustPlan(t, config{measurements: []string{"ab" + strings.Repeat("00", 47)}}))
-	applyVerdictPolicies(&failed, config{}, ev, nil, operatorKeysReport{})
+	applyVerdictPolicies(&failed, config{}, ev, nil, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if failed.Partial || verdictExitCode(failed) != exitFailed {
 		t.Errorf("failed evidence + webpki: partial=%v exit=%d, want a plain failure", failed.Partial, verdictExitCode(failed))
 	}
@@ -171,7 +171,7 @@ func TestFrontDoorVerdictJSONHonesty(t *testing.T) {
 	failedOutcome := func(ev *evidence) Outcome {
 		verr := &securityError{err: errors.New("rejected")}
 		oc := newOutcome(config{}, ev, nil, verr, mustPlan(t, config{measurements: []string{"ab" + strings.Repeat("00", 47)}}))
-		applyVerdictPolicies(&oc, config{}, ev, nil, operatorKeysReport{})
+		applyVerdictPolicies(&oc, config{}, ev, nil, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 		return oc
 	}
 	renderJSON := func(oc Outcome) map[string]any {
@@ -273,7 +273,7 @@ func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 		ev := genoaFileEvidence(t)
 		ev.frontDoor = frontDoorOther // as a discovery gather would record it
 		var out, errOut bytes.Buffer
-		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 		if code != exitPartial {
 			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitPartial, out.String(), errOut.String())
 		}
@@ -286,7 +286,7 @@ func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 		ev := genoaFileEvidence(t)
 		ev.frontDoor = frontDoorUnobserved // discovery doc fetched over a non-TLS connection
 		var out, errOut bytes.Buffer
-		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 		if code != exitPartial {
 			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitPartial, out.String(), errOut.String())
 		}
@@ -296,7 +296,7 @@ func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 		ev := genoaFileEvidence(t)
 		ev.frontDoor = frontDoorAttested
 		var out, errOut bytes.Buffer
-		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 		if code != exitVerified {
 			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
 		}
@@ -311,7 +311,7 @@ func TestVerifyEvidenceFrontDoorExitCodes(t *testing.T) {
 	t.Run("no front-door property still verifies", func(t *testing.T) {
 		ev := genoaFileEvidence(t) // frontDoorNone — not discovery-sourced
 		var out, errOut bytes.Buffer
-		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, &out, &errOut)
+		code := verifyEvidence(context.Background(), config{output: "text"}, plan, ev, nil, operatorKeysReport{}, measurementsReport{}, &out, &errOut)
 		if code != exitVerified {
 			t.Fatalf("exit = %d, want %d; output:\n%s%s", code, exitVerified, out.String(), errOut.String())
 		}

--- a/internal/cmds/verify/sandbox_test.go
+++ b/internal/cmds/verify/sandbox_test.go
@@ -103,7 +103,7 @@ func TestApplySandboxPolicyReportsProvenance(t *testing.T) {
 	}
 
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{}, ev, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{}, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.SandboxID != id {
 		t.Fatalf("SandboxID = %q, want %q", oc.SandboxID, id)
 	}
@@ -113,7 +113,7 @@ func TestApplySandboxPolicyReportsProvenance(t *testing.T) {
 
 	// A failed hardware verdict must not surface an "attested-looking" ID.
 	failed := Outcome{Verified: false}
-	applySandboxPolicy(&failed, config{}, ev, operatorKeysReport{})
+	applySandboxPolicy(&failed, config{}, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if failed.SandboxID != "" {
 		t.Fatalf("SandboxID = %q on a failed verdict, want empty", failed.SandboxID)
 	}
@@ -153,7 +153,7 @@ func TestApplySandboxPolicySelfSignedFailsMeshCA(t *testing.T) {
 	}
 
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{sandboxID: id, meshCA: caPath}, ev, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{sandboxID: id, meshCA: caPath}, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("self-signed leaf claiming the pinned sandbox ID passed --mesh-ca")
 	}
@@ -165,7 +165,7 @@ func TestApplySandboxPolicySelfSignedFailsMeshCA(t *testing.T) {
 // A malformed sandbox-ID extension fails the verdict rather than being ignored.
 func TestApplySandboxPolicyUnparseableIDFailsClosed(t *testing.T) {
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{}, &evidence{sandboxErr: errSandboxTest}, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{}, &evidence{sandboxErr: errSandboxTest}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("unparseable sandbox-ID extension did not fail the verdict")
 	}
@@ -242,7 +242,7 @@ func TestApplySandboxPolicyVerifiedAgainstMeshCA(t *testing.T) {
 	ev := &evidence{leaf: leaf, sandboxID: id}
 
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{sandboxID: id, meshCA: caPath}, ev, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{sandboxID: id, meshCA: caPath}, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if !oc.Verified {
 		t.Fatalf("verdict failed: %s", oc.Error)
 	}
@@ -252,7 +252,7 @@ func TestApplySandboxPolicyVerifiedAgainstMeshCA(t *testing.T) {
 
 	// A different expected ID on the same chain-valid leaf must still fail.
 	mismatch := Outcome{Verified: true}
-	applySandboxPolicy(&mismatch, config{sandboxID: "someother", meshCA: caPath}, ev, operatorKeysReport{})
+	applySandboxPolicy(&mismatch, config{sandboxID: "someother", meshCA: caPath}, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if mismatch.Verified {
 		t.Fatal("a mismatched --sandbox-id passed on a chain-valid leaf")
 	}
@@ -263,7 +263,7 @@ func TestApplySandboxPolicyVerifiedAgainstMeshCA(t *testing.T) {
 func TestApplySandboxPolicyMeshCANeedsALeaf(t *testing.T) {
 	_, caPath := caSignedLeaf(t, "abc")
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{meshCA: caPath}, &evidence{}, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{meshCA: caPath}, &evidence{}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("--mesh-ca silently passed with no leaf to check")
 	}
@@ -273,7 +273,7 @@ func TestApplySandboxPolicyMeshCANeedsALeaf(t *testing.T) {
 // discovery target) must fail the pin rather than skip it.
 func TestApplySandboxPolicyPinNeedsALeaf(t *testing.T) {
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{sandboxID: "8d9f6c2b1a0e"}, &evidence{}, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{sandboxID: "8d9f6c2b1a0e"}, &evidence{}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("--sandbox-id silently passed with no leaf to check")
 	}
@@ -286,7 +286,7 @@ func TestApplySandboxPolicyPinNeedsALeaf(t *testing.T) {
 // pin the operator asked for can never be silently dropped.
 func TestApplySandboxPolicyUnreadableOperatorKeysFile(t *testing.T) {
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{operatorKeys: filepath.Join(t.TempDir(), "absent")}, &evidence{}, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{operatorKeys: filepath.Join(t.TempDir(), "absent")}, &evidence{}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("an unreadable --operator-keys file passed at apply time")
 	}
@@ -321,7 +321,7 @@ func TestApplySandboxPolicyOperatorKeys(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			oc := Outcome{Verified: true}
-			applySandboxPolicy(&oc, config{operatorKeys: keysPath}, &evidence{}, tc.report)
+			applySandboxPolicy(&oc, config{operatorKeys: keysPath}, &evidence{}, tc.report, &verifyPlan{}, measurementsReport{})
 			if oc.Verified != tc.want {
 				t.Fatalf("Verified = %v, want %v (error: %s)", oc.Verified, tc.want, oc.Error)
 			}
@@ -350,7 +350,7 @@ func TestMeshCABundleErrors(t *testing.T) {
 	// And at policy-application time, where the file is read again.
 	leaf, _ := caSignedLeaf(t, "abc")
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, config{meshCA: notPEM}, &evidence{leaf: leaf}, operatorKeysReport{})
+	applySandboxPolicy(&oc, config{meshCA: notPEM}, &evidence{leaf: leaf}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	if oc.Verified {
 		t.Fatal("an unusable --mesh-ca bundle passed at apply time")
 	}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -29,6 +29,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
+	measurementspkg "github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
@@ -108,24 +109,25 @@ type config struct {
 	fromFile      string
 	discoveryPath string
 
-	measurements     []string
-	measurementsFile string
-	imageManifest    string
-	expectedRTMR3Hex string
-	operatorPubkey   string
-	rtmrs            []string
-	operatorKeys     string
-	sandboxID        string
-	workload         string
-	allowlistFile    string
-	meshCA           string
-	initDataHex      string
-	allowDebug       bool
-	minTCBBootloader uint
-	minTCBTEE        uint
-	minTCBSNP        uint
-	minTCBMicrocode  uint
-	expectedRDHex    string
+	measurements       []string
+	measurementsFile   string
+	imageManifest      string
+	expectedRTMR3Hex   string
+	operatorPubkey     string
+	rtmrs              []string
+	operatorKeys       string
+	measurementsConfig string
+	sandboxID          string
+	workload           string
+	allowlistFile      string
+	meshCA             string
+	initDataHex        string
+	allowDebug         bool
+	minTCBBootloader   uint
+	minTCBTEE          uint
+	minTCBSNP          uint
+	minTCBMicrocode    uint
+	expectedRDHex      string
 
 	output       string
 	showEvidence bool
@@ -206,6 +208,7 @@ responder chose).`,
 	f.StringVar(&cfg.expectedRTMR3Hex, "expected-rtmr3", "", "DEPRECATED, prefer --rtmr 3=<sha384-hex>: identical pin under identical rules, one flag for every register. Retained so existing invocations keep working")
 	f.StringVar(&cfg.operatorPubkey, "operator-pkey", "", "path to the operator PUBLIC key PEM (the verbatim file bytes the guest initrd hashed, as written by `openssl ec -pubout`) — derives and pins RTMR[3] as the bare operator-key seed, SHA-384(0x00*48 ‖ SHA-384(pubkey)), so the register need not be computed by hand. Mutually exclusive with --expected-rtmr3, and like it a deployment property, NOT a cluster identity, so it requires --image-manifest. The bare seed is the value a node with no per-workload RTMR[3] extends reports, which today is every node (the workload measurer ships only inside the kata guest image). TDX evidence only — with SNP evidence this is a policy error")
 	f.StringSliceVar(&cfg.rtmrs, "rtmr", nil, "expected TDX runtime measurement register(s) as <index>=<sha384-hex> (repeatable). RTMR[1] pins the guest kernel and RTMR[2] the kernel command line carrying the dm-verity root hash: these ARE the image, so pinning them by hand cannot be combined with --image-manifest, which pins the same two plus the MRTD from one provenanced build. RTMR[3] is the operator-key/workload chain extended inside whatever image the host booted, so --rtmr 3= REQUIRES --image-manifest — alone it would read as proof of identity while proving none. RTMR[0] is not pinnable. TDX evidence only — with SNP evidence any pin here is a policy error")
+	f.StringVar(&cfg.measurementsConfig, "measurements-config", "", "measurements config listing the VM images this cluster runs. Pins the target to those images, and for kind=cds also fails unless the set the target serves at /measurements is exactly the same. Cannot be combined with --measurements, --measurements-file or --image-manifest")
 	f.StringVar(&cfg.operatorKeys, "operator-keys", "", "PEM bundle of expected operator public keys; verification fails unless the key set the attested target serves at /operator-keys matches it (kind=cds targets)")
 	f.StringVar(&cfg.sandboxID, "sandbox-id", "", "expected CRI pod sandbox ID on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the ID (docs/ratls.md)")
 	f.StringVar(&cfg.workload, "workload", "", "expected matched-workload name on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the stamp (docs/ratls.md)")
@@ -294,7 +297,7 @@ func run(ctx context.Context, cfg config, out, errOut io.Writer) int {
 		fmt.Fprintf(errOut, "error: could not obtain evidence: %v\n", err)
 		return exitNoEvidence
 	}
-	return verifyEvidence(ctx, cfg, plan, ev, held, gatherOperatorKeys(ctx, cfg, ev), out, errOut)
+	return verifyEvidence(ctx, cfg, plan, ev, held, gatherOperatorKeys(ctx, cfg, ev), gatherMeasurements(ctx, cfg, ev), out, errOut)
 }
 
 // targetDescription names the evidence source for a verdict produced before
@@ -352,7 +355,7 @@ func gatherOperatorKeys(ctx context.Context, cfg config, ev *evidence) operatorK
 // both work — then renders the verdict. The verification attempt (including the
 // KDS fetch) is bounded by --timeout; an unobtainable-collateral failure is
 // exit 3, not a verification verdict.
-func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evidence, held *heldAllowlist, opKeys operatorKeysReport, out, errOut io.Writer) int {
+func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evidence, held *heldAllowlist, opKeys operatorKeysReport, servedMeasurements measurementsReport, out, errOut io.Writer) int {
 	if cfg.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, cfg.timeout)
@@ -366,7 +369,7 @@ func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evide
 	oc := newOutcome(cfg, ev, result, verr, plan)
 	oc.OperatorKeys = opKeys.fingerprints
 	oc.OperatorKeysNote = opKeys.note
-	applyVerdictPolicies(&oc, cfg, ev, held, opKeys)
+	applyVerdictPolicies(&oc, cfg, ev, held, opKeys, plan, servedMeasurements)
 	applyInitDataNote(&oc, result, plan)
 	render(cfg, oc, out)
 	return verdictExitCode(oc)
@@ -377,8 +380,8 @@ func verifyEvidence(ctx context.Context, cfg config, plan *verifyPlan, ev *evide
 // the verdict), then the honesty demotions, which only ever turn a passing
 // verdict partial. Ordering matters: applyChainAnchorPolicy reads the pinned
 // chain check's outcome from oc.Verified.
-func applyVerdictPolicies(oc *Outcome, cfg config, ev *evidence, held *heldAllowlist, opKeys operatorKeysReport) {
-	applySandboxPolicy(oc, cfg, ev, opKeys)
+func applyVerdictPolicies(oc *Outcome, cfg config, ev *evidence, held *heldAllowlist, opKeys operatorKeysReport, plan *verifyPlan, servedMeasurements measurementsReport) {
+	applySandboxPolicy(oc, cfg, ev, opKeys, plan, servedMeasurements)
 	applyWorkloadPolicy(oc, cfg, ev, held)
 	applyFrontDoorPolicy(oc, ev)
 	applyChainAnchorPolicy(oc, cfg, ev)
@@ -491,6 +494,9 @@ type verifyPlan struct {
 	meshCA *x509.CertPool
 	// initDataHash is the parsed --init-data pin, nil when the flag is unset.
 	initDataHash []byte
+	// refValues is the parsed --measurements-config, empty when unset. It
+	// both pins the target and is compared against what the target serves.
+	refValues measurementspkg.ReferenceValues
 }
 
 // buildPolicy parses the measurement allowlist, resolves the register pins and
@@ -520,9 +526,22 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 	// failure rather than the typo it is. Refuse the pair up front, before any
 	// file is read, so a contradictory invocation is a usage error here just as
 	// it already is in the client-side verifier.
+	if cfg.measurementsConfig != "" && (len(cfg.measurements) > 0 || cfg.measurementsFile != "" || cfg.imageManifest != "") {
+		return nil, fmt.Errorf("--measurements-config cannot be combined with --measurements, --measurements-file or --image-manifest: it already pins whole images, and a second allowlist beside it can only narrow or contradict that")
+	}
 	if cfg.imageManifest != "" && (len(cfg.measurements) > 0 || cfg.measurementsFile != "") {
 		used := allowlistFlagsUsed(cfg)
 		return nil, fmt.Errorf("%s cannot be combined with --image-manifest: the manifest pins MRTD exactly (together with RTMR[1] and RTMR[2] from the same build), so a launch-measurement allowlist beside it can only narrow that single digest or contradict it, and a contradiction is a policy no guest can ever satisfy. To pin this image, drop %s; to accept several firmware images instead, drop --image-manifest — which also gives up its RTMR[1]/RTMR[2] guest kernel and rootfs pins", used, used)
+	}
+
+	// Read once, here, like every other file-backed pin on this path.
+	var refValues measurementspkg.ReferenceValues
+	if cfg.measurementsConfig != "" {
+		loaded, err := measurementspkg.Load(cfg.measurementsConfig)
+		if err != nil {
+			return nil, err
+		}
+		refValues = loaded
 	}
 
 	hexes := append([]string{}, cfg.measurements...)
@@ -608,6 +627,7 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 		// ever verified through the delegated attestation-api path. It is not
 		// what enforces it today — see rtmrPins.manual.
 		policy: &ratls.VerifyPolicy{
+			Entries:      refValues.Entries,
 			Measurements: measurements,
 			RTMRs:        pins.manual,
 			AllowDebug:   cfg.allowDebug,
@@ -615,6 +635,7 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 		pins:         pins,
 		meshCA:       caPool,
 		initDataHash: initDataHash,
+		refValues:    refValues,
 	}, nil
 }
 
@@ -1109,7 +1130,7 @@ type Outcome struct {
 // applySandboxPolicy surfaces the leaf's sandbox ID and enforces --sandbox-id /
 // --operator-keys. It only ever demotes Verified — nothing here can rescue a
 // failed hardware verification (docs/ratls.md).
-func applySandboxPolicy(oc *Outcome, cfg config, ev *evidence, opKeys operatorKeysReport) {
+func applySandboxPolicy(oc *Outcome, cfg config, ev *evidence, opKeys operatorKeysReport, plan *verifyPlan, servedMeasurements measurementsReport) {
 	fail := func(format string, args ...any) {
 		oc.Verified = false
 		if oc.Error == "" {
@@ -1166,6 +1187,8 @@ func applySandboxPolicy(oc *Outcome, cfg config, ev *evidence, opKeys operatorKe
 		}
 	}
 
+	checkMeasurementsConfig(cfg, plan, servedMeasurements, fail)
+
 	// The served key list is authenticated by being fetched over the attested
 	// serving cert. A failed fetch fails closed when the operator asked for the
 	// check (a 404 is not an error — it maps to the empty-set digest in
@@ -1192,6 +1215,16 @@ func applySandboxPolicy(oc *Outcome, cfg config, ev *evidence, opKeys operatorKe
 	if !bytes.Equal(opKeys.digest, expected) {
 		fail("served /operator-keys digest %x does not match the --operator-keys set (%x)", opKeys.digest, expected)
 	}
+}
+
+// checkMeasurementsConfig compares the set the target reports enforcing against
+// the operator's own file. A swapped config leaves the launch measurement
+// untouched, so this is what makes the substitution visible.
+func checkMeasurementsConfig(cfg config, plan *verifyPlan, served measurementsReport, fail func(string, ...any)) {
+	if cfg.measurementsConfig == "" {
+		return
+	}
+	checkServedMeasurements(plan.refValues, served, fail)
 }
 
 // applyWorkloadPolicy surfaces the leaf's matched-workload stamp and enforces

--- a/internal/cmds/verify/workload_test.go
+++ b/internal/cmds/verify/workload_test.go
@@ -192,7 +192,7 @@ func TestApplyWorkloadPolicyPins(t *testing.T) {
 			t.Fatalf("loadHeldAllowlist: %v", err)
 		}
 		oc := Outcome{Verified: true}
-		applySandboxPolicy(&oc, cfg, ev, operatorKeysReport{})
+		applySandboxPolicy(&oc, cfg, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 		applyWorkloadPolicy(&oc, cfg, ev, held)
 		return oc
 	}
@@ -286,7 +286,7 @@ func TestHeldAllowlistIsReadOnce(t *testing.T) {
 	cfg := config{allowlistFile: path, meshCA: caPath}
 	ev := &evidence{leaf: leaf, workload: matched}
 	oc := Outcome{Verified: true}
-	applySandboxPolicy(&oc, cfg, ev, operatorKeysReport{})
+	applySandboxPolicy(&oc, cfg, ev, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
 	applyWorkloadPolicy(&oc, cfg, ev, held)
 	if !oc.Verified {
 		t.Fatalf("verdict re-read the file instead of using the loaded bytes: %s", oc.Error)

--- a/pkg/measurements/measurements.go
+++ b/pkg/measurements/measurements.go
@@ -419,3 +419,77 @@ func duplicateKey(obj []byte) (string, error) {
 	}
 	return "", nil
 }
+
+// ParseServed decodes a document a component serves to describe the reference
+// values it is enforcing. Unlike [Parse] it tolerates an empty set — a
+// component enforcing nothing is a report a verifier must be able to read and
+// act on, not a document to reject — and it is not the path an operator's own
+// file takes. See pkg/allowlist ParseJSON vs ParseServedJSON for the same split.
+func ParseServed(data []byte) (ReferenceValues, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var f wire
+	if err := dec.Decode(&f); err != nil {
+		return ReferenceValues{}, fmt.Errorf("decode served measurements: %w", err)
+	}
+	if f.SchemaVersion != SchemaVersion1 {
+		return ReferenceValues{}, fmt.Errorf("served schema_version %q, want %q", f.SchemaVersion, SchemaVersion1)
+	}
+	if f.TEE != TEESNP && f.TEE != TEETDX {
+		return ReferenceValues{}, fmt.Errorf("served tee %q, want %q or %q", f.TEE, TEESNP, TEETDX)
+	}
+	set := ReferenceValues{TEE: f.TEE}
+	for i, we := range f.Measurements {
+		e, err := we.validate(f.TEE, i)
+		if err != nil {
+			return ReferenceValues{}, err
+		}
+		set.Entries = append(set.Entries, e)
+	}
+	return set, nil
+}
+
+// Serve renders the set as a document describing what is being enforced. It
+// accepts an empty set, which [Format] does not: "pinning nothing" is exactly
+// the state a verifier most needs reported.
+func Serve(s ReferenceValues) ([]byte, error) {
+	if len(s.Entries) == 0 {
+		f := wire{SchemaVersion: SchemaVersion1, TEE: s.TEE, Measurements: []wireEntry{}}
+		out, err := json.MarshalIndent(f, "", "  ")
+		if err != nil {
+			return nil, fmt.Errorf("encode served measurements: %w", err)
+		}
+		return append(out, '\n'), nil
+	}
+	return Format(s)
+}
+
+// Diff reports the entries each side pins and the other does not, matched on
+// what decides admission — the digest and its registers. Names are diagnostic
+// only, so two entries naming one image differently are still the same pin.
+func Diff(want, got ReferenceValues) (missing, extra []Entry) {
+	index := func(s ReferenceValues) map[string]Entry {
+		m := make(map[string]Entry, len(s.Entries))
+		for _, e := range s.Entries {
+			m[tupleKey(e)] = e
+		}
+		return m
+	}
+	w, g := index(want), index(got)
+	for k, e := range w {
+		if _, ok := g[k]; !ok {
+			missing = append(missing, e)
+		}
+	}
+	for k, e := range g {
+		if _, ok := w[k]; !ok {
+			extra = append(extra, e)
+		}
+	}
+	sortEntries(missing)
+	sortEntries(extra)
+	return missing, extra
+}
+
+func sortEntries(e []Entry) {
+	sort.Slice(e, func(i, j int) bool { return tupleKey(e[i]) < tupleKey(e[j]) })
+}


### PR DESCRIPTION
- CDS serves what it is enforcing at /measurements, built from the resolved values rather than re-read from disk — re-reading would attest the file, not the policy. Works in flat-flag mode too.
- An empty set is served, not 404'd: "admits any measurement" is the state a verifier most needs told.
- c8s verify --measurements-config pins the target from the file and, for kind=cds, requires the served set to match it exactly in both directions.
- The fetch is bound to the attested serving cert, so a substituted endpoint cannot answer for CDS on the second connection.
- A failed or skipped fetch fails the verdict; it never passes unchecked.