### PR TITLE
fix(credrelease): authorize operators through RBAC

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -519,6 +519,22 @@ and again on the RA-TLS credential-release connection:
   none) and, being self-signed, verify its own signature with its attested
   key.
 
+The released kubeconfig's client certificate is
+`CN=operator, O=c8s:node-operators`, with a one-hour default (and baked
+node-image) TTL. The node image's baked `cred-release-rbac` RKE2 AddOn binds
+that group to the
+built-in `cluster-admin` ClusterRole through ordinary RBAC. This grants
+Kubernetes platform-admin access only; it does not grant guest OS or root
+access. `system:masters` is deliberately avoided because it bypasses normal
+authorization/Webhook policy and cannot be revoked through RBAC.
+
+Deleting or changing the live ClusterRoleBinding removes authorization
+immediately, but RKE2 reapplies the baked AddOn when the server restarts. For
+durable revocation, disable or skip the `cred-release-rbac` AddOn before
+removing the binding, or relaunch without `opkeydata` (or with rotated
+`opkeydata`) to stop renewal. An already-issued certificate can remain usable
+for up to its one-hour TTL while the binding exists.
+
 What the gate proves: a genuine guest of the manifest's platform booted
 exactly the pinned image, was launched to trust exactly this operator key,
 and (on TDX) ran exactly the expected measured workloads. What it does not prove: anything about images or keys the

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -522,18 +522,32 @@ and again on the RA-TLS credential-release connection:
 The released kubeconfig's client certificate is
 `CN=operator, O=c8s:node-operators`, with a one-hour default (and baked
 node-image) TTL. The node image's baked `cred-release-rbac` RKE2 AddOn binds
-that group to the
-built-in `cluster-admin` ClusterRole through ordinary RBAC. This grants
-Kubernetes platform-admin access only; it does not grant guest OS or root
-access. `system:masters` is deliberately avoided because it bypasses normal
-authorization/Webhook policy and cannot be revoked through RBAC.
+that group to the built-in `cluster-admin` ClusterRole through ordinary RBAC,
+and `cred-release.service` does not start serving until that binding exists,
+so a released credential is authorized the moment it is issued.
+`system:masters` is deliberately avoided because it bypasses authorization
+and admission webhooks and cannot be revoked through RBAC. The default group
+is only meaningful where such a binding exists: on a cluster that is not the
+c8s node image, create an equivalent `ClusterRoleBinding` or pass `--cert-org`
+for a group that cluster already authorizes.
 
-Deleting or changing the live ClusterRoleBinding removes authorization
-immediately, but RKE2 reapplies the baked AddOn when the server restarts. For
-durable revocation, disable or skip the `cred-release-rbac` AddOn before
-removing the binding, or relaunch without `opkeydata` (or with rotated
-`opkeydata`) to stop renewal. An already-issued certificate can remain usable
-for up to its one-hour TTL while the binding exists.
+Do not read the binding as a privilege boundary. On this single-node cluster
+`cluster-admin` is root-equivalent on the guest: `kube-system` is exempt from
+PodSecurity admission, so a privileged pod with a hostPath mount of `/` is one
+`kubectl` away. RBAC is used for revocability and policy, not containment; the
+credential's blast radius is bounded by who can obtain it (the attestation gate
+above), by the one-hour TTL, and by the verity root and per-boot ephemeral
+writable state of the guest.
+
+Revocation is a launch-time decision. Deleting or editing the live
+ClusterRoleBinding cuts access immediately, but only until the next boot: the
+manifest is baked into the read-only root and everything RKE2 writes, the
+cluster state included, lives on the scratch disk, which is re-encrypted with
+a fresh random key every boot. `.skip` markers and `config.yaml.d` drop-ins
+are lost with it, so there is no in-guest switch that survives a restart, by
+design. To revoke durably, relaunch without `opkeydata`, or with a rotated
+operator key, so the old key can no longer obtain a certificate. A certificate
+already issued stays usable for the remainder of its one-hour TTL.
 
 What the gate proves: a genuine guest of the manifest's platform booted
 exactly the pinned image, was launched to trust exactly this operator key,

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -6,6 +6,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	defaultCertTTL = time.Hour
+	defaultCertOrg = "c8s:node-operators"
+	defaultCertCN  = "operator"
+)
+
 // NewCmd builds the `cred-release` subcommand: the in-guest service that
 // issues an operator a short-lived kube client cert, gated on possession of
 // the operator key bound into the launch identity (TDX RTMR[3] / SNP
@@ -20,8 +26,9 @@ func NewCmd() *cobra.Command {
 			"kube client certificate to a caller who proves possession of the\n" +
 			"operator key whose public half was bound into the launch identity\n" +
 			"(TDX: RTMR[3]; SNP: HOSTDATA) at launch.\n" +
-			"It gives an external operator console-free, non-TOFU cluster-admin\n" +
-			"access with no pre-shared secret and no trust in the host. The cert\n" +
+			"It gives an external operator console-free, non-TOFU, RBAC-backed\n" +
+			"cluster-admin access with no pre-shared secret and no trust in the\n" +
+			"host. The cert\n" +
 			"is signed by the cluster's client CA and the kubeconfig anchors to\n" +
 			"the serving CA (RKE2 paths by default; any distribution works via\n" +
 			"--client-ca-cert/--client-ca-key/--server-ca-cert — on kubeadm all\n" +
@@ -37,9 +44,9 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")
-	f.DurationVar(&cfg.CertTTL, "cert-ttl", 24*time.Hour, "lifetime of issued operator certs")
-	f.StringVar(&cfg.CertOrg, "cert-org", "system:masters", "Kubernetes group (cert Subject O) for the issued cert")
-	f.StringVar(&cfg.CertCN, "cert-cn", "operator", "Kubernetes user (cert Subject CN) for the issued cert")
+	f.DurationVar(&cfg.CertTTL, "cert-ttl", defaultCertTTL, "lifetime of issued operator certs")
+	f.StringVar(&cfg.CertOrg, "cert-org", defaultCertOrg, "Kubernetes group (cert Subject O) for the issued cert")
+	f.StringVar(&cfg.CertCN, "cert-cn", defaultCertCN, "Kubernetes user (cert Subject CN) for the issued cert")
 	// No default: the baked unit always passes the flag explicitly.
 	_ = cmd.MarkFlagRequired("platform")
 	return cmd

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -28,11 +28,14 @@ func NewCmd() *cobra.Command {
 			"(TDX: RTMR[3]; SNP: HOSTDATA) at launch.\n" +
 			"It gives an external operator console-free, non-TOFU, RBAC-backed\n" +
 			"cluster-admin access with no pre-shared secret and no trust in the\n" +
-			"host. The cert\n" +
-			"is signed by the cluster's client CA and the kubeconfig anchors to\n" +
-			"the serving CA (RKE2 paths by default; any distribution works via\n" +
-			"--client-ca-cert/--client-ca-key/--server-ca-cert — on kubeadm all\n" +
-			"three are /etc/kubernetes/pki/ca.crt).",
+			"host. The cert is signed by the cluster's client CA and the\n" +
+			"kubeconfig anchors to the serving CA (RKE2 paths by default; any\n" +
+			"distribution works via --client-ca-cert/--client-ca-key/\n" +
+			"--server-ca-cert — on kubeadm all three are\n" +
+			"/etc/kubernetes/pki/ca.crt). Authorization is the cluster's RBAC on\n" +
+			"the issued group: the c8s node image bakes a ClusterRoleBinding for\n" +
+			"the default --cert-org; elsewhere create one or pass a group the\n" +
+			"cluster already binds, or every request is denied.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), cfg)
 		},
@@ -45,7 +48,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.DurationVar(&cfg.CertTTL, "cert-ttl", defaultCertTTL, "lifetime of issued operator certs")
-	f.StringVar(&cfg.CertOrg, "cert-org", defaultCertOrg, "Kubernetes group (cert Subject O) for the issued cert")
+	f.StringVar(&cfg.CertOrg, "cert-org", defaultCertOrg, "Kubernetes group (cert Subject O) for the issued cert; the cluster's RBAC must bind it (the c8s node image binds the default to cluster-admin)")
 	f.StringVar(&cfg.CertCN, "cert-cn", defaultCertCN, "Kubernetes user (cert Subject CN) for the issued cert")
 	// No default: the baked unit always passes the flag explicitly.
 	_ = cmd.MarkFlagRequired("platform")

--- a/internal/cmds/credrelease/cmd_test.go
+++ b/internal/cmds/credrelease/cmd_test.go
@@ -1,7 +1,6 @@
 package credrelease
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -43,8 +42,5 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 	pf := flags.Lookup("platform")
 	if pf == nil || pf.Annotations[cobra.BashCompOneRequiredFlag] == nil {
 		t.Errorf("--platform is not marked required")
-	}
-	if !strings.Contains(cmd.Long, "RBAC-backed\ncluster-admin") {
-		t.Errorf("long help does not describe the credential as RBAC-backed cluster-admin access: %q", cmd.Long)
 	}
 }

--- a/internal/cmds/credrelease/cmd_test.go
+++ b/internal/cmds/credrelease/cmd_test.go
@@ -1,6 +1,7 @@
 package credrelease
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -22,8 +23,8 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 		{"client-ca-cert", defaultClientCACert},
 		{"client-ca-key", defaultClientCAKey},
 		{"server-ca-cert", defaultServerCACert},
-		{"cert-ttl", "24h0m0s"},
-		{"cert-org", "system:masters"},
+		{"cert-ttl", "1h0m0s"},
+		{"cert-org", "c8s:node-operators"},
 		{"cert-cn", "operator"},
 	}
 	flags := cmd.Flags()
@@ -42,5 +43,8 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 	pf := flags.Lookup("platform")
 	if pf == nil || pf.Annotations[cobra.BashCompOneRequiredFlag] == nil {
 		t.Errorf("--platform is not marked required")
+	}
+	if !strings.Contains(cmd.Long, "RBAC-backed\ncluster-admin") {
+		t.Errorf("long help does not describe the credential as RBAC-backed cluster-admin access: %q", cmd.Long)
 	}
 }

--- a/internal/cmds/credrelease/handler_test.go
+++ b/internal/cmds/credrelease/handler_test.go
@@ -57,7 +57,7 @@ func TestHandlerReleasesServerCA(t *testing.T) {
 	}
 	ca.pem = certutil.EncodeCertPEM(serverCA.Cert.Raw)
 
-	h, err := NewHandler(pubPEM, ca, "system:masters", "operator", time.Hour)
+	h, err := NewHandler(pubPEM, ca, defaultCertOrg, defaultCertCN, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestHandlerReleasesServerCA(t *testing.T) {
 // endpoint that issues cluster-admin credentials.
 func TestReleaseRefusesATokenBoundToAnotherCSR(t *testing.T) {
 	signer, pubPEM := newOperatorAuth(t)
-	h, err := NewHandler(pubPEM, testCA(t), "system:masters", "operator", time.Hour)
+	h, err := NewHandler(pubPEM, testCA(t), defaultCertOrg, defaultCertCN, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func csrPEMFromKey(t *testing.T, key crypto.Signer) []byte {
 
 // TestNewHandlerRejectsBadPubkey: the measured key must be an ECDSA PKIX PEM.
 func TestNewHandlerRejectsBadPubkey(t *testing.T) {
-	if _, err := NewHandler([]byte("not a key"), testCA(t), "system:masters", "operator", time.Hour); err == nil {
+	if _, err := NewHandler([]byte("not a key"), testCA(t), defaultCertOrg, defaultCertCN, time.Hour); err == nil {
 		t.Error("expected error for non-PEM operator pubkey")
 	}
 }
@@ -217,7 +217,7 @@ func TestHandlerToleratesTokenClockSkew(t *testing.T) {
 	}
 	pubPEM := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubDER})
 
-	h, err := NewHandler(pubPEM, testCA(t), "system:masters", "operator", time.Hour)
+	h, err := NewHandler(pubPEM, testCA(t), defaultCertOrg, defaultCertCN, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -271,7 +271,7 @@ func TestHandlerSigningFailureIsServerError(t *testing.T) {
 	signer, pubPEM := newOperatorAuth(t)
 	ca := testCA(t)
 	ca.key = stubSigner{}
-	h, err := NewHandler(pubPEM, ca, "system:masters", "operator", time.Hour)
+	h, err := NewHandler(pubPEM, ca, defaultCertOrg, defaultCertCN, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func (errReader) Read([]byte) (int, error) { return 0, errors.New("boom") }
 // method, authorization, body decoding, CSR validation, and signing.
 func TestServeHTTPErrorPaths(t *testing.T) {
 	signer, pubPEM := newOperatorAuth(t)
-	h, err := NewHandler(pubPEM, testCA(t), "system:masters", "operator", time.Hour)
+	h, err := NewHandler(pubPEM, testCA(t), defaultCertOrg, defaultCertCN, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cmds/credrelease/node_image_test.go
+++ b/internal/cmds/credrelease/node_image_test.go
@@ -2,284 +2,137 @@ package credrelease
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+	rbacv1 "k8s.io/api/rbac/v1"
+	sigsyaml "sigs.k8s.io/yaml"
 )
 
+// The node image bakes the operator identity twice: the unit spells out the
+// cert flags, and the RKE2 AddOn binds that group to cluster-admin. Nothing
+// else ties the two files to this package, so load both here and check they
+// agree with each other and with the binary's defaults (which cmd_test.go
+// pins to literals).
 const (
 	nodeImageCredReleaseService = "../../../node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service"
+	nodeImageCredReleaseDropIns = nodeImageCredReleaseService + ".d/*.conf"
 	nodeImageCredReleaseRBAC    = "../../../node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml"
 )
 
-type nodeImageClusterRoleBinding struct {
-	APIVersion string `yaml:"apiVersion"`
-	Kind       string `yaml:"kind"`
-	Metadata   struct {
-		Name string `yaml:"name"`
-	} `yaml:"metadata"`
-	RoleRef struct {
-		APIGroup string `yaml:"apiGroup"`
-		Kind     string `yaml:"kind"`
-		Name     string `yaml:"name"`
-	} `yaml:"roleRef"`
-	Subjects []struct {
-		APIGroup string `yaml:"apiGroup"`
-		Kind     string `yaml:"kind"`
-		Name     string `yaml:"name"`
-	} `yaml:"subjects"`
-}
-
-// TestNodeImageCredentialReleaseConfiguration is an independent oracle for
-// the baked privilege boundary. Keep the expected values literal: sharing
-// command defaults here would let both sides drift to a privileged value.
 func TestNodeImageCredentialReleaseConfiguration(t *testing.T) {
-	service, err := os.ReadFile(filepath.Clean(nodeImageCredReleaseService))
+	unit, err := os.ReadFile(filepath.Clean(nodeImageCredReleaseService))
 	if err != nil {
 		t.Fatalf("read node-image credential-release service: %v", err)
 	}
-
-	args, err := credentialReleaseExecStart(service)
+	// systemd continues a line only on a bare trailing backslash; one followed
+	// by whitespace makes the next line a bogus directive and the unit fails
+	// to load. Reject it here rather than letting the truncated ExecStart
+	// parse to the binary defaults below.
+	if regexp.MustCompile(`\\[ \t]+\n`).Match(unit) {
+		t.Fatal("cred-release.service has a backslash followed by whitespace: not a systemd continuation")
+	}
+	// Join continuation lines, then take the single ExecStart.
+	joined := strings.ReplaceAll(string(unit), "\\\n", " ")
+	if n := strings.Count(joined, "\nExecStart="); n != 1 {
+		t.Fatalf("ExecStart directive count = %d, want exactly 1", n)
+	}
+	_, rest, _ := strings.Cut(joined, "\nExecStart=")
+	execStart, _, _ := strings.Cut(rest, "\n")
+	args := strings.Fields(execStart)
+	if len(args) < 2 || args[0] != "/usr/local/bin/c8s" || args[1] != "cred-release" {
+		t.Fatalf("ExecStart = %q, want /usr/local/bin/c8s cred-release ...", execStart)
+	}
+	// The unit spells the identity out (see its comment); a missing flag here
+	// would otherwise pass silently on the binary defaults. And the only
+	// environment expansion is the platform: anything else would let a
+	// drop-in's Environment= rewrite the identity out of sight of this test.
+	for _, flag := range []string{"--cert-ttl", "--cert-org", "--cert-cn"} {
+		if !slices.Contains(args, flag) {
+			t.Errorf("ExecStart does not spell out %s", flag)
+		}
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "$") && arg != "--platform=${CRED_PLATFORM}" {
+			t.Errorf("ExecStart argument %q expands the environment", arg)
+		}
+	}
+	// Drop-ins can reset ExecStart or inject environment; mkosi.sync renders
+	// one with only Environment=CRED_PLATFORM, so any baked drop-in that
+	// touches Exec*/Environment* is an override this test would not see.
+	dropIns, err := filepath.Glob(nodeImageCredReleaseDropIns)
 	if err != nil {
-		t.Fatalf("parse node-image credential-release service: %v", err)
+		t.Fatal(err)
 	}
-	if strings.Contains(strings.Join(args, "\x00"), "system:masters") {
-		t.Fatal("credential-release ExecStart must not grant system:masters")
+	for _, path := range dropIns {
+		conf, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, line := range strings.Split(string(conf), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "Exec") || strings.HasPrefix(line, "Environment") {
+				t.Errorf("%s overrides the unit: %q", path, line)
+			}
+		}
 	}
-	assertSingleNodeImageFlag(t, args, "--cert-ttl", "1h")
-	assertSingleNodeImageFlag(t, args, "--cert-org", "c8s:node-operators")
-	assertSingleNodeImageFlag(t, args, "--cert-cn", "operator")
+
+	// Parse the baked flags with the real command so the test sees exactly
+	// what the binary sees (last-wins duplicates, --flag=value forms, ...).
+	flags := NewCmd().Flags()
+	if err := flags.Parse(args[2:]); err != nil {
+		t.Fatalf("parse baked ExecStart flags: %v", err)
+	}
+	org, _ := flags.GetString("cert-org")
+	cn, _ := flags.GetString("cert-cn")
+	ttl, _ := flags.GetDuration("cert-ttl")
+	if org != defaultCertOrg || cn != defaultCertCN || ttl != defaultCertTTL {
+		t.Errorf("baked identity = O=%s CN=%s ttl=%v, want the binary defaults O=%s CN=%s ttl=%v",
+			org, cn, ttl, defaultCertOrg, defaultCertCN, defaultCertTTL)
+	}
+	// system:* groups are apiserver-reserved; system:masters in particular
+	// bypasses RBAC and cannot be revoked.
+	if strings.HasPrefix(org, "system:") {
+		t.Errorf("baked --cert-org %q is an apiserver-reserved group", org)
+	}
 
 	body, err := os.ReadFile(filepath.Clean(nodeImageCredReleaseRBAC))
 	if err != nil {
 		t.Fatalf("read node-image credential-release RBAC manifest: %v", err)
 	}
-	if bytes.Contains(body, []byte("system:masters")) {
-		t.Fatal("credential-release RBAC manifest must not grant system:masters")
+	// Exactly one document: a strict typed decode reads only the first, so
+	// count them separately.
+	docs := yaml.NewDecoder(bytes.NewReader(body))
+	if err := docs.Decode(new(yaml.Node)); err != nil {
+		t.Fatalf("decode RBAC manifest: %v", err)
 	}
-	binding, err := decodeSingleNodeImageRBAC(body)
-	if err != nil {
-		t.Fatalf("decode node-image credential-release RBAC manifest: %v", err)
+	if err := docs.Decode(new(yaml.Node)); err != io.EOF {
+		t.Fatalf("RBAC manifest must hold exactly one document (second decode: %v)", err)
+	}
+	var binding rbacv1.ClusterRoleBinding
+	if err := sigsyaml.UnmarshalStrict(body, &binding); err != nil {
+		t.Fatalf("decode RBAC manifest as ClusterRoleBinding: %v", err)
 	}
 	if binding.APIVersion != "rbac.authorization.k8s.io/v1" || binding.Kind != "ClusterRoleBinding" {
 		t.Errorf("typeMeta = %s %s, want rbac.authorization.k8s.io/v1 ClusterRoleBinding", binding.APIVersion, binding.Kind)
 	}
-	if binding.Metadata.Name != "c8s-node-operators" {
-		t.Errorf("binding name = %q, want c8s-node-operators", binding.Metadata.Name)
+	// The unit's ExecStartPre waits for this binding by name so a released
+	// credential is never ahead of its authorization.
+	if binding.Name == "" || !strings.Contains(joined, "get clusterrolebinding "+binding.Name+" ") {
+		t.Errorf("cred-release.service does not wait for ClusterRoleBinding %q before serving", binding.Name)
 	}
-	if binding.RoleRef.APIGroup != "rbac.authorization.k8s.io" || binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != "cluster-admin" {
-		t.Errorf("roleRef = %#v, want ClusterRole cluster-admin in rbac.authorization.k8s.io", binding.RoleRef)
+	wantRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: "cluster-admin"}
+	if binding.RoleRef != wantRef {
+		t.Errorf("roleRef = %+v, want %+v", binding.RoleRef, wantRef)
 	}
-	if len(binding.Subjects) != 1 {
-		t.Fatalf("subjects = %#v, want exactly one group subject", binding.Subjects)
-	}
-	subject := binding.Subjects[0]
-	if subject.APIGroup != "rbac.authorization.k8s.io" || subject.Kind != "Group" || subject.Name != "c8s:node-operators" {
-		t.Errorf("subject = %#v, want Group c8s:node-operators in rbac.authorization.k8s.io", subject)
-	}
-}
-
-func credentialReleaseExecStart(service []byte) ([]string, error) {
-	logicalLines, err := systemdLogicalLines(string(service))
-	if err != nil {
-		return nil, err
-	}
-
-	var execStarts []string
-	for _, line := range logicalLines {
-		key, value, ok := strings.Cut(line, "=")
-		if ok && strings.TrimSpace(key) == "ExecStart" {
-			execStarts = append(execStarts, strings.TrimSpace(value))
-		}
-	}
-	if len(execStarts) != 1 {
-		return nil, fmt.Errorf("ExecStart directive count = %d, want exactly 1", len(execStarts))
-	}
-
-	args := strings.Fields(execStarts[0])
-	if len(args) < 2 || args[0] != "/usr/local/bin/c8s" || args[1] != "cred-release" {
-		return nil, fmt.Errorf("ExecStart command = %q, want /usr/local/bin/c8s cred-release", execStarts[0])
-	}
-	return args, nil
-}
-
-func systemdLogicalLines(service string) ([]string, error) {
-	var logicalLines []string
-	var continued []string
-	for _, physicalLine := range strings.Split(strings.ReplaceAll(service, "\r\n", "\n"), "\n") {
-		line := strings.TrimSpace(physicalLine)
-		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
-			continue
-		}
-
-		continues := strings.HasSuffix(line, "\\")
-		if continues {
-			line = strings.TrimSpace(strings.TrimSuffix(line, "\\"))
-		}
-		continued = append(continued, line)
-		if !continues {
-			logicalLines = append(logicalLines, strings.Join(continued, " "))
-			continued = nil
-		}
-	}
-	if len(continued) != 0 {
-		return nil, fmt.Errorf("unterminated systemd line continuation")
-	}
-	return logicalLines, nil
-}
-
-func assertSingleNodeImageFlag(t *testing.T, args []string, flag, want string) {
-	t.Helper()
-	got, err := singleLongFlagValue(args, flag)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	if got != want {
-		t.Errorf("%s = %q, want literal %q", flag, got, want)
-	}
-}
-
-func singleLongFlagValue(args []string, flag string) (string, error) {
-	var values []string
-	equalsPrefix := flag + "="
-	for i, arg := range args {
-		switch {
-		case arg == flag:
-			if i+1 == len(args) || strings.HasPrefix(args[i+1], "--") {
-				values = append(values, "")
-			} else {
-				values = append(values, args[i+1])
-			}
-		case strings.HasPrefix(arg, equalsPrefix):
-			values = append(values, strings.TrimPrefix(arg, equalsPrefix))
-		}
-	}
-	if len(values) != 1 {
-		return "", fmt.Errorf("%s occurrence count = %d, want exactly 1", flag, len(values))
-	}
-	if values[0] == "" {
-		return "", fmt.Errorf("%s has no value", flag)
-	}
-	return values[0], nil
-}
-
-func decodeSingleNodeImageRBAC(body []byte) (nodeImageClusterRoleBinding, error) {
-	decoder := yaml.NewDecoder(bytes.NewReader(body))
-	decoder.KnownFields(true)
-
-	var binding nodeImageClusterRoleBinding
-	if err := decoder.Decode(&binding); err != nil {
-		return binding, err
-	}
-	for document := 2; ; document++ {
-		var extra yaml.Node
-		err := decoder.Decode(&extra)
-		if err == io.EOF {
-			return binding, nil
-		}
-		if err != nil {
-			return binding, fmt.Errorf("decode YAML document %d: %w", document, err)
-		}
-		if !emptyYAMLDocument(&extra) {
-			return binding, fmt.Errorf("unexpected non-empty YAML document %d", document)
-		}
-	}
-}
-
-func emptyYAMLDocument(document *yaml.Node) bool {
-	if document == nil || len(document.Content) == 0 {
-		return true
-	}
-	node := document
-	if document.Kind == yaml.DocumentNode {
-		node = document.Content[0]
-	}
-	return node.Kind == yaml.ScalarNode && node.Tag == "!!null" && node.Value == ""
-}
-
-func TestCredentialReleaseExecStartParserRejectsOverrides(t *testing.T) {
-	tests := []struct {
-		name    string
-		service string
-		flag    string
-	}{
-		{
-			name:    "missing ExecStart",
-			service: "[Service]\nExecStartPre=/bin/true\n",
-		},
-		{
-			name: "second ExecStart",
-			service: "[Service]\n" +
-				"ExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators\n" +
-				"ExecStart=/usr/local/bin/c8s cred-release --cert-org system:masters\n",
-		},
-		{
-			name:    "separated duplicate flag",
-			service: "[Service]\nExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators --cert-org system:masters\n",
-			flag:    "--cert-org",
-		},
-		{
-			name:    "equals duplicate flag",
-			service: "[Service]\nExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators --cert-org=system:masters\n",
-			flag:    "--cert-org",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			args, err := credentialReleaseExecStart([]byte(tt.service))
-			if err == nil && tt.flag != "" {
-				_, err = singleLongFlagValue(args, tt.flag)
-			}
-			if err == nil {
-				t.Fatal("accepted ambiguous credential-release command")
-			}
-		})
-	}
-}
-
-func TestDecodeSingleNodeImageRBACRejectsAmbiguousYAML(t *testing.T) {
-	const valid = `apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: c8s-node-operators
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: cluster-admin
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: c8s:node-operators
-`
-	tests := []struct {
-		name string
-		body string
-	}{
-		{name: "duplicate field", body: valid + "kind: ServiceAccount\n"},
-		{name: "unknown top-level field", body: valid + "privileged: true\n"},
-		{
-			name: "unknown nested field",
-			body: strings.Replace(valid, "  name: c8s-node-operators\n", "  name: c8s-node-operators\n  namespace: kube-system\n", 1),
-		},
-		{name: "second resource", body: valid + "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: hidden\n"},
-		{name: "empty object document", body: valid + "---\n{}\n"},
-		{name: "resource after empty document", body: valid + "---\n# empty\n---\napiVersion: v1\nkind: ConfigMap\n"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, err := decodeSingleNodeImageRBAC([]byte(tt.body)); err == nil {
-				t.Fatal("accepted ambiguous RBAC YAML")
-			}
-		})
-	}
-
-	if _, err := decodeSingleNodeImageRBAC([]byte(valid + "---\n# an empty trailing document is harmless\n")); err != nil {
-		t.Fatalf("rejects empty trailing YAML document: %v", err)
+	wantSubjects := []rbacv1.Subject{{APIGroup: rbacv1.GroupName, Kind: rbacv1.GroupKind, Name: org}}
+	if len(binding.Subjects) != 1 || binding.Subjects[0] != wantSubjects[0] {
+		t.Errorf("subjects = %+v, want %+v (the baked --cert-org group)", binding.Subjects, wantSubjects)
 	}
 }

--- a/internal/cmds/credrelease/node_image_test.go
+++ b/internal/cmds/credrelease/node_image_test.go
@@ -1,0 +1,285 @@
+package credrelease
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	nodeImageCredReleaseService = "../../../node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service"
+	nodeImageCredReleaseRBAC    = "../../../node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml"
+)
+
+type nodeImageClusterRoleBinding struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	RoleRef struct {
+		APIGroup string `yaml:"apiGroup"`
+		Kind     string `yaml:"kind"`
+		Name     string `yaml:"name"`
+	} `yaml:"roleRef"`
+	Subjects []struct {
+		APIGroup string `yaml:"apiGroup"`
+		Kind     string `yaml:"kind"`
+		Name     string `yaml:"name"`
+	} `yaml:"subjects"`
+}
+
+// TestNodeImageCredentialReleaseConfiguration is an independent oracle for
+// the baked privilege boundary. Keep the expected values literal: sharing
+// command defaults here would let both sides drift to a privileged value.
+func TestNodeImageCredentialReleaseConfiguration(t *testing.T) {
+	service, err := os.ReadFile(filepath.Clean(nodeImageCredReleaseService))
+	if err != nil {
+		t.Fatalf("read node-image credential-release service: %v", err)
+	}
+
+	args, err := credentialReleaseExecStart(service)
+	if err != nil {
+		t.Fatalf("parse node-image credential-release service: %v", err)
+	}
+	if strings.Contains(strings.Join(args, "\x00"), "system:masters") {
+		t.Fatal("credential-release ExecStart must not grant system:masters")
+	}
+	assertSingleNodeImageFlag(t, args, "--cert-ttl", "1h")
+	assertSingleNodeImageFlag(t, args, "--cert-org", "c8s:node-operators")
+	assertSingleNodeImageFlag(t, args, "--cert-cn", "operator")
+
+	body, err := os.ReadFile(filepath.Clean(nodeImageCredReleaseRBAC))
+	if err != nil {
+		t.Fatalf("read node-image credential-release RBAC manifest: %v", err)
+	}
+	if bytes.Contains(body, []byte("system:masters")) {
+		t.Fatal("credential-release RBAC manifest must not grant system:masters")
+	}
+	binding, err := decodeSingleNodeImageRBAC(body)
+	if err != nil {
+		t.Fatalf("decode node-image credential-release RBAC manifest: %v", err)
+	}
+	if binding.APIVersion != "rbac.authorization.k8s.io/v1" || binding.Kind != "ClusterRoleBinding" {
+		t.Errorf("typeMeta = %s %s, want rbac.authorization.k8s.io/v1 ClusterRoleBinding", binding.APIVersion, binding.Kind)
+	}
+	if binding.Metadata.Name != "c8s-node-operators" {
+		t.Errorf("binding name = %q, want c8s-node-operators", binding.Metadata.Name)
+	}
+	if binding.RoleRef.APIGroup != "rbac.authorization.k8s.io" || binding.RoleRef.Kind != "ClusterRole" || binding.RoleRef.Name != "cluster-admin" {
+		t.Errorf("roleRef = %#v, want ClusterRole cluster-admin in rbac.authorization.k8s.io", binding.RoleRef)
+	}
+	if len(binding.Subjects) != 1 {
+		t.Fatalf("subjects = %#v, want exactly one group subject", binding.Subjects)
+	}
+	subject := binding.Subjects[0]
+	if subject.APIGroup != "rbac.authorization.k8s.io" || subject.Kind != "Group" || subject.Name != "c8s:node-operators" {
+		t.Errorf("subject = %#v, want Group c8s:node-operators in rbac.authorization.k8s.io", subject)
+	}
+}
+
+func credentialReleaseExecStart(service []byte) ([]string, error) {
+	logicalLines, err := systemdLogicalLines(string(service))
+	if err != nil {
+		return nil, err
+	}
+
+	var execStarts []string
+	for _, line := range logicalLines {
+		key, value, ok := strings.Cut(line, "=")
+		if ok && strings.TrimSpace(key) == "ExecStart" {
+			execStarts = append(execStarts, strings.TrimSpace(value))
+		}
+	}
+	if len(execStarts) != 1 {
+		return nil, fmt.Errorf("ExecStart directive count = %d, want exactly 1", len(execStarts))
+	}
+
+	args := strings.Fields(execStarts[0])
+	if len(args) < 2 || args[0] != "/usr/local/bin/c8s" || args[1] != "cred-release" {
+		return nil, fmt.Errorf("ExecStart command = %q, want /usr/local/bin/c8s cred-release", execStarts[0])
+	}
+	return args, nil
+}
+
+func systemdLogicalLines(service string) ([]string, error) {
+	var logicalLines []string
+	var continued []string
+	for _, physicalLine := range strings.Split(strings.ReplaceAll(service, "\r\n", "\n"), "\n") {
+		line := strings.TrimSpace(physicalLine)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+
+		continues := strings.HasSuffix(line, "\\")
+		if continues {
+			line = strings.TrimSpace(strings.TrimSuffix(line, "\\"))
+		}
+		continued = append(continued, line)
+		if !continues {
+			logicalLines = append(logicalLines, strings.Join(continued, " "))
+			continued = nil
+		}
+	}
+	if len(continued) != 0 {
+		return nil, fmt.Errorf("unterminated systemd line continuation")
+	}
+	return logicalLines, nil
+}
+
+func assertSingleNodeImageFlag(t *testing.T, args []string, flag, want string) {
+	t.Helper()
+	got, err := singleLongFlagValue(args, flag)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if got != want {
+		t.Errorf("%s = %q, want literal %q", flag, got, want)
+	}
+}
+
+func singleLongFlagValue(args []string, flag string) (string, error) {
+	var values []string
+	equalsPrefix := flag + "="
+	for i, arg := range args {
+		switch {
+		case arg == flag:
+			if i+1 == len(args) || strings.HasPrefix(args[i+1], "--") {
+				values = append(values, "")
+			} else {
+				values = append(values, args[i+1])
+			}
+		case strings.HasPrefix(arg, equalsPrefix):
+			values = append(values, strings.TrimPrefix(arg, equalsPrefix))
+		}
+	}
+	if len(values) != 1 {
+		return "", fmt.Errorf("%s occurrence count = %d, want exactly 1", flag, len(values))
+	}
+	if values[0] == "" {
+		return "", fmt.Errorf("%s has no value", flag)
+	}
+	return values[0], nil
+}
+
+func decodeSingleNodeImageRBAC(body []byte) (nodeImageClusterRoleBinding, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(body))
+	decoder.KnownFields(true)
+
+	var binding nodeImageClusterRoleBinding
+	if err := decoder.Decode(&binding); err != nil {
+		return binding, err
+	}
+	for document := 2; ; document++ {
+		var extra yaml.Node
+		err := decoder.Decode(&extra)
+		if err == io.EOF {
+			return binding, nil
+		}
+		if err != nil {
+			return binding, fmt.Errorf("decode YAML document %d: %w", document, err)
+		}
+		if !emptyYAMLDocument(&extra) {
+			return binding, fmt.Errorf("unexpected non-empty YAML document %d", document)
+		}
+	}
+}
+
+func emptyYAMLDocument(document *yaml.Node) bool {
+	if document == nil || len(document.Content) == 0 {
+		return true
+	}
+	node := document
+	if document.Kind == yaml.DocumentNode {
+		node = document.Content[0]
+	}
+	return node.Kind == yaml.ScalarNode && node.Tag == "!!null" && node.Value == ""
+}
+
+func TestCredentialReleaseExecStartParserRejectsOverrides(t *testing.T) {
+	tests := []struct {
+		name    string
+		service string
+		flag    string
+	}{
+		{
+			name:    "missing ExecStart",
+			service: "[Service]\nExecStartPre=/bin/true\n",
+		},
+		{
+			name: "second ExecStart",
+			service: "[Service]\n" +
+				"ExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators\n" +
+				"ExecStart=/usr/local/bin/c8s cred-release --cert-org system:masters\n",
+		},
+		{
+			name:    "separated duplicate flag",
+			service: "[Service]\nExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators --cert-org system:masters\n",
+			flag:    "--cert-org",
+		},
+		{
+			name:    "equals duplicate flag",
+			service: "[Service]\nExecStart=/usr/local/bin/c8s cred-release --cert-org c8s:node-operators --cert-org=system:masters\n",
+			flag:    "--cert-org",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args, err := credentialReleaseExecStart([]byte(tt.service))
+			if err == nil && tt.flag != "" {
+				_, err = singleLongFlagValue(args, tt.flag)
+			}
+			if err == nil {
+				t.Fatal("accepted ambiguous credential-release command")
+			}
+		})
+	}
+}
+
+func TestDecodeSingleNodeImageRBACRejectsAmbiguousYAML(t *testing.T) {
+	const valid = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: c8s-node-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: c8s:node-operators
+`
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "duplicate field", body: valid + "kind: ServiceAccount\n"},
+		{name: "unknown top-level field", body: valid + "privileged: true\n"},
+		{
+			name: "unknown nested field",
+			body: strings.Replace(valid, "  name: c8s-node-operators\n", "  name: c8s-node-operators\n  namespace: kube-system\n", 1),
+		},
+		{name: "second resource", body: valid + "---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: hidden\n"},
+		{name: "empty object document", body: valid + "---\n{}\n"},
+		{name: "resource after empty document", body: valid + "---\n# empty\n---\napiVersion: v1\nkind: ConfigMap\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := decodeSingleNodeImageRBAC([]byte(tt.body)); err == nil {
+				t.Fatal("accepted ambiguous RBAC YAML")
+			}
+		})
+	}
+
+	if _, err := decodeSingleNodeImageRBAC([]byte(valid + "---\n# an empty trailing document is harmless\n")); err != nil {
+		t.Fatalf("rejects empty trailing YAML document: %v", err)
+	}
+}

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -31,8 +31,13 @@ type Config struct {
 	ServerCACert string
 	// CertTTL is the lifetime of issued operator certs.
 	CertTTL time.Duration
-	// CertOrg / CertCN are the Kubernetes group / user the issued cert
-	// carries. v1: O=system:masters, CN=operator (cluster-admin).
+	// CertOrg / CertCN are the Kubernetes group / user the issued cert carries.
+	// The baked RKE2 AddOn grants defaultCertOrg cluster-admin. Deleting or
+	// changing the live binding revokes its RBAC access immediately, but RKE2
+	// reapplies the manifest at restart. To make revocation survive restart,
+	// disable or skip the cred-release-rbac AddOn before changing the binding;
+	// alternatively, relaunch without opkeydata or with a different operator key
+	// to prevent renewal by the old key (an issued cert lives until its TTL).
 	CertOrg string
 	CertCN  string
 }

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -32,12 +32,9 @@ type Config struct {
 	// CertTTL is the lifetime of issued operator certs.
 	CertTTL time.Duration
 	// CertOrg / CertCN are the Kubernetes group / user the issued cert carries.
-	// The baked RKE2 AddOn grants defaultCertOrg cluster-admin. Deleting or
-	// changing the live binding revokes its RBAC access immediately, but RKE2
-	// reapplies the manifest at restart. To make revocation survive restart,
-	// disable or skip the cred-release-rbac AddOn before changing the binding;
-	// alternatively, relaunch without opkeydata or with a different operator key
-	// to prevent renewal by the old key (an issued cert lives until its TTL).
+	// Authorization is ordinary RBAC on that group: the node image's baked
+	// cred-release-rbac AddOn binds defaultCertOrg to cluster-admin. Revocation
+	// semantics are in docs/operator.md.
 	CertOrg string
 	CertCN  string
 }

--- a/internal/cmds/credrelease/run_test.go
+++ b/internal/cmds/credrelease/run_test.go
@@ -77,9 +77,9 @@ func runnableConfig(t *testing.T) Config {
 		ClientCACert:      clientCert,
 		ClientCAKey:       clientKey,
 		ServerCACert:      serverCert,
-		CertTTL:           time.Hour,
-		CertOrg:           "system:masters",
-		CertCN:            "operator",
+		CertTTL:           defaultCertTTL,
+		CertOrg:           defaultCertOrg,
+		CertCN:            defaultCertCN,
 	}
 }
 

--- a/internal/cmds/credrelease/sign.go
+++ b/internal/cmds/credrelease/sign.go
@@ -98,8 +98,10 @@ func parseCAKey(der []byte, pemType string) (crypto.Signer, error) {
 
 // signOperatorCert signs csr with the cluster CA, producing a kube CLIENT
 // certificate with the requested identity. The caller sets group/CN via
-// SignParams — v1 uses O=system:masters (cluster-admin), matching the baked
-// admin. TTL is short so the operator re-releases.
+// signParams. The baked RKE2 AddOn binds the default group to cluster-admin;
+// authorization therefore follows the live ClusterRoleBinding, not certificate
+// expiry alone. See Config.CertOrg for durable revocation requirements. TTL is
+// short so the operator re-releases.
 type signParams struct {
 	csr      *x509.CertificateRequest
 	org      string // certificate Subject O -> maps to a Kubernetes group

--- a/internal/cmds/credrelease/sign.go
+++ b/internal/cmds/credrelease/sign.go
@@ -98,10 +98,8 @@ func parseCAKey(der []byte, pemType string) (crypto.Signer, error) {
 
 // signOperatorCert signs csr with the cluster CA, producing a kube CLIENT
 // certificate with the requested identity. The caller sets group/CN via
-// signParams. The baked RKE2 AddOn binds the default group to cluster-admin;
-// authorization therefore follows the live ClusterRoleBinding, not certificate
-// expiry alone. See Config.CertOrg for durable revocation requirements. TTL is
-// short so the operator re-releases.
+// signParams; what that identity may do is the cluster's RBAC, not the
+// signer's concern. TTL is short so the operator re-releases.
 type signParams struct {
 	csr      *x509.CertificateRequest
 	org      string // certificate Subject O -> maps to a Kubernetes group

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -54,12 +54,15 @@ func TestSignOperatorCert(t *testing.T) {
 	ca := testCA(t)
 	csr := testCSR(t)
 	now := time.Now()
+	// Distinct from the default so a signer that ignored signParams.ttl and
+	// used the default would fail here.
+	const ttl = 90 * time.Minute
 
 	certPEM, err := ca.signOperatorCert(signParams{
 		csr: csr,
 		org: defaultCertOrg,
 		cn:  defaultCertCN,
-		ttl: defaultCertTTL,
+		ttl: ttl,
 	}, now)
 	if err != nil {
 		t.Fatalf("signOperatorCert: %v", err)
@@ -89,8 +92,8 @@ func TestSignOperatorCert(t *testing.T) {
 		t.Errorf("issued cert does not chain to CA: %v", err)
 	}
 	// TTL.
-	if got := cert.NotAfter.Sub(now).Round(time.Hour); got != defaultCertTTL {
-		t.Errorf("TTL = %v, want %v", got, defaultCertTTL)
+	if got := cert.NotAfter.Sub(now).Round(time.Minute); got != ttl {
+		t.Errorf("TTL = %v, want %v", got, ttl)
 	}
 }
 

--- a/internal/cmds/credrelease/sign_test.go
+++ b/internal/cmds/credrelease/sign_test.go
@@ -57,9 +57,9 @@ func TestSignOperatorCert(t *testing.T) {
 
 	certPEM, err := ca.signOperatorCert(signParams{
 		csr: csr,
-		org: "system:masters",
-		cn:  "operator",
-		ttl: 24 * time.Hour,
+		org: defaultCertOrg,
+		cn:  defaultCertCN,
+		ttl: defaultCertTTL,
 	}, now)
 	if err != nil {
 		t.Fatalf("signOperatorCert: %v", err)
@@ -68,11 +68,11 @@ func TestSignOperatorCert(t *testing.T) {
 	cert := parseLeaf(t, certPEM)
 
 	// Identity: the signer sets Subject from signParams, not the CSR.
-	if cert.Subject.CommonName != "operator" {
-		t.Errorf("CN = %q, want operator", cert.Subject.CommonName)
+	if cert.Subject.CommonName != defaultCertCN {
+		t.Errorf("CN = %q, want %q", cert.Subject.CommonName, defaultCertCN)
 	}
-	if len(cert.Subject.Organization) != 1 || cert.Subject.Organization[0] != "system:masters" {
-		t.Errorf("O = %v, want [system:masters]", cert.Subject.Organization)
+	if len(cert.Subject.Organization) != 1 || cert.Subject.Organization[0] != defaultCertOrg {
+		t.Errorf("O = %v, want [%s]", cert.Subject.Organization, defaultCertOrg)
 	}
 	// Client auth only.
 	if len(cert.ExtKeyUsage) != 1 || cert.ExtKeyUsage[0] != x509.ExtKeyUsageClientAuth {
@@ -89,8 +89,8 @@ func TestSignOperatorCert(t *testing.T) {
 		t.Errorf("issued cert does not chain to CA: %v", err)
 	}
 	// TTL.
-	if got := cert.NotAfter.Sub(now).Round(time.Hour); got != 24*time.Hour {
-		t.Errorf("TTL = %v, want 24h", got)
+	if got := cert.NotAfter.Sub(now).Round(time.Hour); got != defaultCertTTL {
+		t.Errorf("TTL = %v, want %v", got, defaultCertTTL)
 	}
 }
 
@@ -101,7 +101,7 @@ func TestSignOperatorCertValidityWindow(t *testing.T) {
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	certPEM, err := ca.signOperatorCert(signParams{
-		csr: testCSR(t), org: "system:masters", cn: "operator", ttl: time.Hour,
+		csr: testCSR(t), org: defaultCertOrg, cn: defaultCertCN, ttl: time.Hour,
 	}, now)
 	if err != nil {
 		t.Fatalf("signOperatorCert: %v", err)
@@ -124,7 +124,7 @@ func TestSignOperatorCertRejectsBadCSR(t *testing.T) {
 	csr.Signature = []byte("tampered") // invalidate the self-signature
 
 	if _, err := ca.signOperatorCert(signParams{
-		csr: csr, org: "system:masters", cn: "operator", ttl: time.Hour,
+		csr: csr, org: defaultCertOrg, cn: defaultCertCN, ttl: time.Hour,
 	}, time.Now()); err == nil {
 		t.Error("expected error for CSR with invalid self-signature")
 	}
@@ -215,7 +215,7 @@ func TestLoadClusterCAReleasesServerCA(t *testing.T) {
 	// A cert issued by the loaded CA chains to the CLIENT CA: proves the cert
 	// and the key both came from the client-CA files.
 	certPEM, err := ca.signOperatorCert(signParams{
-		csr: testCSR(t), org: "system:masters", cn: "operator", ttl: time.Hour,
+		csr: testCSR(t), org: defaultCertOrg, cn: defaultCertCN, ttl: time.Hour,
 	}, time.Now())
 	if err != nil {
 		t.Fatal(err)

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -70,16 +70,8 @@ The other disks are optional; each is owned by one unit under
 - label `opkeydata` — an ISO carrying the operator public key; its
   presence turns on attested credential release (`cred-release.service`,
   see [operator.md]). The baked `cred-release-rbac` RKE2 AddOn binds the
-  issued certificate's `O=c8s:node-operators` group to the built-in
-  `cluster-admin` role through ordinary RBAC. Certificates use
-  `CN=operator` and a one-hour default/baked TTL. This is Kubernetes
-  platform-admin access only, not guest OS/root access; `system:masters` is
-  intentionally avoided because it bypasses authorization/Webhook policy and
-  is not RBAC-revocable. Deleting or changing the live binding revokes access
-  immediately, but RKE2 reapplies the baked AddOn at server restart. Disable
-  or skip that AddOn before removal for durable revocation, or relaunch
-  without `opkeydata`/with rotated key material to stop renewal; an existing
-  certificate remains usable for up to its TTL while the binding exists.
+  issued certificate's group to `cluster-admin` through ordinary RBAC;
+  identity, TTL and revocation are documented in [operator.md].
 
 Migration state (see [#264] for the full plan):
 

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -69,7 +69,17 @@ The other disks are optional; each is owned by one unit under
   cluster; absent means single-node server (`rke2-role.service`).
 - label `opkeydata` — an ISO carrying the operator public key; its
   presence turns on attested credential release (`cred-release.service`,
-  see [operator.md]).
+  see [operator.md]). The baked `cred-release-rbac` RKE2 AddOn binds the
+  issued certificate's `O=c8s:node-operators` group to the built-in
+  `cluster-admin` role through ordinary RBAC. Certificates use
+  `CN=operator` and a one-hour default/baked TTL. This is Kubernetes
+  platform-admin access only, not guest OS/root access; `system:masters` is
+  intentionally avoided because it bypasses authorization/Webhook policy and
+  is not RBAC-revocable. Deleting or changing the live binding revokes access
+  immediately, but RKE2 reapplies the baked AddOn at server restart. Disable
+  or skip that AddOn before removal for durable revocation, or relaunch
+  without `opkeydata`/with rotated key material to stop renewal; an existing
+  certificate remains usable for up to its TTL while the binding exists.
 
 Migration state (see [#264] for the full plan):
 

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -33,12 +33,19 @@ Type=simple
 # Waits bounded (10 min) rather than failing fast: on a slow first boot the
 # CA can take minutes to appear, and 5 quick ExecStartPre failures 10s apart
 # would exhaust StartLimitBurst in under a minute and give up until reboot.
-ExecStartPre=/bin/sh -c 'for _ in $(seq 1 120); do [ -r /var/lib/rancher/rke2/server/tls/client-ca.key ] && exit 0; sleep 5; done; exit 1'
+# Also waits for the c8s-node-operators ClusterRoleBinding (the baked
+# cred-release-rbac AddOn): the issued group has no authority until RKE2's
+# deploy controller has applied it, and nothing on the operator side retries
+# a 403, so do not release a credential the cluster would still refuse.
+ExecStartPre=/bin/sh -c 'for _ in $(seq 1 120); do [ -r /var/lib/rancher/rke2/server/tls/client-ca.key ] && /var/lib/rancher/rke2/bin/kubectl --kubeconfig /etc/rancher/rke2/rke2.yaml --cache-dir /run/cred-release/kubecache get clusterrolebinding c8s-node-operators >/dev/null 2>&1 && exit 0; sleep 5; done; exit 1'
 TimeoutStartSec=630
 # ${CRED_PLATFORM} comes from a drop-in the c8s sync hook renders from the
 # build's required C8S_PLATFORM. The `=` form matters: with the variable
 # unset systemd would elide a bare word, but --platform= expands to an empty
 # value, which platform validation rejects — fail closed, never a default.
+# The --cert-* flags equal the binary defaults; they are spelled out so the
+# measured unit states the issued identity, and the cred-release-rbac AddOn
+# must bind the same group (checked by credrelease's node_image_test.go).
 ExecStart=/usr/local/bin/c8s cred-release \
     --listen :8443 \
     --attestation-api-url http://127.0.0.1:8400 \
@@ -48,8 +55,9 @@ ExecStart=/usr/local/bin/c8s cred-release \
     --cert-cn operator
 Restart=on-failure
 RestartSec=10
-# Reads two files: the initrd-staged operator pubkey (/etc/confai) and the
-# RKE2 client-CA key. No mount needed. Keep the rest of the FS read-only.
+# Reads the initrd-staged operator pubkey (/etc/confai), the RKE2 client-CA
+# key, and (ExecStartPre only) the RKE2 admin kubeconfig. Writes only the
+# kubectl cache under /run. Keep the rest of the FS read-only.
 ProtectSystem=strict
 ReadOnlyPaths=/etc/confai /var/lib/rancher/rke2/server/tls
 ReadWritePaths=/run

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -43,8 +43,8 @@ ExecStart=/usr/local/bin/c8s cred-release \
     --listen :8443 \
     --attestation-api-url http://127.0.0.1:8400 \
     --platform=${CRED_PLATFORM} \
-    --cert-ttl 24h \
-    --cert-org system:masters \
+    --cert-ttl 1h \
+    --cert-org c8s:node-operators \
     --cert-cn operator
 Restart=on-failure
 RestartSec=10

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml
@@ -1,0 +1,20 @@
+# Baked into server/manifests so RKE2 grants credential-release operators
+# cluster-admin through an ordinary RBAC binding.
+# Deleting or changing the live ClusterRoleBinding immediately revokes its
+# access. RKE2 reapplies AddOn cred-release-rbac from this file at restart, so
+# durable revocation requires disabling or skipping that AddOn before changing
+# the binding. Alternatively, relaunch without opkeydata or with a different
+# operator key to stop renewal by the old key; already-issued certs remain
+# usable until their one-hour TTL expires while this binding exists.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: c8s-node-operators
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: c8s:node-operators

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/cred-release-rbac.yaml
@@ -1,11 +1,9 @@
-# Baked into server/manifests so RKE2 grants credential-release operators
-# cluster-admin through an ordinary RBAC binding.
-# Deleting or changing the live ClusterRoleBinding immediately revokes its
-# access. RKE2 reapplies AddOn cred-release-rbac from this file at restart, so
-# durable revocation requires disabling or skipping that AddOn before changing
-# the binding. Alternatively, relaunch without opkeydata or with a different
-# operator key to stop renewal by the old key; already-issued certs remain
-# usable until their one-hour TTL expires while this binding exists.
+# Baked into server/manifests so RKE2 grants the group cred-release.service
+# issues (--cert-org) cluster-admin through an ordinary, revocable RBAC
+# binding instead of the unrevocable system:masters. cred-release.service
+# waits for this binding by name before it serves. RKE2 reapplies the AddOn
+# on every boot (the cluster state is ephemeral); revocation is a launch-time
+# decision, see docs/operator.md.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
## Summary

- issue credential-release client certificates as `CN=operator, O=c8s:node-operators` for one hour instead of placing operators in `system:masters` for 24 hours
- bake an RKE2 `ClusterRoleBinding` that grants that group `cluster-admin` through ordinary RBAC, and have `cred-release.service` wait for the binding before it serves so a released credential is authorized the moment it is issued
- cross-check the baked unit, the RBAC manifest and the binary defaults in one test, and document identity, TTL and revocation in `docs/operator.md`

## Security

- keeps platform-admin access inside the RBAC authorization path; `system:masters` bypasses RBAC and admission webhooks and cannot be revoked
- the binding is not a privilege boundary: on this single-node cluster `cluster-admin` is root-equivalent on the guest, which was already true with `system:masters`. Blast radius is bounded by the attestation gate on who can obtain a credential, the one-hour TTL, and the guest's verity root plus per-boot ephemeral writable state
- revocation is a launch-time decision. Deleting the live binding cuts access until the next boot, since RKE2 state lives on the scratch disk that is re-encrypted with a fresh key every boot. To revoke durably, relaunch without `opkeydata` or with a rotated operator key. An already-issued certificate stays usable for the rest of its one-hour TTL

## Testing

- `go test -race -count=1 -timeout=120s ./internal/cmds/credrelease`
- `go vet ./internal/cmds/credrelease`
- `git diff --check`