### PR TITLE
fix(chart): stop deriving volumed kubeletRoot from the host distro

### DIFF
--- a/internal/cmds/volumed/cmd.go
+++ b/internal/cmds/volumed/cmd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"os/signal"
 	"path/filepath"
 	"syscall"
@@ -107,6 +108,17 @@ func runDaemon(ctx context.Context, cfg config) error {
 }
 
 func runNode(ctx context.Context, cfg config) error {
+	// A running kubelet creates <root>/pods before it starts any pod, so its
+	// absence means the flag does not name this node's kubelet root dir.
+	podsDir := filepath.Join(cfg.kubeletRoot, "pods")
+	fi, err := os.Stat(podsDir)
+	if err == nil && !fi.IsDir() {
+		err = fmt.Errorf("%s is not a directory", podsDir)
+	}
+	if err != nil {
+		return fmt.Errorf("--kubelet-root %q is not the kubelet's root dir on this node: %v", cfg.kubeletRoot, err)
+	}
+
 	opener := &Opener{Ops: SystemOps{}, Targets: KubeletTargets{Root: cfg.kubeletRoot}, MaxMounts: cfg.maxMounts}
 	srv := &Server{
 		Identity: PeerIdentity{},

--- a/internal/cmds/volumed/cmd_test.go
+++ b/internal/cmds/volumed/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -45,11 +46,22 @@ func TestValidateRequiresEveryDependency(t *testing.T) {
 	}
 }
 
+// kubeletRootWithPods returns a kubelet-root stand-in carrying the pods
+// directory a live kubelet guarantees.
+func kubeletRootWithPods(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "pods"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 // The daemon makes no network calls, so a full run is exercised here: it serves
 // on its socket and unwinds when its context goes.
 func TestRunDaemonServesUntilItsContextIsDone(t *testing.T) {
 	cfg := goodConfig(t.TempDir())
-	cfg.kubeletRoot, cfg.cgroupRoot = t.TempDir(), t.TempDir()
+	cfg.kubeletRoot, cfg.cgroupRoot = kubeletRootWithPods(t), t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -88,9 +100,33 @@ func TestRunDaemonRejectsAnIncompleteConfig(t *testing.T) {
 
 func TestRunDaemonReportsAnUnusableSocketDir(t *testing.T) {
 	cfg := goodConfig(filepath.Join(t.TempDir(), "absent"))
-	cfg.kubeletRoot, cfg.cgroupRoot = t.TempDir(), t.TempDir()
+	cfg.kubeletRoot, cfg.cgroupRoot = kubeletRootWithPods(t), t.TempDir()
 	if err := runDaemon(context.Background(), cfg); err == nil {
 		t.Fatal("ran with a socket directory that does not exist")
+	}
+}
+
+// A kubelet root without the pods directory every live kubelet creates is not
+// this node's kubelet root: refusing to serve beats mounting volumes where no
+// pod will look.
+func TestRunDaemonRejectsAKubeletRootWithoutPods(t *testing.T) {
+	withPodsFile := t.TempDir()
+	if err := os.WriteFile(filepath.Join(withPodsFile, "pods"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, root := range map[string]string{
+		"no pods entry":  t.TempDir(),
+		"pods is a file": withPodsFile,
+	} {
+		cfg := goodConfig(t.TempDir())
+		cfg.kubeletRoot, cfg.cgroupRoot = root, t.TempDir()
+		err := runDaemon(context.Background(), cfg)
+		if err == nil {
+			t.Fatalf("%s: served without a pods directory", name)
+		}
+		if !strings.Contains(err.Error(), cfg.kubeletRoot) {
+			t.Errorf("%s: error does not name the bad root: %v", name, err)
+		}
 	}
 }
 

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -27,23 +27,6 @@
 {{- printf "%s-volumed" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{/*
-  c8s.volumedKubeletRoot — the kubelet's root dir on the host. An explicit
-  volumed.hostPaths.kubeletRoot wins; empty derives from the host distro
-  (kata.distro / nriImagePolicy.distro, same source as c8s.tlsLb.resolver).
-  RKE2 runs its kubelet with --root-dir under the agent dir; anything else
-  takes the upstream default.
-*/}}
-{{- define "c8s.volumedKubeletRoot" -}}
-{{- if .Values.volumed.hostPaths.kubeletRoot -}}
-{{- .Values.volumed.hostPaths.kubeletRoot -}}
-{{- else if or (eq .Values.kata.distro "rke2") (eq .Values.nriImagePolicy.distro "rke2") -}}
-/var/lib/rancher/rke2/agent/kubelet
-{{- else -}}
-/var/lib/kubelet
-{{- end -}}
-{{- end -}}
-
 {{/* volumed runs its own debian-slim image carrying cryptsetup/veritysetup,
    which the distroless operator image cannot. Same repository/tag/digest
    contract as the other per-role images. */}}

--- a/internal/helmchart/c8s/templates/volumed-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/volumed-daemonset.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.volumed.enabled }}
+{{- $kubeletRoot := required "volumed.hostPaths.kubeletRoot is required" .Values.volumed.hostPaths.kubeletRoot }}
 {{- /*
   Node agent that opens encrypted volumes for the pods on it (docs/volumes.md).
 
@@ -68,7 +69,7 @@ spec:
             - --socket-dir
             - {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }}
             - --kubelet-root
-            - {{ include "c8s.volumedKubeletRoot" . | quote }}
+            - {{ $kubeletRoot | quote }}
             - --cgroup-root
             - {{ .Values.volumed.hostPaths.cgroupRoot | quote }}
             - --reap-interval
@@ -79,7 +80,7 @@ spec:
             # Bidirectional: the mount is made here and has to reach the
             # workload's pod directory on the node.
             - name: kubelet-root
-              mountPath: {{ include "c8s.volumedKubeletRoot" . }}
+              mountPath: {{ $kubeletRoot }}
               mountPropagation: Bidirectional
             - name: dev
               mountPath: /dev
@@ -101,7 +102,7 @@ spec:
       volumes:
         - name: kubelet-root
           hostPath:
-            path: {{ include "c8s.volumedKubeletRoot" . }}
+            path: {{ $kubeletRoot }}
             type: Directory
         - name: dev
           hostPath:

--- a/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.volumed.enabled }}
+{{- $kubeletRoot := required "volumed.hostPaths.kubeletRoot is required" .Values.volumed.hostPaths.kubeletRoot }}
 {{- /*
   Pre-delete DaemonSet that reaps the device-mapper stack volumed opened on
   each node (files/scripts/volumed-teardown.sh). It runs before the release is
@@ -76,7 +77,7 @@ spec:
             # Bidirectional: the mounts live in the host namespace, so the
             # unmount has to propagate back out of this pod.
             - name: kubelet-root
-              mountPath: {{ include "c8s.volumedKubeletRoot" . }}
+              mountPath: {{ $kubeletRoot }}
               mountPropagation: Bidirectional
             - name: dev
               mountPath: /dev
@@ -97,7 +98,7 @@ spec:
       volumes:
         - name: kubelet-root
           hostPath:
-            path: {{ include "c8s.volumedKubeletRoot" . }}
+            path: {{ $kubeletRoot }}
             type: Directory
         - name: dev
           hostPath:

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -1062,11 +1062,8 @@ volumed:
   ## socket directory (nriImagePolicy.hostPaths.runtimeDir), which is the only
   ## hostPath the deny-host-namespaces VAP admits into a cw pod.
   hostPaths:
-    ## The kubelet's root dir, holding per-pod volume directories. Empty
-    ## derives it from the host distro (kata.distro / nriImagePolicy.distro,
-    ## set by `c8s install` and required from GitOps installs for the
-    ## containerd layout anyway): rke2 keeps it under its agent dir.
-    kubeletRoot: ""
+    ## Kubelet's root dir; override only when the kubelet runs a custom --root-dir.
+    kubeletRoot: /var/lib/kubelet
     cgroupRoot: /sys/fs/cgroup
 
   ## Volumes open on one node at once. Each costs two device-mapper devices and

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7133,22 +7133,17 @@ func TestChartVolumedSocketDirTracksTheVAPCarveOut(t *testing.T) {
 	}
 }
 
-// The kubelet root dir differs by distro: RKE2 runs its kubelet with
-// --root-dir under the agent dir, everything else takes the upstream default.
-// volumed resolves pod volume directories beneath it, so the wrong value
-// mounts volumes where no pod looks for them.
-func TestChartVolumedKubeletRootTracksDistro(t *testing.T) {
+// volumed resolves pod volume directories beneath the kubelet root, so the
+// rendered arg, mount, and hostPath must agree, and an explicit value must win.
+func TestChartVolumedKubeletRoot(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		args []string
 		want string
 	}{
 		{"default", nil, "/var/lib/kubelet"},
-		{"k8s distro", []string{"--set-string", "nriImagePolicy.distro=k8s"}, "/var/lib/kubelet"},
-		{"rke2 via nri distro", []string{"--set-string", "nriImagePolicy.distro=rke2"}, "/var/lib/rancher/rke2/agent/kubelet"},
-		{"rke2 via kata distro", []string{"--set-string", "kata.distro=rke2"}, "/var/lib/rancher/rke2/agent/kubelet"},
+		{"rke2 distro keeps the default", []string{"--set-string", "nriImagePolicy.distro=rke2"}, "/var/lib/kubelet"},
 		{"explicit wins", []string{
-			"--set-string", "nriImagePolicy.distro=rke2",
 			"--set-string", "volumed.hostPaths.kubeletRoot=/custom/kubelet",
 		}, "/custom/kubelet"},
 	} {
@@ -7180,7 +7175,42 @@ func TestChartVolumedKubeletRootTracksDistro(t *testing.T) {
 			if v.HostPath.Path != tc.want {
 				t.Errorf("kubelet-root hostPath = %q, want %q", v.HostPath.Path, tc.want)
 			}
+			// The teardown hook unmounts under the same root; a divergent
+			// path would sweep the wrong tree.
+			hook := renderedDaemonSet(t, out, "c8s-volumed-teardown").Spec.Template.Spec
+			hc, ok := findContainer(hook.InitContainers, "teardown")
+			if !ok {
+				t.Fatal("teardown init container missing")
+			}
+			hm, ok := containerVolumeMount(hc, "kubelet-root")
+			if !ok {
+				t.Fatal("no kubelet-root mount in the teardown hook")
+			}
+			if hm.MountPath != tc.want {
+				t.Errorf("hook kubelet-root mountPath = %q, want %q", hm.MountPath, tc.want)
+			}
+			hv, ok := podVolume(hook, "kubelet-root")
+			if !ok || hv.HostPath == nil {
+				t.Fatal("no kubelet-root hostPath volume in the teardown hook")
+			}
+			if hv.HostPath.Path != tc.want {
+				t.Errorf("hook kubelet-root hostPath = %q, want %q", hv.HostPath.Path, tc.want)
+			}
 		})
+	}
+}
+
+// An empty kubeletRoot would render an empty hostPath the apiserver rejects
+// long after helm reports success; the chart refuses to render it instead.
+func TestChartVolumedKubeletRootMustNotBeEmpty(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set", "volumed.enabled=true",
+		"--set-string", "volumed.hostPaths.kubeletRoot=")
+	if err == nil {
+		t.Fatal("rendered with an empty volumed.hostPaths.kubeletRoot")
+	}
+	if !strings.Contains(out, "volumed.hostPaths.kubeletRoot is required") {
+		t.Errorf("render error does not name the value: %s", out)
 	}
 }
 


### PR DESCRIPTION
## Bug

`c8s install --volumes` on a stock current RKE2 node times out at `helm --wait`: the chart derives `volumed.hostPaths.kubeletRoot=/var/lib/rancher/rke2/agent/kubelet` for the rke2 distro (#512), but current RKE2 passes `--root-dir` to its kubelet only when its own config sets one, leaving the root at the upstream `/var/lib/kubelet` (observed on RKE2 v1.35.6+rke2r1). The derived path does not exist, the `type: Directory` hostPath mount fails, and volumed never leaves ContainerCreating — with no actionable error from the install.

## Fix

Drop the distro derivation: `volumed.hostPaths.kubeletRoot` defaults to `/var/lib/kubelet`, which every running kubelet creates, and an explicit value covers kubelets running a custom `--root-dir`. Wrong values now fail loudly: an empty value fails at render (`required`), and volumed exits at startup naming the root when `<kubelet-root>/pods` is missing, instead of going Ready and mounting volumes where no pod looks.
