### PR TITLE
feat(node-guest-image): fail closed on a non-CC NVIDIA GPU

### DIFF
--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -144,6 +144,15 @@ jobs:
       - name: Run the gpu-node-label unit test
         run: make test-node-guest-image-gpu-label
 
+  gpu-cc:
+    name: gpu-cc-enforce logic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run the gpu-cc-enforce unit test
+        run: make test-node-guest-image-gpu-cc
+
   rke2-role:
     name: rke2-role dispatch (script)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-gpu-cc test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -145,6 +145,9 @@ test-node-guest-image-role:
 # GPU-node label logic (root-free unit test; fakes the PCI tree).
 test-node-guest-image-gpu-label:
 	./node-guest-image/tests/gpu-node-label-test.sh
+
+test-node-guest-image-gpu-cc:
+	./node-guest-image/tests/gpu-cc-enforce-test.sh
 
 # Role-gated unit wiring under real systemd in a privileged container.
 # Needs only docker.

--- a/README.md
+++ b/README.md
@@ -621,7 +621,8 @@ than let you discover them:
   which does not expose nested virtualization.
 
 - **GPU attestation is not wired end to end.** GPU passthrough into
-  confidential pods works, and a locked guest fails closed on a non-CC GPU.
+  confidential pods works, and both the kata GPU guest and the node CVM fail
+  closed on a non-CC GPU.
   [attestation-rs](https://github.com/confidential-dot-ai/attestation-rs)
   verifies NVIDIA GPU and NVSwitch evidence (SPDM via NRAS, nonce-bound to the
   CPU TEE evidence), but c8s does not collect GPU evidence in the guest or

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/gpu-cc-enforce.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/gpu-cc-enforce.service
@@ -1,0 +1,29 @@
+# Fail the boot when a passed-through NVIDIA GPU is not in CC mode. The kata
+# GPU guest has the same gate (nvidia-gpu-ready); confos's nvidia-cc-ready
+# deliberately tolerates non-CC launches, which the c8s node must not.
+[Unit]
+Description=Refuse to start the node unless every NVIDIA GPU is in confidential-compute mode
+# nvidia-cc-ready is where the driver is proven up and the ready state set;
+# order after it so nvidia-smi answers, but do not Require it: on a GPU-less
+# boot it is a no-op and this unit is too.
+After=nvidia-cc-ready.service
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/gpu-cc-enforce.sh
+# nvidia-cc-ready already waited up to 180s for the driver; this is one query.
+TimeoutStartSec=60
+# Fail closed: a non-CC GPU powers the VM off rather than leaving a node that
+# schedules unprotected GPU memory.
+FailureAction=poweroff-force
+
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).
+RestrictAddressFamilies=AF_UNIX
+
+[Install]
+WantedBy=multi-user.target
+# Preset creates the .requires links, so rke2 cannot start while this unit
+# is failing or has not run.
+RequiredBy=rke2-server.service rke2-agent.service

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -20,6 +20,9 @@ enable nri-node-ip.service
 # Label GPU launches before rke2 registers the node; the baked
 # nvidia-device-plugin DaemonSet selects on the label.
 enable gpu-node-label.service
+# Fail closed on a non-CC GPU before rke2 registers the node; RequiredBy the
+# rke2 pair so a failed gate never schedules the GPU.
+enable gpu-cc-enforce.service
 # Role dispatch + the role-gated rke2 pair.
 enable rke2-role.service
 enable rke2-server.service

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-cc-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/gpu-cc-enforce.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# gpu-cc-enforce: refuse to bring up a node CVM whose passed-through NVIDIA
+# GPUs are not in confidential-compute (CC) mode.
+#
+# confos's nvidia-cc-ready sets the CC ready state but never fails: on a
+# non-CC GPU it logs and exits 0, and the baked device plugin then advertises
+# a GPU whose memory the host can read. The c8s node is confidential-only, so
+# the unit that runs this script fails the boot instead (FailureAction powers
+# the VM off; rke2 Requires= it and never starts).
+#
+# The gate is CC status per GPU, not the ready state: a CC GPU left un-readied
+# is unusable for CUDA but still protected, and nvidia-cc-ready already logs
+# that case loudly. nvidia-smi itself failing is fatal: a driver that is not
+# up cannot vouch for anything.
+#
+# PCI presence (vendor 0x10de) mirrors gpu-node-label.sh so a GPU-less boot
+# of the same image is a clean no-op.
+set -eu
+
+fail() {
+    echo "gpu-cc-enforce: $1 — refusing to start the node (GPU memory would be unprotected). Enable GPU CC mode on the host (nvidia_gpu_tools.py --set-cc-mode=on)." >&2
+    exit 1
+}
+
+present=0
+for vendor in /sys/bus/pci/devices/*/vendor; do
+    [ -e "$vendor" ] || continue
+    if [ "$(cat "$vendor")" = "0x10de" ]; then
+        present=1
+        break
+    fi
+done
+if [ "$present" = 0 ]; then
+    echo "gpu-cc-enforce: no NVIDIA GPU present; nothing to enforce"
+    exit 0
+fi
+
+status=$(nvidia-smi conf-compute -f 2>&1) || fail "nvidia-smi conf-compute -f failed: $status"
+
+# Driver 595 prints "CC status: ON"; older drivers "CC feature: ON". One line
+# per GPU with -i, one aggregate line without; either way every line must be
+# on, and at least one must exist.
+lines=$(printf '%s\n' "$status" | grep -iE 'cc (feature|status)[[:space:]]*:' || true)
+[ -n "$lines" ] || fail "cannot parse CC status from nvidia-smi: $status"
+if printf '%s\n' "$lines" | grep -qviE ':[[:space:]]*(on|enabled)[[:space:]]*$'; then
+    fail "GPU not in CC mode ($lines)"
+fi
+
+echo "gpu-cc-enforce: all NVIDIA GPUs in CC mode"

--- a/node-guest-image/tests/gpu-cc-enforce-test.sh
+++ b/node-guest-image/tests/gpu-cc-enforce-test.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Unit test for gpu-cc-enforce.sh: a GPU-less boot is a no-op, every CC-on
+# wording passes, and any GPU with CC off, an unparseable status, or a dead
+# driver fails the gate. Root-free: fakes the PCI sysfs tree under a temp root
+# and shadows nvidia-smi with a stub on PATH.
+set -u
+
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$TESTS_DIR/lib.sh"
+SCRIPT=${GPU_CC_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/gpu-cc-enforce.sh"}
+[[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
+
+not() { ! "$@"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/bin"
+
+# Run the production script verbatim with the sysfs root rebased into $WORK
+# and the stub nvidia-smi first on PATH.
+run_enforce() {
+    sed -e "s|/sys/bus/pci/devices|$WORK/sys/bus/pci/devices|g" "$SCRIPT" \
+        | PATH="$WORK/bin:$PATH" sh 2>"$WORK/stderr"
+}
+set_vendor() { # set_vendor HEXID
+    rm -rf "$WORK/sys/bus/pci/devices"
+    mkdir -p "$WORK/sys/bus/pci/devices/0000:0b:00.0"
+    printf '%s' "$1" > "$WORK/sys/bus/pci/devices/0000:0b:00.0/vendor"
+}
+# stub_smi RC OUTPUT... — nvidia-smi prints each OUTPUT line and exits RC.
+stub_smi() {
+    local rc=$1; shift
+    { echo '#!/bin/sh'; printf 'echo "%s"\n' "$@"; echo "exit $rc"; } > "$WORK/bin/nvidia-smi"
+    chmod +x "$WORK/bin/nvidia-smi"
+}
+stderr_has() { grep -q "$1" "$WORK/stderr"; }
+
+CASE="no nvidia device"
+set_vendor 0x8086
+stub_smi 1 "No devices were found"
+ok "no-op without a GPU even when nvidia-smi fails" run_enforce
+
+CASE="cc on (driver 595 wording)"
+set_vendor 0x10de
+stub_smi 0 "CC status: ON"
+ok "passes" run_enforce
+
+CASE="cc on (older 'CC feature' wording)"
+stub_smi 0 "CC feature: ON"
+ok "passes" run_enforce
+
+CASE="cc off"
+stub_smi 0 "CC status: OFF"
+ok "fails" not run_enforce
+ok "names the cause" stderr_has "not in CC mode"
+
+CASE="one of two gpus off"
+stub_smi 0 "GPU 0: CC status: ON" "GPU 1: CC status: OFF"
+ok "fails when any GPU is off" not run_enforce
+
+CASE="unparseable status"
+stub_smi 0 "Confidential Compute is not supported on this device"
+ok "fails when no CC status line is printed" not run_enforce
+ok "names the cause" stderr_has "cannot parse"
+
+CASE="driver not up"
+stub_smi 9 "NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver"
+ok "fails when nvidia-smi errors" not run_enforce
+ok "names the cause" stderr_has "conf-compute -f failed"
+
+summarize "gpu-cc-enforce"


### PR DESCRIPTION
Node-as-CVM counterpart of the kata guest's `nvidia-gpu-ready` gate.

confos's `nvidia-cc-ready` sets the CC ready state but never fails: with CC off it logs "not a confidential launch" and exits 0, and the baked device plugin then advertises a GPU whose memory the host can read.

- `gpu-cc-enforce.service` runs after `nvidia-cc-ready`, before rke2, and is `RequiredBy` both rke2 units via the preset. `FailureAction=poweroff-force`, like the kata guest.
- `gpu-cc-enforce.sh` no-ops without an NVIDIA PCI function; otherwise every `CC status`/`CC feature` line from `nvidia-smi conf-compute -f` must be `ON`. An unparseable status or a dead driver also fails.
- Unit test (`make test-node-guest-image-gpu-cc`) and CI job.

The gate is CC status, not ready state: a CC GPU left un-readied is unusable but still protected, and `nvidia-cc-ready` already logs that case.

No debug escape hatch: unlike the kata `-debug` guest, `C8S_DEV=1` node builds also fail closed. Bring-up on non-CC parts can use confos's plain `gpu` image.

Positive GPU attestation to the relying party remains unwired (see [Known gaps](https://github.com/confidential-dot-ai/c8s#known-gaps-and-open-items)).
