### PR TITLE
fix(getsecret,getcert): enforce the memory-only invariant on secret outputs

### DIFF
--- a/cmd/get-cert/README.md
+++ b/cmd/get-cert/README.md
@@ -49,7 +49,7 @@ get-cert \
 | `--san` | | *(required)* | Subject Alternative Name — IP address or hostname |
 | `--out` | `-o` | *(stdout)* | Path to write the signed certificate chain PEM |
 | `--key` | | *(ephemeral)* | Path to an existing PEM private key for the CSR |
-| `--key-out` | | | Path to write the generated private key PEM |
+| `--key-out` | | | Path to write the private key PEM; must be on a memory-backed filesystem |
 | `--key-mode` | | `0600` | Octal mode for a generated private key |
 | `--renew-interval` | | `0` | Re-obtain the certificate at this interval; `0` runs once and exits |
 | `--reload-nginx` | | `true` | SIGHUP nginx after certificate renewal or watched file changes |
@@ -59,6 +59,8 @@ get-cert \
 ## Output path validation
 
 Before generating keys or contacting cds, get-cert verifies that the output directories for `--out` and `--key-out` exist and are writable. This prevents requesting certificates that can't be saved.
+
+The `--key-out` directory must additionally sit on a memory-backed filesystem (tmpfs or ramfs): the private key must never reach storage the host can read. In Kubernetes the injected cert volume is already a Memory-medium emptyDir, so this holds automatically; for manual runs point `--key-out` at a tmpfs such as `/dev/shm`. The cert and CA outputs are public and carry no such restriction.
 
 ## SAN detection
 

--- a/internal/cmds/cmdsutil/cmdsutil.go
+++ b/internal/cmds/cmdsutil/cmdsutil.go
@@ -57,10 +57,27 @@ func ValidateAttestationAPIURL(flagName, u string) error {
 // callers needn't wrap. Shared by get-secret (--out-dir) and get-cert
 // (--key-out): each secret-writing sidecar gets the same refusal shape.
 func RequireRAMBackedDir(flagName, dir string) error {
-	if err := fileutil.RequireRAMBacked(dir); err != nil {
-		return fmt.Errorf("%s: %w", flagName, err)
+	root, err := OpenRAMBackedDir(flagName, dir)
+	if err != nil {
+		return err
 	}
-	return nil
+	return root.Close()
+}
+
+// OpenRAMBackedDir opens dir, verifies the filesystem behind that open handle
+// is RAM-backed, then returns the still-open root. Secret writers must use the
+// returned root for every write so replacing dir's pathname cannot redirect
+// bytes after verification.
+func OpenRAMBackedDir(flagName, dir string) (*os.Root, error) {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("%s: open %s: %w", flagName, dir, err)
+	}
+	if err := fileutil.RequireRAMBackedRoot(root); err != nil {
+		_ = root.Close()
+		return nil, fmt.Errorf("%s: %w", flagName, err)
+	}
+	return root, nil
 }
 
 // ParseFlags is the standard fs.Parse(args) call used by every Run-style

--- a/internal/cmds/cmdsutil/cmdsutil.go
+++ b/internal/cmds/cmdsutil/cmdsutil.go
@@ -13,6 +13,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 )
 
 // RunMain is the body of the per-binary thin shim under cmd/<name>/main.go.
@@ -48,6 +50,17 @@ func ValidateAttestationAPIURL(flagName, u string) error {
 		return nil
 	}
 	return ValidateHTTPURL(flagName, u)
+}
+
+// RequireRAMBackedDir returns an error unless dir sits on tmpfs/ramfs
+// (fileutil.RequireRAMBacked). The flagName is interpolated into the error so
+// callers needn't wrap. Shared by get-secret (--out-dir) and get-cert
+// (--key-out): each secret-writing sidecar gets the same refusal shape.
+func RequireRAMBackedDir(flagName, dir string) error {
+	if err := fileutil.RequireRAMBacked(dir); err != nil {
+		return fmt.Errorf("%s: %w", flagName, err)
+	}
+	return nil
 }
 
 // ParseFlags is the standard fs.Parse(args) call used by every Run-style

--- a/internal/cmds/cmdsutil/cmdsutil_test.go
+++ b/internal/cmds/cmdsutil/cmdsutil_test.go
@@ -44,6 +44,21 @@ func TestRequireRAMBackedDir(t *testing.T) {
 	}
 }
 
+func TestOpenRAMBackedDir(t *testing.T) {
+	dir := t.TempDir()
+	root, err := OpenRAMBackedDir("--out-dir", dir)
+	if fileutil.RequireRAMBacked(dir) == nil {
+		if err != nil {
+			t.Fatalf("RAM-backed dir refused: %v", err)
+		}
+		defer root.Close()
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), "--out-dir") {
+		t.Fatalf("want a --out-dir-prefixed refusal, got %v", err)
+	}
+}
+
 func TestValidateHTTPURL(t *testing.T) {
 	cases := []struct {
 		url     string

--- a/internal/cmds/cmdsutil/cmdsutil_test.go
+++ b/internal/cmds/cmdsutil/cmdsutil_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 )
 
 func TestRunMainSuccess(t *testing.T) {
@@ -26,6 +28,20 @@ func TestRunMainHelpDoesNotExit(t *testing.T) {
 	RunMain(func(args []string) error {
 		return flag.ErrHelp
 	})
+}
+
+func TestRequireRAMBackedDir(t *testing.T) {
+	dir := t.TempDir()
+	err := RequireRAMBackedDir("--out-dir", dir)
+	if fileutil.RequireRAMBacked(dir) == nil {
+		if err != nil {
+			t.Fatalf("RAM-backed dir refused: %v", err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), "--out-dir") {
+		t.Fatalf("want a --out-dir-prefixed refusal, got %v", err)
+	}
 }
 
 func TestValidateHTTPURL(t *testing.T) {

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -128,7 +128,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags.StringVarP(&cfg.OutPath, "out", "o", "", "Path to write the signed certificate chain PEM (prints to stdout if omitted)")
 	flags.StringVar(&cfg.CAOutPath, "ca-out", "", "Path to write just the mesh CA bundle PEM (the issuer certs trailing the leaf in the CDS chain), e.g. for nginx to serve at a discovery endpoint without a separate ConfigMap")
 	flags.StringVar(&cfg.KeyPath, "key", "", "Path to a PEM private key to use for the CSR (generates an ephemeral key if omitted)")
-	flags.StringVar(&cfg.KeyOutPath, "key-out", "", "Path to write the generated private key PEM (only used with ephemeral keys); must be on a memory-backed filesystem")
+	flags.StringVar(&cfg.KeyOutPath, "key-out", "", "Path to write the private key PEM (reused on restart if already present); must be on a memory-backed filesystem")
 	flags.StringVar(&cfg.KeyMode, "key-mode", "0600", "octal mode for generated private key")
 	flags.StringVar(&cfg.SAN, "san", "", "Subject Alternative Name for the certificate (IP address or hostname)")
 	flags.BoolVarP(&cfg.Verbose, "verbose", "v", false, "Enable debug logging")

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -128,7 +128,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags.StringVarP(&cfg.OutPath, "out", "o", "", "Path to write the signed certificate chain PEM (prints to stdout if omitted)")
 	flags.StringVar(&cfg.CAOutPath, "ca-out", "", "Path to write just the mesh CA bundle PEM (the issuer certs trailing the leaf in the CDS chain), e.g. for nginx to serve at a discovery endpoint without a separate ConfigMap")
 	flags.StringVar(&cfg.KeyPath, "key", "", "Path to a PEM private key to use for the CSR (generates an ephemeral key if omitted)")
-	flags.StringVar(&cfg.KeyOutPath, "key-out", "", "Path to write the generated private key PEM (only used with ephemeral keys)")
+	flags.StringVar(&cfg.KeyOutPath, "key-out", "", "Path to write the generated private key PEM (only used with ephemeral keys); must be on a memory-backed filesystem")
 	flags.StringVar(&cfg.KeyMode, "key-mode", "0600", "octal mode for generated private key")
 	flags.StringVar(&cfg.SAN, "san", "", "Subject Alternative Name for the certificate (IP address or hostname)")
 	flags.BoolVarP(&cfg.Verbose, "verbose", "v", false, "Enable debug logging")
@@ -219,6 +219,9 @@ func run(cfg config) error {
 	}
 
 	if err := validateOutputPaths(cfg.OutPath, cfg.KeyOutPath, cfg.DiscoveryOutPath); err != nil {
+		return err
+	}
+	if err := requireKeyOutRAMBacked(cfg.KeyOutPath); err != nil {
 		return err
 	}
 	slog.Debug("output paths validated")
@@ -738,6 +741,19 @@ func validateHostname(s string) error {
 // isIPSAN returns true if the SAN is an IP address.
 func isIPSAN(san string) bool {
 	return net.ParseIP(san) != nil
+}
+
+// requireKeyOutRAMBacked enforces that --key-out sits on tmpfs/ramfs: the
+// private key must never reach persistent storage, which the host reads at
+// will. The cert and CA outputs are public and stay unconstrained.
+func requireKeyOutRAMBacked(keyOutPath string) error {
+	if keyOutPath == "" {
+		return nil
+	}
+	if err := fileutil.RequireRAMBacked(filepath.Dir(keyOutPath)); err != nil {
+		return fmt.Errorf("--key-out: %w", err)
+	}
+	return nil
 }
 
 // validateOutputPaths checks that output file locations are writable before

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -750,10 +750,7 @@ func requireKeyOutRAMBacked(keyOutPath string) error {
 	if keyOutPath == "" {
 		return nil
 	}
-	if err := fileutil.RequireRAMBacked(filepath.Dir(keyOutPath)); err != nil {
-		return fmt.Errorf("--key-out: %w", err)
-	}
-	return nil
+	return cmdsutil.RequireRAMBackedDir("--key-out", filepath.Dir(keyOutPath))
 }
 
 // validateOutputPaths checks that output file locations are writable before

--- a/internal/cmds/getcert/run_test.go
+++ b/internal/cmds/getcert/run_test.go
@@ -566,6 +566,26 @@ func TestValidateOutputPaths(t *testing.T) {
 	})
 }
 
+// TestRequireKeyOutRAMBacked: the private key's memory-only invariant is
+// enforced, not merely documented.
+func TestRequireKeyOutRAMBacked(t *testing.T) {
+	t.Run("empty key-out exempt", func(t *testing.T) {
+		if err := requireKeyOutRAMBacked(""); err != nil {
+			t.Fatalf("requireKeyOutRAMBacked(\"\"): %v", err)
+		}
+	})
+
+	t.Run("persistent storage refused", func(t *testing.T) {
+		dir := t.TempDir()
+		if fileutil.RequireRAMBacked(dir) == nil {
+			t.Skipf("%s is RAM-backed; no on-disk path to reject", dir)
+		}
+		if err := requireKeyOutRAMBacked(filepath.Join(dir, "key.pem")); err == nil {
+			t.Fatal("expected a key-out on persistent storage to be refused")
+		}
+	})
+}
+
 func TestLoadOrGenerateKey(t *testing.T) {
 	t.Run("generate ephemeral", func(t *testing.T) {
 		key, keyPEM, err := loadOrGenerateKey(config{})

--- a/internal/cmds/getsecret/flow_test.go
+++ b/internal/cmds/getsecret/flow_test.go
@@ -333,7 +333,8 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 	if string(values["DB"]) != existing || string(values["NEW"]) != minted {
 		t.Fatalf("values = %q, %q; want both sentinels", values["DB"], values["NEW"])
 	}
-	if err := writeAll(cfg, values); err != nil {
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, values); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -170,10 +170,28 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 // secret bytes are readable by the host. Checked before fetching so a
 // misconfigured dir fails fast, without touching the secret store.
 func prepareOutDir(dir string) error {
+	// Vet the nearest existing ancestor before creating anything: MkdirAll
+	// cannot cross a mountpoint, so the new dirs land on the same filesystem,
+	// and a refusal leaves no directories behind on the persistent storage
+	// it refuses to use.
+	probe := dir
+	for {
+		if _, err := os.Stat(probe); err == nil {
+			break
+		}
+		parent := filepath.Dir(probe)
+		if parent == probe {
+			break
+		}
+		probe = parent
+	}
+	if err := cmdsutil.RequireRAMBackedDir("--out-dir", probe); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create %s: %w", dir, err)
 	}
-	return cmdsutil.RequireRAMBackedDir("--out-dir", dir)
+	return nil
 }
 
 // writeAll writes every value atomically (temp file then rename) so a consumer

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -78,9 +78,11 @@ func run(cfg config) error {
 		return err
 	}
 
-	if err := prepareOutDir(cfg.OutDir); err != nil {
+	outRoot, err := prepareOutDir(cfg.OutDir)
+	if err != nil {
 		return err
 	}
+	defer outRoot.Close()
 
 	var values map[string][]byte
 	err = sidecar.Retry(ctx, cfg.Config, "secret", func(ctx context.Context) error {
@@ -91,7 +93,7 @@ func run(cfg config) error {
 	if err != nil {
 		return err
 	}
-	if err := writeAll(cfg, values); err != nil {
+	if err := writeAll(outRoot, cfg, values); err != nil {
 		return err
 	}
 	slog.Info("secrets written", "count", len(values), "dir", cfg.OutDir)
@@ -169,7 +171,7 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 // flag documents "must be memory-backed", and on any other filesystem the
 // secret bytes are readable by the host. Checked before fetching so a
 // misconfigured dir fails fast, without touching the secret store.
-func prepareOutDir(dir string) error {
+func prepareOutDir(dir string) (*os.Root, error) {
 	// Vet the nearest existing ancestor before creating anything: MkdirAll
 	// cannot cross a mountpoint, so the new dirs land on the same filesystem,
 	// and a refusal leaves no directories behind on the persistent storage
@@ -178,6 +180,8 @@ func prepareOutDir(dir string) error {
 	for {
 		if _, err := os.Stat(probe); err == nil {
 			break
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("stat %s: %w", probe, err)
 		}
 		parent := filepath.Dir(probe)
 		if parent == probe {
@@ -186,30 +190,24 @@ func prepareOutDir(dir string) error {
 		probe = parent
 	}
 	if err := cmdsutil.RequireRAMBackedDir("--out-dir", probe); err != nil {
-		return err
+		return nil, err
 	}
 	if err := os.MkdirAll(dir, 0o750); err != nil {
-		return fmt.Errorf("create %s: %w", dir, err)
+		return nil, fmt.Errorf("create %s: %w", dir, err)
 	}
-	return nil
+	return cmdsutil.OpenRAMBackedDir("--out-dir", dir)
 }
 
 // writeAll writes every value atomically (temp file then rename) so a consumer
 // polling for a file never reads a torn one.
-func writeAll(cfg config, values map[string][]byte) error {
+func writeAll(root *os.Root, cfg config, values map[string][]byte) error {
 	mode, err := parseFileMode(cfg.FileMode)
 	if err != nil {
 		return err
 	}
-	// In run() the out-dir already exists: prepareOutDir created and vetted
-	// it. Kept so writeAll stands alone for its direct (test) callers.
-	if err := os.MkdirAll(cfg.OutDir, 0o750); err != nil {
-		return fmt.Errorf("create %s: %w", cfg.OutDir, err)
-	}
 	for name, value := range values {
-		dest := filepath.Join(cfg.OutDir, name)
-		if err := fileutil.WriteAtomic(dest, value, mode); err != nil {
-			return fmt.Errorf("write %s: %w", dest, err)
+		if err := fileutil.WriteAtomicRoot(root, name, value, mode); err != nil {
+			return fmt.Errorf("write %s: %w", name, err)
 		}
 	}
 	return nil

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/cmds/sidecar"
 	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
@@ -172,10 +173,7 @@ func prepareOutDir(dir string) error {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return fmt.Errorf("create %s: %w", dir, err)
 	}
-	if err := fileutil.RequireRAMBacked(dir); err != nil {
-		return fmt.Errorf("--out-dir: %w", err)
-	}
-	return nil
+	return cmdsutil.RequireRAMBackedDir("--out-dir", dir)
 }
 
 // writeAll writes every value atomically (temp file then rename) so a consumer
@@ -185,6 +183,8 @@ func writeAll(cfg config, values map[string][]byte) error {
 	if err != nil {
 		return err
 	}
+	// In run() the out-dir already exists: prepareOutDir created and vetted
+	// it. Kept so writeAll stands alone for its direct (test) callers.
 	if err := os.MkdirAll(cfg.OutDir, 0o750); err != nil {
 		return fmt.Errorf("create %s: %w", cfg.OutDir, err)
 	}

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -77,6 +77,10 @@ func run(cfg config) error {
 		return err
 	}
 
+	if err := prepareOutDir(cfg.OutDir); err != nil {
+		return err
+	}
+
 	var values map[string][]byte
 	err = sidecar.Retry(ctx, cfg.Config, "secret", func(ctx context.Context) error {
 		var err error
@@ -158,6 +162,20 @@ func fetchOne(ctx context.Context, cfg config, client *http.Client, pub crypto.P
 		return nil, fmt.Errorf("created by another replica but not readable: %w", err)
 	}
 	return value, nil
+}
+
+// prepareOutDir creates the out-dir and enforces that it is RAM-backed: the
+// flag documents "must be memory-backed", and on any other filesystem the
+// secret bytes are readable by the host. Checked before fetching so a
+// misconfigured dir fails fast, without touching the secret store.
+func prepareOutDir(dir string) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	if err := fileutil.RequireRAMBacked(dir); err != nil {
+		return fmt.Errorf("--out-dir: %w", err)
+	}
+	return nil
 }
 
 // writeAll writes every value atomically (temp file then rename) so a consumer

--- a/internal/cmds/getsecret/run_test.go
+++ b/internal/cmds/getsecret/run_test.go
@@ -8,7 +8,20 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/sidecar"
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 )
+
+// TestPrepareOutDir: the "must be memory-backed" invariant on --out-dir is
+// enforced, not merely documented.
+func TestPrepareOutDir(t *testing.T) {
+	dir := t.TempDir()
+	if fileutil.RequireRAMBacked(dir) == nil {
+		t.Skipf("%s is RAM-backed; no on-disk path to reject", dir)
+	}
+	if err := prepareOutDir(filepath.Join(dir, "secrets")); err == nil {
+		t.Fatal("expected an out-dir on persistent storage to be refused")
+	}
+}
 
 func TestParseSecretSpec(t *testing.T) {
 	for _, tc := range []struct {

--- a/internal/cmds/getsecret/run_test.go
+++ b/internal/cmds/getsecret/run_test.go
@@ -3,6 +3,7 @@ package getsecret
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,7 @@ func TestPrepareOutDir(t *testing.T) {
 		t.Skipf("%s is RAM-backed; no on-disk path to reject", dir)
 	}
 	out := filepath.Join(dir, "secrets")
-	if err := prepareOutDir(out); err == nil {
+	if _, err := prepareOutDir(out); err == nil {
 		t.Fatal("expected an out-dir on persistent storage to be refused")
 	}
 	if _, err := os.Stat(out); !os.IsNotExist(err) {
@@ -138,11 +139,12 @@ func TestValidateTrimsURL(t *testing.T) {
 
 func TestWriteAll(t *testing.T) {
 	cfg := validConfig(t)
+	root := openOutRoot(t, cfg.OutDir)
 	values := map[string][]byte{
 		"DB":    []byte("s3cret"),
 		"OTHER": {0x00, 0xff, '\n', '"'}, // raw bytes, not text
 	}
-	if err := writeAll(cfg, values); err != nil {
+	if err := writeAll(root, cfg, values); err != nil {
 		t.Fatal(err)
 	}
 	for name, want := range values {
@@ -168,7 +170,8 @@ func TestWriteAll(t *testing.T) {
 // must not find a temp file and mistake it for its secret.
 func TestWriteAllLeavesNoTempFiles(t *testing.T) {
 	cfg := validConfig(t)
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
 		t.Fatal(err)
 	}
 	entries, err := os.ReadDir(cfg.OutDir)
@@ -188,10 +191,11 @@ func TestWriteAllLeavesNoTempFiles(t *testing.T) {
 // than fail or append.
 func TestWriteAllOverwrites(t *testing.T) {
 	cfg := validConfig(t)
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("first")}); err != nil {
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("first")}); err != nil {
 		t.Fatal(err)
 	}
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("second")}); err != nil {
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("second")}); err != nil {
 		t.Fatal(err)
 	}
 	got, err := os.ReadFile(filepath.Join(cfg.OutDir, "DB"))
@@ -203,10 +207,14 @@ func TestWriteAllOverwrites(t *testing.T) {
 	}
 }
 
-func TestWriteAllCreatesDir(t *testing.T) {
+func TestWriteAllWritesPreparedDir(t *testing.T) {
 	cfg := validConfig(t)
 	cfg.OutDir = filepath.Join(cfg.OutDir, "nested", "secrets")
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
+	if err := os.MkdirAll(cfg.OutDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("v")}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(filepath.Join(cfg.OutDir, "DB")); err != nil {
@@ -246,14 +254,15 @@ func ptr(c config) *config { return &c }
 // with no file on disk.
 func TestWriteAllUnwritable(t *testing.T) {
 	cfg := validConfig(t)
-	cfg.OutDir = filepath.Join(cfg.OutDir, "readonly", "secrets")
-	if err := os.MkdirAll(filepath.Dir(cfg.OutDir), 0o500); err != nil {
+	cfg.OutDir = filepath.Join(cfg.OutDir, "readonly")
+	if err := os.MkdirAll(cfg.OutDir, 0o500); err != nil {
 		t.Fatal(err)
 	}
 	if os.Geteuid() == 0 {
 		t.Skip("running as root, which ignores the directory mode")
 	}
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
 		t.Fatal("an unwritable directory reported success")
 	}
 }
@@ -261,9 +270,63 @@ func TestWriteAllUnwritable(t *testing.T) {
 func TestWriteAllRejectsBadMode(t *testing.T) {
 	cfg := validConfig(t)
 	cfg.FileMode = "notamode"
-	if err := writeAll(cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
+	root := openOutRoot(t, cfg.OutDir)
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("v")}); err == nil {
 		t.Fatal("a bad file mode was accepted")
 	}
+}
+
+// The final RAM-backed check returns an open root. Keeping it through the
+// write is what prevents an attacker from replacing --out-dir after startup.
+func TestWriteAllStaysInVerifiedOutDirAfterPathReplacement(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("RAM-backed output verification is linux-only")
+	}
+	base, err := os.MkdirTemp("/dev/shm", "c8s-getsecret-")
+	if err != nil {
+		t.Skipf("cannot create a temporary directory in /dev/shm: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(base) })
+	if err := fileutil.RequireRAMBacked(base); err != nil {
+		t.Skipf("/dev/shm is not usable tmpfs: %v", err)
+	}
+
+	cfg := validConfig(t)
+	cfg.OutDir = filepath.Join(base, "out")
+	root, err := prepareOutDir(cfg.OutDir)
+	if err != nil {
+		t.Fatalf("prepareOutDir: %v", err)
+	}
+	defer root.Close()
+
+	moved := filepath.Join(base, "moved")
+	if err := os.Rename(cfg.OutDir, moved); err != nil {
+		t.Fatalf("move verified directory: %v", err)
+	}
+	trap := t.TempDir()
+	if err := os.Symlink(trap, cfg.OutDir); err != nil {
+		t.Fatalf("replace verified directory: %v", err)
+	}
+
+	if err := writeAll(root, cfg, map[string][]byte{"DB": []byte("secret")}); err != nil {
+		t.Fatalf("writeAll: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(moved, "DB")); err != nil || string(got) != "secret" {
+		t.Fatalf("original verified directory holds %q, %v; want secret", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(trap, "DB")); !os.IsNotExist(err) {
+		t.Fatalf("write followed replacement --out-dir, stat error = %v", err)
+	}
+}
+
+func openOutRoot(t *testing.T, dir string) *os.Root {
+	t.Helper()
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		t.Fatalf("open output root: %v", err)
+	}
+	t.Cleanup(func() { _ = root.Close() })
+	return root
 }
 
 // A malformed RTMR pin is a typo in rendered config; pinning nothing is not

--- a/internal/cmds/getsecret/run_test.go
+++ b/internal/cmds/getsecret/run_test.go
@@ -18,8 +18,12 @@ func TestPrepareOutDir(t *testing.T) {
 	if fileutil.RequireRAMBacked(dir) == nil {
 		t.Skipf("%s is RAM-backed; no on-disk path to reject", dir)
 	}
-	if err := prepareOutDir(filepath.Join(dir, "secrets")); err == nil {
+	out := filepath.Join(dir, "secrets")
+	if err := prepareOutDir(out); err == nil {
 		t.Fatal("expected an out-dir on persistent storage to be refused")
+	}
+	if _, err := os.Stat(out); !os.IsNotExist(err) {
+		t.Fatal("refusal must not create the out-dir on the storage it rejects")
 	}
 }
 

--- a/internal/fileutil/atomic.go
+++ b/internal/fileutil/atomic.go
@@ -2,8 +2,12 @@
 package fileutil
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // WriteAtomic writes data to path via a same-directory temp file plus
@@ -15,17 +19,44 @@ import (
 // replace on POSIX filesystems; a /tmp tmp would silently degrade to a
 // copy+remove on cross-mount writes.
 func WriteAtomic(path string, data []byte, mode os.FileMode) error {
+	if path != "" && os.IsPathSeparator(path[len(path)-1]) {
+		return fmt.Errorf("write atomically: path %q ends in a path separator", path)
+	}
 	dir := filepath.Dir(path)
 	base := filepath.Base(path)
-	tmp, err := os.CreateTemp(dir, "."+base+".*.tmp")
+	root, err := os.OpenRoot(dir)
 	if err != nil {
 		return err
 	}
-	tmpName := tmp.Name()
+	defer root.Close()
+	return WriteAtomicRoot(root, base, data, mode)
+}
+
+// WriteAtomicRoot writes data to a file directly beneath root via a
+// same-directory temp file plus root.Rename. Keeping the directory handle
+// through the rename prevents a later replacement of its pathname from
+// redirecting the write.
+func WriteAtomicRoot(root *os.Root, name string, data []byte, mode os.FileMode) error {
+	if root == nil {
+		return fmt.Errorf("write atomically: nil directory root")
+	}
+	if name == "" || name == "." || name == ".." || strings.ContainsAny(name, `/\\`) {
+		return fmt.Errorf("write atomically: %q is not a file name directly beneath the directory root", name)
+	}
+
+	tmpName, err := atomicTempName(name)
+	if err != nil {
+		return err
+	}
+	tmp, err := root.OpenFile(tmpName, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
 	cleanup := true
 	defer func() {
 		if cleanup {
-			_ = os.Remove(tmpName)
+			_ = tmp.Close()
+			_ = root.Remove(tmpName)
 		}
 	}()
 
@@ -40,9 +71,17 @@ func WriteAtomic(path string, data []byte, mode os.FileMode) error {
 	if err := tmp.Close(); err != nil {
 		return err
 	}
-	if err := os.Rename(tmpName, path); err != nil {
+	if err := root.Rename(tmpName, name); err != nil {
 		return err
 	}
 	cleanup = false
 	return nil
+}
+
+func atomicTempName(name string) (string, error) {
+	var suffix [12]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("generate atomic-write temp name: %w", err)
+	}
+	return "." + name + "." + hex.EncodeToString(suffix[:]) + ".tmp", nil
 }

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -40,13 +40,23 @@ func TestWriteAtomicOverwritesExisting(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	if err := WriteAtomic(path, []byte("new"), 0o644); err != nil {
+	if err := WriteAtomic(path, []byte("new"), 0o600); err != nil {
 		t.Fatalf("WriteAtomic: %v", err)
 	}
 
 	got, _ := os.ReadFile(path)
 	if string(got) != "new" {
 		t.Errorf("content = %q, want new", got)
+	}
+	// The rename replaces the wider-mode original: overwriting tightens
+	// permissions rather than inheriting them, a contract secret writers
+	// rely on.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
+		t.Errorf("mode after overwrite = %o, want 600", info.Mode().Perm())
 	}
 }
 

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -107,3 +107,64 @@ func TestWriteAtomicRenameFailureCleansUpTemp(t *testing.T) {
 		t.Errorf("temp file not cleaned up, dir contains: %v", entries)
 	}
 }
+
+func TestWriteAtomicRejectsTrailingSeparator(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "dest")
+	if err := os.Mkdir(dest, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteAtomic(dest+string(os.PathSeparator), []byte("secret"), 0o600); err == nil {
+		t.Fatal("expected trailing path separator to be rejected")
+	}
+	entries, err := os.ReadDir(dest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("trailing separator created nested output: %v", entries)
+	}
+}
+
+func TestWriteAtomicRootStaysInOpenedDirectoryAfterPathReplacement(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires unprivileged symbolic links")
+	}
+	base := t.TempDir()
+	out := filepath.Join(base, "out")
+	if err := os.Mkdir(out, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	moved := filepath.Join(base, "moved")
+	if err := os.Rename(out, moved); err != nil {
+		t.Fatalf("move opened directory: %v", err)
+	}
+	trap := filepath.Join(base, "trap")
+	if err := os.Mkdir(trap, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(trap, out); err != nil {
+		t.Fatalf("replace opened directory: %v", err)
+	}
+
+	if err := WriteAtomicRoot(root, "secret", []byte("value"), 0o600); err != nil {
+		t.Fatalf("WriteAtomicRoot: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(moved, "secret"))
+	if err != nil {
+		t.Fatalf("read from original directory: %v", err)
+	}
+	if string(got) != "value" {
+		t.Fatalf("original directory content = %q, want value", got)
+	}
+	if _, err := os.Stat(filepath.Join(trap, "secret")); !os.IsNotExist(err) {
+		t.Fatalf("write followed replacement directory, stat error = %v", err)
+	}
+}

--- a/internal/fileutil/atomic_test.go
+++ b/internal/fileutil/atomic_test.go
@@ -40,7 +40,10 @@ func TestWriteAtomicOverwritesExisting(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	if err := WriteAtomic(path, []byte("new"), 0o600); err != nil {
+	// 0o640 rather than 0o600: os.CreateTemp's default is 0600, so only a
+	// non-default mode proves the Chmod runs and the rename replaced the
+	// wider-mode original — the tightening contract secret writers rely on.
+	if err := WriteAtomic(path, []byte("new"), 0o640); err != nil {
 		t.Fatalf("WriteAtomic: %v", err)
 	}
 
@@ -48,15 +51,12 @@ func TestWriteAtomicOverwritesExisting(t *testing.T) {
 	if string(got) != "new" {
 		t.Errorf("content = %q, want new", got)
 	}
-	// The rename replaces the wider-mode original: overwriting tightens
-	// permissions rather than inheriting them, a contract secret writers
-	// rely on.
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatalf("stat: %v", err)
 	}
-	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o600 {
-		t.Errorf("mode after overwrite = %o, want 600", info.Mode().Perm())
+	if runtime.GOOS != "windows" && info.Mode().Perm() != 0o640 {
+		t.Errorf("mode after overwrite = %o, want 640", info.Mode().Perm())
 	}
 }
 

--- a/internal/fileutil/rambacked_linux.go
+++ b/internal/fileutil/rambacked_linux.go
@@ -1,0 +1,23 @@
+package fileutil
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// RequireRAMBacked fails unless dir sits on tmpfs or ramfs. Callers staging
+// secrets (join tokens, private keys) use it to enforce "memory only" rather
+// than merely documenting it: on any other filesystem the bytes are readable
+// by the host.
+func RequireRAMBacked(dir string) error {
+	var st unix.Statfs_t
+	if err := unix.Statfs(dir, &st); err != nil {
+		return fmt.Errorf("statfs %s: %w", dir, err)
+	}
+	// f_type is a 32-bit magic; the field's signedness varies by GOARCH.
+	if m := uint32(st.Type); m != uint32(unix.TMPFS_MAGIC) && m != uint32(unix.RAMFS_MAGIC) {
+		return fmt.Errorf("%s is not RAM-backed (fs magic %#x)", dir, m)
+	}
+	return nil
+}

--- a/internal/fileutil/rambacked_linux.go
+++ b/internal/fileutil/rambacked_linux.go
@@ -2,6 +2,7 @@ package fileutil
 
 import (
 	"fmt"
+	"os"
 
 	"golang.org/x/sys/unix"
 )
@@ -11,13 +12,34 @@ import (
 // than merely documenting it: on any other filesystem the bytes are readable
 // by the host.
 func RequireRAMBacked(dir string) error {
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", dir, err)
+	}
+	defer root.Close()
+	return RequireRAMBackedRoot(root)
+}
+
+// RequireRAMBackedRoot fails unless the directory held by root sits on tmpfs
+// or ramfs. The check uses the open handle rather than root.Name(), so a
+// pathname replacement cannot change the filesystem that is verified.
+func RequireRAMBackedRoot(root *os.Root) error {
+	if root == nil {
+		return fmt.Errorf("cannot verify a nil directory root is RAM-backed")
+	}
+	dir, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("open %s: %w", root.Name(), err)
+	}
+	defer dir.Close()
+
 	var st unix.Statfs_t
-	if err := unix.Statfs(dir, &st); err != nil {
-		return fmt.Errorf("statfs %s: %w", dir, err)
+	if err := unix.Fstatfs(int(dir.Fd()), &st); err != nil {
+		return fmt.Errorf("statfs %s: %w", root.Name(), err)
 	}
 	// f_type is a 32-bit magic; the field's signedness varies by GOARCH.
 	if m := uint32(st.Type); m != uint32(unix.TMPFS_MAGIC) && m != uint32(unix.RAMFS_MAGIC) {
-		return fmt.Errorf("%s is not RAM-backed (fs magic %#x)", dir, m)
+		return fmt.Errorf("%s is not RAM-backed (fs magic %#x)", root.Name(), m)
 	}
 	return nil
 }

--- a/internal/fileutil/rambacked_linux_test.go
+++ b/internal/fileutil/rambacked_linux_test.go
@@ -1,0 +1,29 @@
+package fileutil
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// Pins the sign of the check without using RequireRAMBacked as its own
+// oracle: /proc is procfs on every Linux, so an inverted check fails here
+// deterministically.
+func TestRequireRAMBackedRejectsProcfs(t *testing.T) {
+	if err := RequireRAMBacked("/proc"); err == nil {
+		t.Fatal("procfs accepted as RAM-backed")
+	}
+}
+
+// Accept path against a real tmpfs mount, as volumed's tests do; skipped
+// without mount privileges.
+func TestRequireRAMBackedAcceptsTmpfs(t *testing.T) {
+	dir := t.TempDir()
+	if err := unix.Mount("tmpfs", dir, "tmpfs", 0, ""); err != nil {
+		t.Skipf("cannot mount tmpfs here (needs CAP_SYS_ADMIN in a mount namespace): %v", err)
+	}
+	t.Cleanup(func() { _ = unix.Unmount(dir, unix.MNT_DETACH) })
+	if err := RequireRAMBacked(dir); err != nil {
+		t.Fatalf("tmpfs refused: %v", err)
+	}
+}

--- a/internal/fileutil/rambacked_linux_test.go
+++ b/internal/fileutil/rambacked_linux_test.go
@@ -1,6 +1,8 @@
 package fileutil
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -26,4 +28,47 @@ func TestRequireRAMBackedAcceptsTmpfs(t *testing.T) {
 	if err := RequireRAMBacked(dir); err != nil {
 		t.Fatalf("tmpfs refused: %v", err)
 	}
+}
+
+// The pathname can change after it is opened but before the filesystem check.
+// Verification must inspect the held directory, not look the name up again.
+func TestRequireRAMBackedRootSurvivesPathReplacementBeforeVerification(t *testing.T) {
+	base := ramBackedTempDir(t)
+	out := filepath.Join(base, "out")
+	if err := os.Mkdir(out, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	root, err := os.OpenRoot(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+
+	moved := filepath.Join(base, "moved")
+	if err := os.Rename(out, moved); err != nil {
+		t.Fatalf("move opened directory: %v", err)
+	}
+	if err := os.Symlink("/proc", out); err != nil {
+		t.Fatalf("replace opened directory with procfs symlink: %v", err)
+	}
+
+	if err := RequireRAMBackedRoot(root); err != nil {
+		t.Fatalf("opened tmpfs directory refused after its pathname changed: %v", err)
+	}
+	if err := RequireRAMBacked(out); err == nil {
+		t.Fatal("replacement procfs path accepted as RAM-backed")
+	}
+}
+
+func ramBackedTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/dev/shm", "c8s-rambacked-")
+	if err != nil {
+		t.Skipf("cannot create a temporary directory in /dev/shm: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	if err := RequireRAMBacked(dir); err != nil {
+		t.Skipf("/dev/shm is not usable tmpfs: %v", err)
+	}
+	return dir
 }

--- a/internal/fileutil/rambacked_other.go
+++ b/internal/fileutil/rambacked_other.go
@@ -2,10 +2,22 @@
 
 package fileutil
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+)
 
 // RequireRAMBacked fails closed off Linux: without statfs there is no way to
 // prove dir is memory-backed, so secret staging is refused.
 func RequireRAMBacked(dir string) error {
 	return fmt.Errorf("cannot verify %s is RAM-backed: linux only", dir)
+}
+
+// RequireRAMBackedRoot fails closed off Linux, where the filesystem behind an
+// open directory handle cannot be proven memory-backed.
+func RequireRAMBackedRoot(root *os.Root) error {
+	if root == nil {
+		return fmt.Errorf("cannot verify a nil directory root is RAM-backed: linux only")
+	}
+	return fmt.Errorf("cannot verify %s is RAM-backed: linux only", root.Name())
 }

--- a/internal/fileutil/rambacked_other.go
+++ b/internal/fileutil/rambacked_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package fileutil
+
+import "fmt"
+
+// RequireRAMBacked fails closed off Linux: without statfs there is no way to
+// prove dir is memory-backed, so secret staging is refused.
+func RequireRAMBacked(dir string) error {
+	return fmt.Errorf("cannot verify %s is RAM-backed: linux only", dir)
+}

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   # before nginx-lb starts.
   tls-holder:
     image: nginx:1.27-alpine
-    entrypoint: ["sleep", "infinity"]
+    entrypoint: ["sleep", "2147483647"]
     volumes:
       - tls-certs:/tls
 

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -21,6 +21,16 @@ services:
     image: nginx:1.27-alpine
     # Default nginx serves a welcome page on port 80.
 
+  # Keeps the tmpfs volume mounted across the get-cert → nginx-lb handoff,
+  # the way kubelet holds a pod's emptyDir: docker unmounts a tmpfs-backed
+  # volume (discarding it) once no container uses it, and get-cert exits
+  # before nginx-lb starts.
+  tls-holder:
+    image: nginx:1.27-alpine
+    entrypoint: ["sleep", "infinity"]
+    volumes:
+      - tls-certs:/tls
+
   get-cert:
     build:
       # cmd/get-cert/Dockerfile COPYs build/c8s, so the context must be the
@@ -41,6 +51,7 @@ services:
     depends_on:
       - mock-cds
       - mock-attestation
+      - tls-holder
 
   nginx-lb:
     image: nginx:1.27-alpine
@@ -56,4 +67,10 @@ services:
         condition: service_started
 
 volumes:
+  # tmpfs-backed like the Memory-medium emptyDir the webhook injects in
+  # production: get-cert refuses a --key-out on persistent storage.
   tls-certs:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs


### PR DESCRIPTION
getsecret documents that `--out-dir` must be memory-backed, and getcert writes the workload private key to a volume the webhook requires to be a Memory-medium emptyDir. Neither binary checked — on any other filesystem the secret bytes land where the host can read them.

Both now go through `fileutil.RequireRAMBacked`, copied verbatim from `feat/attested-join` so that branch still merges cleanly. getsecret refuses a non-tmpfs `--out-dir` before touching the secret store; getcert refuses a `--key-out` on persistent storage at startup, next to the existing writability probe. The cert and CA outputs are public and stay unconstrained. Off Linux the check fails closed.

The second commit pins the WriteAtomic contract these writers rely on: overwriting now provably tightens permissions instead of inheriting the old mode. The third moves the flag-prefixed wrapper into cmdsutil, next to the other shared flag validators.

This is a behavior change for anyone pointing these flags at persistent storage. The refusal is loud at startup, before any secret is fetched or key generated, and the chart/webhook path is unaffected — the webhook already rejects non-Memory volumes for both.

Tests mirror join's TestPrepareTokenDir and skip where the temp dir is tmpfs. `TMPDIR=/tmp go test` passes on the touched packages; the default macOS TMPDIR trips a pre-existing unix-socket path-length failure, reproduced on clean main. Linux cross-build clean.