### PR TITLE
node-guest-image: disable the kubelet debugging handlers in the locked image

### DIFF
--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -64,6 +64,23 @@ if [ "$rke2_pod_cidr" != "$cilium_pod_cidr" ]; then
   exit 1
 fi
 
+# The locked image must keep the kubelet debugging handlers off (no kubectl
+# exec/attach/logs for the kubeconfig holder); only the C8S_DEV=1 build may
+# turn them back on, and only through the sync-rendered drop-in.
+if ! grep -qxF '  - enable-debugging-handlers=false' "$rke2_config"; then
+  echo "::error::$rke2_config must pin kubelet-arg enable-debugging-handlers=false"
+  exit 1
+fi
+if grep -rq 'enable-debugging-handlers=true' "$ngi/c8s/mkosi.extra"; then
+  echo "::error::a baked file re-enables the kubelet debugging handlers; only mkosi.sync may, for dev=1"
+  exit 1
+fi
+if ! grep -q -- '--sync-input "dev=\${C8S_DEV:-0}"' "$ngi/build" \
+   || ! grep -q 'SYNC_INPUTS/dev' "$ngi/c8s/mkosi.sync"; then
+  echo "::error::the dev sync-input must flow from $ngi/build (C8S_DEV) into mkosi.sync"
+  exit 1
+fi
+
 # The rke2-role drop-ins only bind if mkosi.sync keeps staging the
 # rke2 tarball's units under /usr/local (systemd's search path);
 # the systemd harness installs its fakes at the same prefix.

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -39,6 +39,10 @@ Layout:
   contract (`C8S_PLATFORM`, `C8S_REF`, `C8S_REGISTRY`, `C8S_DEV`, `C8S_NAME`, `C8S_MEMORY`) and the same profile stack
   and order; only the c8s profile content and kernel fragments come from
   here. Point `CONFOS_DIR` at a confos checkout (default: a sibling dir).
+  The locked image runs the kubelet with `enable-debugging-handlers=false`,
+  so `kubectl exec`, `attach`, `port-forward`, and `logs` fail for every
+  kubeconfig holder; `C8S_DEV=1` turns them back on (with the serial
+  autologin), at a different measurement.
 
 ## Launch requirements
 

--- a/node-guest-image/build
+++ b/node-guest-image/build
@@ -35,9 +35,11 @@
 #                      both TEEs' symbols via confos kernel/required.config.
 #   C8S_DEV=1          demo/debug build: kernel/c8s-dev.config fragment
 #                      (8250 serial re-enabled) + the dev profile
-#                      (console=ttyS0, passwordless serial autologin).
-#                      Different measurement, root shell on the host-visible
-#                      serial socket — never ship. Default name: c8s-dev.
+#                      (console=ttyS0, passwordless serial autologin) +
+#                      kubelet debugging handlers back on (kubectl
+#                      exec/attach/logs work). Different measurement, root
+#                      shell on the host-visible serial socket — never ship.
+#                      Default name: c8s-dev.
 #   C8S_NAME=...       output name (default c8s → output/c8s/)
 #   C8S_MEMORY=...     default-memory recorded in the manifest / used by
 #                      `confos run` (default 16G — etcd OOMs at the 4G default)
@@ -114,6 +116,7 @@ exec bin/confos build "${C8S_NAME:-c8s}" \
     --sync-input "platform=${C8S_PLATFORM}" \
     --sync-input "c8s-ref=${C8S_REF:-}" \
     --sync-input "c8s-registry=${C8S_REGISTRY:-}" \
+    --sync-input "dev=${C8S_DEV:-0}" \
     --kernel-config-fragment "$FRAGMENT" \
     --kernel-builder-package "$KB_PKGS" \
     --platform "$C8S_PLATFORM" \

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/config.yaml
@@ -56,6 +56,13 @@ pod-security-admission-config-file: /etc/rancher/rke2/psa-config.yaml
 # platform-neutral.
 kubelet-arg:
   - max-pods=200
+  # Closes the kubelet's exec/attach/port-forward/logs endpoints: the
+  # kubeconfig cred-release hands out is cluster-admin, and without this any
+  # holder can run commands in every allowlisted pod. Probes are unaffected
+  # (they go over CRI). `kubectl logs` stops working too. The C8S_DEV=1 build
+  # re-enables the handlers via a config.yaml.d drop-in (rendered by
+  # mkosi.sync), which changes the measurement.
+  - enable-debugging-handlers=false
 kube-apiserver-arg:
   - audit-log-path=/var/log/kube-audit/audit.log
   - audit-log-maxage=30

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -96,6 +96,15 @@ printf '[Service]\nEnvironment=CRED_PLATFORM=%s\n' "$PLATFORM" \
 printf '# Self-label so `c8s install --hardware-platform %s` finds this node.\nnode-label:\n  - confidential.ai/%s=true\n' "$LABEL_PLATFORM" "$LABEL_PLATFORM" \
     > "$STAGE_DIR/etc/rancher/rke2/config.yaml.d/50-platform.yaml"
 
+# C8S_DEV=1 builds turn the kubelet debugging handlers back on so `kubectl
+# exec`/`attach`/`logs` work. The base config.yaml pins them off; rke2 passes
+# both flags and the kubelet takes the last one. Rendered only for dev so the
+# locked image has no such drop-in at all.
+if [ "$(cat "$SYNC_INPUTS/dev" 2>/dev/null || true)" = 1 ]; then
+    printf '# DEV build: kubectl exec/attach/logs allowed. Never ship.\nkubelet-arg+:\n  - enable-debugging-handlers=true\n' \
+        > "$STAGE_DIR/etc/rancher/rke2/config.yaml.d/60-dev-debugging-handlers.yaml"
+fi
+
 C8S_REF=$(cat "$SYNC_INPUTS/c8s-ref" 2>/dev/null || true)
 # Pinned c8s release: bakes the same component versions the CLI ships as.
 # docker.yml publishes images under v* tags, so the tag itself is the ref.


### PR DESCRIPTION
In `--cvm-mode=node` the kubeconfig `cred-release` hands out is cluster-admin, and nothing stopped its holder from running `kubectl exec`/`attach`/`port-forward`/`logs` against every allowlisted pod. The pod-as-CVM shape already denies the equivalent RPCs in the kata guest policy; this closes the same surface for the node image.

- `config.yaml`: `kubelet-arg enable-debugging-handlers=false` in the baked (measured) RKE2 config. `kubectl logs` stops too.
- `C8S_DEV=1` keeps a working `kubectl exec`/`logs`: `build` passes a `dev` sync-input and `mkosi.sync` renders a `config.yaml.d` drop-in appending `enable-debugging-handlers=true` (kubelet takes the last flag). The drop-in exists only in dev builds, so the locked measurement carries no such file.
- Invariants gate: the base config must pin the flag off, no baked file may turn it on, and the `dev` sync-input must flow from `build` into `mkosi.sync`.