### PR TITLE
fix(allowlist): retry transient CDS transport failures in the operator CLI

### DIFF
--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -117,13 +117,14 @@ func (o *options) validate() error {
 	return nil
 }
 
-// client builds the allowlist API client over the attested channel to CDS.
-func (o *options) client(ctx context.Context) (allowlistclient.Client, error) {
-	hc, err := o.HTTPClient(ctx)
+// client builds the allowlist API client over the attested channel to CDS,
+// wrapped with the transient-failure retry (see retry.go).
+func (o *options) client(cmd *cobra.Command) (client, error) {
+	hc, err := o.HTTPClient(ctx(cmd))
 	if err != nil {
-		return allowlistclient.Client{}, err
+		return client{}, err
 	}
-	return allowlistclient.NewClientWithHTTP(o.URL, hc), nil
+	return client{api: allowlistclient.NewClientWithHTTP(o.URL, hc), stderr: cmd.ErrOrStderr()}, nil
 }
 
 // signer builds the operator credential. Required only for write subcommands.

--- a/internal/cmds/allowlist/cmd_test.go
+++ b/internal/cmds/allowlist/cmd_test.go
@@ -404,7 +404,7 @@ func TestClientWarnsOnlyWithoutMeasurements(t *testing.T) {
 	t.Run("unpinned warns", func(t *testing.T) {
 		o := base
 		out := captureStderr(t, func() {
-			if _, err := o.client(context.Background()); err != nil {
+			if _, err := o.client(&cobra.Command{}); err != nil {
 				t.Errorf("client: %v", err)
 			}
 		})
@@ -417,7 +417,7 @@ func TestClientWarnsOnlyWithoutMeasurements(t *testing.T) {
 		o := base
 		o.Measurements = []string{strings.Repeat("ab", 48)}
 		out := captureStderr(t, func() {
-			if _, err := o.client(context.Background()); err != nil {
+			if _, err := o.client(&cobra.Command{}); err != nil {
 				t.Errorf("client: %v", err)
 			}
 		})

--- a/internal/cmds/allowlist/read.go
+++ b/internal/cmds/allowlist/read.go
@@ -1,7 +1,6 @@
 package allowlist
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,7 +19,7 @@ func newListCmd(o *options) *cobra.Command {
 		Short: "List the current allowlist floor and workload entries",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			al, version, err := o.fetch(ctx(cmd))
+			al, version, err := o.fetch(cmd)
 			if err != nil {
 				return err
 			}
@@ -39,7 +38,7 @@ func newExportCmd(o *options) *cobra.Command {
 		Short: "Write the full allowlist as canonical JSON (default stdout) for backup or re-upload",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			al, _, err := o.fetch(ctx(cmd))
+			al, _, err := o.fetch(cmd)
 			if err != nil {
 				return err
 			}
@@ -75,7 +74,7 @@ func newDiffCmd(o *options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			live, _, err := o.fetch(ctx(cmd))
+			live, _, err := o.fetch(cmd)
 			if err != nil {
 				return err
 			}
@@ -101,15 +100,15 @@ var errDifferences = fmt.Errorf("allowlist differs")
 // --- shared helpers ---
 
 // fetch builds the CDS client and returns the live allowlist and its version.
-func (o *options) fetch(ctx context.Context) (*pkgallowlist.Allowlist, string, error) {
+func (o *options) fetch(cmd *cobra.Command) (*pkgallowlist.Allowlist, string, error) {
 	if err := o.validate(); err != nil {
 		return nil, "", err
 	}
-	c, err := o.client(ctx)
+	c, err := o.client(cmd)
 	if err != nil {
 		return nil, "", err
 	}
-	return c.List(ctx)
+	return c.List(ctx(cmd))
 }
 
 // loadAllowlistFile reads and validates a full allowlist JSON file — the format

--- a/internal/cmds/allowlist/retry.go
+++ b/internal/cmds/allowlist/retry.go
@@ -1,0 +1,101 @@
+package allowlist
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// client wraps allowlistclient.Client with a bounded retry of transient
+// transport failures. Each attempt re-runs the wrapped call, so writes
+// re-mint their operator token.
+type client struct {
+	api    allowlistclient.Client
+	stderr io.Writer
+}
+
+// Four attempts with doubling waits covers the <=3 consecutive transient
+// failures seen in e2e. retryDelay is a var only so tests can shorten it.
+const retryAttempts = 4
+
+var retryDelay = time.Second
+
+func (c client) List(ctx context.Context) (al *pkgallowlist.Allowlist, version string, err error) {
+	err = c.retry(ctx, func() error {
+		al, version, err = c.api.List(ctx)
+		return err
+	})
+	return al, version, err
+}
+
+func (c client) AddDigest(ctx context.Context, digest types.Digest, image string, auth allowlistclient.Authorizer) error {
+	return c.retry(ctx, func() error { return c.api.AddDigest(ctx, digest, image, auth) })
+}
+
+func (c client) DeleteDigests(ctx context.Context, digests []types.Digest, auth allowlistclient.Authorizer) error {
+	return c.retry(ctx, func() error { return c.api.DeleteDigests(ctx, digests, auth) })
+}
+
+func (c client) ReplaceAll(ctx context.Context, al *pkgallowlist.Allowlist, auth allowlistclient.Authorizer) error {
+	return c.retry(ctx, func() error { return c.api.ReplaceAll(ctx, al, auth) })
+}
+
+func (c client) PutWorkload(ctx context.Context, name string, w pkgallowlist.Workload, auth allowlistclient.Authorizer) error {
+	return c.retry(ctx, func() error { return c.api.PutWorkload(ctx, name, w, auth) })
+}
+
+func (c client) DeleteWorkload(ctx context.Context, name string, auth allowlistclient.Authorizer) error {
+	return c.retry(ctx, func() error { return c.api.DeleteWorkload(ctx, name, auth) })
+}
+
+// retry runs op, retrying only transient transport failures.
+func (c client) retry(ctx context.Context, op func() error) error {
+	delay := retryDelay
+	for attempt := 1; ; attempt++ {
+		err := op()
+		if err == nil || attempt == retryAttempts || ctx.Err() != nil || !isTransient(err) {
+			return err
+		}
+		fmt.Fprintf(c.stderr, "transient CDS connection failure (attempt %d/%d), retrying in %s: %v\n", attempt, retryAttempts, delay, err)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(delay):
+		}
+		delay *= 2
+	}
+}
+
+// isTransient matches failed collateral fetches and transport-level failures
+// only: never an HTTP status error, never an attestation verdict.
+func isTransient(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pv *localverify.PeerVerificationError
+	if errors.As(err, &pv) {
+		var ce *localverify.CollateralError
+		return errors.As(err, &ce)
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.EPIPE) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	// net/http reports a close it observed while the connection was idle with
+	// an unexported error that wraps nothing; match its fixed text.
+	if strings.HasSuffix(err.Error(), "http: server closed idle connection") {
+		return true
+	}
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}

--- a/internal/cmds/allowlist/retry_test.go
+++ b/internal/cmds/allowlist/retry_test.go
@@ -1,0 +1,275 @@
+package allowlist
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// shortRetryDelay drops the retry backoff for a test so retries run in
+// microseconds.
+func shortRetryDelay(t *testing.T) {
+	t.Helper()
+	saved := retryDelay
+	retryDelay = time.Microsecond
+	t.Cleanup(func() { retryDelay = saved })
+}
+
+// connKillingCDS serves digests like servingCDS, but its listener closes the
+// first n accepted connections before any bytes are exchanged — the client
+// sees the same EOF / reset a mid-handshake teardown through a port-forward
+// produces.
+func connKillingCDS(t *testing.T, n int) (url string, accepts, requests *atomic.Int32) {
+	t.Helper()
+	var served atomic.Int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		served.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	var count atomic.Int32
+	srv.Listener = &killingListener{Listener: srv.Listener, kill: n, accepts: &count}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv.URL, &count, &served
+}
+
+type killingListener struct {
+	net.Listener
+	mu      sync.Mutex
+	kill    int
+	accepts *atomic.Int32
+}
+
+func (l *killingListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	l.accepts.Add(1)
+	l.mu.Lock()
+	killed := l.kill > 0
+	if killed {
+		l.kill--
+	}
+	l.mu.Unlock()
+	if killed {
+		conn.Close()
+		return l.Accept()
+	}
+	return conn, nil
+}
+
+func TestAddRetriesTransientConnectionFailures(t *testing.T) {
+	shortRetryDelay(t)
+	// Kill retryAttempts-1 connections so success lands on the last allowed
+	// attempt.
+	url, accepts, requests := connKillingCDS(t, retryAttempts-1)
+	keyPath := writeOperatorKey(t, t.TempDir())
+
+	out, errb, err := runCmd("add", digA, "registry/app@"+digA, "--url", url, "--insecure", "--operator-key", keyPath)
+	if err != nil {
+		t.Fatalf("add: %v (stderr: %s)", err, errb)
+	}
+	if !strings.Contains(out, "added "+digA) {
+		t.Fatalf("expected added output, got %q", out)
+	}
+	if !strings.Contains(errb, "transient CDS connection failure (attempt 3/4)") {
+		t.Fatalf("expected retry notes on the command stderr, got %q", errb)
+	}
+	if got := accepts.Load(); got != int32(retryAttempts) {
+		t.Fatalf("expected %d connections (%d killed + 1 served), got %d", retryAttempts, retryAttempts-1, got)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("expected the handler to see exactly 1 request, got %d", got)
+	}
+}
+
+// countingAuthorizer counts Authorization mints; each retry attempt must
+// re-mint rather than reuse a token.
+type countingAuthorizer struct{ mints atomic.Int32 }
+
+func (a *countingAuthorizer) Authorization(method, path string, body []byte) (string, error) {
+	a.mints.Add(1)
+	return "Bearer test", nil
+}
+
+func TestRetryReMintsOperatorTokenPerAttempt(t *testing.T) {
+	shortRetryDelay(t)
+	url, _, _ := connKillingCDS(t, 1)
+	auth := &countingAuthorizer{}
+	c := client{api: allowlistclient.NewClient(url), stderr: io.Discard}
+
+	digest, err := types.ParseDigest(digA)
+	if err != nil {
+		t.Fatalf("parse digest: %v", err)
+	}
+	if err := c.AddDigest(context.Background(), digest, "registry/app@"+digA, auth); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if got := auth.mints.Load(); got != 2 {
+		t.Fatalf("expected 2 token mints (1 per attempt), got %d", got)
+	}
+}
+
+func TestAddGivesUpAfterBoundedAttempts(t *testing.T) {
+	shortRetryDelay(t)
+	url, accepts, _ := connKillingCDS(t, 1000)
+	keyPath := writeOperatorKey(t, t.TempDir())
+
+	_, _, err := runCmd("add", digA, "registry/app@"+digA, "--url", url, "--insecure", "--operator-key", keyPath)
+	if err == nil {
+		t.Fatal("expected the add to fail")
+	}
+	if !isTransient(err) {
+		t.Fatalf("expected the surfaced error to be the transient one, got %v", err)
+	}
+	if got := accepts.Load(); got != retryAttempts {
+		t.Fatalf("expected exactly %d connection attempts, got %d", retryAttempts, got)
+	}
+}
+
+func TestAddDoesNotRetryServedErrors(t *testing.T) {
+	shortRetryDelay(t)
+	var mu sync.Mutex
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	keyPath := writeOperatorKey(t, t.TempDir())
+
+	_, _, err := runCmd("add", digA, "registry/app@"+digA, "--url", srv.URL, "--insecure", "--operator-key", keyPath)
+	var se *allowlistclient.StatusError
+	if !errors.As(err, &se) || se.Status != http.StatusInternalServerError {
+		t.Fatalf("expected a 500 StatusError, got %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Fatalf("expected exactly 1 request (no retry), got %d", requests)
+	}
+}
+
+func TestRetryNotesEachAttemptOnStderr(t *testing.T) {
+	shortRetryDelay(t)
+	var notes strings.Builder
+	c := client{stderr: &notes}
+	calls := 0
+	err := c.retry(context.Background(), func() error {
+		calls++
+		if calls == 1 {
+			return fmt.Errorf("request failed: %w", io.EOF)
+		}
+		return nil
+	})
+	if err != nil || calls != 2 {
+		t.Fatalf("expected success on attempt 2, got err=%v calls=%d", err, calls)
+	}
+	if !strings.Contains(notes.String(), "transient CDS connection failure (attempt 1/4)") {
+		t.Fatalf("expected a retry note, got %q", notes.String())
+	}
+}
+
+func TestRetryTransientStopsWhenContextDone(t *testing.T) {
+	shortRetryDelay(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var notes strings.Builder
+	c := client{stderr: &notes}
+	calls := 0
+	err := c.retry(ctx, func() error {
+		calls++
+		return fmt.Errorf("request failed: %w", io.EOF)
+	})
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("expected the EOF to surface, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 attempt under a cancelled context, got %d", calls)
+	}
+}
+
+func TestRetryStopsWhenParentDeadlineExpired(t *testing.T) {
+	shortRetryDelay(t)
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	c := client{stderr: io.Discard}
+	calls := 0
+	err := c.retry(ctx, func() error {
+		calls++
+		return fmt.Errorf("request failed: %w", context.DeadlineExceeded)
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected the deadline error to surface, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 attempt under an expired deadline, got %d", calls)
+	}
+}
+
+type timeoutErr struct{}
+
+func (timeoutErr) Error() string   { return "deadline exceeded" }
+func (timeoutErr) Timeout() bool   { return true }
+func (timeoutErr) Temporary() bool { return false }
+
+func TestIsTransient(t *testing.T) {
+	// Wrapped the way the client surfaces them: url.Error / net.OpError
+	// chains under mutate's "request failed" wrap.
+	transient := []error{
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "https://localhost:28450/allowlist/digests", Err: io.EOF}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "https://localhost:28450", Err: io.ErrUnexpectedEOF}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: &net.OpError{Op: "write", Err: os.NewSyscallError("write", syscall.EPIPE)}}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: &net.OpError{Op: "read", Err: os.NewSyscallError("read", syscall.ECONNRESET)}}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: timeoutErr{}}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: errors.New("http: server closed idle connection")}),
+		// A failed collateral fetch inside handshake verification reached no
+		// verdict; the ctx-done gate in retry, not the classifier, owns an
+		// expired parent deadline.
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: &localverify.PeerVerificationError{
+			Err: &localverify.CollateralError{Err: context.DeadlineExceeded},
+		}}),
+	}
+	for _, err := range transient {
+		if !isTransient(err) {
+			t.Errorf("expected transient: %v", err)
+		}
+	}
+	verdicts := []error{
+		nil,
+		context.Canceled,
+		&allowlistclient.StatusError{Status: 500, Body: "boom"},
+		// An attestation verdict is never retried, even when the verifier's
+		// internals happened to wrap a transport-shaped error.
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: &localverify.PeerVerificationError{
+			Err: fmt.Errorf("localverify: peer attestation failed: %w", localverify.ErrMeasurementNotAllowed),
+		}}),
+		fmt.Errorf("request failed: %w", &url.Error{Op: "Post", URL: "x", Err: &localverify.PeerVerificationError{
+			Err: fmt.Errorf("parse report: %w", io.ErrUnexpectedEOF),
+		}}),
+	}
+	for _, err := range verdicts {
+		if isTransient(err) {
+			t.Errorf("expected non-transient: %v", err)
+		}
+	}
+}

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -43,7 +43,7 @@ func newWorkloadListCmd(o *options) *cobra.Command {
 		Short: "List workload entries",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			al, _, err := o.fetch(ctx(cmd))
+			al, _, err := o.fetch(cmd)
 			if err != nil {
 				return err
 			}
@@ -62,7 +62,7 @@ func newWorkloadGetCmd(o *options) *cobra.Command {
 		Short: "Print one workload entry as canonical JSON",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			al, _, err := o.fetch(ctx(cmd))
+			al, _, err := o.fetch(cmd)
 			if err != nil {
 				return err
 			}
@@ -106,7 +106,7 @@ digests in the file are ignored; use 'upload' or 'add'.`,
 
 			findings := lintOffline(&pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: entries})
 
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ func newWorkloadEditCmd(o *options) *cobra.Command {
 				return err
 			}
 			name := args[0]
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}
@@ -227,7 +227,7 @@ func newWorkloadDeleteCmd(o *options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}

--- a/internal/cmds/allowlist/write.go
+++ b/internal/cmds/allowlist/write.go
@@ -38,7 +38,7 @@ for pinning a workload's process policy (see 'allowlist workload').`,
 			if err != nil {
 				return err
 			}
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}
@@ -82,7 +82,7 @@ func newRemoveCmd(o *options) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}
@@ -181,7 +181,7 @@ before upload; --strict makes lint warnings fatal.`,
 				fmt.Fprintln(cmd.ErrOrStderr(), "proceeding anyway (--force)")
 			}
 
-			c, err := o.client(ctx(cmd))
+			c, err := o.client(cmd)
 			if err != nil {
 				return err
 			}

--- a/internal/localverify/ratlsclient.go
+++ b/internal/localverify/ratlsclient.go
@@ -23,52 +23,67 @@ func NewRATLSHTTPClient(measurements [][]byte, verify VerifyFunc, verifyTimeout 
 		MinVersion:         tls.VersionTLS13,
 		InsecureSkipVerify: true, //nolint:gosec // attestation, not PKI, authenticates the peer — verified below
 		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return fmt.Errorf("localverify: no peer certificate")
-			}
-			cert, err := x509.ParseCertificate(rawCerts[0])
-			if err != nil {
-				return fmt.Errorf("localverify: parse peer cert: %w", err)
-			}
-			// Authenticate the certificate body before touching the evidence:
-			// validity within the shared skew window (the nonce-free evidence
-			// has no other freshness bound) and, for a self-issued leaf, its
-			// own signature under its attested key. Cheap, and it keeps an
-			// expired cert from costing an evidence verification.
-			//
-			// Peers on this path are self-signed RA-TLS leaves (this client
-			// verifies no chain and holds no CA), so the classification must
-			// come back BodySelfSigned. Assert it instead of discarding it: a
-			// CA-vouched leaf here would have had NOTHING authenticate its
-			// body — no signature is checked when issuer != subject — so its
-			// window, subject and stamps would be whatever the producer of
-			// the bytes chose, under a genuine attestation extension.
-			body, err := certutil.AuthenticateLeafBody(cert, time.Now())
-			if err != nil {
-				return fmt.Errorf("localverify: peer certificate: %w", err)
-			}
-			if body != certutil.BodySelfSigned {
-				return fmt.Errorf("localverify: peer certificate is not self-signed (issuer != subject) and this client verifies no issuing chain, so nothing authenticates its body")
-			}
-			platform, evidence, erd, err := CertEnvelope(cert)
-			if err != nil {
-				return fmt.Errorf("localverify: peer attestation: %w", err)
-			}
-			// VerifyPeerCertificate carries no context; bound explicitly.
-			ctx := context.Background()
-			if verifyTimeout > 0 {
-				var cancel context.CancelFunc
-				ctx, cancel = context.WithTimeout(ctx, verifyTimeout)
-				defer cancel()
-			}
-			if _, err := verify(ctx, platform, evidence, Params{
-				ExpectedReportData: erd,
-				Measurements:       measurements,
-			}); err != nil {
-				return fmt.Errorf("localverify: peer attestation failed: %w", err)
+			if err := verifyPeerRATLS(rawCerts, measurements, verify, verifyTimeout); err != nil {
+				return &PeerVerificationError{Err: err}
 			}
 			return nil
 		},
 	}
 	return ratls.HTTPClient(tlsCfg)
+}
+
+// PeerVerificationError marks a handshake failure that came from RA-TLS peer
+// verification rather than the transport. Unwrap [CollateralError] to tell a
+// failed collateral fetch (no verdict) from a rejection.
+type PeerVerificationError struct{ Err error }
+
+func (e *PeerVerificationError) Error() string { return e.Err.Error() }
+func (e *PeerVerificationError) Unwrap() error { return e.Err }
+
+func verifyPeerRATLS(rawCerts [][]byte, measurements [][]byte, verify VerifyFunc, verifyTimeout time.Duration) error {
+	if len(rawCerts) == 0 {
+		return fmt.Errorf("localverify: no peer certificate")
+	}
+	cert, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return fmt.Errorf("localverify: parse peer cert: %w", err)
+	}
+	// Authenticate the certificate body before touching the evidence:
+	// validity within the shared skew window (the nonce-free evidence
+	// has no other freshness bound) and, for a self-issued leaf, its
+	// own signature under its attested key. Cheap, and it keeps an
+	// expired cert from costing an evidence verification.
+	//
+	// Peers on this path are self-signed RA-TLS leaves (this client
+	// verifies no chain and holds no CA), so the classification must
+	// come back BodySelfSigned. Assert it instead of discarding it: a
+	// CA-vouched leaf here would have had NOTHING authenticate its
+	// body — no signature is checked when issuer != subject — so its
+	// window, subject and stamps would be whatever the producer of
+	// the bytes chose, under a genuine attestation extension.
+	body, err := certutil.AuthenticateLeafBody(cert, time.Now())
+	if err != nil {
+		return fmt.Errorf("localverify: peer certificate: %w", err)
+	}
+	if body != certutil.BodySelfSigned {
+		return fmt.Errorf("localverify: peer certificate is not self-signed (issuer != subject) and this client verifies no issuing chain, so nothing authenticates its body")
+	}
+	platform, evidence, erd, err := CertEnvelope(cert)
+	if err != nil {
+		return fmt.Errorf("localverify: peer attestation: %w", err)
+	}
+	// VerifyPeerCertificate carries no context; bound explicitly.
+	ctx := context.Background()
+	if verifyTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, verifyTimeout)
+		defer cancel()
+	}
+	if _, err := verify(ctx, platform, evidence, Params{
+		ExpectedReportData: erd,
+		Measurements:       measurements,
+	}); err != nil {
+		return fmt.Errorf("localverify: peer attestation failed: %w", err)
+	}
+	return nil
 }

--- a/internal/localverify/ratlsclient_test.go
+++ b/internal/localverify/ratlsclient_test.go
@@ -261,8 +261,15 @@ func TestNewRATLSHTTPClientHandshake(t *testing.T) {
 	t.Run("verifier rejection fails the handshake", func(t *testing.T) {
 		rec := &recordingVerify{err: errors.New("rejected")}
 		client := NewRATLSHTTPClient(nil, rec.fn, 5*time.Second)
-		if _, err := client.Get(srv.URL); err == nil {
+		_, err := client.Get(srv.URL)
+		if err == nil {
 			t.Fatal("a rejected attestation must fail the request")
+		}
+		// The marker lets callers tell a verification outcome from a
+		// transport failure without matching error shapes.
+		var pv *PeerVerificationError
+		if !errors.As(err, &pv) {
+			t.Fatalf("verification failure must surface as a PeerVerificationError, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
## Bug

On freshly-booted bare-metal SEV-SNP clusters, `c8s allowlist` calls against a port-forwarded CDS failed roughly every other run with `EOF`, `write: broken pipe`, or `context deadline exceeded`, succeeding on re-run; an az-snp cluster showed no flake over dozens of writes. Two verified facts frame it: on bare SNP every call verifies the CDS serving cert **inside the TLS handshake**, including a live AMD KDS VCEK fetch (the cert embeds no chain and the CLI holds no cross-invocation cache), and CDS bounds the whole handshake at 5s — so any in-handshake stall past that bound (a slow KDS fetch, or a saturated fresh guest slowing the CDS/port-forward path) tears the connection down mid-dial; which stall dominated the observed failures is not established.

## Fix

The operator CLI now retries an allowlist operation up to 4 times (1s/2s/4s waits) when the failure is transport-transient (EOF, broken pipe, reset, timeout, net/http idle-close) or a failed collateral fetch, re-minting the operator token per attempt; in-cluster consumers of `pkg/allowlistclient` are untouched. Attestation verdicts and HTTP status errors are never retried — verification failures carry a `localverify.PeerVerificationError` marker so the classifier excludes them by type instead of by error shape — and each retried error is printed, so live use accumulates evidence of which stall actually bites.
