### PR TITLE
getcert: exit once the installed leaf expired and renewals keep failing

### DIFF
--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -681,6 +681,11 @@ Poll timing never changes the match decision.
 
 Every delay is also capped at half the installed leaf's remaining lifetime, and
 a failed renewal retries on a short backoff rather than after a full interval.
+Once the installed leaf has **expired** and renewals still fail, get-cert exits
+instead of retrying forever: as a native sidecar it restarts with fresh client
+state and re-runs the full issuance. A locked guest denies exec probes, so a
+process that keeps running while serving a dead certificate would otherwise
+never be restarted by anything.
 The named-leaf TTL is the shortest CDS issues and `certutil` does not backdate
 `NotBefore`, so a renewal interval alone — the chart's `renewInterval` — is not
 a safe schedule: it must stay strictly below `cds.namedCertTTL`, and the

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -8,11 +8,13 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"regexp"
+	"strings"
 	"syscall"
 	"time"
 
@@ -415,7 +417,26 @@ func newHTTPServer(addr string, handler http.Handler, cfg config) *http.Server {
 		WriteTimeout:      cfg.writeTimeout,
 		IdleTimeout:       cfg.idleTimeout,
 		MaxHeaderBytes:    cfg.maxHeaderBytes,
+		ErrorLog:          log.New(serverLogFilter{}, "", 0),
 	}
+}
+
+// serverLogFilter routes net/http server error lines to slog. The kubelet's
+// tcpSocket probes (the only probe shape a mutual RA-TLS port supports) open
+// the port and drop it every few seconds, which net/http reports as a TLS
+// handshake EOF or reset — demote exactly those to debug so real handshake
+// faults keep a visible log level.
+type serverLogFilter struct{}
+
+func (serverLogFilter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	if strings.Contains(msg, "TLS handshake error") &&
+		(strings.HasSuffix(msg, ": EOF") || strings.HasSuffix(msg, ": connection reset by peer")) {
+		slog.Debug(msg)
+	} else {
+		slog.Info(msg)
+	}
+	return len(p), nil
 }
 
 func normalizeHTTPServerConfig(cfg config) config {

--- a/internal/cmds/cds/serverlog_test.go
+++ b/internal/cmds/cds/serverlog_test.go
@@ -1,0 +1,59 @@
+package cds
+
+import (
+	"context"
+	"log"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+// levelCapture records the level of every slog record routed to it.
+type levelCapture struct {
+	mu      sync.Mutex
+	records map[string]slog.Level
+}
+
+func (c *levelCapture) Enabled(context.Context, slog.Level) bool { return true }
+func (c *levelCapture) Handle(_ context.Context, r slog.Record) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.records[r.Message] = r.Level
+	return nil
+}
+func (c *levelCapture) WithAttrs([]slog.Attr) slog.Handler { return c }
+func (c *levelCapture) WithGroup(string) slog.Handler      { return c }
+
+func TestServerLogFilterDemotesProbeHandshakeNoise(t *testing.T) {
+	capture := &levelCapture{records: map[string]slog.Level{}}
+	old := slog.Default()
+	slog.SetDefault(slog.New(capture))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	logger := log.New(serverLogFilter{}, "", 0)
+	cases := []struct {
+		line string
+		want slog.Level
+	}{
+		{"http: TLS handshake error from 10.0.0.1:33812: EOF", slog.LevelDebug},
+		{"http: TLS handshake error from 10.0.0.1:33812: connection reset by peer", slog.LevelDebug},
+		{"http: TLS handshake error from 10.0.0.1:33812: tls: client offered only unsupported versions", slog.LevelInfo},
+		{"http: panic serving 10.0.0.1:33812: boom", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		logger.Print(tc.line)
+	}
+
+	capture.mu.Lock()
+	defer capture.mu.Unlock()
+	for _, tc := range cases {
+		got, ok := capture.records[tc.line]
+		if !ok {
+			t.Errorf("line %q was not logged at all", tc.line)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("serverLogFilter(%q) logged at %v, want %v", tc.line, got, tc.want)
+		}
+	}
+}

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -304,6 +304,16 @@ func renewLoop(ctx context.Context, cfg config, client attestclient.Client, leaf
 				// close to expiry. Sleeping out --renew-interval here would
 				// leave the workload serving a dead certificate.
 				failures++
+				if leaf != nil && failures >= expiredExitFailures && time.Now().After(leaf.NotAfter) {
+					// The installed leaf is dead and renewal from this process
+					// keeps failing, so retrying in-process serves an expired
+					// certificate indefinitely. Exit instead: as a native
+					// sidecar (restartPolicy: Always) the container restarts
+					// with fresh client state and re-runs the full issuance —
+					// the recovery a locked guest cannot get from an exec
+					// liveness probe (ExecProcessRequest is policy-denied).
+					return fmt.Errorf("installed certificate expired at %s and %d consecutive renewals failed (last: %w); exiting for a clean restart", leaf.NotAfter.Format(time.RFC3339), failures, err)
+				}
 				retry := renewalRetryInterval(cfg, leaf, failures)
 				slog.Error("certificate renewal failed, retrying", "error", err, "retry_in", retry, "failures", failures)
 				renewTimer.Reset(retry)
@@ -350,6 +360,13 @@ const (
 	// maxInitialRetryInterval caps the backoff between attempts at the first
 	// certificate.
 	maxInitialRetryInterval = time.Minute
+
+	// expiredExitFailures is how many consecutive renewal failures the loop
+	// tolerates once the installed leaf has expired before exiting for a clean
+	// sidecar restart. Small, because every request in a renewal attempt is
+	// individually timed out — a failing attempt resolves in seconds — and an
+	// expired leaf means clients are already failing closed against this pod.
+	expiredExitFailures = 3
 
 	// unnamedBackoffAfter is how many consecutive unnamed renewals run at the
 	// fast poll before it doubles toward --renew-interval. A pod can be

--- a/internal/cmds/getcert/run_loop_test.go
+++ b/internal/cmds/getcert/run_loop_test.go
@@ -680,3 +680,81 @@ func TestCDSHTTPClientParsesRTMRPins(t *testing.T) {
 		t.Fatalf("cdsHTTPClient with valid pins: %v", err)
 	}
 }
+
+// Once the installed leaf has expired and renewals keep failing, the loop must
+// exit rather than retry forever: as a native sidecar the container restarts
+// with fresh client state, which is the only self-heal available on a locked
+// guest (exec liveness probes are policy-denied there).
+func TestRunRenewalLoopExitsOnExpiredLeaf(t *testing.T) {
+	holdSIGTERM(t)
+
+	oldBase := renewalRetryBase
+	renewalRetryBase = 10 * time.Millisecond
+	t.Cleanup(func() { renewalRetryBase = oldBase })
+
+	// The initial request installs a leaf that expires almost immediately;
+	// every renewal fails.
+	leaf := &x509.Certificate{NotAfter: time.Now().Add(30 * time.Millisecond)}
+	attempts := stubObtainCert(t, func(n int) (*x509.Certificate, error) {
+		if n == 1 {
+			return leaf, nil
+		}
+		return nil, errors.New("stubbed certificate request failure")
+	})
+
+	cfg := unreachableRenewalConfig()
+	cfg.RenewInterval = 20 * time.Millisecond
+	cfg.ReloadNginx = false
+
+	done := make(chan error, 1)
+	go func() { done <- run(cfg) }()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("run() = nil, want an error once the expired leaf cannot be renewed")
+		}
+		if !strings.Contains(err.Error(), "expired") {
+			t.Errorf("run() = %v, want an error naming the expired certificate", err)
+		}
+		// The initial request plus at least expiredExitFailures failed renewals.
+		if got := len(attempts()); got < 1+expiredExitFailures {
+			t.Errorf("exited after %d attempts, want at least %d", got, 1+expiredExitFailures)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("run did not exit with an expired, unrenewable leaf")
+	}
+}
+
+// A leaf that is still valid never triggers the expired-leaf exit, however many
+// renewals fail.
+func TestRunRenewalLoopKeepsRetryingWhileLeafValid(t *testing.T) {
+	holdSIGTERM(t)
+
+	oldBase := renewalRetryBase
+	renewalRetryBase = 10 * time.Millisecond
+	t.Cleanup(func() { renewalRetryBase = oldBase })
+
+	leaf := &x509.Certificate{NotAfter: time.Now().Add(time.Hour)}
+	attempts := stubObtainCert(t, func(n int) (*x509.Certificate, error) {
+		if n == 1 {
+			return leaf, nil
+		}
+		return nil, errors.New("stubbed certificate request failure")
+	})
+
+	cfg := unreachableRenewalConfig()
+	cfg.RenewInterval = 20 * time.Millisecond
+	cfg.ReloadNginx = false
+
+	done := make(chan error, 1)
+	go func() { done <- run(cfg) }()
+
+	waitForAttempts(t, attempts, 2+expiredExitFailures)
+	select {
+	case err := <-done:
+		t.Fatalf("run exited with %v while the leaf was still valid", err)
+	default:
+	}
+	terminateRun(t, done)
+}


### PR DESCRIPTION
A tls-lb served an expired mesh leaf for five days: the c8s-cert renewal loop retries forever, exec liveness probes are policy-denied on locked guests (`ExecProcessRequest := false`), and nginx keeps serving whatever certificate it has — so the failure was silent and sticky, with `attest-pq` answering 503 and every pinned client failing closed. A pod restart recovered it immediately.

Two changes:

- **getcert**: once the installed leaf is past `NotAfter` and `expiredExitFailures` (3) consecutive renewals have failed, the loop exits instead of retrying. As a native sidecar (`restartPolicy: Always`) the container restarts with fresh client state and re-runs the full issuance — the only self-heal available where exec probes are blocked. A still-valid leaf keeps the existing retry/backoff behavior.
- **cds**: route `net/http` server error lines through a filter that demotes the TLS-handshake EOF/reset lines kubelet's tcpSocket probes generate (one per probe, every few seconds) to debug, so real handshake faults stay visible.

The root cause of the renewal attempts failing on the incident cluster is still unknown (logs rotated); a watch is running to catch a recurrence with fresh logs.