### PR TITLE
chore(chart): bump nginx-unprivileged digest (OpenSSL 3.5.8)

### DIFF
--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1371,7 +1371,7 @@ tlsLb:
       # core modules tls-lb uses; the full/perl variants ship image-filter,
       # perl and friends whose CVEs would otherwise trip the grype.yml image scan.
       # Accepted CVEs against this pin live in .grype.yaml.
-      digest: "sha256:e88d990b349df8cf4aa82f16642d7a23375016638c9ace4e5c6ca25028e62e65"
+      digest: "sha256:11f3f6249b4ae3d7a4ec2a51797060107b88ead52b33b6ed3c6c33f55ca96200"
       tag: ""
       pullPolicy: IfNotPresent
     # -- Number of nginx replicas.

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -5963,7 +5963,7 @@ func TestChartServesAllowlistSeedInNodeMode(t *testing.T) {
 	if got := seed.Digests[rmD]; got != "ghcr.io/confidential-dot-ai/ratls-mesh@"+rmD {
 		t.Errorf("node-mode seed missing ratls-mesh entry; got %q\nseed: %v", got, seed.Digests)
 	}
-	const nginxD = "sha256:e88d990b349df8cf4aa82f16642d7a23375016638c9ace4e5c6ca25028e62e65"
+	const nginxD = "sha256:11f3f6249b4ae3d7a4ec2a51797060107b88ead52b33b6ed3c6c33f55ca96200"
 	if _, ok := seed.Digests[nginxD]; !ok {
 		t.Errorf("node-mode seed missing tls-lb nginx self-entry\nseed: %v", seed.Digests)
 	}


### PR DESCRIPTION
Upstream rebuilt stable-alpine-slim with Alpine openssl 3.5.8-r0; nginx stays 1.30.4. Verified in the new image: libssl3/libcrypto3 3.5.8-r0. Fixes the six High CVEs (CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63075, CVE-2026-63076) that first turned the tls-lb-image grype scan red on [#500](https://github.com/confidential-dot-ai/c8s/pull/500).

Old: `sha256:e88d990b349df8cf4aa82f16642d7a23375016638c9ace4e5c6ca25028e62e65`
New: `sha256:11f3f6249b4ae3d7a4ec2a51797060107b88ead52b33b6ed3c6c33f55ca96200`