### PR TITLE
fix(nri-image-policy): carry the CDS pins to the baked plugin under node-as-cvm

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -537,6 +537,14 @@ func preflightImagePolicy(ctx context.Context, w io.Writer, values map[string]an
 	if !boolAtPath(values, "nriImagePolicy.enabled") {
 		return "", nil
 	}
+	// Under .baked the node's floor is the one the image build rendered — the
+	// RKE2 system digests included — and the chart cannot see it, so every
+	// baked-floor pod here reads as denied. The plugin has also been enforcing
+	// since boot, so what runs is already admitted and the pins the installer
+	// writes change who may serve the allowlist, not what it admits.
+	if boolAtPath(values, "nriImagePolicy.baked") {
+		return "", nil
+	}
 	// A mode the chart cannot read is the render guard's to reject, not this
 	// preflight's; either way nothing is denied here.
 	if mode, err := stringAtPath(values, "nriImagePolicy.policy.mode"); err != nil || mode != policyModeFailClosed {
@@ -1674,11 +1682,14 @@ func appendCvmModeInstallArgs(helmArgs []string, cvmMode, hardwarePlatform strin
 	// node: the node image bakes host attestation-api and nri-image-policy;
 	// re-rendering them duplicates the baked pair and the baked fail-closed NRI
 	// floor denies the chart copies' own images. ratlsMesh stays: it is not
-	// baked (unlike kata-guest-base).
+	// baked (unlike kata-guest-base). The NRI installer does stay on, in its
+	// baked form — the pins below are the one thing an image built before this
+	// release cannot carry, and the installer is the only path that reaches the
+	// baked plugin's config.
 	if cvmMode == "node" {
 		helmArgs = append(helmArgs,
 			"--set", "attestationApi.enabled=false",
-			"--set", "nriImagePolicy.enabled=false",
+			"--set", "nriImagePolicy.baked=true",
 		)
 	}
 	// --measurements pins the expected launch measurement(s) of this cluster's

--- a/cmd/c8s/install_exec_test.go
+++ b/cmd/c8s/install_exec_test.go
@@ -833,12 +833,14 @@ func TestInstallNodeModeHappyPath(t *testing.T) {
 	}
 
 	// An unstamped build resolves digests at the fallback tag, and only for
-	// components the node shape actually renders.
+	// components the node shape actually renders. nri-image-policy is among
+	// them: the baked installer runs from that image, and its digest is what
+	// derives it into the seed the node's plugin admits it from.
 	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/c8s-operator:main")
 	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/cds:main")
 	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/ratls-mesh:main")
+	mustContainLine(t, calls, "crane digest ghcr.io/confidential-dot-ai/nri-image-policy:main")
 	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/attestation-api")
-	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/nri-image-policy")
 	// volumed stays off without --volumes.
 	mustNotContainPrefix(t, calls, "crane digest ghcr.io/confidential-dot-ai/volumed")
 
@@ -854,6 +856,12 @@ func TestInstallNodeModeHappyPath(t *testing.T) {
 	}
 	if got := treeAt(t, tree, "attestationApi", "enabled"); got != false {
 		t.Errorf("attestationApi.enabled = %#v, want false (baked into the node image)", got)
+	}
+	// The plugin is baked, but its installer stays on (chart default enabled) —
+	// it is the only path that writes this release's CDS pins into the baked
+	// config, so node mode flips the installer's shape, not its presence.
+	if got := treeAt(t, tree, "nriImagePolicy", "baked"); got != true {
+		t.Errorf("nriImagePolicy.baked = %#v, want true", got)
 	}
 	if got := treeAt(t, tree, "attestationApi", "teeDevices", "sevGuest"); got != true {
 		t.Errorf("teeDevices.sevGuest = %#v, want true", got)

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1141,11 +1141,13 @@ func TestAppendCvmModeInstallArgsSetsAttestationApiValue(t *testing.T) {
 			)
 		}
 		// node: the node image bakes attestation-api + nri-image-policy, so the
-		// chart copies are skipped (ratlsMesh is not baked, stays on).
+		// attestation-api copy is skipped and the NRI installer switches to its
+		// baked form — the only path that reaches the baked plugin's CDS pins.
+		// ratlsMesh is not baked, stays on.
 		if mode == "node" {
 			out = append(out,
 				"--set", "attestationApi.enabled=false",
-				"--set", "nriImagePolicy.enabled=false",
+				"--set", "nriImagePolicy.baked=true",
 			)
 		}
 		return out
@@ -1360,8 +1362,6 @@ func TestBuildDigestArgsSkipsDisabledComponent(t *testing.T) {
 		resolved[ref] = true
 		return "sha256:3333333333333333333333333333333333333333333333333333333333333333", nil
 	}
-	// Node-mode shape: attestation-api and nri-image-policy are baked into the
-	// node image and disabled in the chart.
 	disabled := map[string]bool{"attestationApi.enabled": true, "nriImagePolicy.enabled": true}
 	enabled := func(path string) (bool, error) { return !disabled[path], nil }
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -24,11 +24,12 @@ plugin) works unchanged against it. The all-zero digest is pinned via
 `--measurements`, so every RA-TLS hop is verified exactly as in production.
 
 The NRI image-policy plugin runs for real: the harness renders the chart's
-installer DaemonSet and applies it out-of-band (node mode does not render it —
-production node images bake the plugin). The installer patches the node's
-containerd config and restarts it, which kind survives. The install-time
-allowlist floor is generated from the node containerd's image store, because
-`policy.enforceExisting` checks already-running containers against it.
+full installer DaemonSet and applies it out-of-band (node mode renders only
+the baked pins patcher, and the kind node bakes no plugin for it to pin). The
+installer patches the node's containerd config and restarts it, which kind
+survives. The install-time allowlist floor is generated from the node
+containerd's image store, because `policy.enforceExisting` checks
+already-running containers against it.
 
 Two operator-facing commands verify evidence **in-process** with real hardware
 cryptography, which synthetic evidence cannot pass: `c8s verify` and the `c8s

--- a/internal/cmds/nri-image-policy/config.go
+++ b/internal/cmds/nri-image-policy/config.go
@@ -141,13 +141,23 @@ const defaultPullTimeout = 30 * time.Second
 // node's address to. Read only when advertise_host is unset.
 const NodeIPFile = "node-ip"
 
+// defaultConfigPath is the plugin config containerd's plugin_config_path
+// resolves for this plugin, and the file set-cds-pins patches.
+const defaultConfigPath = "/etc/nri/conf.d/image-policy.yaml"
+
 // loadConfig loads configuration from a YAML file.
 func loadConfig(path string) (*config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read config file: %w", err)
 	}
+	return parseConfig(data)
+}
 
+// parseConfig decodes and validates a config document. set-cds-pins reads the
+// file it is about to patch through here, so the patched bytes are accepted by
+// exactly the loader the plugin boots with.
+func parseConfig(data []byte) (*config, error) {
 	cfg := &config{
 		Allowlist: allowlistConfig{
 			Pull: pullConfig{

--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -66,8 +66,11 @@ func startupSourceMode(cfg *config) string {
 // Run executes the nri-image-policy binary. args is the slice of CLI args
 // after the program name.
 func Run(args []string) error {
+	if len(args) > 0 && args[0] == setCDSPinsVerb {
+		return runSetCDSPins(os.Stdout, args[1:])
+	}
 	fs := flag.NewFlagSet("nri-image-policy", flag.ContinueOnError)
-	configPath := fs.String("config", "/etc/nri/conf.d/image-policy.yaml", "path to config file")
+	configPath := fs.String("config", defaultConfigPath, "path to config file")
 	healthAddr := fs.String("health-addr", ":8080", "health check listen address")
 	readTimeout := fs.Duration("read-timeout", 5*time.Second, "HTTP server read timeout")
 	writeTimeout := fs.Duration("write-timeout", 10*time.Second, "HTTP server write timeout")

--- a/internal/cmds/nri-image-policy/setpins.go
+++ b/internal/cmds/nri-image-policy/setpins.go
@@ -1,0 +1,231 @@
+package nriimagepolicy
+
+import (
+	"bytes"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// setCDSPinsVerb selects the pin patcher instead of the plugin daemon.
+const setCDSPinsVerb = "set-cds-pins"
+
+// Outcomes printed on stdout, so the caller can decide whether the plugin
+// needs restarting without diffing the file itself.
+const (
+	pinsUpdated   = "updated"
+	pinsUnchanged = "unchanged"
+)
+
+// runSetCDSPins writes this release's CDS pins into an existing plugin config,
+// leaving every other key as found.
+//
+// A node-as-CVM bakes the config into the measured image, and its
+// allowlist.always_allow floor carries the RKE2 system-image digests that only
+// the image build resolves — so the chart can patch that file but never
+// re-render it.
+func runSetCDSPins(stdout io.Writer, args []string) error {
+	fs := flag.NewFlagSet("nri-image-policy "+setCDSPinsVerb, flag.ContinueOnError)
+	path := fs.String("config", defaultConfigPath, "plugin config to patch in place")
+	rawMeasurements := fs.String("cds-measurements", "", "comma-separated SHA-384 hex CDS launch measurements; empty clears the pins")
+	rawRTMRs := fs.String("cds-rtmrs", "", "comma-separated TDX RTMR pins <index>=<sha384-hex>; empty clears the pins")
+	if err := cmdsutil.ParseFlags(fs, args); err != nil {
+		return err
+	}
+
+	measurements, err := ratls.ParseHexMeasurements(*rawMeasurements)
+	if err != nil {
+		return fmt.Errorf("--cds-measurements: %w", err)
+	}
+	rtmrs, err := ratls.ParseRTMRPinsString(*rawRTMRs)
+	if err != nil {
+		return fmt.Errorf("--cds-rtmrs: %w", err)
+	}
+	wantMeasurements := make([]string, 0, len(measurements))
+	for _, m := range measurements {
+		wantMeasurements = append(wantMeasurements, hex.EncodeToString(m))
+	}
+	wantRTMRs := make([]string, 0, len(rtmrs))
+	for _, idx := range slices.Sorted(maps.Keys(rtmrs)) {
+		wantRTMRs = append(wantRTMRs, fmt.Sprintf("%d=%s", idx, hex.EncodeToString(rtmrs[idx])))
+	}
+
+	data, err := os.ReadFile(*path)
+	if err != nil {
+		return fmt.Errorf("read config file: %w", err)
+	}
+	// The file the plugin boots with must load before and after the patch: a
+	// config that no longer validates leaves a required NRI plugin unable to
+	// register, which blocks every container on the node.
+	cfg, err := parseConfig(data)
+	if err != nil {
+		return fmt.Errorf("%s: %w", *path, err)
+	}
+	if slices.Equal(normalizeHex(cfg.Allowlist.Pull.CDSMeasurements), wantMeasurements) &&
+		slices.Equal(normalizeHex(cfg.Allowlist.Pull.CDSRTMRs), wantRTMRs) {
+		fmt.Fprintln(stdout, pinsUnchanged)
+		return nil
+	}
+
+	patched, err := patchCDSPins(data, wantMeasurements, wantRTMRs)
+	if err != nil {
+		return fmt.Errorf("%s: %w", *path, err)
+	}
+	if _, err := parseConfig(patched); err != nil {
+		return fmt.Errorf("%s: patched config does not load: %w", *path, err)
+	}
+	if err := writeFileAtomic(*path, patched); err != nil {
+		return err
+	}
+	fmt.Fprintln(stdout, pinsUpdated)
+	return nil
+}
+
+// normalizeHex folds the on-disk pins to the case the patched form writes, so
+// a re-run with the same pins compares equal and skips the restart.
+func normalizeHex(vals []string) []string {
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		out = append(out, strings.ToLower(v))
+	}
+	return out
+}
+
+// patchCDSPins replaces allowlist.pull.cds_measurements and cds_rtmrs in a
+// config document, editing the parsed node tree so every other key, and the
+// comments the node image ships, survive the round-trip.
+func patchCDSPins(data []byte, measurements, rtmrs []string) ([]byte, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, fmt.Errorf("config is not a YAML document")
+	}
+	pull, err := mappingPath(doc.Content[0], "allowlist", "pull")
+	if err != nil {
+		return nil, err
+	}
+	setMappingValue(pull, "cds_measurements", stringSeq(measurements))
+	setMappingValue(pull, "cds_rtmrs", stringSeq(rtmrs))
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		return nil, fmt.Errorf("encode config: %w", err)
+	}
+	if err := enc.Close(); err != nil {
+		return nil, fmt.Errorf("encode config: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// mappingPath walks nested mappings. A missing key is an error rather than a
+// created one: the pins belong in the section the plugin already reads, and a
+// config without it is not the one this command was pointed at.
+func mappingPath(n *yaml.Node, keys ...string) (*yaml.Node, error) {
+	for i, key := range keys {
+		v := mappingValue(n, key)
+		if v == nil {
+			return nil, fmt.Errorf("config has no %s section", strings.Join(keys[:i+1], "."))
+		}
+		if v.Kind != yaml.MappingNode {
+			return nil, fmt.Errorf("config key %s is not a mapping", strings.Join(keys[:i+1], "."))
+		}
+		n = v
+	}
+	return n, nil
+}
+
+func mappingValue(n *yaml.Node, key string) *yaml.Node {
+	if n.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			return n.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setMappingValue replaces key's value in place, or appends the pair when the
+// mapping does not carry it yet.
+func setMappingValue(n *yaml.Node, key string, value *yaml.Node) {
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		if n.Content[i].Value == key {
+			value.HeadComment = n.Content[i+1].HeadComment
+			value.LineComment = n.Content[i+1].LineComment
+			value.FootComment = n.Content[i+1].FootComment
+			n.Content[i+1] = value
+			return
+		}
+	}
+	n.Content = append(n.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		value)
+}
+
+// stringSeq renders the pins as a quoted sequence; an empty one stays inline
+// as [] so a cleared list reads the way the shipped config writes it.
+func stringSeq(vals []string) *yaml.Node {
+	n := &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+	if len(vals) == 0 {
+		n.Style = yaml.FlowStyle
+		return n
+	}
+	for _, v := range vals {
+		n.Content = append(n.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: v,
+			Style: yaml.DoubleQuotedStyle,
+		})
+	}
+	return n
+}
+
+// writeFileAtomic replaces path with data, keeping the file's current mode. The
+// temp file is a sibling so the rename never crosses filesystems.
+func writeFileAtomic(path string, data []byte) error {
+	mode := os.FileMode(0o644)
+	if fi, err := os.Stat(path); err == nil {
+		mode = fi.Mode().Perm()
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
+	if err != nil {
+		return fmt.Errorf("create temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write temp file: %w", err)
+	}
+	if err := tmp.Chmod(mode); err != nil {
+		tmp.Close()
+		return fmt.Errorf("chmod temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp file: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("replace %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cmds/nri-image-policy/setpins_test.go
+++ b/internal/cmds/nri-image-policy/setpins_test.go
@@ -1,0 +1,245 @@
+package nriimagepolicy
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	pinA = "7bb3af51e22d5371ebd9f2f1788273938005c9d27e8172f420263e50e27808bbc6f0e0beed195d21f81423da010afbe4"
+	pinB = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+)
+
+// bakedConfig mirrors the shape the node image ships: a floor whose digests
+// only the image build knows, and empty CDS pins.
+const bakedConfig = `# nri-image-policy boot config — the MEASURED boot-time floor.
+platform: "snp"
+
+plugin:
+  health_addr: "unix:///var/run/nri-image-policy/health.sock"
+
+workload_claims:
+  socket_dir: "/var/run/nri-image-policy"
+  proc_root: "/proc"
+  advertise_host: ""
+
+allowlist:
+  always_allow:
+    "sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d": "busybox:1.38.0"
+    "sha256:4f502170a33ec2b687e1b703abe31b1e290ff17cd45fba45b138c73689d3b02c": "docker.io/rancher/rke2-runtime:v1.34.5-rke2r1"
+  pull:
+    url: "https://127.0.0.1:30808"
+    interval: "30s"
+    timeout: "30s"
+    attestation_api_url: "http://127.0.0.1:8400"
+    # Deploy-time values; the installer's post-install config refresh pins them.
+    cds_measurements: []
+
+containerd:
+  socket: "/run/k3s/containerd/containerd.sock"
+  namespace: "k8s.io"
+
+policy:
+  mode: "fail-closed"
+  enforce_existing: true
+  deny_missing_annotation: true
+  label_rules: []
+
+logging:
+  level: "info"
+`
+
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "image-policy.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func setPins(t *testing.T, path string, extra ...string) string {
+	t.Helper()
+	var out bytes.Buffer
+	if err := runSetCDSPins(&out, append([]string{"--config", path}, extra...)); err != nil {
+		t.Fatalf("set-cds-pins: %v", err)
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// The pins land and the baked floor — which the chart cannot re-render, because
+// only the image build resolves the RKE2 system digests — survives untouched.
+func TestSetCDSPinsKeepsTheBakedFloor(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+
+	if got := setPins(t, path, "--cds-measurements", pinA+","+pinB); got != pinsUpdated {
+		t.Fatalf("outcome = %q, want %q", got, pinsUpdated)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("patched config does not load: %v\n%s", err, data)
+	}
+	if got := cfg.Allowlist.Pull.CDSMeasurements; len(got) != 2 || got[0] != pinA || got[1] != pinB {
+		t.Errorf("cds_measurements = %v, want [%s %s]", got, pinA, pinB)
+	}
+	if len(cfg.Allowlist.AlwaysAllow) != 2 {
+		t.Errorf("always_allow = %v, want the 2 baked entries", cfg.Allowlist.AlwaysAllow)
+	}
+	if cfg.Platform != "snp" || cfg.WorkloadClaims.SocketDir != "/var/run/nri-image-policy" {
+		t.Errorf("patch disturbed unrelated keys: platform=%q socket_dir=%q", cfg.Platform, cfg.WorkloadClaims.SocketDir)
+	}
+	if !strings.Contains(string(data), "MEASURED boot-time floor") {
+		t.Errorf("patch dropped the config's comments:\n%s", data)
+	}
+}
+
+// Re-running the same install must not restart containerd, so an unchanged pin
+// set reports unchanged and leaves the file's bytes alone.
+func TestSetCDSPinsIsIdempotent(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	setPins(t, path, "--cds-measurements", pinA)
+
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if got := setPins(t, path, "--cds-measurements", pinA); got != pinsUnchanged {
+		t.Fatalf("second run outcome = %q, want %q", got, pinsUnchanged)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Errorf("unchanged pins rewrote the file:\n%s", second)
+	}
+}
+
+// The on-disk pins are compared case-folded, so a hand-written uppercase digest
+// does not read as a change and cost a restart.
+func TestSetCDSPinsFoldsCaseWhenComparing(t *testing.T) {
+	path := writeConfig(t, strings.Replace(bakedConfig,
+		"cds_measurements: []",
+		`cds_measurements: ["`+strings.ToUpper(pinA)+`"]`, 1))
+
+	if got := setPins(t, path, "--cds-measurements", pinA); got != pinsUnchanged {
+		t.Fatalf("outcome = %q, want %q", got, pinsUnchanged)
+	}
+}
+
+// An install with no --measurements must cost no containerd restart: the baked
+// config already says "accept any attested CDS", so there is nothing to write.
+func TestSetCDSPinsLeavesAnUnpinnedInstallAlone(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	if got := setPins(t, path); got != pinsUnchanged {
+		t.Fatalf("outcome = %q, want %q", got, pinsUnchanged)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(data) != bakedConfig {
+		t.Errorf("empty pins rewrote the baked config:\n%s", data)
+	}
+}
+
+func TestSetCDSPinsWritesRTMRsInIndexOrder(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	setPins(t, path, "--cds-measurements", pinA, "--cds-rtmrs", "2="+pinB+",1="+pinA)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("patched config does not load: %v", err)
+	}
+	want := []string{"1=" + pinA, "2=" + pinB}
+	if got := cfg.Allowlist.Pull.CDSRTMRs; len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("cds_rtmrs = %v, want %v", got, want)
+	}
+}
+
+// An install that drops its pins clears them rather than leaving the previous
+// release's set in force.
+func TestSetCDSPinsClearsPins(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	setPins(t, path, "--cds-measurements", pinA)
+
+	if got := setPins(t, path); got != pinsUpdated {
+		t.Fatalf("outcome = %q, want %q", got, pinsUpdated)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("patched config does not load: %v", err)
+	}
+	if len(cfg.Allowlist.Pull.CDSMeasurements) != 0 {
+		t.Errorf("cds_measurements = %v, want empty", cfg.Allowlist.Pull.CDSMeasurements)
+	}
+}
+
+// Every rejection leaves the file as it was: a config the plugin cannot load
+// would stop a required NRI plugin registering, which blocks every container
+// on the node.
+func TestSetCDSPinsRejectsBadInputWithoutTouchingTheFile(t *testing.T) {
+	cases := map[string]struct {
+		body string
+		args []string
+	}{
+		"measurement is not hex":   {bakedConfig, []string{"--cds-measurements", "nothex"}},
+		"measurement wrong length": {bakedConfig, []string{"--cds-measurements", "aabb"}},
+		"rtmr index 0":             {bakedConfig, []string{"--cds-rtmrs", "0=" + pinA}},
+		"no pull section": {strings.Replace(bakedConfig, "  pull:", "  nopull:", 1),
+			[]string{"--cds-measurements", pinA}},
+		"config already invalid": {strings.Replace(bakedConfig, `url: "https://`, `url: "http://`, 1),
+			[]string{"--cds-measurements", pinA}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			path := writeConfig(t, tc.body)
+			var out bytes.Buffer
+			if err := runSetCDSPins(&out, append([]string{"--config", path}, tc.args...)); err == nil {
+				t.Fatalf("set-cds-pins accepted %v", tc.args)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			if string(data) != tc.body {
+				t.Errorf("rejected input still rewrote the file:\n%s", data)
+			}
+		})
+	}
+}
+
+// The daemon path must stay reachable: only the verb selects the patcher.
+func TestRunDispatchesThesetCDSPinsVerb(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	if err := Run([]string{setCDSPinsVerb, "--config", path, "--cds-measurements", pinA}); err != nil {
+		t.Fatalf("Run %s: %v", setCDSPinsVerb, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read patched config: %v", err)
+	}
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatalf("patched config does not load: %v", err)
+	}
+	if len(cfg.Allowlist.Pull.CDSMeasurements) != 1 {
+		t.Errorf("cds_measurements = %v, want one pin", cfg.Allowlist.Pull.CDSMeasurements)
+	}
+}

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -663,9 +663,10 @@ cache_max_entries = 1024
 {{- /* containerd-prep init-container images (rke2-only): the host NRI plugin
        checks every container node-wide, so its own and kata's busybox prep
        image must be in the floor or a DaemonSet re-roll self-deadlocks on
-       "image not in allowlist: busybox". Only seeded when the plugin enforces. */}}
+       "image not in allowlist: busybox". Only seeded when the plugin enforces,
+       and under .baked the installer runs no prep container. */}}
 {{- if .Values.nriImagePolicy.enabled -}}
-{{- if eq .Values.nriImagePolicy.distro "rke2" -}}
+{{- if and (eq .Values.nriImagePolicy.distro "rke2") (not .Values.nriImagePolicy.baked) -}}
 {{- $prep := .Values.nriImagePolicy.containerdPrep.image -}}
 {{- if $prep.digest -}}
 {{- $_ := set $digests $prep.digest (printf "%s@%s" $prep.repository $prep.digest) -}}
@@ -702,12 +703,12 @@ cache_max_entries = 1024
     - the chart's host NRI plugin (nriImagePolicy.enabled),
     - the in-guest policy-monitor baked into the kata-guest-base image
       (kata.enabled, i.e. --cvm-mode=pod), where the host plugin is off, and
-    - the BAKED host NRI plugin on a node-as-CVM (--cvm-mode=node), where the
-      chart's nriImagePolicy is disabled because the node image bakes the
-      plugin — but that plugin still pulls the live allowlist from CDS, so the
-      seed must be served or CDS starts empty and every un-baked component
+    - the BAKED host NRI plugin on a node-as-CVM (--cvm-mode=node), which pulls
+      the live allowlist from CDS like the chart-installed one, so the seed
+      must be served or CDS starts empty and every un-baked component
       (operator, ratls-mesh, tls-lb's nginx, adopted workloads) is denied
-      until an operator hand-runs `c8s allowlist add`.
+      until an operator hand-runs `c8s allowlist add`. The cvmMode arm also
+      covers a node install that leaves the installer off entirely.
   Gating on nriImagePolicy.enabled alone dropped the seed under both pod and
   node mode.
 */}}

--- a/internal/helmchart/c8s/templates/nri-image-policy-helpers.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-helpers.tpl
@@ -95,6 +95,29 @@ uninstall hook.
 {{- end }}
 
 {{/*
+Host mounts for the node-as-CVM pins installer: the baked config it patches and
+the runtime dir holding the plugin's health socket. It touches neither the
+plugin binary nor containerd's config, so neither is mounted.
+*/}}
+{{- define "nri-image-policy.pinsVolumeMounts" -}}
+- name: host-config-dir
+  mountPath: /host{{ .Values.nriImagePolicy.hostPaths.configDir }}
+- name: host-runtime-dir
+  mountPath: /host{{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+{{- end }}
+
+{{- define "nri-image-policy.pinsVolumes" -}}
+- name: host-config-dir
+  hostPath:
+    path: {{ .Values.nriImagePolicy.hostPaths.configDir }}
+    type: DirectoryOrCreate
+- name: host-runtime-dir
+  hostPath:
+    path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+    type: DirectoryOrCreate
+{{- end }}
+
+{{/*
 Host containerd config directory bind-mounted into the installer.
 */}}
 {{- define "nri-image-policy.containerdConfigDir" -}}

--- a/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
+++ b/internal/helmchart/c8s/templates/nri-image-policy-install-script.tpl
@@ -70,7 +70,6 @@ fi
 
 CONTAINERD_DIR=/host{{ include "nri-image-policy.containerdConfigDir" $root }}
 CONTAINERD_CONFIG_MODE={{ include "nri-image-policy.containerdConfigMode" $root | quote }}
-RESTART_COMMAND={{ include "nri-image-policy.restartCommand" $root | quote }}
 MARK_BEGIN='# BEGIN c8s-nri-image-policy (managed)'
 MARK_END='# END c8s-nri-image-policy (managed)'
 
@@ -144,10 +143,26 @@ else
   fi
 fi
 
-# NRI does not respawn pre-registered plugins on exit. Binary, config, or
-# containerd registration changes therefore require a restart. Shims survive.
-restarted_containerd=0
+restart_needed=0
 if [ "$containerd_changed" = "1" ] || [ "$binary_changed" = "1" ] || [ "$config_changed" = "1" ]; then
+  restart_needed=1
+fi
+{{ include "nri-image-policy.restartAndWait" (dict "root" $root) }}
+{{- end }}
+
+{{/*
+Restart + readiness tail, shared by the installer and the node-as-CVM pins
+script. NRI does not respawn pre-registered plugins on exit, so a binary,
+config or containerd-registration change reaches the plugin only through a
+containerd restart. Shims survive it.
+
+Caller dict: .root. The script must set restart_needed to 0 or 1 first.
+*/}}
+{{- define "nri-image-policy.restartAndWait" -}}
+{{- $root := .root -}}
+RESTART_COMMAND={{ include "nri-image-policy.restartCommand" $root | quote }}
+restarted_containerd=0
+if [ "$restart_needed" = "1" ]; then
   restarted_containerd=1
   echo "restarting containerd (detached via systemd-run): $RESTART_COMMAND"
   # The restart tears down this pod's own containerd shim. Running it in this
@@ -194,6 +209,34 @@ until health=$(curl --unix-socket "$health_socket" --silent --fail --max-time 2 
   sleep 1
 done
 echo "==> nri-image-policy installer finished; plugin healthy: $health"
+{{- end }}
+
+{{/*
+Pins script for a node-as-CVM (--cvm-mode=node), where the node image bakes the
+plugin binary, its containerd registration and the boot config — floor included,
+whose RKE2 system digests only the image build resolves. This release's CDS pins
+are the one thing that config cannot carry, so the installer patches those two
+keys into it and restarts containerd when they change.
+
+Caller dict: .root.
+*/}}
+{{- define "nri-image-policy.pinsScript" -}}
+{{- $root := .root -}}
+set -eu
+
+echo "==> nri-image-policy pins installer starting"
+
+result=$(/usr/local/bin/c8s nri-image-policy set-cds-pins \
+  --config "/host{{ include "nri-image-policy.hostConfigPath" $root }}" \
+  --cds-measurements {{ join "," $root.Values.cds.measurements | quote }} \
+  --cds-rtmrs {{ join "," $root.Values.cds.rtmrs | quote }})
+echo "CDS pins $result"
+
+restart_needed=0
+if [ "$result" = "updated" ]; then
+  restart_needed=1
+fi
+{{ include "nri-image-policy.restartAndWait" (dict "root" $root) }}
 {{- end }}
 
 {{/*

--- a/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
@@ -4,6 +4,11 @@ can reach (node-local NodePort), so operator `c8s allowlist add` writes reach
 admission. CDS itself is pinned separately (cds.node.selector, in cds.yaml).
 The name keeps the historical `-worker` suffix to preserve DaemonSet identity
 across upgrade; there is no longer a `-cds` counterpart.
+
+Under nriImagePolicy.baked (node-as-CVM) the node image already carries the
+plugin, its containerd registration and the boot config, so the same DaemonSet
+runs the pins script instead: it writes this release's CDS pins into that config
+and restarts containerd when they change.
 */}}
 {{- if .Values.nriImagePolicy.enabled }}
 ---
@@ -59,7 +64,7 @@ spec:
                       {{- toYaml .values | nindent 22 }}
                   {{- end }}
       initContainers:
-        {{- if eq .Values.nriImagePolicy.distro "rke2" }}
+        {{- if and (eq .Values.nriImagePolicy.distro "rke2") (not .Values.nriImagePolicy.baked) }}
         - name: containerd-prep
           image: {{ include "c8s-common.image" .Values.nriImagePolicy.containerdPrep.image }}
           imagePullPolicy: {{ .Values.nriImagePolicy.containerdPrep.image.pullPolicy }}
@@ -87,22 +92,33 @@ spec:
           imagePullPolicy: {{ .Values.nriImagePolicy.image.pullPolicy }}
           securityContext:
             privileged: true
+          {{- if not .Values.nriImagePolicy.baked }}
           env:
             # The address CDS dials for this node's sandbox-digests endpoint.
             # The plugin is a host process with no downward API of its own, so
             # the install script hands it down through a file. Inferring it
             # from the route to CDS does not work: the chart points the plugin
             # at the CDS NodePort on loopback.
+            #
+            # Under .baked the node image's nri-node-ip.service writes that file
+            # before containerd starts, so nothing is handed down here.
             - name: NODE_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
             - |
+{{- if .Values.nriImagePolicy.baked }}
+{{ include "nri-image-policy.pinsScript" (dict "root" .) | indent 14 }}
+          volumeMounts:
+            {{- include "nri-image-policy.pinsVolumeMounts" . | nindent 12 }}
+{{- else }}
 {{ include "nri-image-policy.installScript" (dict "root" . "bootConfig" (include "nri-image-policy.bootConfig" (dict "root" .))) | indent 14 }}
           volumeMounts:
             {{- include "nri-image-policy.hostVolumeMounts" . | nindent 12 }}
+{{- end }}
           resources:
             {{- toYaml .Values.nriImagePolicy.resources | nindent 12 }}
       containers:
@@ -118,5 +134,9 @@ spec:
               cpu: 50m
               memory: 32Mi
       volumes:
+        {{- if .Values.nriImagePolicy.baked }}
+        {{- include "nri-image-policy.pinsVolumes" . | nindent 8 }}
+        {{- else }}
         {{- include "nri-image-policy.hostVolumes" . | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/internal/helmchart/c8s/templates/nri-image-policy-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/nri-image-policy-uninstall-hook.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.nriImagePolicy.enabled .Values.nriImagePolicy.uninstall.enabled }}
+{{/* Not under .baked: the plugin, its binary and its containerd registration
+     belong to the node image, so removing them would strip a measured node of
+     the admission gate the chart never installed. */}}
+{{- if and .Values.nriImagePolicy.enabled .Values.nriImagePolicy.uninstall.enabled (not .Values.nriImagePolicy.baked) }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -62,7 +62,15 @@
   exactly the remaining shapes — non-kata and non-node.
 */ -}}
 {{- if and (not .Values.kata.enabled) (not .Values.nriImagePolicy.enabled) (ne .Values.attestationApi.cvmMode "node") -}}
-{{- fail "VALIDATION_ERROR kind=require_host_image_policy: nriImagePolicy.enabled=false requires kata.enabled=true or attestationApi.cvmMode=node. On a non-kata, non-node cluster host nri-image-policy is the only image-admission enforcement; disabling it leaves confidential workloads with no attested allowlist gate. Under kata the in-guest policy-monitor replaces it and under cvmMode=node the node image bakes the plugin (`c8s install --cvm-mode=pod` and `--cvm-mode=node` set nriImagePolicy.enabled=false for you)." -}}
+{{- fail "VALIDATION_ERROR kind=require_host_image_policy: nriImagePolicy.enabled=false requires kata.enabled=true or attestationApi.cvmMode=node. On a non-kata, non-node cluster host nri-image-policy is the only image-admission enforcement; disabling it leaves confidential workloads with no attested allowlist gate. Under kata the in-guest policy-monitor replaces it (`c8s install --cvm-mode=pod` sets nriImagePolicy.enabled=false for you), and under cvmMode=node the node image bakes the plugin — but leaving the installer off there also leaves the baked plugin without this release's CDS pins, so prefer nriImagePolicy.enabled=true with nriImagePolicy.baked=true (`c8s install --cvm-mode=node` sets both)." -}}
+{{- end -}}
+{{- /*
+  nriImagePolicy.baked says the plugin, its containerd registration and its boot
+  config come from the node image. Only a node-as-CVM ships those, so anywhere
+  else it would skip the install and leave the node with no plugin at all.
+*/ -}}
+{{- if and .Values.nriImagePolicy.baked (ne .Values.attestationApi.cvmMode "node") -}}
+{{- fail (printf "VALIDATION_ERROR kind=nri_baked_requires_node: nriImagePolicy.baked=true requires attestationApi.cvmMode=node (got %q). Only the node-as-CVM image bakes the plugin and its containerd registration; anywhere else the installer must install them, so baked would leave the node with no image admission at all." .Values.attestationApi.cvmMode) -}}
 {{- end -}}
 {{- /*
   Under kata the webhook injects c8s-cert/c8s-secret/c8s-volume into every

--- a/internal/helmchart/c8s/values.schema.json
+++ b/internal/helmchart/c8s/values.schema.json
@@ -139,6 +139,7 @@
       ],
       "additionalProperties": false,
       "properties": {
+        "baked": {},
         "bootstrapAllowlist": {
           "type": [
             "object",

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -823,16 +823,25 @@ ratlsMesh:
     monitoringNamespace: monitoring
 
 nriImagePolicy:
-  ## Host-side NRI image admission. Its enabled state is bound to the cvmMode
-  ## shape, not free: it MUST be false where another path already admits — under
-  ## kata (the in-guest policy-monitor; enforce_host_components) and under
-  ## cvmMode=node (the node image bakes a fail-closed plugin) — and MUST be true
-  ## otherwise (pod/gke/aks, where host NRI is the only allowlist gate;
-  ## require_host_image_policy). `c8s install` sets it from --cvm-mode. The
-  ## bootstrapAllowlist below still feeds CDS's served seed whenever a consumer
-  ## exists — host NRI, kata's in-guest monitor, or the node-baked plugin (see
-  ## c8s.serveAllowlistSeed).
+  ## Host-side NRI image admission: the installer DaemonSet. Its enabled state is
+  ## bound to the cvmMode shape, not free: it MUST be false under kata, where the
+  ## in-guest policy-monitor admits instead (enforce_host_components), and MUST
+  ## be true on gke/aks, where host NRI is the only allowlist gate
+  ## (require_host_image_policy). On cvmMode=node it runs in its baked form
+  ## (below) — the plugin comes from the node image, but only this installer
+  ## carries the release's CDS pins to it. `c8s install` sets both from
+  ## --cvm-mode. The bootstrapAllowlist below still feeds CDS's served seed
+  ## whenever a consumer exists — host NRI, kata's in-guest monitor, or the
+  ## node-baked plugin (see c8s.serveAllowlistSeed).
   enabled: true
+  ## Node-as-CVM (`c8s install --cvm-mode=node`, which sets this): the node image
+  ## bakes the plugin binary, its containerd registration and the boot config —
+  ## floor included, whose RKE2 system-image digests only the image build
+  ## resolves. The installer then writes this release's cds.measurements /
+  ## cds.rtmrs into that config and restarts containerd when they change,
+  ## touching nothing else. Requires attestationApi.cvmMode=node
+  ## (nri_baked_requires_node).
+  baked: false
   ## Host Kubernetes distro for the nri-image-policy installer: k8s | rke2.
   ## Selects the containerd config layout it targets — see the subchart's
   ## values.yaml. `c8s install` sets this to the distro detected from the

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -5926,6 +5926,70 @@ func TestChartComponentArgsDoNotRepeatTheEntrypointSubcommand(t *testing.T) {
 	}
 }
 
+// TestChartPinsCDSInNodeMode guards the node-as-CVM pin path. The node image
+// bakes the plugin with empty cds_measurements, and the chart is the only thing
+// that knows this release's pins — so an install that does not carry them into
+// the baked config leaves the component deciding which images may run on the
+// node willing to take its allowlist from ANY RA-TLS-attested CDS, and its
+// sandbox-digests endpoint willing to answer any of them. Regression for a
+// bare-metal run that found exactly that (2026-08-26).
+func TestChartPinsCDSInNodeMode(t *testing.T) {
+	const (
+		pinM = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+		pinR = "1=bbccddeeff00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899aa"
+	)
+	const pinsImageDigest = "sha256:00000000000000000000000000000000000000000000000000000000000000d1"
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=node",
+		"--set", "attestationApi.enabled=false",
+		"--set", "nriImagePolicy.baked=true",
+		"--set", "nriImagePolicy.bootstrapAllowlist.deriveComponents=true",
+		"--set-string", "nriImagePolicy.image.digest="+pinsImageDigest,
+		"--set-string", "cds.measurements[0]="+pinM,
+		"--set-string", "cds.rtmrs[0]="+pinR,
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+
+	ds := renderedDaemonSet(t, out, "c8s-nri-image-policy-worker")
+	script := strings.Join(containerArgs(t, &ds, "install"), "\n")
+	for _, want := range []string{
+		"set-cds-pins",
+		"--cds-measurements \"" + pinM + "\"",
+		"--cds-rtmrs \"" + pinR + "\"",
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("node-mode installer script missing %q\n%s", want, script)
+		}
+	}
+
+	// The baked config carries the image floor whose RKE2 system digests only
+	// the image build resolves, so the installer must patch it, never rewrite
+	// it — and must leave the binary and the containerd registration alone.
+	for _, forbidden := range []string{"IMAGE_POLICY_EOF", "install_file", "render_nri_toml"} {
+		if strings.Contains(script, forbidden) {
+			t.Errorf("node-mode installer script must not run %q — it would replace what the node image measured\n%s", forbidden, script)
+		}
+	}
+	for _, c := range ds.Spec.Template.Spec.InitContainers {
+		if c.Name == "containerd-prep" {
+			t.Errorf("node-mode installer renders containerd-prep; the node image owns the containerd NRI registration")
+		}
+	}
+
+	// The installer image is a chart image, not a baked one, so the node admits
+	// it only through the seed CDS serves.
+	cm := renderedConfigMap(t, out, "c8s-cds-allowlist-seed")
+	seed, err := pkgallowlist.ParseJSON([]byte(cm.Data["allowlist-seed.json"]))
+	if err != nil {
+		t.Fatalf("node-mode seed JSON does not parse: %v\n%s", err, cm.Data["allowlist-seed.json"])
+	}
+	if got := seed.Digests[pinsImageDigest]; got != "ghcr.io/confidential-dot-ai/nri-image-policy@"+pinsImageDigest {
+		t.Errorf("seed[%s] = %q, want the pins installer image; the baked plugin would deny it", pinsImageDigest, got)
+	}
+}
+
 // TestChartServesAllowlistSeedInNodeMode guards the node-as-CVM seed path: with
 // --cvm-mode=node the chart's nriImagePolicy is disabled (the node image bakes
 // the plugin) and kata is off, yet the baked plugin still pulls the live

--- a/node-guest-image/c8s/image-policy.yaml.in
+++ b/node-guest-image/c8s/image-policy.yaml.in
@@ -9,15 +9,15 @@
 # /var/lib/rancher/rke2/agent/etc/containerd/config-v3.toml.d/). This file
 # is the config it boots with, before c8s is installed.
 #
-# TRUST POSTURE: this baked copy is measured; after `c8s install` the
-# chart's installer DaemonSet overwrites it (on the unmeasured overlay
-# upper) with the values-rendered version — real cds_measurements pins, the
-# full image-digest floor. That is deliberate: the measured invariants are
-# the plugin BINARY and the fail-closed NRI registration
-# (required_plugins), while the policy DATA arrives via the CDS RA-TLS +
-# attestation chain and may be updated without an image rebuild. Expect
-# exactly one rke2-server restart from the installer when the config diff
-# lands.
+# TRUST POSTURE: this baked copy is measured, and the floor below stays as
+# built — the RKE2 system digests in it are resolved here and nowhere else.
+# `c8s install` runs the chart's installer in its baked form
+# (nriImagePolicy.baked), which writes the release's cds_measurements /
+# cds_rtmrs into this file on the overlay upper and leaves every other key
+# alone. Expect one rke2-server restart from it when those pins change:
+# NRI does not respawn a pre-registered plugin, so the config reaches the
+# plugin only through containerd. The overlay upper is ephemeral, so each
+# boot starts from the pins below and the installer re-applies.
 #
 # Field names/semantics validated against the plugin's config loader
 # (c8s internal/cmds/nri-image-policy/config.go). Notable constraints:
@@ -42,8 +42,7 @@ plugin:
 
 # The node-CVM admission inventory (c8s docs/ratls.md, "Sandbox identity").
 # get-cert dials this socket for its pod's digests before CDS will issue a
-# certificate. In --cvm-mode=node the chart's nri-image-policy installer is
-# disabled, so nothing rewrites this file after boot and the section must be
+# certificate. The installer only patches the CDS pins, so this section must be
 # baked in; without it the socket is never created and every adopted workload
 # hangs waiting for a certificate that cannot be issued.
 workload_claims:
@@ -53,7 +52,7 @@ workload_claims:
   proc_root: "/proc"
   # Empty falls back to NodeIPFile (node-ip in socket_dir). On a Kubernetes-
   # hosted install the chart's installer writes that from its own status.hostIP;
-  # a node-as-CVM has no installer, so nri-node-ip.service writes it at boot
+  # the baked installer does not, so nri-node-ip.service writes it at boot
   # instead. Without either, this resolves to 127.0.0.1 and the plugin refuses
   # to start with "inventory host is not a routable unicast address".
   advertise_host: ""
@@ -111,8 +110,9 @@ allowlist:
     # :8400). The plugin runs in the host netns as a containerd child, so
     # loopback reaches it.
     attestation_api_url: "http://127.0.0.1:8400"
-    # Deploy-time values; the installer's post-install config refresh pins
-    # them. Empty = accept any RA-TLS-attested CDS measurement (logged).
+    # `c8s install --measurements` / `--measurements-config` writes these; see
+    # TRUST POSTURE above. Empty = accept any RA-TLS-attested CDS measurement
+    # (logged), which is what every boot starts from.
     cds_measurements: []
 
 containerd:

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -184,7 +184,13 @@ for line in open(sys.argv[1]):
 floor = {d: r for d, r in floor.items() if r != sys.argv[3]}
 with open(sys.argv[2], "w") as f:
     yaml.safe_dump({
-        "nriImagePolicy": {"bootstrapAllowlist": {"digests": floor}},
+        "nriImagePolicy": {
+            # The kind node bakes no plugin or boot config, so the chart's
+            # installer stays off: its baked form would find no config to
+            # patch. The full installer is applied out-of-band below.
+            "enabled": False,
+            "bootstrapAllowlist": {"digests": floor},
+        },
     }, f)
 print(f"floor: {len(floor)} digests")
 PYEOF
@@ -240,10 +246,11 @@ cds_write() {
 # --- NRI image-policy plugin ---
 
 log "Installing the NRI image-policy plugin"
-# Under --cvm-mode=node the chart does not render this DaemonSet (production
-# node images bake the plugin), so the harness renders it from the chart
-# source and applies it out-of-band — same installer, same containerd patch,
-# same plugin.
+# Under --cvm-mode=node the chart renders the installer only in its baked
+# pins-patching form, and the install above leaves even that off (values.yaml):
+# the kind node bakes no plugin for it to pin. The harness renders the full
+# installer from the chart source and applies it out-of-band — same installer,
+# same containerd patch, same plugin.
 NRI_STORE_DIGEST="$(awk -F'\t' '$2 ~ /nri-image-policy:it$/ {print $1; exit}' "$WORKDIR/floor.tsv")"
 CDS_STORE_DIGEST="$(awk -F'\t' '$2 ~ /\/cds:it$/ {print $1; exit}' "$WORKDIR/floor.tsv")"
 [ -n "$NRI_STORE_DIGEST" ] && [ -n "$CDS_STORE_DIGEST" ] || fail "loaded-image digests missing from the floor scan"


### PR DESCRIPTION
The node image bakes the plugin, so --cvm-mode=node deployed no installer — and the installer is the only thing that renders the plugin's boot config. Neither --measurements nor --measurements-config reached it, leaving the component that decides which images may run on the node willing to take its allowlist from any RA-TLS-attested CDS, and its sandbox-digests endpoint willing to answer any of them. Found on bare metal, 2026-08-26.

The installer now stays on there in a baked form: it patches allowlist.pull.cds_measurements/cds_rtmrs into the baked config and restarts containerd when they change, leaving the binary, the containerd registration and the image floor — whose RKE2 system digests only the image build resolves — as the image measured them.

Patching rather than re-rendering is why set-cds-pins is a Go verb on the plugin binary: the image ships no yq, and a torn edit of this file stops a required NRI plugin registering, which blocks every container on the node.