### PR TITLE
cdsattest: carry tunnel headers as ordered pairs so duplicate fields survive

### DIFF
--- a/internal/cmds/cdsattest/backend.go
+++ b/internal/cmds/cdsattest/backend.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -48,7 +49,7 @@ func (EchoBackend) Forward(_ context.Context, req types.TunnelRequest) (types.Tu
 		len(req.Body), req.Method, req.Path, string(req.Body))
 	return types.TunnelResponse{
 		Status:  http.StatusOK,
-		Headers: map[string]string{"Content-Type": "text/plain; charset=utf-8"},
+		Headers: []types.HeaderField{{Name: "Content-Type", Value: "text/plain; charset=utf-8"}},
 		Body:    []byte(msg),
 	}, nil
 }
@@ -224,11 +225,11 @@ func (b *HTTPBackend) Forward(ctx context.Context, env types.TunnelRequest) (typ
 	if err != nil {
 		return types.TunnelResponse{}, fmt.Errorf("build upstream request: %w", err)
 	}
-	for k, v := range env.Headers {
-		if hopByHopHeaders[strings.ToLower(k)] {
+	for _, f := range env.Headers {
+		if hopByHopHeaders[strings.ToLower(f.Name)] {
 			continue
 		}
-		req.Header.Set(k, v)
+		req.Header.Add(f.Name, f.Value)
 	}
 
 	resp, err := b.client.Do(req)
@@ -245,16 +246,30 @@ func (b *HTTPBackend) Forward(ctx context.Context, env types.TunnelRequest) (typ
 		return types.TunnelResponse{}, fmt.Errorf("upstream response exceeds %d byte limit", maxUpstreamResponseBytes)
 	}
 
-	headers := make(map[string]string, len(resp.Header))
-	for k := range resp.Header {
-		if hopByHopHeaders[strings.ToLower(k)] {
-			continue
-		}
-		headers[k] = resp.Header.Get(k)
-	}
 	return types.TunnelResponse{
 		Status:  resp.StatusCode,
-		Headers: headers,
+		Headers: responseHeaderFields(resp.Header),
 		Body:    respBody,
 	}, nil
+}
+
+// responseHeaderFields flattens the upstream header map into ordered pairs:
+// names sorted (the map holds no order to preserve), values of one name in
+// their upstream order, hop-by-hop fields dropped.
+func responseHeaderFields(h http.Header) []types.HeaderField {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		if hopByHopHeaders[strings.ToLower(name)] {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	var fields []types.HeaderField
+	for _, name := range names {
+		for _, value := range h[name] {
+			fields = append(fields, types.HeaderField{Name: name, Value: value})
+		}
+	}
+	return fields
 }

--- a/internal/cmds/cdsattest/backend_test.go
+++ b/internal/cmds/cdsattest/backend_test.go
@@ -187,18 +187,66 @@ func TestHTTPBackendStripsHopByHopHeaders(t *testing.T) {
 		t.Fatal(err)
 	}
 	resp, err := hb.Forward(context.Background(), types.TunnelRequest{
-		Method:  "GET",
-		Path:    "/",
-		Headers: map[string]string{"X-C8s-Session": "sess-id", "X-App": "kept"},
+		Method: "GET",
+		Path:   "/",
+		Headers: []types.HeaderField{
+			{Name: "X-C8s-Session", Value: "sess-id"},
+			{Name: "X-App", Value: "kept"},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := resp.Headers["Keep-Alive"]; ok {
+	if got := headerValues(resp.Headers, "Keep-Alive"); len(got) != 0 {
 		t.Error("hop-by-hop response header not stripped")
 	}
-	if resp.Headers["X-Resp"] != "kept" {
+	if got := headerValues(resp.Headers, "X-Resp"); len(got) != 1 || got[0] != "kept" {
 		t.Errorf("response header lost: %+v", resp.Headers)
+	}
+}
+
+// headerValues collects the values a pair list carries under name.
+func headerValues(fields []types.HeaderField, name string) []string {
+	var values []string
+	for _, f := range fields {
+		if f.Name == name {
+			values = append(values, f.Value)
+		}
+	}
+	return values
+}
+
+// TestHTTPBackendPreservesDuplicateHeaders: the pair-based envelope must carry
+// every value of a repeated field in both directions — the map envelope's
+// collapse of Set-Cookie was the bug the v2 envelope exists to fix.
+func TestHTTPBackendPreservesDuplicateHeaders(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Values("X-Multi"); len(got) != 2 || got[0] != "one" || got[1] != "two" {
+			t.Errorf("duplicate request header not forwarded intact: %v", got)
+		}
+		w.Header().Add("Set-Cookie", "a=1")
+		w.Header().Add("Set-Cookie", "b=2")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	hb, err := NewHTTPBackend(backend.URL, HTTPBackendOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := hb.Forward(context.Background(), types.TunnelRequest{
+		Method: "GET",
+		Path:   "/",
+		Headers: []types.HeaderField{
+			{Name: "X-Multi", Value: "one"},
+			{Name: "X-Multi", Value: "two"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := headerValues(resp.Headers, "Set-Cookie"); len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
+		t.Fatalf("duplicate response header collapsed: %v", got)
 	}
 }
 

--- a/internal/cmds/cdsattest/server_test.go
+++ b/internal/cmds/cdsattest/server_test.go
@@ -158,7 +158,7 @@ func TestFullFlowOverEncryptedEcho(t *testing.T) {
 	resp := tunnel(t, ts.URL, channel, hr.SessionID, types.TunnelRequest{
 		Method:  "POST",
 		Path:    "/v1/echo",
-		Headers: map[string]string{"Content-Type": "application/json"},
+		Headers: []types.HeaderField{{Name: "Content-Type", Value: "application/json"}},
 		Body:    []byte("hi enclave"),
 	})
 	if resp.Status != http.StatusOK {
@@ -262,7 +262,7 @@ func TestTunnelForwardsToUpstream(t *testing.T) {
 	resp := tunnel(t, ts.URL, channel, hr.SessionID, types.TunnelRequest{
 		Method:  "PUT",
 		Path:    "/v1/data",
-		Headers: map[string]string{"Authorization": "Bearer sekret"},
+		Headers: []types.HeaderField{{Name: "Authorization", Value: "Bearer sekret"}},
 		Body:    []byte("payload"),
 	})
 	if resp.Status != http.StatusCreated {
@@ -271,11 +271,60 @@ func TestTunnelForwardsToUpstream(t *testing.T) {
 	if !strings.Contains(string(resp.Body), "upstream saw: /v1/data / payload") {
 		t.Fatalf("unexpected upstream body: %q", resp.Body)
 	}
-	if resp.Headers["X-Echo-Method"] != "PUT" {
-		t.Fatalf("method not forwarded: %q", resp.Headers["X-Echo-Method"])
+	if got := headerValues(resp.Headers, "X-Echo-Method"); len(got) != 1 || got[0] != "PUT" {
+		t.Fatalf("method not forwarded: %q", got)
 	}
-	if resp.Headers["X-Echo-Auth"] != "Bearer sekret" {
-		t.Fatalf("Authorization not forwarded confidentially: %q", resp.Headers["X-Echo-Auth"])
+	if got := headerValues(resp.Headers, "X-Echo-Auth"); len(got) != 1 || got[0] != "Bearer sekret" {
+		t.Fatalf("Authorization not forwarded confidentially: %q", got)
+	}
+}
+
+// TestTunnelPreservesDuplicateHeaders: repeated fields ride the pair-based
+// envelope intact in both directions, through the sealed tunnel and the
+// backend hop — the header map that collapsed Set-Cookie is gone.
+func TestTunnelPreservesDuplicateHeaders(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Values("X-Multi"); len(got) != 2 || got[0] != "one" || got[1] != "two" {
+			t.Errorf("duplicate request header not forwarded intact: %v", got)
+		}
+		w.Header().Add("Set-Cookie", "a=1")
+		w.Header().Add("Set-Cookie", "b=2")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	hb, err := NewHTTPBackend(backend.URL, HTTPBackendOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := writeTestMeshIdentity(t)
+	srv := NewServer(Config{
+		Evidence:             FixtureEvidenceProvider{Raw: json.RawMessage(`{"attestation_report":"AAAA"}`), Platform: "snp", Generation: "genoa"},
+		MeshIdentityCertFile: identity.certFile,
+		MeshIdentityKeyFile:  identity.keyFile,
+		MeshIdentityCAFile:   identity.caFile,
+		Backend:              hb,
+	})
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	nonce := make([]byte, 32)
+	rand.Read(nonce)
+	channel, sessionID := establishSession(t, ts.URL, nonce)
+
+	resp := tunnel(t, ts.URL, channel, sessionID, types.TunnelRequest{
+		Method: "GET",
+		Path:   "/",
+		Headers: []types.HeaderField{
+			{Name: "X-Multi", Value: "one"},
+			{Name: "X-Multi", Value: "two"},
+		},
+	})
+	if resp.Status != http.StatusOK {
+		t.Fatalf("tunnel response status %d", resp.Status)
+	}
+	if got := headerValues(resp.Headers, "Set-Cookie"); len(got) != 2 || got[0] != "a=1" || got[1] != "b=2" {
+		t.Fatalf("duplicate response header collapsed: %v", got)
 	}
 }
 

--- a/pkg/types/verify.go
+++ b/pkg/types/verify.go
@@ -92,6 +92,16 @@ type HandshakeResponse struct {
 	SessionID string `json:"session_id"`
 }
 
+// HeaderField is one HTTP header field in a tunnel envelope, on the wire a
+// two-element CBOR array [name, value]. A pair list preserves duplicate fields
+// (Set-Cookie) and field order, which a header map cannot. CBOR only — the
+// envelope never rides as JSON.
+type HeaderField struct {
+	_     struct{} `cbor:",toarray"`
+	Name  string
+	Value string
+}
+
 // TunnelRequest is the plaintext application request carried inside an
 // over-encrypted record sent to POST /.well-known/c8s/tunnel. The whole request
 // — method, path, headers, and body — is sealed, so a TLS-terminating proxy in
@@ -99,15 +109,15 @@ type HandshakeResponse struct {
 // reconstructed request as plaintext to the backend (the cluster raTLS mesh wraps
 // that hop).
 type TunnelRequest struct {
-	Method  string            `cbor:"method" json:"method"`
-	Path    string            `cbor:"path" json:"path"`
-	Headers map[string]string `cbor:"headers,omitempty" json:"headers,omitempty"`
-	Body    []byte            `cbor:"body,omitempty" json:"body,omitempty"` // raw body, CBOR byte string
+	Method  string        `cbor:"method"`
+	Path    string        `cbor:"path"`
+	Headers []HeaderField `cbor:"headers,omitempty"`
+	Body    []byte        `cbor:"body,omitempty"` // raw body, CBOR byte string
 }
 
 // TunnelResponse is the backend response, sealed back to the client.
 type TunnelResponse struct {
-	Status  int               `cbor:"status" json:"status"`
-	Headers map[string]string `cbor:"headers,omitempty" json:"headers,omitempty"`
-	Body    []byte            `cbor:"body,omitempty" json:"body,omitempty"` // raw body, CBOR byte string
+	Status  int           `cbor:"status"`
+	Headers []HeaderField `cbor:"headers,omitempty"`
+	Body    []byte        `cbor:"body,omitempty"` // raw body, CBOR byte string
 }

--- a/pkg/types/verify_test.go
+++ b/pkg/types/verify_test.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/fxamacker/cbor/v2"
+)
+
+// TestHeaderFieldWireShape pins the header encoding the JS client depends on:
+// one field is a two-element CBOR array [name, value], not a map.
+func TestHeaderFieldWireShape(t *testing.T) {
+	got, err := cbor.Marshal(HeaderField{Name: "Set-Cookie", Value: "a=1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := cbor.Marshal([]string{"Set-Cookie", "a=1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("HeaderField wire shape = %x, want the array form %x", got, want)
+	}
+
+	var back HeaderField
+	if err := cbor.Unmarshal(want, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.Name != "Set-Cookie" || back.Value != "a=1" {
+		t.Fatalf("round-trip = %+v", back)
+	}
+}


### PR DESCRIPTION
The tunnel envelope carried headers as a string map, so repeated fields collapsed: `HTTPBackend.Forward` delivered one `Cookie` to the upstream and returned only the first `Set-Cookie` to the client.

Headers now ride as ordered `[name, value]` pairs (`types.HeaderField`, a two-element CBOR array) in both tunnel envelopes; the backend forwards every pair with `Header.Add` and returns every value of repeated response fields. The protocol is still beta, so the shape changes in place — no version negotiation and no compatibility with the map envelope; AADs and the handshake are unchanged.

Client side: [c8s-verify-js#25](https://github.com/confidential-dot-ai/c8s-verify-js/pull/25) (also updates PROTOCOL.md).