### PR TITLE
fix(ratls-mesh): stop the jump watchdog evicting its own FORWARD guards

### DIFF
--- a/internal/cmds/ratlsmesh/iptables.go
+++ b/internal/cmds/ratlsmesh/iptables.go
@@ -498,10 +498,11 @@ func buildCWEgressGuardRules() []iptablesRule {
 	return rules
 }
 
-// cwJumpRule returns the filter FORWARD jump into the cw guard chain. It must
-// sit at position 1: KUBE-FORWARD's mark-based ACCEPT would otherwise admit
-// DNAT'd Service traffic before the drop runs. Args must stay exactly
-// {"-j", cwChainName} — see the isJumpAtHead literal-compare note.
+// cwJumpRule returns the filter FORWARD jump into the cw guard chain. It rides
+// at the head of FORWARD alongside cwEgressJumpRule: KUBE-FORWARD's mark-based
+// ACCEPT would otherwise admit DNAT'd Service traffic before the drop runs.
+// Args must stay exactly {"-j", cwChainName} — see the parseJumpBlockAtHead
+// literal-compare note.
 func cwJumpRule() iptablesRule {
 	return iptablesRule{
 		table: "filter",
@@ -513,7 +514,7 @@ func cwJumpRule() iptablesRule {
 
 // cwEgressJumpRule returns the filter FORWARD jump into the cw egress guard
 // chain. Args must stay exactly {"-j", cwEgressChainName} — see the
-// isJumpAtHead literal-compare note.
+// parseJumpBlockAtHead literal-compare note.
 func cwEgressJumpRule() iptablesRule {
 	return iptablesRule{
 		table: "filter",

--- a/internal/cmds/ratlsmesh/iptables_linux.go
+++ b/internal/cmds/ratlsmesh/iptables_linux.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -141,10 +142,40 @@ func ensureIptablesJumps(logger *slog.Logger, jumps []iptablesRule) error {
 	return nil
 }
 
-// ensureIptablesJumpsForBinary keeps base-chain jumps at position 1 so the
-// mesh rules run before kube-proxy's service DNAT. If a jump is already at
-// position 1 the call is a cheap no-op; otherwise the jump is re-inserted
-// at the head. Two separate counters distinguish:
+// jumpBlock is the ordered run of mesh jumps that must occupy the head of one
+// base chain, ahead of kube-proxy's service DNAT and of KUBE-FORWARD's
+// mark-based ACCEPT. filter FORWARD carries two of them, so head position is a
+// property of the block rather than of a single rule.
+type jumpBlock struct {
+	table string
+	chain string
+	jumps []iptablesRule
+}
+
+// jumpBlocksFor groups jumps by base chain for one family, preserving
+// declaration order: that order is the head order the watchdog asserts.
+func jumpBlocksFor(jumps []iptablesRule, family iptablesFamily) []jumpBlock {
+	var blocks []jumpBlock
+	index := map[[2]string]int{}
+	for _, jump := range jumps {
+		if jump.family != iptablesFamilyAll && jump.family != family {
+			continue
+		}
+		key := [2]string{jump.table, jump.chain}
+		i, ok := index[key]
+		if !ok {
+			i = len(blocks)
+			index[key] = i
+			blocks = append(blocks, jumpBlock{table: jump.table, chain: jump.chain})
+		}
+		blocks[i].jumps = append(blocks[i].jumps, jump)
+	}
+	return blocks
+}
+
+// ensureIptablesJumpsForBinary keeps each base chain's jump block at the head
+// of that chain. A block already in place is a cheap no-op; otherwise every
+// jump in it is reinserted. Two separate counters distinguish:
 //   - jumpPositionViolations: confirmed-misplaced jumps (real kube-proxy race)
 //   - jumpPositionCheckErrors: transient List failures where the watchdog
 //     still reinserts defensively but the position couldn't be read
@@ -154,67 +185,75 @@ func ensureIptablesJumps(logger *slog.Logger, jumps []iptablesRule) error {
 // signal for kube-proxy contention without the noise of shell-call blips.
 func ensureIptablesJumpsForBinary(logger *slog.Logger, ipt *iptables.IPTables, jumps []iptablesRule) error {
 	bin := iptablesLabel(ipt)
-	family := familyForIPT(ipt)
-	for _, jump := range jumps {
-		if jump.family != iptablesFamilyAll && jump.family != family {
-			continue
-		}
-		atHead, present, err := isJumpAtHead(ipt, jump)
+	for _, block := range jumpBlocksFor(jumps, familyForIPT(ipt)) {
+		atHead, misplaced, err := isJumpBlockAtHead(ipt, block)
 		if err != nil {
-			logger.Debug("position check failed; will reinstall defensively", "bin", bin, "chain", jump.chain, "error", err)
+			logger.Debug("position check failed; will reinstall defensively", "bin", bin, "chain", block.chain, "error", err)
 			jumpPositionCheckErrors.Add(1)
 			publishIptablesMetrics(logger)
 		}
 		if atHead {
 			continue
 		}
-		deleteAllIptablesRules(logger, ipt, jump)
-		if addErr := ipt.Insert(jump.table, jump.chain, 1, jump.args...); addErr != nil {
-			return fmt.Errorf("install %s jump rule on %s: %w", jump.label, bin, addErr)
+		// Reverse order: each insert lands at position 1, so the block's
+		// first jump is the last one inserted.
+		for i := len(block.jumps) - 1; i >= 0; i-- {
+			jump := block.jumps[i]
+			deleteAllIptablesRules(logger, ipt, jump)
+			if addErr := ipt.Insert(jump.table, jump.chain, 1, jump.args...); addErr != nil {
+				return fmt.Errorf("install %s jump rule on %s: %w", jump.label, bin, addErr)
+			}
 		}
-		// Only count as a violation when we know the jump was demoted; a
-		// position-check error or an absent jump during clean startup would
-		// inflate the count and drown the kube-proxy-race signal in noise.
-		if err == nil && present {
-			jumpPositionViolations.Add(1)
+		// Only count jumps we know were demoted; a position-check error or an
+		// absent jump during clean startup would inflate the count and drown
+		// the kube-proxy-race signal in noise.
+		if err == nil && misplaced > 0 {
+			jumpPositionViolations.Add(int64(misplaced))
 			publishIptablesMetrics(logger)
 		}
-		logger.Warn("jump rule restored at chain head", "bin", bin, "chain", jump.chain, "target", jump.label, "present_before_restore", present, "check_error", err)
+		logger.Warn("jump block restored at chain head", "bin", bin, "chain", block.chain, "misplaced_before_restore", misplaced, "check_error", err)
 	}
 	return nil
 }
 
-// isJumpAtHead reports whether the given jump rule is present and whether it
-// is the first appended rule of its base chain. The literal compare against
+// isJumpBlockAtHead reports whether the block's jumps are the first appended
+// rules of its base chain, in the block's order, and how many of them were
+// present elsewhere in the chain. The literal compare against
 // strings.Join(jump.args, " ") only round-trips while jump.args stays at {"-j",
 // chainName}; adding matchers (`-m comment`, conntrack, etc.) would let the
 // kernel renormalize tokens and make the compare always false, causing the
 // watchdog to reinsert every tick.
-func isJumpAtHead(ipt *iptables.IPTables, jump iptablesRule) (atHead bool, present bool, err error) {
-	lines, err := ipt.List(jump.table, jump.chain)
+func isJumpBlockAtHead(ipt *iptables.IPTables, block jumpBlock) (atHead bool, misplaced int, err error) {
+	lines, err := ipt.List(block.table, block.chain)
 	if err != nil {
-		return false, false, err
+		return false, 0, err
 	}
-	atHead, present = parseJumpAtHead(strings.Join(lines, "\n"), jump)
-	return atHead, present, nil
+	atHead, misplaced = parseJumpBlockAtHead(strings.Join(lines, "\n"), block)
+	return atHead, misplaced, nil
 }
 
-func parseJumpAtHead(out string, jump iptablesRule) (atHead bool, present bool) {
-	prefix := "-A " + jump.chain + " "
-	want := strings.Join(jump.args, " ")
-	firstRule := true
+func parseJumpBlockAtHead(out string, block jumpBlock) (atHead bool, misplaced int) {
+	prefix := "-A " + block.chain + " "
+	var installed []string
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.HasPrefix(line, prefix) {
 			continue
 		}
-		got := strings.TrimSpace(strings.TrimPrefix(line, prefix))
-		if got == want {
-			return firstRule, true
-		}
-		firstRule = false
+		installed = append(installed, strings.TrimSpace(strings.TrimPrefix(line, prefix)))
 	}
-	return false, false
+	atHead = true
+	for i, jump := range block.jumps {
+		want := strings.Join(jump.args, " ")
+		if i < len(installed) && installed[i] == want {
+			continue
+		}
+		atHead = false
+		if slices.Contains(installed, want) {
+			misplaced++
+		}
+	}
+	return atHead, misplaced
 }
 
 // jumpPositionViolations counts confirmed kube-proxy races: the watchdog

--- a/internal/cmds/ratlsmesh/iptables_linux_test.go
+++ b/internal/cmds/ratlsmesh/iptables_linux_test.go
@@ -52,51 +52,124 @@ func TestParseExcludeUIDs(t *testing.T) {
 	}
 }
 
-func TestParseJumpAtHead(t *testing.T) {
-	jump := iptablesRule{
-		chain: "PREROUTING",
-		args:  []string{"-j", preroutingChainName},
-	}
+func TestParseJumpBlockAtHead(t *testing.T) {
+	nat := jumpBlock{table: "nat", chain: "PREROUTING", jumps: []iptablesRule{
+		{chain: "PREROUTING", args: []string{"-j", preroutingChainName}},
+	}}
+	forward := jumpBlock{table: "filter", chain: "FORWARD", jumps: []iptablesRule{
+		cwJumpRule(), cwEgressJumpRule(),
+	}}
 	tests := []struct {
-		name        string
-		out         string
-		wantAtHead  bool
-		wantPresent bool
+		name          string
+		block         jumpBlock
+		out           string
+		wantAtHead    bool
+		wantMisplaced int
 	}{
 		{
-			name: "absent on clean chain",
-			out:  "-P PREROUTING ACCEPT\n",
+			name:  "absent on clean chain",
+			block: nat,
+			out:   "-P PREROUTING ACCEPT\n",
 		},
 		{
-			name: "at head",
+			name:  "at head",
+			block: nat,
 			out: `-P PREROUTING ACCEPT
 -A PREROUTING -j RATLS-MESH-PREROUTING
 -A PREROUTING -j KUBE-SERVICES
 `,
-			wantAtHead:  true,
-			wantPresent: true,
+			wantAtHead: true,
 		},
 		{
-			name: "demoted below kube services",
+			name:  "demoted below kube services",
+			block: nat,
 			out: `-P PREROUTING ACCEPT
 -A PREROUTING -j KUBE-SERVICES
 -A PREROUTING -j RATLS-MESH-PREROUTING
 `,
-			wantPresent: true,
+			wantMisplaced: 1,
 		},
 		{
-			name: "other chain ignored",
+			name:  "other chain ignored",
+			block: nat,
 			out: `-A OUTPUT -j RATLS-MESH-PREROUTING
 -A PREROUTING -j KUBE-SERVICES
 `,
 		},
+		// The two FORWARD guards cannot both be rule 1. Reading head position
+		// per rule made the second one look demoted on every tick, and the
+		// watchdog then unhooked a guard on every tick to "repair" it.
+		{
+			name:  "sibling guards in block order are at head",
+			block: forward,
+			out: `-P FORWARD ACCEPT
+-A FORWARD -j RATLS-MESH-CW
+-A FORWARD -j RATLS-MESH-CW-EGRESS
+-A FORWARD -j KUBE-FORWARD
+`,
+			wantAtHead: true,
+		},
+		{
+			name:  "sibling guards out of block order",
+			block: forward,
+			out: `-P FORWARD ACCEPT
+-A FORWARD -j RATLS-MESH-CW-EGRESS
+-A FORWARD -j RATLS-MESH-CW
+-A FORWARD -j KUBE-FORWARD
+`,
+			wantMisplaced: 2,
+		},
+		{
+			name:  "whole block demoted below kube forward",
+			block: forward,
+			out: `-P FORWARD ACCEPT
+-A FORWARD -j KUBE-FORWARD
+-A FORWARD -j RATLS-MESH-CW
+-A FORWARD -j RATLS-MESH-CW-EGRESS
+`,
+			wantMisplaced: 2,
+		},
+		{
+			name:  "one sibling absent",
+			block: forward,
+			out: `-P FORWARD ACCEPT
+-A FORWARD -j RATLS-MESH-CW
+-A FORWARD -j KUBE-FORWARD
+`,
+			wantMisplaced: 0,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gotAtHead, gotPresent := parseJumpAtHead(tc.out, jump)
-			if gotAtHead != tc.wantAtHead || gotPresent != tc.wantPresent {
-				t.Fatalf("parseJumpAtHead = (atHead=%v, present=%v), want (%v, %v)", gotAtHead, gotPresent, tc.wantAtHead, tc.wantPresent)
+			gotAtHead, gotMisplaced := parseJumpBlockAtHead(tc.out, tc.block)
+			if gotAtHead != tc.wantAtHead || gotMisplaced != tc.wantMisplaced {
+				t.Fatalf("parseJumpBlockAtHead = (atHead=%v, misplaced=%d), want (%v, %d)", gotAtHead, gotMisplaced, tc.wantAtHead, tc.wantMisplaced)
 			}
 		})
+	}
+}
+
+func TestJumpBlocksFor(t *testing.T) {
+	jumps := append(jumpRules(), cwJumpRule(), cwEgressJumpRule())
+	jumps = append(jumps, iptablesRule{table: "nat", chain: "PREROUTING", family: iptablesFamilyIPv6, args: []string{"-j", "V6-ONLY"}})
+
+	blocks := jumpBlocksFor(jumps, iptablesFamilyIPv4)
+	if len(blocks) != 3 {
+		t.Fatalf("v4 blocks = %d, want 3 (nat OUTPUT, nat PREROUTING, filter FORWARD)", len(blocks))
+	}
+	forward := blocks[2]
+	if forward.table != "filter" || forward.chain != "FORWARD" {
+		t.Fatalf("third block = %s/%s, want filter/FORWARD", forward.table, forward.chain)
+	}
+	if len(forward.jumps) != 2 {
+		t.Fatalf("FORWARD block holds %d jumps, want both cw guards", len(forward.jumps))
+	}
+	if got := forward.jumps[0].args[1]; got != cwChainName {
+		t.Errorf("FORWARD block head = %q, want %q", got, cwChainName)
+	}
+
+	v6 := jumpBlocksFor(jumps, iptablesFamilyIPv6)
+	if len(v6[1].jumps) != 2 {
+		t.Errorf("v6 nat PREROUTING block holds %d jumps, want the all-family jump plus the v6-only one", len(v6[1].jumps))
 	}
 }

--- a/internal/cmds/ratlsmesh/iptables_test.go
+++ b/internal/cmds/ratlsmesh/iptables_test.go
@@ -198,17 +198,17 @@ func TestJumpRules(t *testing.T) {
 	assertContains(t, "prerouting jump", jumps[1].args, "-j", preroutingChainName)
 }
 
-// TestJumpRulesArgsShape guards the assumption isJumpAtHead relies on: each
-// jump's args is exactly {"-j", chain}. Any matcher (e.g. -m comment, conntrack)
-// would let iptables -S renormalize tokens, defeat the literal string compare
-// in isJumpAtHead, and turn the watchdog into a reinsert-every-tick loop. Catch
+// TestJumpRulesArgsShape guards the assumption parseJumpBlockAtHead relies on:
+// each jump's args is exactly {"-j", chain}. Any matcher (e.g. -m comment,
+// conntrack) would let iptables -S renormalize tokens, defeat the literal
+// string compare, and turn the watchdog into a reinsert-every-tick loop. Catch
 // the regression here instead of in a noisy production race.
 func TestJumpRulesArgsShape(t *testing.T) {
 	jumps := append(append(jumpRules(), cwJumpRule()), cwEgressJumpRule())
 	jumps = append(jumps, guestFilterJumps()...)
 	for i, jump := range jumps {
 		if len(jump.args) != 2 || jump.args[0] != "-j" {
-			t.Fatalf("jump %d args = %v; isJumpAtHead requires {\"-j\", <chain>}", i, jump.args)
+			t.Fatalf("jump %d args = %v; parseJumpBlockAtHead requires {\"-j\", <chain>}", i, jump.args)
 		}
 	}
 }

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -580,7 +580,7 @@ func newIptablesSyncCommand() *cobra.Command {
 	fs.StringVar(&cfg.excludeSourceNamespaces, "exclude-source-namespaces", defaultMeshExcludedSourceNamespacesCSV(), "comma-separated local source namespaces excluded from transparent mesh interception")
 	fs.StringSliceVar(&cfg.nodeIPs, "node-ip", nil, "local node IP(s); repeat or comma-separate for dual-stack (one per family). Defaults to NODE_IP env. Each address must be a non-loopback, non-unspecified IP bound to a local interface.")
 	fs.DurationVar(&cfg.resyncPeriod, "resync-period", 30*time.Second, "periodic full ipset reconciliation interval")
-	fs.DurationVar(&cfg.watchdogPeriod, "watchdog-period", 2*time.Second, "interval at which the base-chain jump rules are re-asserted at position 1 (bounds the race window against kube-proxy reinserting KUBE-SERVICES)")
+	fs.DurationVar(&cfg.watchdogPeriod, "watchdog-period", 2*time.Second, "interval at which the base-chain jump rules are re-asserted at the head of their chain (bounds the race window against kube-proxy reinserting KUBE-SERVICES)")
 	fs.IntVar(&cfg.ipsetMaxElem, "ipset-maxelem", defaultIPSetMaxElem, "maximum members per managed ipset")
 	fs.StringVar(&cfg.cwInboundPassthrough, "cw-inbound-passthrough", formatCWPassthrough(defaultCWPassthrough), "comma-separated proto:source-port replies exempted from the always-on cw inbound guard (which drops FORWARD-path traffic to confidential.ai/cw pods). Each entry matches only a destination port in 32768-60999 and, for TCP, a reply segment shape. Empty = strict drop-all; DNS is the default")
 	fs.StringVar(&cfg.readyFile, "ready-file", "", "path to write after initial ipset and iptables sync succeeds")

--- a/internal/cmds/ratlsmesh/netfilter_fake_test.go
+++ b/internal/cmds/ratlsmesh/netfilter_fake_test.go
@@ -314,6 +314,62 @@ func TestEnsureIptablesJumps(t *testing.T) {
 		}
 	})
 
+	// Regression: the cw inbound and egress guards share filter FORWARD, so
+	// one of them is always rule 2. Checking head position per rule made that
+	// one look demoted forever, and every watchdog tick then deleted and
+	// reinserted both — each repair leaving FORWARD unguarded for the length
+	// of two iptables execs, which is how plaintext reached a cw pod.
+	t.Run("sibling FORWARD guards at head are a no-op", func(t *testing.T) {
+		nf := installFakeNetfilter(t)
+		silenceIptablesMetricsFile(t)
+		mustInitFakeIptables(t)
+		atHead := "-P FORWARD ACCEPT\n-A FORWARD -j " + cwChainName +
+			"\n-A FORWARD -j " + cwEgressChainName + "\n-A FORWARD -j KUBE-FORWARD\n"
+		nf.set("list_iptables_FORWARD", atHead)
+		nf.set("list_ip6tables_FORWARD", atHead)
+
+		violBefore := jumpPositionViolations.Load()
+		if err := ensureIptablesJumps(testLogger(), []iptablesRule{cwJumpRule(), cwEgressJumpRule()}); err != nil {
+			t.Fatalf("ensureIptablesJumps: %v", err)
+		}
+		calls := nf.calls()
+		for _, op := range []string{"-I FORWARD", "-D FORWARD"} {
+			if got := len(callsContaining(calls, "", op)); got != 0 {
+				t.Errorf("%s issued for an in-order guard block:\n%s", op, strings.Join(calls, "\n"))
+			}
+		}
+		if d := jumpPositionViolations.Load() - violBefore; d != 0 {
+			t.Errorf("violations advanced by %d for an in-order guard block", d)
+		}
+	})
+
+	t.Run("demoted FORWARD guards restored in block order", func(t *testing.T) {
+		nf := installFakeNetfilter(t)
+		silenceIptablesMetricsFile(t)
+		mustInitFakeIptables(t)
+		demoted := "-P FORWARD ACCEPT\n-A FORWARD -j KUBE-FORWARD\n-A FORWARD -j " + cwChainName +
+			"\n-A FORWARD -j " + cwEgressChainName + "\n"
+		nf.set("list_iptables_FORWARD", demoted)
+		nf.set("list_ip6tables_FORWARD", demoted)
+		nf.set("del_budget", "4")
+
+		violBefore := jumpPositionViolations.Load()
+		if err := ensureIptablesJumps(testLogger(), []iptablesRule{cwJumpRule(), cwEgressJumpRule()}); err != nil {
+			t.Fatalf("ensureIptablesJumps: %v", err)
+		}
+		calls := callsContaining(nf.calls(), "iptables ", "-I FORWARD 1 -j ")
+		if len(calls) != 2 {
+			t.Fatalf("v4 insert count = %d, want 2\n%s", len(calls), strings.Join(calls, "\n"))
+		}
+		// Inserts land at position 1, so the last one issued ends up first.
+		if !strings.Contains(calls[0], "-j "+cwEgressChainName) || !strings.Contains(calls[1], "-j "+cwChainName) {
+			t.Errorf("inserts issued in the wrong order, leaving the block reversed:\n%s", strings.Join(calls, "\n"))
+		}
+		if d := jumpPositionViolations.Load() - violBefore; d != 4 {
+			t.Errorf("violations advanced by %d, want 4 (two demoted jumps per binary)", d)
+		}
+	})
+
 	t.Run("family-scoped jump touches only its binary", func(t *testing.T) {
 		nf := installFakeNetfilter(t)
 		silenceIptablesMetricsFile(t)


### PR DESCRIPTION
The watchdog asserted head position per jump rule, so the two mesh jumps sharing filter FORWARD each read the other as demoted and swapped places every tick, leaving FORWARD unhooked from the cw inbound guard between the delete and the insert — long enough for a DNAT'd Service-VIP dial to reach a confidential workload in plaintext.

Group jumps by base chain and assert the block — the mesh jumps must be that chain's first rules, in declaration order — so a block already in place is a no-op and the guard stays hooked.

- ensureIptablesJumpsForBinary now iterates jumpBlocksFor(jumps, family) rather than individual rules, and reinserts a block's jumps in reverse so the head order matches the declaration order.
- parseJumpBlockAtHead replaces parseJumpAtHead: it compares the chain's leading -A rules against the whole block instead of looking for one rule at position 1.
- jumpPositionViolations counts each jump that was present but out of place, keeping the metric (and the RATLSMeshJumpPositionViolations alert, which this bug fired continuously) a signal for real kube-proxy races.
- Measured against real iptables in a netns, 20 quiet watchdog ticks: 80 violations and 80 unguarded windows before, 0 after.
- Regression coverage at both levels: parseJumpBlockAtHead over the sibling orderings, and TestEnsureIptablesJumps subtests asserting no -D/-I for an in-order block and correct restore order for a demoted one.