### PR TITLE
feat(node-guest-image): fail closed when the scratch disk is missing

### DIFF
--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -81,8 +81,7 @@ fi
 # tdx-metal-e2e.yml is vendored from confidential-ci; the bait +
 # tripwire are a c8s-local patch until the source takes the same
 # edit — a re-vendor would silently delete them.
-# 'serial: confai-scratch' rides along: without it the initrd ignores the
-# e2e VM's write-storage disk and scratch-enforce powers the VM off.
+# 'serial: confai-scratch' rides along: scratch-enforce powers the e2e VM off without it.
 for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert' 'serial: confai-scratch'; do
   if ! grep -qF "$marker" .github/workflows/tdx-metal-e2e.yml; then
     echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped a c8s-local patch — re-apply it"
@@ -94,6 +93,14 @@ done
 # would power off every healthy node. Pin the contract at the pinned ref.
 if ! grep -qF '"$SCRATCH_DEV" scratch' confos/mkosi/initrd/mkosi.extra/init; then
   echo "::error::confos initrd no longer opens the scratch disk as dm 'scratch'; scratch-enforce.sh gates on that name — update both together"
+  exit 1
+fi
+
+# The scratch floor is prose in the README and a sector count in the gate;
+# a bump must touch both.
+if ! grep -qF 'MIN_SECTORS=125000000' "$ngi/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh" \
+   || ! grep -qF 'at least 64G' "$ngi/README.md"; then
+  echo "::error::scratch floor drifted: scratch-enforce.sh MIN_SECTORS (64G = 125000000 sectors) and the README's 'at least 64G' must move together"
   exit 1
 fi
 

--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -87,5 +87,11 @@ for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert'; do
     exit 1
   fi
 done
+# The e2e VM must keep the serial the initrd matches its write-storage disk
+# on; scratch-enforce would power the VM off without it.
+if ! grep -qF 'serial: confai-scratch' .github/workflows/tdx-metal-e2e.yml; then
+  echo "::error::tdx-metal-e2e.yml lost 'serial: confai-scratch': re-vendoring dropped the scratch disk serial — re-apply the c8s-local patch"
+  exit 1
+fi
 
 echo "all node-guest-image invariants hold at CONFOS_REF $CONFOS_REF"

--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -81,16 +81,19 @@ fi
 # tdx-metal-e2e.yml is vendored from confidential-ci; the bait +
 # tripwire are a c8s-local patch until the source takes the same
 # edit — a re-vendor would silently delete them.
-for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert'; do
+# 'serial: confai-scratch' rides along: without it the initrd ignores the
+# e2e VM's write-storage disk and scratch-enforce powers the VM off.
+for marker in 'hostname: cidata-bait' 'assert the host cidata disk is inert' 'serial: confai-scratch'; do
   if ! grep -qF "$marker" .github/workflows/tdx-metal-e2e.yml; then
-    echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped the cidata bait/tripwire — re-apply the c8s-local patch"
+    echo "::error::tdx-metal-e2e.yml lost '$marker': re-vendoring dropped a c8s-local patch — re-apply it"
     exit 1
   fi
 done
-# The e2e VM must keep the serial the initrd matches its write-storage disk
-# on; scratch-enforce would power the VM off without it.
-if ! grep -qF 'serial: confai-scratch' .github/workflows/tdx-metal-e2e.yml; then
-  echo "::error::tdx-metal-e2e.yml lost 'serial: confai-scratch': re-vendoring dropped the scratch disk serial — re-apply the c8s-local patch"
+
+# scratch-enforce keys on the initrd's dm mapping name; a confos rename
+# would power off every healthy node. Pin the contract at the pinned ref.
+if ! grep -qF '"$SCRATCH_DEV" scratch' confos/mkosi/initrd/mkosi.extra/init; then
+  echo "::error::confos initrd no longer opens the scratch disk as dm 'scratch'; scratch-enforce.sh gates on that name — update both together"
   exit 1
 fi
 

--- a/.github/workflows/node-guest-image-lint.yml
+++ b/.github/workflows/node-guest-image-lint.yml
@@ -153,6 +153,15 @@ jobs:
       - name: Run the gpu-cc-enforce unit test
         run: make test-node-guest-image-gpu-cc
 
+  scratch:
+    name: scratch-enforce logic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run the scratch-enforce unit test
+        run: make test-node-guest-image-scratch
+
   rke2-role:
     name: rke2-role dispatch (script)
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-gpu-cc test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-gpu-cc test-node-guest-image-scratch test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -148,6 +148,9 @@ test-node-guest-image-gpu-label:
 
 test-node-guest-image-gpu-cc:
 	./node-guest-image/tests/gpu-cc-enforce-test.sh
+
+test-node-guest-image-scratch:
+	./node-guest-image/tests/scratch-enforce-test.sh
 
 # Role-gated unit wiring under real systemd in a privileged container.
 # Needs only docker.

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -46,7 +46,8 @@ Every node VM needs a write-storage disk with virtio-blk serial
 `confai-scratch`, at least 64G. The initrd encrypts it and uses it as the
 rootfs upper. Without it, the guest boots anyway on a 2G RAM tmpfs, comes
 up Ready, and wedges once RKE2 fills it — that's a flapping node, not a
-boot error. The serial is what matters: labels don't work, and the disk
+boot error. `scratch-enforce.service` closes that hole: it powers the VM
+off before rke2 starts when the initrd fell back to tmpfs. The serial is what matters: labels don't work, and the disk
 must be one of `/dev/vdb`–`vdd`. In KubeVirt that's `disk: {bus: virtio}`
 plus `serial: confai-scratch` (see the vendored `tdx-metal-e2e.yml`); with
 confidential-metal, pass `--datadisk-gi` — its default is 0, meaning no

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -43,15 +43,17 @@ Layout:
 ## Launch requirements
 
 Every node VM needs a write-storage disk with virtio-blk serial
-`confai-scratch`, at least 64G. The initrd encrypts it and uses it as the
-rootfs upper. Without it, the guest boots anyway on a 2G RAM tmpfs, comes
-up Ready, and wedges once RKE2 fills it — that's a flapping node, not a
-boot error. `scratch-enforce.service` closes that hole: it powers the VM
-off before rke2 starts when the initrd fell back to tmpfs. The serial is what matters: labels don't work, and the disk
-must be one of `/dev/vdb`–`vdd`. In KubeVirt that's `disk: {bus: virtio}`
-plus `serial: confai-scratch` (see the vendored `tdx-metal-e2e.yml`); with
-confidential-metal, pass `--datadisk-gi` — its default is 0, meaning no
-disk.
+`confai-scratch`, at least 64G. The serial is what matters: labels don't
+work, and the disk must be one of `/dev/vdb`–`vdd`. In KubeVirt that's
+`disk: {bus: virtio}` plus `serial: confai-scratch` (see the vendored
+`tdx-metal-e2e.yml`); confidential-metal attaches one by default
+(`--datadisk-gi`, 0 opts out).
+
+The initrd encrypts the disk and mounts it as the rootfs upper, via a dm
+mapping named `scratch`. Without the disk it falls back to a 2G RAM tmpfs:
+the guest comes up Ready, then wedges once RKE2 fills it — a flapping
+node, not a boot error. `scratch-enforce.service` closes that hole by
+checking for the dm mapping and powering the VM off before rke2 starts.
 
 A second disk with serial `confai-containerd` is recommended so the image
 cache stays off guest RAM. `confai-models`, `opkeydata`, and `joindata`

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -55,9 +55,24 @@ the guest comes up Ready, then wedges once RKE2 fills it — a flapping
 node, not a boot error. `scratch-enforce.service` closes that hole by
 checking for the dm mapping and powering the VM off before rke2 starts.
 
-A second disk with serial `confai-containerd` is recommended so the image
-cache stays off guest RAM. `confai-models`, `opkeydata`, and `joindata`
-are optional; missing ones are a clean no-op.
+The other disks are optional; a missing one is a clean no-op. Each is
+owned by one unit under `c8s/mkosi.extra`, whose header comment carries
+the full contract (threat model, fallback, file format):
+
+- serial `confai-containerd` (or filesystem label `containerd`) —
+  recommended. Backs containerd's image cache with a per-boot encrypted
+  ext4 instead of a 32G RAM tmpfs (`containerd-data-disk.service`).
+- serial `confai-models` — a pre-populated, read-only ext4 of model
+  weights, mounted at `/var/lib/models` so hundreds of GiB survive a
+  relaunch. Unencrypted: weights are public, integrity is the workload's
+  digest check (`models-disk.service`).
+- label `joindata` — an ISO of single-line files (`role`, `server`,
+  tokens, node IPs) that picks server vs agent and joins the cluster.
+  Absent means single-node server (`rke2-role.service`, contract v0 in
+  `rke2-role.sh`).
+- label `opkeydata` — an ISO carrying the operator public key the initrd
+  hashes into RTMR[3]; its presence turns on attested credential release
+  (`cred-release.service`, see [operator.md]).
 
 Migration state (see [#264] for the full plan):
 
@@ -79,3 +94,4 @@ Migration state (see [#264] for the full plan):
 
 [confidential-os-builder]: https://github.com/confidential-dot-ai/confidential-os-builder
 [#264]: https://github.com/confidential-dot-ai/c8s/issues/264
+[operator.md]: ../docs/operator.md

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -40,6 +40,22 @@ Layout:
   and order; only the c8s profile content and kernel fragments come from
   here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
 
+## Launch requirements
+
+Every node VM needs a write-storage disk with virtio-blk serial
+`confai-scratch`, at least 64G. The initrd encrypts it and uses it as the
+rootfs upper. Without it, the guest boots anyway on a 2G RAM tmpfs, comes
+up Ready, and wedges once RKE2 fills it — that's a flapping node, not a
+boot error. The serial is what matters: labels don't work, and the disk
+must be one of `/dev/vdb`–`vdd`. In KubeVirt that's `disk: {bus: virtio}`
+plus `serial: confai-scratch` (see the vendored `tdx-metal-e2e.yml`); with
+confidential-metal, pass `--datadisk-gi` — its default is 0, meaning no
+disk.
+
+A second disk with serial `confai-containerd` is recommended so the image
+cache stays off guest RAM. `confai-models`, `opkeydata`, and `joindata`
+are optional; missing ones are a clean no-op.
+
 Migration state (see [#264] for the full plan):
 
 1. This directory is the canonical definition: `c8s-image.yml` builds via

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -43,8 +43,8 @@ Layout:
 ## Launch requirements
 
 Every node VM needs a write-storage disk with virtio-blk serial
-`confai-scratch`, at least 64G. The serial is what matters: labels don't
-work, and the disk must be one of `/dev/vdb`–`vdd`. In KubeVirt that's
+`confai-scratch`, at least 64G. The serial is what matters: the confos
+initrd scans `/dev/vd{b,c,d}` for it and ignores labels. In KubeVirt that's
 `disk: {bus: virtio}` plus `serial: confai-scratch` (see the vendored
 `tdx-metal-e2e.yml`); confidential-metal attaches one by default
 (`--datadisk-gi`, 0 opts out).
@@ -55,24 +55,20 @@ the guest comes up Ready, then wedges once RKE2 fills it — a flapping
 node, not a boot error. `scratch-enforce.service` closes that hole by
 checking for the dm mapping and powering the VM off before rke2 starts.
 
-The other disks are optional; a missing one is a clean no-op. Each is
-owned by one unit under `c8s/mkosi.extra`, whose header comment carries
-the full contract (threat model, fallback, file format):
+The other disks are optional; each is owned by one unit under
+`c8s/mkosi.extra`, whose header carries the full contract:
 
-- serial `confai-containerd` (or filesystem label `containerd`) —
-  recommended. Backs containerd's image cache with a per-boot encrypted
-  ext4 instead of a 32G RAM tmpfs (`containerd-data-disk.service`).
-- serial `confai-models` — a pre-populated, read-only ext4 of model
-  weights, mounted at `/var/lib/models` so hundreds of GiB survive a
-  relaunch. Unencrypted: weights are public, integrity is the workload's
-  digest check (`models-disk.service`).
-- label `joindata` — an ISO of single-line files (`role`, `server`,
-  tokens, node IPs) that picks server vs agent and joins the cluster.
-  Absent means single-node server (`rke2-role.service`, contract v0 in
-  `rke2-role.sh`).
-- label `opkeydata` — an ISO carrying the operator public key the initrd
-  hashes into RTMR[3]; its presence turns on attested credential release
-  (`cred-release.service`, see [operator.md]).
+- serial `confai-containerd` (or label `containerd`) — recommended:
+  backs containerd's image cache, which otherwise lives in a RAM tmpfs
+  (`containerd-data-disk.service`).
+- serial `confai-models` — a pre-populated, read-only weights disk
+  mounted at `/var/lib/models` so a large cache survives relaunch
+  (`models-disk.service`).
+- label `joindata` — an ISO that picks server vs agent and joins the
+  cluster; absent means single-node server (`rke2-role.service`).
+- label `opkeydata` — an ISO carrying the operator public key; its
+  presence turns on attested credential release (`cred-release.service`,
+  see [operator.md]).
 
 Migration state (see [#264] for the full plan):
 

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -62,8 +62,9 @@ The other disks are optional; each is owned by one unit under
   backs containerd's image cache, which otherwise lives in a RAM tmpfs
   (`containerd-data-disk.service`).
 - serial `confai-models` — a pre-populated, read-only weights disk
-  mounted at `/var/lib/models` so a large cache survives relaunch
-  (`models-disk.service`).
+  mounted at `/var/lib/models` so a large cache survives relaunch. It is
+  unencrypted and host-writable: attach it only for public weights whose
+  digests the workload verifies itself (`models-disk.service`).
 - label `joindata` — an ISO that picks server vs agent and joins the
   cluster; absent means single-node server (`rke2-role.service`).
 - label `opkeydata` — an ISO carrying the operator public key; its

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -18,12 +18,7 @@
 # header): kubelet/Cilium need the container/k8s symbols, all =y because
 # nvidia-modules-latch.service disables module loading after boot.
 #
-# LAUNCH REQUIREMENTS (unlike the gpu image these are hard):
-#   - a virtio-blk disk with serial=confai-scratch, >=64G — the default 2G
-#     tmpfs overlay upper cannot hold RKE2's /var/lib/rancher
-#   - ideally a second disk labeled `containerd` (virtio-scsi preferred) so
-#     the image cache stays off guest RAM (containerd-data-disk.service)
-# See ../README.md "Launch requirements".
+# Launch requirements (hard, unlike the gpu image's): ../README.md.
 
 [Content]
 Packages=

--- a/node-guest-image/c8s/mkosi.conf
+++ b/node-guest-image/c8s/mkosi.conf
@@ -23,7 +23,7 @@
 #     tmpfs overlay upper cannot hold RKE2's /var/lib/rancher
 #   - ideally a second disk labeled `containerd` (virtio-scsi preferred) so
 #     the image cache stays off guest RAM (containerd-data-disk.service)
-# See docs/C8S-IMAGE.md.
+# See ../README.md "Launch requirements".
 
 [Content]
 Packages=

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/scratch-enforce.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/scratch-enforce.service
@@ -1,0 +1,25 @@
+# Fail the boot when the confos initrd fell back to the 2G tmpfs rootfs
+# upper instead of the confai-scratch disk. confos deliberately tolerates
+# that fallback; the c8s node must not (rke2 wedges when the tmpfs fills).
+[Unit]
+Description=Refuse to start the node unless the rootfs upper is on the scratch disk
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/bin/scratch-enforce.sh
+# One sysfs scan; the dm device exists since the initrd or not at all.
+TimeoutStartSec=30
+# Fail closed: power off rather than leave a node that registers Ready and
+# then wedges — a powered-off node does not flap.
+FailureAction=poweroff-force
+
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).
+RestrictAddressFamilies=AF_UNIX
+
+[Install]
+WantedBy=multi-user.target
+# Preset creates the .requires links, so rke2 cannot start while this unit
+# is failing or has not run.
+RequiredBy=rke2-server.service rke2-agent.service

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/scratch-enforce.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/scratch-enforce.service
@@ -3,13 +3,14 @@
 # that fallback; the c8s node must not (rke2 wedges when the tmpfs fills).
 [Unit]
 Description=Refuse to start the node unless the rootfs upper is on the scratch disk
+# No After=: the dm mapping exists from the initrd or not at all, so the
+# one sysfs scan needs no other unit up.
 Before=rke2-server.service rke2-agent.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/bin/scratch-enforce.sh
-# One sysfs scan; the dm device exists since the initrd or not at all.
 TimeoutStartSec=30
 # Fail closed: power off rather than leave a node that registers Ready and
 # then wedges — a powered-off node does not flap.

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -23,6 +23,9 @@ enable gpu-node-label.service
 # Fail closed on a non-CC GPU before rke2 registers the node; RequiredBy the
 # rke2 pair so a failed gate never schedules the GPU.
 enable gpu-cc-enforce.service
+# Fail closed when the initrd fell back to the tmpfs rootfs upper; RequiredBy
+# the rke2 pair so a scratch-less node powers off instead of flapping.
+enable scratch-enforce.service
 # Role dispatch + the role-gated rke2 pair.
 enable rke2-role.service
 enable rke2-server.service

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
@@ -10,15 +10,22 @@
 set -eu
 
 fail() {
-    echo "scratch-enforce: $1 — refusing to start the node (the rootfs upper is a 2G RAM tmpfs and rke2 wedges when it fills). Attach a virtio-blk disk with serial=confai-scratch, >=64G." >&2
+    echo "scratch-enforce: $1 — refusing to start the node. Attach a virtio-blk disk with serial=confai-scratch, >=64G." >&2
     exit 1
 }
 
+# The 64G floor in 512-byte sectors, decimal so a 64GB or 64GiB disk both
+# pass; the hazard is a toy disk that re-creates the wedge with more rope.
+MIN_SECTORS=125000000
+
 for name in /sys/block/dm-*/dm/name; do
     [ -e "$name" ] || continue
-    if [ "$(cat "$name")" = "scratch" ]; then
-        echo "scratch-enforce: rootfs upper is on the encrypted scratch disk"
-        exit 0
+    [ "$(cat "$name")" = "scratch" ] || continue
+    sectors=$(cat "$(dirname "$(dirname "$name")")/size" 2>/dev/null || echo 0)
+    if [ "$sectors" -lt "$MIN_SECTORS" ]; then
+        fail "scratch disk too small ($((sectors / 2048)) MiB, need >=64G)"
     fi
+    echo "scratch-enforce: rootfs upper is on the encrypted scratch disk"
+    exit 0
 done
 fail "initrd fell back to the tmpfs overlay (no dm device named scratch)"

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
@@ -1,12 +1,8 @@
 #!/bin/sh
 # scratch-enforce: refuse to bring up a node CVM that booted without its
-# confai-scratch write-storage disk.
-#
-# The confos initrd tolerates a missing disk and falls back to a 2G tmpfs
-# rootfs upper: the node comes up Ready, then wedges once rke2 fills it — a
-# flapping node instead of a failed boot. The c8s node needs the disk, so
-# the unit running this script fails the boot instead (FailureAction powers
-# the VM off; rke2 Requires= it and never starts).
+# confai-scratch write-storage disk — the initrd's silent fallback is a 2G
+# tmpfs rootfs upper the node later wedges on (see ../README.md "Launch
+# requirements"). The unit running this fails the boot instead.
 #
 # The gate is what the initrd actually did, not disk presence: on success
 # the rootfs upper sits on a plain-mode dm mapping named "scratch". Sysfs,

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
@@ -14,14 +14,13 @@ fail() {
     exit 1
 }
 
-# The 64G floor in 512-byte sectors, decimal so a 64GB or 64GiB disk both
-# pass; the hazard is a toy disk that re-creates the wedge with more rope.
+# 64G in 512-byte sectors — decimal, so a 64GB or 64GiB disk both pass.
 MIN_SECTORS=125000000
 
-for name in /sys/block/dm-*/dm/name; do
-    [ -e "$name" ] || continue
-    [ "$(cat "$name")" = "scratch" ] || continue
-    sectors=$(cat "$(dirname "$(dirname "$name")")/size" 2>/dev/null || echo 0)
+for d in /sys/block/dm-*; do
+    [ -e "$d/dm/name" ] || continue
+    [ "$(cat "$d/dm/name")" = "scratch" ] || continue
+    sectors=$(cat "$d/size" 2>/dev/null || echo 0)
     if [ "$sectors" -lt "$MIN_SECTORS" ]; then
         fail "scratch disk too small ($((sectors / 2048)) MiB, need >=64G)"
     fi

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# scratch-enforce: refuse to bring up a node CVM that booted without its
+# confai-scratch write-storage disk.
+#
+# The confos initrd tolerates a missing disk and falls back to a 2G tmpfs
+# rootfs upper: the node comes up Ready, then wedges once rke2 fills it — a
+# flapping node instead of a failed boot. The c8s node needs the disk, so
+# the unit running this script fails the boot instead (FailureAction powers
+# the VM off; rke2 Requires= it and never starts).
+#
+# The gate is what the initrd actually did, not disk presence: on success
+# the rootfs upper sits on a plain-mode dm mapping named "scratch". Sysfs,
+# not /dev/mapper — the dm state needs no udev.
+set -eu
+
+fail() {
+    echo "scratch-enforce: $1 — refusing to start the node (the rootfs upper is a 2G RAM tmpfs and rke2 wedges when it fills). Attach a virtio-blk disk with serial=confai-scratch, >=64G." >&2
+    exit 1
+}
+
+for name in /sys/block/dm-*/dm/name; do
+    [ -e "$name" ] || continue
+    if [ "$(cat "$name")" = "scratch" ]; then
+        echo "scratch-enforce: rootfs upper is on the encrypted scratch disk"
+        exit 0
+    fi
+done
+fail "initrd fell back to the tmpfs overlay (no dm device named scratch)"

--- a/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
+++ b/node-guest-image/c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh
@@ -20,7 +20,10 @@ MIN_SECTORS=125000000
 for d in /sys/block/dm-*; do
     [ -e "$d/dm/name" ] || continue
     [ "$(cat "$d/dm/name")" = "scratch" ] || continue
-    sectors=$(cat "$d/size" 2>/dev/null || echo 0)
+    # An unreadable or empty size must fail closed: a non-number would only
+    # make [ complain, and set -e ignores a failed if condition.
+    sectors=$(cat "$d/size" 2>/dev/null || true)
+    case "$sectors" in ''|*[!0-9]*) sectors=0 ;; esac
     if [ "$sectors" -lt "$MIN_SECTORS" ]; then
         fail "scratch disk too small ($((sectors / 2048)) MiB, need >=64G)"
     fi

--- a/node-guest-image/tests/gpu-cc-enforce-test.sh
+++ b/node-guest-image/tests/gpu-cc-enforce-test.sh
@@ -10,8 +10,6 @@ TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SCRIPT=${GPU_CC_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/gpu-cc-enforce.sh"}
 [[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
 
-not() { ! "$@"; }
-
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 mkdir -p "$WORK/bin"
@@ -33,7 +31,6 @@ stub_smi() {
     { echo '#!/bin/sh'; printf 'echo "%s"\n' "$@"; echo "exit $rc"; } > "$WORK/bin/nvidia-smi"
     chmod +x "$WORK/bin/nvidia-smi"
 }
-stderr_has() { grep -q "$1" "$WORK/stderr"; }
 
 CASE="no nvidia device"
 set_vendor 0x8086

--- a/node-guest-image/tests/gpu-node-label-test.sh
+++ b/node-guest-image/tests/gpu-node-label-test.sh
@@ -12,8 +12,6 @@ SCRIPT=${GPU_LABEL_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/gpu-node
 [[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
 
 # negation wrapper: ok runs "$@" directly, so a bare ! is not a command.
-not() { ! "$@"; }
-
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 FRAGMENT="$WORK/etc/rancher/rke2/config.yaml.d/20-gpu-node-label.yaml"

--- a/node-guest-image/tests/gpu-node-label-test.sh
+++ b/node-guest-image/tests/gpu-node-label-test.sh
@@ -11,7 +11,6 @@ TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SCRIPT=${GPU_LABEL_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/gpu-node-label.sh"}
 [[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
 
-# negation wrapper: ok runs "$@" directly, so a bare ! is not a command.
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 FRAGMENT="$WORK/etc/rancher/rke2/config.yaml.d/20-gpu-node-label.yaml"

--- a/node-guest-image/tests/lib.sh
+++ b/node-guest-image/tests/lib.sh
@@ -26,6 +26,11 @@ ok() {
     fi
 }
 
+not() { ! "$@"; }
+
+# stderr_has PATTERN — the last run's stderr (captured in $WORK) names the cause.
+stderr_has() { grep -q "$1" "$WORK/stderr"; }
+
 # summarize TITLE — print totals; exit 1 if anything failed.
 summarize() {
     note ""

--- a/node-guest-image/tests/scratch-enforce-test.sh
+++ b/node-guest-image/tests/scratch-enforce-test.sh
@@ -51,4 +51,9 @@ printf '16777216' > "$WORK/sys/block/dm-0/size" # 8Gi
 ok "fails" not run_enforce
 ok "names the cause" stderr_has "too small"
 
+CASE="scratch size unreadable"
+set_dm scratch
+: > "$WORK/sys/block/dm-0/size"
+ok "fails closed" not run_enforce
+
 summarize "scratch-enforce"

--- a/node-guest-image/tests/scratch-enforce-test.sh
+++ b/node-guest-image/tests/scratch-enforce-test.sh
@@ -16,13 +16,14 @@ trap 'rm -rf "$WORK"' EXIT
 run_enforce() {
     sed -e "s|/sys/block|$WORK/sys/block|g" "$SCRIPT" | sh 2>"$WORK/stderr"
 }
-set_dm() { # set_dm NAME... — one dm-N per name; none = tmpfs fallback boot
+set_dm() { # set_dm NAME... — one 80Gi dm-N per name; none = tmpfs fallback boot
     rm -rf "$WORK/sys/block"
     mkdir -p "$WORK/sys/block"
     local i=0 name
     for name in "$@"; do
         mkdir -p "$WORK/sys/block/dm-$i/dm"
         printf '%s' "$name" > "$WORK/sys/block/dm-$i/dm/name"
+        printf '167772160' > "$WORK/sys/block/dm-$i/size"
         i=$((i + 1))
     done
 }
@@ -43,5 +44,11 @@ ok "names the cause" stderr_has "tmpfs overlay"
 CASE="other dm devices only"
 set_dm containerd
 ok "fails" not run_enforce
+
+CASE="scratch too small"
+set_dm scratch
+printf '16777216' > "$WORK/sys/block/dm-0/size" # 8Gi
+ok "fails" not run_enforce
+ok "names the cause" stderr_has "too small"
 
 summarize "scratch-enforce"

--- a/node-guest-image/tests/scratch-enforce-test.sh
+++ b/node-guest-image/tests/scratch-enforce-test.sh
@@ -9,8 +9,6 @@ TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 SCRIPT=${SCRATCH_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh"}
 [[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
 
-not() { ! "$@"; }
-
 WORK=$(mktemp -d)
 trap 'rm -rf "$WORK"' EXIT
 
@@ -28,7 +26,6 @@ set_dm() { # set_dm NAME... — one dm-N per name; none = tmpfs fallback boot
         i=$((i + 1))
     done
 }
-stderr_has() { grep -q "$1" "$WORK/stderr"; }
 
 CASE="scratch upper"
 set_dm scratch

--- a/node-guest-image/tests/scratch-enforce-test.sh
+++ b/node-guest-image/tests/scratch-enforce-test.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Unit test for scratch-enforce.sh: passes only when a dm device named
+# "scratch" exists, i.e. the initrd really backed the rootfs upper with the
+# confai-scratch disk. Root-free: fakes the dm sysfs tree under a temp root.
+set -u
+
+TESTS_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "$TESTS_DIR/lib.sh"
+SCRIPT=${SCRATCH_SCRIPT:-"$TESTS_DIR/../c8s/mkosi.extra/usr/local/bin/scratch-enforce.sh"}
+[[ -x "$SCRIPT" ]] || { echo "script not found: $SCRIPT"; exit 2; }
+
+not() { ! "$@"; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+# Run the production script verbatim with the sysfs root rebased into $WORK.
+run_enforce() {
+    sed -e "s|/sys/block|$WORK/sys/block|g" "$SCRIPT" | sh 2>"$WORK/stderr"
+}
+set_dm() { # set_dm NAME... — one dm-N per name; none = tmpfs fallback boot
+    rm -rf "$WORK/sys/block"
+    mkdir -p "$WORK/sys/block"
+    local i=0 name
+    for name in "$@"; do
+        mkdir -p "$WORK/sys/block/dm-$i/dm"
+        printf '%s' "$name" > "$WORK/sys/block/dm-$i/dm/name"
+        i=$((i + 1))
+    done
+}
+stderr_has() { grep -q "$1" "$WORK/stderr"; }
+
+CASE="scratch upper"
+set_dm scratch
+ok "passes" run_enforce
+
+CASE="scratch among other dm devices"
+set_dm containerd scratch
+ok "passes" run_enforce
+
+CASE="tmpfs fallback (no dm devices)"
+set_dm
+ok "fails" not run_enforce
+ok "names the cause" stderr_has "tmpfs overlay"
+
+CASE="other dm devices only"
+set_dm containerd
+ok "fails" not run_enforce
+
+summarize "scratch-enforce"


### PR DESCRIPTION
A node VM provisioned without its `confai-scratch` disk boots on the initrd's 2G tmpfs fallback, registers Ready, and wedges under load.

- `scratch-enforce.service` + `scratch-enforce.sh`, mirroring the gpu-cc-enforce pattern (#507): oneshot before the rke2 pair, `RequiredBy=` both, `FailureAction=poweroff-force`. The gate checks what the initrd actually did — the plain-mode dm mapping named `scratch` — rather than re-scanning disks, and refuses a mapping below the 64G floor (decimal, so 64GB and 64GiB disks both pass; an undersized disk re-creates the wedge with more rope).
- Root-free unit test (`make test-node-guest-image-scratch`), wired into node-guest-image lint; shared `not`/`stderr_has` helpers moved into `tests/lib.sh`.
- Invariants: `tdx-metal-e2e.yml` must keep `serial: confai-scratch` (joined to the existing re-vendor marker loop), and the pinned confos checkout must still open the scratch disk as dm `scratch` — a confos rename would otherwise turn this gate into a poweroff of every healthy node.
- Docs: launch requirements live in `node-guest-image/README.md` (also naming the dm mapping, the enforced floor, and confidential-metal's default-on datadisk), and `mkosi.conf` points there instead of the nonexistent `docs/C8S-IMAGE.md` (c8s-workspace#178).

Provisioning-side defaults are confidential-metal#208; this gate is defense in depth and stays useful after it lands.