### PR TITLE
fix(node-image): disable rke2-traefik, RKE2 v1.36's bundled ingress

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -273,7 +273,8 @@ func preflightCDSNode(ctx context.Context, chartPath string) error {
 // preflightTLSLBHostPort fails fast when tls-lb's host port is already bound on
 // every node, so the tls-lb pod would sit Pending and `--wait` would time out
 // with an opaque scheduler error. The classic collision is a bundled ingress
-// controller (rke2 ships rke2-ingress-nginx on host 80/443). Reads chart
+// controller (rke2 <= v1.35 ships rke2-ingress-nginx, v1.36+ rke2-traefik,
+// both on host 80/443). Reads chart
 // defaults, so the caller gates it to the default (no -f) path where they apply.
 func preflightTLSLBHostPort(ctx context.Context, chartPath, namespace string) error {
 	out, err := exec.CommandContext(ctx, "helm", "show", "values", chartPath).Output()

--- a/cmd/c8s/install_test.go
+++ b/cmd/c8s/install_test.go
@@ -1028,6 +1028,13 @@ func TestHostPortConflict(t *testing.T) {
 			wantHolder:  "kube-system/rke2-ingress-nginx-abc",
 		},
 		{
+			name:        "single node, traefik holds 443 (rke2 v1.36+ default ingress)",
+			pods:        []corev1.Pod{pod("kube-system", "rke2-traefik-abc", "node-a", 443)},
+			nodes:       []string{"node-a"},
+			wantBlocked: true,
+			wantHolder:  "kube-system/rke2-traefik-abc",
+		},
+		{
 			name: "two nodes, ingress on both",
 			pods: []corev1.Pod{
 				pod("kube-system", "ing-a", "node-a", 443),

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1131,7 +1131,8 @@ tlsLb:
   # on the node IP (kubelet/CNI portmap DNATs the host port to the in-pod
   # unprivileged listener, so nginx needs no privileged bind). This grabs the
   # node's 443: on clusters whose ingress already owns it (notably RKE2, which
-  # bundles rke2-ingress-nginx on hostPort 80/443) the tls-lb pod stays
+  # bundles an ingress on hostPort 80/443 — rke2-ingress-nginx through v1.35,
+  # rke2-traefik from v1.36) the tls-lb pod stays
   # Pending ("didn't have free ports for the requested pod ports"); set
   # enabled: false there (reach tls-lb through its Service or your own
   # ingress) or point https at a free host port. https is the host port to

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -30,12 +30,15 @@ cluster-cidr: 10.52.0.0/16
 service-cidr: 10.53.0.0/16
 cluster-dns: 10.53.0.10
 
-# Drop RKE2's bundled ingress-nginx: it binds hostPorts 80/443, which collide
-# with c8s tls-lb's hostPort 443 (the attested front door for workloads —
-# `c8s install` preflights this exact conflict). The node image's external
-# surface is tls-lb, not a generic ingress.
+# Drop RKE2's bundled ingress: it binds hostPorts 80/443, which collide with
+# c8s tls-lb's hostPort 443 (the attested front door for workloads —
+# `c8s install` preflights this exact conflict). RKE2 <= v1.35 bundles
+# rke2-ingress-nginx; v1.36+ bundles rke2-traefik — disable both so the image
+# works across versions. The node image's external surface is tls-lb, not a
+# generic ingress.
 disable:
   - rke2-ingress-nginx
+  - rke2-traefik
 
 # Add a stable hostname SAN to the apiserver serving cert. The operator
 # reaches the guest at a per-launch KubeVirt-assigned IP that RKE2 can't know


### PR DESCRIPTION
RKE2 v1.36 (stable channel since 2026-05) replaced rke2-ingress-nginx with rke2-traefik as the bundled ingress. The node image's baked RKE2 config disables only nginx, so on current RKE2 the tls-lb hostPort-443 preflight fails with `kube-system/rke2-traefik-…` holding the port — hit live on a v1.36.3 cluster. The preflight's holder detection is already name-agnostic; this disables both ingresses in the node image, refreshes the two comments that named only nginx, and adds a traefik case to the preflight test.

Companion docs update: [confidential.ai-website#59](https://github.com/confidential-dot-ai/confidential.ai-website/pull/59).