### PR TITLE
ci(meat): read the OpenAI key from OPENAI_MEATTY_API_KEY

### DIFF
--- a/.github/workflows/meat.yml
+++ b/.github/workflows/meat.yml
@@ -15,16 +15,31 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Small PRs are quicker to read whole than abridged. Expressions can't add,
+  # so the count lives in its own job, ahead of the environment approval gate.
+  size:
+    name: Measure PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      large: ${{ steps.count.outputs.large }}
+    steps:
+      - id: count
+        env:
+          ADDITIONS: ${{ github.event.pull_request.additions }}
+          DELETIONS: ${{ github.event.pull_request.deletions }}
+        run: echo "large=$(( ADDITIONS + DELETIONS > 700 ))" >> "$GITHUB_OUTPUT"
+
   meat:
     name: Reading diff (advisory)
+    needs: size
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: meat-review
     # Fork PRs can't post comments (read-only token) and must not touch secrets.
-    # Small PRs are quicker to read whole than abridged.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.additions + github.event.pull_request.deletions > 700
+      && needs.size.outputs.large == '1'
     # Advisory: a flaky LLM run never blocks the PR.
     continue-on-error: true
     steps:

--- a/.github/workflows/meat.yml
+++ b/.github/workflows/meat.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           # Provided via the `meat-review` environment (required approval).
           # A missing LLM degrades the advisory to a skip (with a notice), not a red row.
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_MEATTY_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           if "$(go env GOPATH)/bin/meat" -json -staged > meat.json 2> meat.err; then

--- a/.github/workflows/meat.yml
+++ b/.github/workflows/meat.yml
@@ -21,7 +21,10 @@ jobs:
     timeout-minutes: 30
     environment: meat-review
     # Fork PRs can't post comments (read-only token) and must not touch secrets.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Small PRs are quicker to read whole than abridged.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.additions + github.event.pull_request.deletions > 700
     # Advisory: a flaky LLM run never blocks the PR.
     continue-on-error: true
     steps:


### PR DESCRIPTION
Point the meat workflow's `OPENAI_API_KEY` env at the `OPENAI_MEATTY_API_KEY` secret, and skip PRs with 700 or fewer changed lines (additions + deletions).