### PR TITLE
test(integration): read the front-door curl body once before asserting

### DIFF
--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -716,8 +716,14 @@ EOF
 kubectl apply -f "$WORKDIR/curl-lb.yaml"
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/it-curl-lb --timeout=120s \
     || fail "front-door request to the adopted workload failed"
-kubectl logs it-curl-lb | grep -q "Welcome to nginx" \
-    || fail "front door did not proxy the adopted workload: $(kubectl logs it-curl-lb)"
+# Read the body once: piping a live `kubectl logs` into `grep -q` is a race
+# under pipefail (grep exits on the match and the producer can die to SIGPIPE)
+# and re-reading in the failure message can show a body grep never saw.
+BODY="$(kubectl logs it-curl-lb)" || fail "could not read the it-curl-lb logs"
+case "$BODY" in
+    *"Welcome to nginx"*) ;;
+    *) fail "front door did not proxy the adopted workload: $BODY" ;;
+esac
 pass "tls-lb routes the front door to the adopted workload over the mesh"
 
 log "Uninstall"


### PR DESCRIPTION
PR #514's Integration (cluster) run failed with:

```
FAIL: front door did not proxy the adopted workload: <!DOCTYPE html>
...
<h1>Welcome to nginx!</h1>
```

— the expected string is right there in the body. The check was:

```bash
kubectl logs it-curl-lb | grep -q "Welcome to nginx"     || fail "front door did not proxy the adopted workload: $(kubectl logs it-curl-lb)"
```

Two ways that fails with the body present, both under `set -o pipefail`: `grep -q` exits on the match and `kubectl logs` dies to SIGPIPE on its next write (pipeline reports 141 although grep matched), or the first `kubectl logs` errors transiently and the message's *second* read succeeds and prints the body. Evidence for flake-not-regression: main was green at the same code (dfa1799 07:30Z and 388cc5c 13:10Z), the signature never recurred in the last 25 CI runs, and the failing run's `it-curl-lb` pod had Completed successfully with the right body.

Fix: read the body once, match it in-shell. No pipe, no SIGPIPE, and the failure message can no longer show a body grep never saw; a failed log read fails with its own message. `bash -n` + `shellcheck -S warning` clean.