### PR TITLE
fix(lb): embed the AMD VCEK in bare-SNP attestation evidence

### DIFF
--- a/internal/cmds/cdsattest/cmd.go
+++ b/internal/cmds/cdsattest/cmd.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/confidential-dot-ai/c8s/internal/snpvcek"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -108,6 +109,8 @@ func run(cfg config) error {
 			Client:     attestationclient.NewClient(cfg.attestationAPIURL),
 			Platform:   types.Platform(cfg.platform),
 			Generation: cfg.generation,
+			VCEK:       snpvcek.New(),
+			Log:        logger,
 		}
 	default:
 		return fmt.Errorf("one of --attestation-api-url or --evidence-fixture is required")

--- a/internal/cmds/cdsattest/evidence.go
+++ b/internal/cmds/cdsattest/evidence.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 
+	"github.com/confidential-dot-ai/c8s/internal/snpvcek"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -32,6 +34,11 @@ type LiveEvidenceProvider struct {
 	// platforms auto-detect (az-snp) or have no generation concept (TDX),
 	// and the bundle field is left empty for them.
 	Generation string
+	// VCEK inlines the AMD VCEK into bare-SNP evidence the attestation-api
+	// returns chainless, so offline verifiers (c8s-verify-js) can check the
+	// chain without network. Nil disables embedding.
+	VCEK *snpvcek.Embedder
+	Log  *slog.Logger // defaults to slog.Default()
 }
 
 // Evidence implements EvidenceProvider against the attestation-api.
@@ -51,7 +58,23 @@ func (p LiveEvidenceProvider) Evidence(ctx context.Context, reportData []byte) (
 	if platform != string(types.PlatformSnp) {
 		generation = ""
 	}
-	return resp.Evidence, platform, generation, nil
+	evidence := resp.Evidence
+	if p.VCEK != nil {
+		enriched, err := p.VCEK.Embed(ctx, platform, evidence)
+		if err != nil {
+			p.log().Warn("evidence carries no inline VCEK; offline verifiers (c8s-verify-js) will reject it", "error", err)
+		} else {
+			evidence = enriched
+		}
+	}
+	return evidence, platform, generation, nil
+}
+
+func (p LiveEvidenceProvider) log() *slog.Logger {
+	if p.Log != nil {
+		return p.Log
+	}
+	return slog.Default()
 }
 
 // FixtureEvidenceProvider serves a recorded evidence file. DEV/DEMO ONLY: the

--- a/internal/cmds/cdsattest/evidence_test.go
+++ b/internal/cmds/cdsattest/evidence_test.go
@@ -2,7 +2,9 @@ package cdsattest
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -10,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/snpvcek"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -134,5 +137,101 @@ func TestLiveEvidenceProviderError(t *testing.T) {
 	_, _, _, err := p.Evidence(context.Background(), []byte("rd"))
 	if err == nil || !strings.Contains(err.Error(), "attestation-api") {
 		t.Fatalf("expected attestation-api error, got %v", err)
+	}
+}
+
+// The real bare-metal evidence shared with localverify's tests: its report can
+// be paired with its true VCEK by a KDS-stubbed embedder.
+const snpFixturePath = "../../localverify/testdata/snp-evidence-genoa.json"
+
+func loadSnpFixture(t *testing.T) (chainless json.RawMessage, vcekDER []byte) {
+	t.Helper()
+	raw, err := os.ReadFile(snpFixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Evidence struct {
+			AttestationReport string `json:"attestation_report"`
+			CertChain         struct {
+				Vcek string `json:"vcek"`
+			} `json:"cert_chain"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	vcekDER, err = base64.StdEncoding.DecodeString(envelope.Evidence.CertChain.Vcek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainless, err = json.Marshal(map[string]any{
+		"attestation_report": envelope.Evidence.AttestationReport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return chainless, vcekDER
+}
+
+type cannedGetter struct {
+	body []byte
+	err  error
+}
+
+func (g cannedGetter) Get(string) ([]byte, error) { return g.body, g.err }
+
+func chainlessEvidenceAPI(t *testing.T, evidence json.RawMessage) *httptest.Server {
+	t.Helper()
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(types.AttestResponse{Platform: "snp", Evidence: evidence})
+	}))
+	t.Cleanup(api.Close)
+	return api
+}
+
+func TestLiveEvidenceProviderEmbedsVCEK(t *testing.T) {
+	chainless, vcekDER := loadSnpFixture(t)
+	api := chainlessEvidenceAPI(t, chainless)
+
+	p := LiveEvidenceProvider{
+		Client:     attestationclient.NewClient(api.URL),
+		Platform:   types.PlatformSnp,
+		Generation: "genoa",
+		VCEK:       snpvcek.NewWithGetter(cannedGetter{body: vcekDER}),
+	}
+	ev, _, _, err := p.Evidence(context.Background(), []byte("rd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got struct {
+		CertChain struct {
+			Vcek string `json:"vcek"`
+		} `json:"cert_chain"`
+	}
+	if err := json.Unmarshal(ev, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.CertChain.Vcek != base64.StdEncoding.EncodeToString(vcekDER) {
+		t.Fatalf("cert_chain.vcek = %q, want the embedded VCEK", got.CertChain.Vcek)
+	}
+}
+
+func TestLiveEvidenceProviderServesChainlessWhenKDSUnreachable(t *testing.T) {
+	chainless, _ := loadSnpFixture(t)
+	api := chainlessEvidenceAPI(t, chainless)
+
+	p := LiveEvidenceProvider{
+		Client:     attestationclient.NewClient(api.URL),
+		Platform:   types.PlatformSnp,
+		Generation: "genoa",
+		VCEK:       snpvcek.NewWithGetter(cannedGetter{err: errors.New("kds unreachable")}),
+	}
+	ev, _, _, err := p.Evidence(context.Background(), []byte("rd"))
+	if err != nil {
+		t.Fatalf("a failed embed must not fail the request: %v", err)
+	}
+	if string(ev) != string(chainless) {
+		t.Fatalf("evidence = %s, want the original chainless evidence", ev)
 	}
 }

--- a/internal/cmds/getcert/discovery_vcek_test.go
+++ b/internal/cmds/getcert/discovery_vcek_test.go
@@ -1,0 +1,182 @@
+package getcert
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/snpvcek"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// snpFixturePath is real bare-metal SNP evidence (shared with localverify's
+// tests) whose report a KDS-stubbed embedder can pair with its true VCEK.
+const snpFixturePath = "../../localverify/testdata/snp-evidence-genoa.json"
+
+func loadSnpFixture(t *testing.T) (chainless json.RawMessage, vcekDER []byte) {
+	t.Helper()
+	raw, err := os.ReadFile(snpFixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Evidence struct {
+			AttestationReport string `json:"attestation_report"`
+			CertChain         struct {
+				Vcek string `json:"vcek"`
+			} `json:"cert_chain"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	vcekDER, err = base64.StdEncoding.DecodeString(envelope.Evidence.CertChain.Vcek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainless, err = json.Marshal(map[string]any{
+		"attestation_report": envelope.Evidence.AttestationReport,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return chainless, vcekDER
+}
+
+// stubVCEKEmbedder swaps the package embedder for one whose KDS fetch is
+// canned, and restores it on cleanup.
+func stubVCEKEmbedder(t *testing.T, body []byte, err error) {
+	t.Helper()
+	old := vcekEmbedder
+	vcekEmbedder = snpvcek.NewWithGetter(cannedGetter{body: body, err: err})
+	t.Cleanup(func() { vcekEmbedder = old })
+}
+
+type cannedGetter struct {
+	body []byte
+	err  error
+}
+
+func (g cannedGetter) Get(string) ([]byte, error) { return g.body, g.err }
+
+// startFakeServersWithEvidence is startFakeServers with the attestation-api
+// serving the given snp evidence.
+func startFakeServersWithEvidence(t *testing.T, issuedChain string, evidence json.RawMessage) (cdsURL, attURL string) {
+	t.Helper()
+
+	att := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/attest" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"platform": "snp", "evidence": evidence})
+	}))
+	t.Cleanup(att.Close)
+
+	var mu sync.Mutex
+	cds := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.URL.Path {
+		case "/authenticate":
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"challenge": base64.StdEncoding.EncodeToString([]byte("the-challenge")),
+			})
+		case "/attest":
+			_, _ = w.Write([]byte(issuedChain))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(cds.Close)
+
+	return cds.URL, att.URL
+}
+
+func discoveryEvidence(t *testing.T, path string) (types.DiscoveryDocument, struct {
+	AttestationReport string `json:"attestation_report"`
+	CertChain         *struct {
+		Vcek string `json:"vcek"`
+	} `json:"cert_chain"`
+}) {
+	t.Helper()
+	var doc types.DiscoveryDocument
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("discovery json: %v", err)
+	}
+	var ev struct {
+		AttestationReport string `json:"attestation_report"`
+		CertChain         *struct {
+			Vcek string `json:"vcek"`
+		} `json:"cert_chain"`
+	}
+	if err := json.Unmarshal(doc.Attestation.Evidence, &ev); err != nil {
+		t.Fatalf("discovery evidence: %v", err)
+	}
+	return doc, ev
+}
+
+func TestObtainCertEmbedsVCEKInDiscoveryEvidence(t *testing.T) {
+	chainless, vcekDER := loadSnpFixture(t)
+	stubVCEKEmbedder(t, vcekDER, nil)
+
+	dir := t.TempDir()
+	chain := testIssuedChainPEM(t)
+	cdsURL, attURL := startFakeServersWithEvidence(t, chain, chainless)
+
+	cfg := config{
+		CDSURL:            cdsURL,
+		AttestationApiURL: attURL,
+		SAN:               "host.example.com",
+		OutPath:           filepath.Join(dir, "cert.pem"),
+		DiscoveryOutPath:  filepath.Join(dir, "discovery.json"),
+	}
+	if _, err := obtainCert(context.Background(), cfg, plaintextCDSClient(cfg.CDSURL)); err != nil {
+		t.Fatalf("obtainCert: %v", err)
+	}
+
+	_, ev := discoveryEvidence(t, cfg.DiscoveryOutPath)
+	if ev.CertChain == nil || ev.CertChain.Vcek != base64.StdEncoding.EncodeToString(vcekDER) {
+		t.Fatalf("discovery evidence cert_chain = %+v, want the embedded VCEK", ev.CertChain)
+	}
+}
+
+func TestObtainCertWritesDiscoveryWhenKDSUnreachable(t *testing.T) {
+	chainless, _ := loadSnpFixture(t)
+	stubVCEKEmbedder(t, nil, errors.New("kds unreachable"))
+
+	dir := t.TempDir()
+	chain := testIssuedChainPEM(t)
+	cdsURL, attURL := startFakeServersWithEvidence(t, chain, chainless)
+
+	cfg := config{
+		CDSURL:            cdsURL,
+		AttestationApiURL: attURL,
+		SAN:               "host.example.com",
+		OutPath:           filepath.Join(dir, "cert.pem"),
+		DiscoveryOutPath:  filepath.Join(dir, "discovery.json"),
+	}
+	c := captureDefaultLogger(t)
+	if _, err := obtainCert(context.Background(), cfg, plaintextCDSClient(cfg.CDSURL)); err != nil {
+		t.Fatalf("obtainCert: %v", err)
+	}
+
+	_, ev := discoveryEvidence(t, cfg.DiscoveryOutPath)
+	if ev.CertChain != nil {
+		t.Fatalf("cert_chain = %+v, want none when KDS is unreachable", ev.CertChain)
+	}
+	if _, ok := c.find("discovery evidence carries no inline VCEK; offline verifiers (c8s-verify-js) will reject it until a renewal embeds one"); !ok {
+		t.Fatal("no warning logged for chainless discovery evidence")
+	}
+}

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/fileutil"
+	"github.com/confidential-dot-ai/c8s/internal/snpvcek"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
@@ -210,6 +211,11 @@ func cdsHTTPClient(cfg config) (*http.Client, error) {
 
 // obtainCertFn is a var so renewal-loop tests can observe attempts.
 var obtainCertFn = obtainCert
+
+// vcekEmbedder inlines the AMD VCEK into bare-SNP discovery evidence; one
+// instance so its cache survives renewals. A var so tests can stub the KDS
+// fetch.
+var vcekEmbedder = snpvcek.New()
 
 func run(cfg config) error {
 	slog.Info("starting get-cert", "san", cfg.SAN)
@@ -562,6 +568,14 @@ func obtainCert(ctx context.Context, cfg config, client attestclient.Client) (*x
 		return nil, fmt.Errorf("attestation failed: %w", err)
 	}
 	slog.Info("certificate obtained")
+
+	if cfg.DiscoveryOutPath != "" {
+		if enriched, err := vcekEmbedder.Embed(ctx, result.Platform, result.Evidence); err != nil {
+			slog.Warn("discovery evidence carries no inline VCEK; offline verifiers (c8s-verify-js) will reject it until a renewal embeds one", "error", err)
+		} else {
+			result.Evidence = enriched
+		}
+	}
 
 	if err := writeOutputs(cfg, keyPEM, result); err != nil {
 		return nil, err

--- a/internal/snpvcek/snpvcek.go
+++ b/internal/snpvcek/snpvcek.go
@@ -1,0 +1,163 @@
+// Package snpvcek inlines the AMD VCEK certificate into bare SEV-SNP
+// attestation evidence that lacks cert_chain.vcek, so offline verifiers
+// (c8s-verify-js) can check the chain without network. The VCEK is public
+// per-chip collateral: attestation-go derives its AMD KDS URL from the report
+// and verifies report + chain against the bundled AMD roots before the fetched
+// certificate is embedded or cached, so an embedded certificate can only fail
+// a client's verification, never forge it.
+//
+// Delete this package once attestation-api embeds the chain itself at /attest.
+package snpvcek
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/go-sev-guest/verify/trust"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/snp"
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+)
+
+// One bounded fetch per Embed; after a KDS failure no call retries until the
+// backoff has passed (the sidecar calls Embed per unauthenticated request).
+const (
+	kdsTimeout     = 5 * time.Second
+	failureBackoff = 30 * time.Second
+)
+
+// Embedder fetches the process's VCEK and embeds it into evidence. One entry
+// is cached, keyed by its KDS URL (chip and TCB): a process attests one chip,
+// and the URL changes only on a firmware update. Safe for concurrent use; the
+// zero value is not usable, call New.
+type Embedder struct {
+	fetch trust.HTTPSGetter
+
+	mu          sync.Mutex
+	cachedURL   string
+	cachedDER   []byte
+	lastFailure time.Time
+}
+
+// New returns an Embedder that fetches from AMD KDS.
+func New() *Embedder {
+	return NewWithGetter(&trust.SimpleHTTPSGetter{})
+}
+
+// NewWithGetter is New with a caller-supplied collateral getter (tests).
+func NewWithGetter(getter trust.HTTPSGetter) *Embedder {
+	return &Embedder{fetch: getter}
+}
+
+// Embed returns evidence with cert_chain.vcek inlined. Evidence for a platform
+// other than "snp", or already carrying a VCEK, passes through unchanged. On
+// any failure it returns the original evidence and the error: callers log and
+// ship the evidence chainless, which online verifiers handle by fetching the
+// VCEK themselves.
+func (e *Embedder) Embed(ctx context.Context, platform string, evidence json.RawMessage) (json.RawMessage, error) {
+	if platform != "snp" {
+		return evidence, nil
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(evidence, &fields); err != nil {
+		return evidence, fmt.Errorf("parse snp evidence: %w", err)
+	}
+	if hasVCEK(fields["cert_chain"]) {
+		return evidence, nil
+	}
+	var reportB64 string
+	if err := json.Unmarshal(fields["attestation_report"], &reportB64); err != nil {
+		return evidence, fmt.Errorf("parse attestation_report: %w", err)
+	}
+	reportBytes, err := base64.StdEncoding.DecodeString(reportB64)
+	if err != nil {
+		return evidence, fmt.Errorf("decode attestation_report: %w", err)
+	}
+
+	vcekDER, err := e.vcek(ctx, reportBytes)
+	if err != nil {
+		return evidence, err
+	}
+
+	chain, err := json.Marshal(snp.SnpCertChain{Vcek: base64.StdEncoding.EncodeToString(vcekDER)})
+	if err != nil {
+		return evidence, err
+	}
+	fields["cert_chain"] = chain
+	enriched, err := json.Marshal(fields)
+	if err != nil {
+		return evidence, err
+	}
+	return enriched, nil
+}
+
+// hasVCEK reports whether a raw cert_chain value already carries a VCEK.
+func hasVCEK(certChain json.RawMessage) bool {
+	var chain snp.SnpCertChain
+	return json.Unmarshal(certChain, &chain) == nil && chain.Vcek != ""
+}
+
+// vcek returns the report's VCEK DER, from the cache or AMD KDS. The report is
+// verified by attestation-go — the engine behind `c8s verify`, which derives
+// the KDS URL from the report itself (Zen4c-aware) and fetches through a
+// capturing getter — before a fetched certificate is returned or cached, so
+// one bad KDS response can never poison the cache.
+func (e *Embedder) vcek(ctx context.Context, reportBytes []byte) ([]byte, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	// The fetch outlives the caller's cancellation: an aborted client request
+	// must not record a KDS failure (arming the backoff) or waste the fetch.
+	verifyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), kdsTimeout)
+	defer cancel()
+
+	capture := &capturingGetter{e: e, ctx: verifyCtx}
+	_, err := snp.VerifyReportContext(verifyCtx, reportBytes, nil, teetypes.VerifyParams{},
+		teetypes.PlatformSNP, snp.MinReportVersion, snp.Options{Getter: capture})
+	if err != nil {
+		// Arm the backoff only when KDS was actually tried: a fetch that
+		// failed, or a fetched body the verification rejected.
+		if capture.attempted {
+			e.lastFailure = time.Now()
+		}
+		return nil, fmt.Errorf("evidence did not verify against AMD collateral: %w", err)
+	}
+	if capture.url != "" {
+		e.cachedURL, e.cachedDER = capture.url, capture.body
+	}
+	if len(e.cachedDER) == 0 {
+		return nil, fmt.Errorf("verification succeeded without a VCEK; refusing to embed")
+	}
+	return e.cachedDER, nil
+}
+
+// capturingGetter serves the Embedder's cached VCEK for its URL, fetches
+// anything else through the inner getter (honoring the failure backoff), and
+// records the fetch for the Embedder to cache once verification succeeds.
+type capturingGetter struct {
+	e         *Embedder
+	ctx       context.Context
+	attempted bool
+	url       string
+	body      []byte
+}
+
+func (g *capturingGetter) Get(url string) ([]byte, error) {
+	if url == g.e.cachedURL {
+		return g.e.cachedDER, nil
+	}
+	if since := time.Since(g.e.lastFailure); since < failureBackoff {
+		return nil, fmt.Errorf("AMD KDS fetch failed %s ago; backing off", since.Round(time.Second))
+	}
+	g.attempted = true
+	body, err := trust.GetWith(g.ctx, g.e.fetch, url)
+	if err != nil {
+		return nil, err
+	}
+	g.url, g.body = url, body
+	return body, nil
+}

--- a/internal/snpvcek/snpvcek_test.go
+++ b/internal/snpvcek/snpvcek_test.go
@@ -1,0 +1,293 @@
+package snpvcek
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-sev-guest/abi"
+
+	"github.com/confidential-dot-ai/c8s/internal/localverify"
+)
+
+// The Genoa fixture is real bare-metal evidence (report v5, Zen4c CPUID
+// family 0x19 model 0xA0) shared with the localverify tests.
+const fixturePath = "../localverify/testdata/snp-evidence-genoa.json"
+
+// fixture returns the fixture's evidence without its cert_chain, plus the
+// stripped VCEK DER.
+func fixture(t *testing.T) (chainless json.RawMessage, vcekDER []byte) {
+	t.Helper()
+	raw, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope struct {
+		Evidence struct {
+			AttestationReport string `json:"attestation_report"`
+			CertChain         struct {
+				Vcek string `json:"vcek"`
+			} `json:"cert_chain"`
+		} `json:"evidence"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	vcekDER, err = base64.StdEncoding.DecodeString(envelope.Evidence.CertChain.Vcek)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainless, err = json.Marshal(map[string]any{
+		"attestation_report": envelope.Evidence.AttestationReport,
+		"cert_chain":         nil,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return chainless, vcekDER
+}
+
+// testReport synthesizes a minimal report for the shapes the fixture cannot
+// cover (VLEK signer, v2 without CPUID).
+func testReport(t *testing.T, version byte) []byte {
+	t.Helper()
+	raw := make([]byte, abi.ReportSize)
+	raw[0] = version
+	raw[0x08+2] = 0x02 // policy bit 17 (reserved-must-be-one)
+	raw[0x34] = 1      // signature algo: ECDSA P-384
+	if version >= 3 {
+		raw[0x188], raw[0x189], raw[0x18A] = 0x19, 0xA0, 0x02 // Zen4c CPUID
+	}
+	copy(raw[0x180:0x188], []byte{0x0c, 0, 0, 0, 0, 0, 0x1c, 0x1c}) // reported TCB
+	for i := 0; i < 64; i++ {
+		raw[0x1A0+i] = byte(i + 1) // chip id
+	}
+	if _, err := abi.ReportToProto(raw); err != nil {
+		t.Fatalf("synthesized report does not parse: %v", err)
+	}
+	return raw
+}
+
+func syntheticEvidence(t *testing.T, report []byte) json.RawMessage {
+	t.Helper()
+	ev, err := json.Marshal(map[string]any{
+		"attestation_report": base64.StdEncoding.EncodeToString(report),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ev
+}
+
+func selfSignedDER(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "not-the-vcek"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return der
+}
+
+// fakeGetter serves canned bytes and records requested URLs.
+type fakeGetter struct {
+	urls []string
+	body []byte
+	err  error
+}
+
+func (g *fakeGetter) Get(url string) ([]byte, error) {
+	g.urls = append(g.urls, url)
+	if g.err != nil {
+		return nil, g.err
+	}
+	return g.body, nil
+}
+
+func TestEmbedNonSnpPassthrough(t *testing.T) {
+	g := &fakeGetter{}
+	e := NewWithGetter(g)
+	in := json.RawMessage(`{"anything":"at-all"}`)
+	out, err := e.Embed(context.Background(), "az-snp", in)
+	if err != nil || string(out) != string(in) {
+		t.Fatalf("Embed() = %q, %v; want passthrough", out, err)
+	}
+	if len(g.urls) != 0 {
+		t.Fatalf("getter consulted for non-snp platform: %v", g.urls)
+	}
+}
+
+func TestEmbedExistingChainPassthrough(t *testing.T) {
+	g := &fakeGetter{}
+	e := NewWithGetter(g)
+	in := json.RawMessage(`{"attestation_report":"AAAA","cert_chain":{"vcek":"BBBB"}}`)
+	out, err := e.Embed(context.Background(), "snp", in)
+	if err != nil || string(out) != string(in) {
+		t.Fatalf("Embed() = %q, %v; want passthrough", out, err)
+	}
+	if len(g.urls) != 0 {
+		t.Fatalf("getter consulted despite inline VCEK: %v", g.urls)
+	}
+}
+
+// The embedded output must verify fully offline: a cancelled context makes
+// localverify's KDS-fetch path fail, so success proves the inline-VCEK
+// envelope path (the same property c8s-verify-js relies on).
+func TestEmbedOutputVerifiesOffline(t *testing.T) {
+	chainless, vcekDER := fixture(t)
+	g := &fakeGetter{body: vcekDER}
+	e := NewWithGetter(g)
+
+	out, err := e.Embed(context.Background(), "snp", chainless)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Zen4c collateral is served under the Genoa product line.
+	wantURL := "https://kdsintf.amd.com/vcek/v1/Genoa/" +
+		"b5f9a4c8280e63c97d288db6648577dc2b848884aa682d7a227ba40e50deb2b0" +
+		"d112b599d87aaccda78d06f4254b1e81c4d953ef3c699db39d4e06013e9fa4ce" +
+		"?blSPL=10&teeSPL=0&snpSPL=27&ucodeSPL=27"
+	if len(g.urls) != 1 || g.urls[0] != wantURL {
+		t.Fatalf("KDS URL(s) = %v, want [%s]", g.urls, wantURL)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	res, err := localverify.Verify(ctx, "snp", out, localverify.Params{})
+	if err != nil {
+		t.Fatalf("embedded evidence must verify offline: %v", err)
+	}
+	if !res.SignatureValid {
+		t.Fatal("signature_valid must be true")
+	}
+
+	// Second call is served from the cache.
+	if _, err := e.Embed(context.Background(), "snp", chainless); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.urls) != 1 {
+		t.Fatalf("getter consulted on cache hit: %v", g.urls)
+	}
+}
+
+func TestEmbedFailureReturnsOriginalAndBacksOff(t *testing.T) {
+	chainless, vcekDER := fixture(t)
+	g := &fakeGetter{err: errors.New("kds down")}
+	e := NewWithGetter(g)
+
+	out, err := e.Embed(context.Background(), "snp", chainless)
+	if err == nil || string(out) != string(chainless) {
+		t.Fatalf("Embed() = %q, %v; want original evidence + error", out, err)
+	}
+	if len(g.urls) != 1 {
+		t.Fatalf("getter calls = %v, want 1", g.urls)
+	}
+
+	// Within the backoff window the getter is not consulted again.
+	if _, err := e.Embed(context.Background(), "snp", chainless); err == nil {
+		t.Fatal("want error during backoff")
+	}
+	if len(g.urls) != 1 {
+		t.Fatalf("getter consulted during backoff: %v", g.urls)
+	}
+
+	// After the backoff expires (and KDS recovers) the fetch succeeds.
+	e.lastFailure = time.Now().Add(-2 * failureBackoff)
+	g.err = nil
+	g.body = vcekDER
+	if _, err := e.Embed(context.Background(), "snp", chainless); err != nil {
+		t.Fatal(err)
+	}
+	if len(g.urls) != 2 {
+		t.Fatalf("getter not consulted after backoff: %v", g.urls)
+	}
+}
+
+func TestEmbedRejectsNonCertificate(t *testing.T) {
+	chainless, _ := fixture(t)
+	g := &fakeGetter{body: []byte("<html>rate limited</html>")}
+	e := NewWithGetter(g)
+	out, err := e.Embed(context.Background(), "snp", chainless)
+	if err == nil || string(out) != string(chainless) {
+		t.Fatalf("Embed() = %q, %v; want original evidence + error", out, err)
+	}
+	if e.cachedDER != nil {
+		t.Fatal("garbage response was cached")
+	}
+}
+
+func TestEmbedRejectsCertificateThatDidNotSignReport(t *testing.T) {
+	chainless, _ := fixture(t)
+	g := &fakeGetter{body: selfSignedDER(t)}
+	e := NewWithGetter(g)
+	out, err := e.Embed(context.Background(), "snp", chainless)
+	if err == nil || string(out) != string(chainless) {
+		t.Fatalf("Embed() = %q, %v; want original evidence + error", out, err)
+	}
+	if e.cachedDER != nil {
+		t.Fatal("mismatched certificate was cached")
+	}
+}
+
+// A VLEK-signed report has no KDS-fetchable cert: Embed must fail without a
+// fetch, and without arming the backoff.
+func TestEmbedVlekSignedReport(t *testing.T) {
+	raw := testReport(t, 3)
+	raw[0x48] = 0x04 // signer_info: signing key = VLEK
+	g := &fakeGetter{}
+	e := NewWithGetter(g)
+	out, err := e.Embed(context.Background(), "snp", syntheticEvidence(t, raw))
+	if err == nil {
+		t.Fatalf("want error for a VLEK-signed report, got %q", out)
+	}
+	if len(g.urls) != 0 {
+		t.Fatalf("getter consulted for a VLEK report: %v", g.urls)
+	}
+	if !e.lastFailure.IsZero() {
+		t.Fatal("backoff armed without a KDS attempt")
+	}
+}
+
+// Bare-metal verification requires report v3+; a v2 report must fail without
+// a fetch (its KDS URL is not derivable — no CPUID product info).
+func TestEmbedV2ReportRejected(t *testing.T) {
+	g := &fakeGetter{}
+	e := NewWithGetter(g)
+	_, err := e.Embed(context.Background(), "snp", syntheticEvidence(t, testReport(t, 2)))
+	if err == nil {
+		t.Fatal("want error for a v2 report")
+	}
+	if len(g.urls) != 0 {
+		t.Fatalf("getter consulted for a v2 report: %v", g.urls)
+	}
+}
+
+func TestEmbedMalformedEvidence(t *testing.T) {
+	e := NewWithGetter(&fakeGetter{})
+	for _, in := range []string{`[]`, `{"attestation_report":42}`, `{"attestation_report":"!!!"}`, `{"attestation_report":"AAAA"}`} {
+		out, err := e.Embed(context.Background(), "snp", json.RawMessage(in))
+		if err == nil || string(out) != in {
+			t.Fatalf("Embed(%q) = %q, %v; want original + error", in, out, err)
+		}
+	}
+}


### PR DESCRIPTION
## Bug

On bare-metal SEV-SNP the hypervisor provides no cert table, so attestation-api evidence carries `cert_chain: null` and the tls-lb ships it verbatim in both the `/v1/discovery` document and the live attest-pq/attest-lb bundles. The c8s-verify-js WASM verifier is offline by design and fails closed with `evidence missing cert_chain.vcek`, so every JS-client flow is impossible on bare SNP; `c8s verify` passes only because it fetches the VCEK from AMD KDS itself.

## Fix

get-cert (discovery document) and the cds-attest sidecar (live bundles) now inline the AMD KDS VCEK into chainless bare-SNP evidence, matching what az-snp evidence already carries. The fetch runs through attestation-go's verifier, which derives the KDS URL from the report (Zen4c-aware) and must accept report + chain before anything is embedded or cached — one cached entry, 5s fetch bound, 30s failure backoff. If KDS is unreachable, the evidence ships chainless with an explicit warning, exactly as today.

Follow-up: the common-source fix is attestation-api embedding the chain at `/attest` (its VCEK cache is already warm), which also covers bare RA-TLS serving certs — whose missing VCEK forces the in-handshake KDS fetch behind the #526 allowlist flake — and lets `internal/snpvcek` be deleted.
