### PR TITLE
fix(chart): derive volumed kubeletRoot from the host distro

### DIFF
--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -27,6 +27,23 @@
 {{- printf "%s-volumed" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+  c8s.volumedKubeletRoot — the kubelet's root dir on the host. An explicit
+  volumed.hostPaths.kubeletRoot wins; empty derives from the host distro
+  (kata.distro / nriImagePolicy.distro, same source as c8s.tlsLb.resolver).
+  RKE2 runs its kubelet with --root-dir under the agent dir; anything else
+  takes the upstream default.
+*/}}
+{{- define "c8s.volumedKubeletRoot" -}}
+{{- if .Values.volumed.hostPaths.kubeletRoot -}}
+{{- .Values.volumed.hostPaths.kubeletRoot -}}
+{{- else if or (eq .Values.kata.distro "rke2") (eq .Values.nriImagePolicy.distro "rke2") -}}
+/var/lib/rancher/rke2/agent/kubelet
+{{- else -}}
+/var/lib/kubelet
+{{- end -}}
+{{- end -}}
+
 {{/* volumed runs its own debian-slim image carrying cryptsetup/veritysetup,
    which the distroless operator image cannot. Same repository/tag/digest
    contract as the other per-role images. */}}

--- a/internal/helmchart/c8s/templates/volumed-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/volumed-daemonset.yaml
@@ -68,7 +68,7 @@ spec:
             - --socket-dir
             - {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }}
             - --kubelet-root
-            - {{ .Values.volumed.hostPaths.kubeletRoot | quote }}
+            - {{ include "c8s.volumedKubeletRoot" . | quote }}
             - --cgroup-root
             - {{ .Values.volumed.hostPaths.cgroupRoot | quote }}
             - --reap-interval
@@ -79,7 +79,7 @@ spec:
             # Bidirectional: the mount is made here and has to reach the
             # workload's pod directory on the node.
             - name: kubelet-root
-              mountPath: {{ .Values.volumed.hostPaths.kubeletRoot }}
+              mountPath: {{ include "c8s.volumedKubeletRoot" . }}
               mountPropagation: Bidirectional
             - name: dev
               mountPath: /dev
@@ -101,7 +101,7 @@ spec:
       volumes:
         - name: kubelet-root
           hostPath:
-            path: {{ .Values.volumed.hostPaths.kubeletRoot }}
+            path: {{ include "c8s.volumedKubeletRoot" . }}
             type: Directory
         - name: dev
           hostPath:

--- a/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
@@ -76,7 +76,7 @@ spec:
             # Bidirectional: the mounts live in the host namespace, so the
             # unmount has to propagate back out of this pod.
             - name: kubelet-root
-              mountPath: {{ .Values.volumed.hostPaths.kubeletRoot }}
+              mountPath: {{ include "c8s.volumedKubeletRoot" . }}
               mountPropagation: Bidirectional
             - name: dev
               mountPath: /dev
@@ -97,7 +97,7 @@ spec:
       volumes:
         - name: kubelet-root
           hostPath:
-            path: {{ .Values.volumed.hostPaths.kubeletRoot }}
+            path: {{ include "c8s.volumedKubeletRoot" . }}
             type: Directory
         - name: dev
           hostPath:

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1062,7 +1062,11 @@ volumed:
   ## socket directory (nriImagePolicy.hostPaths.runtimeDir), which is the only
   ## hostPath the deny-host-namespaces VAP admits into a cw pod.
   hostPaths:
-    kubeletRoot: /var/lib/kubelet
+    ## The kubelet's root dir, holding per-pod volume directories. Empty
+    ## derives it from the host distro (kata.distro / nriImagePolicy.distro,
+    ## set by `c8s install` and required from GitOps installs for the
+    ## containerd layout anyway): rke2 keeps it under its agent dir.
+    kubeletRoot: ""
     cgroupRoot: /sys/fs/cgroup
 
   ## Volumes open on one node at once. Each costs two device-mapper devices and

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7133,6 +7133,57 @@ func TestChartVolumedSocketDirTracksTheVAPCarveOut(t *testing.T) {
 	}
 }
 
+// The kubelet root dir differs by distro: RKE2 runs its kubelet with
+// --root-dir under the agent dir, everything else takes the upstream default.
+// volumed resolves pod volume directories beneath it, so the wrong value
+// mounts volumes where no pod looks for them.
+func TestChartVolumedKubeletRootTracksDistro(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", nil, "/var/lib/kubelet"},
+		{"k8s distro", []string{"--set-string", "nriImagePolicy.distro=k8s"}, "/var/lib/kubelet"},
+		{"rke2 via nri distro", []string{"--set-string", "nriImagePolicy.distro=rke2"}, "/var/lib/rancher/rke2/agent/kubelet"},
+		{"rke2 via kata distro", []string{"--set-string", "kata.distro=rke2"}, "/var/lib/rancher/rke2/agent/kubelet"},
+		{"explicit wins", []string{
+			"--set-string", "nriImagePolicy.distro=rke2",
+			"--set-string", "volumed.hostPaths.kubeletRoot=/custom/kubelet",
+		}, "/custom/kubelet"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := append([]string{"--set", "volumed.enabled=true"}, tc.args...)
+			out, err := helmTemplate(t, args...)
+			if err != nil {
+				t.Fatalf("helm template: %v\n%s", err, out)
+			}
+			spec := renderedDaemonSet(t, out, "c8s-volumed").Spec.Template.Spec
+			c, ok := findContainer(spec.Containers, "volumed")
+			if !ok {
+				t.Fatal("volumed container missing")
+			}
+			if got := argAfter(c.Args, "--kubelet-root"); got != tc.want {
+				t.Errorf("--kubelet-root = %q, want %q", got, tc.want)
+			}
+			mount, ok := containerVolumeMount(c, "kubelet-root")
+			if !ok {
+				t.Fatal("no kubelet-root mount")
+			}
+			if mount.MountPath != tc.want {
+				t.Errorf("kubelet-root mountPath = %q, want %q", mount.MountPath, tc.want)
+			}
+			v, ok := podVolume(spec, "kubelet-root")
+			if !ok || v.HostPath == nil {
+				t.Fatal("no kubelet-root hostPath volume")
+			}
+			if v.HostPath.Path != tc.want {
+				t.Errorf("kubelet-root hostPath = %q, want %q", v.HostPath.Path, tc.want)
+			}
+		})
+	}
+}
+
 // argAfter returns the value following flag in an argv, or "" if absent.
 func argAfter(args []string, flag string) string {
 	for i, a := range args {


### PR DESCRIPTION
`volumed.hostPaths.kubeletRoot` defaulted to `/var/lib/kubelet` with no rke2 handling, so on rke2 nodes (kubelet root `/var/lib/rancher/rke2/agent/kubelet`) the volumed DaemonSet resolved pod volume directories where no pod looks for them — encrypted volumes could never land.

- `kubeletRoot` now defaults to empty and derives from the detected distro (`kata.distro` / `nriImagePolicy.distro`), the same source `c8s.tlsLb.resolver` already uses
- an explicit value still wins; DaemonSet and uninstall hook share the new `c8s.volumedKubeletRoot` helper
- render tests cover default, k8s, rke2 (via either distro key), and explicit-wins

Found while wiring the encrypted-volumes e2e (the metal lanes boot rke2 node images). Full `internal/helmchart` suite green.