### PR TITLE
ci(grype): drop the push-to-main trigger

### DIFF
--- a/.github/workflows/grype.yml
+++ b/.github/workflows/grype.yml
@@ -6,9 +6,11 @@ on:
   # at the next audit.
   schedule:
     - cron: "17 6 * * 1"
-  push:
+  # No push trigger: a fresh advisory against an unchanged pin would paint
+  # main red without any commit to blame; PRs and the weekly run cover it.
+  pull_request:
     branches: [main]
-    paths: &paths
+    paths:
       - "**.go"
       - "go.mod"
       - "go.sum"
@@ -16,9 +18,6 @@ on:
       - "go.work.sum"
       - "internal/helmchart/c8s/values.yaml"
       - ".github/workflows/grype.yml"
-  pull_request:
-    branches: [main]
-    paths: *paths
 
 permissions:
   contents: read


### PR DESCRIPTION
A new advisory against an unchanged image pin turns pushes to main red without any commit to blame — as with the current OpenSSL 3.5.7 batch ([#500](https://github.com/confidential-dot-ai/c8s/pull/500)), where no rebuilt nginx-unprivileged image exists to bump to. PRs keep the scan (same path filter) and the weekly scheduled run still surfaces fresh advisories; the YAML anchor moves from the removed push block into pull_request.