### PR TITLE
fix(tls-lb): track the live CDS mesh CA at the discovery endpoints

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -290,6 +290,15 @@ trusts them, and the mesh degrades as old leaves expire. Recovery is to
 restart every workload so its get-cert init container re-runs the CDS
 provisioning flow.
 
+The tls-lb discovery endpoints (`/.well-known/mesh-ca.pem`,
+`/.well-known/cds-cert.pem`, `/v1/discovery`) track the new CA without a
+tls-lb restart: the c8s-cert sidecar polls CDS's `/ca` every
+`tlsLb.certProvisioning.caWatchInterval` (default 1m) over the same
+RA-TLS-verified channel it obtains certificates on, and re-issues its leaf —
+rewriting the served CA bundle and discovery document — as soon as CDS holds
+a CA the served bundle is missing. External clients that pinned the old CA
+must still re-fetch it from the discovery endpoint.
+
 There is **no scheduled in-process CA rotation today** — no cds flag or
 loop drives it, so every CA fingerprint change is a restart-shaped
 re-bootstrap. (An unwired rotator exists at `internal/issuer.CARotator`:

--- a/internal/cmds/getcert/cmd_test.go
+++ b/internal/cmds/getcert/cmd_test.go
@@ -28,6 +28,7 @@ func TestNewCmdFlagDefaultsAndRequired(t *testing.T) {
 		{"key-mode", "0600"},
 		{"discovery-public-tls-mode", "cds"},
 		{"reload-watch-interval", "1m0s"},
+		{"ca-watch-interval", "0s"},
 		{"initial-retry-timeout", "2m0s"},
 		{"initial-retry-interval", "2s"},
 		{"reload-nginx", "true"},

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -26,6 +26,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -63,6 +64,7 @@ type config struct {
 	ContinueOnInitialError bool
 	ReloadWatchPaths       []string
 	ReloadWatchInterval    time.Duration
+	CAWatchInterval        time.Duration
 	DiscoveryOutPath       string
 	DiscoveryCDSCertURL    string
 	DiscoveryMeshCAURL     string
@@ -85,6 +87,7 @@ var procRoot = "/proc"
 
 var (
 	errInvalidDiscoveryPublicTLSMode             = errors.New("invalid discovery public TLS mode")
+	errInvalidCAWatchInterval                    = errors.New("invalid CA watch interval")
 	errInvalidReloadWatchInterval                = errors.New("invalid reload watch interval")
 	errInvalidUnnamedRenewInterval               = errors.New("invalid unnamed renew interval")
 	errReloadWatchRequiresRenewInterval          = errors.New("reload watch requires renew interval")
@@ -136,6 +139,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags.BoolVar(&cfg.ContinueOnInitialError, "continue-on-initial-error", false, "In renewal mode, keep running when the first certificate request fails, retrying on a capped backoff until a certificate is issued")
 	flags.StringArrayVar(&cfg.ReloadWatchPaths, "reload-watch", nil, "File path to poll for changes and reload nginx when it changes (repeatable)")
 	flags.DurationVar(&cfg.ReloadWatchInterval, "reload-watch-interval", time.Minute, "Poll interval for --reload-watch paths")
+	flags.DurationVar(&cfg.CAWatchInterval, "ca-watch-interval", 0, "Poll CDS's /ca at this interval and renew immediately when the bundle at --ca-out no longer contains the CA CDS currently holds. A CDS restart regenerates the mesh CA in-memory, so without this the pod serves the dead CA until the next scheduled renewal (0 = disabled; requires --ca-out and --renew-interval)")
 	flags.StringVar(&cfg.DiscoveryOutPath, "discovery-out", "", "Path to write JSON discovery metadata for the issued certificate and attestation evidence")
 	flags.StringVar(&cfg.DiscoveryCDSCertURL, "discovery-cds-cert-url", "", "Public URL path where the CDS certificate PEM is served")
 	flags.StringVar(&cfg.DiscoveryMeshCAURL, "discovery-mesh-ca-url", "", "Public URL path where the mesh CA PEM is served")
@@ -246,6 +250,10 @@ func run(cfg config) error {
 // --renew-interval, and — while the installed leaf is unnamed and
 // --workload-claims is on — off the fast unnamed interval, so the pod's first
 // post-completion renewal picks up its matched-workload stamp promptly.
+// With --ca-watch-interval it also polls CDS's /ca and renews immediately when
+// the served CA bundle no longer contains the CA CDS holds, so a CDS restart
+// (which regenerates the mesh CA in-memory) does not leave the discovery
+// endpoints serving a dead CA until the next scheduled renewal.
 //
 // Until the first certificate lands the cadence is the initial-retry backoff
 // instead: c8s-cert-wait holds the workload on that certificate
@@ -284,11 +292,35 @@ func renewLoop(ctx context.Context, cfg config, client attestclient.Client, leaf
 		slog.Info("watching files for nginx reload", "paths", cfg.ReloadWatchPaths, "interval", cfg.ReloadWatchInterval)
 	}
 
+	var caWatchC <-chan time.Time
+	if cfg.CAWatchInterval > 0 {
+		caTicker := time.NewTicker(cfg.CAWatchInterval)
+		defer caTicker.Stop()
+		caWatchC = caTicker.C
+		slog.Info("watching cds mesh CA for changes", "interval", cfg.CAWatchInterval, "ca_path", cfg.CAOutPath)
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			slog.Info("shutting down cert renewer")
 			return nil
+		case <-caWatchC:
+			// While no certificate is installed the initial-retry backoff is
+			// already re-asking as fast as allowed.
+			if !haveCert {
+				continue
+			}
+			stale, err := servedCAStale(ctx, client, cfg.CAOutPath)
+			if err != nil {
+				slog.Warn("mesh CA check failed", "error", err)
+				continue
+			}
+			if !stale {
+				continue
+			}
+			slog.Info("cds holds a mesh CA the served bundle is missing, renewing now")
+			renewTimer.Reset(0)
 		case <-renewTimer.C:
 			renewed, err := obtainCertFn(ctx, cfg, client)
 			if err != nil && !haveCert {
@@ -645,6 +677,17 @@ func validateConfig(cfg config) error {
 			return fmt.Errorf("%w: --renew-interval must be greater than 0 when --reload-watch is set", errReloadWatchRequiresRenewInterval)
 		}
 	}
+	if cfg.CAWatchInterval < 0 {
+		return fmt.Errorf("%w: --ca-watch-interval must be 0 (disabled) or positive, got %v", errInvalidCAWatchInterval, cfg.CAWatchInterval)
+	}
+	if cfg.CAWatchInterval > 0 {
+		if cfg.CAOutPath == "" {
+			return fmt.Errorf("%w: --ca-watch-interval requires --ca-out, the served bundle it compares against", errInvalidCAWatchInterval)
+		}
+		if cfg.RenewInterval <= 0 {
+			return fmt.Errorf("%w: --ca-watch-interval requires --renew-interval, the loop that re-issues on a CA change", errInvalidCAWatchInterval)
+		}
+	}
 	// A fast poll is a full attestation round-trip, so a sub-second value is
 	// never what an operator means; 0 is the documented "disabled".
 	if cfg.UnnamedRenewInterval != 0 && cfg.UnnamedRenewInterval < time.Second {
@@ -834,6 +877,37 @@ func caBundleFromChain(chainPEM []byte) ([]byte, error) {
 		return nil, fmt.Errorf("no CA certificate found after the leaf in the issued chain")
 	}
 	return out, nil
+}
+
+// servedCAStale reports whether the bundle written at caOutPath is missing a
+// certificate CDS currently serves at /ca. The fetch rides the same
+// RA-TLS-verified client the issuance flow uses, so the refresh trusts CDS for
+// exactly the reason the initial fetch did. A stale bundle means every client
+// following the documented recovery recipe — re-fetch the mesh CA from the
+// discovery endpoint — pins a CA nothing signs with anymore.
+func servedCAStale(ctx context.Context, client attestclient.Client, caOutPath string) (bool, error) {
+	currentPEM, err := client.MeshCA(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fetch current mesh CA from cds: %w", err)
+	}
+	current, err := certutil.ParsePEMCertificates(currentPEM)
+	if err != nil {
+		return false, fmt.Errorf("parse mesh CA from cds: %w", err)
+	}
+	servedPEM, err := os.ReadFile(caOutPath)
+	if err != nil {
+		return false, fmt.Errorf("read served mesh CA: %w", err)
+	}
+	served, err := certutil.ParsePEMCertificates(servedPEM)
+	if err != nil {
+		return false, fmt.Errorf("parse served mesh CA: %w", err)
+	}
+	for _, cur := range current {
+		if !slices.ContainsFunc(served, cur.Equal) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // writeOutputs writes the certificate, key, and optional discovery metadata.

--- a/internal/cmds/getcert/run_loop_test.go
+++ b/internal/cmds/getcert/run_loop_test.go
@@ -5,7 +5,10 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -660,6 +663,132 @@ func waitForFile(t *testing.T, path string, done <-chan error) {
 			t.Fatalf("no certificate at %s: get-cert waited out --renew-interval instead of retrying", path)
 		case <-time.After(5 * time.Millisecond):
 		}
+	}
+}
+
+// startFakeCAServer serves /ca with whatever bundle serve() returns, so a test
+// can swap the "current" CDS mesh CA mid-flight.
+func startFakeCAServer(t *testing.T, serve func() string) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ca" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, serve())
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestServedCAStale(t *testing.T) {
+	caA := testCertificatePEM(t)
+	caB := testCertificatePEM(t)
+
+	writeServed := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "ca.pem")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name    string
+		cds     string
+		served  string
+		want    bool
+		wantErr bool
+	}{
+		{name: "same CA", cds: caA, served: caA, want: false},
+		{name: "regenerated CA", cds: caB, served: caA, want: true},
+		{name: "served bundle still carries the current CA", cds: caA, served: caB + caA, want: false},
+		{name: "unparseable cds bundle", cds: "not pem", served: caA, wantErr: true},
+		{name: "unparseable served bundle", cds: caA, served: "not pem", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := startFakeCAServer(t, func() string { return tt.cds })
+			stale, err := servedCAStale(context.Background(), plaintextCDSClient(url), writeServed(t, tt.served))
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("servedCAStale err = %v, wantErr %v", err, tt.wantErr)
+			}
+			if stale != tt.want {
+				t.Fatalf("servedCAStale = %v, want %v", stale, tt.want)
+			}
+		})
+	}
+
+	t.Run("missing served bundle", func(t *testing.T) {
+		url := startFakeCAServer(t, func() string { return caA })
+		if _, err := servedCAStale(context.Background(), plaintextCDSClient(url), filepath.Join(t.TempDir(), "missing.pem")); err == nil {
+			t.Fatal("servedCAStale succeeded, want read error")
+		}
+	})
+
+	t.Run("cds unreachable", func(t *testing.T) {
+		if _, err := servedCAStale(context.Background(), plaintextCDSClient("http://127.0.0.1:1"), writeServed(t, caA)); err == nil {
+			t.Fatal("servedCAStale succeeded, want transport error")
+		}
+	})
+}
+
+// A CDS whose /ca stops matching the served bundle triggers an immediate
+// renewal instead of waiting out --renew-interval (an hour here, so any
+// renewal inside the deadline can only have come from the CA watch); while the
+// bundles match the watch must stay quiet.
+func TestRenewLoopRenewsWhenCDSMeshCAChanges(t *testing.T) {
+	caA := testCertificatePEM(t)
+	caB := testCertificatePEM(t)
+
+	var mu sync.Mutex
+	current := caA
+	url := startFakeCAServer(t, func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return current
+	})
+
+	caPath := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(caPath, []byte(caA), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	attempts := stubObtainCert(t, func(int) (*x509.Certificate, error) {
+		return &x509.Certificate{NotAfter: time.Now().Add(time.Hour)}, nil
+	})
+
+	cfg := unreachableRenewalConfig()
+	cfg.CAOutPath = caPath
+	cfg.CAWatchInterval = 10 * time.Millisecond
+	cfg.ReloadNginx = false
+
+	leaf := &x509.Certificate{NotAfter: time.Now().Add(time.Hour)}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- renewLoop(ctx, cfg, plaintextCDSClient(url), leaf, true) }()
+
+	// Matching bundles: many watch ticks must pass without a renewal.
+	time.Sleep(100 * time.Millisecond)
+	if got := attempts(); len(got) != 0 {
+		t.Fatalf("%d renewals while the CA matched, want 0", len(got))
+	}
+
+	mu.Lock()
+	current = caB
+	mu.Unlock()
+	waitForAttempts(t, attempts, 1)
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("renewLoop returned %v, want nil on shutdown", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("renewLoop did not shut down when the context was cancelled")
 	}
 }
 

--- a/internal/cmds/getcert/run_test.go
+++ b/internal/cmds/getcert/run_test.go
@@ -434,6 +434,17 @@ func TestValidateConfigAccepts(t *testing.T) {
 				DiscoveryPublicTLSMode: "webpki",
 			},
 		},
+		{
+			name: "ca watch with ca-out and renew",
+			cfg: config{
+				CDSURL:            "http://cds:8443",
+				AttestationApiURL: "http://attestation-api:8400",
+				SAN:               "host.example.com",
+				CAOutPath:         "/tls/ca.pem",
+				RenewInterval:     time.Hour,
+				CAWatchInterval:   time.Minute,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -459,6 +470,19 @@ func TestValidateConfigRejects(t *testing.T) {
 		{"empty attestation url", func(c *config) { c.AttestationApiURL = "" }},
 		{"empty san", func(c *config) { c.SAN = "" }},
 		{"url san", func(c *config) { c.SAN = "https://host.example.com" }},
+		{"negative ca watch interval", func(c *config) {
+			c.CAOutPath = "/tls/ca.pem"
+			c.RenewInterval = time.Hour
+			c.CAWatchInterval = -time.Minute
+		}},
+		{"ca watch without ca-out", func(c *config) {
+			c.RenewInterval = time.Hour
+			c.CAWatchInterval = time.Minute
+		}},
+		{"ca watch without renew interval", func(c *config) {
+			c.CAOutPath = "/tls/ca.pem"
+			c.CAWatchInterval = time.Minute
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -484,6 +484,9 @@ so it adds discovery output and verbose logging to the shared get-cert flow.
 - --discovery-mesh-ca-url={{ .Values.tlsLb.discovery.meshCAPath }}
 {{- end }}
 {{- end }}
+{{- with .Values.tlsLb.certProvisioning.caWatchInterval }}
+- --ca-watch-interval={{ . }}
+{{- end }}
 {{- if .Values.tlsLb.certProvisioning.verbose }}
 - --verbose
 {{- end }}

--- a/internal/helmchart/c8s/values.schema.json
+++ b/internal/helmchart/c8s/values.schema.json
@@ -359,6 +359,7 @@
           ],
           "additionalProperties": false,
           "properties": {
+            "caWatchInterval": {},
             "renewInterval": {},
             "verbose": {}
           }

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1314,6 +1314,13 @@ tlsLb:
     # -- How often the c8s-cert sidecar renews the TLS certificate and SIGHUPs
     #    nginx. Must be shorter than the cert TTL issued by CDS.
     renewInterval: "1h"
+    # -- How often the c8s-cert sidecar checks that the mesh CA it serves at
+    #    the discovery endpoints still matches the CA CDS currently holds,
+    #    renewing immediately when it does not. A CDS restart regenerates the
+    #    mesh CA in-memory, so without this the pod serves the dead CA (and a
+    #    discovery document chained to it) until the next scheduled renewal.
+    #    "0" disables the check.
+    caWatchInterval: "1m"
 
   # -- Attestation + over-encryption sidecar (the c8s-verify protocol). When
   # enabled, an in-pod `c8s cds-attest` container serves the *dynamic*

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -190,6 +190,11 @@ func TestChartDefaultRendersReplacementStack(t *testing.T) {
 		"--renew-interval=1h",
 		"--reload-nginx=true",
 		"--continue-on-initial-error",
+		// The CA watch keeps the served mesh CA tracking the live CDS CA: a
+		// CDS restart regenerates the mesh CA in-memory, and without the watch
+		// the /.well-known/mesh-ca.pem discovery endpoint serves the dead CA
+		// until the next scheduled renewal.
+		"--ca-watch-interval=1m",
 	)
 	if cert.RestartPolicy == nil || *cert.RestartPolicy != corev1.ContainerRestartPolicyAlways {
 		t.Fatalf("c8s-cert restartPolicy = %v, want Always (single long-lived sidecar so its pidns anchors shareProcessNamespace under kata)", cert.RestartPolicy)
@@ -2651,6 +2656,7 @@ func TestChartRendersTLSLBAttestSidecar(t *testing.T) {
 func TestTLSLBCertProvisioningValuesDriveGetCertContainers(t *testing.T) {
 	out, err := helmTemplate(t,
 		"--set-string", "tlsLb.certProvisioning.renewInterval=30m",
+		"--set-string", "tlsLb.certProvisioning.caWatchInterval=2m",
 		"--set", "tlsLb.certProvisioning.verbose=true",
 		"--set", "tlsLb.nginx.runAsUser=201",
 		"--set", "tlsLb.nginx.runAsGroup=202",
@@ -2660,7 +2666,7 @@ func TestTLSLBCertProvisioningValuesDriveGetCertContainers(t *testing.T) {
 		t.Fatalf("helm template: %v\n%s", err, out)
 	}
 	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
-	assertContainerArgs(t, cert, "--verbose", "--renew-interval=30m")
+	assertContainerArgs(t, cert, "--verbose", "--renew-interval=30m", "--ca-watch-interval=2m")
 	if got := cert.SecurityContext.RunAsUser; got == nil || *got != 201 {
 		t.Fatalf("c8s-cert runAsUser = %v, want 201", got)
 	}

--- a/pkg/attestclient/client.go
+++ b/pkg/attestclient/client.go
@@ -295,6 +295,13 @@ func (c Client) AttestContext(ctx context.Context, req attestRequest) (string, e
 	return string(body), nil
 }
 
+// MeshCA fetches the mesh CA bundle CDS currently serves at /ca.
+// Authenticity comes from the RA-TLS transport the client was constructed
+// over, the same channel that authenticates the CA trailing an issued chain.
+func (c Client) MeshCA(ctx context.Context) ([]byte, error) {
+	return c.do(ctx, http.MethodGet, "/ca", nil)
+}
+
 // Healthz checks liveness of the CDS service.
 func (c Client) Healthz() (bool, error) {
 	return c.ok("/healthz")

--- a/pkg/attestclient/client_http_test.go
+++ b/pkg/attestclient/client_http_test.go
@@ -140,6 +140,42 @@ func TestAttestTransportError(t *testing.T) {
 	}
 }
 
+func TestMeshCA(t *testing.T) {
+	t.Run("returns the served bundle", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/ca" {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write([]byte("CA-PEM"))
+		}))
+		defer srv.Close()
+
+		c := NewClientWithHTTP(srv.URL, srv.Client())
+		got, err := c.MeshCA(context.Background())
+		if err != nil {
+			t.Fatalf("MeshCA: %v", err)
+		}
+		if string(got) != "CA-PEM" {
+			t.Fatalf("MeshCA = %q, want CA-PEM", got)
+		}
+	})
+
+	t.Run("non-2xx is a StatusError", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "gone", http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		c := NewClientWithHTTP(srv.URL, srv.Client())
+		_, err := c.MeshCA(context.Background())
+		var statusErr *StatusError
+		if !errors.As(err, &statusErr) || statusErr.Status != http.StatusServiceUnavailable {
+			t.Fatalf("error = %v, want StatusError 503", err)
+		}
+	})
+}
+
 func TestHealthzNotReady(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)


### PR DESCRIPTION
Since [#503](https://github.com/confidential-dot-ai/c8s/pull/503) removed the mesh-CA handoff, a CDS pod restart (eviction, node upgrade — not just reinstall) regenerates the mesh CA in-memory. The in-cluster mesh re-certs against the new CA, but tls-lb keeps serving the previous CA at `/.well-known/mesh-ca.pem` — with a leaf at `/.well-known/cds-cert.pem` and a discovery document at `/v1/discovery` chained to it — until its next scheduled renewal (up to `tlsLb.certProvisioning.renewInterval`, default 1h) or a manual tls-lb restart. An external client re-fetching the CA from the discovery endpoint to recover its pin gets a CA nothing signs with anymore. Observed on AKS v0.8.0: after `kubectl delete pod` on CDS, freshly issued workload leaves chained to the new CA while `/.well-known/mesh-ca.pem` still served the old one.

Fix: get-cert's renewal loop gains `--ca-watch-interval`. It polls CDS's `/ca` over the same RA-TLS-verified client the issuance flow uses — the refresh trusts CDS for exactly the reason the initial fetch did — and re-issues immediately when the bundle at `--ca-out` no longer contains the CA CDS holds, rewriting the leaf, CA bundle, and discovery document together and SIGHUP-ing nginx. The chart enables the watch for the tls-lb c8s-cert sidecar via `tlsLb.certProvisioning.caWatchInterval` (default 1m, `"0"` disables).