### PR TITLE
fix(cli): exclude the measurements config from the c8s_node build

### DIFF
--- a/cmd/c8s/measurements_config.go
+++ b/cmd/c8s/measurements_config.go
@@ -1,3 +1,5 @@
+//go:build !c8s_node
+
 package main
 
 import (

--- a/cmd/c8s/measurements_config_test.go
+++ b/cmd/c8s/measurements_config_test.go
@@ -1,3 +1,5 @@
+//go:build !c8s_node
+
 package main
 
 import (


### PR DESCRIPTION
`cmd/c8s/measurements_config.go` uses the install-only flag variables (`installMeasurements`, `installRTMRs`, `installMeasurementsConfig`), which live behind `//go:build !c8s_node`. `make build-c8s-node` therefore fails, and with it the [Kata guest base workflow](https://github.com/confidential-dot-ai/c8s/actions/workflows/kata-guest-base.yml) on every push since [#492](https://github.com/confidential-dot-ai/c8s/pull/492) — including the [v0.8.0 release commit](https://github.com/confidential-dot-ai/c8s/actions/runs/33168045920), so no `kata-guest-base:v0.8.0` guest was published and a `--cvm-mode=pod` install of v0.8.0 cannot converge.

Put the file and its test behind the same build tag.