### PR TITLE
feat(cli): add c8s operator-keygen

### DIFF
--- a/cmd/c8s/keys.go
+++ b/cmd/c8s/keys.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/keys"
+
+func init() {
+	rootCmd.AddCommand(keys.NewCmd())
+}

--- a/internal/cmds/keys/cmd.go
+++ b/internal/cmds/keys/cmd.go
@@ -1,0 +1,20 @@
+// Package keys implements the `c8s keys` command group: operator EC keys.
+// The private half signs allowlist, secrets, and volume writes (and
+// get-kubeconfig); the public half is what CDS pins at install
+// (c8s install --operator-keys).
+package keys
+
+import "github.com/spf13/cobra"
+
+// NewCmd returns the `c8s keys` command group.
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "keys",
+		Short: "Manage operator keys",
+		Long: `Manage the operator EC keypair that authorizes platform writes. The private
+key signs allowlist, secrets, and volume writes (and get-kubeconfig); the
+public key is what CDS pins at install (c8s install --operator-keys).`,
+	}
+	cmd.AddCommand(newKeygenCmd())
+	return cmd
+}

--- a/internal/cmds/keys/new.go
+++ b/internal/cmds/keys/new.go
@@ -1,0 +1,88 @@
+package keys
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+)
+
+// newKeygenCmd returns the `c8s keys new` subcommand.
+func newKeygenCmd() *cobra.Command {
+	var out, pubOut string
+	cmd := &cobra.Command{
+		Use:   "new",
+		Short: "Generate an operator EC keypair (P-256)",
+		Long: `Generate an operator keypair: the private key that signs allowlist,
+secret, and volume writes, and the public key CDS pins at install
+(c8s install --operator-keys).
+
+Both files are created new — an existing file is never overwritten. The
+private key is written 0600.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if out == "" {
+				return fmt.Errorf("--out is required: where to write the private key PEM")
+			}
+			if pubOut == "" {
+				return fmt.Errorf("--pub-out is required: where to write the public key PEM")
+			}
+			if out == pubOut {
+				return fmt.Errorf("--out and --pub-out must differ: one file cannot hold both halves")
+			}
+			return run(cmd, out, pubOut)
+		},
+	}
+	cmd.Flags().StringVar(&out, "out", "", "private key output path (written 0600, never overwritten)")
+	cmd.Flags().StringVar(&pubOut, "pub-out", "", "public key output path (never overwritten)")
+	return cmd
+}
+
+func run(cmd *cobra.Command, out, pubOut string) error {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return fmt.Errorf("generate key: %w", err)
+	}
+	keyPEM, err := certutil.MarshalECKeyPEM(key)
+	if err != nil {
+		return fmt.Errorf("encode private key: %w", err)
+	}
+	pubDER, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		return fmt.Errorf("encode public key: %w", err)
+	}
+	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
+
+	// The private half is written first and O_EXCL: a keypair whose private
+	// half silently replaced an older one would strand whatever the older
+	// public half was pinned on.
+	if err := writeNew(out, keyPEM, 0o600); err != nil {
+		return err
+	}
+	if err := writeNew(pubOut, pubPEM, 0o644); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "wrote %s (private, 0600) and %s (public)\n", out, pubOut)
+	return nil
+}
+
+// writeNew writes p to path, O_EXCL with the given mode.
+func writeNew(path string, p []byte, mode os.FileMode) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(p); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/cmds/keys/new_test.go
+++ b/internal/cmds/keys/new_test.go
@@ -1,0 +1,91 @@
+package keys
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+)
+
+func TestNewKeyRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "operator.key")
+	pubPath := filepath.Join(dir, "operator.pub")
+
+	cmd := NewCmd()
+	cmd.SetArgs([]string{"new", "--out", keyPath, "--pub-out", pubPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+
+	keyPEM, err := os.ReadFile(keyPath)
+	if err != nil {
+		t.Fatalf("read private: %v", err)
+	}
+	// The private half must load into the signer every write command uses.
+	if _, err := operatorauth.NewSignerFromKeyPEM(keyPEM); err != nil {
+		t.Fatalf("private key does not parse as an operator key: %v", err)
+	}
+	info, err := os.Stat(keyPath)
+	if err != nil {
+		t.Fatalf("stat private: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("private key mode = %o, want 0600", info.Mode().Perm())
+	}
+
+	pubPEM, err := os.ReadFile(pubPath)
+	if err != nil {
+		t.Fatalf("read public: %v", err)
+	}
+	// The public half must parse the way CDS pins it (cds.operatorKeys).
+	parsed, err := operatorauth.ParsePublicKeysPEM(pubPEM)
+	if err != nil {
+		t.Fatalf("public key does not parse as an operator key set: %v", err)
+	}
+	if len(parsed) != 1 {
+		t.Fatalf("parsed %d public keys, want 1", len(parsed))
+	}
+	priv, err := certutil.ParseECPrivateKey(keyPEM)
+	if err != nil {
+		t.Fatalf("re-parse private: %v", err)
+	}
+	if !priv.PublicKey.Equal(parsed[0]) {
+		t.Error("public half does not match the private half")
+	}
+}
+
+func TestNewKeyRefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "operator.key")
+	pubPath := filepath.Join(dir, "operator.pub")
+	if err := os.WriteFile(keyPath, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cmd := NewCmd()
+	cmd.SetArgs([]string{"new", "--out", keyPath, "--pub-out", pubPath})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "operator.key") {
+		t.Fatalf("want refusal naming the existing file, got %v", err)
+	}
+}
+
+func TestNewKeyRequiresBothPaths(t *testing.T) {
+	for _, args := range [][]string{
+		{"new", "--out", filepath.Join(t.TempDir(), "k")},
+		{"new", "--pub-out", filepath.Join(t.TempDir(), "p")},
+		{"new"},
+	} {
+		cmd := NewCmd()
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs(args)
+		if err := cmd.Execute(); err == nil {
+			t.Errorf("args %v: want an error, got nil", args)
+		}
+	}
+}


### PR DESCRIPTION
Mint an operator P-256 keypair natively instead of sending every operator through two openssl incantations.

```
c8s keys new --out operator.key --pub-out operator.pub
```

- private half: PKCS#8 PEM, 0600; public half: PKIX `PUBLIC KEY` PEM — the exact formats `operatorauth.NewSignerFromKeyPEM` and CDS's `operatorKeys` parser take
- both writes `O_EXCL`: an existing file is never overwritten
- tests round-trip both halves through the signer and the key-set parser, and cover the overwrite and missing-flag refusals

Motivation beyond ergonomics: the SNP e2e lane needs keygen inside the node guest, which ships the c8s CLI but no openssl/python — today a throwaway key would have to cross the serial console. Docs still show the openssl equivalent; left untouched since it remains valid.