### PR TITLE
fix(volumed): close volumes at pod termination before kubelet wipes them

### DIFF
--- a/docs/volumes.md
+++ b/docs/volumes.md
@@ -317,9 +317,14 @@ The key must already be in the store. Unlike a secret — where the first pod to
 ask is the one that defines the value — `get-volume` only ever reads, so a pod
 scheduled before `c8s volume create` has run retries and then fails.
 
-Teardown follows the pod's cgroup, not its kubelet directory: kubelet cannot
-remove that directory while a volume is mounted under it, so it survives exactly
-as long as the mount that would be torn down.
+Teardown is the sidecar's last act. Kubelet terminates sidecars only after the
+workload's containers have exited, so the close it posts lands while nothing
+holds the mount — and before kubelet's own emptyDir cleanup reaches the
+directory, which would otherwise delete every file straight through a live
+read-write mount. The cgroup reaper backstops pods that die without that
+graceful stop — a crashed sidecar, a force delete, a hard eviction — but it
+collects the mappings, not the data: only a graceful termination closes the
+volume before kubelet's cleanup can reach it.
 
 ### Possession of the blob is the authorization
 

--- a/internal/cmds/getvolume/endtoend_test.go
+++ b/internal/cmds/getvolume/endtoend_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -41,7 +42,12 @@ func (o *recordingOps) CryptOpen(_ context.Context, device, mapper string, key [
 	return nil
 }
 
-func (o *recordingOps) CryptClose(context.Context, string) error { return nil }
+func (o *recordingOps) CryptClose(context.Context, string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = append(o.calls, "CryptClose")
+	return nil
+}
 
 func (o *recordingOps) VerityOpen(_ context.Context, _, mapper string, v volume.Verity) error {
 	o.mu.Lock()
@@ -51,7 +57,12 @@ func (o *recordingOps) VerityOpen(_ context.Context, _, mapper string, v volume.
 	return nil
 }
 
-func (o *recordingOps) VerityClose(context.Context, string) error { return nil }
+func (o *recordingOps) VerityClose(context.Context, string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = append(o.calls, "VerityClose")
+	return nil
+}
 
 func (o *recordingOps) MountRO(_ context.Context, _ string, target *os.File, fsType string) error {
 	return o.recordMount("MountRO", target, fsType, true)
@@ -70,7 +81,12 @@ func (o *recordingOps) recordMount(op string, target *os.File, fsType string, re
 	return nil
 }
 
-func (o *recordingOps) Unmount(context.Context, string) error { return nil }
+func (o *recordingOps) Unmount(context.Context, string) error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.calls = append(o.calls, "Unmount")
+	return nil
+}
 
 // This path never sweeps: the daemon under test is already serving.
 func (o *recordingOps) ListMappings(context.Context) ([]string, error) { return nil, nil }
@@ -357,5 +373,39 @@ func TestSidecarOpensAVolumeInGuestEndToEnd(t *testing.T) {
 	}
 	if string(ops.key) != string(stored) {
 		t.Error("the key handed to dm-crypt is not the one CDS released")
+	}
+}
+
+// At termination the sidecar posts a close — with the run context already gone,
+// as SIGTERM leaves it — and the daemon unwinds the pod's whole stack.
+func TestSidecarClosesItsVolumesAtTermination(t *testing.T) {
+	endpoint := startInventory(t)
+	_, url := newFakeCDS(t, map[string][]reply{
+		"GET /secrets/tenant-a/volumes/weights": {{status: http.StatusOK, value: testBlobJSON(t)}},
+	})
+
+	socketDir := t.TempDir()
+	ops := startDaemon(t, socketDir)
+
+	cfg := flowConfig(t, url)
+	cfg.SocketDir = socketDir
+	daemon, daemonBase := daemonClient(cfg)
+	runCtx, cancel := context.WithCancel(context.Background())
+	if err := openAllWith(runCtx, cfg, http.DefaultClient, testKey(t), endpoint, daemon, daemonBase); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	cancel()
+
+	closeCtx, done := context.WithTimeout(context.Background(), closeTimeout)
+	defer done()
+	if err := closeWith(closeCtx, daemon, daemonBase); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	ops.mu.Lock()
+	defer ops.mu.Unlock()
+	got := strings.Join(ops.calls, ",")
+	if !strings.HasSuffix(got, "Unmount,VerityClose,CryptClose") {
+		t.Fatalf("calls = %q, want the close to unwind mount, verity, then crypt", got)
 	}
 }

--- a/internal/cmds/getvolume/run.go
+++ b/internal/cmds/getvolume/run.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/sidecar"
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
@@ -82,6 +83,14 @@ func run(cfg config) error {
 		return err
 	}
 
+	// A done ctx is the pod terminating — mid-pass or after idling — and any
+	// volume opened by then must be released before kubelet's cleanup runs.
+	defer func() {
+		if ctx.Err() != nil {
+			closeVolumes(cfg)
+		}
+	}()
+
 	if err := sidecar.Retry(ctx, cfg.Config, "volume", func(ctx context.Context) error {
 		return openAll(ctx, cfg, pins)
 	}); err != nil {
@@ -94,6 +103,42 @@ func run(cfg config) error {
 	// is torn down leaves its status reflecting the workload rather than this
 	// sidecar.
 	<-ctx.Done()
+	return nil
+}
+
+// closeTimeout bounds the termination-time release, inside the pod's remaining
+// grace.
+const closeTimeout = 10 * time.Second
+
+// closeVolumes releases this pod's volumes at termination, before kubelet's
+// volume cleanup runs (see volumed.ClosePath). Failure is logged, not fatal:
+// the node's reaper collects whatever this misses.
+func closeVolumes(cfg config) {
+	ctx, cancel := context.WithTimeout(context.Background(), closeTimeout)
+	defer cancel()
+	daemon, base := daemonClient(cfg)
+	if err := closeWith(ctx, daemon, base); err != nil {
+		slog.Warn("volumes not released; the node reaper will collect them", "error", err)
+		return
+	}
+	slog.Info("volumes released")
+}
+
+// closeWith is closeVolumes once the client exists.
+func closeWith(ctx context.Context, daemon *http.Client, base string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+volumed.ClosePath, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := daemon.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("close volumes: %s: %s", resp.Status, strings.TrimSpace(string(detail)))
+	}
 	return nil
 }
 

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -165,6 +165,13 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 		return err
 	}
 
+	// A cancelled caller is one that has already posted its close (the sidecar
+	// cancels the open before it does), so a mapping landing now would outlive
+	// its pod with only the reaper behind it.
+	if err := ctx.Err(); err != nil {
+		o.teardown(ctx, m)
+		return err
+	}
 	// A concurrent identical request may have won the race; keep one mapping
 	// and tear the loser down outside the lock.
 	o.mu.Lock()
@@ -250,39 +257,59 @@ func (o *Opener) Close(ctx context.Context, podUID, name string) {
 	}
 	o.mu.Unlock()
 	if ok {
-		o.teardown(ctx, m)
+		o.closeMount(ctx, mountKey(podUID, name), m)
 	}
 }
 
-// ClosePod tears down every volume a pod holds, for when the pod goes away, and
-// reports how many it closed.
+// ClosePod tears down every volume a pod holds — the sidecar's termination
+// close, and the reaper's collection of a dead pod — and reports how many it
+// closed.
 func (o *Opener) ClosePod(ctx context.Context, podUID string) int {
 	if podUID == "" {
 		return 0
 	}
 	o.mu.Lock()
-	var doomed []*mount
+	doomed := map[string]*mount{}
 	for k, m := range o.mounts {
 		if m.pod.UID == podUID {
-			doomed = append(doomed, m)
+			doomed[k] = m
 			delete(o.mounts, k)
 		}
 	}
 	o.mu.Unlock()
-	for _, m := range doomed {
-		o.teardown(ctx, m)
+	closed := 0
+	for k, m := range doomed {
+		if o.closeMount(ctx, k, m) {
+			closed++
+		}
 	}
-	return len(doomed)
+	return closed
+}
+
+// closeMount tears m down and reports success. A mapping that refuses to close
+// keeps its record: it still holds the key and the device, so it must stay
+// visible to deviceConflict and to the reaper, which retries it each sweep.
+func (o *Opener) closeMount(ctx context.Context, key string, m *mount) bool {
+	if o.teardown(ctx, m) {
+		return true
+	}
+	o.mu.Lock()
+	if _, taken := o.mounts[key]; !taken {
+		o.mounts[key] = m
+	}
+	o.mu.Unlock()
+	return false
 }
 
 // teardown unwinds in reverse and does not stop at the first failure: the
 // device-mapper targets hold the key, so a failed unmount must not leave them
-// behind.
-func (o *Opener) teardown(ctx context.Context, m *mount) {
+// behind. It reports whether the crypt mapping — the layer holding the key and
+// the device — actually closed.
+func (o *Opener) teardown(ctx context.Context, m *mount) bool {
 	cleanup, cancel := cleanupContext(ctx)
 	defer cancel()
 	modeFor(m.mutable).close(cleanup, o.Ops, m.pod.UID, m.name, m.target)
-	_ = o.Ops.CryptClose(cleanup, m.cryptDev)
+	return o.Ops.CryptClose(cleanup, m.cryptDev) == nil
 }
 
 // SweepStale closes the c8s mappings left on this node by an earlier volumed,

--- a/internal/cmds/volumed/open_test.go
+++ b/internal/cmds/volumed/open_test.go
@@ -822,3 +822,49 @@ func TestSweepStaleTouchesOnlyC8sMappings(t *testing.T) {
 		t.Error("closed a device-mapper target this platform did not open")
 	}
 }
+
+// A caller cancelled before its mapping lands has already posted its close, so
+// the mapping must not land — it would outlive the pod with only the reaper
+// behind it.
+func TestOpenDoesNotLandForACancelledCaller(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	ctx, cancel := context.WithCancel(context.Background())
+	ops.afterCryptOpen = cancel
+
+	if err := o.Open(ctx, testRequest(t)); err == nil {
+		t.Fatal("a cancelled open landed")
+	}
+	if o.Len() != 0 {
+		t.Fatalf("opener holds %d mounts, want 0", o.Len())
+	}
+	if c, v, m := ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("cancelled open leaked crypt=%d verity=%d mounts=%d", c, v, m)
+	}
+}
+
+// A mapping that refuses to close keeps its record, so the device stays marked
+// in use and the next close retries the teardown.
+func TestCloseKeepsTheRecordOfAStuckMapping(t *testing.T) {
+	ops := newOps()
+	o := testOpener(t, ops)
+	if err := o.Open(context.Background(), testRequest(t)); err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	ops.failOn = "CryptClose"
+	if n := o.ClosePod(context.Background(), testPodUID); n != 0 {
+		t.Fatalf("a stuck close reported %d closed, want 0", n)
+	}
+	if o.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want the stuck 1", o.Len())
+	}
+
+	ops.failOn = ""
+	if n := o.ClosePod(context.Background(), testPodUID); n != 1 {
+		t.Fatalf("retry closed %d, want 1", n)
+	}
+	if o.Len() != 0 {
+		t.Fatalf("opener holds %d mounts, want 0", o.Len())
+	}
+}

--- a/internal/cmds/volumed/reaper.go
+++ b/internal/cmds/volumed/reaper.go
@@ -28,7 +28,9 @@ type PodLiveness interface {
 	Live(pod PodCgroup) (bool, error)
 }
 
-// Reaper tears down volumes whose pod has gone away.
+// Reaper tears down volumes whose pod has gone away. It is the fallback behind
+// the sidecar's close at termination (ClosePath): a pod that dies without one —
+// a crashed sidecar, a force delete — still gets its volumes collected.
 //
 // The signal is the pod's cgroup emptying of processes, which the runtime does
 // as it removes the last container. Neither the pod's kubelet directory nor its

--- a/internal/cmds/volumed/server.go
+++ b/internal/cmds/volumed/server.go
@@ -19,6 +19,11 @@ import (
 // VolumePath is the route the fetcher sidecar posts to.
 const VolumePath = "/volume"
 
+// ClosePath is the route the sidecar posts to at termination, releasing its
+// pod's volumes before kubelet's emptyDir cleanup can delete through the live
+// mount. See docs/volumes.md — teardown.
+const ClosePath = "/volume/close"
+
 // GuestPort is the in-guest loopback port this daemon serves on under kata,
 // after the attestation-service on 8400 and the token route on 8401. A kata
 // guest holds one pod whose containers share its network namespace, so loopback
@@ -96,6 +101,7 @@ func (s *Server) logger() *slog.Logger {
 func (s *Server) Serve(ctx context.Context, l net.Listener) error {
 	mux := http.NewServeMux()
 	mux.Handle("POST "+VolumePath, http.HandlerFunc(s.handleOpen))
+	mux.Handle("POST "+ClosePath, http.HandlerFunc(s.handleClose))
 
 	srv := &http.Server{
 		Handler:           mux,
@@ -177,6 +183,33 @@ func (s *Server) handleOpen(w http.ResponseWriter, r *http.Request) {
 		s.logger().Error("volume open failed", "pod", pod.UID, "name", req.Name, "error", err)
 		http.Error(w, fmt.Sprintf("could not open the volume: %v", err), http.StatusInternalServerError)
 	}
+}
+
+// handleClose releases every volume the calling pod holds. The caller is
+// resolved from kernel peer credentials, so a pod can only ever close its own
+// volumes; closing what is not open is a no-op, because teardown races pod
+// deletion by design.
+func (s *Server) handleClose(w http.ResponseWriter, r *http.Request) {
+	conn, _ := r.Context().Value(connKey{}).(net.Conn)
+	peer := workloadclaims.PeerFromConn(conn)
+	defer peer.Close()
+
+	pod, err := s.Identity.Resolve(peer)
+	if err != nil {
+		s.logger().Warn("volume close rejected", "reason", err)
+		http.Error(w, "caller could not be resolved", http.StatusForbidden)
+		return
+	}
+	release, ok := s.acquire(pod.UID)
+	if !ok {
+		http.Error(w, "too many concurrent requests", http.StatusTooManyRequests)
+		return
+	}
+	defer release()
+	if n := s.Opener.ClosePod(r.Context(), pod.UID); n > 0 {
+		s.logger().Info("volumes closed", "pod", pod.UID, "volumes", n)
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // acquire bounds concurrent opens per pod.

--- a/internal/cmds/volumed/server_test.go
+++ b/internal/cmds/volumed/server_test.go
@@ -333,3 +333,97 @@ func TestAcquireIsRaceFree(t *testing.T) {
 		t.Fatalf("in-flight table leaked %d entries", len(s.inFlight))
 	}
 }
+
+// postClose posts the bodiless termination close.
+func (f *serverFixture) postClose(t *testing.T) *http.Response {
+	t.Helper()
+	resp, err := f.client.Post("http://volumed"+ClosePath, "application/json", nil)
+	if err != nil {
+		t.Fatalf("post close: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func TestServerClosesTheCallingPodsVolumes(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity())
+	if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("open: status %d", got)
+	}
+	if got := f.postClose(t).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("close: status %d, want %d", got, http.StatusNoContent)
+	}
+	if f.opener.Len() != 0 {
+		t.Fatalf("opener holds %d mounts, want 0", f.opener.Len())
+	}
+	if c, v, m := f.ops.leaked(); c != 0 || v != 0 || m != 0 {
+		t.Fatalf("close left crypt=%d verity=%d mounts=%d behind", c, v, m)
+	}
+}
+
+// Closing with nothing open is success: teardown races pod deletion by design.
+func TestServerCloseWithNothingOpenIsANoOp(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity())
+	if got := f.postClose(t).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", got, http.StatusNoContent)
+	}
+}
+
+func TestServerRefusesUnresolvableCloseCaller(t *testing.T) {
+	f := newServerFixture(t, fakeIdentity{err: errors.New("no pod cgroup")})
+	if got := f.postClose(t).StatusCode; got != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", got, http.StatusForbidden)
+	}
+}
+
+// switchIdentity is an Identity whose answer the test changes between requests.
+type switchIdentity struct {
+	mu  sync.Mutex
+	pod PodCgroup
+}
+
+func (s *switchIdentity) Resolve(workloadclaims.Peer) (PodCgroup, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pod, nil
+}
+
+func (s *switchIdentity) set(pod PodCgroup) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pod = pod
+}
+
+// A close releases the caller's own volumes and nobody else's: the pod comes
+// from peer credentials, and the request has no say.
+func TestServerCloseIsScopedToTheCallingPod(t *testing.T) {
+	ident := &switchIdentity{pod: testPod(testPodUID)}
+	f := newServerFixture(t, ident)
+	if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("open: status %d", got)
+	}
+	ident.set(testPod("00000000-0000-4000-8000-000000000000"))
+	if got := f.postClose(t).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("close: status %d", got)
+	}
+	if f.opener.Len() != 1 {
+		t.Fatalf("another pod's close took the mount: %d mounts, want 1", f.opener.Len())
+	}
+}
+
+// A restarted sidecar whose close already ran re-opens and mounts afresh.
+func TestServerReopensAfterClose(t *testing.T) {
+	f := newServerFixture(t, resolvedIdentity())
+	if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("open: status %d", got)
+	}
+	if got := f.postClose(t).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("close: status %d", got)
+	}
+	if got := f.post(t, openBody(t)).StatusCode; got != http.StatusNoContent {
+		t.Fatalf("re-open: status %d", got)
+	}
+	if f.opener.Len() != 1 {
+		t.Fatalf("opener holds %d mounts, want 1", f.opener.Len())
+	}
+}


### PR DESCRIPTION
## Bug

On node-CVM, a mutable encrypted volume comes back empty after every pod replacement: writes reach the backing image, the unmount is clean, and the re-opened filesystem carries the same ext4 UUID — nothing re-formats it, yet it holds nothing. Kubelet's emptyDir teardown runs `os.RemoveAll` on the pod's volume directory while volumed's read-write mount is still there, deleting every file through dm-crypt into the image before the cgroup reaper's unmount lands 15-30s later; immutable volumes survive only because their read-only mount makes the wipe fail with EROFS.

## Fix

The get-volume sidecar now posts `/volume/close` to volumed when it is terminated: native sidecars are signalled only after all main containers exit, and kubelet tears volumes down only after every container terminates, so the unmount deterministically precedes kubelet's `RemoveAll`. The route resolves the caller from kernel peer credentials so a pod can only release its own volumes, a mapping that refuses to close keeps its record so the reaper retries it, and the cgroup reaper remains the fallback for non-graceful deaths (sidecar crash, force delete, hard eviction), which keep today's behavior.
