### PR TITLE
feat: static allowlist measured into RTMR[3]

### DIFF
--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -81,6 +81,27 @@ if ! grep -q -- '--sync-input "dev=\${C8S_DEV:-0}"' "$ngi/build" \
   exit 1
 fi
 
+# The policy mode is measured on every boot: the preset must enable the
+# measurer and the socket unit (RequiredBy links exist only for enabled
+# units), mkosi.sync must render the measurer's platform drop-in, and the
+# README must document the policydata disk the measurer reads.
+preset="$ngi/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset"
+for unit in c8s-policy-measure.service c8s-attest-socket.service; do
+  if ! grep -qxF "enable $unit" "$preset"; then
+    echo "::error::$preset must enable $unit; without the preset line rke2 starts without it"
+    exit 1
+  fi
+done
+if ! grep -q 'Environment=POLICY_PLATFORM=' "$ngi/c8s/mkosi.sync" \
+   || ! grep -q -- '--platform=\${POLICY_PLATFORM}' "$ngi/c8s/mkosi.extra/etc/systemd/system/c8s-policy-measure.service"; then
+  echo "::error::c8s-policy-measure.service takes --platform=\${POLICY_PLATFORM}, which mkosi.sync must render"
+  exit 1
+fi
+if ! grep -qF 'label `policydata`' "$ngi/README.md"; then
+  echo "::error::$ngi/README.md must document the policydata disk beside joindata and opkeydata"
+  exit 1
+fi
+
 # The rke2-role drop-ins only bind if mkosi.sync keeps staging the
 # rke2 tarball's units under /usr/local (systemd's search path);
 # the systemd harness installs its fakes at the same prefix.

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -401,6 +401,36 @@ jobs:
           # matrix publishes both measured platform variants.
           C8S_PLATFORM="${{ matrix.platform }}" C8S_NAME="$VARIANT" ../c8s/node-guest-image/build
 
+      - name: Set up Go for systemfloor
+        uses: ./c8s/.github/actions/setup-go-c8s
+        with:
+          go-version-file: c8s/go.mod
+          cache-dependency-path: c8s/go.sum
+
+      - name: Emit the system-floor rule skeleton beside manifest.json
+        # system-floor.json is the reviewer's starting point for
+        # `c8s allowlist render --sealed --system-floor`: one entry per RKE2
+        # floor image with argv from the image config. It lands in
+        # output/$VARIANT, so the gate uploads it with manifest.json and
+        # `confos push` publishes it (the artifact carries every regular file
+        # there). The bundles are the ones mkosi.sync staged into the image,
+        # read from its sha256-verified cache.
+        working-directory: c8s
+        run: |
+          set -euo pipefail
+          cache=../confidential-os-builder/mkosi/base/mkosi.pkgcache/c8s
+          version=$(sed -n 's/^RKE2_VERSION="\(.*\)"$/\1/p' node-guest-image/c8s/mkosi.sync)
+          [ -n "$version" ] || { echo "::error::could not read RKE2_VERSION from mkosi.sync"; exit 1; }
+          cache_ver="${version//+/-}"
+          manifests=node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests
+          go run ./node-guest-image/c8s/systemfloor \
+            -floor "../confidential-os-builder/output/${VARIANT}/system-floor.json" \
+            -bundle "$cache/rke2-images-core-${cache_ver}.tar.zst" \
+            -bundle "$cache/rke2-images-cilium-${cache_ver}.tar.zst" \
+            -manifest "$manifests/local-path-storage.yaml" \
+            -manifest "$manifests/nvidia-device-plugin.yaml" \
+            >/dev/null
+
       - name: Make the tools trees cache-safe
         # The post-job cache tar runs unprivileged; mkosi builds these trees as
         # root, so their saves fail without this. Runs after all use.
@@ -442,6 +472,7 @@ jobs:
           path: |
             confidential-os-builder/output/${{ env.VARIANT }}/manifest.json
             confidential-os-builder/output/${{ env.VARIANT }}/roothash
+            confidential-os-builder/output/${{ env.VARIANT }}/system-floor.json
           if-no-files-found: error
 
       - name: Upload resolved kernel snapshot (gate)

--- a/.github/workflows/tdx-metal-static-e2e.yml
+++ b/.github/workflows/tdx-metal-static-e2e.yml
@@ -32,8 +32,9 @@
 # what reviews.json, the reviewer's completion of the RKE2 system floor,
 # means for this lane.
 #
-# NOT COVERED, DELIBERATELY. Two assertions in the design need a fault
-# injector inside the guest: delaying the plugin past its deadline and
+# NOT COVERED, DELIBERATELY. Two assertions in docs/static-allowlist.md
+# (Known gaps) need a fault injector inside the guest: delaying the plugin
+# past its deadline and
 # asserting no entrypoint runs, and a container present when the plugin
 # synchronizes. The locked image has no console, no ssh and, in static mode,
 # no privileged pod, and a dev image variant boots to another measurement;

--- a/.github/workflows/tdx-metal-static-e2e.yml
+++ b/.github/workflows/tdx-metal-static-e2e.yml
@@ -1,0 +1,513 @@
+# ═══════════════════════════════════════════════════════════════════════════
+# c8s on TDX BARE METAL: the STATIC ALLOWLIST lane (c8s-owned, not vendored)
+# ═══════════════════════════════════════════════════════════════════════════
+#
+# Boots the published, unmodified c8s node image as Intel TDX CVMs on
+# tdx-gh-runner in both boot modes and asserts docs/static-allowlist.md:
+#
+#   static node   booted with a policydata disk and no operator key. The
+#                 node measures the bundle into RTMR[3]; the sealed NRI plugin
+#                 admits only complete rules; CDS pins every requester on the
+#                 static tuple. Asserted here: `get-kubeconfig
+#                 --static-allowlist` and `install --static-allowlist
+#                 --static-node-attest` work; a
+#                 privileged copy of cilium is refused at start; `kubectl exec`
+#                 and `kubectl debug` are refused; the sample workload with a
+#                 ConfigMap mount, an unlisted env var or another argv is
+#                 refused while the matching one runs and scales to 2;
+#                 `c8s verify --static-allowlist` exits 0.
+#   dynamic node  booted with an opkeydata disk, as tdx-metal-e2e.yml does.
+#                 Asserted here: the dynamic register is the operator-key seed
+#                 extended by the dynamic mode event; the static gate refuses
+#                 the node; a privileged pod on it (admitted by the floor)
+#                 extends RTMR[3] with the static events and the static
+#                 verifier still refuses it.
+#   tampered boot a static VM whose bundle member differs by one byte from
+#                 the reviewed bytes (a trailing newline: same JSON, other
+#                 measurement) powers itself off before RKE2 starts.
+#
+# The bundle is built on the runner from the image's published evidence
+# (manifest.json, system-floor.json) and the fixtures under
+# test/e2e/static/: see build-bundle.sh for the fixed-point check and for
+# what reviews.json, the reviewer's completion of the RKE2 system floor,
+# means for this lane.
+#
+# NOT COVERED, DELIBERATELY. Two assertions in the design need a fault
+# injector inside the guest: delaying the plugin past its deadline and
+# asserting no entrypoint runs, and a container present when the plugin
+# synchronizes. The locked image has no console, no ssh and, in static mode,
+# no privileged pod, and a dev image variant boots to another measurement;
+# both stay unit-tested (internal/cmds/nri-image-policy). One more is not
+# buildable here: "the same workload on a second, unsealed node of the same
+# image is refused a certificate" needs a two-node cluster, and under
+# KubeVirt masquerade every guest is 10.0.2.2, so two nodes cannot join one
+# cluster. The dynamic node is a separate single-node cluster instead.
+#
+# POWER-OFF ASSERTIONS use runStrategy RerunOnFailure: KubeVirt restarts a
+# guest under Always. Under RerunOnFailure a guest-initiated power-off leaves
+# the VMI Succeeded, the VM controller then deletes the VMI and the VM
+# reports Stopped; cvm.sh wait-stopped accepts either observation. Manual
+# would need the start subresource the namespace-scoped SA does not hold.
+#
+# NODE ATTEST ADDRESS: `c8s install --static-allowlist` attests every node
+# at its InternalIP:8400, and under KubeVirt masquerade a guest's InternalIP
+# is 10.0.2.2, which the runner cannot reach. The install step therefore
+# passes `--static-node-attest c8s-node=$STATIC_IP:8400`, the VMI's pod
+# address every other step reaches the guest through; c8s-node is the baked
+# node name the cidata tripwire asserts.
+#
+# Same host conventions as tdx-metal-e2e.yml: no serial console, the guest
+# signals are attestation-api :8400, kube-apiserver :6443, cred-release :8443
+# and the attested kubeconfig; the outer cluster is renumbered so the guests'
+# 10.42/10.43 do not collide; dispatch-only until it has a green history.
+name: tdx-metal-static-e2e
+
+on:
+  workflow_call:
+    inputs:
+      c8s_ref:
+        description: 'c8s ref to test. Defaults to the ref paired with the node image.'
+        required: false
+        type: string
+        default: ''
+      keep_cvm:
+        description: 'leave the CVMs running for debugging instead of tearing them down'
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      c8s_ref:
+        description: 'c8s git ref to install + test. Empty = the c8sRef pinned in the tdx-rke2-image-refs CM (the bundle names the component digests at this ref, so a mismatched ref gets its own components denied).'
+        required: false
+        default: ''
+      keep_cvm:
+        description: 'Skip teardown to debug a failure. The reaper still clears the CVMs after 3h.'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # One at a time: the lane boots CVMs off a shared RWO rootdisk PVC.
+  group: tdx-metal-static-e2e
+  cancel-in-progress: false
+
+env:
+  NS: confai-images
+  REFS_CM: tdx-rke2-image-refs
+  VM_STATIC: c8s-tdx-static-${{ github.run_id }}-${{ github.run_attempt }}
+  VM_DYN: c8s-tdx-dyn-${{ github.run_id }}-${{ github.run_attempt }}
+  VM_TAMPER: c8s-tdx-tamper-${{ github.run_id }}-${{ github.run_attempt }}
+  # Bundle, evidence and per-node outputs; the scripts live in the c8s
+  # checkout at the paired ref.
+  OUT: /tmp/static-e2e
+  E2E: /tmp/c8s-src/test/e2e/static
+
+jobs:
+  e2e:
+    name: cvm (tdx-metal-static/rke2-node)
+    # The host-side launcher runner on tdx-gh-runner; its bm-e2e SA is scoped
+    # to confai-images and kubectl uses the in-cluster token.
+    runs-on: cvm-launcher-tdx
+    # Three boots (tampered ~5m, static ~15m with install and asserts,
+    # dynamic ~12m with install), the CLI build and the bundle render.
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: tools (kubectl, go, crane, helm, yq, xorriso)
+        run: |
+          set -euo pipefail
+          # Every fetch here crosses the public internet from an ephemeral ARC
+          # pod, and one hiccup fails the lane before it reaches a CVM.
+          mkdir -p "$PWD/bin"
+          # retry <shell-snippet>: 4 attempts, exponential backoff 2s/4s/8s.
+          # A file, not a function, because each `run:` block is a fresh shell.
+          printf '%s\n' \
+            'retry() {' \
+            '  local i delay=2' \
+            '  for i in 1 2 3 4; do' \
+            '    if eval "$1"; then return 0; fi' \
+            '    [ "$i" -eq 4 ] && break' \
+            '    echo "attempt $i failed, retrying in ${delay}s: $1" >&2' \
+            '    sleep "$delay"' \
+            '    delay=$((delay * 2))' \
+            '  done' \
+            '  echo "::error::gave up after 4 attempts: $1" >&2' \
+            '  return 1' \
+            '}' > bin/retry.sh
+          . bin/retry.sh
+          retry 'curl -fsSL "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o bin/kubectl'
+          chmod +x bin/kubectl
+          echo "$PWD/bin" >> "$GITHUB_PATH"
+          if ! command -v go >/dev/null; then
+            # `|| true`: under `set -e` a failed substitution exits before the
+            # pinned fallback on the next line can be reached.
+            GOVER="$(curl -fsSL https://go.dev/VERSION?m=text 2>/dev/null | head -1 | sed 's/^go//' || true)"
+            [ -n "$GOVER" ] || GOVER=1.26.3
+            retry "curl -fsSL 'https://go.dev/dl/go${GOVER}.linux-amd64.tar.gz' | sudo tar -C /usr/local -xz"
+          fi
+          # $GITHUB_PATH only affects LATER steps, so `go` is still not on PATH
+          # inside THIS one. The `go install`s below need it here and now.
+          export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH"
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
+          echo "$HOME/go/bin" >> "$GITHUB_PATH"
+          # crane: image-artifacts.sh and `c8s allowlist render` shell out to
+          # it. Pinned rather than fetched through the GitHub releases API,
+          # which rate-limits by IP on a shared self-hosted host.
+          command -v crane >/dev/null || retry 'go install github.com/google/go-containerregistry/cmd/crane@v0.21.6'
+          # yq: build-bundle.sh merges the static overlay into the values
+          # `c8s render-values` emits.
+          command -v yq >/dev/null || retry 'go install github.com/mikefarah/yq/v4@v4.47.1'
+          # helm: c8s install and `c8s allowlist render` shell out to it.
+          if ! command -v helm >/dev/null; then
+            retry 'curl -fsSL https://get.helm.sh/helm-v3.19.0-linux-amd64.tar.gz | tar -xz -C "$PWD/bin" --strip-components=1 linux-amd64/helm'
+          fi
+          # An ISO9660 tool: `c8s policy-disk` writes the policydata image
+          # with the first of xorrisofs, genisoimage, mkisofs on PATH.
+          if ! command -v xorrisofs >/dev/null && ! command -v genisoimage >/dev/null && ! command -v mkisofs >/dev/null; then
+            retry 'sudo apt-get update -qq && sudo apt-get install -y -qq xorriso'
+          fi
+
+      # reap-before-provision: a killed run leaks CVMs (and their scratch
+      # PVCs). Fail SAFE: only reap on a positive "completed", or on age. An
+      # unknown status (403/404/no token) KEEPS the CVM rather than killing a
+      # live run.
+      - name: reap leaked CVMs from finished runs
+        run: |
+          set +e +o pipefail
+          NOW=$(date -u +%s)
+          for vm in $(kubectl -n "$NS" get vm -l ci.confidential.ai/managed=true -o name 2>/dev/null); do
+            rid=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/run-id}' 2>/dev/null)
+            standing=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.labels.ci\.confidential\.ai/standing}' 2>/dev/null)
+            [ "$standing" = "true" ] && { echo "keeping $vm (standing runner)"; continue; }
+            [ -z "$rid" ] && continue
+            [ "$rid" = "${{ github.run_id }}" ] && continue
+            ct=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null)
+            age=$(( NOW - $(date -u -d "$ct" +%s 2>/dev/null || echo "$NOW") ))
+            # Ask GitHub whether the owning run is actually finished, rather than
+            # waiting out the 3h age fallback while a CVM squats a finite host.
+            # ANY org repo can invoke this lane, so the owning repo is read from
+            # the annotation (a label value cannot hold the '/' in owner/repo).
+            # NOTE: this needs `actions: read`. Without it the call 403s, $st is
+            # empty, and we degrade to exactly the age-only behaviour this
+            # replaces, which is safe but slow.
+            orepo=$(kubectl -n "$NS" get "$vm" -o jsonpath='{.metadata.annotations.ci\.confidential\.ai/repo}' 2>/dev/null)
+            st=$(gh api "repos/${orepo:-${{ github.repository }}}/actions/runs/$rid" -q .status 2>/dev/null)
+            if [ "$st" = "completed" ]; then
+              echo "reaping $vm (run ${orepo:-${{ github.repository }}}#$rid completed)"
+              kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+              kubectl -n "$NS" delete pvc "${vm#virtualmachine.kubevirt.io/}-scratch" --ignore-not-found --wait=false
+            elif [ -z "$st" ] && [ "$age" -gt 10800 ]; then
+              echo "reaping $vm (status unknown, age ${age}s > 3h -> orphaned)"
+              kubectl -n "$NS" delete "$vm" --ignore-not-found --wait=false
+              kubectl -n "$NS" delete pvc "${vm#virtualmachine.kubevirt.io/}-scratch" --ignore-not-found --wait=false
+            else
+              echo "keeping $vm (run ${orepo:-${{ github.repository }}}#$rid status=${st:-unknown} age=${age}s)"
+            fi
+          done
+          exit 0
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: resolve image refs + the paired c8s ref
+        run: |
+          set -euo pipefail
+          for k in image rootPvc mrtd rtmr1 rtmr2 c8sRef; do
+            v=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath="{.data.$k}" 2>/dev/null)
+            [ -n "$v" ] || { echo "::error::$REFS_CM missing '$k'. The TDX refs CM is the single source of truth for image+measurement+paired ref (rtmr1/rtmr2 complete the image tuple the static entry pins)"; exit 1; }
+            echo "$k=$v" >> "$GITHUB_ENV"
+          done
+          # Optional: the oras tag published beside a digest-pinned image.
+          v=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.imageTag}' 2>/dev/null || true)
+          [ -z "$v" ] || echo "imageTag=$v" >> "$GITHUB_ENV"
+          # An explicit input overrides the pin, but say so loudly: the bundle
+          # names this ref's digests and the node admits nothing else.
+          if [ -n '${{ inputs.c8s_ref }}' ]; then
+            echo "::warning title=version pairing::testing c8s_ref='${{ inputs.c8s_ref }}' against an image built from '$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.c8sRef}')': the baked CDS floor entry may deny this ref's CDS"
+            echo "c8sRef=${{ inputs.c8s_ref }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: preflight, the pinned ref still matches the pinned image
+        # c8sRef and image are separate CM fields, so they can drift apart with
+        # nothing to notice. The image's own -cdi tags carry the c8s ref its
+        # components were baked from; reproducible builds mean one digest can
+        # hold SEVERAL such tags, so agreement is "c8sRef is among them".
+        # Advisory: an operator may deliberately pair a newer CLI with an
+        # older image, and only the baked floor can say whether that is denied.
+        continue-on-error: true
+        if: inputs.c8s_ref == ''
+        run: |
+          set -euo pipefail
+          repo="${image%%@*}"; repo="${repo%%:*}"
+          case "$image" in
+            *@*) want="${image#*@}" ;;
+            *)   want="$(crane digest "$image" 2>/dev/null || true)" ;;
+          esac
+          [ -n "$want" ] || { echo "could not resolve '$image' to a digest; skipping"; exit 0; }
+          matched=0; tagged=""
+          for t in $(crane ls "$repo" 2>/dev/null | grep -E '^rke2-tdx-cdi-[0-9a-f]{7,}$'); do
+            [ "$(crane digest "$repo:$t" 2>/dev/null)" = "$want" ] || continue
+            r="${t#rke2-tdx-cdi-}"
+            tagged="${tagged:+$tagged }$r"
+            [ "$r" = "$c8sRef" ] && matched=1
+          done
+          [ -n "$tagged" ] || { echo "no sha-suffixed tag points at the pinned image; nothing to compare"; exit 0; }
+          [ "$matched" = 1 ] && { echo "c8sRef '$c8sRef' matches the pinned image's build ref"; exit 0; }
+          echo "::warning title=stale c8sRef::the CM pins c8sRef='$c8sRef' but its image was built from [$tagged]. The CLI under test is not the one shipped in this image; re-seed c8sRef unless the pairing is deliberate"
+
+      - name: preflight, TDX device capacity
+        # KubeVirt's socket device-plugin probes the QGS socket ONLY at
+        # virt-handler startup and never re-checks; after a host reboot it
+        # advertises 0 forever. The remedy needs cluster-scoped rights the
+        # bm-e2e SA deliberately lacks, so this reports rather than fixes.
+        # This lane runs the static and the dynamic CVM side by side at the
+        # end, so it needs two devices, not one.
+        run: |
+          set -uo pipefail
+          if kubectl auth can-i get nodes >/dev/null 2>&1; then
+            N=$(kubectl get node -l kubevirt.io/tdx=true -o jsonpath='{.items[0].status.allocatable.devices\.kubevirt\.io/tdx}' 2>/dev/null)
+            echo "devices.kubevirt.io/tdx = ${N:-unknown}"
+            if [ "${N:-0}" = "0" ]; then
+              echo "::error title=TDX devices exhausted::virt-handler is advertising 0 TDX devices. Fix on the host: kubectl -n kubevirt rollout restart daemonset/virt-handler"
+              exit 1
+            fi
+            if [ "${N:-0}" -lt 2 ]; then
+              echo "::warning title=TDX device capacity::only ${N} TDX device(s) allocatable; the dynamic CVM boots beside the static one and may not schedule"
+            fi
+          else
+            echo "no node read permission (expected: bm-e2e is namespace-scoped); relying on the scheduling gate below"
+          fi
+
+      - name: build the c8s CLI at the paired ref
+        run: |
+          set -euo pipefail
+          # Same exposure as the tools step: this clone and the module fetches
+          # behind `go install` cross the public internet under `set -e`.
+          . "$GITHUB_WORKSPACE/bin/retry.sh"
+          retry 'rm -rf /tmp/c8s-src && git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src'
+          git -C /tmp/c8s-src checkout -q "$c8sRef" || { echo "::error::bad c8s ref '$c8sRef': refusing to silently test main"; exit 1; }
+          echo "c8s ref sha: $(git -C /tmp/c8s-src rev-parse HEAD)"
+          retry '( cd /tmp/c8s-src && go install ./cmd/c8s )'
+          c8s --version || true
+          [ -x "$E2E/build-bundle.sh" ] || { echo "::error::c8s ref '$c8sRef' carries no test/e2e/static/: the static lane needs a ref with the static allowlist"; exit 1; }
+
+      - name: resolve the image's manifest and system floor
+        # Both come from the oras artifact published beside the CDI image,
+        # matched on the whole mrtd+rtmr1+rtmr2 tuple; a hand-built stub would
+        # only prove the gate accepts the shape this step chose.
+        run: |
+          set -euo pipefail
+          mkdir -p "$OUT"
+          E2E_OUT="$OUT" bash "$E2E/image-artifacts.sh"
+
+      - name: build the policy bundle
+        # Rendered from the values `c8s install` computes at the paired ref,
+        # the image's floor and the sample workload; completed by
+        # test/e2e/static/reviews.json; proven to be the fixed point of
+        # `c8s render-values --static-allowlist`; written as the ISO, the
+        # KubeVirt Secret and the expected RTMR[3]. The tampered copy differs
+        # by one trailing newline: identical JSON, another measurement.
+        run: |
+          set -euo pipefail
+          export E2E_IMAGE_MANIFEST="$OUT/image-manifest.json"
+          export E2E_SYSTEM_FLOOR="$OUT/system-floor.json"
+          export E2E_IMAGE_TAG="$c8sRef"
+          export E2E_OUT="$OUT"
+          export E2E_POLICYDATA_SECRET="$VM_STATIC-policydata"
+          bash "$E2E/build-bundle.sh"
+          kubectl -n "$NS" apply -f "$OUT/policydata-secret.yaml"
+          { cat "$OUT/bundle/static-allowlist.json"; echo; } > "$OUT/tampered-static-allowlist.json"
+          kubectl -n "$NS" create secret generic "$VM_TAMPER-policydata" \
+            --from-file=static-allowlist.json="$OUT/tampered-static-allowlist.json" --dry-run=client -o yaml | kubectl apply -f -
+          echo "RTMR3=$(cat "$OUT/rtmr3")" >> "$GITHUB_ENV"
+          echo "INDEX_DIGEST=$(cat "$OUT/index-digest")" >> "$GITHUB_ENV"
+
+      - name: tampered bundle, the node powers itself off
+        # c8s-policy-measure lints the member as sealed before it measures
+        # anything; bytes that are not the canonical form fail the unit and
+        # FailureAction=poweroff-force stops the guest before RKE2 starts.
+        run: |
+          set -euo pipefail
+          export CVM_POLICYDATA_SECRET="$VM_TAMPER-policydata" CVM_RUN_STRATEGY=RerunOnFailure
+          bash "$E2E/cvm.sh" create "$VM_TAMPER"
+          bash "$E2E/cvm.sh" wait-stopped "$VM_TAMPER" 600
+          kubectl -n "$NS" delete vm "$VM_TAMPER" --ignore-not-found --wait=true --timeout=120s
+          kubectl -n "$NS" delete pvc "$VM_TAMPER-scratch" --ignore-not-found --wait=false
+
+      - name: boot the static CVM
+        run: |
+          set -euo pipefail
+          export CVM_POLICYDATA_SECRET="$VM_STATIC-policydata"
+          bash "$E2E/cvm.sh" create "$VM_STATIC"
+          IP=$(bash "$E2E/cvm.sh" wait-running "$VM_STATIC")
+          echo "STATIC_IP=$IP" >> "$GITHUB_ENV"
+          bash "$E2E/cvm.sh" assert-tdx "$VM_STATIC"
+
+      - name: wait for the static guest's services
+        run: |
+          set -euo pipefail
+          bash "$E2E/cvm.sh" wait-services "$STATIC_IP"
+
+      - name: get an attested kubeconfig from the static node (RA-TLS, static gate)
+        # No operator key exists: the gate pins the image tuple plus RTMR[3]
+        # recomputed from the bundle, and cred-release serves any attested
+        # caller in static mode.
+        run: |
+          set -euo pipefail
+          c8s get-kubeconfig --node "$STATIC_IP" --static-allowlist "$OUT/bundle" \
+            --image-manifest "$OUT/image-manifest.json" --out /tmp/guest.kubeconfig --timeout 180s
+          [ -s /tmp/guest.kubeconfig ] || { echo "::error::no kubeconfig returned"; exit 1; }
+          WHO=$(KUBECONFIG=/tmp/guest.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+          [ "$WHO" = operator ] || { echo "::error::unexpected identity '$WHO'"; exit 1; }
+          echo "OK: attested kubeconfig from the static node, identity=$WHO"
+          KUBECONFIG=/tmp/guest.kubeconfig kubectl get nodes -o wide
+
+      - name: assert the host cidata disk is inert
+        run: .github/scripts/cidata-tripwire.sh
+
+      - name: install c8s with the static allowlist
+        # Every component digest and the CDS measurements entry come from the
+        # bundle; the node preflight attests RTMR[3] through the node's
+        # attestation-api at the masquerade address (see the header).
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          c8s install --cvm-mode node --single-node --hardware-platform tdx \
+            --static-allowlist "$OUT/bundle" \
+            --image-manifest "$OUT/image-manifest.json" \
+            --static-node-attest "c8s-node=$STATIC_IP:8400"
+          kubectl -n c8s-system get pods -o wide
+
+      - name: assert components converged (static)
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          bash /tmp/c8s-src/test/e2e/components-ready.sh
+
+      - name: assert the sealed rules around the sample workload
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          bash "$E2E/workload.sh"
+
+      - name: assert kubectl exec and kubectl debug are refused
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          bash "$E2E/debug-refused.sh"
+
+      - name: assert a privileged copy of cilium is refused at start
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/guest.kubeconfig
+          bash "$E2E/privileged-copy-denied.sh"
+
+      - name: assert c8s verify --static-allowlist verifies the front door
+        run: |
+          set -euo pipefail
+          export E2E_LB_URL="https://$STATIC_IP:443"
+          export E2E_IMAGE_MANIFEST="$OUT/image-manifest.json"
+          export E2E_BUNDLE="$OUT/bundle"
+          export E2E_OUT="$OUT/verify-static"
+          bash "$E2E/verify.sh"
+
+      - name: per-run operator key + opkeydata secret (dynamic node)
+        # The initrd hashes the file named `pubkey` off the opkeydata disk into
+        # RTMR[3]; the node then extends the dynamic mode event on top.
+        run: |
+          set -euo pipefail
+          umask 077
+          openssl ecparam -name prime256v1 -genkey -noout -out /tmp/op.key
+          openssl ec -in /tmp/op.key -pubout -out /tmp/op.pub 2>/dev/null
+          kubectl -n "$NS" create secret generic "$VM_DYN-opkey" \
+            --from-file=pubkey=/tmp/op.pub --dry-run=client -o yaml | kubectl apply -f -
+          echo "operator key bound (sha384 $(sha384sum < /tmp/op.pub | cut -c1-16)...)"
+
+      - name: boot the dynamic CVM
+        run: |
+          set -euo pipefail
+          export CVM_OPKEY_SECRET="$VM_DYN-opkey"
+          bash "$E2E/cvm.sh" create "$VM_DYN"
+          IP=$(bash "$E2E/cvm.sh" wait-running "$VM_DYN")
+          echo "DYN_IP=$IP" >> "$GITHUB_ENV"
+          bash "$E2E/cvm.sh" assert-tdx "$VM_DYN"
+
+      - name: wait for the dynamic guest's services
+        run: |
+          set -euo pipefail
+          bash "$E2E/cvm.sh" wait-services "$DYN_IP"
+
+      - name: get an attested kubeconfig from the dynamic node; the static gate refuses it
+        run: |
+          set -euo pipefail
+          c8s get-kubeconfig --node "$DYN_IP" --operator-key /tmp/op.key \
+            --image-manifest "$OUT/image-manifest.json" --out /tmp/dyn.kubeconfig --timeout 180s
+          WHO=$(KUBECONFIG=/tmp/dyn.kubeconfig kubectl auth whoami -o jsonpath='{.status.userInfo.username}')
+          [ "$WHO" = operator ] || { echo "::error::unexpected identity '$WHO'"; exit 1; }
+          echo "OK: operator-key-bound kubeconfig from the dynamic node (dynamic chain intact after the mode event)"
+          if out=$(c8s get-kubeconfig --node "$DYN_IP" --static-allowlist "$OUT/bundle" \
+              --image-manifest "$OUT/image-manifest.json" --out /tmp/never.kubeconfig --timeout 60s 2>&1); then
+            echo "::error title=SECURITY REGRESSION::the static gate released a credential from a dynamic node"; exit 1
+          fi
+          grep -q 'RTMR\[3\] mismatch' <<<"$out" || { echo "::error::the static gate refused the dynamic node, but not on RTMR[3]: $out"; exit 1; }
+          echo "OK: the static gate refuses the dynamic node on RTMR[3]"
+
+      - name: install c8s on the dynamic node (operator key, as tdx-metal-e2e.yml)
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/dyn.kubeconfig
+          c8s install --cvm-mode node --single-node --hardware-platform tdx \
+            --image-tag "$c8sRef" \
+            --operator-keys /tmp/op.pub \
+            --measurements "$mrtd" \
+            --resolve-digests=true
+          bash /tmp/c8s-src/test/e2e/components-ready.sh
+
+      - name: forge the static events on the dynamic node; the static verifier still refuses it
+        run: |
+          set -euo pipefail
+          export KUBECONFIG=/tmp/dyn.kubeconfig
+          export E2E_LB_URL="https://$DYN_IP:443"
+          export E2E_IMAGE_MANIFEST="$OUT/image-manifest.json"
+          export E2E_BUNDLE="$OUT/bundle"
+          export E2E_OPERATOR_PUB=/tmp/op.pub
+          export E2E_OUT="$OUT/verify-dyn"
+          bash "$E2E/forge-rtmr3.sh"
+          if c8s get-kubeconfig --node "$DYN_IP" --static-allowlist "$OUT/bundle" \
+              --image-manifest "$OUT/image-manifest.json" --out /tmp/never.kubeconfig --timeout 60s; then
+            echo "::error title=SECURITY REGRESSION::the static gate released a credential from a dynamic node carrying the forged register"; exit 1
+          fi
+          echo "OK: the static gate still refuses the dynamic node after the forge"
+
+      - name: summary
+        if: always()
+        run: |
+          {
+            echo "### c8s static allowlist on TDX metal"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| image | \`${image:-?}\` |"
+            echo "| rootPvc | \`${rootPvc:-?}\` |"
+            echo "| c8s ref | \`${c8sRef:-?}\` |"
+            echo "| MRTD | \`${mrtd:0:32}...\` |"
+            echo "| bundle index | \`${INDEX_DIGEST:-?}\` |"
+            echo "| static RTMR[3] | \`${RTMR3:0:32}...\` |"
+            echo "| static guest | \`${STATIC_IP:-?}\` |"
+            echo "| dynamic guest | \`${DYN_IP:-?}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: teardown
+        if: always() && inputs.keep_cvm != true
+        run: |
+          set +e
+          for vm in "$VM_TAMPER" "$VM_STATIC" "$VM_DYN"; do
+            kubectl -n "$NS" delete vm "$vm" --ignore-not-found --wait=true --timeout=120s
+            kubectl -n "$NS" delete secret "$vm-cloudinit" "$vm-opkey" "$vm-policydata" --ignore-not-found
+            kubectl -n "$NS" delete pvc "$vm-scratch" --ignore-not-found --wait=false
+          done
+          exit 0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: build install build-c8s build-c8s-node build-get-cert build-ratls-mesh \
        build-nri-image-policy build-policy-monitor build-rtmr3-measurer build-volumed \
-       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-gpu-cc test-node-guest-image-scratch test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload mutation-check mutation-full vet fmt lint clean \
+       test test-integration test-integration-cluster test-node-guest-image-role test-node-guest-image-gpu-label test-node-guest-image-gpu-cc test-node-guest-image-scratch test-node-guest-image-role-systemd test-node-guest-image-cloud-init test-e2e-cw-label-policy test-e2e-mesh-cw-enforcement test-e2e-allowlist-enforcement test-e2e-components-ready test-e2e-cw-workload \
+       test-e2e-static-build-bundle test-e2e-static-workload test-e2e-static-debug-refused test-e2e-static-privileged-copy-denied test-e2e-static-verify test-e2e-static-forge-rtmr3 mutation-check mutation-full vet fmt lint clean \
        manifests generate check-crd-chart install-controller-gen require-controller-gen \
        policy-test print-opa-version
 
@@ -205,6 +206,50 @@ test-e2e-components-ready:
 # C8S_ALLOWLIST_URL and C8S_MEASUREMENTS. Runs post-merge in both metal lanes.
 test-e2e-cw-workload:
 	./test/e2e/cw-workload.sh
+
+# Builds the policy bundle a static-allowlist node boots with and proves it
+# is the fixed point of `c8s render-values --static-allowlist`. Needs c8s,
+# helm, crane, jq, yq, go and an ISO9660 tool, plus E2E_IMAGE_MANIFEST,
+# E2E_SYSTEM_FLOOR, E2E_IMAGE_TAG and E2E_OUT. Runs post-merge in the
+# tdx-metal-static-e2e lane.
+test-e2e-static-build-bundle:
+	./test/e2e/static/build-bundle.sh
+
+# Live-cluster check that the sealed rules admit the sample workload and
+# refuse its ConfigMap-mount, unlisted-env and other-argv variants. Needs
+# kubectl pointed at a static-allowlist cluster. Runs post-merge in the
+# tdx-metal-static-e2e lane.
+test-e2e-static-workload:
+	./test/e2e/static/workload.sh
+
+# Live-cluster check that kubectl exec and kubectl debug are refused on a
+# sealed node. Needs kubectl pointed at a static-allowlist cluster running
+# demo-nginx (test-e2e-static-workload). Runs post-merge in the
+# tdx-metal-static-e2e lane.
+test-e2e-static-debug-refused:
+	./test/e2e/static/debug-refused.sh
+
+# Live-cluster check that a privileged copy of cilium is refused on a sealed
+# node. Needs kubectl pointed at a static-allowlist cluster. Runs post-merge
+# in the tdx-metal-static-e2e lane.
+test-e2e-static-privileged-copy-denied:
+	./test/e2e/static/privileged-copy-denied.sh
+
+# Verifies a static cluster's front door from outside with
+# `c8s verify --static-allowlist`. Needs c8s, curl and jq, plus E2E_LB_URL,
+# E2E_IMAGE_MANIFEST and E2E_BUNDLE. Runs post-merge in the
+# tdx-metal-static-e2e lane.
+test-e2e-static-verify:
+	./test/e2e/static/verify.sh
+
+# Live check that a dynamic node cannot forge the static register: a
+# privileged pod extends RTMR[3] with the static events and the static
+# verifier still refuses the node. Needs kubectl pointed at a dynamic
+# node-mode TDX cluster with c8s installed, plus E2E_LB_URL,
+# E2E_IMAGE_MANIFEST, E2E_BUNDLE and E2E_OPERATOR_PUB. Runs post-merge in the
+# tdx-metal-static-e2e lane.
+test-e2e-static-forge-rtmr3:
+	./test/e2e/static/forge-rtmr3.sh
 
 # Parse + decision tests for the baked kata-agent policy. The guest evaluates
 # it with regorus, which reads Rego v0 plus the future keywords, so the checks

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
 - [c8s-verify](https://github.com/confidential-dot-ai/c8s-verify-js), verify a c8s cluster from a browser
 - [attestation-rs](https://github.com/confidential-dot-ai/attestation-rs), the TEE evidence verification service c8s uses
 - [RA-TLS](docs/ratls.md), how attested TLS works in c8s — the handshake step by step, the guarantees, and which certificate is used where
+- [Static allowlist](docs/static-allowlist.md), sealing a TDX node-as-CVM cluster to one reviewed policy bundle measured into RTMR[3]
 
 ## Features
 
@@ -300,6 +301,13 @@ See [docs/kata.md](docs/kata.md) for the runtime details and
   downstream consumers onto a new root of trust. See
   [Managing the allowlist](#managing-the-image-allowlist).
 
+- **Or seal the cluster to a reviewed bundle.** On TDX node-as-CVM,
+  `c8s install --static-allowlist <bundle> --image-manifest manifest.json`
+  installs onto nodes that measured a policy bundle into RTMR[3]. There are
+  no operator keys and no allowlist writes; the node admits only the pods the
+  bundle describes, and a relying party verifies that from one quote. See
+  [docs/static-allowlist.md](docs/static-allowlist.md).
+
 ### A note on QEMU
 
 - **Pod-as-CVM needs no host QEMU.** kata-deploy ships the kata-static
@@ -328,7 +336,10 @@ cannot forge it. The wire contract is
 [PROTOCOL.md](https://github.com/confidential-dot-ai/c8s-verify-js/blob/main/PROTOCOL.md).
 
 Operators and CLIs can verify directly: `c8s cds verify` checks a CDS's
-attestation and reports the operator keys it pins.
+attestation and reports the operator keys it pins. On a static cluster,
+`c8s verify --static-allowlist <bundle> --image-manifest manifest.json`
+recomputes RTMR[3] from the reviewed bundle and checks that the node runs
+only that bundle ([docs/static-allowlist.md](docs/static-allowlist.md)).
 
 ## Components
 
@@ -338,7 +349,8 @@ attestation and reports the operator keys it pins.
 | [`cmd/c8s`](cmd/c8s/) | Operator and install CLI for CRDs, status mirroring, webhook injection, and the embedded Helm chart | [operator docs](docs/operator.md) |
 | [`cmd/get-cert`](cmd/get-cert/) | CLI tool and init-container for TEE-attested certificate provisioning | [README](cmd/get-cert/README.md) |
 | [`cmd/ratls-mesh`](cmd/ratls-mesh/) | Transparent L4 proxy wrapping inter-node K8s traffic in RA-TLS | [README](cmd/ratls-mesh/README.md) |
-| [`cmd/nri-image-policy`](cmd/nri-image-policy/) | NRI plugin enforcing the image and argv allowlist on the host; also the node's admission inventory | [allowlist](docs/allowlist-and-capabilities.md) |
+| [`cmd/nri-image-policy`](cmd/nri-image-policy/) | NRI plugin enforcing the image and argv allowlist on the host, or the whole sealed rule on a static-allowlist node; also the node's admission inventory | [allowlist](docs/allowlist-and-capabilities.md), [static allowlist](docs/static-allowlist.md) |
+| `c8s policy-measure`, `c8s policy-disk` | Node-side measurer that commits the boot's policy mode and bundle to RTMR[3] (`internal/cmds/policymeasure`), and the CLI that builds the `policydata` disk (`internal/cmds/policydisk`) | [static allowlist](docs/static-allowlist.md) |
 | [`cmd/policy-monitor`](cmd/policy-monitor/) | The same enforcement and inventory in-guest, baked into the pod-as-CVM image | [image policy](docs/kata-image-policy.md) |
 | [`cmd/volumed`](cmd/volumed/) | Encrypted-volume agent — opens volumes into a pod's mount namespace, as a node DaemonSet or in-guest (`--guest`) under pod-as-CVM | [volumes](docs/volumes.md) |
 
@@ -351,7 +363,8 @@ attestation and reports the operator keys it pins.
 | [`pkg/attestclient`](pkg/attestclient/) | High-level client for the CDS attestation flow |
 | [`pkg/attestationclient`](pkg/attestationclient/) | Low-level HTTP client for the attestation-api |
 | [`pkg/allowlistclient`](pkg/allowlistclient/) | CRUD client for the CDS allowlist API |
-| [`pkg/allowlist`](pkg/allowlist/) | Allowlist types, argv policy, and secret grants |
+| [`pkg/allowlist`](pkg/allowlist/) | Allowlist types, argv policy, secret grants, and the sealed schema (`Index.Admit`, `LintSealed`) |
+| [`pkg/policybundle`](pkg/policybundle/) | Policy bundle loading, its measured index, and the on-node policy state |
 | [`pkg/workloadclaims`](pkg/workloadclaims/) | Sandbox-token fetch and the admission-inventory socket contract |
 | [`pkg/overenc`](pkg/overenc/) | Post-quantum over-encryption channel and its identity transcript |
 | [`pkg/operatorauth`](pkg/operatorauth/) | Operator-key signing and verification for allowlist and secret writes |
@@ -359,7 +372,7 @@ attestation and reports the operator keys it pins.
 | [`pkg/issuerapi`](pkg/issuerapi/) | Certificate issuer API types |
 | [`pkg/earsigner`](pkg/earsigner/) | EAR token-signing key lifecycle, rotation, and JWKS serving |
 | [`pkg/jwks`](pkg/jwks/) | JWKS parsing and key selection |
-| [`pkg/runtimemeasure`](pkg/runtimemeasure/) | TDX image-pin manifests and RTMR[3] measurement replay |
+| [`pkg/runtimemeasure`](pkg/runtimemeasure/) | TDX image-pin manifests, RTMR[3] mode events, and static-policy and workload measurement replay |
 | [`pkg/certutil`](pkg/certutil/) | Certificate utility functions |
 
 ## Repository layout
@@ -371,7 +384,8 @@ cmd/               Binaries: c8s, get-cert, ratls-mesh, nri-image-policy,
                    the Dockerfile for the `c8s cds` subcommand,
                    internal/cmds/cds)
 internal/          Operator, webhook, attestation, mesh CA, secret store,
-                   embedded Helm chart
+                   embedded Helm chart, and the c8s subcommands
+                   (internal/cmds: cds, policymeasure, policydisk, ...)
 pkg/               Public Go libraries (see Libraries above)
 kata-guest-base/   Confidential guest image recipe for pod-as-CVM
 node-guest-image/  The node-image definition for node-as-CVM (new home;
@@ -503,6 +517,18 @@ GitOps consumers, `c8s render-values --operator-keys operator.pub` embeds the
 PEM content (the chart value takes content, never a file path); the chart
 wiring is described in [docs/operator.md](docs/operator.md).
 
+### Static allowlist
+
+A static cluster has no operator key and no write path. The nodes boot a
+reviewed policy bundle (`policydata` disk) and measure it into RTMR[3]; the
+node image's sealed NRI plugin admits only the containers the bundle
+describes, and CDS serves the bundle and nothing else. Render the sealed
+document with `c8s allowlist render --sealed`, check it with `c8s allowlist
+lint --sealed`, build the disk with `c8s policy-disk`, and install with
+`c8s install --static-allowlist <bundle> --image-manifest manifest.json`. A
+policy change is a new bundle and a relaunch. See
+[docs/static-allowlist.md](docs/static-allowlist.md).
+
 ## Docker images
 
 All images are published to GHCR on pushes to `main`. Release-worthy merges also
@@ -559,13 +585,17 @@ than let you discover them:
   can bind the node's privileged inventory port can vouch for a sandbox it
   does not run.
 
-- **The image allowlist gates digest and command line, not the rest of the
-  pod spec.** Each container's `command` prefix and `args` remainder are
-  enforced against the effective argv, and bind-mount destinations and env
-  variable names are enforceable in the guest; capabilities and the
+- **The dynamic image allowlist gates digest and command line, not the rest
+  of the pod spec.** Each container's `command` prefix and `args` remainder
+  are enforced against the effective argv, and bind-mount destinations and
+  env variable names are enforceable in the guest; capabilities and the
   remaining pod-spec fields are not. Nothing enforces which images run
   *together* — every running image must be allowlisted, but no gate requires
-  the set in one pod to match a single workload entry.
+  the set in one pod to match a single workload entry. A static allowlist
+  closes the pod-spec half on TDX node-as-CVM: the sealed plugin matches env
+  values, mount sources, privileges, host namespaces, devices, and hooks
+  against a complete rule ([docs/static-allowlist.md](docs/static-allowlist.md));
+  its own open items are listed there.
 
 - **Secrets and encrypted volumes under pod-as-CVM carry weaker guarantees
   than on a node.** Both work — the injected fetchers redeem their sandbox

--- a/cmd/c8s/exec_fake_test.go
+++ b/cmd/c8s/exec_fake_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -103,6 +104,7 @@ func resetCLIState(t *testing.T) {
 		installHardwarePlatform, installImagePullSecret, installImageTag             string
 		installOperatorKeys, installUpstream, renderValuesDistro                     string
 		installStaticAllowlist, installImageManifest, installMeasurementsConfig      string
+		installStaticNodeAttest                                                      map[string]string
 		uninstallNamespace, uninstallRelease                                         string
 		installValues, installWorkloadRefs, installMeasurements                      []string
 		installInventoryCIDRs, installRTMRs                                          []string
@@ -117,6 +119,7 @@ func resetCLIState(t *testing.T) {
 		installHardwarePlatform, installImagePullSecret, installImageTag,
 		installOperatorKeys, installUpstream, renderValuesDistro,
 		installStaticAllowlist, installImageManifest, installMeasurementsConfig,
+		maps.Clone(installStaticNodeAttest),
 		uninstallNamespace, uninstallRelease,
 		slices.Clone(installValues), slices.Clone(installWorkloadRefs), slices.Clone(installMeasurements),
 		slices.Clone(installInventoryCIDRs), slices.Clone(installRTMRs),
@@ -132,6 +135,7 @@ func resetCLIState(t *testing.T) {
 		installHardwarePlatform, installImagePullSecret, installImageTag = saved.installHardwarePlatform, saved.installImagePullSecret, saved.installImageTag
 		installOperatorKeys, installUpstream, renderValuesDistro = saved.installOperatorKeys, saved.installUpstream, saved.renderValuesDistro
 		installStaticAllowlist, installImageManifest, installMeasurementsConfig = saved.installStaticAllowlist, saved.installImageManifest, saved.installMeasurementsConfig
+		installStaticNodeAttest = saved.installStaticNodeAttest
 		installRTMRs = saved.installRTMRs
 		uninstallNamespace, uninstallRelease = saved.uninstallNamespace, saved.uninstallRelease
 		installValues, installWorkloadRefs, installMeasurements = saved.installValues, saved.installWorkloadRefs, saved.installMeasurements
@@ -155,7 +159,7 @@ func resetCLIState(t *testing.T) {
 	installVolumes = false
 	installOperatorKeys, installForce = "", false
 	installStaticAllowlist, installImageManifest, installMeasurementsConfig = "", "", ""
-	installRTMRs = nil
+	installStaticNodeAttest, installRTMRs = nil, nil
 	cleanupStaticInstall()
 	installUpstream, installWorkloadRefs = "", nil
 	installResolveDigests, installAttestEnabled, installMeasurements = true, true, nil

--- a/cmd/c8s/exec_fake_test.go
+++ b/cmd/c8s/exec_fake_test.go
@@ -102,9 +102,10 @@ func resetCLIState(t *testing.T) {
 		installNamespace, installRelease, installCertKeyMode, installCvmMode         string
 		installHardwarePlatform, installImagePullSecret, installImageTag             string
 		installOperatorKeys, installUpstream, renderValuesDistro                     string
+		installStaticAllowlist, installImageManifest, installMeasurementsConfig      string
 		uninstallNamespace, uninstallRelease                                         string
 		installValues, installWorkloadRefs, installMeasurements                      []string
-		installInventoryCIDRs                                                        []string
+		installInventoryCIDRs, installRTMRs                                          []string
 		installWait, installCRDs, installGetCertRunAsNonRoot, installKataDebug       bool
 		installSingleNode, installForce, installResolveDigests, installAttestEnabled bool
 		uninstallWait, uninstallKataSweep, uninstallHostSweepOnly, uninstallForce    bool
@@ -115,9 +116,10 @@ func resetCLIState(t *testing.T) {
 		installNamespace, installRelease, installCertKeyMode, installCvmMode,
 		installHardwarePlatform, installImagePullSecret, installImageTag,
 		installOperatorKeys, installUpstream, renderValuesDistro,
+		installStaticAllowlist, installImageManifest, installMeasurementsConfig,
 		uninstallNamespace, uninstallRelease,
 		slices.Clone(installValues), slices.Clone(installWorkloadRefs), slices.Clone(installMeasurements),
-		slices.Clone(installInventoryCIDRs),
+		slices.Clone(installInventoryCIDRs), slices.Clone(installRTMRs),
 		installWait, installCRDs, installGetCertRunAsNonRoot, installKataDebug,
 		installSingleNode, installForce, installResolveDigests, installAttestEnabled,
 		uninstallWait, uninstallKataSweep, uninstallHostSweepOnly, uninstallForce,
@@ -129,6 +131,8 @@ func resetCLIState(t *testing.T) {
 		installNamespace, installRelease, installCertKeyMode, installCvmMode = saved.installNamespace, saved.installRelease, saved.installCertKeyMode, saved.installCvmMode
 		installHardwarePlatform, installImagePullSecret, installImageTag = saved.installHardwarePlatform, saved.installImagePullSecret, saved.installImageTag
 		installOperatorKeys, installUpstream, renderValuesDistro = saved.installOperatorKeys, saved.installUpstream, saved.renderValuesDistro
+		installStaticAllowlist, installImageManifest, installMeasurementsConfig = saved.installStaticAllowlist, saved.installImageManifest, saved.installMeasurementsConfig
+		installRTMRs = saved.installRTMRs
 		uninstallNamespace, uninstallRelease = saved.uninstallNamespace, saved.uninstallRelease
 		installValues, installWorkloadRefs, installMeasurements = saved.installValues, saved.installWorkloadRefs, saved.installMeasurements
 		installInventoryCIDRs = saved.installInventoryCIDRs
@@ -150,6 +154,9 @@ func resetCLIState(t *testing.T) {
 	installSingleNode, installImagePullSecret, installImageTag = false, "", ""
 	installVolumes = false
 	installOperatorKeys, installForce = "", false
+	installStaticAllowlist, installImageManifest, installMeasurementsConfig = "", "", ""
+	installRTMRs = nil
+	cleanupStaticInstall()
 	installUpstream, installWorkloadRefs = "", nil
 	installResolveDigests, installAttestEnabled, installMeasurements = true, true, nil
 	uninstallNamespace, uninstallRelease = "c8s-system", "c8s"

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -1101,8 +1101,19 @@ resolves adopted workload images into nriImagePolicy.bootstrapAllowlist.digests
 so image admission (the host NRI plugin, or the in-guest policy-monitor under
 --cvm-mode=pod) allows those rollouts.
 
+--static-allowlist <bundle> installs onto nodes that booted a policy bundle
+(docs/static-allowlist.md): a directory of members, or the static-allowlist.json
+alone. Requires --image-manifest, --cvm-mode=node and --hardware-platform=tdx.
+The bundle is linted as sealed, every node is attested through its
+attestation-api and must report RTMR[3] = the bundle's static register, and every
+running container must carry a digest the bundle names. Component digests and
+the CDS measurements entry (MRTD, RTMR[1], RTMR[2], RTMR[3]) come from the
+bundle and the manifest, so --operator-keys, --resolve-digests, --measurements,
+--measurements-config and --rtmrs are refused. Sets staticAllowlist.enabled,
+nriImagePolicy.enabled=false and cds.persistence.enabled=false.
+
 Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
---resolve-digests=false.`,
+--resolve-digests=false or --static-allowlist is given.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateCvmMode(installCvmMode); err != nil {
 			return err
@@ -1113,6 +1124,10 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		if err := validateDebugFlag(installCvmMode, installKataDebug); err != nil {
 			return err
 		}
+		if err := staticInstallPreflight(cmd); err != nil {
+			return err
+		}
+		defer cleanupStaticInstall()
 		// Substitute any "-f -" before anything reads installValues, so the
 		// preflights and helm all see the piped values at a real path.
 		substituted, stdinCleanup, err := materializeStdinValues(installValues, cmd.InOrStdin())
@@ -1131,17 +1146,21 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		if _, err := upstreamAddress(installUpstream, adoptions); err != nil {
 			return err
 		}
-		if warn, err := operatorKeysPreflight(installOperatorKeys, installValues, installForce); err != nil {
-			return err
-		} else if warn != "" {
-			fmt.Fprintln(os.Stderr, "warning: "+warn)
+		// A static install has no operator keys by design and pins every
+		// register from the bundle, so neither guard applies to it.
+		if staticState == nil {
+			if warn, err := operatorKeysPreflight(installOperatorKeys, installValues, installForce); err != nil {
+				return err
+			} else if warn != "" {
+				fmt.Fprintln(os.Stderr, "warning: "+warn)
+			}
+			if warn, err := tdxRTMRPinWarning(installHardwarePlatform, installRTMRs, installValues); err != nil {
+				return err
+			} else if warn != "" {
+				fmt.Fprintln(os.Stderr, "warning: "+warn)
+			}
 		}
 		if warn, err := podModeMeasurementsPreflight(installCvmMode, installPinnedMeasurementArgs(), installValues, installForce); err != nil {
-			return err
-		} else if warn != "" {
-			fmt.Fprintln(os.Stderr, "warning: "+warn)
-		}
-		if warn, err := tdxRTMRPinWarning(installHardwarePlatform, installRTMRs, installValues); err != nil {
 			return err
 		} else if warn != "" {
 			fmt.Fprintln(os.Stderr, "warning: "+warn)
@@ -1261,7 +1280,7 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 		// Digest resolution off + default values: verify at least the
 		// operator image exists (see preflightOperatorImage); a -f owner may
 		// pin different repositories or digests.
-		if !installResolveDigests && len(installValues) == 0 {
+		if !installResolveDigests && len(installValues) == 0 && staticState == nil {
 			if err := preflightOperatorImage(cmd.Context(), components, imageTag); err != nil {
 				return err
 			}
@@ -1288,6 +1307,20 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 			return err
 		} else if warn != "" {
 			fmt.Fprintln(os.Stderr, "warning: "+warn)
+		}
+
+		// Static allowlist: every node must already be sealed to the bundle,
+		// and every running container must be one the bundle names. Both are
+		// facts about the cluster, read-only, so they run with -f too.
+		if staticState != nil {
+			if err := preflightStaticNodes(cmd.Context(), os.Stdout, staticState); err != nil {
+				return err
+			}
+			if warn, err := preflightStaticImages(cmd.Context(), staticState.allowlist, installForce); err != nil {
+				return err
+			} else if warn != "" {
+				fmt.Fprintln(os.Stderr, "warning: "+warn)
+			}
 		}
 
 		// --cvm-mode=pod: label every kata-targeted node for the declared
@@ -1361,6 +1394,10 @@ Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 // the hint says how to fix it.
 func printAttestVerifyHint(w io.Writer, attestEnabled bool) {
 	if !attestEnabled {
+		return
+	}
+	if installStaticAllowlist != "" {
+		printStaticVerifyHint(w)
 		return
 	}
 	if len(installMeasurements) > 0 {
@@ -2496,6 +2533,8 @@ func init() {
 	installCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing registry-credential Secret (kubernetes.io/dockerconfigjson) in the release namespace; the chart appends it to every component's imagePullSecrets, so all pods can pull the c8s images from an authenticated registry (e.g. a private mirror) from first start. The Secret itself is never created or managed by the install — the install fails fast if it is missing or has the wrong type")
 	installCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main' for an unstamped build). Override to pin a specific branch/tag/release")
 	installCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; sets cds.operatorKeys. Without it, allowlist writes are disabled (reads still served). See the README \"Operator allowlist credentials\"")
-	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), --cvm-mode=pod without --measurements (no cw workload can start), and a fail-closed image policy that would deny the cluster's own platform pods (they do not come back after the containerd restart)")
+	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), --cvm-mode=pod without --measurements (no cw workload can start), a fail-closed image policy that would deny the cluster's own platform pods (they do not come back after the containerd restart), and a --static-allowlist bundle that does not name every running image")
+	installCmd.Flags().StringVar(&installStaticAllowlist, "static-allowlist", "", "policy bundle the nodes booted with (a directory of members, or the static-allowlist.json alone). Pins every component digest and the CDS measurements entry from it, attests every node against its RTMR[3], and sets staticAllowlist.enabled. Requires --image-manifest, --cvm-mode=node and --hardware-platform=tdx; excludes --operator-keys, --resolve-digests, --measurements, --measurements-config and --rtmrs")
+	installCmd.Flags().StringVar(&installImageManifest, "image-manifest", "", "build-artifact manifest of the node image (mrtd, rtmr1, rtmr2): the image half of the static tuple; required with --static-allowlist")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -1110,7 +1110,9 @@ running container must carry a digest the bundle names. Component digests and
 the CDS measurements entry (MRTD, RTMR[1], RTMR[2], RTMR[3]) come from the
 bundle and the manifest, so --operator-keys, --resolve-digests, --measurements,
 --measurements-config and --rtmrs are refused. Sets staticAllowlist.enabled,
-nriImagePolicy.enabled=false and cds.persistence.enabled=false.
+nriImagePolicy.enabled=false and cds.persistence.enabled=false. A node whose
+InternalIP the installer cannot reach (a NAT binding between them) is attested
+at the host:port given by --static-node-attest <node-name>=<host:port>.
 
 Requires the 'helm' and 'kubectl' CLIs to be on PATH, and 'crane' unless
 --resolve-digests=false or --static-allowlist is given.`,
@@ -2536,5 +2538,6 @@ func init() {
 	installCmd.Flags().BoolVar(&installForce, "force", false, "proceed past guarded prompts — currently: install without --operator-keys (allowlist writes disabled), --cvm-mode=pod without --measurements (no cw workload can start), a fail-closed image policy that would deny the cluster's own platform pods (they do not come back after the containerd restart), and a --static-allowlist bundle that does not name every running image")
 	installCmd.Flags().StringVar(&installStaticAllowlist, "static-allowlist", "", "policy bundle the nodes booted with (a directory of members, or the static-allowlist.json alone). Pins every component digest and the CDS measurements entry from it, attests every node against its RTMR[3], and sets staticAllowlist.enabled. Requires --image-manifest, --cvm-mode=node and --hardware-platform=tdx; excludes --operator-keys, --resolve-digests, --measurements, --measurements-config and --rtmrs")
 	installCmd.Flags().StringVar(&installImageManifest, "image-manifest", "", "build-artifact manifest of the node image (mrtd, rtmr1, rtmr2): the image half of the static tuple; required with --static-allowlist")
+	installCmd.Flags().StringToStringVar(&installStaticNodeAttest, "static-node-attest", nil, "<node-name>=<host:port> (repeatable/comma-separated) where the --static-allowlist node preflight reaches that node's attestation-api instead of InternalIP:8400, for nodes behind a NAT binding (a KubeVirt masquerade guest). Every named node must exist; requires --static-allowlist")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/c8s/install_static.go
+++ b/cmd/c8s/install_static.go
@@ -29,6 +29,10 @@ import (
 var (
 	installStaticAllowlist string
 	installImageManifest   string
+	// installStaticNodeAttest maps a node name to the host:port its
+	// attestation-api is reached at when that is not the node's InternalIP
+	// (a NAT binding between the installer and the node).
+	installStaticNodeAttest map[string]string
 )
 
 // staticInstall is what --static-allowlist resolves to, loaded once per run:
@@ -42,6 +46,8 @@ type staticInstall struct {
 	// tree take it through --set-file, so it lives on disk until the run
 	// ends.
 	measurementsFile string
+	// nodeAttest is --static-node-attest, host:port per node name, validated.
+	nodeAttest map[string]string
 }
 
 // staticState is the run's loaded --static-allowlist, nil when the flag is
@@ -62,7 +68,15 @@ const staticNodeTimeout = 30 * time.Second
 // flags that supply them by other means are refused rather than merged.
 func staticInstallPreflight(cmd *cobra.Command) error {
 	if installStaticAllowlist == "" {
+		if len(installStaticNodeAttest) > 0 {
+			return fmt.Errorf("--static-node-attest requires --static-allowlist: it only redirects the node attestation of a static install")
+		}
 		return nil
+	}
+	for name, addr := range installStaticNodeAttest {
+		if _, _, err := net.SplitHostPort(addr); err != nil {
+			return fmt.Errorf("--static-node-attest %s=%s: want <node-name>=<host:port>: %w", name, addr, err)
+		}
 	}
 	if installImageManifest == "" {
 		return fmt.Errorf("--static-allowlist requires --image-manifest: the static entry pins the image tuple (MRTD, RTMR[1], RTMR[2]) beside the bundle's RTMR[3], and the bundle alone names no image")
@@ -97,6 +111,7 @@ func staticInstallPreflight(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+	s.nodeAttest = maps.Clone(installStaticNodeAttest)
 	staticState = s
 	return nil
 }
@@ -267,31 +282,49 @@ func preflightStaticNodes(ctx context.Context, w io.Writer, s *staticInstall) er
 	if len(list.Items) == 0 {
 		return fmt.Errorf("--static-allowlist: the cluster reports no nodes to attest")
 	}
+	// An override for a node that does not exist is a typo that would
+	// silently fall back to an InternalIP; refuse before any attest.
+	unknown := maps.Clone(s.nodeAttest)
+	for _, node := range list.Items {
+		delete(unknown, node.Name)
+	}
+	if len(unknown) > 0 {
+		return fmt.Errorf("--static-node-attest names nodes the cluster does not have: %s", strings.Join(slices.Sorted(maps.Keys(unknown)), ", "))
+	}
 	rtmr3 := s.bundle.RTMR3()
 	for _, node := range list.Items {
-		ip := internalIP(node)
-		if ip == "" {
-			return fmt.Errorf("--static-allowlist: node %s reports no InternalIP address to attest through", node.Name)
+		addr, source := attestAddress(node, s.nodeAttest)
+		if addr == "" {
+			return fmt.Errorf("--static-allowlist: node %s reports no InternalIP address to attest through; pass --static-node-attest %s=<host:port>", node.Name, node.Name)
 		}
 		nodeCtx, cancel := context.WithTimeout(ctx, staticNodeTimeout)
-		err := staticNodeVerifier(nodeCtx, "http://"+net.JoinHostPort(ip, "8400")+"/attest", s.pins, rtmr3)
+		err := staticNodeVerifier(nodeCtx, "http://"+addr+"/attest", s.pins, rtmr3)
 		cancel()
 		if err != nil {
-			return fmt.Errorf("--static-allowlist: node %s (%s) is not sealed to this bundle: %w — every node must have booted the measured image with this bundle attached as its policydata disk", node.Name, ip, err)
+			return fmt.Errorf("--static-allowlist: node %s (%s) is not sealed to this bundle: %w — every node must have booted the measured image with this bundle attached as its policydata disk", node.Name, addr, err)
 		}
-		fmt.Fprintf(w, "+ node %s: static mode, RTMR[3] matches the bundle\n", node.Name)
+		fmt.Fprintf(w, "+ node %s: static mode, RTMR[3] matches the bundle (attested at %s, %s)\n", node.Name, addr, source)
 	}
 	return nil
 }
 
-// internalIP is the address the node's attestation-api listens on.
-func internalIP(node corev1.Node) string {
+// attestAddress is the host:port a node's attestation-api is reached at:
+// the --static-node-attest override when one names the node, else the
+// node's InternalIP on port 8400. source says which, for the progress line.
+// Empty when the node has neither.
+func attestAddress(node corev1.Node, overrides map[string]string) (addr, source string) {
+	if o, ok := overrides[node.Name]; ok {
+		// Validated by staticInstallPreflight; re-joined so an IPv6 host
+		// keeps its brackets.
+		host, port, _ := net.SplitHostPort(o)
+		return net.JoinHostPort(host, port), "--static-node-attest"
+	}
 	for _, a := range node.Status.Addresses {
 		if a.Type == corev1.NodeInternalIP {
-			return a.Address
+			return net.JoinHostPort(a.Address, "8400"), "InternalIP"
 		}
 	}
-	return ""
+	return "", ""
 }
 
 // preflightStaticImages fails when a container the cluster runs has a digest

--- a/cmd/c8s/install_static.go
+++ b/cmd/c8s/install_static.go
@@ -1,0 +1,364 @@
+//go:build !c8s_node
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"net"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/distribution/reference"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/getkubeconfig"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+var (
+	installStaticAllowlist string
+	installImageManifest   string
+)
+
+// staticInstall is what --static-allowlist resolves to, loaded once per run:
+// the bundle the nodes booted with, its sealed document, and the image tuple
+// the static entry pins beside the bundle's register.
+type staticInstall struct {
+	bundle    policybundle.Bundle
+	allowlist *pkgallowlist.Allowlist
+	pins      runtimemeasure.ImagePins
+	// measurementsFile holds the rendered static entry; helm and the values
+	// tree take it through --set-file, so it lives on disk until the run
+	// ends.
+	measurementsFile string
+}
+
+// staticState is the run's loaded --static-allowlist, nil when the flag is
+// unset. Shared the way the install flags are: the value builder and the
+// preflights all read it.
+var staticState *staticInstall
+
+// staticNodeVerifier attests one node and requires the static tuple. A var so
+// tests replace the network round trip.
+var staticNodeVerifier = getkubeconfig.VerifyStaticNode
+
+// staticNodeTimeout bounds each node's attest round trip.
+const staticNodeTimeout = 30 * time.Second
+
+// staticInstallPreflight validates the --static-allowlist flag set and loads
+// the bundle and manifest before anything touches a cluster or a registry.
+// Every pin and digest of a static install comes from the bundle, so the
+// flags that supply them by other means are refused rather than merged.
+func staticInstallPreflight(cmd *cobra.Command) error {
+	if installStaticAllowlist == "" {
+		return nil
+	}
+	if installImageManifest == "" {
+		return fmt.Errorf("--static-allowlist requires --image-manifest: the static entry pins the image tuple (MRTD, RTMR[1], RTMR[2]) beside the bundle's RTMR[3], and the bundle alone names no image")
+	}
+	if installCvmMode != "node" || installHardwarePlatform != "tdx" {
+		return fmt.Errorf("--static-allowlist requires --%s=node and --%s=tdx (got %q and %q): the policy bundle is measured into RTMR[3] by the node image, which only a TDX node-as-CVM has", flagCvmMode, flagHardwarePlatform, installCvmMode, installHardwarePlatform)
+	}
+	var refused []string
+	if installOperatorKeys != "" {
+		refused = append(refused, "--operator-keys")
+	}
+	if cmd.Flags().Changed("resolve-digests") && installResolveDigests {
+		refused = append(refused, "--resolve-digests=true")
+	}
+	if len(installMeasurements) > 0 {
+		refused = append(refused, "--measurements")
+	}
+	if installMeasurementsConfig != "" {
+		refused = append(refused, "--measurements-config")
+	}
+	if len(installRTMRs) > 0 {
+		refused = append(refused, "--rtmrs")
+	}
+	if len(refused) > 0 {
+		return fmt.Errorf("--static-allowlist cannot be combined with %s: the bundle supplies every component digest and the measurements entry, and a static node takes no operator writes", strings.Join(refused, ", "))
+	}
+	// Digests come from the bundle, never a registry: what the node admits is
+	// what the bundle names, and a freshly resolved tag would be denied.
+	installResolveDigests = false
+
+	s, err := loadStaticInstall(installStaticAllowlist, installImageManifest)
+	if err != nil {
+		return err
+	}
+	staticState = s
+	return nil
+}
+
+// loadStaticInstall reads the manifest and the bundle, lints the member as a
+// node would, and renders the static entry the chart carries as
+// cds.measurementsConfig.
+func loadStaticInstall(bundlePath, manifestPath string) (*staticInstall, error) {
+	pins, err := runtimemeasure.LoadImageManifest(manifestPath)
+	if err != nil {
+		return nil, fmt.Errorf("--image-manifest: %w", err)
+	}
+	bundle, err := policybundle.Load(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("--static-allowlist: %w", err)
+	}
+	member := bundle.Members[policybundle.MemberStaticAllowlist]
+	if err := pkgallowlist.LintSealed(member); err != nil {
+		return nil, fmt.Errorf("--static-allowlist %s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	al, err := pkgallowlist.ParseJSON(member)
+	if err != nil {
+		return nil, fmt.Errorf("--static-allowlist %s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	doc, err := measurements.Format(measurements.StaticReferenceValues(pins, bundle.RTMR3()))
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.CreateTemp("", "c8s-static-measurements-*.json")
+	if err != nil {
+		return nil, fmt.Errorf("write static measurements config: %w", err)
+	}
+	if _, err := f.Write(doc); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return nil, fmt.Errorf("write static measurements config: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return nil, fmt.Errorf("write static measurements config: %w", err)
+	}
+	return &staticInstall{bundle: bundle, allowlist: al, pins: pins, measurementsFile: f.Name()}, nil
+}
+
+// cleanupStaticInstall removes the run's rendered measurements file.
+func cleanupStaticInstall() {
+	if staticState == nil {
+		return
+	}
+	os.Remove(staticState.measurementsFile)
+	staticState = nil
+}
+
+// pinArgs is installPins' static arm: the whole-image consumers (CDS itself,
+// ratls-mesh, tls-lb) get the file with all four registers; the flat lists
+// carry the image tuple only. RTMR[3] cannot go into them: flat pins land in
+// container argv, that argv is in the bundle, and the register is derived
+// from the bundle, so pinning it there would make the bundle depend on its
+// own digest. The injected sidecars take no flat pins at all under a static
+// allowlist: the operator gets --static-allowlist and each sidecar pins CDS
+// to the tuple of its own quote (--cds-pins-from-own-quote), RTMR[3]
+// included.
+func (s *staticInstall) pinArgs() (digests [][]byte, rtmrs map[int][]byte, helmArgs []string) {
+	return [][]byte{slices.Clone(s.pins.MRTD[:])},
+		map[int][]byte{1: slices.Clone(s.pins.RTMR1[:]), 2: slices.Clone(s.pins.RTMR2[:])},
+		[]string{
+			"--set-file", "cds.measurementsConfig=" + s.measurementsFile,
+			"--set-file", "ratlsMesh.measurementsConfig=" + s.measurementsFile,
+		}
+}
+
+// appendStaticDigestArgs is the digestResolver of a static install: the chart
+// values that switch static mode on, and each rendered component pinned to
+// the digest the bundle names for its repository.
+func appendStaticDigestArgs(ctx context.Context, chartPath string, setArgs []string, _ string, components []c8sComponent) ([]string, error) {
+	// The mode values go in first: the enabled predicate below must see the
+	// chart plugin off, or it would demand the plugin image from the bundle.
+	setArgs = staticModeArgs(setArgs)
+	enabled, err := componentEnabledPredicate(ctx, chartPath, setArgs)
+	if err != nil {
+		return nil, err
+	}
+	return staticDigestArgs(setArgs, components, staticState.allowlist, enabled)
+}
+
+// staticModeArgs are the chart values that switch static mode on.
+func staticModeArgs(setArgs []string) []string {
+	return append(setArgs,
+		"--set", "staticAllowlist.enabled=true",
+		"--set", "nriImagePolicy.enabled=false",
+		"--set", "cds.persistence.enabled=false",
+	)
+}
+
+// staticDigestArgs pins each rendered component to the digest the bundle
+// names for its repository.
+func staticDigestArgs(setArgs []string, components []c8sComponent, al *pkgallowlist.Allowlist, enabled func(valuePath string) (bool, error)) ([]string, error) {
+	for _, c := range components {
+		if c.enabledPath != "" {
+			on, err := enabled(c.enabledPath)
+			if err != nil {
+				return nil, fmt.Errorf("component %s: resolve %s: %w", c.valuePrefix, c.enabledPath, err)
+			}
+			if !on {
+				continue
+			}
+		}
+		digest, err := bundleComponentDigest(al, c.repository)
+		if err != nil {
+			return nil, fmt.Errorf("component %s: %w", c.valuePrefix, err)
+		}
+		setArgs = append(setArgs,
+			"--set-string", c.valuePrefix+".repository="+c.repository,
+			"--set-string", c.valuePrefix+".digest="+digest,
+		)
+	}
+	return setArgs, nil
+}
+
+// bundleComponentDigest returns the one digest the bundle names for
+// repository. A component the bundle does not name would be denied on its own
+// node, and two digests for one repository leave no way to pick.
+func bundleComponentDigest(al *pkgallowlist.Allowlist, repository string) (string, error) {
+	want, err := reference.ParseDockerRef(repository)
+	if err != nil {
+		return "", fmt.Errorf("repository %q: %w", repository, err)
+	}
+	repo := reference.TrimNamed(want).String()
+	digests := map[string]bool{}
+	for _, w := range al.Workloads {
+		for _, c := range slices.Concat(w.InitContainers, w.Containers) {
+			if c.Image == "" {
+				continue
+			}
+			named, err := reference.ParseDockerRef(c.Image)
+			if err != nil || reference.TrimNamed(named).String() != repo {
+				continue
+			}
+			digests[c.Digest.String()] = true
+		}
+	}
+	switch len(digests) {
+	case 0:
+		return "", fmt.Errorf("no entry in the bundle names image %s; the node would deny it — render the bundle with `c8s allowlist render --sealed --chart-values <values>` for this release", repo)
+	case 1:
+		for d := range digests {
+			return d, nil
+		}
+	}
+	return "", fmt.Errorf("the bundle names %d digests for image %s (%s); the chart can pin only one", len(digests), repo, strings.Join(slices.Sorted(maps.Keys(digests)), ", "))
+}
+
+// preflightStaticNodes attests every node through its attestation-api and
+// requires the static tuple: the register a node sealed to this bundle
+// reports. A node still in dynamic mode, or sealed to another bundle,
+// fails the install before the chart renders. The containers a node runs
+// are not visible through the API, so what they are is the sealed plugin's
+// verdict on the node; preflightStaticImages checks their digests instead.
+func preflightStaticNodes(ctx context.Context, w io.Writer, s *staticInstall) error {
+	out, err := exec.CommandContext(ctx, "kubectl", "get", "nodes", "-o", "json").Output()
+	if err != nil {
+		return fmt.Errorf("kubectl get nodes: %w", err)
+	}
+	var list corev1.NodeList
+	if err := json.Unmarshal(out, &list); err != nil {
+		return fmt.Errorf("parse node list: %w", err)
+	}
+	if len(list.Items) == 0 {
+		return fmt.Errorf("--static-allowlist: the cluster reports no nodes to attest")
+	}
+	rtmr3 := s.bundle.RTMR3()
+	for _, node := range list.Items {
+		ip := internalIP(node)
+		if ip == "" {
+			return fmt.Errorf("--static-allowlist: node %s reports no InternalIP address to attest through", node.Name)
+		}
+		nodeCtx, cancel := context.WithTimeout(ctx, staticNodeTimeout)
+		err := staticNodeVerifier(nodeCtx, "http://"+net.JoinHostPort(ip, "8400")+"/attest", s.pins, rtmr3)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("--static-allowlist: node %s (%s) is not sealed to this bundle: %w — every node must have booted the measured image with this bundle attached as its policydata disk", node.Name, ip, err)
+		}
+		fmt.Fprintf(w, "+ node %s: static mode, RTMR[3] matches the bundle\n", node.Name)
+	}
+	return nil
+}
+
+// internalIP is the address the node's attestation-api listens on.
+func internalIP(node corev1.Node) string {
+	for _, a := range node.Status.Addresses {
+		if a.Type == corev1.NodeInternalIP {
+			return a.Address
+		}
+	}
+	return ""
+}
+
+// preflightStaticImages fails when a container the cluster runs has a digest
+// the bundle does not name: the sealed plugin admits only bundle entries, so
+// such a container is one no node will restart. --force installs anyway and
+// returns the same list as a warning.
+func preflightStaticImages(ctx context.Context, al *pkgallowlist.Allowlist, force bool) (warn string, err error) {
+	podsJSON, err := exec.CommandContext(ctx, "kubectl", "get", "pods", "--all-namespaces", "-o", "json").Output()
+	if err != nil {
+		return "", fmt.Errorf("kubectl get pods --all-namespaces: %w", err)
+	}
+	var list corev1.PodList
+	if err := json.Unmarshal(podsJSON, &list); err != nil {
+		return "", fmt.Errorf("parse pod list: %w", err)
+	}
+	unlisted := unlistedImages(list.Items, bundleDigests(al))
+	if len(unlisted) == 0 {
+		return "", nil
+	}
+	summary := fmt.Sprintf("%d running image(s) the bundle does not name", len(unlisted))
+	if force {
+		return "installing a static allowlist beside " + summary + "; the sealed plugin will not admit those containers again", nil
+	}
+	return "", fmt.Errorf("--static-allowlist: the cluster runs %s, which the sealed plugin denies:\n  %s\nAdd their entries to the bundle (`c8s allowlist render --sealed`) and reboot the nodes with it, or re-run with --force to install anyway",
+		summary, strings.Join(unlisted, "\n  "))
+}
+
+// bundleDigests is every container digest the bundle's entries name.
+func bundleDigests(al *pkgallowlist.Allowlist) map[string]bool {
+	out := map[string]bool{}
+	for _, w := range al.Workloads {
+		for _, c := range slices.Concat(w.InitContainers, w.Containers) {
+			out[c.Digest.String()] = true
+		}
+	}
+	return out
+}
+
+// unlistedImages lists, one "namespace/pod  repository@digest" line per
+// (namespace, digest), every container whose digest is not in admitted. Pods
+// the kubelet has finished with are skipped, as is a container that has not
+// pulled yet (no digest to compare).
+func unlistedImages(pods []corev1.Pod, admitted map[string]bool) []string {
+	seen := map[string]bool{}
+	var lines []string
+	for _, p := range pods {
+		if p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		for _, st := range podContainerStatuses(p) {
+			digest := imageDigest(st.ImageID, st.Image)
+			if digest == "" || admitted[digest] {
+				continue
+			}
+			if key := p.Namespace + "\x00" + digest; !seen[key] {
+				seen[key] = true
+				lines = append(lines, fmt.Sprintf("%s/%s  %s@%s", p.Namespace, p.Name, imageRepository(st.Image, st.ImageID), digest))
+			}
+		}
+	}
+	slices.Sort(lines)
+	return lines
+}
+
+// printStaticVerifyHint says how a relying party verifies the cluster it just
+// installed: the same bundle and manifest, the entry name from the bundle.
+func printStaticVerifyHint(w io.Writer) {
+	fmt.Fprintln(w, "+ static allowlist installed; every node is sealed to the bundle and CDS issues only to its entries.")
+	fmt.Fprintf(w, "  Clients verify with the same bundle: c8s verify https://<tls-lb> --kind lb --image-manifest %s --static-allowlist %s --workload <entry> --mesh-ca <ca.pem>\n", installImageManifest, installStaticAllowlist)
+}

--- a/cmd/c8s/install_static_test.go
+++ b/cmd/c8s/install_static_test.go
@@ -1,0 +1,482 @@
+//go:build !c8s_node
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	staticCDSDigest      = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	staticOperatorDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	staticTenantDigest   = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+// sealedEntry is a complete unprivileged rule for image at digest.
+func sealedEntry(image, digest string) string {
+	return `{"digest":"` + digest + `","image":"` + image + `@` + digest + `",` +
+		`"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
+		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
+		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}`
+}
+
+// writeStaticFixture writes a bundle directory naming the cds and operator
+// images plus a tenant, and a TDX manifest; both are what --static-allowlist
+// and --image-manifest take.
+func writeStaticFixture(t *testing.T) (bundleDir, manifest string, al *pkgallowlist.Allowlist) {
+	t.Helper()
+	doc := `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{` +
+		`"cds":{"containers":[` + sealedEntry("ghcr.io/confidential-dot-ai/cds", staticCDSDigest) + `]},` +
+		`"operator":{"containers":[` + sealedEntry("ghcr.io/confidential-dot-ai/c8s", staticOperatorDigest) + `]},` +
+		`"web":{"containers":[` + sealedEntry("registry.example/web", staticTenantDigest) + `]}}}`
+	parsed, err := pkgallowlist.ParseJSON([]byte(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := parsed.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundleDir = t.TempDir()
+	if err := os.WriteFile(filepath.Join(bundleDir, policybundle.MemberStaticAllowlist), canonical, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifest = filepath.Join(t.TempDir(), "manifest.json")
+	content := `{"mrtd":"` + strings.Repeat("1a", 48) + `","rtmr1":"` + strings.Repeat("2b", 48) + `","rtmr2":"` + strings.Repeat("3c", 48) + `"}`
+	if err := os.WriteFile(manifest, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return bundleDir, manifest, parsed
+}
+
+// staticFlags sets the install flag state of a static node/tdx install and
+// restores everything at cleanup.
+func staticFlags(t *testing.T, bundle, manifest string) *cobra.Command {
+	t.Helper()
+	resetCLIState(t)
+	installCvmMode, installHardwarePlatform = "node", "tdx"
+	installStaticAllowlist, installImageManifest = bundle, manifest
+	cmd := &cobra.Command{}
+	cmd.Flags().String(flagCvmMode, "node", "")
+	cmd.Flags().BoolVar(&installResolveDigests, "resolve-digests", true, "")
+	return cmd
+}
+
+func TestStaticInstallPreflightFlagRules(t *testing.T) {
+	bundle, manifest, _ := writeStaticFixture(t)
+	for _, tc := range []struct {
+		name   string
+		mutate func(cmd *cobra.Command)
+		want   string
+	}{
+		{"no image manifest", func(*cobra.Command) { installImageManifest = "" }, "requires --image-manifest"},
+		{"pod mode", func(*cobra.Command) { installCvmMode = "pod" }, "--cvm-mode=node"},
+		{"snp", func(*cobra.Command) { installHardwarePlatform = "sev-snp" }, "--hardware-platform=tdx"},
+		{"operator keys", func(*cobra.Command) { installOperatorKeys = "keys.pem" }, "--operator-keys"},
+		{"measurements", func(*cobra.Command) { installMeasurements = []string{"aa"} }, "--measurements"},
+		{"measurements config", func(*cobra.Command) { installMeasurementsConfig = "m.json" }, "--measurements-config"},
+		{"rtmrs", func(*cobra.Command) { installRTMRs = []string{"1=aa"} }, "--rtmrs"},
+		{"explicit resolve-digests", func(cmd *cobra.Command) {
+			if err := cmd.Flags().Set("resolve-digests", "true"); err != nil {
+				t.Fatal(err)
+			}
+		}, "--resolve-digests=true"},
+		{"iso bundle", func(*cobra.Command) { installStaticAllowlist = filepath.Join(bundle, "policydata.iso") }, "ISO images cannot be read here"},
+		{"snp manifest", func(*cobra.Command) {
+			p := filepath.Join(t.TempDir(), "snp.json")
+			if err := os.WriteFile(p, []byte(`{"version":3,"snp_variants":[]}`), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			installImageManifest = p
+		}, "--image-manifest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := staticFlags(t, bundle, manifest)
+			tc.mutate(cmd)
+			err := staticInstallPreflight(cmd)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("staticInstallPreflight(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+			if staticState != nil {
+				t.Errorf("staticInstallPreflight(%s) left state loaded after refusing", tc.name)
+			}
+		})
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		cmd := staticFlags(t, bundle, manifest)
+		if err := staticInstallPreflight(cmd); err != nil {
+			t.Fatalf("staticInstallPreflight: %v", err)
+		}
+		if installResolveDigests {
+			t.Error("installResolveDigests left on; a static install must not consult a registry")
+		}
+		if staticState == nil {
+			t.Fatal("staticState not loaded")
+		}
+		doc, err := os.ReadFile(staticState.measurementsFile)
+		if err != nil {
+			t.Fatalf("measurements file: %v", err)
+		}
+		set, err := measurements.Parse(doc)
+		if err != nil {
+			t.Fatalf("Parse(measurements file) = %v", err)
+		}
+		entry, err := set.StaticEntry()
+		if err != nil {
+			t.Fatalf("StaticEntry() = %v", err)
+		}
+		if want := staticState.bundle.RTMR3(); !bytes.Equal(entry.RTMRs[3], want[:]) {
+			t.Errorf("entry RTMR[3] = %x, want the bundle's %x", entry.RTMRs[3], want)
+		}
+		file := staticState.measurementsFile
+		cleanupStaticInstall()
+		if _, err := os.Stat(file); !os.IsNotExist(err) {
+			t.Errorf("cleanup left %s behind: %v", file, err)
+		}
+	})
+
+	t.Run("unsealed member", func(t *testing.T) {
+		dir := t.TempDir()
+		data, _ := os.ReadFile(filepath.Join(bundle, policybundle.MemberStaticAllowlist))
+		if err := os.WriteFile(filepath.Join(dir, policybundle.MemberStaticAllowlist), append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cmd := staticFlags(t, dir, manifest)
+		err := staticInstallPreflight(cmd)
+		if err == nil || !strings.Contains(err.Error(), "not its canonical form") {
+			t.Fatalf("staticInstallPreflight(unsealed) = %v, want the sealed lint error", err)
+		}
+	})
+}
+
+// The flat lists carry the image tuple only: RTMR[3] would otherwise reach
+// container argv, and the bundle carrying that argv is what the register is
+// derived from (see pinArgs).
+func TestInstallPinsStaticKeepsRTMR3OutOfTheFlatLists(t *testing.T) {
+	bundle, manifest, _ := writeStaticFixture(t)
+	cmd := staticFlags(t, bundle, manifest)
+	if err := staticInstallPreflight(cmd); err != nil {
+		t.Fatal(err)
+	}
+	digests, rtmrs, helmArgs, err := installPins()
+	if err != nil {
+		t.Fatalf("installPins: %v", err)
+	}
+	if len(digests) != 1 || hex.EncodeToString(digests[0]) != strings.Repeat("1a", 48) {
+		t.Errorf("digests = %x, want the manifest MRTD only", digests)
+	}
+	if _, pinned := rtmrs[3]; pinned || len(rtmrs) != 2 {
+		t.Errorf("flat rtmrs = %v, want RTMR[1] and RTMR[2] only", rtmrs)
+	}
+	joined := strings.Join(helmArgs, " ")
+	for _, want := range []string{"--set-file cds.measurementsConfig=" + staticState.measurementsFile, "--set-file ratlsMesh.measurementsConfig=" + staticState.measurementsFile} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("helm args %v missing %s", helmArgs, want)
+		}
+	}
+
+	got, err := appendCvmModeInstallArgs([]string{"upgrade"}, "node", "tdx")
+	if err != nil {
+		t.Fatalf("appendCvmModeInstallArgs: %v", err)
+	}
+	for _, arg := range got {
+		if strings.HasPrefix(arg, "cds.rtmrs[") && strings.HasPrefix(strings.SplitN(arg, "=", 2)[1], "3=") {
+			t.Errorf("flat value %q pins RTMR[3]", arg)
+		}
+	}
+	if !slices.Contains(got, "cds.rtmrs[0]=1="+strings.Repeat("2b", 48)) {
+		t.Errorf("args %v missing the RTMR[1] flat pin", got)
+	}
+}
+
+func TestStaticDigestArgs(t *testing.T) {
+	_, _, al := writeStaticFixture(t)
+	components := []c8sComponent{
+		{valuePrefix: "cds.image", repository: "ghcr.io/confidential-dot-ai/cds"},
+		{valuePrefix: "image", repository: "ghcr.io/confidential-dot-ai/c8s"},
+		{valuePrefix: "nriImagePolicy.image", repository: "ghcr.io/confidential-dot-ai/nri-image-policy", enabledPath: "nriImagePolicy.enabled"},
+	}
+	enabled := func(path string) (bool, error) { return path != "nriImagePolicy.enabled", nil }
+
+	got, err := staticDigestArgs(nil, components, al, enabled)
+	if err != nil {
+		t.Fatalf("staticDigestArgs: %v", err)
+	}
+	for _, want := range []string{
+		"cds.image.repository=ghcr.io/confidential-dot-ai/cds", "cds.image.digest=" + staticCDSDigest,
+		"image.repository=ghcr.io/confidential-dot-ai/c8s", "image.digest=" + staticOperatorDigest,
+	} {
+		if !slices.Contains(got, want) {
+			t.Errorf("args %v missing %s", got, want)
+		}
+	}
+	if slices.ContainsFunc(got, func(a string) bool { return strings.HasPrefix(a, "nriImagePolicy.image.") }) {
+		t.Errorf("args %v pin the disabled plugin image", got)
+	}
+
+	// A component the bundle does not name is denied on the node: refuse.
+	volumed := []c8sComponent{{valuePrefix: "volumed.image", repository: "ghcr.io/confidential-dot-ai/volumed"}}
+	if _, err := staticDigestArgs(nil, volumed, al, enabled); err == nil || !strings.Contains(err.Error(), "no entry in the bundle names image ghcr.io/confidential-dot-ai/volumed") {
+		t.Errorf("staticDigestArgs(unlisted component) = %v, want a refusal naming the image", err)
+	}
+
+	// Two digests for one repository leave nothing to pick.
+	two := *al
+	two.Workloads = map[string]pkgallowlist.Workload{}
+	for k, v := range al.Workloads {
+		two.Workloads[k] = v
+	}
+	dup := al.Workloads["cds"]
+	dup.Containers = []pkgallowlist.Container{{Digest: mustDigest(t, staticTenantDigest), Image: "ghcr.io/confidential-dot-ai/cds:other"}}
+	two.Workloads["cds-other"] = dup
+	if _, err := staticDigestArgs(nil, components[:1], &two, enabled); err == nil || !strings.Contains(err.Error(), "names 2 digests") {
+		t.Errorf("staticDigestArgs(ambiguous) = %v, want a refusal", err)
+	}
+}
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// The shared builder in static mode: no tags, the mode values, the bundle's
+// digests and the measurements file all reach the values tree.
+func TestBuildValueArgsStaticAllowlist(t *testing.T) {
+	bundle, manifest, _ := writeStaticFixture(t)
+	f := newFakeBin(t)
+	f.tool(t, "helm", helmShowValuesBody)
+	chart := writeChart(t, "nriImagePolicy:\n  enabled: true\ncds:\n  image:\n    repository: ghcr.io/confidential-dot-ai/cds\n")
+	cmd := staticFlags(t, bundle, manifest)
+	if err := staticInstallPreflight(cmd); err != nil {
+		t.Fatal(err)
+	}
+	components := []c8sComponent{
+		{valuePrefix: "cds.image", repository: "ghcr.io/confidential-dot-ai/cds"},
+		{valuePrefix: "nriImagePolicy.image", repository: "ghcr.io/confidential-dot-ai/nri-image-policy", enabledPath: "nriImagePolicy.enabled"},
+	}
+	args, err := buildValueArgs(context.Background(), cmd, chart, components, "main", "rke2", appendResolvedDigestArgs)
+	if err != nil {
+		t.Fatalf("buildValueArgs: %v", err)
+	}
+	tree, err := valueArgsToTree(args)
+	if err != nil {
+		t.Fatalf("valueArgsToTree: %v", err)
+	}
+	image := treeAt(t, tree, "cds", "image").(map[string]any)
+	if _, hasTag := image["tag"]; hasTag {
+		t.Errorf("static values emit a tag beside the bundle digest: %#v", image)
+	}
+	if image["digest"] != staticCDSDigest {
+		t.Errorf("cds.image.digest = %#v, want %s from the bundle", image["digest"], staticCDSDigest)
+	}
+	if got := treeAt(t, tree, "staticAllowlist", "enabled"); got != true {
+		t.Errorf("staticAllowlist.enabled = %#v, want true", got)
+	}
+	if got := treeAt(t, tree, "nriImagePolicy", "enabled"); got != false {
+		t.Errorf("nriImagePolicy.enabled = %#v, want false", got)
+	}
+	if got := treeAt(t, tree, "cds", "persistence", "enabled"); got != false {
+		t.Errorf("cds.persistence.enabled = %#v, want false", got)
+	}
+	config, _ := treeAt(t, tree, "cds", "measurementsConfig").(string)
+	set, err := measurements.Parse([]byte(config))
+	if err != nil {
+		t.Fatalf("cds.measurementsConfig does not parse: %v\n%s", err, config)
+	}
+	if _, err := set.StaticEntry(); err != nil {
+		t.Errorf("cds.measurementsConfig is not a static entry: %v", err)
+	}
+	if _, pinned := treeAt(t, tree, "nriImagePolicy").(map[string]any)["image"]; pinned {
+		t.Error("the disabled plugin image was pinned from the bundle")
+	}
+}
+
+func nodeListFile(t *testing.T, nodes ...corev1.Node) string {
+	t.Helper()
+	data, err := json.Marshal(corev1.NodeList{Items: nodes})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "nodes.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func node(name, ip string) corev1.Node {
+	n := corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if ip != "" {
+		n.Status.Addresses = []corev1.NodeAddress{{Type: corev1.NodeInternalIP, Address: ip}}
+	}
+	return n
+}
+
+func TestPreflightStaticNodes(t *testing.T) {
+	bundle, manifest, _ := writeStaticFixture(t)
+	cmd := staticFlags(t, bundle, manifest)
+	if err := staticInstallPreflight(cmd); err != nil {
+		t.Fatal(err)
+	}
+	wantRTMR3 := staticState.bundle.RTMR3()
+
+	type call struct {
+		url   string
+		rtmr3 [runtimemeasure.Size]byte
+	}
+	var calls []call
+	verdicts := map[string]error{}
+	prev := staticNodeVerifier
+	staticNodeVerifier = func(_ context.Context, attestURL string, pins runtimemeasure.ImagePins, rtmr3 [runtimemeasure.Size]byte) error {
+		calls = append(calls, call{attestURL, rtmr3})
+		if hex.EncodeToString(pins.MRTD[:]) != strings.Repeat("1a", 48) {
+			t.Errorf("verifier got MRTD %x, want the manifest's", pins.MRTD)
+		}
+		return verdicts[attestURL]
+	}
+	t.Cleanup(func() { staticNodeVerifier = prev })
+
+	t.Run("every node attested at its InternalIP", func(t *testing.T) {
+		calls = nil
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t, node("a", "10.0.0.1"), node("b", "fd00::2"))+`"`)
+		var out bytes.Buffer
+		if err := preflightStaticNodes(context.Background(), &out, staticState); err != nil {
+			t.Fatalf("preflightStaticNodes: %v", err)
+		}
+		mustContainLine(t, f.calls(t), "kubectl get nodes -o json")
+		want := []string{"http://10.0.0.1:8400/attest", "http://[fd00::2]:8400/attest"}
+		for i, c := range calls {
+			if c.url != want[i] || c.rtmr3 != wantRTMR3 {
+				t.Errorf("call %d = %s %x, want %s %x", i, c.url, c.rtmr3, want[i], wantRTMR3)
+			}
+		}
+		if len(calls) != 2 {
+			t.Fatalf("verifier called %d times, want once per node", len(calls))
+		}
+		if !strings.Contains(out.String(), "+ node a: static mode") || !strings.Contains(out.String(), "+ node b: static mode") {
+			t.Errorf("progress = %q, want a line per node", out.String())
+		}
+	})
+
+	t.Run("an unsealed node fails the install", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t, node("a", "10.0.0.1"), node("b", "10.0.0.2"))+`"`)
+		verdicts["http://10.0.0.2:8400/attest"] = context.DeadlineExceeded
+		t.Cleanup(func() { delete(verdicts, "http://10.0.0.2:8400/attest") })
+		err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState)
+		if err == nil || !strings.Contains(err.Error(), "node b (10.0.0.2) is not sealed to this bundle") {
+			t.Fatalf("preflightStaticNodes = %v, want node b named", err)
+		}
+	})
+
+	t.Run("a node without an address fails", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t, node("a", ""))+`"`)
+		err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState)
+		if err == nil || !strings.Contains(err.Error(), "no InternalIP") {
+			t.Fatalf("preflightStaticNodes = %v, want the missing address named", err)
+		}
+	})
+
+	t.Run("no nodes fails", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t)+`"`)
+		if err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState); err == nil {
+			t.Fatal("preflightStaticNodes(no nodes) = nil, want an error")
+		}
+	})
+}
+
+func TestUnlistedImages(t *testing.T) {
+	_, _, al := writeStaticFixture(t)
+	admitted := bundleDigests(al)
+	status := func(image, id string) corev1.ContainerStatus {
+		return corev1.ContainerStatus{Image: image, ImageID: id}
+	}
+	pod := func(ns, name string, phase corev1.PodPhase, statuses ...corev1.ContainerStatus) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
+			Status:     corev1.PodStatus{Phase: phase, ContainerStatuses: statuses},
+		}
+	}
+	got := unlistedImages([]corev1.Pod{
+		pod("c8s-system", "cds", corev1.PodRunning, status("ghcr.io/confidential-dot-ai/cds:v1", "ghcr.io/confidential-dot-ai/cds@"+staticCDSDigest)),
+		pod("default", "web", corev1.PodRunning, status("registry.example/web:1", "registry.example/web@"+staticTenantDigest)),
+		pod("kube-system", "cilium", corev1.PodRunning, status("quay.io/cilium/cilium:v1", "quay.io/cilium/cilium@sha256:4444444444444444444444444444444444444444444444444444444444444444")),
+		pod("kube-system", "cilium-2", corev1.PodRunning, status("quay.io/cilium/cilium:v1", "quay.io/cilium/cilium@sha256:4444444444444444444444444444444444444444444444444444444444444444")),
+		pod("default", "done", corev1.PodSucceeded, status("busybox:1", "docker.io/library/busybox@sha256:5555555555555555555555555555555555555555555555555555555555555555")),
+		pod("default", "pending", corev1.PodPending, status("busybox:1", "")),
+	}, admitted)
+	want := []string{"kube-system/cilium  quay.io/cilium/cilium@sha256:4444444444444444444444444444444444444444444444444444444444444444"}
+	if !slices.Equal(got, want) {
+		t.Errorf("unlistedImages() = %v, want %v", got, want)
+	}
+}
+
+func TestPreflightStaticImages(t *testing.T) {
+	_, _, al := writeStaticFixture(t)
+	running := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: "extra"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{
+			Image: "quay.io/x/extra:1", ImageID: "quay.io/x/extra@sha256:6666666666666666666666666666666666666666666666666666666666666666",
+		}}},
+	}
+	t.Run("unlisted image refused", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+podListFile(t, running)+`"`)
+		_, err := preflightStaticImages(context.Background(), al, false)
+		if err == nil || !strings.Contains(err.Error(), "kube-system/extra  quay.io/x/extra@sha256:6666") {
+			t.Fatalf("preflightStaticImages = %v, want the unlisted image named", err)
+		}
+		mustContainLine(t, f.calls(t), "kubectl get pods --all-namespaces -o json")
+	})
+	t.Run("force warns", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+podListFile(t, running)+`"`)
+		warn, err := preflightStaticImages(context.Background(), al, true)
+		if err != nil || !strings.Contains(warn, "1 running image(s)") {
+			t.Fatalf("preflightStaticImages(force) = %q, %v; want a warning", warn, err)
+		}
+	})
+	t.Run("all listed passes", func(t *testing.T) {
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+podListFile(t)+`"`)
+		if warn, err := preflightStaticImages(context.Background(), al, false); err != nil || warn != "" {
+			t.Fatalf("preflightStaticImages(empty cluster) = %q, %v; want quiet", warn, err)
+		}
+	})
+}
+
+func TestPrintStaticVerifyHint(t *testing.T) {
+	resetCLIState(t)
+	installStaticAllowlist, installImageManifest = "bundle/", "manifest.json"
+	var out bytes.Buffer
+	printAttestVerifyHint(&out, true)
+	if !strings.Contains(out.String(), "c8s verify https://<tls-lb> --kind lb --image-manifest manifest.json --static-allowlist bundle/ --workload <entry> --mesh-ca <ca.pem>") {
+		t.Errorf("hint = %q, want the static verify command", out.String())
+	}
+}

--- a/cmd/c8s/install_static_test.go
+++ b/cmd/c8s/install_static_test.go
@@ -94,6 +94,13 @@ func TestStaticInstallPreflightFlagRules(t *testing.T) {
 		{"measurements", func(*cobra.Command) { installMeasurements = []string{"aa"} }, "--measurements"},
 		{"measurements config", func(*cobra.Command) { installMeasurementsConfig = "m.json" }, "--measurements-config"},
 		{"rtmrs", func(*cobra.Command) { installRTMRs = []string{"1=aa"} }, "--rtmrs"},
+		{"node attest without a bundle", func(*cobra.Command) {
+			installStaticAllowlist = ""
+			installStaticNodeAttest = map[string]string{"a": "203.0.113.9:8400"}
+		}, "--static-node-attest requires --static-allowlist"},
+		{"node attest without a port", func(*cobra.Command) {
+			installStaticNodeAttest = map[string]string{"a": "203.0.113.9"}
+		}, "--static-node-attest a=203.0.113.9"},
 		{"explicit resolve-digests", func(cmd *cobra.Command) {
 			if err := cmd.Flags().Set("resolve-digests", "true"); err != nil {
 				t.Fatal(err)
@@ -388,7 +395,7 @@ func TestPreflightStaticNodes(t *testing.T) {
 		verdicts["http://10.0.0.2:8400/attest"] = context.DeadlineExceeded
 		t.Cleanup(func() { delete(verdicts, "http://10.0.0.2:8400/attest") })
 		err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState)
-		if err == nil || !strings.Contains(err.Error(), "node b (10.0.0.2) is not sealed to this bundle") {
+		if err == nil || !strings.Contains(err.Error(), "node b (10.0.0.2:8400) is not sealed to this bundle") {
 			t.Fatalf("preflightStaticNodes = %v, want node b named", err)
 		}
 	})
@@ -399,6 +406,45 @@ func TestPreflightStaticNodes(t *testing.T) {
 		err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState)
 		if err == nil || !strings.Contains(err.Error(), "no InternalIP") {
 			t.Fatalf("preflightStaticNodes = %v, want the missing address named", err)
+		}
+	})
+
+	t.Run("an override replaces the InternalIP of the node it names", func(t *testing.T) {
+		calls = nil
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t, node("a", "10.0.2.2"), node("b", ""))+`"`)
+		staticState.nodeAttest = map[string]string{"a": "203.0.113.9:8400", "b": "[fd00::9]:8401"}
+		t.Cleanup(func() { staticState.nodeAttest = nil })
+		var out bytes.Buffer
+		if err := preflightStaticNodes(context.Background(), &out, staticState); err != nil {
+			t.Fatalf("preflightStaticNodes: %v", err)
+		}
+		want := []string{"http://203.0.113.9:8400/attest", "http://[fd00::9]:8401/attest"}
+		if len(calls) != 2 {
+			t.Fatalf("verifier called %d times, want once per node", len(calls))
+		}
+		for i, c := range calls {
+			if c.url != want[i] {
+				t.Errorf("call %d = %s, want %s", i, c.url, want[i])
+			}
+		}
+		if !strings.Contains(out.String(), "attested at 203.0.113.9:8400, --static-node-attest") {
+			t.Errorf("progress = %q, want the override named", out.String())
+		}
+	})
+
+	t.Run("an override naming an absent node fails before any attest", func(t *testing.T) {
+		calls = nil
+		f := newFakeBin(t)
+		f.tool(t, "kubectl", `/bin/cat "`+nodeListFile(t, node("a", "10.0.0.1"))+`"`)
+		staticState.nodeAttest = map[string]string{"c": "203.0.113.9:8400", "b": "203.0.113.8:8400"}
+		t.Cleanup(func() { staticState.nodeAttest = nil })
+		err := preflightStaticNodes(context.Background(), &bytes.Buffer{}, staticState)
+		if err == nil || !strings.Contains(err.Error(), "nodes the cluster does not have: b, c") {
+			t.Fatalf("preflightStaticNodes = %v, want the absent nodes named", err)
+		}
+		if len(calls) != 0 {
+			t.Errorf("verifier called %d times, want none", len(calls))
 		}
 	})
 

--- a/cmd/c8s/measurements_config.go
+++ b/cmd/c8s/measurements_config.go
@@ -17,6 +17,13 @@ import (
 // flat so the consumers that read a plain digest list — the NRI plugin, the
 // operator's initdata — keep pinning exactly what they pin today.
 func installPins() (digests [][]byte, rtmrs map[int][]byte, helmArgs []string, err error) {
+	if installStaticAllowlist != "" {
+		if staticState == nil {
+			return nil, nil, nil, fmt.Errorf("--static-allowlist is set but not loaded: staticInstallPreflight must run first")
+		}
+		digests, rtmrs, helmArgs = staticState.pinArgs()
+		return digests, rtmrs, helmArgs, nil
+	}
 	if installMeasurementsConfig == "" {
 		digests, err = ratls.ParseHexMeasurementsList(installMeasurements)
 		if err != nil {

--- a/cmd/c8s/operator.go
+++ b/cmd/c8s/operator.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -32,6 +33,30 @@ func validateOperatorPlatform(platform string, kataEnforce bool) error {
 	return nil
 }
 
+// validateStaticAllowlist refuses what a sealed node cannot use: under
+// --static-allowlist the injected sidecars pin CDS from their own quote, so
+// flat pins or a measurements file would be forwarded nowhere and only
+// suggest a pin that is not applied; and the kata guest shape has no node
+// socket to mount. The socket directory must be absolute and clean: the
+// webhook writes it verbatim into the sidecars' mounts and argv, and the
+// sealed rule the bundle carries (allowlist render --sealed) names the clean
+// form.
+func validateStaticAllowlist(static bool, measurements, rtmrs []string, measurementsConfig string, guest bool, socketDir string) error {
+	if !static {
+		return nil
+	}
+	if !filepath.IsAbs(socketDir) || filepath.Clean(socketDir) != socketDir {
+		return fmt.Errorf("--attestation-socket-dir %q must be an absolute, clean path (the node image serves the socket under %s)", socketDir, webhook.DefaultAttestationSocketDir)
+	}
+	if len(measurements) > 0 || len(rtmrs) > 0 || measurementsConfig != "" {
+		return fmt.Errorf("--static-allowlist pins CDS from each sidecar's own quote; it cannot be combined with --cds-measurements, --cds-rtmrs or --measurements-config")
+	}
+	if guest {
+		return fmt.Errorf("--static-allowlist cannot be combined with --workload-claims-guest: a sealed node mounts its attestation socket into the sidecars, which a kata guest cannot")
+	}
+	return nil
+}
+
 var operatorCmd = &cobra.Command{
 	Use:   "operator",
 	Short: "Run the c8s controller-manager and admission webhook",
@@ -44,6 +69,9 @@ Pod-to-pod mTLS is handled by the node-level ratls-mesh DaemonSet, not
 by this command.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := validateOperatorPlatform(operatorHardwarePlatform, kataEnforce); err != nil {
+			return err
+		}
+		if err := validateStaticAllowlist(staticAllowlist, cdsMeasurements, cdsRTMRs, cdsMeasurementsConfig, workloadClaimsGuest, attestationSocketDir); err != nil {
 			return err
 		}
 		// The injected sidecars and the measured initdata document carry a
@@ -80,6 +108,8 @@ by this command.`,
 			HardwarePlatform:        operatorHardwarePlatform,
 			WorkloadClaimsHostDir:   workloadClaimsHostDir,
 			WorkloadClaimsGuest:     workloadClaimsGuest,
+			StaticAllowlist:         staticAllowlist,
+			AttestationSocketDir:    attestationSocketDir,
 		})
 	},
 }
@@ -112,6 +142,8 @@ var (
 	operatorHardwarePlatform string
 	workloadClaimsHostDir    string
 	workloadClaimsGuest      bool
+	staticAllowlist          bool
+	attestationSocketDir     string
 )
 
 func init() {
@@ -141,5 +173,7 @@ func init() {
 	operatorCmd.Flags().StringVar(&operatorHardwarePlatform, "hardware-platform", "", "CPU TEE the injected confidential kata classes target: sev-snp or tdx (required with --kata-enforce; set by the chart to match the RuntimeClasses it renders)")
 	operatorCmd.Flags().StringVar(&workloadClaimsHostDir, "workload-claims-host-dir", "", "host directory holding the nri-image-policy inventory socket (node-CVM); when set, the webhook mounts it into c8s-cert and injects --workload-claims so get-cert redeems a sandbox token (docs/ratls.md)")
 	operatorCmd.Flags().BoolVar(&workloadClaimsGuest, "workload-claims-guest", false, "kata shape: the inventory is policy-monitor inside the guest, reached on guest loopback, so the webhook injects --workload-claims with no socket mount (docs/ratls.md)")
+	operatorCmd.Flags().BoolVar(&staticAllowlist, "static-allowlist", false, "sealed node shape (set by the chart under staticAllowlist.enabled): the injected sidecars mount --attestation-socket-dir read-only, dial the attestation-api socket there and pin CDS to the tuple of their own quote (--cds-pins-from-own-quote) instead of --cds-measurements/--cds-rtmrs")
+	operatorCmd.Flags().StringVar(&attestationSocketDir, "attestation-socket-dir", webhook.DefaultAttestationSocketDir, "node directory holding attestation-api.sock, mounted into the injected sidecars under --static-allowlist")
 	rootCmd.AddCommand(operatorCmd)
 }

--- a/cmd/c8s/operator_test.go
+++ b/cmd/c8s/operator_test.go
@@ -30,3 +30,35 @@ func TestValidateOperatorPlatform(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateStaticAllowlist(t *testing.T) {
+	for _, tc := range []struct {
+		name               string
+		static             bool
+		measurements, rtmr []string
+		measurementsConfig string
+		guest              bool
+		socketDir          string
+		wantErr            string
+	}{
+		{name: "off with flat pins", measurements: []string{"aa"}},
+		{name: "off with a relative socket dir", socketDir: "confai"},
+		{name: "static alone", static: true},
+		{name: "static with a custom socket dir", static: true, socketDir: "/run/node-attest"},
+		{name: "static with measurements", static: true, measurements: []string{"aa"}, wantErr: "cannot be combined with --cds-measurements"},
+		{name: "static with rtmrs", static: true, rtmr: []string{"1=aa"}, wantErr: "cannot be combined with --cds-measurements"},
+		{name: "static with measurements file", static: true, measurementsConfig: "/etc/c8s-measurements/cds.json", wantErr: "cannot be combined with --cds-measurements"},
+		{name: "static in the kata guest shape", static: true, guest: true, wantErr: "--workload-claims-guest"},
+		{name: "static with a trailing slash", static: true, socketDir: "/run/confai/", wantErr: "--attestation-socket-dir"},
+		{name: "static with a relative socket dir", static: true, socketDir: "run/confai", wantErr: "--attestation-socket-dir"},
+		{name: "static with a dotted socket dir", static: true, socketDir: "/run/../run/confai", wantErr: "--attestation-socket-dir"},
+	} {
+		if tc.socketDir == "" {
+			tc.socketDir = webhook.DefaultAttestationSocketDir
+		}
+		err := validateStaticAllowlist(tc.static, tc.measurements, tc.rtmr, tc.measurementsConfig, tc.guest, tc.socketDir)
+		if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+			t.Errorf("validateStaticAllowlist(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+		}
+	}
+}

--- a/cmd/c8s/policy_disk.go
+++ b/cmd/c8s/policy_disk.go
@@ -1,0 +1,9 @@
+//go:build !c8s_node
+
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/policydisk"
+
+func init() {
+	rootCmd.AddCommand(policydisk.NewCmd())
+}

--- a/cmd/c8s/policy_measure.go
+++ b/cmd/c8s/policy_measure.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/confidential-dot-ai/c8s/internal/cmds/policymeasure"
+
+func init() {
+	rootCmd.AddCommand(policymeasure.NewCmd())
+}

--- a/cmd/c8s/render_values.go
+++ b/cmd/c8s/render_values.go
@@ -86,6 +86,15 @@ Requires the 'helm' CLI on PATH, and 'crane' unless --resolve-digests=false.`,
 		if err := validateDebugFlag(installCvmMode, installKataDebug); err != nil {
 			return err
 		}
+		if installStaticAllowlist != "" {
+			if err := validateHardwarePlatform(installHardwarePlatform); err != nil {
+				return err
+			}
+		}
+		if err := staticInstallPreflight(cmd); err != nil {
+			return err
+		}
+		defer cleanupStaticInstall()
 		if _, err := exec.LookPath("helm"); err != nil {
 			return fmt.Errorf("helm CLI not found on PATH: %w", err)
 		}
@@ -166,7 +175,11 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, c
 	// --set-string (like repository/digest), never --set: an all-digit or
 	// zero-padded tag (a date or build-id tag) would otherwise be int-coerced
 	// (e.g. 0640 -> 640).
-	if !installResolveDigests {
+	//
+	// A static install pins every component from the bundle instead, so it
+	// emits no tag either.
+	static := installStaticAllowlist != ""
+	if !installResolveDigests && !static {
 		for _, c := range components {
 			setArgs = append(setArgs, "--set-string", c.valuePrefix+".tag="+imageTag)
 		}
@@ -228,12 +241,14 @@ func buildValueArgs(ctx context.Context, cmd *cobra.Command, chartPath string, c
 		}
 		setArgs = append(setArgs, "--set-file", "cds.operatorKeys="+installOperatorKeys)
 	}
-	if installResolveDigests {
-		var err error
+	switch {
+	case static:
+		setArgs, err = appendStaticDigestArgs(ctx, chartPath, setArgs, imageTag, components)
+	case installResolveDigests:
 		setArgs, err = resolveDigests(ctx, chartPath, setArgs, imageTag, components)
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 	return appendWebhookInstallArgs(setArgs, cmd), nil
 }
@@ -428,5 +443,7 @@ func init() {
 	renderValuesCmd.Flags().StringVar(&installImagePullSecret, "image-pull-secret", "", "name of an existing dockerconfigjson Secret the chart wires into every component's imagePullSecrets")
 	renderValuesCmd.Flags().StringVar(&installImageTag, "image-tag", "", "component image tag to resolve digests at (default: the CLI build version, or 'main'). Override to pin a specific branch/tag/release")
 	renderValuesCmd.Flags().StringVar(&installOperatorKeys, "operator-keys", "", "path to a PEM bundle of operator EC public keys that authorize `c8s allowlist` writes; the file's content is embedded as cds.operatorKeys in the emitted values (the chart value is PEM content, never a path)")
+	renderValuesCmd.Flags().StringVar(&installStaticAllowlist, "static-allowlist", "", "policy bundle the nodes booted with (a directory of members, or the static-allowlist.json alone): emits staticAllowlist.enabled=true, the static measurements entry and every component digest from the bundle. Requires --image-manifest, --cvm-mode=node and --hardware-platform=tdx; excludes --operator-keys, --resolve-digests, --measurements, --measurements-config and --rtmrs")
+	renderValuesCmd.Flags().StringVar(&installImageManifest, "image-manifest", "", "build-artifact manifest of the node image (mrtd, rtmr1, rtmr2) the static measurements entry pins beside the bundle's RTMR[3]; required with --static-allowlist")
 	rootCmd.AddCommand(renderValuesCmd)
 }

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -7,6 +7,14 @@ read and write. This document complements
 a kata guest) and [`ratls.md`](ratls.md) (how the allowlist is bound into
 attestation).
 
+The allowlist runs in one of two modes. In **dynamic** mode, the default, CDS
+serves a document an operator key can change at runtime and the enforcers
+described here poll it. In **static** mode a TDX node boots a reviewed policy
+bundle, measures it into RTMR[3], and the baked NRI plugin enforces the
+**sealed** document it contains with no write path at all; see
+[`static-allowlist.md`](static-allowlist.md). This document describes the
+dynamic behaviour and names each point where sealed mode differs.
+
 > **Trust model.** The host, hypervisor, and Kubernetes control plane are
 > untrusted; the trust boundary is the TEE. The image *reference* a pod presents
 > (`docker.io/vllm/vllm-openai:v0.6.3`) is chosen by the untrusted host and is
@@ -61,6 +69,40 @@ semantics](#a-digest-may-run-many-ways).
   }
 }
 ```
+
+A sealed document adds three optional fields per container, which dynamic
+consumers ignore and which existing documents canonicalize without:
+
+```json
+{
+  "digest": "sha256:<vllm>",
+  "command": { "policy": "exact", "argv": ["python3"] },
+  "args":    { "policy": "exact", "argv": ["-m", "vllm.entrypoints.openai.api_server"] },
+  "env": {
+    "policy": "exact",
+    "names": ["PATH", "POD_IP"],
+    "values": { "PATH": { "value": "/usr/local/bin:/usr/bin" }, "POD_IP": { "from": "podIP" } }
+  },
+  "mounts": {
+    "policy": "exact",
+    "destinations": ["/etc/hosts", "/models"],
+    "rules": {
+      "/etc/hosts": { "source": "platform" },
+      "/models":    { "source": "pvc", "review": "weights are parsed by a bounded loader" }
+    }
+  }
+}
+```
+
+`env.values` pins each listed name to a literal (`value`) or to a pod field
+(`from`: `podIP`, `podName`, `podNamespace`, `podUID`, `hostIP`, `nodeName`).
+`mounts.rules` gives each destination a source class (`emptyDir`,
+`serviceAccountToken`, `pvc`, `platform`, `nodeState`, `hostPath`) and, for
+`pvc` and `nodeState`, a `review`. `privileges` is absent on an unprivileged
+entry; when present it marks a node-TCB entry: `privileged`,
+`hostNamespaces`, `capabilities`, `devices`, `hostPaths`, `unmaskedProc`, and
+a required `review`. The key sets of `values` and `rules`, when present, must
+equal `names` and `destinations`.
 
 `schema` is the format identity. It is the first field of the canonical
 serialization (`allowlist.Canonical`), so any holder of an equivalent document
@@ -178,9 +220,12 @@ data to a container running injected code.
 table names filesystem types (`proc`, `sysfs`, `tmpfs`, `devpts`, `mqueue`,
 `cgroup`) and carries nothing in, so pinning it would only make an operator
 restate the OCI base set to say nothing. `env` constrains variable **names**;
-values are never matched, because the allowlist is served to every enforcer and
-values carry secrets. `LD_PRELOAD` is the case that motivates it — an injected
-name is code execution inside an otherwise-allowlisted image.
+in dynamic mode values are never matched, because the allowlist is served to
+every enforcer and values carry secrets. `LD_PRELOAD` is the case that
+motivates it — an injected name is code execution inside an otherwise-allowlisted
+image. A sealed document is reviewed and measured, not secret, so there every
+name also carries a value rule (`values`), and the sealed plugin matches the
+value.
 
 ```json
 "mounts": { "policy": "exact", "destinations": ["/etc/hosts", "/config"] },
@@ -199,15 +244,24 @@ a `deny` default would refuse every real pod and adopting the field would mean
 adopting an outage. That makes these opt-in: a digest with no policy is
 constrained exactly as much as it was before.
 
-Two limits worth stating. They bind only digests a `workloads` entry names —
-floor digests are admitted on the digest alone, so `c8s allowlist add` does not
-produce a mount-gated image. And **the in-guest `policy-monitor` is the enforcer
-that honours them**: it reads the guest's own OCI spec, so it sees both the
-mount table and the environment. The host NRI plugin sees the CRI container and
-reports neither, and an unobserved field is treated as nothing-to-refuse rather
-than as a violation — so under `--cvm-mode=node`, where that plugin is the only
-enforcer, a `mounts` or `env` policy admits every container. `c8s allowlist
-lint` warns when a document carries one; `--cvm-mode=pod` silences it.
+Two limits worth stating for dynamic mode. They bind only digests a
+`workloads` entry names — floor digests are admitted on the digest alone, so
+`c8s allowlist add` does not produce a mount-gated image. And **the in-guest
+`policy-monitor` is the enforcer that honours them**: it reads the guest's own
+OCI spec, so it sees both the mount table and the environment. The dynamic
+host NRI plugin sees the CRI container and reports neither, and an unobserved
+field is treated as nothing-to-refuse rather than as a violation — so under
+`--cvm-mode=node`, where that plugin is the only enforcer, a `mounts` or `env`
+policy admits every container. `c8s allowlist lint` warns when a document
+carries one; `--cvm-mode=pod` silences it.
+
+Neither limit holds in sealed mode. There is no floor, and the sealed plugin
+observes every field: env names and values, each bind source classified from
+its kubelet path (`/var/lib/kubelet/pods/<uid>/volumes/kubernetes.io~<plugin>/<name>`)
+or from the platform and node-state directories, host namespaces, devices not
+explained by a CDI spec, and OCI hooks at CreateContainer; capabilities and
+masked paths from the OCI spec at PostCreateContainer. An observed field with
+no rule is a denial, never a pass ([`static-allowlist.md`](static-allowlist.md)).
 
 ## Secret grants (`secrets`)
 
@@ -243,10 +297,13 @@ Three independent points enforce, at different strengths:
 
 1. **Host NRI plugin** (`nri-image-policy`), at CreateContainer, per container.
    Resolves the image digest and checks the effective argv against the allowlist
-   index. Digest and argv are its whole scope: it reports no mount table and no
-   environment, so `mounts` and `env` policy is vacuously satisfied here. Fail-closed before the allowlist first loads. Runs on the untrusted
-   side of the TEE boundary for kata pods, so it is defense-in-depth there, and
-   the primary gate for non-kata (base-mode) pods.
+   index. In dynamic mode digest and argv are its whole scope: it reports no
+   mount table and no environment, so `mounts` and `env` policy is vacuously
+   satisfied here. Fail-closed before the allowlist first loads. Runs on the
+   untrusted side of the TEE boundary for kata pods, so it is defense-in-depth
+   there, and the primary gate for non-kata (base-mode) pods. In sealed mode
+   the same plugin matches the whole observation against a complete rule
+   (`Index.Admit`), with no digest-only path.
 
 2. **In-guest policy-monitor** (under kata), watching each new container's
    `config.json`. This is the load-bearing gate for confidential pods: the host
@@ -292,12 +349,20 @@ is not implemented and is out of scope here.
 ### The injected-container carve-out
 
 c8s injects two init containers into every confidential pod — `c8s-cert`
-(get-cert) and `c8s-cert-wait`. They pass the issuance gate by **digest**, not
-by name: injected component images are allowlist floor entries, so a workload
-entry never has to enumerate c8s's own sidecars. Nothing rests on the container
-*name*, which the host writes. get-cert runs with per-pod dynamic arguments,
-which is exactly why standalone/injected images are digest-only floor entries:
-their argv is not fixed and must not be argv-policed.
+(get-cert) and `c8s-cert-wait`. In dynamic mode they pass the issuance gate by
+**digest**, not by name: injected component images are allowlist floor entries,
+so a workload entry never has to enumerate c8s's own sidecars. Nothing rests on
+the container *name*, which the host writes. get-cert runs with per-pod dynamic
+arguments, which is exactly why standalone/injected images are digest-only floor
+entries there: their argv is not fixed and must not be argv-policed.
+
+A sealed document has no floor, so the injected containers need complete
+rules like any other. `c8s allowlist render --sealed --workloads` runs the
+webhook mutator in-process on each pod template and derives the rules for
+`c8s-cert`, `c8s-cert-wait`, `c8s-secret`, and `c8s-volume` from the
+containers it produces; per-pod values become `from` rules. That is why
+`--workloads` requires `--chart-values`: the sidecar argv comes from the
+operator the chart deploys.
 
 ## Distribution and trust
 
@@ -356,6 +421,12 @@ The guest-baked seed remains a flat `sha256_digests` list — it is the floor,
 measured into the SNP launch digest, and keeping it digest-only means a policy
 change never requires a guest-image rebuild.
 
+In static mode the seed is the measured bundle member itself:
+`--allowlist-seed /run/confai/policy/static-allowlist.json`, a `hostPath` the
+node's `c8s-policy-measure.service` wrote, with `digests` empty. The chart
+renders no seed ConfigMap, and CDS refuses to start unless its own evidence
+carries the register that commits to those bytes.
+
 ## CLI
 
 `c8s allowlist` reads and mutates the allowlist. Reads are unauthenticated (the
@@ -372,8 +443,11 @@ c8s allowlist
   add <digest> <image>              add a floor digest
   remove <digest>...                remove floor digests (warns on component-floor images)
   upload <file>                     replace the whole allowlist (diff-first, required-components guard)
-  lint <file|-> [--online] [--strict]
+  lint <file|-> [--online] [--strict] [--sealed]
   inspect-image <ref>               show an image's digest + baked entrypoint/cmd
+  render --sealed [--system-floor FILE] [--chart-values FILE] [--workloads FILE]
+                                    render a sealed document from the chart, the
+                                    node image's system floor and workload manifests
 
   workload list | get <name>
   workload apply <file|-> [--dry-run]
@@ -423,6 +497,18 @@ entries alike but for their grants are exactly the case worth catching.
 `workload apply` runs that check against the served allowlist as well as the
 file, because the entry a new one collides with is usually one already there.
 
+`lint --sealed` lints a static-allowlist bundle member. Every shortfall is an
+error: the file must be byte-equal to its canonical form, `digests` must be
+`{}` and `workloads` an object, every `privileges` block needs a `review`,
+every unprivileged entry needs exact `command`, `mounts`, and `env` and exact
+or deny `args`, every exact `env` needs `values` and every exact `mounts`
+needs `rules`, every `pvc` and `nodeState` rule needs a `review`, and a
+`hostPath` rule is allowed only on a privileged entry. The node, the sealed
+plugin, `c8s policy-disk`, `c8s install`, `c8s get-kubeconfig`, and
+`c8s verify` run the same function; CDS relies on the node's measurement and
+refuses to start unless the members index to `digest` and derive the pinned
+RTMR[3].
+
 ## Operator credentials
 
 Generating an operator key and pinning its public half is unchanged; see the
@@ -430,3 +516,8 @@ README and [`operator.md`](operator.md). Rotating the pinned set rolls CDS, and
 a verifier detects a changed write policy by comparing the served
 `/operator-keys` list against its own bundle. Secret grants (`secrets`) are
 managed with the same `workload edit`/`apply` flow.
+
+A static cluster has no operator keys: the chart refuses `cds.operatorKeys`
+beside `staticAllowlist.enabled`, CDS refuses `--operator-keys` beside
+`--static-allowlist`, and every `c8s allowlist` write is rejected. Changing
+the policy means rendering a new bundle and relaunching the nodes with it.

--- a/docs/install-flows.md
+++ b/docs/install-flows.md
@@ -36,6 +36,7 @@ evidence is read (native device, GKE managed CVM, Azure vTPM).
 |---|---|---|
 | **base** | `--cvm-mode=node` (or `gke`/`aks`) | Normal Kubernetes pods on CVM nodes. No kata, no per-pod confidentiality. **Single-tenant** — the node is one trust domain. Host-side mesh + attestation + image policy. The dev/baseline shape. |
 | **kata** | `--cvm-mode=pod` | Installs the kata runtime + RuntimeClasses **and enforces them**: the webhook *injects* a kata RuntimeClass into every in-scope workload pod, a ValidatingAdmissionPolicy *rejects* non-kata pods, and the host-side mesh/attestation/image-policy move into the guest image. The production "pod-as-CVM" shape — kata is enforcing, there is no kata-without-enforcement mode. |
+| **static** (a base variant) | `--cvm-mode=node --hardware-platform=tdx --static-allowlist <bundle> --image-manifest manifest.json` | Base mode on TDX nodes that booted a reviewed policy bundle and measured it into RTMR[3]. No operator keys and no allowlist writes; the node image's sealed NRI plugin enforces the bundle, so the chart's `nriImagePolicy` install is off; every c8s pod dials the node's attestation socket; kata is refused. See [`static-allowlist.md`](static-allowlist.md). |
 
 ```mermaid
 flowchart LR
@@ -116,6 +117,13 @@ any other pod on it can reach. Multi-tenant isolation requires `--cvm-mode=pod`.
  │+webhook │ │ (runc) │ │nri-img-pol │ │   (host DaemonSet) │
  └─────────┘ └────────┘ └────────────┘ └───────────────────┘
 ```
+
+**static** — base mode with a stronger adversary: `cluster-admin` itself.
+The host-side components (kubelet, containerd, the sealed NRI plugin,
+attestation-api, cred-release) are measured node-image content, and RTMR[3]
+commits to the policy bundle, so the control plane can scale, restart, and
+delete allowed pods but cannot run anything the bundle does not describe. The
+node stays single-tenant. See [`static-allowlist.md`](static-allowlist.md).
 
 **kata** — the host is adversarial. Workloads and the c8s CDS run
 inside `kata-qemu-snp` CVMs whose memory is SEV-SNP-encrypted; the security
@@ -198,6 +206,15 @@ Key properties (see `templates/webhook.yaml`, `controller/runner.go`):
 - CDS comes up during the main install and, living in the excluded release
   namespace, is never gated on the webhook — bootstrap services must not be
   gated behind the workloads that depend on them.
+- `--static-allowlist` adds preflights before helm runs: the bundle's
+  `static-allowlist.json` is linted as sealed; `--operator-keys`, an explicit
+  `--resolve-digests=true`, `--measurements`, `--measurements-config` and
+  `--rtmrs` are refused; every component digest is looked up in the bundle;
+  every node is attested at `http://<InternalIP>:8400/attest` (or at the
+  address `--static-node-attest <node>=<host:port>` names) and must report
+  the image tuple plus RTMR[3] derived from the bundle; and every running
+  container must carry a digest the bundle names (`--force` installs past
+  that last check).
 
 ---
 
@@ -366,7 +383,15 @@ c8s install --cvm-mode=pod --hardware-platform=sev-snp --operator-keys operator-
 c8s install --cvm-mode=pod --hardware-platform=sev-snp -f single-node.values.yaml \
   --workload-ref vllm=vllm/deployment/serving:8000 --upstream vllm
 
-# Uninstall: helm uninstall + sweep the kata artifacts off every node.
+# Static (base on TDX): the nodes booted the policy bundle; the bundle
+# supplies every component digest and the measurements entry, so no
+# --operator-keys, --measurements or --rtmrs. See docs/static-allowlist.md.
+c8s install --cvm-mode=node --hardware-platform=tdx \
+  --static-allowlist bundle/ --image-manifest manifest.json
+
+# Uninstall: helm uninstall + sweep the kata artifacts off every node. On a
+# static cluster the sealed plugin stays in the node image; only the release
+# goes.
 c8s uninstall
 ```
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -9,6 +9,7 @@ covers and why the kind harness is shaped the way it is.
 | docker-compose | `make test-integration` | Integration | get-cert's RA-TLS flow against mock CDS + mock attestation-api, nginx serving the issued leaf |
 | kind cluster | `make test-integration-cluster` | Integration (cluster) | the full node-mode control plane and workload path (below) |
 | live-cluster scripts | `test/e2e/*.sh` | snp/tdx-metal-e2e | cw-label policy, mesh enforcement, allowlist enforcement, control-plane convergence on real TEEs |
+| static allowlist scripts | `test/e2e/static/*.sh` | tdx-metal-static-e2e | a TDX node sealed to a policy bundle: bundle build and fixed-point check, refused ConfigMap/env/argv variants of the sample workload, `kubectl exec`/`debug` refused, a privileged cilium copy refused, `c8s verify --static-allowlist`, and a dynamic node that cannot forge the static register |
 
 ## The kind harness
 
@@ -78,7 +79,12 @@ No TEE properties are asserted: hardware verification, measurements that mean
 anything, kata guests, encrypted volumes (volumed needs device-mapper control
 of the node kernel), `get-kubeconfig` (SNP-gated), and the
 `c8s allowlist`/`c8s verify` CLIs (in-process hardware verification, above).
-The metal lanes (snp-metal-e2e, tdx-metal-e2e, cvm-e2e) own those.
+The metal lanes (snp-metal-e2e, tdx-metal-e2e, cvm-e2e) own those. Static
+mode ([`static-allowlist.md`](static-allowlist.md)) is out of scope too: it
+needs a TDX node whose measured `c8s-policy-measure.service` extends RTMR[3],
+and mock-attestation serves SNP-shaped evidence with no registers, so the
+kind harness cannot render `staticAllowlist.enabled`; the tdx-metal-static
+lane owns it.
 
 ## Running it
 

--- a/docs/kata-guest-base.md
+++ b/docs/kata-guest-base.md
@@ -212,15 +212,21 @@ Requires a guest kernel exposing the TDX RTMR-extend sysfs
 [`pkg/runtimemeasure`](../pkg/runtimemeasure/runtimemeasure.go), the
 single source of truth for both sides:
 `event = SHA384("sha256:"+hex)`, `RTMR3' = SHA384(RTMR3 ‖ event)`,
-folded from the boot value (all zeros — or from the operator-key seed
-`ForOperatorKey` on nodes launched with one). Golden vectors in
+folded in this order: the boot value (all zeros), the operator-key seed
+(`ForOperatorKey`, on nodes launched with one), the mode event
+(`ModeDynamic`, extended by the node image's `c8s-policy-measure.service`
+before containerd starts; `ForDynamic`), then the per-workload events. A
+static-allowlist node folds `ModeStatic` and then the policy event instead
+and nothing after (`ForStaticAllowlist`,
+[`static-allowlist.md`](static-allowlist.md)). Golden vectors in
 `pkg/runtimemeasure/runtimemeasure_test.go` freeze it; every verifier
 MUST build on `pkg/runtimemeasure`, never re-derive the convention
-(`c8s get-kubeconfig` and `c8s verify --operator-pkey` already do;
-`c8s verify --rtmr 3=` takes the folded value directly). Note that
-`c8s verify --operator-pkey` pins the *bare* seed only — no per-workload
-extends — since `rtmr3-measurer` ships in this guest image, not on the node
-CVMs that command targets.
+(`c8s get-kubeconfig`, `c8s verify --operator-pkey` and
+`c8s verify --static-allowlist` already do; `c8s verify --rtmr 3=` takes
+the folded value directly). `c8s verify --operator-pkey` pins the
+seed-plus-mode register only — no per-workload extends — since
+`rtmr3-measurer` ships in this guest image, not on the node CVMs that
+command targets.
 
 **Dedup and restart safety.** RTMR[3] is hardware-append-only, so each
 DISTINCT image must extend exactly once: restarts and replicas (same

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -613,11 +613,12 @@ What the gate proves: a genuine guest of the manifest's platform booted
 exactly the pinned image, was launched to trust exactly this operator key,
 and (on TDX) ran exactly the expected measured workloads. Under
 `--static-allowlist` it proves instead that the node measured exactly the
-reviewed bundle, so its sealed plugin admits only that bundle's entries. What it does not prove: anything about images or keys the
-manifest and flags do not name, or the provenance of the manifest file itself
-— select it deliberately from the trusted image build. An RTMR[3]-only gate
-would prove much less: the untrusted host stages the operator public key, so
-it can boot **any** image and reproduce the operator-key/mode register — the
+reviewed bundle, so its sealed plugin admits only that bundle's entries.
+What it does not prove: anything about images or keys the manifest and
+flags do not name, or the provenance of the manifest file itself — select
+it deliberately from the trusted image build. An RTMR[3]-only gate would
+prove much less: the untrusted host stages the operator public key, so it
+can boot **any** image and reproduce the operator-key/mode register — the
 image tuple is the identity anchor, and RTMR[3] then binds the key and
 workload set to it.
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -433,14 +433,16 @@ conflict with `--image-manifest` because they *are* the image, while 3
 requires it.) `--operator-pkey <file>` is the same pin
 without the arithmetic: point it at the operator **public** key PEM (the
 verbatim bytes the guest initrd hashed, as written by `openssl ec -pubout`)
-and `verify` derives the bare operator-key seed,
-`SHA-384(0x00*48 ‖ SHA-384(pubkey))`, itself. The two are mutually exclusive
-— one register, one expected value — and `--operator-pkey` carries the same
-`--image-manifest` requirement. Note its scope: it pins the **bare** seed,
-i.e. a node with no per-workload RTMR[3] extends on top. That is what every
-node reports today, because the workload measurer ships only inside the kata
-guest image; `c8s get-kubeconfig` is the command that also folds
-`--workload-image` extends into the expected register. Supplying any of these
+and `verify` derives the dynamic-mode register of an operator-key boot
+itself: the seed `SHA-384(0x00*48 ‖ SHA-384(pubkey))` extended by the mode
+event `SHA-384("c8s/rtmr3/mode/dynamic/v1")` that the node image extends
+before containerd starts. The two are mutually exclusive — one register, one
+expected value — and `--operator-pkey` carries the same `--image-manifest`
+requirement. Note its scope: it pins the seed-plus-mode register, i.e. a node
+with no per-workload RTMR[3] extends on top. That is what every node reports
+today, because the workload measurer ships only inside the kata guest image;
+`c8s get-kubeconfig` is the command that also folds `--workload-image`
+extends into the expected register. Supplying any of these
 flags against SEV-SNP evidence is a policy error, not an ignored option: SNP
 has no runtime measurement registers.
 
@@ -507,8 +509,10 @@ and again on the RA-TLS credential-release connection:
   generic artifact-hash `manifest.json` is not an image pin and is rejected;
 - **RTMR[3] chain (TDX)** — the register must equal the operator-key seed
   (`pkg/runtimemeasure.ForOperatorKey` over the exact pubkey PEM bytes)
-  extended, in order, by each digest-pinned `--workload-image` ref (tags are
-  rejected). With no `--workload-image` the register must equal the bare seed;
+  extended by the dynamic mode event (`runtimemeasure.ForDynamic`), then, in
+  order, by each digest-pinned `--workload-image` ref (tags are rejected).
+  With no `--workload-image` the register must equal `ForDynamic(seed)`; the
+  bare seed is rejected;
 - **guest image + operator key (SEV-SNP)** — the report's MEASUREMENT must be
   one of the per-SMP launch digests pinned by `snp_variants` (one image has
   one digest per vCPU count), and HOSTDATA must equal `SHA-256(operator
@@ -555,7 +559,7 @@ and (on TDX) ran exactly the expected measured workloads. What it does not prove
 manifest and flags do not name, or the provenance of the manifest file itself
 — select it deliberately from the trusted image build. An RTMR[3]-only gate
 would prove much less: the untrusted host stages the operator public key, so
-it can boot **any** image and reproduce the bare operator-key register — the
+it can boot **any** image and reproduce the operator-key/mode register — the
 image tuple is the identity anchor, and RTMR[3] then binds the key and
 workload set to it.
 

--- a/docs/operator.md
+++ b/docs/operator.md
@@ -332,11 +332,43 @@ off. To keep dynamic entries across restarts set `cds.persistence.enabled=true`
 Component/floor digests are unaffected — they are re-seeded and, unlike dynamic
 entries, are also enforced from the baked floor.
 
+### Static allowlist
+
+Under `staticAllowlist.enabled=true` (set by `c8s install --static-allowlist`,
+see [`static-allowlist.md`](static-allowlist.md)) CDS serves the bundle the
+node measured into RTMR[3] and nothing else. The chart renders CDS with
+`--static-allowlist --policy-dir /run/confai/policy --allowlist-seed
+/run/confai/policy/static-allowlist.json` and
+`--attestation-api-url unix:///run/confai/attestation-api.sock`, mounts the
+policy directory and the socket directory read-only as `hostPath` volumes of
+type `Directory`, and gives the pod supplementary group 65532 so it can
+connect to the root-owned socket. There is no `cds.operatorKeys`, no
+persistence, and no seed ConfigMap: every start reseeds from the measured
+member, so a restart cannot add entries and allowlist writes do not exist.
+`cds.measurementsConfig` carries one entry, `{MRTD, RTMR[1], RTMR[2],
+RTMR[3] = ForStaticAllowlist(index)}`, which `/attest` requires of every
+requester and CDS requires of its own evidence at start. The render fails
+(`VALIDATION_ERROR kind=static_allowlist_*`) on `cds.operatorKeys`,
+`cds.persistence.enabled`, `kata.enabled`, `attestationApi.enabled`,
+`nriImagePolicy.enabled`, a `cvmMode` other than `node`, a platform other than
+TDX, or an empty `cds.measurementsConfig`.
+
 ## Attestation-api
 
 The attestation-api DaemonSet binds pod loopback and is served to on-node
 consumers by its attest-proxy sidecar over a Unix socket in
 `nriImagePolicy.hostPaths.runtimeDir`; no Service renders.
+
+The c8s node image serves the same API itself: `c8s-attest-socket.service`
+runs `c8s attest-proxy` in front of the baked attestation-api on the
+root-owned `unix:///run/confai/attestation-api.sock` (mode 0660, group
+65532). The baked NRI plugin config dials that path, and under
+`staticAllowlist.enabled` so do CDS, tls-lb, ratls-mesh, the operator, and
+every injected sidecar (`staticAllowlist.attestationSocketDir`, default
+`/run/confai`). A path in a measured config, unlike an address, is one the
+control plane cannot repoint; the verdict stays unsigned, the socket is what
+makes it immutable. The chart refuses `attestationApi.enabled` beside
+`staticAllowlist.enabled` because nothing would dial the DaemonSet.
 
 Two operational notes:
 
@@ -446,6 +478,19 @@ extends into the expected register. Supplying any of these
 flags against SEV-SNP evidence is a policy error, not an ignored option: SNP
 has no runtime measurement registers.
 
+`--static-allowlist <bundle>` is the static-mode sibling of
+`--operator-pkey` ([`static-allowlist.md`](static-allowlist.md)). The bundle
+is a directory of members or the `static-allowlist.json` alone (an `.iso` is
+refused). `verify` lints the member as sealed, derives the static register
+`Extend(Extend(Zero, SHA-384("c8s/rtmr3/mode/static/v1")),
+SHA-384("c8s/rtmr3/policy/v1:" ‖ index))` from it, and holds the leaf's
+matched-workload stamp to the member's own bytes. It requires
+`--image-manifest`, `--workload`, and `--mesh-ca` (the stamp is CA-vouched,
+and the mesh CA carries no evidence of its own yet), and conflicts with
+`--operator-pkey`, `--expected-rtmr3`, `--rtmr 3=`, and `--allowlist`. A
+verified verdict reports `static_policy_digest`, the index digest the
+register was derived from.
+
 A TDX verdict pinned on MRTD alone is **rejected**, not warned about, when no
 operator-pinned CA anchor (`--mesh-ca`) stands beside the measurements: the
 measurement pins are then the entire trust anchor, so an incomplete image
@@ -512,7 +557,12 @@ and again on the RA-TLS credential-release connection:
   extended by the dynamic mode event (`runtimemeasure.ForDynamic`), then, in
   order, by each digest-pinned `--workload-image` ref (tags are rejected).
   With no `--workload-image` the register must equal `ForDynamic(seed)`; the
-  bare seed is rejected;
+  bare seed is rejected. With `--static-allowlist <bundle>` in place of
+  `--operator-key` the register must instead equal
+  `runtimemeasure.ForStaticAllowlist` over the bundle's index, the static
+  mode event followed by the policy event ([`static-allowlist.md`](static-allowlist.md));
+  `--workload-image` is then a usage error, and the credential is fetched
+  without an operator token;
 - **guest image + operator key (SEV-SNP)** — the report's MEASUREMENT must be
   one of the per-SMP launch digests pinned by `snp_variants` (one image has
   one digest per vCPU count), and HOSTDATA must equal `SHA-256(operator
@@ -553,9 +603,17 @@ design. To revoke durably, relaunch without `opkeydata`, or with a rotated
 operator key, so the old key can no longer obtain a certificate. A certificate
 already issued stays usable for the remainder of its one-hour TTL.
 
+A static node has no operator key and nothing to revoke: `cred-release`
+serves any caller once the node's RTMR[3] matches the bundle, because the
+static design already treats `cluster-admin` as the adversary. Relaunching
+with another bundle changes the register, and clients pinned to the old
+bundle refuse the node.
+
 What the gate proves: a genuine guest of the manifest's platform booted
 exactly the pinned image, was launched to trust exactly this operator key,
-and (on TDX) ran exactly the expected measured workloads. What it does not prove: anything about images or keys the
+and (on TDX) ran exactly the expected measured workloads. Under
+`--static-allowlist` it proves instead that the node measured exactly the
+reviewed bundle, so its sealed plugin admits only that bundle's entries. What it does not prove: anything about images or keys the
 manifest and flags do not name, or the provenance of the manifest file itself
 — select it deliberately from the trusted image build. An RTMR[3]-only gate
 would prove much less: the untrusted host stages the operator public key, so

--- a/docs/ratls.md
+++ b/docs/ratls.md
@@ -332,11 +332,14 @@ What it does **not** guarantee:
   (GAP). Operator-side, `c8s verify --image-manifest` pins the full
   MRTD+RTMR[1]+RTMR[2] image tuple exactly — which is why it replaces
   `--measurements` rather than combining with it — and `--rtmr 3=`
-  (or `--operator-pkey`, which derives the same value from the operator public
-  key) pins the runtime register, requiring the image pin because the host
-  chooses the image and the runtime chain alone identifies nothing;
-  `c8s get-kubeconfig` requires the
-  full tuple plus the operator-key/workload RTMR[3] chain. `c8s verify` does
+  (or `--operator-pkey`, which derives the operator-key seed plus the dynamic
+  mode event from the operator public key, or `--static-allowlist`, which
+  derives the static mode event plus the policy event from a reviewed bundle;
+  [`static-allowlist.md`](static-allowlist.md)) pins the runtime register,
+  requiring the image pin because the host chooses the image and the runtime
+  chain alone identifies nothing; `c8s get-kubeconfig` requires the full
+  tuple plus either the operator-key/mode/workload RTMR[3] chain or the static
+  tuple. `c8s verify` does
   not silently drop `--min-tcb-*` on TDX the way the mesh policy does: an
   SNP-shaped floor against TDX evidence is a policy failure naming the
   platform, and on SNP the floor is re-checked against the verified claims.
@@ -858,7 +861,10 @@ Adjacent surfaces that are deliberately **not** RA-TLS:
   [c8s-verify-js](https://github.com/confidential-dot-ai/c8s-verify-js).
 - **Attested RKE2 credential release** (`c8s cred-release`) and the
   operator/allowlist CLIs are RA-TLS *clients* of the surfaces above rather
-  than new certificate types.
+  than new certificate types. On a static-allowlist node cred-release serves
+  any caller, and the injected sidecars pin CDS to the node's own
+  image tuple read from a fresh quote over the node's attestation socket
+  (`--cds-pins-from-own-quote`) instead of flat measurement lists.
 
 ## Reading order for the curious
 

--- a/docs/static-allowlist.md
+++ b/docs/static-allowlist.md
@@ -1,0 +1,554 @@
+# Static allowlist: a fixed workload set measured into RTMR[3]
+
+A static allowlist seals a TDX node-as-CVM cluster to one reviewed policy
+bundle. The node measures the bundle into RTMR[3] before RKE2 starts, the
+baked NRI plugin admits only the containers the bundle describes, and CDS
+issues certificates only to pods on nodes that carry that register. A
+relying party recomputes the register from the bundle it reviewed and checks
+one fresh quote.
+
+This document is the concept and operations reference. The dynamic
+allowlist, where an operator key authorizes `c8s allowlist` writes, is
+described in [`allowlist-and-capabilities.md`](allowlist-and-capabilities.md);
+the node image side in [`node-guest-image/README.md`](../node-guest-image/README.md).
+
+## Goal
+
+A user reviews one generic node image and one policy bundle. From one quote
+they can then verify that the cluster runs only that set of pods and that the
+operator, who holds `cluster-admin`, cannot read user data. The operator can
+still scale, restart, and delete allowed pods.
+
+Out of scope, by decision: availability and liveness (any failure may power
+the node off), routing and where tls-lb forwards plaintext, SEV-SNP,
+pod-as-CVM, operator keys, and browser clients. Clusters with the same image
+tuple and the same bundle are indistinguishable to a relying party.
+
+## Adversary
+
+The adversary holds `cluster-admin` on the running cluster and controls the
+hypervisor, every disk other than the published image, the network, and the
+launch attachments. They have no code execution inside the CVM at boot. They
+want plaintext, secrets, or memory.
+
+Trusted: TDX; the measured image (kernel, initrd, systemd units, containerd,
+RKE2 including kubelet and API server, attestation-api, the NRI plugin, CDS,
+tls-lb); the reviewed code of every allowlisted workload. Privileged platform
+pods (cilium, volumed, the NVIDIA device plugin) are node TCB: pinned by the
+bundle, not proven harmless.
+
+## Trust chain
+
+`pkg/runtimemeasure` owns the arithmetic. Every side, the node, the
+installer, and every verifier, derives the register through that package.
+
+```text
+manifest.json {MRTD, RTMR[1], RTMR[2]}     published with each generic image build
+
+Extend(reg, event) = SHA-384(reg ‖ event)   the hardware extend primitive
+
+static boot:
+  RTMR[3]     = Extend(Extend(Zero, mode_static), policy)
+  mode_static = SHA-384("c8s/rtmr3/mode/static/v1")
+  policy      = SHA-384("c8s/rtmr3/policy/v1:" ‖ index)
+  index       = {"static-allowlist.json":"sha256:<hex>"}
+                JSON with sorted keys and no whitespace, one entry per bundle
+                member, each digest over the member's raw bytes
+
+dynamic boot:
+  RTMR[3]      = Extend(seed, mode_dynamic), then one extend per measured workload
+  mode_dynamic = SHA-384("c8s/rtmr3/mode/dynamic/v1")
+  seed         = ForOperatorKey(pubkey) on an operator-key boot, else Zero
+```
+
+The static tuple is `{MRTD, RTMR[1], RTMR[2], RTMR[3]}`. The verifier
+recomputes RTMR[3] from the reviewed bundle, exactly as `--operator-pkey`
+derives it from the key on a dynamic node. The policy digest needs no
+certificate extension: it is in the register, and every mesh leaf already
+carries the allowlist digest in its matched-workload stamp (`.1.5`,
+[`ratls.md`](ratls.md)).
+
+**Every boot extends a mode event before containerd starts.** A dynamic boot
+extends `mode_dynamic`, a static boot `mode_static` and then `policy`. Without
+this, a dynamic node, where `cluster-admin` is node root through any
+privileged pod, could write the static events into the register itself and
+pass every static check. `c8s policy-measure` also refuses a register that is
+not the launch value (`Zero`, or `ForOperatorKey` of the initrd-staged key)
+before it extends anything.
+
+## The policy bundle
+
+A bundle is a flat set of JSON members. `static-allowlist.json` is the only
+member today and is required; `pkg/policybundle` refuses any other name until
+a consumer exists for it. Limits: 64 members, 8 MiB each. The index digests
+the raw member bytes, so a member that differs by one byte is a different
+bundle.
+
+`c8s allowlist lint --sealed` requires `static-allowlist.json` to be
+byte-equal to its own canonical form. The reviewed bytes are the measured
+bytes, and CDS stamps every leaf with the SHA-256 of the same bytes.
+
+### Attaching the bundle at launch
+
+The node looks the bundle up as an ISO9660 disk with volume label
+`policydata` (`/dev/disk/by-label/policydata`). `c8s policy-disk` builds it.
+
+- **KubeVirt**: a Secret holding the members, mounted as a `secret` volume
+  with `volumeLabel: policydata` on a virtio disk. `c8s policy-disk
+  --kubevirt-secret NAME` writes that Secret and the disk and volume entries
+  to add to the VirtualMachine.
+- **libvirt**: a CD-ROM device pointing at the ISO (`xorrisofs -V
+  policydata -J -R`).
+
+A static node has no operator key. `c8s policy-measure` fails, and the unit
+powers the node off, when an `opkeydata` disk is attached beside
+`policydata`.
+
+### Node-side state
+
+`c8s-policy-measure.service` runs on every boot before `rke2-server` and
+`rke2-agent`, which require it. It writes the measured state to a tmpfs
+directory that every static consumer reads:
+
+| Path | Content |
+|---|---|
+| `/run/confai/policy/mode` | `static` or `dynamic`, written last |
+| `/run/confai/policy/digest` | lowercase hex SHA-256 of the index (static only) |
+| `/run/confai/policy/<member>` | the raw member bytes (static only) |
+| `/run/confai/attestation-api.sock` | attestation-api, served by `c8s-attest-socket.service` |
+
+On a TDX boot the unit:
+
+1. Reads RTMR[3] back. It must equal `Zero`, or `ForOperatorKey` of the
+   initrd-staged public key when one exists.
+2. Without a `policydata` disk: extends `mode_dynamic`, writes
+   `mode=dynamic`, exits 0.
+3. With one: fails if `opkeydata` is present, mounts the ISO read-only,
+   reads every member under the bundle limits, lints
+   `static-allowlist.json` as sealed, writes the members and the index digest
+   under `/run/confai/policy`, extends `mode_static` and then `policy`, reads
+   the register back and compares it, and writes `mode=static` last.
+
+Any failure exits non-zero and `FailureAction=poweroff-force` powers the node
+off. On an SEV-SNP image the unit writes `mode=dynamic` without touching any
+register; a `policydata` disk there is fatal.
+
+`c8s-attest-socket.service` fronts the confos `attestation-api.service`
+(loopback `:8400`) with `c8s attest-proxy` on `/run/confai/attestation-api.sock`.
+Root owns the socket, mode 0660, group 65532, so CDS (uid 65532, given that
+supplementary group by the chart) and the injected sidecars can connect. The
+socket is what makes the verifier immutable to the control plane: the baked
+plugin config and the sealed CDS argv name a path, not an address, so no
+chart value or pod restart can point either at another verifier.
+
+In static mode `cred-release.service` starts without an operator key. RTMR[3]
+must equal the value recomputed from `/run/confai/policy`, and any caller
+receives the operator credential. The caller attests the node, not the other
+way round: `c8s get-kubeconfig` verifies the RA-TLS serving certificate of
+`cred-release` and presents no evidence of its own. `cluster-admin` is the
+adversary in this design, so that gives nothing away.
+
+## Mode is explicit, never inferred
+
+No component infers static mode from a file's presence:
+
+- The baked plugin config sets `allowlist.policy_dir: /run/confai/policy`.
+  At start the plugin reads `mode`. `static` requires the member, the digest
+  file, and sysfs RTMR[3] equal to `ForStaticAllowlist(index)`. `dynamic` on
+  TDX requires the register to equal `ForDynamic(seed)`. A missing or unknown
+  mode, or a register mismatch, powers the node off.
+- CDS runs with `--static-allowlist` and refuses to start unless `mode` reads
+  `static`, the members index to `digest`, that index derives the RTMR[3] the
+  measurements entry pins, and its own evidence over the socket carries the
+  full static tuple.
+- The chart renders static mode from `staticAllowlist.enabled=true`.
+  `c8s install --static-allowlist` refuses a node whose RTMR[3] disagrees
+  with the bundle.
+
+## The sealed document
+
+A sealed `static-allowlist.json` is a `c8s.allowlist/v1` document in which
+`digests` is `{}` and every container carries a complete rule. Dynamic
+consumers ignore the new fields, and a document without them canonicalizes
+byte-identically.
+
+```json
+{
+  "schema": "c8s.allowlist/v1",
+  "digests": {},
+  "workloads": {
+    "demo-nginx": {
+      "label": "docker.io/library/nginx:1.27",
+      "containers": [
+        {
+          "digest": "sha256:<nginx>",
+          "image": "docker.io/library/nginx:1.27",
+          "command": { "policy": "exact", "argv": ["/docker-entrypoint.sh"] },
+          "args":    { "policy": "exact", "argv": ["nginx", "-g", "daemon off;"] },
+          "env": {
+            "policy": "exact",
+            "names": ["KUBERNETES_SERVICE_HOST", "PATH", "POD_IP"],
+            "values": {
+              "KUBERNETES_SERVICE_HOST": { "value": "10.53.0.1" },
+              "PATH": { "value": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" },
+              "POD_IP": { "from": "podIP" }
+            }
+          },
+          "mounts": {
+            "policy": "exact",
+            "destinations": ["/data", "/dev/shm", "/etc/hosts", "/var/run/secrets/kubernetes.io/serviceaccount"],
+            "rules": {
+              "/data": { "source": "pvc", "review": "read-only model weights; the server parses them with a bounded loader" },
+              "/dev/shm": { "source": "platform" },
+              "/etc/hosts": { "source": "platform" },
+              "/var/run/secrets/kubernetes.io/serviceaccount": { "source": "serviceAccountToken" }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Environment values
+
+Under `env.policy: exact`, every observed name must be listed and every
+listed name carries a rule. `{"value": "..."}` matches byte-exact.
+`{"from": SOURCE}` matches the value the plugin reads for that pod field;
+`SOURCE` is one of `podIP`, `podName`, `podNamespace`, `podUID`, `hostIP`, or
+`nodeName`. There is no unconstrained value: a name the reviewer cannot pin is
+a container the reviewer cannot admit. `render --sealed` refuses `envFrom` and
+ConfigMap, Secret, or resource-field references for that reason.
+
+### Mount rules
+
+Under `mounts.policy: exact`, every bind destination carries a `source` class:
+
+| Class | What the plugin classifies there | Review |
+|---|---|---|
+| `emptyDir` | `kubernetes.io~empty-dir` volumes | no |
+| `serviceAccountToken` | the kubelet's `kube-api-access-*` projected volume | no |
+| `pvc` | CSI and local volumes, and local-path-storage's `/opt/local-path-provisioner/` | required: why operator-supplied contents cannot steer the workload |
+| `platform` | the kubelet's `/etc/hosts`, `/etc/hostname`, `/etc/resolv.conf`, `/dev/termination-log`, `/dev/shm`, and the plugin's own socket directory `/run/nri-image-policy` | no |
+| `nodeState` | binds from `/run/confai`: the attestation socket and the policy directory | required: why the entry may reach the node's verifier or policy state |
+| `hostPath` | anything else, admitted only through `privileges.hostPaths` | through `privileges.review` |
+
+`nodeState` is its own class rather than `platform` so the `platform` rule
+every container carries for `/etc/hosts` can never admit the attestation
+socket bound there. ConfigMap, Secret, other projected, downward-API, and
+hostPath volumes classify outside the reviewed classes; `render --sealed`
+turns them into a `hostPath` rule with `privileges.hostPaths:
+["/var/lib/kubelet/pods/"]` (or the host path as bound) and a `privileges`
+block the reviewer must complete.
+
+### Privileges
+
+`privileges` marks an entry as node TCB. It carries `privileged`,
+`hostNamespaces` (`net`, `pid`, `ipc`), `capabilities` (OCI form, beyond the
+runtime default set), `devices`, `hostPaths` (an entry ending in `/` admits
+the subtree), `unmaskedProc`, and a `review` string that says why the entry is
+acceptable. A privileged entry holds every capability and device, so those
+lists are not compared for it. An entry without `privileges` must pin
+`command`, `mounts`, and `env` exactly and `args` exactly or `deny`.
+
+### What `lint --sealed` checks
+
+`c8s allowlist lint --sealed FILE` runs the offline lint and then, as errors:
+
+- the file is byte-equal to its canonical form;
+- `digests` is `{}` and `workloads` is an object (the form the CDS store
+  serves back, so the stamp matches the measured bytes);
+- every `privileges` block has a non-empty `review`;
+- every unprivileged entry has exact `command`, `mounts`, and `env`, and
+  `args` exact or deny;
+- every exact `env` carries `values` and every exact `mounts` carries `rules`;
+- every `pvc` and `nodeState` rule has a `review`;
+- a `hostPath` rule appears only on an entry with `privileges`.
+
+The same function runs in the node (`c8s policy-measure`), the plugin,
+`c8s policy-disk`, `c8s install`, `c8s get-kubeconfig`, and `c8s verify`, so
+none of them can disagree. CDS trusts the node's measurement instead: it
+refuses to start unless the members index to `digest`, that index derives the
+pinned RTMR[3], and its own evidence carries the tuple.
+
+## What the sealed plugin enforces
+
+On a static boot the NRI plugin loads the measured member, checks the index
+against `digest` and sysfs RTMR[3] against `ForStaticAllowlist(index)`, and
+runs with no digest floor, no `always_allow`, no pull loop, no exempt
+namespaces, and `policy.mode` forced to fail-closed. It pins CDS to the
+node's own tuple, read from a fresh quote of itself over the attestation
+socket, so no installer writes pins into the measured config and a CDS on an
+unsealed node of the same image is refused.
+
+- **Synchronize.** In a valid static boot no container exists when the plugin
+  registers. Any container reported at Synchronize powers the node off.
+- **CreateContainer** builds an observation: argv, env names and values, bind
+  sources classified as in the table, host namespaces, devices not explained
+  by a CDI spec under `/etc/cdi` or `/var/run/cdi`, whether any OCI hook is
+  present, and privilege. `Index.Admit` must match a complete rule; hooks are
+  never admitted. `policy.label_rules` still apply (deny only).
+- **PostCreateContainer** loads the OCI spec through containerd for
+  capabilities and masked paths and caches a verdict. **StartContainer**
+  returns the cached verdict; containerd deletes the task before the
+  entrypoint runs. No cached verdict at start means re-evaluate, else deny.
+- Every hook answers within 1.5 s and a timeout denies. containerd's own
+  request timeout is 2 s, and the unpatched `containerd/nri` admits a request
+  whose plugin call times out (see [Known gaps](#known-gaps-and-follow-ups)).
+- The plugin writes `-1000` to its own `oom_score_adj`, since a plugin the
+  kernel kills mid-request admits that request.
+
+Any fatal condition after `mode` reads `static` calls `systemctl poweroff
+--force --force`, falling back to the reboot syscall.
+
+## CDS and the chart
+
+CDS runs with `--static-allowlist --policy-dir /run/confai/policy
+--allowlist-seed /run/confai/policy/static-allowlist.json` and a `unix://`
+`--attestation-api-url`. It refuses `--operator-keys` and
+`--allowlist-persistent`, requires `--ratls-platform=tdx`, and requires a
+`--measurements-config` with exactly one entry pinning RTMR[1], RTMR[2], and
+RTMR[3]. `/attest` enforces that entry for every requester: a pod on an
+unsealed node of the same image, or on a node sealed to another bundle,
+presents a different RTMR[3] and is denied even when its containers match a
+workload entry. Each start reseeds from the measured member, so no stored
+entry can outlive the bundle.
+
+`c8s install --static-allowlist` sets these chart values:
+
+| Value | Default | Static install |
+|---|---|---|
+| `staticAllowlist.enabled` | `false` | `true` |
+| `staticAllowlist.policyDir` | `/run/confai/policy` | unchanged |
+| `staticAllowlist.attestationSocketDir` | `/run/confai` | unchanged |
+| `nriImagePolicy.enabled` | | `false` (the image bakes the sealed plugin) |
+| `cds.persistence.enabled` | | `false` |
+| `cds.measurementsConfig`, `ratlsMesh.measurementsConfig` | | one entry `static-allowlist`: MRTD, RTMR[1], RTMR[2] from the manifest, RTMR[3] from the bundle |
+| `cds.measurements`, `cds.rtmrs`, `ratlsMesh.*` | | MRTD and RTMR[1], RTMR[2] only |
+| `<component>.repository`, `<component>.digest` | | the digest the bundle names for each deployed component |
+
+When `staticAllowlist.enabled` is true the chart:
+
+- mounts `policyDir` and `attestationSocketDir` into the CDS pod read-only as
+  `hostPath` volumes of type `Directory`, and gives the pod supplementary
+  group 65532;
+- has CDS, tls-lb, ratls-mesh, and the operator dial
+  `unix://<attestationSocketDir>/attestation-api.sock`; no pod carries a
+  `HOST_IP` environment variable and no unprivileged argv contains
+  `$(HOST_IP)`;
+- sets `enableServiceLinks: false` on every c8s pod, so the environment is
+  the one the sealed rules list;
+- passes `--static-allowlist --attestation-socket-dir <dir>` to the operator,
+  which mounts the socket directory into every injected sidecar and passes
+  `--cds-pins-from-own-quote` instead of flat CDS pins;
+- carves the two hostPaths out of the deny-host-namespaces
+  ValidatingAdmissionPolicy on the same terms as the inventory socket
+  directory.
+
+RTMR[3] goes only into the measurements config file, never into the flat
+lists: flat pins land in container argv, that argv is in the bundle, and the
+register is derived from the bundle.
+
+The render fails (`VALIDATION_ERROR kind=static_allowlist_*`) when
+`staticAllowlist.enabled` is combined with any of: `attestationApi.cvmMode`
+other than `node`, a platform other than TDX, `cds.operatorKeys`,
+`cds.persistence.enabled`, `kata.enabled`, `attestationApi.enabled`,
+`nriImagePolicy.enabled`, or an empty `cds.measurementsConfig`.
+
+## Sealing a cluster
+
+The bundle client commands take the bundle as a directory (every regular
+file is a member) or as the `static-allowlist.json` file alone (a one-member
+bundle). They refuse an `.iso`: pass the directory the ISO was built from.
+The examples use `bundle/`.
+
+### 1. Render the sealed document
+
+`render --sealed` needs the chart values the cluster is installed with. The
+component digests in that file are the digests the c8s entries pin, and
+`c8s install --static-allowlist` later pins the same digests from the bundle.
+Derive a measurements config from the image manifest and render the values
+for the target release:
+
+```sh
+c8s measurements derive manifest.json > image.measurements.json
+c8s render-values --cvm-mode=node --hardware-platform=tdx --image-tag TAG \
+  --measurements-config image.measurements.json > values.yaml
+```
+
+Add the static keys to `values.yaml`: `staticAllowlist.enabled: true`,
+`nriImagePolicy.enabled: false`, `cds.persistence.enabled: false`. The
+measurements config content is not yet the static entry; that is fine for
+rendering, because it reaches CDS and ratls-mesh through a ConfigMap, never
+through argv. Then render:
+
+```sh
+c8s allowlist render --sealed --system-floor system-floor.json \
+  --chart-values values.yaml --workloads workloads.yaml \
+  --report review.txt > bundle/static-allowlist.json
+```
+
+- `--system-floor` is the `system-floor.json` the image build publishes
+  beside `manifest.json`: one skeleton entry per RKE2 floor image with the
+  image's own `entrypoint` and `cmd`. The build cannot see the static pod
+  manifests, so `env`, `mounts`, and `privileges.review` start empty. Complete
+  them from a dynamic node's observations before linting.
+- `--chart-values` renders the chart with `helm template` and derives one
+  entry per c8s pod from the image configs and the templates.
+- `--workloads` takes Pod, Deployment, StatefulSet, DaemonSet, Job, and
+  CronJob manifests; it requires `--chart-values` because it runs the
+  webhook mutator in-process on each pod template, so `c8s-cert`,
+  `c8s-cert-wait`, `c8s-secret`, and `c8s-volume` get rules from the same
+  code that injects them.
+- `render` needs `helm` on `PATH`, and `crane` to read image configs.
+- The report lists every executable, argv, env rule, mount rule, and
+  privilege. Reviews for privileged entries, `pvc`, and `nodeState` mounts
+  start empty; `lint --sealed` refuses the document until you complete them.
+- Pods that do not set `enableServiceLinks: false` get a warning: the kubelet
+  adds one environment variable per Service in the namespace, which no rule
+  can pin. `KUBERNETES_SERVICE_HOST` defaults to `10.53.0.1`, the node
+  image's service CIDR; override with `--kubernetes-service-host`.
+
+### 2. Lint and build the disk
+
+```sh
+c8s allowlist lint --sealed bundle/static-allowlist.json
+c8s policy-disk --member bundle/static-allowlist.json -o policydata.iso
+```
+
+`policy-disk` prints `index-digest: sha256:<hex>` and `rtmr3: <hex>`, the
+values a node sealed to this bundle reports. Record them. For KubeVirt:
+
+```sh
+c8s policy-disk --member bundle/static-allowlist.json -o policydata.iso \
+  --kubevirt-secret c8s-policydata > policydata-secret.yaml
+```
+
+The Secret goes to stdout and the digest lines to stderr. The file ends with
+the disk and volume entries to add to the VirtualMachine, as comments.
+`policy-disk` needs `xorrisofs`, `genisoimage`, or `mkisofs` on `PATH`.
+
+### 3. Launch the nodes
+
+Attach `policydata.iso` (label `policydata`) to the generic node image with
+no `opkeydata` disk. A node that fails to seal powers off.
+
+### 4. Get a kubeconfig
+
+```sh
+c8s get-kubeconfig --node NODE_IP --image-manifest manifest.json \
+  --static-allowlist bundle/ --out guest.kubeconfig
+```
+
+`--static-allowlist` replaces `--operator-key`: the gate pins the image tuple
+from the manifest and RTMR[3] derived from the bundle, and fetches the
+credential without an operator token. It is mutually exclusive with
+`--operator-key` and `--workload-image`.
+
+### 5. Install
+
+```sh
+c8s install --cvm-mode=node --hardware-platform=tdx \
+  --static-allowlist bundle/ --image-manifest manifest.json
+```
+
+Before the chart renders, `install`:
+
+- lints `static-allowlist.json` as sealed;
+- requires `--cvm-mode=node` and `--hardware-platform=tdx`;
+- refuses `--operator-keys`, an explicit `--resolve-digests=true`,
+  `--measurements`, `--measurements-config`, and `--rtmrs`, and forces digest
+  resolution off: every component digest comes from the bundle, and a
+  component the bundle does not name fails the install;
+- attests every node through `http://NODE_INTERNAL_IP:8400/attest` and
+  requires the static tuple, RTMR[3] included. When a node's InternalIP is
+  not routable from where you run `install` (a KubeVirt masquerade guest),
+  pass `--static-node-attest NODE_NAME=HOST:PORT` for that node;
+- lists every running container whose digest the bundle does not name and
+  fails; `--force` installs anyway with a warning. The containers' argv, env,
+  and mounts are not visible through the API, so that check stays the sealed
+  plugin's.
+
+A static install emits no image tag: every component is pinned by the
+digest the bundle names for its repository. For GitOps, `c8s render-values` takes the same `--static-allowlist` and
+`--image-manifest` flags and emits the install-time values, static entry
+included. Rendering the bundle again against those values produces the same
+bytes.
+
+### 6. Verify from outside
+
+```sh
+c8s verify https://TLS_LB --kind lb --image-manifest manifest.json \
+  --static-allowlist bundle/ --workload ENTRY --mesh-ca mesh-ca.pem -o json
+```
+
+`--static-allowlist` is a sibling of `--operator-pkey`: it derives and pins
+RTMR[3] from the bundle and holds the leaf's matched-workload stamp to the
+bundle's own document. It requires `--image-manifest`, `--workload`, and
+`--mesh-ca`, and conflicts with `--operator-pkey`, `--expected-rtmr3`,
+`--rtmr 3=`, and `--allowlist`. A verified verdict reports
+`static_policy_digest` (`sha256:<hex>` of the index), the value RTMR[3] was
+derived from. Exit codes are the `c8s verify` contract: `0` verified, `1`
+usage, `2` policy failed, `3` evidence unavailable, `4` partially verified
+([`operator.md`](operator.md#verifying-attestation-after-install)).
+
+`install` and `verify` take the same bundle the node booted with, never the
+disk on the node: they recompute the index and RTMR[3] from it.
+
+## What the operator can still do
+
+- Scale, restart, and delete allowed pods; deny service; reboot into another
+  bundle, which pinned clients reject.
+- Point a Service or EndpointSlice at another allowed pod, and choose where
+  tls-lb forwards plaintext. This design makes no claim about where user
+  data goes after the front door.
+- Supply PVC contents at mount paths whose rule's `review` says why that
+  cannot steer the workload. Volume integrity and encryption are the volume
+  design ([`volumes.md`](volumes.md)).
+- Run another copy of a privileged platform pod with its sealed argv and env
+  and drive it through its own API. Such entries are reviewed node TCB.
+- Read Kubernetes Secrets in etcd. Workloads take secrets from CDS
+  `/secrets`; the sealed rules admit no Secret or ConfigMap mount outside a
+  reviewed `privileges.hostPaths`.
+- Obtain the operator kubeconfig: `cred-release` serves any caller in
+  static mode. `cluster-admin` is the adversary already.
+
+## Known gaps and follow-ups
+
+- **containerd admits a timed-out plugin call.** `containerd/nri` v0.12.2
+  registers the plugin with its validators before the reply and turns a
+  deadline or closed-connection error into a nil reply, so `required_plugins`
+  refuses later requests but the request that timed out is admitted. The fix
+  ships as `node-guest-image/c8s/patches/containerd-nri-fail-closed.patch`
+  for the image pipeline to build into RKE2's containerd with the
+  `+c8s.nri-failclosed` version marker. Until that containerd ships, the
+  baked `image-policy.yaml.in` keeps `runtime.require_fail_closed: false` and
+  the plugin's own 1.5 s deadline and OOM protection are the mitigation.
+- **The attestation-api socket is a proxy, not a native listener.**
+  attestation-api lives in attestation-rs and listens on loopback only;
+  `c8s-attest-socket.service` fronts it with `c8s attest-proxy` inside the
+  measured image. A native unix listener is a follow-up in that repository.
+- **The mesh CA is not evidence-authenticated.** Only leaves carry RA-TLS
+  evidence, so `verify --static-allowlist` still needs `--mesh-ca` to vouch
+  for the matched-workload stamp. Authenticating the CA by its own evidence
+  would make `--mesh-ca` optional.
+- **`install` cannot preflight observed container specs.** containerd is not
+  visible through the API, so `install` checks running image digests against
+  the bundle and leaves argv, env, and mounts to the sealed plugin.
+- **CDI and GPU workloads are denied in sealed mode.** A CDI device injects
+  OCI hooks and host bind mounts; the hooks rule denies the container, and the
+  binds classify as `hostPath`. GPU workloads on a sealed node need a typed
+  rule.
+- **local-path-storage's helper pod has no admissible rule.** Its `busybox`
+  argv is per PVC. Static images ship without local-path-storage until a
+  typed rule exists.
+- **SEV-SNP** has no runtime register. The same policy digest would go
+  through HOSTDATA, as `HostDataForOperatorKey` does for the operator key.
+- **The threat model and requirements documents** live in the c8s-workspace
+  repository, not here.
+- **Two power-off assertions have no e2e coverage**: delaying the plugin past
+  its deadline and a container present at Synchronize both need an in-guest
+  fault injector, which a locked image does not carry.
+- **A launch wrapper** that attaches the bundle and the generic image in one
+  step is a follow-up.

--- a/docs/static-allowlist.md
+++ b/docs/static-allowlist.md
@@ -19,7 +19,7 @@ they can then verify that the cluster runs only that set of pods and that the
 operator, who holds `cluster-admin`, cannot read user data. The operator can
 still scale, restart, and delete allowed pods.
 
-Out of scope, by decision: availability and liveness (any failure may power
+Out of scope: availability and liveness (any failure may power
 the node off), routing and where tls-lb forwards plaintext, SEV-SNP,
 pod-as-CVM, operator keys, and browser clients. Clusters with the same image
 tuple and the same bundle are indistinguishable to a relying party.
@@ -201,7 +201,7 @@ byte-identically.
               "/data": { "source": "pvc", "review": "read-only model weights; the server parses them with a bounded loader" },
               "/dev/shm": { "source": "platform" },
               "/etc/hosts": { "source": "platform" },
-              "/var/run/secrets/kubernetes.io/serviceaccount": { "source": "serviceAccountToken" }
+              "/var/run/secrets/kubernetes.io/serviceaccount": { "source": "serviceAccountToken", "review": "nginx reads nothing under the token directory" }
             }
           }
         }
@@ -228,19 +228,27 @@ Under `mounts.policy: exact`, every bind destination carries a `source` class:
 | Class | What the plugin classifies there | Review |
 |---|---|---|
 | `emptyDir` | `kubernetes.io~empty-dir` volumes | no |
-| `serviceAccountToken` | the kubelet's `kube-api-access-*` projected volume | no |
-| `pvc` | CSI and local volumes, and local-path-storage's `/opt/local-path-provisioner/` | required: why operator-supplied contents cannot steer the workload |
+| `serviceAccountToken` | a `kube-api-access-*` projected volume | required: the name is not reserved, so why operator-chosen files at that path cannot steer the workload |
+| `pvc` | CSI volumes (`kubernetes.io~csi`), from a claim or inline | required: why operator-supplied contents cannot steer the workload |
 | `platform` | the kubelet's `/etc/hosts`, `/etc/hostname`, `/etc/resolv.conf`, `/dev/termination-log`, `/dev/shm`, and the plugin's own socket directory `/run/nri-image-policy` | no |
 | `nodeState` | binds from `/run/confai`: the attestation socket and the policy directory | required: why the entry may reach the node's verifier or policy state |
-| `hostPath` | anything else, admitted only through `privileges.hostPaths` | through `privileges.review` |
+| `hostPath` | anything else, admitted only from the rule's `path` and through `privileges.hostPaths` | through `privileges.review` |
 
 `nodeState` is its own class rather than `platform` so the `platform` rule
 every container carries for `/etc/hosts` can never admit the attestation
-socket bound there. ConfigMap, Secret, other projected, downward-API, and
-hostPath volumes classify outside the reviewed classes; `render --sealed`
-turns them into a `hostPath` rule with `privileges.hostPaths:
-["/var/lib/kubelet/pods/"]` (or the host path as bound) and a `privileges`
-block the reviewer must complete.
+socket bound there. ConfigMap, Secret, other projected, downward-API,
+hostPath, and local (`kubernetes.io~local-volume`, whose backing directory
+the PersistentVolume names) volumes classify outside the reviewed classes;
+`render --sealed` turns them into a `hostPath` rule whose `path` is the host
+source as bound (`/var/lib/kubelet/pods/` for the kubelet's volumes), lists
+the same source under `privileges.hostPaths`, and leaves a `privileges` block
+the reviewer must complete. A `path` ending in `/` admits the subtree; a
+listed source is admitted only at the destination whose rule names it.
+
+The `serviceAccountToken` review exists because Kubernetes reserves nothing
+about the volume name: a pod may declare its own projected volume called
+`kube-api-access-x` with ConfigMap or Secret items and mount it at the
+token path. The rule admits it; the review says why that cannot matter.
 
 ### Privileges
 
@@ -249,8 +257,16 @@ block the reviewer must complete.
 runtime default set), `devices`, `hostPaths` (an entry ending in `/` admits
 the subtree), `unmaskedProc`, and a `review` string that says why the entry is
 acceptable. A privileged entry holds every capability and device, so those
-lists are not compared for it. An entry without `privileges` must pin
-`command`, `mounts`, and `env` exactly and `args` exactly or `deny`.
+lists are not compared for it.
+
+`privileges` loosens nothing else. Every entry, privileged or not, pins
+`command`, `mounts`, and `env` exactly and `args` exactly or `deny`: an open
+argv on a privileged image is a root shell on the node for anyone who can
+create a pod with that digest, and open env or mounts steer a fixed argv
+(`LD_PRELOAD` from an operator volume). An RKE2 static pod whose argv
+carries node-specific values (`--advertise-address`) therefore cannot be
+sealed until the schema can express them; `lint --sealed` refuses the bundle
+rather than admit `any`.
 
 ### What `lint --sealed` checks
 
@@ -260,11 +276,12 @@ lists are not compared for it. An entry without `privileges` must pin
 - `digests` is `{}` and `workloads` is an object (the form the CDS store
   serves back, so the stamp matches the measured bytes);
 - every `privileges` block has a non-empty `review`;
-- every unprivileged entry has exact `command`, `mounts`, and `env`, and
-  `args` exact or deny;
+- every entry has exact `command`, `mounts`, and `env`, and `args` exact or
+  deny;
 - every exact `env` carries `values` and every exact `mounts` carries `rules`;
-- every `pvc` and `nodeState` rule has a `review`;
-- a `hostPath` rule appears only on an entry with `privileges`.
+- every `pvc`, `serviceAccountToken`, and `nodeState` rule has a `review`;
+- a `hostPath` rule appears only on an entry with `privileges`, carries a
+  `path`, and that path lies within `privileges.hostPaths`.
 
 The same function runs in the node (`c8s policy-measure`), the plugin,
 `c8s policy-disk`, `c8s install`, `c8s get-kubeconfig`, and `c8s verify`, so
@@ -393,7 +410,8 @@ c8s allowlist render --sealed --system-floor system-floor.json \
   beside `manifest.json`: one skeleton entry per RKE2 floor image with the
   image's own `entrypoint` and `cmd`. The build cannot see the static pod
   manifests, so `env`, `mounts`, and `privileges.review` start empty. Complete
-  them from a dynamic node's observations before linting.
+  them from a dynamic node's observations before linting; `lint --sealed`
+  refuses an open `env` or `mounts` on a floor entry like on any other.
 - `--chart-values` renders the chart with `helm template` and derives one
   entry per c8s pod from the image configs and the templates.
 - `--workloads` takes Pod, Deployment, StatefulSet, DaemonSet, Job, and
@@ -403,8 +421,12 @@ c8s allowlist render --sealed --system-floor system-floor.json \
   code that injects them.
 - `render` needs `helm` on `PATH`, and `crane` to read image configs.
 - The report lists every executable, argv, env rule, mount rule, and
-  privilege. Reviews for privileged entries, `pvc`, and `nodeState` mounts
-  start empty; `lint --sealed` refuses the document until you complete them.
+  privilege. Reviews for privileged entries and for `pvc`,
+  `serviceAccountToken`, and `nodeState` mounts start empty; `lint --sealed`
+  refuses the document until you complete them.
+- Exec probes and lifecycle hooks are reported as warnings: the kubelet runs
+  them through CRI exec, which no rule covers (see
+  [Known gaps](#known-gaps-and-follow-ups)).
 - Pods that do not set `enableServiceLinks: false` get a warning: the kubelet
   adds one environment variable per Service in the namespace, which no rule
   can pin. `KUBERNETES_SERVICE_HOST` defaults to `10.53.0.1`, the node
@@ -471,10 +493,10 @@ Before the chart renders, `install`:
   plugin's.
 
 A static install emits no image tag: every component is pinned by the
-digest the bundle names for its repository. For GitOps, `c8s render-values` takes the same `--static-allowlist` and
-`--image-manifest` flags and emits the install-time values, static entry
-included. Rendering the bundle again against those values produces the same
-bytes.
+digest the bundle names for its repository. For GitOps, `c8s render-values`
+takes the same `--static-allowlist` and `--image-manifest` flags and emits
+the install-time values, static entry included. Rendering the bundle again
+against those values produces the same bytes.
 
 ### 6. Verify from outside
 
@@ -506,11 +528,17 @@ disk on the node: they recompute the index and RTMR[3] from it.
 - Supply PVC contents at mount paths whose rule's `review` says why that
   cannot steer the workload. Volume integrity and encryption are the volume
   design ([`volumes.md`](volumes.md)).
-- Run another copy of a privileged platform pod with its sealed argv and env
-  and drive it through its own API. Such entries are reviewed node TCB.
+- Run another copy of a privileged platform pod with its sealed argv, env,
+  and mounts and drive it through its own API. Such entries are reviewed
+  node TCB.
 - Read Kubernetes Secrets in etcd. Workloads take secrets from CDS
   `/secrets`; the sealed rules admit no Secret or ConfigMap mount outside a
-  reviewed `privileges.hostPaths`.
+  reviewed `privileges.hostPaths`, except as a projected volume named
+  `kube-api-access-*` at a `serviceAccountToken` destination, which is what
+  that rule's `review` covers.
+- Add an exec probe or a lifecycle hook to an admitted pod, or edit one.
+  The kubelet runs its argv inside the container, and the plugin cannot see
+  it (see [Known gaps](#known-gaps-and-follow-ups)).
 - Obtain the operator kubeconfig: `cred-release` serves any caller in
   static mode. `cluster-admin` is the adversary already.
 
@@ -540,9 +568,36 @@ disk on the node: they recompute the index and RTMR[3] from it.
   OCI hooks and host bind mounts; the hooks rule denies the container, and the
   binds classify as `hostPath`. GPU workloads on a sealed node need a typed
   rule.
+- **Exec probes and lifecycle hooks run unchecked.** The kubelet runs
+  `livenessProbe`, `readinessProbe`, `startupProbe` `exec` commands and
+  `postStart`/`preStop` `exec` hooks inside an admitted container through
+  CRI `ExecSync`, which has no NRI hook, and which
+  `enable-debugging-handlers=false` does not touch (that closes the kubelet's
+  HTTP exec, attach, and logs endpoints only). `cluster-admin` can therefore
+  run an argv of their choosing inside any admitted container and read its
+  output from the pod's events (a failing probe's stdout lands in the event
+  message) without any network egress. `render --sealed` warns about every
+  such probe and hook so the reviewer sees them, and the RA-TLS mesh key
+  under `/run/c8s/certs` is one thing such a probe can read. Closing it
+  needs an `ExecSync` refusal in the fail-closed containerd patch and a
+  plugin that refuses a containerd without it. Until then the bundle does
+  not protect against it.
+- **Not sealed: working directory, user, seccomp, and pod pid sharing.** A
+  rule pins argv, env, and mounts; the operator still chooses the
+  container's `workingDir`, `runAsUser`/`runAsGroup`, the seccomp profile,
+  and `shareProcessNamespace`, and the plugin does not read those from the
+  spec. With every argv, env, and mount pinned, a sibling container in a
+  shared pid namespace can read this one's `/proc/<pid>/root` only through
+  its own sealed argv. Sealing them needs schema fields the reviewer can
+  fill (`render` cannot resolve a named image `USER` without the image's
+  `/etc/passwd`), a follow-up.
 - **local-path-storage's helper pod has no admissible rule.** Its `busybox`
-  argv is per PVC. Static images ship without local-path-storage until a
-  typed rule exists.
+  argv is per PVC. The generic image still ships local-path-storage
+  (`node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/local-path-storage.yaml`),
+  so a sealed bundle omits its floor entry (as the e2e lane's `reviews.json`
+  does) and its pods are refused on a sealed node until a typed per-PVC
+  argv rule exists. A `local` PersistentVolume classifies as a host path
+  for the same reason: its backing directory is the operator's choice.
 - **SEV-SNP** has no runtime register. The same policy digest would go
   through HOSTDATA, as `HostDataForOperatorKey` does for the operator key.
 - **The threat model and requirements documents** live in the c8s-workspace

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/lestrrat-go/httprc/v3 v3.0.6
 	github.com/lestrrat-go/jwx/v3 v3.2.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/opencontainers/runtime-spec v1.3.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1
@@ -118,7 +119,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containerd/containerd/v2 v2.3.4
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/nri v0.12.2
+	github.com/containerd/platforms v1.0.0-rc.4
 	github.com/coreos/go-iptables v0.8.0
 	github.com/distribution/reference v0.6.0
 	github.com/fsnotify/fsnotify v1.10.1
@@ -61,7 +62,6 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/containerd/platforms v1.0.0-rc.4 // indirect
 	github.com/containerd/plugin v1.1.0 // indirect
 	github.com/containerd/ttrpc v1.2.9 // indirect
 	github.com/containerd/typeurl/v2 v2.3.0 // indirect

--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -5,11 +5,11 @@
 // per-container argv and path policy, looked up by container digest).
 //
 // Reads (list, export, diff, workload list/get, lint, inspect-image) are
-// unauthenticated, and render and lint --sealed produce and check the sealed
-// document a static-allowlist node measures. Writes (add, remove, upload, workload apply/edit/delete) are
-// authorized by an operator EC private key whose public key CDS pins
-// (cds --operator-keys); the CLI mints a short-lived, body-bound token per write
-// via pkg/operatorauth.
+// unauthenticated. render and lint --sealed produce and check the sealed
+// document a static-allowlist node measures. Writes (add, remove, upload,
+// workload apply/edit/delete) are authorized by an operator EC private key
+// whose public key CDS pins (cds --operator-keys); the CLI mints a
+// short-lived, body-bound token per write via pkg/operatorauth.
 package allowlist
 
 import (

--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -5,7 +5,8 @@
 // per-container argv and path policy, looked up by container digest).
 //
 // Reads (list, export, diff, workload list/get, lint, inspect-image) are
-// unauthenticated. Writes (add, remove, upload, workload apply/edit/delete) are
+// unauthenticated, and render and lint --sealed produce and check the sealed
+// document a static-allowlist node measures. Writes (add, remove, upload, workload apply/edit/delete) are
 // authorized by an operator EC private key whose public key CDS pins
 // (cds --operator-keys); the CLI mints a short-lived, body-bound token per write
 // via pkg/operatorauth.
@@ -45,6 +46,10 @@ var defaultRequiredComponents = []string{
 	"attestation-api",
 	"nginx",
 }
+
+// extraCommands are constructors registered from files behind a build tag:
+// render needs the embedded chart, which the node build leaves out.
+var extraCommands []func(o *options) *cobra.Command
 
 // options holds the flags shared by every subcommand.
 type options struct {
@@ -103,6 +108,9 @@ allowlist").`,
 		newLintCmd(o),
 		newInspectImageCmd(o),
 	)
+	for _, extra := range extraCommands {
+		cmd.AddCommand(extra(o))
+	}
 	return cmd
 }
 

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -36,7 +36,8 @@ same.
 --sealed lints a static-allowlist bundle member: the file must be byte-equal
 to its canonical form, carry no floor digests, and give every container a
 complete rule (exact argv, env values, mount sources; a review for every pvc
-mount and every privileged entry). Every shortfall is an error.`,
+mount, every nodeState mount and every privileged entry). Every shortfall is
+an error.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, err := readFileOrStdin(cmd, args[0])

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -15,7 +15,7 @@ import (
 )
 
 func newLintCmd(o *options) *cobra.Command {
-	var online, strict bool
+	var online, strict, sealed bool
 	var cvmMode string
 	cmd := &cobra.Command{
 		Use:   "lint <file|->",
@@ -31,7 +31,12 @@ exists in its registry via crane.
 Two entries declaring the same containers with the same argv policy are an
 error: release requires exactly one entry to match, so both are refused
 forever. Errors exit non-zero on their own; --strict makes warnings do the
-same.`,
+same.
+
+--sealed lints a static-allowlist bundle member: the file must be byte-equal
+to its canonical form, carry no floor digests, and give every container a
+complete rule (exact argv, env values, mount sources; a review for every pvc
+mount and every privileged entry). Every shortfall is an error.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, err := readFileOrStdin(cmd, args[0])
@@ -43,7 +48,11 @@ same.`,
 				return err
 			}
 			findings := lintOffline(al)
-			findings = append(findings, unobservedFieldPolicies(al, cvmMode)...)
+			if sealed {
+				findings = append(findings, lintSealed(data)...)
+			} else {
+				findings = append(findings, unobservedFieldPolicies(al, cvmMode)...)
+			}
 			if online {
 				if err := crane.Require(); err != nil {
 					return err
@@ -70,7 +79,23 @@ same.`,
 	cmd.Flags().BoolVar(&online, "online", false, "also check each digest exists in its registry via crane")
 	cmd.Flags().BoolVar(&strict, "strict", false, "exit non-zero if there are any warnings")
 	cmd.Flags().StringVar(&cvmMode, "cvm-mode", "", "deployment mode the allowlist targets (pod, node, gke, aks); pod silences the mount/env scope warning")
+	cmd.Flags().BoolVar(&sealed, "sealed", false, "lint as a static-allowlist bundle member: canonical bytes, no floor, a complete rule per container")
 	return cmd
+}
+
+// lintSealed reports every sealed-mode shortfall as an error. The document
+// already parsed, so the only failure SealedFindings can return is the
+// document's own.
+func lintSealed(data []byte) []finding {
+	msgs, err := pkgallowlist.SealedFindings(data)
+	if err != nil {
+		return []finding{errorf("%v", err)}
+	}
+	out := make([]finding, 0, len(msgs))
+	for _, m := range msgs {
+		out = append(out, errorf("%s", m))
+	}
+	return out
 }
 
 func newInspectImageCmd(o *options) *cobra.Command {

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -35,9 +35,9 @@ same.
 
 --sealed lints a static-allowlist bundle member: the file must be byte-equal
 to its canonical form, carry no floor digests, and give every container a
-complete rule (exact argv, env values, mount sources; a review for every pvc
-mount, every nodeState mount and every privileged entry). Every shortfall is
-an error.`,
+complete rule (exact argv, env values, mount sources, privileged or not; a
+review for every pvc, serviceAccountToken and nodeState mount and every
+privileged entry). Every shortfall is an error.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			data, err := readFileOrStdin(cmd, args[0])
@@ -84,9 +84,8 @@ an error.`,
 	return cmd
 }
 
-// lintSealed reports every sealed-mode shortfall as an error. The document
-// already parsed, so the only failure SealedFindings can return is the
-// document's own.
+// lintSealed reports every sealed-mode shortfall as an error; a parse or
+// canonicalization failure is one finding.
 func lintSealed(data []byte) []finding {
 	msgs, err := pkgallowlist.SealedFindings(data)
 	if err != nil {

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -382,12 +382,12 @@ func TestLintSealed(t *testing.T) {
 	complete := `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
 		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
 		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}`
-	al := mustParseAllowlist(t, `{"schema":"c8s.allowlist/v1","workloads":{"web":{"containers":[`+complete+`]}}}`)
+	al := mustParseAllowlist(t, `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[`+complete+`]}}}`)
 	canonical, err := al.Canonical()
 	if err != nil {
 		t.Fatal(err)
 	}
-	incomplete := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"web":{"initContainers":null,"containers":[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"any"}}]}}}`
+	incomplete := `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"initContainers":null,"containers":[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"any"}}]}}}`
 	dynamicWarning := "only the in-guest policy-monitor observes"
 	for _, tc := range []struct {
 		name      string

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -374,3 +374,53 @@ func TestLintWarnsOnUnobservedMountAndEnvPolicy(t *testing.T) {
 		t.Fatalf("lint --cvm-mode=pod output = %q, want no findings", out)
 	}
 }
+
+// --sealed lints a bundle member: the bytes must be canonical and every
+// container needs a complete rule. It replaces the unobserved-field warning,
+// which describes the dynamic enforcers a sealed document never meets.
+func TestLintSealed(t *testing.T) {
+	complete := `{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
+		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
+		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}`
+	al := mustParseAllowlist(t, `{"schema":"c8s.allowlist/v1","workloads":{"web":{"containers":[`+complete+`]}}}`)
+	canonical, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	incomplete := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"web":{"initContainers":null,"containers":[{"digest":"` + digA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"any"}}]}}}`
+	dynamicWarning := "only the in-guest policy-monitor observes"
+	for _, tc := range []struct {
+		name      string
+		body      string
+		wantErr   string
+		wantOut   []string
+		rejectOut []string
+	}{
+		{"clean", string(canonical), "", []string{"ok: no findings\n"}, []string{dynamicWarning}},
+		{"trailing newline", string(canonical) + "\n", "lint error(s)", []string{"error: document bytes are not its canonical form"}, nil},
+		{"incomplete rules", incomplete, "lint error(s)", []string{
+			"error: " + `workload "web" containers[0] ` + digA + ": mounts must be exact",
+			"error: " + `workload "web" containers[0] ` + digA + ": env must be exact",
+		}, []string{dynamicWarning}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, _, err := runCmd("lint", "--sealed", writeFile(t, "doc.json", tc.body))
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("lint --sealed(%s) = %q, %v; want nil error", tc.name, out, err)
+			case tc.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tc.wantErr)):
+				t.Fatalf("lint --sealed(%s) = %q, %v; want error containing %q", tc.name, out, err, tc.wantErr)
+			}
+			for _, want := range tc.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("lint --sealed(%s) output = %q, want it to contain %q", tc.name, out, want)
+				}
+			}
+			for _, reject := range tc.rejectOut {
+				if strings.Contains(out, reject) {
+					t.Errorf("lint --sealed(%s) output = %q, want no %q", tc.name, out, reject)
+				}
+			}
+		})
+	}
+}

--- a/internal/cmds/allowlist/render.go
+++ b/internal/cmds/allowlist/render.go
@@ -51,8 +51,10 @@ operator's own injection, so c8s-cert and its siblings get rules too.
 
 The canonical document goes to stdout; a review report listing every
 executable, argv, env rule, mount rule and privilege goes to stderr or
---report. Reviews (privileged entries, pvc and nodeState mounts) start empty:
-complete them, then run 'c8s allowlist lint --sealed'.`,
+--report. Reviews (privileged entries, pvc, serviceAccountToken and nodeState
+mounts) start empty: complete them, then run 'c8s allowlist lint --sealed'.
+Exec probes and lifecycle hooks are reported as warnings: the kubelet runs
+them through CRI exec, which no sealed rule covers.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !sealed {
@@ -194,7 +196,7 @@ func (r *renderer) addChart(rendered []byte, namespace string) error {
 	}
 	r.operator = &cfg
 	if cfg.WorkloadClaimsHostDir != "" {
-		r.cluster.platformDir = hostPathAsBound(cfg.WorkloadClaimsHostDir)
+		r.cluster.platformDir = pkgallowlist.BindSource(cfg.WorkloadClaimsHostDir)
 		r.report.notef("platform socket directory: %s (the operator's --workload-claims-host-dir); binds from it are platform mounts", r.cluster.platformDir)
 	}
 	return r.addManifests(manifests, namespace, "chart")
@@ -335,8 +337,11 @@ func writeContainerReport(w io.Writer, where string, c pkgallowlist.Container) {
 		for _, d := range c.Mounts.Destinations {
 			r := c.Mounts.Rules[d]
 			fmt.Fprintf(w, "    mount: %s source=%s", d, r.Source)
-			if r.Source == pkgallowlist.SourcePVC {
+			switch r.Source {
+			case pkgallowlist.SourcePVC, pkgallowlist.SourceNodeState, pkgallowlist.SourceServiceAccountToken:
 				fmt.Fprintf(w, " review=%q", r.Review)
+			case pkgallowlist.SourceHostPath:
+				fmt.Fprintf(w, " path=%s", r.Path)
 			}
 			fmt.Fprintln(w)
 		}

--- a/internal/cmds/allowlist/render.go
+++ b/internal/cmds/allowlist/render.go
@@ -1,0 +1,361 @@
+//go:build !c8s_node
+
+package allowlist
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/internal/crane"
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+func init() {
+	extraCommands = append(extraCommands, newRenderCmd)
+}
+
+// defaultKubernetesServiceHost is the API server's Service IP on the node
+// image's service CIDR (node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/
+// config.yaml: service-cidr 10.53.0.0/16).
+const defaultKubernetesServiceHost = "10.53.0.1"
+
+// chartKubeVersion is the chart's kubeVersion floor, pinned so rendering
+// does not depend on the helm client's compiled default.
+const chartKubeVersion = "1.30.0"
+
+func newRenderCmd(_ *options) *cobra.Command {
+	var (
+		sealed                       bool
+		systemFloor, chartValues     string
+		workloads, chartDir          string
+		releaseName, releaseNS       string
+		serviceHost, servicePort     string
+		reportPath, workloadsDefault string
+	)
+	cmd := &cobra.Command{
+		Use:   "render --sealed [--system-floor FILE] [--chart-values FILE] [--workloads FILE]",
+		Short: "Render a complete sealed allowlist from the chart, the node image and workload manifests",
+		Long: `Render the static-allowlist bundle member for a sealed cluster: one entry per
+pod the chart deploys (helm template on --chart-values), per system image in
+the node image's --system-floor file, and per workload in --workloads. Every
+container gets a complete rule: argv from the image config and the template
+with Kubernetes semantics, env values from the image, the kubelet and the
+template (fieldRefs become 'from' rules), every bind mount with its source
+class, and the privileges the pod asks for. Workload pods run through the
+operator's own injection, so c8s-cert and its siblings get rules too.
+
+The canonical document goes to stdout; a review report listing every
+executable, argv, env rule, mount rule and privilege goes to stderr or
+--report. Reviews (privileged entries, pvc mounts) start empty: complete them,
+then run 'c8s allowlist lint --sealed'.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if !sealed {
+				return fmt.Errorf("--sealed is required: render produces static-allowlist bundle members only")
+			}
+			if systemFloor == "" && chartValues == "" && workloads == "" {
+				return fmt.Errorf("nothing to render: pass --system-floor, --chart-values or --workloads")
+			}
+			if workloads != "" && chartValues == "" {
+				return fmt.Errorf("--workloads needs --chart-values: the injected sidecar rules come from the operator the chart deploys")
+			}
+			if chartValues != "" {
+				if err := crane.Require(); err != nil {
+					return err
+				}
+			}
+			reportOut := cmd.ErrOrStderr()
+			if reportPath != "" {
+				f, err := os.Create(reportPath)
+				if err != nil {
+					return err
+				}
+				defer f.Close()
+				reportOut = f
+			}
+			r := &renderer{
+				images:  &imageResolver{ctx: ctx(cmd)},
+				cluster: clusterFacts{serviceHost: serviceHost, servicePort: servicePort},
+				report:  &report{},
+				entries: map[string]pkgallowlist.Workload{},
+			}
+			if systemFloor != "" {
+				if err := r.addSystemFloor(systemFloor); err != nil {
+					return err
+				}
+			}
+			if chartValues != "" {
+				dir := chartDir
+				if dir == "" {
+					extracted, err := extractChart()
+					if err != nil {
+						return err
+					}
+					defer os.RemoveAll(extracted)
+					dir = extracted
+				}
+				rendered, err := helmTemplate(ctx(cmd), dir, releaseName, releaseNS, chartKubeVersion, chartValues)
+				if err != nil {
+					return err
+				}
+				if err := r.addChart(rendered, releaseNS); err != nil {
+					return err
+				}
+			}
+			if workloads != "" {
+				data, err := readFileOrStdin(cmd, workloads)
+				if err != nil {
+					return err
+				}
+				if err := r.addWorkloads(data, workloadsDefault); err != nil {
+					return err
+				}
+			}
+			doc, err := r.document()
+			if err != nil {
+				return err
+			}
+			r.report.write(reportOut, r.entries)
+			_, err = cmd.OutOrStdout().Write(doc)
+			return err
+		},
+	}
+	f := cmd.Flags()
+	f.BoolVar(&sealed, "sealed", false, "render a static-allowlist bundle member (required)")
+	f.StringVar(&systemFloor, "system-floor", "", "system-floor.json emitted by the node image build")
+	f.StringVar(&chartValues, "chart-values", "", "helm values file the cluster is installed with")
+	f.StringVar(&workloads, "workloads", "", "YAML manifests of the workloads to admit (Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob); '-' reads stdin")
+	f.StringVar(&chartDir, "chart", "", "chart directory (default: the chart embedded in this binary)")
+	f.StringVar(&releaseName, "release-name", "c8s", "helm release name")
+	f.StringVar(&releaseNS, "release-namespace", "c8s-system", "helm release namespace")
+	f.StringVar(&workloadsDefault, "workloads-namespace", "default", "namespace for --workloads objects that name none")
+	f.StringVar(&serviceHost, "kubernetes-service-host", defaultKubernetesServiceHost, "cluster IP of the kubernetes Service (the KUBERNETES_SERVICE_HOST the kubelet injects)")
+	f.StringVar(&servicePort, "kubernetes-service-port", "443", "port of the kubernetes Service")
+	f.StringVar(&reportPath, "report", "", "write the review report here instead of stderr")
+	return cmd
+}
+
+// renderer accumulates entries from every input and the report about them.
+type renderer struct {
+	images  *imageResolver
+	cluster clusterFacts
+	report  *report
+	entries map[string]pkgallowlist.Workload
+	// operator is the webhook configuration recovered from the chart, applied
+	// to every workload pod.
+	operator *webhook.Config
+}
+
+func (r *renderer) add(name string, w pkgallowlist.Workload) error {
+	if _, dup := r.entries[name]; dup {
+		return fmt.Errorf("two inputs produce the entry name %q", name)
+	}
+	r.entries[name] = w
+	return nil
+}
+
+func (r *renderer) addSystemFloor(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	floor, err := pkgallowlist.ParseSystemFloor(data)
+	if err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	ws, err := floor.Workloads()
+	if err != nil {
+		return err
+	}
+	for name, w := range ws {
+		if err := r.add(name, w); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addChart renders every pod the chart deploys. helm hooks are skipped and
+// reported; a claim on a storage class whose provisioner runs a helper pod
+// (local-path) is an error, because that pod has no admissible rule.
+func (r *renderer) addChart(rendered []byte, namespace string) error {
+	manifests, err := parseManifests(rendered)
+	if err != nil {
+		return fmt.Errorf("rendered chart: %w", err)
+	}
+	cfg, err := operatorConfig(manifests, namespace)
+	if err != nil {
+		return err
+	}
+	r.operator = &cfg
+	if cfg.WorkloadClaimsHostDir != "" {
+		r.cluster.platformDir = hostPathAsBound(cfg.WorkloadClaimsHostDir)
+		r.report.notef("platform socket directory: %s (the operator's --workload-claims-host-dir); binds from it are platform mounts", r.cluster.platformDir)
+	}
+	return r.addManifests(manifests, namespace, "chart")
+}
+
+func (r *renderer) addWorkloads(data []byte, namespace string) error {
+	manifests, err := parseManifests(data)
+	if err != nil {
+		return fmt.Errorf("workloads: %w", err)
+	}
+	return r.addManifests(manifests, namespace, "workloads")
+}
+
+func (r *renderer) addManifests(manifests []manifest, namespace, source string) error {
+	for _, m := range manifests {
+		if claim, ok := m.localPathClaim(); ok {
+			return fmt.Errorf("%s: %s uses local-path storage, whose provisioner runs a per-claim helper pod that no sealed rule admits; use another storage class or no persistence", source, claim)
+		}
+	}
+	for _, m := range manifests {
+		pod, ok := m.pod(namespace)
+		if !ok {
+			continue
+		}
+		if m.isHook() {
+			r.report.skipf("%s %s/%s is a helm hook; hooks run outside the sealed steady state and get no entry", m.Kind, pod.Namespace, pod.Name)
+			continue
+		}
+		if r.operator != nil {
+			if _, err := webhook.Mutate(pod, pod.Namespace, *r.operator); err != nil {
+				return fmt.Errorf("%s %s/%s: admission would refuse it: %w", m.Kind, pod.Namespace, pod.Name, err)
+			}
+		}
+		init, main, err := podRules(pod, r.images, r.cluster, r.report)
+		if err != nil {
+			return err
+		}
+		if err := r.add(pod.Name, pkgallowlist.Workload{Label: m.Kind + "/" + pod.Namespace + "/" + pod.Name, InitContainers: init, Containers: main}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// localPathClass reports a claim the local-path provisioner would serve: the
+// class named outright, or the unset default, which is local-path on RKE2.
+// An empty class name disables dynamic provisioning (the claim binds a
+// pre-provisioned volume), so no helper pod runs for it.
+func localPathClass(class *string) bool {
+	return class == nil || *class == "local-path"
+}
+
+// document assembles the canonical bytes, normalizing through a parse
+// round-trip so hand-built structs serialize like parsed ones, and records
+// the sealed findings the reviewer still owes.
+func (r *renderer) document() ([]byte, error) {
+	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Digests: map[string]string{}, Workloads: r.entries}
+	draft, err := al.Canonical()
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := pkgallowlist.ParseJSON(draft)
+	if err != nil {
+		return nil, fmt.Errorf("rendered document does not parse: %w", err)
+	}
+	doc, err := parsed.Canonical()
+	if err != nil {
+		return nil, err
+	}
+	findings, err := pkgallowlist.SealedFindings(doc)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range findings {
+		r.report.warnf("%s", f)
+	}
+	r.entries = parsed.Workloads
+	return doc, nil
+}
+
+// report is the reviewer's view of what was rendered: every rule in
+// readable form, what was skipped, and what still needs a human.
+type report struct {
+	notes    []string
+	warnings []string
+	skipped  []string
+}
+
+func (r *report) notef(format string, args ...any) {
+	r.notes = append(r.notes, fmt.Sprintf(format, args...))
+}
+
+func (r *report) warnf(format string, args ...any) {
+	r.warnings = append(r.warnings, fmt.Sprintf(format, args...))
+}
+
+func (r *report) skipf(format string, args ...any) {
+	r.skipped = append(r.skipped, fmt.Sprintf(format, args...))
+}
+
+func (r *report) write(w io.Writer, entries map[string]pkgallowlist.Workload) {
+	for _, name := range sortedWorkloadNames(entries) {
+		e := entries[name]
+		fmt.Fprintf(w, "entry %s", name)
+		if e.Label != "" {
+			fmt.Fprintf(w, " (%s)", e.Label)
+		}
+		fmt.Fprintln(w)
+		for i, c := range e.InitContainers {
+			writeContainerReport(w, fmt.Sprintf("initContainers[%d]", i), c)
+		}
+		for i, c := range e.Containers {
+			writeContainerReport(w, fmt.Sprintf("containers[%d]", i), c)
+		}
+	}
+	for _, s := range r.notes {
+		fmt.Fprintf(w, "note: %s\n", s)
+	}
+	for _, s := range r.skipped {
+		fmt.Fprintf(w, "skipped: %s\n", s)
+	}
+	for _, s := range r.warnings {
+		fmt.Fprintf(w, "warning: %s\n", s)
+	}
+}
+
+func writeContainerReport(w io.Writer, where string, c pkgallowlist.Container) {
+	fmt.Fprintf(w, "  %s %s\n", where, c.Image)
+	fmt.Fprintf(w, "    argv: %s\n", containerSummary(c))
+	if c.Env.Policy == pkgallowlist.PolicyExact {
+		for _, n := range c.Env.Names {
+			fmt.Fprintf(w, "    env: %s\n", envRuleSummary(n, c.Env.Values[n]))
+		}
+	} else {
+		fmt.Fprintln(w, "    env: any")
+	}
+	if c.Mounts.Policy == pkgallowlist.PolicyExact {
+		for _, d := range c.Mounts.Destinations {
+			r := c.Mounts.Rules[d]
+			fmt.Fprintf(w, "    mount: %s source=%s", d, r.Source)
+			if r.Source == pkgallowlist.SourcePVC {
+				fmt.Fprintf(w, " review=%q", r.Review)
+			}
+			fmt.Fprintln(w)
+		}
+	} else {
+		fmt.Fprintln(w, "    mounts: any")
+	}
+	if p := c.Privileges; p != nil {
+		fmt.Fprintf(w, "    privileges: privileged=%t hostNamespaces=[%s] capabilities=[%s] devices=[%s] hostPaths=[%s] unmaskedProc=%t review=%q\n",
+			p.Privileged, strings.Join(p.HostNamespaces, " "), strings.Join(p.Capabilities, " "),
+			strings.Join(p.Devices, " "), strings.Join(p.HostPaths, " "), p.UnmaskedProc, p.Review)
+	}
+}
+
+func envRuleSummary(name string, v pkgallowlist.EnvValue) string {
+	if v.From != "" {
+		return name + " from " + v.From
+	}
+	if v.Value != nil {
+		return name + "=" + *v.Value
+	}
+	return name
+}

--- a/internal/cmds/allowlist/render.go
+++ b/internal/cmds/allowlist/render.go
@@ -51,8 +51,8 @@ operator's own injection, so c8s-cert and its siblings get rules too.
 
 The canonical document goes to stdout; a review report listing every
 executable, argv, env rule, mount rule and privilege goes to stderr or
---report. Reviews (privileged entries, pvc mounts) start empty: complete them,
-then run 'c8s allowlist lint --sealed'.`,
+--report. Reviews (privileged entries, pvc and nodeState mounts) start empty:
+complete them, then run 'c8s allowlist lint --sealed'.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if !sealed {

--- a/internal/cmds/allowlist/render_helm.go
+++ b/internal/cmds/allowlist/render_helm.go
@@ -1,0 +1,260 @@
+//go:build !c8s_node
+
+package allowlist
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/internal/helmchart"
+	"github.com/confidential-dot-ai/c8s/internal/webhook"
+)
+
+// helmTimeout bounds one `helm template` run; rendering is local, so a
+// minute is generous.
+const helmTimeout = time.Minute
+
+// helmTemplate renders the chart with the given values file and returns the
+// multi-document YAML, exactly as `c8s install` would hand it to the cluster.
+func helmTemplate(ctx context.Context, chartDir, release, namespace, kubeVersion, valuesFile string) ([]byte, error) {
+	if _, err := exec.LookPath("helm"); err != nil {
+		return nil, fmt.Errorf("this command needs the 'helm' CLI on PATH: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(ctx, helmTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "helm", "template", release, chartDir,
+		"--namespace", namespace, "--kube-version", kubeVersion, "-f", valuesFile)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("helm template: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return out, nil
+}
+
+// extractChart writes the embedded chart to a temp dir; the caller removes it.
+func extractChart() (string, error) {
+	dir, err := os.MkdirTemp("", "c8s-chart-*")
+	if err != nil {
+		return "", err
+	}
+	if err := os.CopyFS(dir, helmchart.ChartFS); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+	return filepath.Join(dir, helmchart.ChartRoot), nil
+}
+
+// manifest is one Kubernetes object read from rendered YAML, decoded only as
+// far as this command needs: pods (own or templated), ConfigMaps for the
+// operator's measurements file, and claims for their storage class.
+type manifest struct {
+	Kind     string            `json:"kind"`
+	Metadata metav1.ObjectMeta `json:"metadata"`
+	Spec     manifestSpec      `json:"spec"`
+	Data     map[string]string `json:"data"`
+}
+
+type manifestSpec struct {
+	corev1.PodSpec
+	Template    corev1.PodTemplateSpec `json:"template"`
+	JobTemplate struct {
+		Spec struct {
+			Template corev1.PodTemplateSpec `json:"template"`
+		} `json:"spec"`
+	} `json:"jobTemplate"`
+	StorageClassName     *string                        `json:"storageClassName"`
+	VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates"`
+}
+
+// localPathClaim names the first claim in the manifest the local-path
+// provisioner would serve: a PersistentVolumeClaim object, a StatefulSet's
+// volumeClaimTemplates entry, or a pod's ephemeral volume.
+func (m manifest) localPathClaim() (string, bool) {
+	if m.Kind == "PersistentVolumeClaim" && localPathClass(m.Spec.StorageClassName) {
+		return "PersistentVolumeClaim " + m.Metadata.Name, true
+	}
+	for _, t := range m.Spec.VolumeClaimTemplates {
+		if localPathClass(t.Spec.StorageClassName) {
+			return fmt.Sprintf("%s %s volumeClaimTemplates %s", m.Kind, m.Metadata.Name, t.Name), true
+		}
+	}
+	pod, ok := m.pod("")
+	if !ok {
+		return "", false
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.Ephemeral != nil && v.Ephemeral.VolumeClaimTemplate != nil && localPathClass(v.Ephemeral.VolumeClaimTemplate.Spec.StorageClassName) {
+			return fmt.Sprintf("%s %s ephemeral volume %s", m.Kind, m.Metadata.Name, v.Name), true
+		}
+	}
+	return "", false
+}
+
+// isHook reports a helm hook resource; hooks run outside the steady state
+// this document describes and are reported as skipped.
+func (m manifest) isHook() bool {
+	_, ok := m.Metadata.Annotations["helm.sh/hook"]
+	return ok
+}
+
+// pod returns the pod a manifest would create, or false for a kind that
+// creates none.
+func (m manifest) pod(defaultNamespace string) (*corev1.Pod, bool) {
+	var tmpl corev1.PodTemplateSpec
+	switch m.Kind {
+	case "Pod":
+		tmpl = corev1.PodTemplateSpec{ObjectMeta: m.Metadata, Spec: m.Spec.PodSpec}
+	case "Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "Job":
+		tmpl = m.Spec.Template
+	case "CronJob":
+		tmpl = m.Spec.JobTemplate.Spec.Template
+	default:
+		return nil, false
+	}
+	pod := &corev1.Pod{ObjectMeta: tmpl.ObjectMeta, Spec: tmpl.Spec}
+	pod.Name = m.Metadata.Name
+	pod.Namespace = m.Metadata.Namespace
+	if pod.Namespace == "" {
+		pod.Namespace = defaultNamespace
+	}
+	return pod, true
+}
+
+var documentSeparator = regexp.MustCompile(`(?m)^---[ \t]*$`)
+
+// parseManifests splits multi-document YAML and decodes each object.
+func parseManifests(data []byte) ([]manifest, error) {
+	var out []manifest
+	for i, doc := range documentSeparator.Split(string(data), -1) {
+		if strings.TrimSpace(doc) == "" {
+			continue
+		}
+		var m manifest
+		if err := sigsyaml.Unmarshal([]byte(doc), &m); err != nil {
+			return nil, fmt.Errorf("document %d: %w", i+1, err)
+		}
+		if m.Kind == "" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// operatorConfig rebuilds the webhook's Config from the operator's rendered
+// args, so the sidecars rendered here are the ones the cluster injects. The
+// flag names mirror cmd/c8s/operator.go; a measurements file is read from
+// the ConfigMap the chart mounts at that path.
+func operatorConfig(manifests []manifest, namespace string) (webhook.Config, error) {
+	var operator *corev1.Container
+	var pod *corev1.Pod
+	for _, m := range manifests {
+		p, ok := m.pod(namespace)
+		if !ok {
+			continue
+		}
+		for i := range p.Spec.Containers {
+			if c := &p.Spec.Containers[i]; len(c.Args) > 0 && c.Args[0] == "operator" {
+				operator, pod = c, p
+			}
+		}
+	}
+	if operator == nil {
+		return webhook.Config{}, fmt.Errorf("the rendered chart deploys no operator container; injected sidecar rules need its --get-cert-image and CDS pins")
+	}
+	var cfg webhook.Config
+	var certFSGroup, runAsUser, runAsGroup int64
+	var runAsNonRoot bool
+	var measurementsConfig string
+	fs := pflag.NewFlagSet("operator", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.StringVar(&cfg.GetCertImage, "get-cert-image", "", "")
+	fs.StringVar(&cfg.CDSURL, "cds-url", "", "")
+	fs.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "")
+	fs.StringSliceVar(&cfg.CDSMeasurements, "cds-measurements", nil, "")
+	fs.StringSliceVar(&cfg.CDSRTMRs, "cds-rtmrs", nil, "")
+	fs.StringVar(&measurementsConfig, "measurements-config", "", "")
+	fs.Int64Var(&certFSGroup, "cert-fs-group", 65532, "")
+	fs.StringVar(&cfg.CertKeyMode, "cert-key-mode", "", "")
+	fs.DurationVar(&cfg.CertRenewInterval, "get-cert-renew-interval", 0, "")
+	fs.Int64Var(&runAsUser, "get-cert-run-as-user", 65532, "")
+	fs.Int64Var(&runAsGroup, "get-cert-run-as-group", 65532, "")
+	fs.BoolVar(&runAsNonRoot, "get-cert-run-as-non-root", true, "")
+	fs.BoolVar(&cfg.KataEnforce, "kata-enforce", false, "")
+	fs.StringVar(&cfg.HardwarePlatform, "hardware-platform", "", "")
+	fs.StringVar(&cfg.WorkloadClaimsHostDir, "workload-claims-host-dir", "", "")
+	fs.BoolVar(&cfg.WorkloadClaimsGuest, "workload-claims-guest", false, "")
+	fs.BoolVar(&cfg.KataGuestReadyGate, "kata-guest-ready-gate", false, "")
+	if err := fs.Parse(operator.Args[1:]); err != nil {
+		return webhook.Config{}, fmt.Errorf("operator args: %w", err)
+	}
+	cfg.CertFSGroup, cfg.GetCertRunAsUser, cfg.GetCertRunAsGroup, cfg.GetCertRunAsNonRoot = &certFSGroup, &runAsUser, &runAsGroup, &runAsNonRoot
+	if measurementsConfig != "" {
+		path, err := mountedConfigMapFile(manifests, pod, operator, measurementsConfig)
+		if err != nil {
+			return webhook.Config{}, err
+		}
+		defer os.Remove(path)
+		if _, err := cmdsutil.LoadMeasurementsConfig(path, "--measurements-config", "--cds-measurements", "--cds-rtmrs", &cfg.CDSMeasurements, &cfg.CDSRTMRs); err != nil {
+			return webhook.Config{}, err
+		}
+	}
+	return cfg, nil
+}
+
+// mountedConfigMapFile finds the ConfigMap key a container reads at filePath
+// and writes it to a temp file the caller removes.
+func mountedConfigMapFile(manifests []manifest, pod *corev1.Pod, c *corev1.Container, filePath string) (string, error) {
+	dir, key := filepath.Split(filePath)
+	dir = filepath.Clean(dir)
+	var volumeName string
+	for _, vm := range c.VolumeMounts {
+		if filepath.Clean(vm.MountPath) == dir {
+			volumeName = vm.Name
+		}
+	}
+	var configMap string
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == volumeName && v.ConfigMap != nil {
+			configMap = v.ConfigMap.Name
+		}
+	}
+	if configMap == "" {
+		return "", fmt.Errorf("operator reads %s, but no ConfigMap volume is mounted at %s", filePath, dir)
+	}
+	for _, m := range manifests {
+		if m.Kind != "ConfigMap" || m.Metadata.Name != configMap {
+			continue
+		}
+		content, ok := m.Data[key]
+		if !ok {
+			return "", fmt.Errorf("ConfigMap %s has no key %q", configMap, key)
+		}
+		f, err := os.CreateTemp("", "c8s-measurements-*.json")
+		if err != nil {
+			return "", err
+		}
+		if _, err := f.WriteString(content); err != nil {
+			_ = f.Close()
+			_ = os.Remove(f.Name())
+			return "", err
+		}
+		return f.Name(), f.Close()
+	}
+	return "", fmt.Errorf("ConfigMap %s is not among the rendered manifests", configMap)
+}

--- a/internal/cmds/allowlist/render_helm.go
+++ b/internal/cmds/allowlist/render_helm.go
@@ -200,6 +200,8 @@ func operatorConfig(manifests []manifest, namespace string) (webhook.Config, err
 	fs.StringVar(&cfg.WorkloadClaimsHostDir, "workload-claims-host-dir", "", "")
 	fs.BoolVar(&cfg.WorkloadClaimsGuest, "workload-claims-guest", false, "")
 	fs.BoolVar(&cfg.KataGuestReadyGate, "kata-guest-ready-gate", false, "")
+	fs.BoolVar(&cfg.StaticAllowlist, "static-allowlist", false, "")
+	fs.StringVar(&cfg.AttestationSocketDir, "attestation-socket-dir", "", "")
 	if err := fs.Parse(operator.Args[1:]); err != nil {
 		return webhook.Config{}, fmt.Errorf("operator args: %w", err)
 	}

--- a/internal/cmds/allowlist/render_pod.go
+++ b/internal/cmds/allowlist/render_pod.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/crane"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -94,10 +95,24 @@ type clusterFacts struct {
 	platformDir string
 }
 
-// platformSource reports whether a host path is the node's socket directory
-// or lies under it.
-func (c clusterFacts) platformSource(hostPath string) bool {
-	return c.platformDir != "" && (hostPath == c.platformDir || strings.HasPrefix(hostPath, c.platformDir+"/"))
+// hostPathClass is the rule class of a hostPath volume as the runtime binds
+// it: platform for the node's socket directory, nodeState for the measured
+// image's state directory (policybundle.NodeStateDir: the policy dir and the
+// attestation socket), hostPath for everything else. nodeState is kept apart
+// from platform so the platform rule every container carries for /etc/hosts
+// cannot admit the attestation socket bound there.
+func (c clusterFacts) hostPathClass(hostPath string) string {
+	switch {
+	case underDir(hostPath, c.platformDir):
+		return pkgallowlist.SourcePlatform
+	case underDir(hostPath, policybundle.NodeStateDir):
+		return pkgallowlist.SourceNodeState
+	}
+	return pkgallowlist.SourceHostPath
+}
+
+func underDir(p, dir string) bool {
+	return dir != "" && (p == dir || strings.HasPrefix(p, dir+"/"))
 }
 
 // hostPathAsBound is the source the runtime records for a hostPath volume:
@@ -392,11 +407,14 @@ func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privile
 			if source != v.HostPath.Path {
 				rep.notef("pod %s/%s container %s: hostPath %q is bound as %q", pod.Namespace, pod.Name, c.Name, v.HostPath.Path, source)
 			}
-			if cluster.platformSource(source) {
-				rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePlatform}
-				continue
+			// A nodeState review stays empty here, like a pvc's; the sealed
+			// findings in the report ask for it.
+			switch class := cluster.hostPathClass(source); class {
+			case pkgallowlist.SourceHostPath:
+				hostPath(dest, source)
+			default:
+				rules[dest] = pkgallowlist.MountRule{Source: class}
 			}
-			hostPath(dest, source)
 		case v.ConfigMap != nil, v.Secret != nil, v.Projected != nil, v.DownwardAPI != nil, v.CSI != nil:
 			hostPath(dest, pkgallowlist.KubeletVolumesRoot)
 		default:

--- a/internal/cmds/allowlist/render_pod.go
+++ b/internal/cmds/allowlist/render_pod.go
@@ -103,28 +103,12 @@ type clusterFacts struct {
 // cannot admit the attestation socket bound there.
 func (c clusterFacts) hostPathClass(hostPath string) string {
 	switch {
-	case underDir(hostPath, c.platformDir):
+	case pkgallowlist.UnderDir(hostPath, c.platformDir):
 		return pkgallowlist.SourcePlatform
-	case underDir(hostPath, policybundle.NodeStateDir):
+	case pkgallowlist.UnderDir(hostPath, policybundle.NodeStateDir):
 		return pkgallowlist.SourceNodeState
 	}
 	return pkgallowlist.SourceHostPath
-}
-
-func underDir(p, dir string) bool {
-	return dir != "" && (p == dir || strings.HasPrefix(p, dir+"/"))
-}
-
-// hostPathAsBound is the source the runtime records for a hostPath volume:
-// containerd cleans the path and resolves symlinks, and /var/run is a symlink
-// to /run on the node image. A trailing slash in the spec must not become a
-// subtree grant by accident, so the cleaned form is what the rule carries.
-func hostPathAsBound(specPath string) string {
-	p := path.Clean(specPath)
-	if p == "/var/run" || strings.HasPrefix(p, "/var/run/") {
-		return "/run" + strings.TrimPrefix(p, "/var/run")
-	}
-	return p
 }
 
 // serviceEnv is what the kubelet injects for the API server Service whatever
@@ -184,10 +168,11 @@ func containerRule(pod *corev1.Pod, c *corev1.Container, images *imageResolver, 
 		len(priv.HostNamespaces) == 0 && len(priv.Capabilities) == 0 {
 		priv = nil
 	}
-	command, args, err := argvRules(c, img, kubeletEnv, priv != nil)
+	command, args, err := argvRules(c, img, kubeletEnv)
 	if err != nil {
 		return pkgallowlist.Container{}, err
 	}
+	reportKubeletExec(pod, c, rep)
 	return pkgallowlist.Container{
 		Digest:     img.digest,
 		Image:      img.label,
@@ -287,24 +272,19 @@ func expandEnv(s string, env kubeletEnv) (string, string) {
 
 // argvRules pins the effective argv with Kubernetes semantics: command
 // overrides the image Entrypoint, args overrides Cmd, and a command without
-// args drops the image Cmd. A privileged entry whose argv expands a per-pod
-// variable gets an unconstrained segment; an unprivileged one is an error.
-func argvRules(c *corev1.Container, img *imageFacts, env kubeletEnv, privileged bool) (command, args pkgallowlist.ArgvPolicy, err error) {
-	// expand substitutes literals; a per-pod reference leaves the segment
-	// unconstrained for a privileged entry and is an error otherwise.
-	expand := func(tokens []string, what string) (out []string, unconstrained bool, err error) {
+// args drops the image Cmd. An argv that expands a per-pod variable is an
+// error for every entry: a sealed document has no open argv.
+func argvRules(c *corev1.Container, img *imageFacts, env kubeletEnv) (command, args pkgallowlist.ArgvPolicy, err error) {
+	expand := func(tokens []string, what string) ([]string, error) {
+		var out []string
 		for _, t := range tokens {
 			v, dynamic := expandEnv(t, env)
-			if dynamic == "" {
-				out = append(out, v)
-				continue
+			if dynamic != "" {
+				return nil, fmt.Errorf("%s expands $(%s), whose value varies per pod; no exact rule can pin it", what, dynamic)
 			}
-			if !privileged {
-				return nil, false, fmt.Errorf("%s expands $(%s), whose value varies per pod; no exact rule can pin it", what, dynamic)
-			}
-			return nil, true, nil
+			out = append(out, v)
 		}
-		return out, false, nil
+		return out, nil
 	}
 	cmdPart, argPart := img.entrypoint, img.cmd
 	switch {
@@ -316,32 +296,51 @@ func argvRules(c *corev1.Container, img *imageFacts, env kubeletEnv, privileged 
 	case len(c.Args) > 0:
 		argPart = c.Args
 	}
-	cmdPart, cmdAny, err := expand(cmdPart, "command")
-	if err != nil {
+	if cmdPart, err = expand(cmdPart, "command"); err != nil {
 		return command, args, err
 	}
-	argPart, argAny, err := expand(argPart, "args")
-	if err != nil {
+	if argPart, err = expand(argPart, "args"); err != nil {
 		return command, args, err
 	}
-	if len(cmdPart) == 0 && len(argPart) == 0 && !cmdAny && !argAny {
+	if len(cmdPart) == 0 && len(argPart) == 0 {
 		return command, args, fmt.Errorf("no argv: the image has no Entrypoint or Cmd and the template sets neither command nor args")
 	}
-	if len(cmdPart) == 0 && !cmdAny {
+	if len(cmdPart) == 0 {
 		// An image with only a Cmd runs it as the whole argv.
-		cmdPart, cmdAny, argPart, argAny = argPart, argAny, nil, false
+		cmdPart, argPart = argPart, nil
 	}
-	command, args = pkgallowlist.ArgvRule(cmdPart), pkgallowlist.ArgvRule(argPart)
-	unconstrained := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny}
-	switch {
-	case cmdAny:
-		// An unconstrained command consumes the whole argv, so nothing is
-		// left for an args rule to anchor on.
-		command, args = unconstrained, unconstrained
-	case argAny:
-		args = unconstrained
+	return pkgallowlist.ArgvRule(cmdPart), pkgallowlist.ArgvRule(argPart), nil
+}
+
+// reportKubeletExec warns about every argv the kubelet runs inside the
+// container through CRI exec: exec probes and lifecycle hooks. No NRI hook
+// sees those, so the sealed plugin cannot hold them to a rule, and whoever
+// can edit the pod can replace them on an admitted container. The reviewer
+// has to know the bundle does not cover them.
+func reportKubeletExec(pod *corev1.Pod, c *corev1.Container, rep *report) {
+	where := fmt.Sprintf("pod %s/%s container %s", pod.Namespace, pod.Name, c.Name)
+	exec := func(kind string, argv []string) {
+		rep.warnf("%s: %s runs %q through CRI exec, which the sealed plugin cannot see; any exec probe or lifecycle hook on an admitted container runs an argv the bundle does not pin", where, kind, strings.Join(argv, " "))
 	}
-	return command, args, nil
+	for _, p := range []struct {
+		kind  string
+		probe *corev1.Probe
+	}{{"livenessProbe", c.LivenessProbe}, {"readinessProbe", c.ReadinessProbe}, {"startupProbe", c.StartupProbe}} {
+		if p.probe != nil && p.probe.Exec != nil {
+			exec(p.kind, p.probe.Exec.Command)
+		}
+	}
+	if c.Lifecycle == nil {
+		return
+	}
+	for _, h := range []struct {
+		kind    string
+		handler *corev1.LifecycleHandler
+	}{{"lifecycle.postStart", c.Lifecycle.PostStart}, {"lifecycle.preStop", c.Lifecycle.PreStop}} {
+		if h.handler != nil && h.handler.Exec != nil {
+			exec(h.kind, h.handler.Exec.Command)
+		}
+	}
 }
 
 // privilegesOf reads the pod and container security settings into a
@@ -377,8 +376,8 @@ func privilegesOf(pod *corev1.Pod, c *corev1.Container) *pkgallowlist.Privileges
 
 // mountRules classifies every bind the container will carry: the template's
 // volumeMounts by their volume source, plus what the kubelet adds. A source
-// the node supplies goes under privileges.hostPaths, recorded as the runtime
-// binds it.
+// the node supplies is bound to its destination by the rule's path and
+// listed under privileges.hostPaths, both recorded as the runtime binds it.
 func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privileges, cluster clusterFacts, rep *report) (map[string]pkgallowlist.MountRule, error) {
 	volumes := make(map[string]corev1.Volume, len(pod.Spec.Volumes))
 	for _, v := range pod.Spec.Volumes {
@@ -386,7 +385,7 @@ func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privile
 	}
 	rules := map[string]pkgallowlist.MountRule{}
 	hostPath := func(dest, source string) {
-		rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourceHostPath}
+		rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourceHostPath, Path: source}
 		priv.HostPaths = append(priv.HostPaths, source)
 	}
 	for _, vm := range c.VolumeMounts {
@@ -398,12 +397,14 @@ func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privile
 		switch {
 		case v.EmptyDir != nil:
 			rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourceEmptyDir}
-		case v.PersistentVolumeClaim != nil, v.Ephemeral != nil:
-			// The review stays empty here; the sealed findings in the report
-			// ask for it.
+		case v.PersistentVolumeClaim != nil, v.Ephemeral != nil, v.CSI != nil:
+			// The kubelet binds an inline CSI volume from the same
+			// kubernetes.io~csi path as a claim's, which the plugin classifies
+			// as pvc. The review stays empty here; the sealed findings in the
+			// report ask for it.
 			rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePVC}
 		case v.HostPath != nil:
-			source := hostPathAsBound(v.HostPath.Path)
+			source := pkgallowlist.BindSource(v.HostPath.Path)
 			if source != v.HostPath.Path {
 				rep.notef("pod %s/%s container %s: hostPath %q is bound as %q", pod.Namespace, pod.Name, c.Name, v.HostPath.Path, source)
 			}
@@ -415,7 +416,7 @@ func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privile
 			default:
 				rules[dest] = pkgallowlist.MountRule{Source: class}
 			}
-		case v.ConfigMap != nil, v.Secret != nil, v.Projected != nil, v.DownwardAPI != nil, v.CSI != nil:
+		case v.ConfigMap != nil, v.Secret != nil, v.Projected != nil, v.DownwardAPI != nil:
 			hostPath(dest, pkgallowlist.KubeletVolumesRoot)
 		default:
 			return nil, fmt.Errorf("volume %q has a source type this tool cannot classify", vm.Name)
@@ -433,6 +434,9 @@ func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privile
 	if _, taken := rules[termination]; !taken {
 		rules[termination] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePlatform}
 	}
+	// The review stays empty here too: the kubelet's volume name is not
+	// reserved, so the reviewer says why operator-chosen files at that path
+	// cannot steer the workload.
 	automount := pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken
 	if _, taken := rules[serviceAccountMountPath]; automount && !taken {
 		rules[serviceAccountMountPath] = pkgallowlist.MountRule{Source: pkgallowlist.SourceServiceAccountToken}

--- a/internal/cmds/allowlist/render_pod.go
+++ b/internal/cmds/allowlist/render_pod.go
@@ -1,0 +1,424 @@
+//go:build !c8s_node
+
+package allowlist
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/confidential-dot-ai/c8s/internal/crane"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// platformMounts are the binds the kubelet and containerd add to every
+// container's OCI spec besides the termination log.
+var platformMounts = []string{"/etc/hosts", "/etc/hostname", "/etc/resolv.conf", "/dev/shm"}
+
+const serviceAccountMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+// fieldRefSources maps the kubelet fieldRef paths a rule can express to the
+// From source whose value a sealed enforcer compares against.
+var fieldRefSources = map[string]string{
+	"metadata.name":      pkgallowlist.FromPodName,
+	"metadata.namespace": pkgallowlist.FromPodNamespace,
+	"metadata.uid":       pkgallowlist.FromPodUID,
+	"status.podIP":       pkgallowlist.FromPodIP,
+	"status.hostIP":      pkgallowlist.FromHostIP,
+	"spec.nodeName":      pkgallowlist.FromNodeName,
+}
+
+// imageFacts is what the registry says about one image: its digest and the
+// baked process defaults a pod template may override.
+type imageFacts struct {
+	label      string // repo@digest
+	digest     types.Digest
+	entrypoint []string
+	cmd        []string
+	env        []string
+}
+
+// imageResolver resolves image references through crane once each.
+type imageResolver struct {
+	ctx   context.Context
+	cache map[string]*imageFacts
+}
+
+func (r *imageResolver) resolve(ref string) (*imageFacts, error) {
+	if f, ok := r.cache[ref]; ok {
+		return f, nil
+	}
+	named, err := reference.ParseDockerRef(ref)
+	if err != nil {
+		return nil, fmt.Errorf("image %q: %w", ref, err)
+	}
+	repo := reference.TrimNamed(named).String()
+	digest := ""
+	if d, ok := named.(reference.Digested); ok {
+		digest = d.Digest().String()
+	} else if digest, err = crane.Digest(r.ctx, ref); err != nil {
+		return nil, err
+	}
+	parsed, err := types.ParseDigest(digest)
+	if err != nil {
+		return nil, fmt.Errorf("image %q: %w", ref, err)
+	}
+	label := repo + "@" + parsed.String()
+	cfg, err := crane.Config(r.ctx, label)
+	if err != nil {
+		return nil, err
+	}
+	f := &imageFacts{label: label, digest: parsed, entrypoint: cfg.Config.Entrypoint, cmd: cfg.Config.Cmd, env: cfg.Config.Env}
+	if r.cache == nil {
+		r.cache = map[string]*imageFacts{}
+	}
+	r.cache[ref] = f
+	return f, nil
+}
+
+// clusterFacts are the per-cluster constants every container rule depends
+// on: the API server Service address the kubelet puts in the environment and
+// the host directory the node serves its inventory and attestation sockets
+// from, which the operator passes as --workload-claims-host-dir. Binds from
+// that directory are platform mounts; it is empty until a chart is rendered.
+type clusterFacts struct {
+	serviceHost string
+	servicePort string
+	platformDir string
+}
+
+// platformSource reports whether a host path is the node's socket directory
+// or lies under it.
+func (c clusterFacts) platformSource(hostPath string) bool {
+	return c.platformDir != "" && (hostPath == c.platformDir || strings.HasPrefix(hostPath, c.platformDir+"/"))
+}
+
+// hostPathAsBound is the source the runtime records for a hostPath volume:
+// containerd cleans the path and resolves symlinks, and /var/run is a symlink
+// to /run on the node image. A trailing slash in the spec must not become a
+// subtree grant by accident, so the cleaned form is what the rule carries.
+func hostPathAsBound(specPath string) string {
+	p := path.Clean(specPath)
+	if p == "/var/run" || strings.HasPrefix(p, "/var/run/") {
+		return "/run" + strings.TrimPrefix(p, "/var/run")
+	}
+	return p
+}
+
+// serviceEnv is what the kubelet injects for the API server Service whatever
+// enableServiceLinks says.
+func (c clusterFacts) serviceEnv() map[string]string {
+	addr := c.serviceHost + ":" + c.servicePort
+	return map[string]string{
+		"KUBERNETES_SERVICE_HOST":       c.serviceHost,
+		"KUBERNETES_SERVICE_PORT":       c.servicePort,
+		"KUBERNETES_SERVICE_PORT_HTTPS": c.servicePort,
+		"KUBERNETES_PORT":               "tcp://" + addr,
+		"KUBERNETES_PORT_443_TCP":       "tcp://" + addr,
+		"KUBERNETES_PORT_443_TCP_PROTO": "tcp",
+		"KUBERNETES_PORT_443_TCP_PORT":  c.servicePort,
+		"KUBERNETES_PORT_443_TCP_ADDR":  c.serviceHost,
+	}
+}
+
+// podRules derives one rule per container of a pod, init containers first.
+func podRules(pod *corev1.Pod, images *imageResolver, cluster clusterFacts, rep *report) (init, main []pkgallowlist.Container, err error) {
+	where := pod.Namespace + "/" + pod.Name
+	if pod.Spec.EnableServiceLinks == nil || *pod.Spec.EnableServiceLinks {
+		rep.warnf("pod %s: enableServiceLinks is not false; the kubelet adds env vars for every Service in the namespace, which no exact rule can list", where)
+	}
+	for i := range pod.Spec.InitContainers {
+		c, err := containerRule(pod, &pod.Spec.InitContainers[i], images, cluster, rep)
+		if err != nil {
+			return nil, nil, fmt.Errorf("pod %s initContainers[%d] %q: %w", where, i, pod.Spec.InitContainers[i].Name, err)
+		}
+		init = append(init, c)
+	}
+	for i := range pod.Spec.Containers {
+		c, err := containerRule(pod, &pod.Spec.Containers[i], images, cluster, rep)
+		if err != nil {
+			return nil, nil, fmt.Errorf("pod %s containers[%d] %q: %w", where, i, pod.Spec.Containers[i].Name, err)
+		}
+		main = append(main, c)
+	}
+	return init, main, nil
+}
+
+func containerRule(pod *corev1.Pod, c *corev1.Container, images *imageResolver, cluster clusterFacts, rep *report) (pkgallowlist.Container, error) {
+	img, err := images.resolve(c.Image)
+	if err != nil {
+		return pkgallowlist.Container{}, err
+	}
+	env, kubeletEnv, err := envRules(pod, c, img, cluster)
+	if err != nil {
+		return pkgallowlist.Container{}, err
+	}
+	priv := privilegesOf(pod, c)
+	mounts, err := mountRules(pod, c, priv, cluster, rep)
+	if err != nil {
+		return pkgallowlist.Container{}, err
+	}
+	if len(priv.HostPaths) == 0 && !priv.Privileged && !priv.UnmaskedProc &&
+		len(priv.HostNamespaces) == 0 && len(priv.Capabilities) == 0 {
+		priv = nil
+	}
+	command, args, err := argvRules(c, img, kubeletEnv, priv != nil)
+	if err != nil {
+		return pkgallowlist.Container{}, err
+	}
+	return pkgallowlist.Container{
+		Digest:     img.digest,
+		Image:      img.label,
+		Command:    command,
+		Args:       args,
+		Mounts:     pkgallowlist.MountRules(mounts),
+		Env:        pkgallowlist.EnvRules(env),
+		Privileges: priv,
+	}, nil
+}
+
+// kubeletEnv is what the kubelet expands $(VAR) references against: the API
+// server Service variables and the template's own env. Image config Env and
+// the HOSTNAME the runtime sets are not in it, so references to them stay
+// verbatim in the running container. dynamic holds the fieldRef names, whose
+// value the kubelet knows only per pod.
+type kubeletEnv struct {
+	literals map[string]string
+	dynamic  map[string]bool
+}
+
+// envRules reproduces the container's environment as the kubelet and
+// containerd assemble it: image config Env, HOSTNAME, the API server Service
+// variables, then the template's own env, which overrides by name. It also
+// returns the kubelet's expansion environment for argvRules.
+func envRules(pod *corev1.Pod, c *corev1.Container, img *imageFacts, cluster clusterFacts) (map[string]pkgallowlist.EnvValue, kubeletEnv, error) {
+	if len(c.EnvFrom) != 0 {
+		return nil, kubeletEnv{}, fmt.Errorf("envFrom pulls names from a ConfigMap or Secret the operator controls; no exact rule can list them")
+	}
+	rules := map[string]pkgallowlist.EnvValue{}
+	literal := func(name, value string) { rules[name] = pkgallowlist.EnvValue{Value: &value} }
+	for _, kv := range img.env {
+		name, value, _ := strings.Cut(kv, "=")
+		literal(name, value)
+	}
+	switch {
+	case pod.Spec.Hostname != "":
+		literal("HOSTNAME", pod.Spec.Hostname)
+	case pod.Spec.HostNetwork:
+		rules["HOSTNAME"] = pkgallowlist.EnvValue{From: pkgallowlist.FromNodeName}
+	default:
+		rules["HOSTNAME"] = pkgallowlist.EnvValue{From: pkgallowlist.FromPodName}
+	}
+	env := kubeletEnv{literals: cluster.serviceEnv(), dynamic: map[string]bool{}}
+	for name, value := range env.literals {
+		literal(name, value)
+	}
+	// A value sees only the entries declared before it; argv sees them all.
+	for _, e := range c.Env {
+		switch {
+		case e.ValueFrom == nil:
+			value, dynamic := expandEnv(e.Value, env)
+			if dynamic != "" {
+				return nil, kubeletEnv{}, fmt.Errorf("env %s references $(%s), whose value varies per pod; no exact rule can pin the result", e.Name, dynamic)
+			}
+			literal(e.Name, value)
+			env.literals[e.Name] = value
+			delete(env.dynamic, e.Name)
+		case e.ValueFrom.FieldRef != nil:
+			from, ok := fieldRefSources[e.ValueFrom.FieldRef.FieldPath]
+			if !ok {
+				return nil, kubeletEnv{}, fmt.Errorf("env %s: fieldRef %q has no from source (want one of metadata.name, metadata.namespace, metadata.uid, status.podIP, status.hostIP, spec.nodeName)", e.Name, e.ValueFrom.FieldRef.FieldPath)
+			}
+			rules[e.Name] = pkgallowlist.EnvValue{From: from}
+			env.dynamic[e.Name] = true
+			delete(env.literals, e.Name)
+		default:
+			return nil, kubeletEnv{}, fmt.Errorf("env %s takes its value from a ConfigMap, Secret or resource field the operator controls; no exact rule can pin it", e.Name)
+		}
+	}
+	return rules, env, nil
+}
+
+var envRefRE = regexp.MustCompile(`\$\$?\([A-Za-z_][A-Za-z0-9_]*\)`)
+
+// expandEnv applies the kubelet's $(VAR) expansion: a known literal is
+// substituted, $$(VAR) is the escape for a literal $(VAR), an unknown name
+// stays verbatim. A reference to a per-pod name makes the result dynamic,
+// and that name is returned.
+func expandEnv(s string, env kubeletEnv) (string, string) {
+	dynamic := ""
+	out := envRefRE.ReplaceAllStringFunc(s, func(m string) string {
+		if strings.HasPrefix(m, "$$") {
+			return m[1:]
+		}
+		name := m[2 : len(m)-1]
+		if v, ok := env.literals[name]; ok {
+			return v
+		}
+		if env.dynamic[name] {
+			dynamic = name
+		}
+		return m
+	})
+	return out, dynamic
+}
+
+// argvRules pins the effective argv with Kubernetes semantics: command
+// overrides the image Entrypoint, args overrides Cmd, and a command without
+// args drops the image Cmd. A privileged entry whose argv expands a per-pod
+// variable gets an unconstrained segment; an unprivileged one is an error.
+func argvRules(c *corev1.Container, img *imageFacts, env kubeletEnv, privileged bool) (command, args pkgallowlist.ArgvPolicy, err error) {
+	// expand substitutes literals; a per-pod reference leaves the segment
+	// unconstrained for a privileged entry and is an error otherwise.
+	expand := func(tokens []string, what string) (out []string, unconstrained bool, err error) {
+		for _, t := range tokens {
+			v, dynamic := expandEnv(t, env)
+			if dynamic == "" {
+				out = append(out, v)
+				continue
+			}
+			if !privileged {
+				return nil, false, fmt.Errorf("%s expands $(%s), whose value varies per pod; no exact rule can pin it", what, dynamic)
+			}
+			return nil, true, nil
+		}
+		return out, false, nil
+	}
+	cmdPart, argPart := img.entrypoint, img.cmd
+	switch {
+	case len(c.Command) > 0:
+		cmdPart, argPart = c.Command, nil
+		if len(c.Args) > 0 {
+			argPart = c.Args
+		}
+	case len(c.Args) > 0:
+		argPart = c.Args
+	}
+	cmdPart, cmdAny, err := expand(cmdPart, "command")
+	if err != nil {
+		return command, args, err
+	}
+	argPart, argAny, err := expand(argPart, "args")
+	if err != nil {
+		return command, args, err
+	}
+	if len(cmdPart) == 0 && len(argPart) == 0 && !cmdAny && !argAny {
+		return command, args, fmt.Errorf("no argv: the image has no Entrypoint or Cmd and the template sets neither command nor args")
+	}
+	if len(cmdPart) == 0 && !cmdAny {
+		// An image with only a Cmd runs it as the whole argv.
+		cmdPart, cmdAny, argPart, argAny = argPart, argAny, nil, false
+	}
+	command, args = pkgallowlist.ArgvRule(cmdPart), pkgallowlist.ArgvRule(argPart)
+	unconstrained := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny}
+	switch {
+	case cmdAny:
+		// An unconstrained command consumes the whole argv, so nothing is
+		// left for an args rule to anchor on.
+		command, args = unconstrained, unconstrained
+	case argAny:
+		args = unconstrained
+	}
+	return command, args, nil
+}
+
+// privilegesOf reads the pod and container security settings into a
+// Privileges skeleton with an empty review. HostPaths is filled by
+// mountRules. A container with nothing beyond the ordinary is unprivileged
+// (the caller drops the empty skeleton).
+func privilegesOf(pod *corev1.Pod, c *corev1.Container) *pkgallowlist.Privileges {
+	p := &pkgallowlist.Privileges{}
+	if pod.Spec.HostNetwork {
+		p.HostNamespaces = append(p.HostNamespaces, pkgallowlist.HostNamespaceNet)
+	}
+	if pod.Spec.HostPID {
+		p.HostNamespaces = append(p.HostNamespaces, pkgallowlist.HostNamespacePID)
+	}
+	if pod.Spec.HostIPC {
+		p.HostNamespaces = append(p.HostNamespaces, pkgallowlist.HostNamespaceIPC)
+	}
+	if sc := c.SecurityContext; sc != nil {
+		if sc.Privileged != nil && *sc.Privileged {
+			p.Privileged = true
+		}
+		if sc.ProcMount != nil && *sc.ProcMount == corev1.UnmaskedProcMount {
+			p.UnmaskedProc = true
+		}
+		if sc.Capabilities != nil {
+			for _, cap := range sc.Capabilities.Add {
+				p.Capabilities = append(p.Capabilities, "CAP_"+strings.ToUpper(string(cap)))
+			}
+		}
+	}
+	return p
+}
+
+// mountRules classifies every bind the container will carry: the template's
+// volumeMounts by their volume source, plus what the kubelet adds. A source
+// the node supplies goes under privileges.hostPaths, recorded as the runtime
+// binds it.
+func mountRules(pod *corev1.Pod, c *corev1.Container, priv *pkgallowlist.Privileges, cluster clusterFacts, rep *report) (map[string]pkgallowlist.MountRule, error) {
+	volumes := make(map[string]corev1.Volume, len(pod.Spec.Volumes))
+	for _, v := range pod.Spec.Volumes {
+		volumes[v.Name] = v
+	}
+	rules := map[string]pkgallowlist.MountRule{}
+	hostPath := func(dest, source string) {
+		rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourceHostPath}
+		priv.HostPaths = append(priv.HostPaths, source)
+	}
+	for _, vm := range c.VolumeMounts {
+		v, ok := volumes[vm.Name]
+		if !ok {
+			return nil, fmt.Errorf("volumeMount %q names no volume", vm.Name)
+		}
+		dest := path.Clean(vm.MountPath)
+		switch {
+		case v.EmptyDir != nil:
+			rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourceEmptyDir}
+		case v.PersistentVolumeClaim != nil, v.Ephemeral != nil:
+			// The review stays empty here; the sealed findings in the report
+			// ask for it.
+			rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePVC}
+		case v.HostPath != nil:
+			source := hostPathAsBound(v.HostPath.Path)
+			if source != v.HostPath.Path {
+				rep.notef("pod %s/%s container %s: hostPath %q is bound as %q", pod.Namespace, pod.Name, c.Name, v.HostPath.Path, source)
+			}
+			if cluster.platformSource(source) {
+				rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePlatform}
+				continue
+			}
+			hostPath(dest, source)
+		case v.ConfigMap != nil, v.Secret != nil, v.Projected != nil, v.DownwardAPI != nil, v.CSI != nil:
+			hostPath(dest, pkgallowlist.KubeletVolumesRoot)
+		default:
+			return nil, fmt.Errorf("volume %q has a source type this tool cannot classify", vm.Name)
+		}
+	}
+	for _, dest := range platformMounts {
+		if _, taken := rules[dest]; !taken {
+			rules[dest] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePlatform}
+		}
+	}
+	termination := c.TerminationMessagePath
+	if termination == "" {
+		termination = corev1.TerminationMessagePathDefault
+	}
+	if _, taken := rules[termination]; !taken {
+		rules[termination] = pkgallowlist.MountRule{Source: pkgallowlist.SourcePlatform}
+	}
+	automount := pod.Spec.AutomountServiceAccountToken == nil || *pod.Spec.AutomountServiceAccountToken
+	if _, taken := rules[serviceAccountMountPath]; automount && !taken {
+		rules[serviceAccountMountPath] = pkgallowlist.MountRule{Source: pkgallowlist.SourceServiceAccountToken}
+	}
+	sort.Strings(priv.HostPaths)
+	return rules, nil
+}

--- a/internal/cmds/allowlist/render_pod_test.go
+++ b/internal/cmds/allowlist/render_pod_test.go
@@ -1,0 +1,35 @@
+//go:build !c8s_node
+
+package allowlist
+
+import (
+	"testing"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+func TestHostPathClass(t *testing.T) {
+	cluster := clusterFacts{platformDir: "/run/nri-image-policy"}
+	for _, tc := range []struct {
+		name, hostPath, want string
+	}{
+		{"plugin socket dir", "/run/nri-image-policy", pkgallowlist.SourcePlatform},
+		{"plugin socket dir file", "/run/nri-image-policy/inventory.sock", pkgallowlist.SourcePlatform},
+		{"plugin socket dir sibling", "/run/nri-image-policy-evil/x", pkgallowlist.SourceHostPath},
+		{"node state dir", policybundle.NodeStateDir, pkgallowlist.SourceNodeState},
+		{"attestation socket", policybundle.NodeStateDir + "/attestation-api.sock", pkgallowlist.SourceNodeState},
+		{"policy dir member", policybundle.DefaultPolicyDir + "/static-allowlist.json", pkgallowlist.SourceNodeState},
+		{"node state dir sibling", policybundle.NodeStateDir + "-evil/attestation-api.sock", pkgallowlist.SourceHostPath},
+		{"host path", "/lib/modules", pkgallowlist.SourceHostPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := cluster.hostPathClass(tc.hostPath); got != tc.want {
+				t.Fatalf("hostPathClass(%s) = %q, want %q", tc.hostPath, got, tc.want)
+			}
+		})
+	}
+	if got := (clusterFacts{}).hostPathClass("/run/nri-image-policy"); got != pkgallowlist.SourceHostPath {
+		t.Fatalf("hostPathClass(plugin dir) = %q with no chart rendered, want hostPath", got)
+	}
+}

--- a/internal/cmds/allowlist/render_test.go
+++ b/internal/cmds/allowlist/render_test.go
@@ -338,6 +338,71 @@ func TestRenderSealed(t *testing.T) {
 
 func str(s string) *string { return &s }
 
+// staticChartFixture is chartFixture as the chart renders it under
+// staticAllowlist.enabled: the operator dials the node's attestation socket,
+// carries no CDS pins and gets --static-allowlist.
+var staticChartFixture = strings.NewReplacer(
+	"- --attestation-api-url=unix:///run/c8s/attestation-api.sock\n", "- --attestation-api-url=unix:///run/confai/attestation-api.sock\n",
+	"            - --cds-measurements=aa\n", "            - --static-allowlist\n            - --attestation-socket-dir=/run/confai\n",
+).Replace(chartFixture)
+
+// Under a static allowlist the injected sidecars take their CDS pins from
+// their own quote and reach the verifier over the node's state directory,
+// which render classifies as a nodeState mount owing a review.
+func TestRenderSealed_StaticAllowlist(t *testing.T) {
+	cranetest.Install(t)
+	if !strings.Contains(staticChartFixture, "--static-allowlist") || strings.Contains(staticChartFixture, "--cds-measurements") {
+		t.Fatalf("static fixture not derived:\n%s", staticChartFixture)
+	}
+	installHelm(t, staticChartFixture)
+	workloads := writeFile(t, "w.yaml", workloadsFixture)
+	report := filepath.Join(t.TempDir(), "report.txt")
+
+	out, stderr, err := runCmd(renderArgs(t, "--workloads", workloads, "--report", report)...)
+	if err != nil {
+		t.Fatalf("render: %v\n%s", err, stderr)
+	}
+	al, err := pkgallowlist.ParseJSON([]byte(out))
+	if err != nil {
+		t.Fatalf("ParseJSON(render output) = %v\n%s", err, out)
+	}
+	var cert pkgallowlist.Container
+	for _, c := range al.Workloads["web"].InitContainers {
+		if len(c.Args.Argv) > 0 && c.Args.Argv[0] == "get-cert" {
+			cert = c
+		}
+	}
+	if cert.Digest.String() == "" {
+		t.Fatalf("no c8s-cert rule among %+v", al.Workloads["web"].InitContainers)
+	}
+	argv := strings.Join(cert.Args.Argv, " ")
+	if !strings.Contains(argv, " --cds-pins-from-own-quote") || !strings.Contains(argv, " --attestation-api-url=unix:///run/confai/attestation-api.sock") {
+		t.Errorf("c8s-cert argv = %q, want the own-quote flag and the node socket URL", argv)
+	}
+	if strings.Contains(argv, "--cds-measurements") || strings.Contains(argv, "--cds-rtmrs") {
+		t.Errorf("c8s-cert argv = %q, want no flat CDS pin under a static allowlist", argv)
+	}
+	if got := cert.Mounts.Rules["/run/confai"].Source; got != pkgallowlist.SourceNodeState {
+		t.Errorf("c8s-cert /run/confai source = %q, want nodeState (the node's state directory)", got)
+	}
+	if got := cert.Mounts.Rules["/run/c8s/workload-claims"].Source; got != pkgallowlist.SourcePlatform {
+		t.Errorf("c8s-cert /run/c8s/workload-claims source = %q, want platform", got)
+	}
+	if cert.Privileges != nil {
+		t.Errorf("c8s-cert privileges = %+v, want none (the state directory is a nodeState mount, not a host path grant)", cert.Privileges)
+	}
+	rep, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := `mount "/run/confai" is a nodeState bind without a review`; !strings.Contains(string(rep), want) {
+		t.Errorf("report lacks %q:\n%s", want, rep)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want the report in --report only", stderr)
+	}
+}
+
 func TestRenderSealed_Refusals(t *testing.T) {
 	for _, tc := range []struct {
 		name      string

--- a/internal/cmds/allowlist/render_test.go
+++ b/internal/cmds/allowlist/render_test.go
@@ -70,6 +70,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          livenessProbe:
+            exec:
+              command: ["/bin/cds", "healthz"]
           volumeMounts:
             - name: data
               mountPath: /var/lib/cds
@@ -91,7 +94,7 @@ spec:
         - name: attestation-api
           image: ghcr.io/confidential-dot-ai/attestation-api:dev
           command: ["/attestation-api"]
-          args: ["--node-ip=$(HOST_IP)"]
+          args: ["--listen=:8400"]
           env:
             - name: HOST_IP
               valueFrom:
@@ -269,11 +272,19 @@ func TestRenderSealed(t *testing.T) {
 	if got := strings.Join(api.Privileges.HostPaths, " "); got != "/dev/tdx_guest "+pkgallowlist.KubeletVolumesRoot {
 		t.Errorf("attestation-api hostPaths = %q, want the cleaned device path and the kubelet volumes root", got)
 	}
+	for dest, want := range map[string]pkgallowlist.MountRule{
+		"/dev/tdx_guest":   {Source: pkgallowlist.SourceHostPath, Path: "/dev/tdx_guest"},
+		"/etc/attestation": {Source: pkgallowlist.SourceHostPath, Path: pkgallowlist.KubeletVolumesRoot},
+	} {
+		if got := api.Mounts.Rules[dest]; got != want {
+			t.Errorf("attestation-api mount %s = %+v, want %+v (a hostPath rule binds its source)", dest, got, want)
+		}
+	}
 	if api.Mounts.Rules["/run/c8s"].Source != pkgallowlist.SourcePlatform {
 		t.Errorf("/run/c8s source = %q, want platform (bound from the operator's --workload-claims-host-dir)", api.Mounts.Rules["/run/c8s"].Source)
 	}
-	if api.Args.Policy != pkgallowlist.PolicyAny || api.Command.Policy != pkgallowlist.PolicyExact {
-		t.Errorf("attestation-api argv = %s/%s, want exact command and any args ($(HOST_IP) varies per node)", api.Command.Policy, api.Args.Policy)
+	if api.Args.Policy != pkgallowlist.PolicyExact || api.Command.Policy != pkgallowlist.PolicyExact {
+		t.Errorf("attestation-api argv = %s/%s, want exact command and args", api.Command.Policy, api.Args.Policy)
 	}
 	if _, ok := api.Mounts.Rules[serviceAccountMountPath]; !ok {
 		t.Error("attestation-api lacks the service account token mount")
@@ -317,7 +328,11 @@ func TestRenderSealed(t *testing.T) {
 		"argv: command=exact[/bin/app] args=exact[cds --listen=:8443 --kubernetes=" + defaultKubernetesServiceHost + "]",
 		"env: HOSTNAME from podName",
 		"mount: /var/lib/cds source=emptyDir",
+		"mount: /etc/attestation source=hostPath path=" + pkgallowlist.KubeletVolumesRoot,
+		`mount: /var/run/secrets/kubernetes.io/serviceaccount source=serviceAccountToken review=""`,
 		"privileges: privileged=true hostNamespaces=[net]",
+		`warning: pod c8s-system/c8s-cds container cds: livenessProbe runs "/bin/cds healthz" through CRI exec`,
+		"serviceAccountToken bind without a review",
 		"note: platform socket directory: /run/nri-image-policy",
 		`note: pod c8s-system/c8s-attestation-api container attestation-api: hostPath "/dev/tdx_guest/" is bound as "/dev/tdx_guest"`,
 		"skipped: DaemonSet c8s-system/c8s-uninstall is a helm hook",
@@ -418,7 +433,8 @@ func TestRenderSealed_Refusals(t *testing.T) {
 		{"claim on the default class", chartFixture + "---\nkind: PersistentVolumeClaim\nmetadata:\n  name: cds-data\nspec:\n  accessModes: [ReadWriteOnce]\n", "", nil, "PersistentVolumeClaim cds-data uses local-path storage"},
 		{"statefulset volumeClaimTemplates on the default class", chartFixture, "kind: StatefulSet\nmetadata:\n  name: db\nspec:\n  volumeClaimTemplates:\n    - metadata:\n        name: data\n      spec:\n        accessModes: [ReadWriteOnce]\n  template:\n    spec:\n      containers:\n        - name: db\n          image: registry.example.com/db:1\n", nil, "StatefulSet db volumeClaimTemplates data uses local-path storage"},
 		{"ephemeral volume on the default class", chartFixture, strings.Replace(workloadsFixture, "      containers:", "      volumes:\n        - name: scratch\n          ephemeral:\n            volumeClaimTemplate:\n              spec:\n                accessModes: [ReadWriteOnce]\n      containers:", 1), nil, "Deployment web ephemeral volume scratch uses local-path storage"},
-		{"unprivileged argv with a per-pod variable", chartFixture, strings.Replace(workloadsFixture, `value: "8080"`, "valueFrom:\n                fieldRef:\n                  fieldPath: status.podIP\n          args: [\"--port=$(PORT)\"]", 1), nil, "expands $(PORT)"},
+		{"argv with a per-pod variable", chartFixture, strings.Replace(workloadsFixture, `value: "8080"`, "valueFrom:\n                fieldRef:\n                  fieldPath: status.podIP\n          args: [\"--port=$(PORT)\"]", 1), nil, "expands $(PORT)"},
+		{"privileged argv with a per-pod variable", strings.Replace(chartFixture, `args: ["--listen=:8400"]`, `args: ["--node-ip=$(HOST_IP)"]`, 1), "", nil, "args expands $(HOST_IP)"},
 		{"envFrom", chartFixture, strings.Replace(workloadsFixture, "env:", "envFrom:\n            - configMapRef:\n                name: cm\n          env:", 1), nil, "envFrom"},
 		{"secretKeyRef", chartFixture, strings.Replace(workloadsFixture, `value: "8080"`, "valueFrom:\n                secretKeyRef:\n                  name: s\n                  key: k", 1), nil, "Secret"},
 		{"unknown volume", chartFixture, strings.Replace(workloadsFixture, "env:", "volumeMounts:\n            - name: nope\n              mountPath: /x\n          env:", 1), nil, "names no volume"},
@@ -477,8 +493,7 @@ func TestExpandEnv(t *testing.T) {
 
 // argvRules follows the kubelet: command/args override Entrypoint/Cmd, and
 // $(VAR) expands only against the Service variables and the template env,
-// never the image config. A per-pod reference is admissible only for a
-// privileged entry, and then the segment it lands in is unconstrained.
+// never the image config. A per-pod reference is an error for every entry.
 func TestArgvRules(t *testing.T) {
 	img := &imageFacts{entrypoint: []string{"/bin/app"}, cmd: []string{"serve"}}
 	cmdOnly := &imageFacts{cmd: []string{"/pause"}}
@@ -486,7 +501,6 @@ func TestArgvRules(t *testing.T) {
 		literals: map[string]string{"KUBERNETES_SERVICE_HOST": "10.53.0.1", "PORT": "8080"},
 		dynamic:  map[string]bool{"HOST_IP": true},
 	}
-	unconstrained := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny}
 	deny := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny}
 	exact := func(argv ...string) pkgallowlist.ArgvPolicy {
 		return pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: argv}
@@ -495,7 +509,6 @@ func TestArgvRules(t *testing.T) {
 		name        string
 		c           corev1.Container
 		img         *imageFacts
-		privileged  bool
 		wantCommand pkgallowlist.ArgvPolicy
 		wantArgs    pkgallowlist.ArgvPolicy
 		wantErr     string
@@ -507,17 +520,14 @@ func TestArgvRules(t *testing.T) {
 		{name: "cmd-only image runs its cmd", img: cmdOnly, wantCommand: exact("/pause"), wantArgs: deny},
 		{name: "image env is not expanded", c: corev1.Container{Args: []string{"$(PATH)"}}, img: img, wantCommand: exact("/bin/app"), wantArgs: exact("$(PATH)")},
 		{name: "HOSTNAME is not expanded", c: corev1.Container{Args: []string{"$(HOSTNAME)"}}, img: img, wantCommand: exact("/bin/app"), wantArgs: exact("$(HOSTNAME)")},
-		{name: "per-pod reference unprivileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: img, wantErr: "args expands $(HOST_IP)"},
-		{name: "per-pod reference in args privileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: img, privileged: true, wantCommand: exact("/bin/app"), wantArgs: unconstrained},
-		{name: "per-pod reference in command privileged", c: corev1.Container{Command: []string{"/sync", "--node-ip", "$(HOST_IP)"}}, img: img, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
-		{name: "per-pod reference in command with exact args privileged", c: corev1.Container{Command: []string{"/sync", "$(HOST_IP)"}, Args: []string{"-v"}}, img: img, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
-		{name: "per-pod reference on a cmd-only image privileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: &imageFacts{}, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
-		{name: "per-pod reference on a cmd-only image unprivileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: &imageFacts{}, wantErr: "args expands $(HOST_IP)"},
+		{name: "per-pod reference in args", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: img, wantErr: "args expands $(HOST_IP)"},
+		{name: "per-pod reference in command", c: corev1.Container{Command: []string{"/sync", "--node-ip", "$(HOST_IP)"}}, img: img, wantErr: "command expands $(HOST_IP)"},
+		{name: "per-pod reference on a cmd-only image", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: &imageFacts{}, wantErr: "args expands $(HOST_IP)"},
 		{name: "no argv", img: &imageFacts{}, wantErr: "no argv"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			c := tc.c
-			command, args, err := argvRules(&c, tc.img, env, tc.privileged)
+			command, args, err := argvRules(&c, tc.img, env)
 			if tc.wantErr != "" {
 				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
 					t.Fatalf("argvRules(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
@@ -531,21 +541,6 @@ func TestArgvRules(t *testing.T) {
 				t.Errorf("argvRules(%s) = %s, want %s", tc.name, got, want)
 			}
 		})
-	}
-}
-
-func TestHostPathAsBound(t *testing.T) {
-	for _, tc := range []struct{ in, want string }{
-		{"/etc/cni/net.d/", "/etc/cni/net.d"},
-		{"/var/run/nri-image-policy", "/run/nri-image-policy"},
-		{"/var/run/nri-image-policy/", "/run/nri-image-policy"},
-		{"/var/run", "/run"},
-		{"/var/runtime", "/var/runtime"},
-		{"/dev/../etc", "/etc"},
-	} {
-		if got := hostPathAsBound(tc.in); got != tc.want {
-			t.Errorf("hostPathAsBound(%q) = %q, want %q", tc.in, got, tc.want)
-		}
 	}
 }
 

--- a/internal/cmds/allowlist/render_test.go
+++ b/internal/cmds/allowlist/render_test.go
@@ -1,0 +1,521 @@
+//go:build !c8s_node
+
+package allowlist
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/confidential-dot-ai/c8s/internal/crane/cranetest"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// chartFixture is what `helm template` produces for the pods render cares
+// about: the operator (whose args configure injection), a plain deployment,
+// a privileged DaemonSet with host paths, and a hook to skip.
+const chartFixture = `---
+# Source: c8s/templates/operator.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: c8s-operator
+  namespace: c8s-system
+spec:
+  template:
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: operator
+          image: ghcr.io/confidential-dot-ai/c8s-operator@` + digA + `
+          args:
+            - operator
+            - --leader-election-namespace=c8s-system
+            - --get-cert-image=ghcr.io/confidential-dot-ai/c8s-operator@` + digA + `
+            - --cds-url=https://c8s-cds.c8s-system.svc:8443
+            - --attestation-api-url=unix:///run/c8s/attestation-api.sock
+            - --cds-measurements=aa
+            - --cert-fs-group=65532
+            - --cert-key-mode=0640
+            - --get-cert-renew-interval=2h
+            - --workload-claims-host-dir=/var/run/nri-image-policy
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: c8s-cds
+  namespace: c8s-system
+spec:
+  template:
+    spec:
+      enableServiceLinks: false
+      automountServiceAccountToken: false
+      containers:
+        - name: cds
+          image: ghcr.io/confidential-dot-ai/cds:dev
+          args: ["cds", "--listen=:8443", "--kubernetes=$(KUBERNETES_SERVICE_HOST)"]
+          env:
+            - name: LOG_LEVEL
+              value: debug
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/cds
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: c8s-attestation-api
+  namespace: c8s-system
+spec:
+  template:
+    spec:
+      enableServiceLinks: false
+      hostNetwork: true
+      containers:
+        - name: attestation-api
+          image: ghcr.io/confidential-dot-ai/attestation-api:dev
+          command: ["/attestation-api"]
+          args: ["--node-ip=$(HOST_IP)"]
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          securityContext:
+            privileged: true
+            capabilities:
+              add: [NET_ADMIN]
+          volumeMounts:
+            - name: dev
+              mountPath: /dev/tdx_guest
+            - name: config
+              mountPath: /etc/attestation
+            - name: runtime
+              mountPath: /run/c8s
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev/tdx_guest/
+        - name: config
+          configMap:
+            name: attestation-config
+        - name: runtime
+          hostPath:
+            path: /var/run/nri-image-policy/
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: c8s-uninstall
+  namespace: c8s-system
+  annotations:
+    helm.sh/hook: pre-delete
+spec:
+  template:
+    spec:
+      containers:
+        - name: cleanup
+          image: ghcr.io/confidential-dot-ai/c8s-operator:dev
+`
+
+const workloadsFixture = `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: apps
+spec:
+  template:
+    metadata:
+      annotations:
+        confidential.ai/cw: web
+    spec:
+      containers:
+        - name: app
+          image: registry.example.com/web:1.2
+          env:
+            - name: PORT
+              value: "8080"
+`
+
+const floorFixture = `{"schema":"c8s.system-floor/v1","images":[{"ref":"docker.io/rancher/mirrored-pause:3.6","digest":"` + digC + `","entrypoint":["/pause"],"cmd":null,"env":{},"mounts":{},"privileges":{"review":"sandbox"}}]}`
+
+// installHelm puts a helm stub on PATH that prints fixture for `template`
+// and records its argv.
+func installHelm(t *testing.T, fixture string) (argvFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	fixturePath := filepath.Join(dir, "rendered.yaml")
+	argvFile = filepath.Join(dir, "argv")
+	if err := os.WriteFile(fixturePath, []byte(fixture), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argvFile + "\ncat " + fixturePath + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "helm"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argvFile
+}
+
+func renderArgs(t *testing.T, extra ...string) []string {
+	t.Helper()
+	dir := t.TempDir()
+	values := writeFile(t, "values.yaml", "image:\n  digest: "+digA+"\n")
+	chart := filepath.Join(dir, "chart")
+	if err := os.MkdirAll(chart, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return append([]string{"render", "--sealed", "--chart-values", values, "--chart", chart}, extra...)
+}
+
+func TestRenderSealed(t *testing.T) {
+	cranetest.Install(t)
+	argvFile := installHelm(t, chartFixture)
+	workloads := writeFile(t, "w.yaml", workloadsFixture)
+	floor := writeFile(t, "floor.json", floorFixture)
+	report := filepath.Join(t.TempDir(), "report.txt")
+
+	out, stderr, err := runCmd(renderArgs(t, "--workloads", workloads, "--system-floor", floor, "--report", report)...)
+	if err != nil {
+		t.Fatalf("render: %v\n%s", err, stderr)
+	}
+	argv, _ := os.ReadFile(argvFile)
+	for _, want := range []string{"template", "c8s", "--namespace", "c8s-system", "--kube-version", chartKubeVersion} {
+		if !strings.Contains(string(argv), want) {
+			t.Errorf("helm argv = %q, want it to contain %q", argv, want)
+		}
+	}
+
+	al, err := pkgallowlist.ParseJSON([]byte(out))
+	if err != nil {
+		t.Fatalf("ParseJSON(render output) = %v\n%s", err, out)
+	}
+	canonical, _ := al.Canonical()
+	if string(canonical) != out {
+		t.Errorf("render output is not canonical:\n%s", out)
+	}
+	if len(al.Digests) != 0 {
+		t.Errorf("Digests = %v, want empty", al.Digests)
+	}
+	for _, name := range []string{"c8s-operator", "c8s-cds", "c8s-attestation-api", "web", "system-mirrored-pause-3.6"} {
+		if _, ok := al.Workloads[name]; !ok {
+			t.Errorf("Workloads lacks %q; have %v", name, sortedWorkloadNames(al.Workloads))
+		}
+	}
+	if _, ok := al.Workloads["c8s-uninstall"]; ok {
+		t.Error("a helm hook got an entry")
+	}
+
+	cds := al.Workloads["c8s-cds"].Containers[0]
+	if got := strings.Join(cds.Command.Argv, " "); got != "/bin/app" || cds.Command.Policy != pkgallowlist.PolicyExact {
+		t.Errorf("cds command = %s %v, want exact [/bin/app] (image entrypoint kept under template args)", cds.Command.Policy, cds.Command.Argv)
+	}
+	if got := strings.Join(cds.Args.Argv, " "); got != "cds --listen=:8443 --kubernetes="+defaultKubernetesServiceHost {
+		t.Errorf("cds args = %q, want the template args with $(KUBERNETES_SERVICE_HOST) expanded", got)
+	}
+	for name, want := range map[string]pkgallowlist.EnvValue{
+		"PATH":                    {Value: str("/usr/bin:/bin")},
+		"APP_MODE":                {Value: str("prod")},
+		"LOG_LEVEL":               {Value: str("debug")},
+		"HOSTNAME":                {From: pkgallowlist.FromPodName},
+		"POD_NAMESPACE":           {From: pkgallowlist.FromPodNamespace},
+		"KUBERNETES_SERVICE_HOST": {Value: str(defaultKubernetesServiceHost)},
+		"KUBERNETES_PORT":         {Value: str("tcp://" + defaultKubernetesServiceHost + ":443")},
+	} {
+		got := cds.Env.Values[name]
+		if got.From != want.From || (got.Value == nil) != (want.Value == nil) || (got.Value != nil && *got.Value != *want.Value) {
+			t.Errorf("cds env %s = %s, want %s", name, envRuleSummary(name, got), envRuleSummary(name, want))
+		}
+	}
+	for dest, want := range map[string]string{
+		"/var/lib/cds":         pkgallowlist.SourceEmptyDir,
+		"/etc/hosts":           pkgallowlist.SourcePlatform,
+		"/dev/termination-log": pkgallowlist.SourcePlatform,
+	} {
+		if got := cds.Mounts.Rules[dest].Source; got != want {
+			t.Errorf("cds mount %s source = %q, want %q", dest, got, want)
+		}
+	}
+	if _, ok := cds.Mounts.Rules[serviceAccountMountPath]; ok {
+		t.Error("cds mounts the service account token although automountServiceAccountToken is false")
+	}
+	if cds.Privileges != nil {
+		t.Errorf("cds privileges = %+v, want none", cds.Privileges)
+	}
+
+	api := al.Workloads["c8s-attestation-api"].Containers[0]
+	if api.Privileges == nil {
+		t.Fatal("attestation-api has no privileges block")
+	}
+	if !api.Privileges.Privileged || strings.Join(api.Privileges.HostNamespaces, ",") != "net" || strings.Join(api.Privileges.Capabilities, ",") != "CAP_NET_ADMIN" {
+		t.Errorf("attestation-api privileges = %+v, want privileged, net namespace, CAP_NET_ADMIN", api.Privileges)
+	}
+	if got := strings.Join(api.Privileges.HostPaths, " "); got != "/dev/tdx_guest "+pkgallowlist.KubeletVolumesRoot {
+		t.Errorf("attestation-api hostPaths = %q, want the cleaned device path and the kubelet volumes root", got)
+	}
+	if api.Mounts.Rules["/run/c8s"].Source != pkgallowlist.SourcePlatform {
+		t.Errorf("/run/c8s source = %q, want platform (bound from the operator's --workload-claims-host-dir)", api.Mounts.Rules["/run/c8s"].Source)
+	}
+	if api.Args.Policy != pkgallowlist.PolicyAny || api.Command.Policy != pkgallowlist.PolicyExact {
+		t.Errorf("attestation-api argv = %s/%s, want exact command and any args ($(HOST_IP) varies per node)", api.Command.Policy, api.Args.Policy)
+	}
+	if _, ok := api.Mounts.Rules[serviceAccountMountPath]; !ok {
+		t.Error("attestation-api lacks the service account token mount")
+	}
+
+	web := al.Workloads["web"]
+	if len(web.InitContainers) != 2 || len(web.Containers) != 1 {
+		t.Fatalf("web has %d init and %d main containers, want the injected c8s-cert and c8s-cert-wait plus app", len(web.InitContainers), len(web.Containers))
+	}
+	var cert pkgallowlist.Container
+	for _, c := range web.InitContainers {
+		if len(c.Args.Argv) > 0 && c.Args.Argv[0] == "get-cert" {
+			cert = c
+		}
+	}
+	if cert.Digest.String() == "" {
+		t.Fatalf("no c8s-cert rule among %+v", web.InitContainers)
+	}
+	if cert.Env.Values["C8S_WORKLOAD_ID"].Value == nil || *cert.Env.Values["C8S_WORKLOAD_ID"].Value != "web" {
+		t.Errorf("c8s-cert C8S_WORKLOAD_ID = %+v, want literal web", cert.Env.Values["C8S_WORKLOAD_ID"])
+	}
+	if cert.Env.Values["HOST_IP"].From != pkgallowlist.FromHostIP || cert.Env.Values["C8S_POD_UID"].From != pkgallowlist.FromPodUID {
+		t.Errorf("c8s-cert fieldRef env = %+v, want hostIP and podUID sources", cert.Env.Values)
+	}
+	if cert.Mounts.Rules["/etc/c8s/certs"].Source != pkgallowlist.SourceEmptyDir || cert.Mounts.Rules["/run/c8s/workload-claims"].Source != pkgallowlist.SourcePlatform {
+		t.Errorf("c8s-cert mounts = %+v, want the cert emptyDir and the platform claims socket", cert.Mounts.Rules)
+	}
+	if !strings.Contains(strings.Join(cert.Args.Argv, " "), "--cds-measurements=aa") {
+		t.Errorf("c8s-cert argv = %v, want the operator's CDS pins", cert.Args.Argv)
+	}
+	if cert.Privileges != nil {
+		t.Errorf("c8s-cert privileges = %+v, want none", cert.Privileges)
+	}
+
+	rep, err := os.ReadFile(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"entry c8s-cds",
+		"argv: command=exact[/bin/app] args=exact[cds --listen=:8443 --kubernetes=" + defaultKubernetesServiceHost + "]",
+		"env: HOSTNAME from podName",
+		"mount: /var/lib/cds source=emptyDir",
+		"privileges: privileged=true hostNamespaces=[net]",
+		"note: platform socket directory: /run/nri-image-policy",
+		`note: pod c8s-system/c8s-attestation-api container attestation-api: hostPath "/dev/tdx_guest/" is bound as "/dev/tdx_guest"`,
+		"skipped: DaemonSet c8s-system/c8s-uninstall is a helm hook",
+		"warning: pod apps/web: enableServiceLinks is not false",
+		"privileges.review is empty",
+	} {
+		if !strings.Contains(string(rep), want) {
+			t.Errorf("report lacks %q:\n%s", want, rep)
+		}
+	}
+	if strings.Contains(string(rep), "warning: pod c8s-system/c8s-cds: enableServiceLinks") {
+		t.Errorf("report warns about enableServiceLinks on a pod that sets it false:\n%s", rep)
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want the report in --report only", stderr)
+	}
+}
+
+func str(s string) *string { return &s }
+
+func TestRenderSealed_Refusals(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fixture   string
+		workloads string
+		args      []string
+		want      string
+	}{
+		{"without --sealed", chartFixture, "", []string{"render"}, "--sealed is required"},
+		{"workloads without chart", chartFixture, "", []string{"render", "--sealed", "--workloads", "x"}, "--workloads needs --chart-values"},
+		{"no operator in the chart", "kind: ConfigMap\nmetadata:\n  name: x\n", "", nil, "deploys no operator"},
+		{"local-path claim", chartFixture + "---\nkind: PersistentVolumeClaim\nmetadata:\n  name: cds-data\nspec:\n  storageClassName: local-path\n", "", nil, "PersistentVolumeClaim cds-data uses local-path storage"},
+		{"claim on the default class", chartFixture + "---\nkind: PersistentVolumeClaim\nmetadata:\n  name: cds-data\nspec:\n  accessModes: [ReadWriteOnce]\n", "", nil, "PersistentVolumeClaim cds-data uses local-path storage"},
+		{"statefulset volumeClaimTemplates on the default class", chartFixture, "kind: StatefulSet\nmetadata:\n  name: db\nspec:\n  volumeClaimTemplates:\n    - metadata:\n        name: data\n      spec:\n        accessModes: [ReadWriteOnce]\n  template:\n    spec:\n      containers:\n        - name: db\n          image: registry.example.com/db:1\n", nil, "StatefulSet db volumeClaimTemplates data uses local-path storage"},
+		{"ephemeral volume on the default class", chartFixture, strings.Replace(workloadsFixture, "      containers:", "      volumes:\n        - name: scratch\n          ephemeral:\n            volumeClaimTemplate:\n              spec:\n                accessModes: [ReadWriteOnce]\n      containers:", 1), nil, "Deployment web ephemeral volume scratch uses local-path storage"},
+		{"unprivileged argv with a per-pod variable", chartFixture, strings.Replace(workloadsFixture, `value: "8080"`, "valueFrom:\n                fieldRef:\n                  fieldPath: status.podIP\n          args: [\"--port=$(PORT)\"]", 1), nil, "expands $(PORT)"},
+		{"envFrom", chartFixture, strings.Replace(workloadsFixture, "env:", "envFrom:\n            - configMapRef:\n                name: cm\n          env:", 1), nil, "envFrom"},
+		{"secretKeyRef", chartFixture, strings.Replace(workloadsFixture, `value: "8080"`, "valueFrom:\n                secretKeyRef:\n                  name: s\n                  key: k", 1), nil, "Secret"},
+		{"unknown volume", chartFixture, strings.Replace(workloadsFixture, "env:", "volumeMounts:\n            - name: nope\n              mountPath: /x\n          env:", 1), nil, "names no volume"},
+		{"admission refusal", chartFixture, strings.Replace(workloadsFixture, "    spec:\n", "    spec:\n      hostNetwork: true\n", 1), nil, "admission would refuse"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cranetest.Install(t)
+			installHelm(t, tc.fixture)
+			args := tc.args
+			if args == nil {
+				args = renderArgs(t)
+				if tc.workloads != "" {
+					args = append(args, "--workloads", writeFile(t, "w.yaml", tc.workloads))
+				}
+			}
+			_, _, err := runCmd(args...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("render(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderSealedRequiresHelmAndCrane(t *testing.T) {
+	cranetest.Install(t)
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "crane"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	_, _, err := runCmd(renderArgs(t)...)
+	if err == nil || !strings.Contains(err.Error(), "helm") {
+		t.Errorf("render without helm = %v, want a helm-not-found error", err)
+	}
+	t.Setenv("PATH", "")
+	_, _, err = runCmd(renderArgs(t)...)
+	if err == nil || !strings.Contains(err.Error(), "crane") {
+		t.Errorf("render without crane = %v, want a crane-not-found error", err)
+	}
+}
+
+func TestExpandEnv(t *testing.T) {
+	env := kubeletEnv{literals: map[string]string{"A": "1"}, dynamic: map[string]bool{"IP": true}}
+	for _, tc := range []struct{ in, want, dynamic string }{
+		{"x$(A)y", "x1y", ""},
+		{"$$(A)", "$(A)", ""},
+		{"$(UNSET)", "$(UNSET)", ""},
+		{"http://$(IP):80", "http://$(IP):80", "IP"},
+	} {
+		got, dynamic := expandEnv(tc.in, env)
+		if got != tc.want || dynamic != tc.dynamic {
+			t.Errorf("expandEnv(%q) = (%q, %q), want (%q, %q)", tc.in, got, dynamic, tc.want, tc.dynamic)
+		}
+	}
+}
+
+// argvRules follows the kubelet: command/args override Entrypoint/Cmd, and
+// $(VAR) expands only against the Service variables and the template env,
+// never the image config. A per-pod reference is admissible only for a
+// privileged entry, and then the segment it lands in is unconstrained.
+func TestArgvRules(t *testing.T) {
+	img := &imageFacts{entrypoint: []string{"/bin/app"}, cmd: []string{"serve"}}
+	cmdOnly := &imageFacts{cmd: []string{"/pause"}}
+	env := kubeletEnv{
+		literals: map[string]string{"KUBERNETES_SERVICE_HOST": "10.53.0.1", "PORT": "8080"},
+		dynamic:  map[string]bool{"HOST_IP": true},
+	}
+	unconstrained := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyAny}
+	deny := pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyDeny}
+	exact := func(argv ...string) pkgallowlist.ArgvPolicy {
+		return pkgallowlist.ArgvPolicy{Policy: pkgallowlist.PolicyExact, Argv: argv}
+	}
+	for _, tc := range []struct {
+		name        string
+		c           corev1.Container
+		img         *imageFacts
+		privileged  bool
+		wantCommand pkgallowlist.ArgvPolicy
+		wantArgs    pkgallowlist.ArgvPolicy
+		wantErr     string
+	}{
+		{name: "entrypoint and cmd", img: img, wantCommand: exact("/bin/app"), wantArgs: exact("serve")},
+		{name: "command drops the image cmd", c: corev1.Container{Command: []string{"/sh"}}, img: img, wantCommand: exact("/sh"), wantArgs: deny},
+		{name: "command and args", c: corev1.Container{Command: []string{"/sh"}, Args: []string{"-c", "x"}}, img: img, wantCommand: exact("/sh"), wantArgs: exact("-c", "x")},
+		{name: "args keep the entrypoint", c: corev1.Container{Args: []string{"--port=$(PORT)"}}, img: img, wantCommand: exact("/bin/app"), wantArgs: exact("--port=8080")},
+		{name: "cmd-only image runs its cmd", img: cmdOnly, wantCommand: exact("/pause"), wantArgs: deny},
+		{name: "image env is not expanded", c: corev1.Container{Args: []string{"$(PATH)"}}, img: img, wantCommand: exact("/bin/app"), wantArgs: exact("$(PATH)")},
+		{name: "HOSTNAME is not expanded", c: corev1.Container{Args: []string{"$(HOSTNAME)"}}, img: img, wantCommand: exact("/bin/app"), wantArgs: exact("$(HOSTNAME)")},
+		{name: "per-pod reference unprivileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: img, wantErr: "args expands $(HOST_IP)"},
+		{name: "per-pod reference in args privileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: img, privileged: true, wantCommand: exact("/bin/app"), wantArgs: unconstrained},
+		{name: "per-pod reference in command privileged", c: corev1.Container{Command: []string{"/sync", "--node-ip", "$(HOST_IP)"}}, img: img, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
+		{name: "per-pod reference in command with exact args privileged", c: corev1.Container{Command: []string{"/sync", "$(HOST_IP)"}, Args: []string{"-v"}}, img: img, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
+		{name: "per-pod reference on a cmd-only image privileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: &imageFacts{}, privileged: true, wantCommand: unconstrained, wantArgs: unconstrained},
+		{name: "per-pod reference on a cmd-only image unprivileged", c: corev1.Container{Args: []string{"--ip=$(HOST_IP)"}}, img: &imageFacts{}, wantErr: "args expands $(HOST_IP)"},
+		{name: "no argv", img: &imageFacts{}, wantErr: "no argv"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c
+			command, args, err := argvRules(&c, tc.img, env, tc.privileged)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("argvRules(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("argvRules(%s) = %v, want nil", tc.name, err)
+			}
+			if got, want := containerSummary(pkgallowlist.Container{Command: command, Args: args}), containerSummary(pkgallowlist.Container{Command: tc.wantCommand, Args: tc.wantArgs}); got != want {
+				t.Errorf("argvRules(%s) = %s, want %s", tc.name, got, want)
+			}
+		})
+	}
+}
+
+func TestHostPathAsBound(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/etc/cni/net.d/", "/etc/cni/net.d"},
+		{"/var/run/nri-image-policy", "/run/nri-image-policy"},
+		{"/var/run/nri-image-policy/", "/run/nri-image-policy"},
+		{"/var/run", "/run"},
+		{"/var/runtime", "/var/runtime"},
+		{"/dev/../etc", "/etc"},
+	} {
+		if got := hostPathAsBound(tc.in); got != tc.want {
+			t.Errorf("hostPathAsBound(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestLocalPathClass(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		class *string
+		want  bool
+	}{
+		{"unset means the cluster default", nil, true},
+		{"empty disables dynamic provisioning", str(""), false},
+		{"named", str("local-path"), true},
+		{"other class", str("nfs"), false},
+	} {
+		if got := localPathClass(tc.class); got != tc.want {
+			t.Errorf("localPathClass(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestParseManifests(t *testing.T) {
+	ms, err := parseManifests([]byte("---\n# comment\n---\nkind: Pod\nmetadata:\n  name: p\nspec:\n  containers:\n    - name: c\n      image: i\n---\nkind: CronJob\nmetadata:\n  name: j\nspec:\n  jobTemplate:\n    spec:\n      template:\n        spec:\n          containers:\n            - name: c\n              image: i\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ms) != 2 {
+		t.Fatalf("parseManifests = %d documents, want 2", len(ms))
+	}
+	for i, wantName := range []string{"p", "j"} {
+		pod, ok := ms[i].pod("ns")
+		if !ok || pod.Name != wantName || pod.Namespace != "ns" || len(pod.Spec.Containers) != 1 {
+			t.Errorf("manifest[%d].pod() = %v %+v, want pod %s in ns with one container", i, ok, pod, wantName)
+		}
+	}
+	if _, err := parseManifests([]byte("kind: [")); err == nil {
+		t.Error("parseManifests(bad yaml) = nil, want error")
+	}
+}

--- a/internal/cmds/cds/attest_rtmr_test.go
+++ b/internal/cmds/cds/attest_rtmr_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -136,5 +137,63 @@ func TestAttestSNPUnaffectedByRTMRPins(t *testing.T) {
 	w := postAttest(t, h, issueChallenge(t, h), csrPEM)
 	if w.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// staticEntries parses a static-allowlist measurements config exactly as CDS
+// loads it from the chart, so the wire shape (rtmr[3] pinned) is what is
+// enforced here.
+func staticEntries(t *testing.T, rtmr3 string) []measurements.Entry {
+	t.Helper()
+	set, err := measurements.Parse([]byte(`{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"static-allowlist","mrtd":"` + testMRTD + `","rtmr":[null,"` + testRTMR1 + `","` + testRTMR2 + `","` + rtmr3 + `"]}]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := set.StaticEntry(); err != nil {
+		t.Fatal(err)
+	}
+	return set.Entries
+}
+
+// Static mode's whole point on /attest: the entry pins RTMR[3], so a pod on
+// an unsealed node of the same image (or a node sealed to another bundle)
+// presents a different register and is refused even though MRTD, RTMR[1] and
+// RTMR[2] all match.
+func TestAttestStaticEntryPinsRTMR3(t *testing.T) {
+	sealed := strings.Repeat("5e", 48)
+	for _, tc := range []struct {
+		name     string
+		reported string
+		want     int
+	}{
+		{"sealed node", sealed, http.StatusOK},
+		{"unsealed node of the same image", strings.Repeat("00", 48), http.StatusForbidden},
+		{"node sealed to another bundle", strings.Repeat("6f", 48), http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := tdxVerdict(t, testMRTD, testRTMR1, testRTMR2)
+			v.Claims.PlatformData["rtmr_3"] = tc.reported
+			stub := testattest.New(t)
+			stub.SetVerdict(v)
+
+			h := newTestAttestHandler(t, stub.URL, nil)
+			h.Entries = staticEntries(t, sealed)
+
+			csrPEM, _ := generateCSR(t)
+			w := postAttestTDX(t, h, issueChallenge(t, h), csrPEM)
+			if w.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, tc.want, w.Body.String())
+			}
+			if tc.want == http.StatusForbidden {
+				var envelope types.ErrorResponse
+				if err := json.Unmarshal(w.Body.Bytes(), &envelope); err != nil {
+					t.Fatalf("decode error envelope: %v", err)
+				}
+				if envelope.Error != types.ErrorCodeMeasurementDenied {
+					t.Fatalf("error code = %q, want %q", envelope.Error, types.ErrorCodeMeasurementDenied)
+				}
+			}
+		})
 	}
 }

--- a/internal/cmds/cds/cmd.go
+++ b/internal/cmds/cds/cmd.go
@@ -11,6 +11,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/cmds/verify"
 	"github.com/confidential-dot-ai/c8s/internal/issuer"
 	"github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -72,8 +73,10 @@ func NewCmd() *cobra.Command {
 	flags.StringVar(&cfg.allowlistDB, "allowlist-db", "", "Path to the allowlist SQLite database")
 	flags.BoolVar(&cfg.allowlistPersistent, "allowlist-persistent", false, "whether --allowlist-db is on durable storage; false makes CDS warn at startup that operator-added digests and the mesh CA do not survive a restart")
 	flags.StringSliceVar(&cfg.inventoryCIDRs, "sandbox-inventory-cidr", nil, "CIDR(s) holding the node addresses CDS may dial for a sandbox's admission inventory (repeatable). It is what stops a workload pointing the callback at its own pod IP and answering as the inventory (docs/ratls.md). Unset, CDS derives one host route per node from the live node list and refuses sandbox tokens until that syncs")
-	flags.StringVar(&cfg.allowlistSeed, "allowlist-seed", "", "Path to a JSON allowlist (version + digests map) seeded into the store at startup before serving; missing digests are added, existing entries are left untouched (empty disables seeding)")
+	flags.StringVar(&cfg.allowlistSeed, "allowlist-seed", "", "Path to a c8s.allowlist/v1 document (digests map and workload entries) seeded into the store at startup before serving; missing digests and entries are added, existing ones are left untouched (empty disables seeding)")
 	flags.StringVar(&cfg.operatorKeys, "operator-keys", "", "Path to a PEM bundle of pinned operator EC public keys; /allowlist writes (POST/PUT/DELETE) require an operator token signed by one of them (empty = writes disabled, reads still served)")
+	flags.BoolVar(&cfg.staticAllowlist, "static-allowlist", false, "serve the static allowlist a node measured into RTMR[3] at boot. Requires --ratls-platform=tdx, a --measurements-config with one entry pinning RTMR[1], RTMR[2] and RTMR[3], --allowlist-seed=<policy-dir>/static-allowlist.json and a unix:// --attestation-api-url; refuses --operator-keys and --allowlist-persistent. At start <policy-dir>/mode must read static, the members must match <policy-dir>/digest, and this pod's own evidence must match the entry, or CDS exits")
+	flags.StringVar(&cfg.policyDir, "policy-dir", policybundle.DefaultPolicyDir, "directory c8s-policy-measure publishes the boot's policy mode, bundle digest and bundle members in (read under --static-allowlist)")
 
 	flags.Float64Var(&cfg.rateLimit, "rate-limit", 10, "max requests per second per source IP on attestation endpoints")
 	flags.IntVar(&cfg.rateBurst, "rate-burst", 20, "max burst size per source IP")
@@ -154,6 +157,8 @@ type config struct {
 	rotationJitter      float64
 	ratlsPlatform       string
 	ratlsCertTTL        time.Duration
+	staticAllowlist     bool
+	policyDir           string
 
 	rateLimit                float64
 	rateBurst                int

--- a/internal/cmds/cds/measurementsconfig_test.go
+++ b/internal/cmds/cds/measurementsconfig_test.go
@@ -174,3 +174,24 @@ func containsPin(pins []string, want string) bool {
 	}
 	return false
 }
+
+// A static entry's RTMR[3] is fanned into the flat list on purpose: the
+// gates that take one register set (/attest-key, the sandbox-digests
+// callback) then hold callers to the sealed register too, not only /attest.
+func TestResolveMeasurementsConfigCarriesStaticRTMR3(t *testing.T) {
+	reg3 := "333300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	path := writeConfig(t, `{"schema_version":"1","tee":"tdx","measurements":[
+		{"name":"static-allowlist","mrtd":"00`+cfgDigestA+`","rtmr":[null,"`+cfgReg1+`","`+cfgReg2+`","`+reg3+`"]}]}`)
+
+	cfg := config{measurementsConfig: path, ratlsPlatform: "tdx"}
+	set, err := resolveMeasurementsConfig(&cfg)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if _, err := set.StaticEntry(); err != nil {
+		t.Fatalf("StaticEntry() = %v, want the parsed entry to qualify", err)
+	}
+	if !containsPin(cfg.rtmrs, "3="+reg3) {
+		t.Errorf("flat rtmrs %v missing the RTMR[3] pin", cfg.rtmrs)
+	}
+}

--- a/internal/cmds/cds/run.go
+++ b/internal/cmds/cds/run.go
@@ -32,6 +32,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/earsigner"
 	measurementspkg "github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 	"golang.org/x/time/rate"
@@ -58,6 +59,13 @@ func run(cfg config) error {
 	}
 	if err := validateConfig(cfg); err != nil {
 		return err
+	}
+	var staticEntry measurementspkg.Entry
+	if cfg.staticAllowlist {
+		staticEntry, err = validateStaticConfig(cfg, pinned)
+		if err != nil {
+			return err
+		}
 	}
 	cfg.ratlsPlatform = ratls.NormalizePlatform(cfg.ratlsPlatform)
 
@@ -184,7 +192,23 @@ func run(cfg config) error {
 	// allowlist (CDS, attestation-api, system images) rather than an empty
 	// set; an unseeded store would deny every worker pull until an operator
 	// populated it. Fail closed on any seed error.
-	if cfg.allowlistSeed != "" {
+	//
+	// Static mode gates the seed on the node's measured verdict and seeds the
+	// bytes that verdict covered, so the served allowlist is the measured one.
+	switch {
+	case cfg.staticAllowlist:
+		bundle, err := verifyStaticNode(ctx, cfg, staticEntry)
+		if err != nil {
+			return err
+		}
+		member := bundle.Members[policybundle.MemberStaticAllowlist]
+		if err := seedStoreFrom(&allowlistStore, member, cfg.allowlistSeed); err != nil {
+			return fmt.Errorf("seed allowlist: %w", err)
+		}
+		if err := checkStaticStamp(&allowlistStore, member); err != nil {
+			return fmt.Errorf("--static-allowlist: %w", err)
+		}
+	case cfg.allowlistSeed != "":
 		if err := seedStore(&allowlistStore, cfg.allowlistSeed); err != nil {
 			return fmt.Errorf("seed allowlist: %w", err)
 		}

--- a/internal/cmds/cds/seed.go
+++ b/internal/cmds/cds/seed.go
@@ -22,7 +22,13 @@ func seedStore(store *allowlist.Store, path string) error {
 	if err != nil {
 		return fmt.Errorf("read allowlist seed %q: %w", path, err)
 	}
+	return seedStoreFrom(store, data, path)
+}
 
+// seedStoreFrom seeds store from an in-memory document; path names it in
+// errors. Static mode passes the bytes the boot verdict covered rather than
+// re-reading the file, so the seed is exactly what was measured.
+func seedStoreFrom(store *allowlist.Store, data []byte, path string) error {
 	seed, err := pkgallowlist.ParseJSON(data)
 	if err != nil {
 		return fmt.Errorf("parse allowlist seed %q: %w", path, err)

--- a/internal/cmds/cds/static.go
+++ b/internal/cmds/cds/static.go
@@ -11,17 +11,12 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
-
-// selfAttestTimeout bounds the self-attestation round trip over the node's
-// attestation socket at start.
-const selfAttestTimeout = 15 * time.Second
 
 // staticSeedPath is the one --allowlist-seed static mode accepts: the bundle
 // member the node measured, read from the measurer's output directory.
@@ -98,7 +93,7 @@ func verifyStaticNode(ctx context.Context, cfg config, entry measurements.Entry)
 // cannot read the register, and the same verdict path is what /attest
 // applies to every requester.
 func verifySelfEvidence(ctx context.Context, attestationAPIURL string, entry measurements.Entry) error {
-	ctx, cancel := context.WithTimeout(ctx, selfAttestTimeout)
+	ctx, cancel := context.WithTimeout(ctx, attestationclient.OwnTupleTimeout)
 	defer cancel()
 
 	own, err := attestationclient.NewClient(attestationAPIURL).OwnTupleEntry(ctx)

--- a/internal/cmds/cds/static.go
+++ b/internal/cmds/cds/static.go
@@ -1,0 +1,136 @@
+package cds
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"maps"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// selfAttestTimeout bounds the self-attestation round trip over the node's
+// attestation socket at start.
+const selfAttestTimeout = 15 * time.Second
+
+// staticSeedPath is the one --allowlist-seed static mode accepts: the bundle
+// member the node measured, read from the measurer's output directory.
+func staticSeedPath(policyDir string) string {
+	return filepath.Join(policyDir, policybundle.MemberStaticAllowlist)
+}
+
+// validateStaticConfig refuses every flag combination under which a static
+// CDS could admit something the bundle did not seal: an operator key (writes
+// to the store), a persistent store (entries surviving a reseed), a
+// verifier reached over the network (a control-plane-chosen verdict), a seed
+// other than the measured member, or a measurements entry that leaves a
+// register unpinned. It returns the one entry /attest enforces.
+func validateStaticConfig(cfg config, pinned measurements.ReferenceValues) (measurements.Entry, error) {
+	if ratls.NormalizePlatform(cfg.ratlsPlatform) != measurements.TEETDX {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist requires --ratls-platform=tdx: only TDX has the runtime register the policy is measured into")
+	}
+	if cfg.measurementsConfig == "" {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist requires --measurements-config with the cluster's static entry (MRTD, RTMR[1], RTMR[2], RTMR[3])")
+	}
+	if cfg.operatorKeys != "" {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist cannot be combined with --operator-keys: the allowlist is sealed at boot and takes no operator writes")
+	}
+	if cfg.allowlistPersistent {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist cannot be combined with --allowlist-persistent: every start reseeds from the measured bundle so no stored entry can outlive it")
+	}
+	if want := staticSeedPath(cfg.policyDir); filepath.Clean(cfg.allowlistSeed) != want {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist requires --allowlist-seed=%s (the measured bundle member), got %q", want, cfg.allowlistSeed)
+	}
+	if !strings.HasPrefix(cfg.attestationApiURL, "unix://") {
+		return measurements.Entry{}, fmt.Errorf("--static-allowlist requires a unix:// --attestation-api-url: a verifier reached over the network is one the control plane can substitute")
+	}
+	entry, err := pinned.StaticEntry()
+	if err != nil {
+		return measurements.Entry{}, fmt.Errorf("--measurements-config: %w", err)
+	}
+	return entry, nil
+}
+
+// verifyStaticNode is the static start gate: the measurer must have written
+// mode=static, the members under the policy dir must index to the digest it
+// published, that index must derive the RTMR[3] the static entry pins, and
+// this pod's own evidence — verified by the node's local attestation-api —
+// must carry exactly the static tuple. The middle link is what ties the seed
+// to the register: the policy dir is node-root-writable, so a member and
+// digest rewritten together still index consistently, and only the register
+// (which nothing after boot can move) says which bundle was measured. It
+// returns the bundle so the seed comes from the bytes that were checked.
+func verifyStaticNode(ctx context.Context, cfg config, entry measurements.Entry) (policybundle.Bundle, error) {
+	state, err := policybundle.ReadDir(cfg.policyDir)
+	if err != nil {
+		return policybundle.Bundle{}, fmt.Errorf("--static-allowlist: %w", err)
+	}
+	if state.Mode != policybundle.StaticMode {
+		return policybundle.Bundle{}, fmt.Errorf("--static-allowlist: %s reports mode %q, want %s: this node did not boot a policy bundle", filepath.Join(cfg.policyDir, policybundle.ModeFile), state.Mode, policybundle.StaticMode)
+	}
+	if reg := state.Bundle.RTMR3(); !bytes.Equal(reg[:], entry.RTMRs[3]) {
+		return policybundle.Bundle{}, fmt.Errorf("--static-allowlist: members under %s derive RTMR[3] %x, the static entry pins %x: this node's bundle is not the one the cluster was installed with (was a member replaced after boot?)", cfg.policyDir, reg, entry.RTMRs[3])
+	}
+	if err := verifySelfEvidence(ctx, cfg.attestationApiURL, entry); err != nil {
+		return policybundle.Bundle{}, fmt.Errorf("--static-allowlist: this pod's evidence does not match the static entry: %w", err)
+	}
+	digest := state.Bundle.IndexDigest()
+	slog.Info("static allowlist mode: node evidence matches the static entry",
+		"policy_dir", cfg.policyDir,
+		"index_digest", hex.EncodeToString(digest[:]),
+		"rtmr3", hex.EncodeToString(entry.RTMRs[3]))
+	return state.Bundle, nil
+}
+
+// verifySelfEvidence has the node's attestation-api attest and verify this
+// pod and requires the tuple it reports to be the static entry's. The
+// register compare happens on the verifier's verdict, not on sysfs: the pod
+// cannot read the register, and the same verdict path is what /attest
+// applies to every requester.
+func verifySelfEvidence(ctx context.Context, attestationAPIURL string, entry measurements.Entry) error {
+	ctx, cancel := context.WithTimeout(ctx, selfAttestTimeout)
+	defer cancel()
+
+	own, err := attestationclient.NewClient(attestationAPIURL).OwnTupleEntry(ctx)
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(own.Digest, entry.Digest) {
+		return fmt.Errorf("MRTD %x does not match the static entry's %x", own.Digest, entry.Digest)
+	}
+	for _, i := range slices.Sorted(maps.Keys(entry.RTMRs)) {
+		if !bytes.Equal(own.RTMRs[i], entry.RTMRs[i]) {
+			return fmt.Errorf("RTMR[%d] does not match the static entry: this node reports %x, the entry pins %x", i, own.RTMRs[i], entry.RTMRs[i])
+		}
+	}
+	return nil
+}
+
+// checkStaticStamp requires the store, seeded from member, to serve a document
+// whose canonical digest is SHA-256 of member itself. That digest is what
+// every leaf's matched-workload stamp carries and what `c8s verify
+// --static-allowlist` holds the stamp to, so a member the store would
+// re-serialize differently (a document without "digests":{} is the known
+// case: the store always serves an empty map) must stop CDS here rather than
+// mint stamps no bundle holder can match.
+func checkStaticStamp(store policyStore, member []byte) error {
+	snapshot, err := loadPolicySnapshot(store)
+	if err != nil {
+		return err
+	}
+	want := sha256.Sum256(member)
+	if !bytes.Equal(snapshot.Digest, want[:]) {
+		return fmt.Errorf("the seeded store serves policy digest %x but the measured %s digests to %x: the member is not in the form the store serves (it must carry \"digests\":{} and a \"workloads\" object, as `c8s allowlist render --sealed` writes it), so leaf stamps would match no verifier's copy of the bundle", snapshot.Digest, policybundle.MemberStaticAllowlist, want)
+	}
+	return nil
+}

--- a/internal/cmds/cds/static_test.go
+++ b/internal/cmds/cds/static_test.go
@@ -1,0 +1,400 @@
+package cds
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/allowlist"
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// staticMember is the bundle member the static tests seal: one sealed entry
+// in canonical form, the only shape a node measures, so the seed has
+// something to add and the store serves it back byte for byte.
+var staticMember = canonicalMember(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`)
+
+func canonicalMember(doc string) string {
+	al, err := pkgallowlist.ParseJSON([]byte(doc))
+	if err != nil {
+		panic(err)
+	}
+	out, err := al.Canonical()
+	if err != nil {
+		panic(err)
+	}
+	return string(out)
+}
+
+// staticFixture is the bundle, image tuple and static entry the tests share.
+type staticFixture struct {
+	bundle policybundle.Bundle
+	pins   runtimemeasure.ImagePins
+	entry  measurements.Entry
+}
+
+func newStaticFixture(t *testing.T) staticFixture {
+	t.Helper()
+	bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: []byte(staticMember)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pins runtimemeasure.ImagePins
+	copy(pins.MRTD[:], mustDecode(t, testMRTD))
+	copy(pins.RTMR1[:], mustDecode(t, testRTMR1))
+	copy(pins.RTMR2[:], mustDecode(t, testRTMR2))
+	set := measurements.StaticReferenceValues(pins, bundle.RTMR3())
+	return staticFixture{bundle: bundle, pins: pins, entry: set.Entries[0]}
+}
+
+// writeMeasurementsConfig renders the fixture's static entry the way install
+// hands it to the chart.
+func (f staticFixture) writeMeasurementsConfig(t *testing.T) string {
+	t.Helper()
+	doc, err := measurements.Format(measurements.StaticReferenceValues(f.pins, f.bundle.RTMR3()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeConfig(t, string(doc))
+}
+
+// writePolicyDir lays out what c8s-policy-measure leaves behind: the member,
+// the index digest and the mode.
+func (f staticFixture) writePolicyDir(t *testing.T, mode string) string {
+	t.Helper()
+	dir := t.TempDir()
+	digest := f.bundle.IndexDigest()
+	for name, data := range map[string][]byte{
+		policybundle.MemberStaticAllowlist: f.bundle.Members[policybundle.MemberStaticAllowlist],
+		policybundle.DigestFile:            []byte(hex.EncodeToString(digest[:]) + "\n"),
+		policybundle.ModeFile:              []byte(mode + "\n"),
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), data, 0o444); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// verdict is a TDX verdict carrying the fixture's tuple with rtmr3 as given.
+func (f staticFixture) verdict(t *testing.T, rtmr3 string) testattest.Verdict {
+	t.Helper()
+	v := tdxVerdict(t, testMRTD, testRTMR1, testRTMR2)
+	v.Claims.PlatformData["rtmr_3"] = rtmr3
+	return v
+}
+
+func (f staticFixture) rtmr3Hex() string {
+	r := f.bundle.RTMR3()
+	return hex.EncodeToString(r[:])
+}
+
+// unixAttestStub serves the fake attestation-api on a unix socket, the only
+// transport static mode accepts. The socket lives under a short temp path:
+// a unix path is capped at 108 bytes and t.TempDir() names can exceed it.
+func unixAttestStub(t *testing.T) (*testattest.Stub, string) {
+	t.Helper()
+	stub := testattest.New(t)
+	stub.SetPlatform(types.PlatformTdx)
+	dir, err := os.MkdirTemp("", "cds-static")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "attestation-api.sock")
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { l.Close() })
+	go func() { _ = http.Serve(l, stub.Config.Handler) }()
+	return stub, "unix://" + socket
+}
+
+func TestValidateStaticConfig(t *testing.T) {
+	f := newStaticFixture(t)
+	set := measurements.StaticReferenceValues(f.pins, f.bundle.RTMR3())
+	valid := func() config {
+		return config{
+			ratlsPlatform:      "tdx",
+			measurementsConfig: "cds.json",
+			allowlistSeed:      "/run/confai/policy/static-allowlist.json",
+			policyDir:          "/run/confai/policy",
+			attestationApiURL:  "unix:///run/confai/attestation-api.sock",
+		}
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(cfg *config)
+		set    measurements.ReferenceValues
+		want   string
+	}{
+		{"valid", func(*config) {}, set, ""},
+		{"snp platform", func(c *config) { c.ratlsPlatform = "snp" }, set, "--ratls-platform=tdx"},
+		{"no measurements config", func(c *config) { c.measurementsConfig = "" }, set, "requires --measurements-config"},
+		{"operator keys", func(c *config) { c.operatorKeys = "keys.pem" }, set, "--operator-keys"},
+		{"persistent store", func(c *config) { c.allowlistPersistent = true }, set, "--allowlist-persistent"},
+		{"seed elsewhere", func(c *config) { c.allowlistSeed = "/etc/cds/allowlist-seed.json" }, set, "--allowlist-seed=/run/confai/policy/static-allowlist.json"},
+		{"tcp verifier", func(c *config) { c.attestationApiURL = "http://127.0.0.1:8400" }, set, "unix://"},
+		{"entry without rtmr3", func(*config) {}, measurements.ReferenceValues{TEE: measurements.TEETDX, Entries: []measurements.Entry{{Digest: set.Entries[0].Digest, RTMRs: map[int][]byte{1: set.Entries[0].RTMRs[1], 2: set.Entries[0].RTMRs[2]}}}}, "must pin RTMR[3]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := valid()
+			tc.mutate(&cfg)
+			entry, err := validateStaticConfig(cfg, tc.set)
+			switch {
+			case tc.want == "" && err != nil:
+				t.Fatalf("validateStaticConfig(%s) = %v, want nil", tc.name, err)
+			case tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)):
+				t.Fatalf("validateStaticConfig(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			case tc.want == "" && entry.Name != measurements.StaticEntryName:
+				t.Fatalf("validateStaticConfig(%s) entry = %q, want %q", tc.name, entry.Name, measurements.StaticEntryName)
+			}
+		})
+	}
+}
+
+func TestVerifyStaticNode(t *testing.T) {
+	f := newStaticFixture(t)
+	for _, tc := range []struct {
+		name  string
+		mode  string
+		rtmr3 string
+		tweak func(t *testing.T, dir string, cfg *config)
+		want  string
+	}{
+		{"sealed node", policybundle.StaticMode, f.rtmr3Hex(), nil, ""},
+		{"dynamic boot", policybundle.DynamicMode, f.rtmr3Hex(), nil, `mode "dynamic", want static`},
+		{"missing policy dir", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, cfg *config) {
+			cfg.policyDir = filepath.Join(dir, "absent")
+		}, "policy mode"},
+		{"member rewritten after measurement", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, _ *config) {
+			member := filepath.Join(dir, policybundle.MemberStaticAllowlist)
+			if err := os.Remove(member); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(member, []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{}}`), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "members index to"},
+		// Node root can rewrite the member AND the digest file consistently;
+		// only the register says which bundle was measured.
+		{"member and digest rewritten together", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, _ *config) {
+			other, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{}}`)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			digest := other.IndexDigest()
+			for name, data := range map[string][]byte{
+				policybundle.MemberStaticAllowlist: other.Members[policybundle.MemberStaticAllowlist],
+				policybundle.DigestFile:            []byte(hex.EncodeToString(digest[:]) + "\n"),
+			} {
+				if err := os.Remove(filepath.Join(dir, name)); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, name), data, 0o444); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}, "derive RTMR[3]"},
+		{"node sealed to another bundle", policybundle.StaticMode, strings.Repeat("ee", 48), nil, "RTMR[3] does not match"},
+		{"unsealed node of the same image", policybundle.StaticMode, strings.Repeat("00", 48), nil, "RTMR[3] does not match"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub, url := unixAttestStub(t)
+			stub.SetVerdict(f.verdict(t, tc.rtmr3))
+			dir := f.writePolicyDir(t, tc.mode)
+			cfg := config{policyDir: dir, attestationApiURL: url}
+			if tc.tweak != nil {
+				tc.tweak(t, dir, &cfg)
+			}
+			bundle, err := verifyStaticNode(context.Background(), cfg, f.entry)
+			if tc.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("verifyStaticNode(%s) = %v, want error containing %q", tc.name, err, tc.want)
+				}
+				if tc.name == "member and digest rewritten together" && len(stub.AttestRequests()) != 0 {
+					t.Error("a bundle the register does not vouch for was self-attested; the register tie comes first")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("verifyStaticNode(%s) = %v, want nil", tc.name, err)
+			}
+			if got := string(bundle.Members[policybundle.MemberStaticAllowlist]); got != staticMember {
+				t.Errorf("verifyStaticNode(%s) member = %q, want the measured bytes", tc.name, got)
+			}
+			// The verdict that admitted this pod is the one every requester
+			// gets: the nonce this pod sent must be what the verifier bound.
+			reqs, verifies := stub.AttestRequests(), stub.VerifyRequests()
+			if len(reqs) != 1 || len(verifies) != 1 {
+				t.Fatalf("attest/verify requests = %d/%d, want 1/1", len(reqs), len(verifies))
+			}
+			if verifies[0].Params == nil || verifies[0].Params.ExpectedReportData == nil {
+				t.Fatal("self-report verified without an expected report_data: the verdict would be replayable")
+			}
+		})
+	}
+}
+
+// Evidence from a non-TDX platform is refused before /verify: the static
+// tuple pins RTMRs, which only TDX reports. (The unix:// transport rule is a
+// flag check, asserted by TestValidateStaticConfig.)
+func TestVerifySelfEvidenceRejectsNonTDXPlatform(t *testing.T) {
+	f := newStaticFixture(t)
+	stub, url := unixAttestStub(t)
+	stub.SetPlatform(types.PlatformSnp)
+	stub.SetVerdict(f.verdict(t, f.rtmr3Hex()))
+	err := verifySelfEvidence(context.Background(), url, f.entry)
+	if err == nil || !strings.Contains(err.Error(), "want TDX") {
+		t.Fatalf("verifySelfEvidence(snp) = %v, want a platform refusal", err)
+	}
+}
+
+// The stamp every leaf carries is the digest of the document the store
+// serves, and `c8s verify --static-allowlist` holds it to SHA-256 of the
+// measured member; the two agree only when the member is already in the
+// store's form. A member without "digests":{} passes the sealed lint yet
+// re-serializes differently, so CDS must refuse it rather than stamp a digest
+// no bundle holder can match.
+func TestCheckStaticStamp(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		member string
+		want   string
+	}{
+		{"store form", staticMember, ""},
+		{"digests null", strings.Replace(staticMember, `"digests":{}`, `"digests":null`, 1), "not in the form the store serves"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := allowlist.OpenInMemory()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer store.Close()
+			if err := seedStoreFrom(&store, []byte(tc.member), "static-allowlist.json"); err != nil {
+				t.Fatal(err)
+			}
+			err = checkStaticStamp(&store, []byte(tc.member))
+			switch {
+			case tc.want == "" && err != nil:
+				t.Fatalf("checkStaticStamp(%s) = %v, want nil", tc.name, err)
+			case tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)):
+				t.Fatalf("checkStaticStamp(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+			if tc.want != "" {
+				return
+			}
+			snapshot, err := loadPolicySnapshot(&store)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := sha256.Sum256([]byte(tc.member)); !bytes.Equal(snapshot.Digest, want[:]) {
+				t.Errorf("snapshot digest = %x, want SHA-256 of the member %x", snapshot.Digest, want)
+			}
+		})
+	}
+}
+
+// run() wires the gate before the seed: a dynamic node never seeds, and a
+// sealed node seeds the measured member and carries on. The sealed case is
+// stopped right after the seed by an invalid inventory CIDR, the first
+// failure point past it, so the test needs no RA-TLS listener.
+func TestRun_StaticAllowlist(t *testing.T) {
+	f := newStaticFixture(t)
+	staticConfig := func(t *testing.T, url, policyDir string) config {
+		t.Helper()
+		cfg := validRunConfig(t, url)
+		cfg.ratlsPlatform = "tdx"
+		cfg.staticAllowlist = true
+		cfg.policyDir = policyDir
+		cfg.allowlistSeed = staticSeedPath(policyDir)
+		cfg.measurementsConfig = f.writeMeasurementsConfig(t)
+		cfg.inventoryCIDRs = []string{"not-a-cidr"}
+		return cfg
+	}
+
+	t.Run("dynamic node exits before seeding", func(t *testing.T) {
+		stub, url := unixAttestStub(t)
+		stub.SetVerdict(f.verdict(t, f.rtmr3Hex()))
+		cfg := staticConfig(t, url, f.writePolicyDir(t, policybundle.DynamicMode))
+		err := run(cfg)
+		if err == nil || !strings.Contains(err.Error(), "--static-allowlist") {
+			t.Fatalf("run() = %v, want the static gate to refuse a dynamic node", err)
+		}
+		if len(stub.AttestRequests()) != 0 {
+			t.Error("run() attested itself on a dynamic node; the mode file is checked first")
+		}
+	})
+
+	t.Run("operator keys refused", func(t *testing.T) {
+		_, url := unixAttestStub(t)
+		cfg := staticConfig(t, url, f.writePolicyDir(t, policybundle.StaticMode))
+		cfg.operatorKeys = writeOperatorKeysPEM(t)
+		err := run(cfg)
+		if err == nil || !strings.Contains(err.Error(), "--operator-keys") {
+			t.Fatalf("run() = %v, want --operator-keys refused under --static-allowlist", err)
+		}
+	})
+
+	t.Run("sealed node seeds the measured member", func(t *testing.T) {
+		stub, url := unixAttestStub(t)
+		stub.SetVerdict(f.verdict(t, f.rtmr3Hex()))
+		cfg := staticConfig(t, url, f.writePolicyDir(t, policybundle.StaticMode))
+		cfg.logLevel = "info"
+
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatal(err)
+		}
+		orig := os.Stdout
+		os.Stdout = w
+		runErr := run(cfg)
+		os.Stdout = orig
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+		_ = w.Close()
+		logged, err := io.ReadAll(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if runErr == nil || !strings.Contains(runErr.Error(), "inventory CIDR") {
+			t.Fatalf("run() = %v, want the inventory CIDR failure past the static gate", runErr)
+		}
+		for _, want := range []string{"static allowlist mode: node evidence matches", `"workloads_added":1`} {
+			if !strings.Contains(string(logged), want) {
+				t.Errorf("startup log missing %q:\n%s", want, logged)
+			}
+		}
+	})
+}
+
+func TestNewCmdStaticAllowlistFlags(t *testing.T) {
+	flags := NewCmd().Flags()
+	for _, tc := range []struct{ flag, want string }{
+		{"static-allowlist", "false"},
+		{"policy-dir", "/run/confai/policy"},
+	} {
+		f := flags.Lookup(tc.flag)
+		if f == nil {
+			t.Fatalf("missing --%s flag", tc.flag)
+		}
+		if f.DefValue != tc.want {
+			t.Errorf("default --%s = %q, want %q", tc.flag, f.DefValue, tc.want)
+		}
+	}
+}

--- a/internal/cmds/cds/static_test.go
+++ b/internal/cmds/cds/static_test.go
@@ -90,11 +90,15 @@ func (f staticFixture) writePolicyDir(t *testing.T, mode string) string {
 	return dir
 }
 
-// verdict is a TDX verdict carrying the fixture's tuple with rtmr3 as given.
-func (f staticFixture) verdict(t *testing.T, rtmr3 string) testattest.Verdict {
+// verdict is a TDX verdict carrying the fixture's tuple with rtmr3 as given;
+// edits apply on top.
+func (f staticFixture) verdict(t *testing.T, rtmr3 string, edits ...func(v *testattest.Verdict)) testattest.Verdict {
 	t.Helper()
 	v := tdxVerdict(t, testMRTD, testRTMR1, testRTMR2)
 	v.Claims.PlatformData["rtmr_3"] = rtmr3
+	for _, edit := range edits {
+		edit(&v)
+	}
 	return v
 }
 
@@ -170,19 +174,21 @@ func TestValidateStaticConfig(t *testing.T) {
 
 func TestVerifyStaticNode(t *testing.T) {
 	f := newStaticFixture(t)
+	other := strings.Repeat("ee", 48)
 	for _, tc := range []struct {
-		name  string
-		mode  string
-		rtmr3 string
-		tweak func(t *testing.T, dir string, cfg *config)
-		want  string
+		name    string
+		mode    string
+		rtmr3   string
+		verdict func(v *testattest.Verdict)
+		tweak   func(t *testing.T, dir string, cfg *config)
+		want    string
 	}{
-		{"sealed node", policybundle.StaticMode, f.rtmr3Hex(), nil, ""},
-		{"dynamic boot", policybundle.DynamicMode, f.rtmr3Hex(), nil, `mode "dynamic", want static`},
-		{"missing policy dir", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, cfg *config) {
+		{"sealed node", policybundle.StaticMode, f.rtmr3Hex(), nil, nil, ""},
+		{"dynamic boot", policybundle.DynamicMode, f.rtmr3Hex(), nil, nil, `mode "dynamic", want static`},
+		{"missing policy dir", policybundle.StaticMode, f.rtmr3Hex(), nil, func(t *testing.T, dir string, cfg *config) {
 			cfg.policyDir = filepath.Join(dir, "absent")
 		}, "policy mode"},
-		{"member rewritten after measurement", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, _ *config) {
+		{"member rewritten after measurement", policybundle.StaticMode, f.rtmr3Hex(), nil, func(t *testing.T, dir string, _ *config) {
 			member := filepath.Join(dir, policybundle.MemberStaticAllowlist)
 			if err := os.Remove(member); err != nil {
 				t.Fatal(err)
@@ -193,7 +199,7 @@ func TestVerifyStaticNode(t *testing.T) {
 		}, "members index to"},
 		// Node root can rewrite the member AND the digest file consistently;
 		// only the register says which bundle was measured.
-		{"member and digest rewritten together", policybundle.StaticMode, f.rtmr3Hex(), func(t *testing.T, dir string, _ *config) {
+		{"member and digest rewritten together", policybundle.StaticMode, f.rtmr3Hex(), nil, func(t *testing.T, dir string, _ *config) {
 			other, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{}}`)})
 			if err != nil {
 				t.Fatal(err)
@@ -211,12 +217,22 @@ func TestVerifyStaticNode(t *testing.T) {
 				}
 			}
 		}, "derive RTMR[3]"},
-		{"node sealed to another bundle", policybundle.StaticMode, strings.Repeat("ee", 48), nil, "RTMR[3] does not match"},
-		{"unsealed node of the same image", policybundle.StaticMode, strings.Repeat("00", 48), nil, "RTMR[3] does not match"},
+		{"node sealed to another bundle", policybundle.StaticMode, other, nil, nil, "RTMR[3] does not match"},
+		{"unsealed node of the same image", policybundle.StaticMode, strings.Repeat("00", 48), nil, nil, "RTMR[3] does not match"},
+		// The same bundle sealed on another image: every register but
+		// RTMR[3] is compared too, or a node running any image with this
+		// bundle would pin requesters on the wrong tuple.
+		{"other image MRTD", policybundle.StaticMode, f.rtmr3Hex(), func(v *testattest.Verdict) { v.Claims.LaunchDigest = other }, nil, "MRTD " + other + " does not match the static entry"},
+		{"other kernel RTMR[1]", policybundle.StaticMode, f.rtmr3Hex(), func(v *testattest.Verdict) { v.Claims.PlatformData["rtmr_1"] = other }, nil, "RTMR[1] does not match the static entry"},
+		{"other rootfs RTMR[2]", policybundle.StaticMode, f.rtmr3Hex(), func(v *testattest.Verdict) { v.Claims.PlatformData["rtmr_2"] = other }, nil, "RTMR[2] does not match the static entry"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			stub, url := unixAttestStub(t)
-			stub.SetVerdict(f.verdict(t, tc.rtmr3))
+			edits := []func(v *testattest.Verdict){}
+			if tc.verdict != nil {
+				edits = append(edits, tc.verdict)
+			}
+			stub.SetVerdict(f.verdict(t, tc.rtmr3, edits...))
 			dir := f.writePolicyDir(t, tc.mode)
 			cfg := config{policyDir: dir, attestationApiURL: url}
 			if tc.tweak != nil {
@@ -229,6 +245,11 @@ func TestVerifyStaticNode(t *testing.T) {
 				}
 				if tc.name == "member and digest rewritten together" && len(stub.AttestRequests()) != 0 {
 					t.Error("a bundle the register does not vouch for was self-attested; the register tie comes first")
+				}
+				// A tuple mismatch comes from the compare, after one
+				// attestation, not from a gate before it.
+				if tc.verdict != nil && len(stub.AttestRequests()) != 1 {
+					t.Errorf("attest requests = %d, want 1", len(stub.AttestRequests()))
 				}
 				return
 			}
@@ -348,6 +369,30 @@ func TestRun_StaticAllowlist(t *testing.T) {
 		err := run(cfg)
 		if err == nil || !strings.Contains(err.Error(), "--operator-keys") {
 			t.Fatalf("run() = %v, want --operator-keys refused under --static-allowlist", err)
+		}
+	})
+
+	// run() gates the seed on the stamp check: a member that passes the
+	// node's ReadDir and FromMembers but is not in the store's form (here
+	// "digests":null) must stop CDS before it serves, which surfaces as the
+	// stamp error rather than the inventory CIDR failure past it.
+	t.Run("member outside the store form is refused after the seed", func(t *testing.T) {
+		nullDigests := strings.Replace(staticMember, `"digests":{}`, `"digests":null`, 1)
+		bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: []byte(nullDigests)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		other := staticFixture{bundle: bundle, pins: f.pins, entry: measurements.StaticReferenceValues(f.pins, bundle.RTMR3()).Entries[0]}
+		stub, url := unixAttestStub(t)
+		stub.SetVerdict(other.verdict(t, other.rtmr3Hex()))
+		cfg := staticConfig(t, url, other.writePolicyDir(t, policybundle.StaticMode))
+		cfg.measurementsConfig = other.writeMeasurementsConfig(t)
+		err = run(cfg)
+		if err == nil || !strings.Contains(err.Error(), "not in the form the store serves") {
+			t.Fatalf("run() = %v, want the stamp gate to refuse the member", err)
+		}
+		if strings.Contains(err.Error(), "inventory CIDR") {
+			t.Fatalf("run() = %v: reached the inventory CIDR check past the stamp gate", err)
 		}
 	})
 

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
@@ -31,25 +32,6 @@ import (
 // Var (not const) so tests can point it at a temp file.
 var operatorPubkeyPath = "/etc/confai/operator-pubkey"
 
-// rtmr3SysfsPath is the TDX runtime-measurement register the initrd extended
-// with the operator key digest before switch_root. Reading it back lets the
-// service confirm the on-disk operator pubkey is the one that was measured.
-// Var (not const) so tests can point it at a temp file.
-var rtmr3SysfsPath = "/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384"
-
-// readOwnRTMR3 reads the guest's current RTMR[3] from the tdx_guest sysfs.
-// Returns the raw 48 bytes.
-func readOwnRTMR3() ([]byte, error) {
-	b, err := os.ReadFile(rtmr3SysfsPath)
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w (is this a TDX guest with runtime measurement?)", rtmr3SysfsPath, err)
-	}
-	if len(b) != 48 {
-		return nil, fmt.Errorf("%s: got %d bytes, want 48", rtmr3SysfsPath, len(b))
-	}
-	return b, nil
-}
-
 // verifyKeyMeasured is the load-bearing anchor check: the operator pubkey file
 // is NOT itself measured (only its hash, via RTMR[3]), so before trusting the
 // on-disk key the service confirms it is the key that was measured. A host
@@ -60,22 +42,22 @@ func readOwnRTMR3() ([]byte, error) {
 // what the operator's own attestation pins to their key: both directions bind
 // to the same measured key, so neither side trusts the host.
 func verifyKeyMeasured(pubkey []byte) error {
-	own, err := readOwnRTMR3()
+	own, err := tdxrtmr.Read(3)
 	if err != nil {
 		return err
 	}
-	// The bare operator-key seed — no workload extends — is correct HERE, at
-	// service startup, even though remote verifiers compare against the seeded
-	// workload chain: the node image runs no workload measurer, so at this
-	// moment RTMR[3] must equal the seed exactly. Any extension beyond it means
-	// an unexpected measurer ran or the register was tampered with, and the
-	// comparison fails closed.
-	want := runtimemeasure.ForOperatorKey(pubkey)
+	// The register must equal the seed extended by exactly one mode event:
+	// cred-release starts after c8s-policy-measure has extended ModeDynamic,
+	// and the node image runs no workload measurer. A bare seed (no mode
+	// event), a static-mode register, or any extension beyond means the wrong
+	// unit ran or the register was tampered with, and the comparison fails
+	// closed.
+	want := runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pubkey))
 	// Not secret (a public-key hash) — plain compare is fine.
-	if !bytes.Equal(own, want[:]) {
+	if own != want {
 		return fmt.Errorf(
-			"operator pubkey does not match the measured RTMR[3]: got %s, key implies %s (was the pubkey file substituted after boot?)",
-			hex.EncodeToString(own), hex.EncodeToString(want[:]))
+			"operator pubkey does not match the measured RTMR[3]: got %s, key implies %s = ForDynamic(ForOperatorKey(key)) (was the pubkey file substituted after boot, or the dynamic mode event not extended?)",
+			hex.EncodeToString(own[:]), hex.EncodeToString(want[:]))
 	}
 	return nil
 }

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -20,6 +20,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -57,6 +58,26 @@ func verifyKeyMeasured(pubkey []byte) error {
 	if own != want {
 		return fmt.Errorf(
 			"operator pubkey does not match the measured RTMR[3]: got %s, key implies %s = ForDynamic(ForOperatorKey(key)) (was the pubkey file substituted after boot, or the dynamic mode event not extended?)",
+			hex.EncodeToString(own[:]), hex.EncodeToString(want[:]))
+	}
+	return nil
+}
+
+// verifyBundleMeasured is the static-mode anchor check: the published bundle
+// under the policy dir is NOT itself measured (only its index, via RTMR[3]),
+// so before serving the service confirms the register holds exactly
+// ForStaticAllowlist of the index recomputed from those files. A member
+// swapped after c8s-policy-measure ran, or a mode file written by hand on a
+// dynamic node, produces a mismatch here.
+func verifyBundleMeasured(bundle policybundle.Bundle) error {
+	own, err := tdxrtmr.Read(3)
+	if err != nil {
+		return err
+	}
+	want := bundle.RTMR3()
+	if own != want {
+		return fmt.Errorf(
+			"published policy bundle does not match the measured RTMR[3]: got %s, bundle implies %s = ForStaticAllowlist(index) (was a member substituted after boot, or mode=static written on a dynamic node?)",
 			hex.EncodeToString(own[:]), hex.EncodeToString(want[:]))
 	}
 	return nil

--- a/internal/cmds/credrelease/binding.go
+++ b/internal/cmds/credrelease/binding.go
@@ -25,13 +25,10 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
-// operatorPubkeyPath is where the measured initrd stages the operator public
-// key it read off the opkeydata disk (and hashed into RTMR[3]). The service
-// reads this file rather than mounting the ISO itself — mounting fails under
-// the unit's systemd hardening, and the initrd is the single, measured reader
-// of the disk anyway.
-// Var (not const) so tests can point it at a temp file.
-var operatorPubkeyPath = "/etc/confai/operator-pubkey"
+// operatorPubkeyPath is the initrd-staged operator key. The service reads
+// the file rather than mounting the ISO itself: mounting fails under the
+// unit's systemd hardening. A var so tests point it at a temp file.
+var operatorPubkeyPath = policybundle.OperatorPubkeyPath
 
 // verifyKeyMeasured is the load-bearing anchor check: the operator pubkey file
 // is NOT itself measured (only its hash, via RTMR[3]), so before trusting the

--- a/internal/cmds/credrelease/binding_test.go
+++ b/internal/cmds/credrelease/binding_test.go
@@ -7,22 +7,22 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
 	"github.com/confidential-dot-ai/c8s/internal/testattest"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
 
-// overrideBindingPaths points the package's sysfs/staging paths at files under
-// a temp dir for the duration of the test. The files do not exist yet; each
+// overrideBindingPaths points the staging path and the RTMR sysfs root at a
+// temp dir for the duration of the test. The files do not exist yet; each
 // test writes what its scenario needs.
 func overrideBindingPaths(t *testing.T) (pubPath, rtmrPath string) {
 	t.Helper()
 	dir := t.TempDir()
 	pubPath = filepath.Join(dir, "operator-pubkey")
-	rtmrPath = filepath.Join(dir, "rtmr3")
-	origPub, origRTMR := operatorPubkeyPath, rtmr3SysfsPath
-	operatorPubkeyPath, rtmr3SysfsPath = pubPath, rtmrPath
-	t.Cleanup(func() { operatorPubkeyPath, rtmr3SysfsPath = origPub, origRTMR })
-	return pubPath, rtmrPath
+	origPub, origRoot := operatorPubkeyPath, tdxrtmr.SysfsRoot
+	operatorPubkeyPath, tdxrtmr.SysfsRoot = pubPath, dir
+	t.Cleanup(func() { operatorPubkeyPath, tdxrtmr.SysfsRoot = origPub, origRoot })
+	return pubPath, tdxrtmr.Path(3)
 }
 
 func writeFileT(t *testing.T, path string, data []byte) {
@@ -32,11 +32,12 @@ func writeFileT(t *testing.T, path string, data []byte) {
 	}
 }
 
-// expectedRTMR3ForKey adapts runtimemeasure.ForOperatorKey for the sysfs
-// fixtures the binding tests write. The formula and hardware vectors are
-// pinned in pkg/runtimemeasure.
+// expectedRTMR3ForKey is the register a dynamic operator-key boot leaves for
+// the sysfs fixtures the binding tests write: the seed extended by the
+// dynamic mode event. The formula and vectors are pinned in
+// pkg/runtimemeasure.
 func expectedRTMR3ForKey(pub []byte) []byte {
-	v := runtimemeasure.ForOperatorKey(pub)
+	v := runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pub))
 	return v[:]
 }
 
@@ -58,7 +59,8 @@ func TestLoadMeasuredOperatorKey(t *testing.T) {
 }
 
 // TestLoadMeasuredOperatorKeyFailsClosed enumerates the ways the anchor check
-// must refuse: substituted key, malformed or missing RTMR, missing/empty key.
+// must refuse: substituted key, a register without the mode event or with
+// the wrong one, malformed or missing RTMR, missing/empty key.
 func TestLoadMeasuredOperatorKeyFailsClosed(t *testing.T) {
 	pub := []byte("operator public key bytes")
 	tests := []struct {
@@ -70,6 +72,30 @@ func TestLoadMeasuredOperatorKeyFailsClosed(t *testing.T) {
 			stage: func(t *testing.T, pubPath, rtmrPath string) {
 				writeFileT(t, pubPath, []byte("a different key the host swapped in"))
 				writeFileT(t, rtmrPath, expectedRTMR3ForKey(pub))
+			},
+		},
+		{
+			name: "bare seed: mode event not extended",
+			stage: func(t *testing.T, pubPath, rtmrPath string) {
+				writeFileT(t, pubPath, pub)
+				seed := runtimemeasure.ForOperatorKey(pub)
+				writeFileT(t, rtmrPath, seed[:])
+			},
+		},
+		{
+			name: "static mode event on an operator-key boot",
+			stage: func(t *testing.T, pubPath, rtmrPath string) {
+				writeFileT(t, pubPath, pub)
+				reg := runtimemeasure.Extend(runtimemeasure.ForOperatorKey(pub), runtimemeasure.ModeStatic)
+				writeFileT(t, rtmrPath, reg[:])
+			},
+		},
+		{
+			name: "keyless dynamic register",
+			stage: func(t *testing.T, pubPath, rtmrPath string) {
+				writeFileT(t, pubPath, pub)
+				reg := runtimemeasure.ForDynamic(runtimemeasure.Zero)
+				writeFileT(t, rtmrPath, reg[:])
 			},
 		},
 		{

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -40,7 +40,7 @@ func NewCmd() *cobra.Command {
 			"cluster already binds, or every request is denied.\n" +
 			"On a static-allowlist boot (--policy-dir mode=static) there is no\n" +
 			"operator key: RTMR[3] must equal the value recomputed from the\n" +
-			"published bundle and any attested caller receives the credential.",
+			"published bundle and any caller receives the credential.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), cfg)
 		},
@@ -49,7 +49,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
 	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (RA-TLS serving quote; on SNP also the HOSTDATA self-verify)")
 	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required)")
-	f.StringVar(&cfg.PolicyDir, "policy-dir", policybundle.DefaultPolicyDir, "policy mode directory c8s-policy-measure wrote; mode=static releases to any attested caller once RTMR[3] matches the bundle")
+	f.StringVar(&cfg.PolicyDir, "policy-dir", policybundle.DefaultPolicyDir, "policy mode directory c8s-policy-measure wrote; mode=static releases to any caller once RTMR[3] matches the bundle")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")

--- a/internal/cmds/credrelease/cmd.go
+++ b/internal/cmds/credrelease/cmd.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 )
 
 const (
@@ -35,7 +37,10 @@ func NewCmd() *cobra.Command {
 			"/etc/kubernetes/pki/ca.crt). Authorization is the cluster's RBAC on\n" +
 			"the issued group: the c8s node image bakes a ClusterRoleBinding for\n" +
 			"the default --cert-org; elsewhere create one or pass a group the\n" +
-			"cluster already binds, or every request is denied.",
+			"cluster already binds, or every request is denied.\n" +
+			"On a static-allowlist boot (--policy-dir mode=static) there is no\n" +
+			"operator key: RTMR[3] must equal the value recomputed from the\n" +
+			"published bundle and any attested caller receives the credential.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return Run(cmd.Context(), cfg)
 		},
@@ -44,6 +49,7 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.ListenAddr, "listen", ":8443", "HTTPS (RA-TLS) bind address")
 	f.StringVar(&cfg.AttestationAPIURL, "attestation-api-url", "http://127.0.0.1:8400", "local attestation-api base URL (RA-TLS serving quote; on SNP also the HOSTDATA self-verify)")
 	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required)")
+	f.StringVar(&cfg.PolicyDir, "policy-dir", policybundle.DefaultPolicyDir, "policy mode directory c8s-policy-measure wrote; mode=static releases to any attested caller once RTMR[3] matches the bundle")
 	f.StringVar(&cfg.ClientCACert, "client-ca-cert", defaultClientCACert, "cluster client-CA cert that signs kube client certs (kubeadm: /etc/kubernetes/pki/ca.crt)")
 	f.StringVar(&cfg.ClientCAKey, "client-ca-key", defaultClientCAKey, "cluster client-CA key (kubeadm: /etc/kubernetes/pki/ca.key)")
 	f.StringVar(&cfg.ServerCACert, "server-ca-cert", defaultServerCACert, "CA that signs the apiserver serving cert; embedded in the released kubeconfig (kubeadm: /etc/kubernetes/pki/ca.crt)")

--- a/internal/cmds/credrelease/cmd_test.go
+++ b/internal/cmds/credrelease/cmd_test.go
@@ -19,6 +19,7 @@ func TestNewCmdDefaultsAndHelp(t *testing.T) {
 		{"listen", ":8443"},
 		{"attestation-api-url", "http://127.0.0.1:8400"},
 		{"platform", ""},
+		{"policy-dir", "/run/confai/policy"},
 		{"client-ca-cert", defaultClientCACert},
 		{"client-ca-key", defaultClientCAKey},
 		{"server-ca-cert", defaultServerCACert},

--- a/internal/cmds/credrelease/handler.go
+++ b/internal/cmds/credrelease/handler.go
@@ -83,7 +83,7 @@ func NewHandler(operatorPubPEM []byte, ca *clusterCA, org, cn string, ttl time.D
 // so no Authorization check. The caller MUST have verified RTMR[3] against
 // the published bundle first (verifyBundleMeasured); on a static node
 // cluster-admin is the adversary the design already assumes, so handing the
-// credential to every attested caller gives nothing away.
+// credential to every caller gives nothing away.
 func NewOpenHandler(ca *clusterCA, org, cn string, ttl time.Duration) *Handler {
 	return &Handler{
 		open:    true,

--- a/internal/cmds/credrelease/handler.go
+++ b/internal/cmds/credrelease/handler.go
@@ -38,10 +38,16 @@ type ReleaseResponse struct {
 }
 
 // Handler serves POST /release-credential. It authorizes the caller against
-// the measured operator key, validates the CSR, and issues a short-lived kube
-// client cert signed by the cluster CA.
+// the measured operator key (dynamic mode) or accepts any caller (static
+// mode, where there is no operator key and RA-TLS is the only gate),
+// validates the CSR, and issues a short-lived kube client cert signed by the
+// cluster CA.
 type Handler struct {
-	verifier operatorauth.Verifier
+	// open is set only by NewOpenHandler. It is a separate field, not a nil
+	// verifier, so the zero value of Handler refuses every request instead
+	// of releasing cluster-admin credentials to anyone.
+	open     bool
+	verifier *operatorauth.Verifier
 	ca       *clusterCA
 	certTTL  time.Duration
 	certOrg  string // Kubernetes group (O) for the issued cert
@@ -64,13 +70,29 @@ func NewHandler(operatorPubPEM []byte, ca *clusterCA, org, cn string, ttl time.D
 		// guest clock is rejected "used before issued". Bounded (still within
 		// operatorauth's 5-min max validity), so it doesn't widen the replay
 		// window meaningfully.
-		verifier: operatorauth.Verifier{Keys: keys, ClockSkew: 60 * time.Second},
+		verifier: &operatorauth.Verifier{Keys: keys, ClockSkew: 60 * time.Second},
 		ca:       ca,
 		certTTL:  ttl,
 		certOrg:  org,
 		certCN:   cn,
 		now:      time.Now,
 	}, nil
+}
+
+// NewOpenHandler builds the static-mode release handler: no operator key,
+// so no Authorization check. The caller MUST have verified RTMR[3] against
+// the published bundle first (verifyBundleMeasured); on a static node
+// cluster-admin is the adversary the design already assumes, so handing the
+// credential to every attested caller gives nothing away.
+func NewOpenHandler(ca *clusterCA, org, cn string, ttl time.Duration) *Handler {
+	return &Handler{
+		open:    true,
+		ca:      ca,
+		certTTL: ttl,
+		certOrg: org,
+		certCN:  cn,
+		now:     time.Now,
+	}
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -88,14 +110,23 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// AUTHORIZE: the caller must hold the operator private key whose public
-	// half is measured into RTMR[3]. operatorauth verifies the Bearer JWT
-	// (ES256/384/512) under the pinned key, enforces <=5min validity, and
-	// binds the token to this method/path/body (pbh) — so a captured token
-	// can't be replayed against a different CSR.
-	if err := h.verifier.Authorize(r, body); err != nil {
-		http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+	// AUTHORIZE (dynamic mode): the caller must hold the operator private
+	// key whose public half is measured into RTMR[3]. operatorauth verifies
+	// the Bearer JWT (ES256/384/512) under the pinned key, enforces <=5min
+	// validity, and binds the token to this method/path/body (pbh) — so a
+	// captured token can't be replayed against a different CSR. Static mode
+	// skips the check; a handler that is neither open nor keyed was not
+	// built by a constructor and must not release anything.
+	switch {
+	case h.open:
+	case h.verifier == nil || h.ca == nil:
+		http.Error(w, "release handler is not configured", http.StatusInternalServerError)
 		return
+	default:
+		if err := h.verifier.Authorize(r, body); err != nil {
+			http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
 	}
 
 	var req ReleaseRequest

--- a/internal/cmds/credrelease/handler_test.go
+++ b/internal/cmds/credrelease/handler_test.go
@@ -161,6 +161,95 @@ func TestReleaseRefusesATokenBoundToAnotherCSR(t *testing.T) {
 	}
 }
 
+// TestOpenHandlerReleasesWithoutAToken: in static mode there is no operator
+// key, so a request without any Authorization header is served, and one with
+// a token for some unrelated key is served too (the header is not consulted).
+func TestOpenHandlerReleasesWithoutAToken(t *testing.T) {
+	h := NewOpenHandler(testCA(t), defaultCertOrg, defaultCertCN, time.Hour)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(ReleaseRequest{CSRPEM: string(csrPEMFromKey(t, key))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, _ := newOperatorAuth(t)
+	strayToken, err := signer.Authorization(http.MethodPost, ReleasePath, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name  string
+		authz string
+	}{
+		{"no Authorization header", ""},
+		{"token for an unrelated key", strayToken},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, ReleasePath, bytes.NewReader(body))
+			if tc.authz != "" {
+				req.Header.Set("Authorization", tc.authz)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("open handler(%s) = %d, body %q; want 200", tc.name, rec.Code, rec.Body.String())
+			}
+			var resp ReleaseResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(resp.CertPEM, "BEGIN CERTIFICATE") {
+				t.Errorf("open handler(%s) released no certificate: %q", tc.name, resp.CertPEM)
+			}
+		})
+	}
+	// A bad CSR is still a client fault: the open handler skips only the
+	// token check, not CSR validation.
+	badBody, err := json.Marshal(ReleaseRequest{CSRPEM: "not a csr"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, ReleasePath, bytes.NewReader(badBody)))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("open handler(bad CSR) = %d, want 400", rec.Code)
+	}
+}
+
+// TestHandlerWithoutAnAuthorizerRefuses: open mode is opt-in through
+// NewOpenHandler. A Handler built any other way without a verifier (a
+// literal, a future constructor bug) must refuse, never release.
+func TestHandlerWithoutAnAuthorizerRefuses(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(ReleaseRequest{CSRPEM: string(csrPEMFromKey(t, key))})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		h    *Handler
+	}{
+		{"zero value", &Handler{}},
+		{"CA but no verifier", &Handler{ca: testCA(t), certTTL: time.Hour, certOrg: defaultCertOrg, certCN: defaultCertCN, now: time.Now}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tc.h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, ReleasePath, bytes.NewReader(body)))
+			if rec.Code != http.StatusInternalServerError {
+				t.Fatalf("Handler(%s) = %d, body %q; want 500", tc.name, rec.Code, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "BEGIN CERTIFICATE") {
+				t.Errorf("Handler(%s) released a certificate without an authorizer", tc.name)
+			}
+		})
+	}
+}
+
 // newOperatorAuth generates a fresh operator keypair, returning a token signer
 // (the operator side) and the PKIX public-key PEM (the measured side).
 func newOperatorAuth(t *testing.T) (*operatorauth.Signer, []byte) {

--- a/internal/cmds/credrelease/node_image_test.go
+++ b/internal/cmds/credrelease/node_image_test.go
@@ -13,6 +13,9 @@ import (
 	"gopkg.in/yaml.v3"
 	rbacv1 "k8s.io/api/rbac/v1"
 	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/policymeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 )
 
 // The node image bakes the operator identity twice: the unit spells out the
@@ -88,6 +91,44 @@ func TestNodeImageCredentialReleaseConfiguration(t *testing.T) {
 	flags := NewCmd().Flags()
 	if err := flags.Parse(args[2:]); err != nil {
 		t.Fatalf("parse baked ExecStart flags: %v", err)
+	}
+	// The policy dir is the measurer's output; the unit must read the one the
+	// measurer writes and be ordered after it, and start on either disk.
+	if dir, _ := flags.GetString("policy-dir"); dir != policybundle.DefaultPolicyDir {
+		t.Errorf("baked --policy-dir = %q, want %q", dir, policybundle.DefaultPolicyDir)
+	}
+	for _, line := range []string{
+		"\nAfter=", "\nRequires=",
+	} {
+		_, rest, ok := strings.Cut(joined, line)
+		directive, _, _ := strings.Cut(rest, "\n")
+		if !ok || !slices.Contains(strings.Fields(directive), "c8s-policy-measure.service") {
+			t.Errorf("cred-release.service %s does not name c8s-policy-measure.service: %q", strings.TrimSpace(line), directive)
+		}
+	}
+	for _, cond := range []string{
+		"ConditionPathExists=|" + policymeasure.DefaultOpkeyDisk,
+		"ConditionPathExists=|" + policymeasure.DefaultPolicyDisk,
+	} {
+		if !strings.Contains(joined, "\n"+cond+"\n") {
+			t.Errorf("cred-release.service lacks the OR condition %q", cond)
+		}
+	}
+	if strings.Contains(joined, "\nConditionPathExists="+policymeasure.DefaultOpkeyDisk+"\n") {
+		t.Error("cred-release.service still requires opkeydata unconditionally; static boots have no operator key")
+	}
+	// The unit now starts on static boots, where the initrd never creates
+	// /etc/confai; a ReadOnlyPaths entry without the `-` prefix makes systemd
+	// fail the mount namespace setup before ExecStart runs.
+	var readOnly []string
+	for _, line := range strings.Split(joined, "\n") {
+		if v, ok := strings.CutPrefix(line, "ReadOnlyPaths="); ok {
+			readOnly = append(readOnly, strings.Fields(v)...)
+		}
+	}
+	confai := filepath.Dir(policymeasure.DefaultOperatorPubkey)
+	if slices.Contains(readOnly, confai) || !slices.Contains(readOnly, "-"+confai) {
+		t.Errorf("cred-release.service ReadOnlyPaths = %q, want -%s: the directory exists only on an opkeydata boot", readOnly, confai)
 	}
 	org, _ := flags.GetString("cert-org")
 	cn, _ := flags.GetString("cert-cn")

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -25,7 +25,7 @@ type Config struct {
 	Platform string
 	// PolicyDir is where c8s-policy-measure published the boot's policy
 	// mode. mode=dynamic gates release on the measured operator key;
-	// mode=static has no operator key and releases to any attested caller
+	// mode=static has no operator key and releases to any caller
 	// once RTMR[3] matches the published bundle.
 	PolicyDir string
 	// ClientCACert / ClientCAKey locate the cluster's client-signing CA

--- a/internal/cmds/credrelease/run.go
+++ b/internal/cmds/credrelease/run.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -22,6 +23,11 @@ type Config struct {
 	AttestationAPIURL string
 	// Platform is the TEE platform ("tdx" or "snp"; no default).
 	Platform string
+	// PolicyDir is where c8s-policy-measure published the boot's policy
+	// mode. mode=dynamic gates release on the measured operator key;
+	// mode=static has no operator key and releases to any attested caller
+	// once RTMR[3] matches the published bundle.
+	PolicyDir string
 	// ClientCACert / ClientCAKey locate the cluster's client-signing CA
 	// (defaults: the RKE2 paths; kubeadm works via /etc/kubernetes/pki/ca.{crt,key}).
 	ClientCACert string
@@ -39,15 +45,19 @@ type Config struct {
 	CertCN  string
 }
 
-// Run loads the measured operator key and cluster CA, then serves the
-// RA-TLS-protected /release-credential endpoint. It blocks until ctx is done.
+// Run reads the policy mode, loads the release authorizer and cluster CA,
+// then serves the RA-TLS-protected /release-credential endpoint. It blocks
+// until ctx is done.
 //
 // Startup order matters for the trust story:
-//  1. LoadMeasuredOperatorKey — read the opkeydata pubkey and CONFIRM it
-//     matches the launch binding (TDX RTMR[3] / SNP HOSTDATA). Fails closed
-//     if the key was substituted after boot.
+//  1. policybundle.ReadDir — the mode c8s-policy-measure committed
+//     to RTMR[3]; missing or inconsistent is fatal, never a default.
 //  2. loadClusterCA — the cluster client-CA that signs the operator's cert.
-//  3. serve over an RA-TLS config so the caller can attest this is the real
+//  3. Dynamic: LoadMeasuredOperatorKey — read the opkeydata pubkey and
+//     CONFIRM it matches the launch binding (TDX RTMR[3] / SNP HOSTDATA).
+//     Static: verifyBundleMeasured — CONFIRM RTMR[3] equals the value the
+//     published bundle implies. Both fail closed on a substituted file.
+//  4. serve over an RA-TLS config so the caller can attest this is the real
 //     guest before trusting the returned cert.
 func Run(ctx context.Context, cfg Config) error {
 	// RA-TLS is mandatory here: this endpoint hands out cluster-admin creds,
@@ -62,19 +72,40 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("--platform: %w", err)
 	}
 
-	operatorPub, err := LoadMeasuredOperatorKey(ctx, cfg.Platform, cfg.AttestationAPIURL)
+	state, err := policybundle.ReadDir(cfg.PolicyDir)
 	if err != nil {
-		return fmt.Errorf("load measured operator key: %w", err)
+		return err
 	}
-
 	ca, err := loadClusterCA(cfg.ClientCACert, cfg.ClientCAKey, cfg.ServerCACert)
 	if err != nil {
 		return fmt.Errorf("load cluster CA: %w", err)
 	}
 
-	handler, err := NewHandler(operatorPub, ca, cfg.CertOrg, cfg.CertCN, cfg.CertTTL)
-	if err != nil {
-		return fmt.Errorf("build handler: %w", err)
+	// The mode decides the authorizer; nothing downstream infers it from a
+	// missing key.
+	var handler *Handler
+	switch state.Mode {
+	case policybundle.StaticMode:
+		// Only TDX has the register the bundle is measured into; the
+		// measurer never writes mode=static elsewhere, so this is tampering.
+		if cfg.Platform != "tdx" {
+			return fmt.Errorf("policy mode is static but platform is %s: static mode is TDX-only", cfg.Platform)
+		}
+		if err := verifyBundleMeasured(state.Bundle); err != nil {
+			return fmt.Errorf("verify static bundle: %w", err)
+		}
+		handler = NewOpenHandler(ca, cfg.CertOrg, cfg.CertCN, cfg.CertTTL)
+	case policybundle.DynamicMode:
+		operatorPub, err := LoadMeasuredOperatorKey(ctx, cfg.Platform, cfg.AttestationAPIURL)
+		if err != nil {
+			return fmt.Errorf("load measured operator key: %w", err)
+		}
+		handler, err = NewHandler(operatorPub, ca, cfg.CertOrg, cfg.CertCN, cfg.CertTTL)
+		if err != nil {
+			return fmt.Errorf("build handler: %w", err)
+		}
+	default:
+		return fmt.Errorf("policy mode %q is not static or dynamic", state.Mode)
 	}
 
 	// RA-TLS serving config: the presented cert embeds a fresh TDX quote

--- a/internal/cmds/credrelease/run_test.go
+++ b/internal/cmds/credrelease/run_test.go
@@ -6,15 +6,21 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -62,8 +68,47 @@ func fakeAttestationAPI(t *testing.T) *httptest.Server {
 	return srv
 }
 
-// runnableConfig stages a measured operator key, on-disk CAs, and a fake
-// attestation-api, returning a Config Run can fully start from.
+// policyDir writes what c8s-policy-measure leaves for the given mode and
+// returns the directory. members is the static bundle (nil on dynamic).
+func policyDir(t *testing.T, mode string, members map[string][]byte) string {
+	t.Helper()
+	dir := t.TempDir()
+	if members != nil {
+		bundle, err := policybundle.FromMembers(members)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for name, data := range members {
+			writeFileT(t, filepath.Join(dir, name), data)
+		}
+		sum := bundle.IndexDigest()
+		writeFileT(t, filepath.Join(dir, policybundle.DigestFile), []byte(hex.EncodeToString(sum[:])))
+	}
+	writeFileT(t, filepath.Join(dir, policybundle.ModeFile), []byte(mode+"\n"))
+	return dir
+}
+
+// sealedBundle is a one-member bundle whose allowlist LintSealed accepts.
+func sealedBundle(t *testing.T) map[string][]byte {
+	t.Helper()
+	doc := `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{"digest":"sha256:` + strings.Repeat("a", 64) + `",` +
+		`"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
+		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
+		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`
+	al, err := allowlist.ParseJSON([]byte(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return map[string][]byte{policybundle.MemberStaticAllowlist: canonical}
+}
+
+// runnableConfig stages a measured operator key, a dynamic policy dir,
+// on-disk CAs, and a fake attestation-api, returning a Config Run can fully
+// start from.
 func runnableConfig(t *testing.T) Config {
 	t.Helper()
 	stageMeasuredOperatorKey(t, freshOperatorPubPEM(t))
@@ -74,6 +119,7 @@ func runnableConfig(t *testing.T) Config {
 		ListenAddr:        "127.0.0.1:0",
 		AttestationAPIURL: fakeAttestationAPI(t).URL,
 		Platform:          "tdx",
+		PolicyDir:         policyDir(t, policybundle.DynamicMode, nil),
 		ClientCACert:      clientCert,
 		ClientCAKey:       clientKey,
 		ServerCACert:      serverCert,
@@ -83,43 +129,119 @@ func runnableConfig(t *testing.T) Config {
 	}
 }
 
+// staticConfig is runnableConfig for a static boot: no operator key, the
+// bundle published under the policy dir, RTMR[3] at the bundle's value.
+func staticConfig(t *testing.T) Config {
+	t.Helper()
+	cfg := runnableConfig(t)
+	members := sealedBundle(t)
+	bundle, err := policybundle.FromMembers(members)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, rtmrPath := overrideBindingPaths(t) // no pubkey staged
+	reg := bundle.RTMR3()
+	writeFileT(t, rtmrPath, reg[:])
+	cfg.PolicyDir = policyDir(t, policybundle.StaticMode, members)
+	return cfg
+}
+
 // TestRunStartupErrors walks Run's fail-closed startup ladder: missing
-// platform, unmeasured key, unreadable CA, non-ECDSA key, and a dead
-// attestation-api at warm-up.
+// platform, unwritten or tampered policy state, unmeasured key or bundle,
+// unreadable CA, non-ECDSA key, and a dead attestation-api at warm-up. Each
+// row names the rung it fails on, so a later rung cannot mask a removed one.
 func TestRunStartupErrors(t *testing.T) {
 	tests := []struct {
-		name string
-		cfg  func(t *testing.T) Config
+		name    string
+		cfg     func(t *testing.T) Config
+		wantErr string // substring naming the rung that failed
 	}{
 		{
-			name: "platform required",
+			name:    "platform required",
+			wantErr: "--platform is required",
 			cfg: func(t *testing.T) Config {
 				return Config{Platform: ""}
 			},
 		},
 		{
-			name: "platform value validated before privileged reads",
+			name:    "platform value validated before privileged reads",
+			wantErr: "--platform:",
 			cfg: func(t *testing.T) Config {
 				return Config{Platform: "foo"}
 			},
 		},
 		{
-			name: "operator key not staged",
+			name:    "policy mode not written",
+			wantErr: "policy mode",
 			cfg: func(t *testing.T) Config {
-				overrideBindingPaths(t) // paths exist, files do not
-				return Config{Platform: "tdx"}
+				overrideBindingPaths(t)
+				return Config{Platform: "tdx", PolicyDir: t.TempDir()}
 			},
 		},
 		{
-			name: "cluster CA unreadable",
+			name:    "operator key not staged",
+			wantErr: "load measured operator key",
+			cfg: func(t *testing.T) Config {
+				cfg := runnableConfig(t)
+				overrideBindingPaths(t) // paths exist, files do not
+				return cfg
+			},
+		},
+		{
+			name:    "static mode on snp",
+			wantErr: "TDX-only",
+			cfg: func(t *testing.T) Config {
+				cfg := staticConfig(t)
+				cfg.Platform = "snp"
+				return cfg
+			},
+		},
+		{
+			name:    "static mode with the register at the dynamic value",
+			wantErr: "does not match the measured RTMR[3]",
+			cfg: func(t *testing.T) Config {
+				cfg := staticConfig(t)
+				_, rtmrPath := overrideBindingPaths(t)
+				reg := runtimemeasure.ForDynamic(runtimemeasure.Zero)
+				writeFileT(t, rtmrPath, reg[:])
+				return cfg
+			},
+		},
+		{
+			name:    "static mode with a member rewritten after measurement",
+			wantErr: "members index to",
+			cfg: func(t *testing.T) Config {
+				cfg := staticConfig(t)
+				member := filepath.Join(cfg.PolicyDir, policybundle.MemberStaticAllowlist)
+				data, err := os.ReadFile(member)
+				if err != nil {
+					t.Fatal(err)
+				}
+				writeFileT(t, member, append(data, ' '))
+				return cfg
+			},
+		},
+		{
+			name:    "static mode with the register missing",
+			wantErr: "verify static bundle: read",
+			cfg: func(t *testing.T) Config {
+				cfg := staticConfig(t)
+				overrideBindingPaths(t)
+				return cfg
+			},
+		},
+		{
+			name:    "cluster CA unreadable",
+			wantErr: "load cluster CA",
 			cfg: func(t *testing.T) Config {
 				stageMeasuredOperatorKey(t, freshOperatorPubPEM(t))
 				missing := filepath.Join(t.TempDir(), "missing")
-				return Config{Platform: "tdx", ClientCACert: missing, ClientCAKey: missing, ServerCACert: missing}
+				return Config{Platform: "tdx", PolicyDir: policyDir(t, policybundle.DynamicMode, nil), ClientCACert: missing, ClientCAKey: missing, ServerCACert: missing}
 			},
 		},
 		{
-			name: "measured key is not an ECDSA PKIX PEM",
+			name:    "measured key is not an ECDSA PKIX PEM",
+			wantErr: "build handler",
 			cfg: func(t *testing.T) Config {
 				cfg := runnableConfig(t)
 				// Measured (RTMR matches) but unusable for operatorauth.
@@ -128,7 +250,8 @@ func TestRunStartupErrors(t *testing.T) {
 			},
 		},
 		{
-			name: "attestation-api down at warm-up",
+			name:    "attestation-api down at warm-up",
+			wantErr: "warm up RA-TLS serving cert",
 			cfg: func(t *testing.T) Config {
 				cfg := runnableConfig(t)
 				cfg.AttestationAPIURL = "http://127.0.0.1:1" // nothing listens
@@ -138,18 +261,33 @@ func TestRunStartupErrors(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if err := Run(context.Background(), tc.cfg(t)); err == nil {
-				t.Fatal("expected error, got nil")
+			err := Run(context.Background(), tc.cfg(t))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Run(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
 			}
 		})
 	}
 }
 
 // TestRunServesAndShutsDown starts the full service (fake attestation-api,
-// temp CAs, measured key), waits for it to accept connections, then cancels
-// the context and expects a clean shutdown.
+// temp CAs, measured key or published bundle), waits for it to accept
+// connections, then cancels the context and expects a clean shutdown.
 func TestRunServesAndShutsDown(t *testing.T) {
-	cfg := runnableConfig(t)
+	for _, tc := range []struct {
+		name string
+		cfg  func(t *testing.T) Config
+	}{
+		{"dynamic", runnableConfig},
+		{"static", staticConfig},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runServesAndShutsDown(t, tc.cfg(t))
+		})
+	}
+}
+
+func runServesAndShutsDown(t *testing.T, cfg Config) {
+	t.Helper()
 	// Reserve a port so the test knows where to probe.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/internal/cmds/getcert/own_quote_pins_test.go
+++ b/internal/cmds/getcert/own_quote_pins_test.go
@@ -1,0 +1,93 @@
+package getcert
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// The own-quote flag and the flat pins are two answers to one question, and
+// the quote is only trustworthy from the node's own verifier.
+func TestValidateConfigOwnQuoteFlagRules(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		edit    func(c *config)
+		wantErr string
+	}{
+		{"unix verifier", func(*config) {}, ""},
+		{"with cds-measurements", func(c *config) { c.CDSMeasurements = strings.Repeat("ab", 48) }, "replaces --cds-measurements"},
+		{"with cds-rtmrs", func(c *config) { c.CDSRTMRs = "1=" + strings.Repeat("ab", 48) }, "replaces --cds-measurements"},
+		{"network verifier", func(c *config) { c.AttestationApiURL = "http://127.0.0.1:8400" }, "unix://"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := config{
+				CDSURL:              "https://cds:8443",
+				AttestationApiURL:   "unix:///run/confai/attestation-api.sock",
+				SAN:                 "host.example.com",
+				CDSPinsFromOwnQuote: true,
+			}
+			tc.edit(&cfg)
+			err := validateConfig(cfg)
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("validateConfig(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Under the flag the CDS client is pinned to the tuple the node's verifier
+// reports for this pod: one whole entry, no loose pins, and no "unpinned"
+// warning since the pin is a real one.
+func TestCDSHTTPClientPinsFromOwnQuote(t *testing.T) {
+	reg := func(b byte) string { return strings.Repeat(hex.EncodeToString([]byte{b}), 48) }
+	stub, url := testattest.NewUnix(t)
+	stub.SetPlatform(types.PlatformTdx)
+	stub.SetVerdict(testattest.TDXVerdict(reg(0x11), map[int]string{0: reg(0), 1: reg(0x21), 2: reg(0x22), 3: reg(0x33)}))
+	cfg := config{CDSURL: "https://cds:8443", AttestationApiURL: url, CDSPinsFromOwnQuote: true}
+
+	c := captureDefaultLogger(t)
+	pins, err := cdsPins(t.Context(), cfg)
+	if err != nil {
+		t.Fatalf("cdsPins(own quote) = %v, want nil", err)
+	}
+	if len(pins.Entries) != 1 || len(pins.Measurements) != 0 || len(pins.RTMRs) != 0 {
+		t.Fatalf("cdsPins(own quote) = %+v, want exactly one entry and no loose pins", pins)
+	}
+	if e := pins.Entries[0]; hex.EncodeToString(e.Digest) != reg(0x11) || hex.EncodeToString(e.RTMRs[3]) != reg(0x33) {
+		t.Fatalf("cdsPins(own quote) entry = %x / RTMR[3] %x, want the quote's tuple", e.Digest, e.RTMRs[3])
+	}
+	if _, ok := c.find("--cds-measurements not set"); ok {
+		t.Fatal("warned about an unpinned CDS although the own-quote pin is set")
+	}
+	if _, err := cdsHTTPClient(t.Context(), cfg); err != nil {
+		t.Fatalf("cdsHTTPClient(own quote) = %v, want nil", err)
+	}
+
+	stub.SetPlatform(types.PlatformSnp)
+	if _, err := cdsHTTPClient(t.Context(), cfg); err == nil || !strings.Contains(err.Error(), "--cds-pins-from-own-quote") {
+		t.Fatalf("cdsHTTPClient(snp verifier) = %v, want a failure naming the flag", err)
+	}
+}
+
+// The self-attestation runs under the caller's context so a SIGTERM during a
+// slow verifier answer ends the sidecar instead of waiting out
+// ownQuoteTimeout.
+func TestCDSPinsFromOwnQuoteHonorsContext(t *testing.T) {
+	stub, url := testattest.NewUnix(t)
+	stub.SetPlatform(types.PlatformTdx)
+	cfg := config{CDSURL: "https://cds:8443", AttestationApiURL: url, CDSPinsFromOwnQuote: true}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, err := cdsPins(ctx, cfg)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cdsPins(cancelled ctx) = %v, want %v", err, context.Canceled)
+	}
+	if n := len(stub.AttestRequests()); n != 0 {
+		t.Fatalf("attest requests under a cancelled context = %d, want 0", n)
+	}
+}

--- a/internal/cmds/getcert/own_quote_pins_test.go
+++ b/internal/cmds/getcert/own_quote_pins_test.go
@@ -76,7 +76,7 @@ func TestCDSHTTPClientPinsFromOwnQuote(t *testing.T) {
 
 // The self-attestation runs under the caller's context so a SIGTERM during a
 // slow verifier answer ends the sidecar instead of waiting out
-// ownQuoteTimeout.
+// attestationclient.OwnTupleTimeout.
 func TestCDSPinsFromOwnQuoteHonorsContext(t *testing.T) {
 	stub, url := testattest.NewUnix(t)
 	stub.SetPlatform(types.PlatformTdx)

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -40,7 +40,6 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
-	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -205,24 +204,15 @@ func cdsHTTPClient(ctx context.Context, cfg config) (*http.Client, error) {
 	return client, nil
 }
 
-// ownQuoteTimeout bounds the self-attestation that derives the CDS pins at
-// start; the verifier is a local socket, so a slow answer means it is not
-// serving.
-const ownQuoteTimeout = 30 * time.Second
-
 // cdsPins is what get-cert holds CDS's RA-TLS certificate to: the node's own
-// tuple under --cds-pins-from-own-quote (a sealed node's argv carries no
-// per-cluster digest, and the tuple includes RTMR[3], so a CDS on an unsealed
-// node of the same image is refused), else the flat flags.
+// tuple under --cds-pins-from-own-quote, else the flat flags.
 func cdsPins(ctx context.Context, cfg config) (ratls.Pins, error) {
 	if cfg.CDSPinsFromOwnQuote {
-		ctx, cancel := context.WithTimeout(ctx, ownQuoteTimeout)
-		defer cancel()
-		entry, err := attestationclient.NewClient(cfg.AttestationApiURL).OwnTupleEntry(ctx)
+		pins, err := ratls.OwnTuplePins(ctx, attestationclient.NewClient(cfg.AttestationApiURL))
 		if err != nil {
 			return ratls.Pins{}, fmt.Errorf("--cds-pins-from-own-quote: %w", err)
 		}
-		return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+		return pins, nil
 	}
 	launch, err := ratls.ParseHexMeasurements(cfg.CDSMeasurements)
 	if err != nil {

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -37,8 +37,10 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/internal/fileutil"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -49,6 +51,7 @@ type config struct {
 	CDSURL                 string
 	CDSMeasurements        string
 	CDSRTMRs               string
+	CDSPinsFromOwnQuote    bool
 	AttestationApiURL      string
 	OutPath                string
 	CAOutPath              string
@@ -124,6 +127,7 @@ alongside a workload that uses the obtained certificate.`,
 	flags.StringVar(&cfg.CDSURL, "cds-url", "", "URL of the CDS service (e.g. https://cds:8443)")
 	flags.StringVar(&cfg.CDSMeasurements, "cds-measurements", "", "comma-separated SHA-384 hex launch measurements for CDS RA-TLS verification (empty = accept any attested CDS)")
 	flags.StringVar(&cfg.CDSRTMRs, "cds-rtmrs", "", "comma-separated TDX RTMR pins <index>=<sha384-hex> CDS's RA-TLS cert must additionally satisfy; ignored when CDS presents SNP evidence (empty = launch-digest pinning only)")
+	flags.BoolVar(&cfg.CDSPinsFromOwnQuote, "cds-pins-from-own-quote", false, "pin CDS to this node's own image tuple {MRTD, RTMR[1..3]}, taken from a fresh quote of this pod verified over the unix --attestation-api-url at start, instead of --cds-measurements and --cds-rtmrs (static allowlist nodes, where the argv is sealed)")
 	flags.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "URL of the node-local attestation-api (http://localhost:8400, or unix:// plus the on-node socket path the chart wires)")
 	flags.StringVarP(&cfg.OutPath, "out", "o", "", "Path to write the signed certificate chain PEM (prints to stdout if omitted)")
 	flags.StringVar(&cfg.CAOutPath, "ca-out", "", "Path to write just the mesh CA bundle PEM (the issuer certs trailing the leaf in the CDS chain), e.g. for nginx to serve at a discovery endpoint without a separate ConfigMap")
@@ -165,8 +169,8 @@ func setupLogging(verbose bool) {
 	slog.SetDefault(slog.New(handler))
 }
 
-func newCDSClient(cfg config) (attestclient.Client, error) {
-	httpClient, err := cdsHTTPClient(cfg)
+func newCDSClient(ctx context.Context, cfg config) (attestclient.Client, error) {
+	httpClient, err := cdsHTTPClient(ctx, cfg)
 	if err != nil {
 		var zero attestclient.Client
 		return zero, err
@@ -174,7 +178,9 @@ func newCDSClient(cfg config) (attestclient.Client, error) {
 	return attestclient.NewClientWithHTTP(cfg.CDSURL, httpClient), nil
 }
 
-func cdsHTTPClient(cfg config) (*http.Client, error) {
+// cdsHTTPClient builds the RA-TLS client for CDS; ctx bounds the
+// self-attestation --cds-pins-from-own-quote performs at start.
+func cdsHTTPClient(ctx context.Context, cfg config) (*http.Client, error) {
 	parsed, err := url.Parse(cfg.CDSURL)
 	if err != nil {
 		return nil, fmt.Errorf("--cds-url: %w", err)
@@ -188,24 +194,49 @@ func cdsHTTPClient(cfg config) (*http.Client, error) {
 		return nil, fmt.Errorf("--cds-url must use https (RA-TLS); got scheme %q", parsed.Scheme)
 	}
 
-	measurements, err := ratls.ParseHexMeasurements(cfg.CDSMeasurements)
+	pins, err := cdsPins(ctx, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("--cds-measurements: %w", err)
-	}
-	if err := cmdsutil.CheckCDSPinned(len(measurements), cfg.WorkloadClaimsGuest,
-		"--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement"); err != nil {
 		return nil, err
 	}
-	rtmrs, err := ratls.ParseRTMRPinsString(cfg.CDSRTMRs)
-	if err != nil {
-		return nil, fmt.Errorf("--cds-rtmrs: %w", err)
-	}
-
-	client, err := ratls.NewVerifyingHTTPClient(ratls.Pins{Measurements: measurements, RTMRs: rtmrs}, cfg.AttestationApiURL)
+	client, err := ratls.NewVerifyingHTTPClient(pins, cfg.AttestationApiURL)
 	if err != nil {
 		return nil, fmt.Errorf("cds RA-TLS client: %w", err)
 	}
 	return client, nil
+}
+
+// ownQuoteTimeout bounds the self-attestation that derives the CDS pins at
+// start; the verifier is a local socket, so a slow answer means it is not
+// serving.
+const ownQuoteTimeout = 30 * time.Second
+
+// cdsPins is what get-cert holds CDS's RA-TLS certificate to: the node's own
+// tuple under --cds-pins-from-own-quote (a sealed node's argv carries no
+// per-cluster digest, and the tuple includes RTMR[3], so a CDS on an unsealed
+// node of the same image is refused), else the flat flags.
+func cdsPins(ctx context.Context, cfg config) (ratls.Pins, error) {
+	if cfg.CDSPinsFromOwnQuote {
+		ctx, cancel := context.WithTimeout(ctx, ownQuoteTimeout)
+		defer cancel()
+		entry, err := attestationclient.NewClient(cfg.AttestationApiURL).OwnTupleEntry(ctx)
+		if err != nil {
+			return ratls.Pins{}, fmt.Errorf("--cds-pins-from-own-quote: %w", err)
+		}
+		return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+	}
+	launch, err := ratls.ParseHexMeasurements(cfg.CDSMeasurements)
+	if err != nil {
+		return ratls.Pins{}, fmt.Errorf("--cds-measurements: %w", err)
+	}
+	if err := cmdsutil.CheckCDSPinned(len(launch), cfg.WorkloadClaimsGuest,
+		"--cds-measurements not set; get-cert accepts any RA-TLS-attested CDS measurement"); err != nil {
+		return ratls.Pins{}, err
+	}
+	rtmrs, err := ratls.ParseRTMRPinsString(cfg.CDSRTMRs)
+	if err != nil {
+		return ratls.Pins{}, fmt.Errorf("--cds-rtmrs: %w", err)
+	}
+	return ratls.Pins{Measurements: launch, RTMRs: rtmrs}, nil
 }
 
 // obtainCertFn is a var so renewal-loop tests can observe attempts.
@@ -223,13 +254,15 @@ func run(cfg config) error {
 	}
 	slog.Debug("output paths validated")
 
-	client, err := newCDSClient(cfg)
+	// The signal context is installed before the CDS client is built so a
+	// SIGTERM interrupts the self-attestation the own-quote pins wait on.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	client, err := newCDSClient(ctx, cfg)
 	if err != nil {
 		return err
 	}
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
 
 	haveCert := true
 	leaf, err := obtainCertWithRetry(ctx, cfg, client)
@@ -675,6 +708,14 @@ func validateConfig(cfg config) error {
 	}
 	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", cfg.AttestationApiURL); err != nil {
 		return err
+	}
+	if cfg.CDSPinsFromOwnQuote {
+		if cfg.CDSMeasurements != "" || cfg.CDSRTMRs != "" {
+			return fmt.Errorf("--cds-pins-from-own-quote replaces --cds-measurements and --cds-rtmrs; pass one form of CDS pin")
+		}
+		if !strings.HasPrefix(cfg.AttestationApiURL, "unix://") {
+			return fmt.Errorf("--cds-pins-from-own-quote requires a unix:// --attestation-api-url: the pins come from the node's own verifier, and a network endpoint is one the control plane can substitute")
+		}
 	}
 	if err := validateSAN(cfg.SAN); err != nil {
 		return fmt.Errorf("--san: %w", err)

--- a/internal/cmds/getcert/run_loop_test.go
+++ b/internal/cmds/getcert/run_loop_test.go
@@ -186,7 +186,7 @@ func TestCDSHTTPClientWarnsOnlyWithoutMeasurements(t *testing.T) {
 
 	t.Run("unpinned warns", func(t *testing.T) {
 		c := captureDefaultLogger(t)
-		if _, err := cdsHTTPClient(base); err != nil {
+		if _, err := cdsHTTPClient(t.Context(), base); err != nil {
 			t.Fatalf("cdsHTTPClient: %v", err)
 		}
 		if _, ok := c.find(warnMsg); !ok {
@@ -198,7 +198,7 @@ func TestCDSHTTPClientWarnsOnlyWithoutMeasurements(t *testing.T) {
 		c := captureDefaultLogger(t)
 		cfg := base
 		cfg.CDSMeasurements = strings.Repeat("ab", 48)
-		if _, err := cdsHTTPClient(cfg); err != nil {
+		if _, err := cdsHTTPClient(t.Context(), cfg); err != nil {
 			t.Fatalf("cdsHTTPClient: %v", err)
 		}
 		if _, ok := c.find(warnMsg); ok {
@@ -799,13 +799,13 @@ func TestCDSHTTPClientParsesRTMRPins(t *testing.T) {
 
 	cfg := base
 	cfg.CDSRTMRs = "1=zz"
-	if _, err := cdsHTTPClient(cfg); err == nil || !strings.Contains(err.Error(), "--cds-rtmrs") {
+	if _, err := cdsHTTPClient(t.Context(), cfg); err == nil || !strings.Contains(err.Error(), "--cds-rtmrs") {
 		t.Fatalf("err = %v, want an RTMR parse failure naming the flag", err)
 	}
 
 	cfg.CDSMeasurements = strings.Repeat("ab", 48)
 	cfg.CDSRTMRs = "1=" + strings.Repeat("cd", 48)
-	if _, err := cdsHTTPClient(cfg); err != nil {
+	if _, err := cdsHTTPClient(t.Context(), cfg); err != nil {
 		t.Fatalf("cdsHTTPClient with valid pins: %v", err)
 	}
 }

--- a/internal/cmds/getcert/run_test.go
+++ b/internal/cmds/getcert/run_test.go
@@ -38,14 +38,14 @@ func TestCDSHTTPClientRejectsPlainHTTP(t *testing.T) {
 	// A non-https --cds-url must be refused, not quietly served over a client
 	// that skips RA-TLS attestation of CDS.
 	for _, scheme := range []string{"http://cds:8443", "cds:8443", "tcp://cds:8443"} {
-		if _, err := cdsHTTPClient(config{CDSURL: scheme, AttestationApiURL: "http://attestation-api:8400"}); err == nil {
+		if _, err := cdsHTTPClient(t.Context(), config{CDSURL: scheme, AttestationApiURL: "http://attestation-api:8400"}); err == nil {
 			t.Fatalf("cdsHTTPClient(%q) succeeded, want error for non-https scheme", scheme)
 		}
 	}
 }
 
 func TestCDSHTTPClientUsesRATLSForHTTPS(t *testing.T) {
-	client, err := cdsHTTPClient(config{
+	client, err := cdsHTTPClient(t.Context(), config{
 		CDSURL:            "https://cds:8443",
 		AttestationApiURL: "http://attestation-api:8400",
 	})
@@ -879,7 +879,7 @@ func TestBuildDiscoveryDocumentRejectsUnparseableCert(t *testing.T) {
 }
 
 func TestNewCDSClientInvalidURL(t *testing.T) {
-	if _, err := newCDSClient(config{CDSURL: "://bad"}); err == nil {
+	if _, err := newCDSClient(t.Context(), config{CDSURL: "://bad"}); err == nil {
 		t.Fatal("newCDSClient succeeded, want error for invalid URL")
 	}
 }

--- a/internal/cmds/getcert/unpinned_cds_test.go
+++ b/internal/cmds/getcert/unpinned_cds_test.go
@@ -14,7 +14,7 @@ func TestUnpinnedCDSRefusedInsideAKataGuest(t *testing.T) {
 		SAN:                 "host.example.com",
 		WorkloadClaimsGuest: true,
 	}
-	_, err := cdsHTTPClient(cfg)
+	_, err := cdsHTTPClient(t.Context(), cfg)
 	if err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
 		t.Fatalf("error = %v, want a refusal to use an unpinned CDS", err)
 	}
@@ -27,7 +27,7 @@ func TestUnpinnedCDSAllowedOutsideAKataGuest(t *testing.T) {
 		AttestationApiURL: "http://attestation-api:8400",
 		SAN:               "host.example.com",
 	}
-	if _, err := cdsHTTPClient(cfg); err != nil {
+	if _, err := cdsHTTPClient(t.Context(), cfg); err != nil {
 		t.Fatalf("cdsHTTPClient: %v", err)
 	}
 }
@@ -41,7 +41,7 @@ func TestPinnedCDSAcceptedInsideAKataGuest(t *testing.T) {
 		CDSMeasurements:     strings.Repeat("ab", 48),
 		WorkloadClaimsGuest: true,
 	}
-	if _, err := cdsHTTPClient(cfg); err != nil {
+	if _, err := cdsHTTPClient(t.Context(), cfg); err != nil {
 		t.Fatalf("cdsHTTPClient: %v", err)
 	}
 }

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -24,11 +24,11 @@ func NewCmd() *cobra.Command {
 		Long: "get-kubeconfig attests a measured c8s CVM and enforces its full\n" +
 			"measured identity. The build-artifact manifest selects the platform:\n" +
 			"on TDX the image tuple (MRTD, RTMR[1], RTMR[2]) plus the RTMR[3] chain\n" +
-			"seeded by the operator's key and extended by the expected workload\n" +
-			"images; on SEV-SNP the pinned per-SMP launch digest plus the\n" +
-			"operator-key HOSTDATA binding. It then exchanges a CSR for a\n" +
-			"short-lived kube client cert over the cred-release endpoint and writes\n" +
-			"a kubeconfig. Verification runs in-process (attestation-go).",
+			"seeded by the operator's key, extended by the dynamic mode event and\n" +
+			"then by the expected workload images; on SEV-SNP the pinned per-SMP\n" +
+			"launch digest plus the operator-key HOSTDATA binding. It then exchanges\n" +
+			"a CSR for a short-lived kube client cert over the cred-release endpoint\n" +
+			"and writes a kubeconfig. Verification runs in-process (attestation-go).",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if cfg.OperatorKeyPath == "" || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
 				return fmt.Errorf("--operator-key, --image-manifest and --out are required")

--- a/internal/cmds/getkubeconfig/cmd.go
+++ b/internal/cmds/getkubeconfig/cmd.go
@@ -28,10 +28,14 @@ func NewCmd() *cobra.Command {
 			"then by the expected workload images; on SEV-SNP the pinned per-SMP\n" +
 			"launch digest plus the operator-key HOSTDATA binding. It then exchanges\n" +
 			"a CSR for a short-lived kube client cert over the cred-release endpoint\n" +
-			"and writes a kubeconfig. Verification runs in-process (attestation-go).",
+			"and writes a kubeconfig. Verification runs in-process (attestation-go).\n\n" +
+			"With --static-allowlist the node booted a policy bundle instead of an\n" +
+			"operator key: RTMR[3] is pinned to the static register derived from the\n" +
+			"bundle (mode event, then the bundle index), and the credential is\n" +
+			"fetched without an operator token.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if cfg.OperatorKeyPath == "" || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
-				return fmt.Errorf("--operator-key, --image-manifest and --out are required")
+			if (cfg.OperatorKeyPath == "" && cfg.StaticAllowlistPath == "") || cfg.ImageManifestPath == "" || cfg.OutPath == "" {
+				return fmt.Errorf("--operator-key (or --static-allowlist), --image-manifest and --out are required")
 			}
 			// --vmi resolves a KubeVirt guest to the address --node would have
 			// been given; --node <host> is a convenience that fills the three
@@ -70,7 +74,8 @@ func NewCmd() *cobra.Command {
 	f.StringVar(&cfg.AttestURL, "attest-url", "", "attestation-api /attest URL (overrides --node)")
 	f.StringVar(&cfg.ReleaseBaseURL, "release-url", "", "cred-release base URL (overrides --node)")
 	f.StringVar(&cfg.APIServerURL, "apiserver-url", "", "apiserver URL for the kubeconfig (overrides --node)")
-	f.StringVar(&cfg.OperatorKeyPath, "operator-key", "", "operator ECDSA private key PEM (its public half is bound into RTMR[3]) (required)")
+	f.StringVar(&cfg.OperatorKeyPath, "operator-key", "", "operator ECDSA private key PEM (its public half is bound into RTMR[3]); required unless --static-allowlist is given")
+	f.StringVar(&cfg.StaticAllowlistPath, "static-allowlist", "", "policy bundle the node booted with (a directory of members, or the static-allowlist.json alone): pins RTMR[3] to the static register derived from it instead of an operator key, and fetches the credential without an operator token, which a static cred-release does not check. Mutually exclusive with --operator-key and --workload-image")
 	f.StringVar(&cfg.ImageManifestPath, "image-manifest", "", "an explicitly selected, provenanced build-artifact manifest carrying the expected guest image's measured identity — TDX: mrtd/rtmr1/rtmr2; SNP: snp_variants. Its shape selects the platform, and the gate pins every value (required)")
 	f.StringArrayVar(&cfg.WorkloadImages, "workload-image", nil, "digest-pinned image ref (\"sha256:<hex>\" or \"name@sha256:<hex>\"; tags rejected) the node's measurer is expected to have extended into RTMR[3]; repeatable, in first-extend order. Omit if the node runs no measured workloads. TDX only — SNP has no runtime-extend register")
 	f.StringVar(&cfg.ContextName, "context", "c8s", "kubeconfig cluster/context/user name")
@@ -79,5 +84,7 @@ func NewCmd() *cobra.Command {
 	f.DurationVar(&cfg.Timeout, "timeout", 30*time.Second, "per-step network timeout")
 	f.DurationVar(&cfg.ReleaseWait, "release-wait", 2*time.Minute, "how long to keep retrying while cred-release is not yet listening (it comes up after attest); 0 fails on the first refused dial")
 	cmd.MarkFlagsMutuallyExclusive("node", "vmi")
+	cmd.MarkFlagsMutuallyExclusive("operator-key", "static-allowlist")
+	cmd.MarkFlagsMutuallyExclusive("workload-image", "static-allowlist")
 	return cmd
 }

--- a/internal/cmds/getkubeconfig/cmd_test.go
+++ b/internal/cmds/getkubeconfig/cmd_test.go
@@ -26,7 +26,7 @@ func execCmd(t *testing.T, args ...string) error {
 func TestNewCmdValidation(t *testing.T) {
 	t.Run("missing operator-key, image-manifest and out", func(t *testing.T) {
 		err := execCmd(t, "--node", "127.0.0.1")
-		if err == nil || !strings.Contains(err.Error(), "--operator-key, --image-manifest and --out are required") {
+		if err == nil || !strings.Contains(err.Error(), "--operator-key (or --static-allowlist), --image-manifest and --out are required") {
 			t.Fatalf("want required-flags error, got %v", err)
 		}
 	})

--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -397,9 +397,9 @@ func TestCheckMeasuredIdentityNoRTMR3Claim(t *testing.T) {
 	}
 }
 
-// --workload-image extends the expected RTMR[3] from the operator-key seed in
-// the given (first-extend) order; tags never pass, and order changes the
-// register.
+// --workload-image extends the expected RTMR[3] from the dynamic-mode register
+// (operator-key seed, then the mode event) in the given (first-extend) order;
+// tags never pass, and order changes the register.
 func TestPolicyForWorkloadImages(t *testing.T) {
 	pub := operatorPub(t)
 	manifest := writeTestManifest(t, tdxManifest())
@@ -410,18 +410,21 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bare.rtmr3 != runtimemeasure.ForOperatorKey(pub) {
-		t.Error("with no workload images the expected register must equal the bare operator-key seed")
+	if bare.rtmr3 != runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pub)) {
+		t.Error("with no workload images the expected register must equal the seed extended by the dynamic mode event")
+	}
+	if bare.rtmr3 == runtimemeasure.ForOperatorKey(pub) {
+		t.Error("the bare operator-key seed must not be accepted: the mode event is load-bearing")
 	}
 
 	chained, err := policyFor(manifest, pub, []string{digA, digB})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(pub),
+	want := runtimemeasure.FromDigestsSeeded(runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pub)),
 		[]string{digA, "sha256:" + strings.Repeat("bb", 32)})
 	if chained.rtmr3 != want {
-		t.Error("workload images must chain onto the operator-key seed via the shared convention")
+		t.Error("workload images must chain onto the dynamic-mode register via the shared convention")
 	}
 
 	reversed, err := policyFor(manifest, pub, []string{digB, digA})
@@ -469,7 +472,7 @@ func TestPolicyForRejectsDuplicateWorkloadImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if single.rtmr3 != runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(pub), []string{dig}) {
+	if single.rtmr3 != runtimemeasure.FromDigestsSeeded(runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pub)), []string{dig}) {
 		t.Error("the deduped, ordered set is what FromDigestsSeeded expects")
 	}
 }

--- a/internal/cmds/getkubeconfig/getkubeconfig_test.go
+++ b/internal/cmds/getkubeconfig/getkubeconfig_test.go
@@ -14,8 +14,10 @@ import (
 )
 
 // TestPolicyForSeedMatchesGuestConvention checks the client computes the same
-// bare-seed value the guest measures at launch:
-// RTMR[3] = SHA384(0x00*48 || SHA384(pubkey)), via the shared convention.
+// value the guest measures on a dynamic operator-key boot, re-derived here by
+// hand: seed = SHA384(0x00*48 || SHA384(pubkey)) from the initrd, then
+// RTMR[3] = SHA384(seed || SHA384("c8s/rtmr3/mode/dynamic/v1")) from the
+// node image's mode event.
 func TestPolicyForSeedMatchesGuestConvention(t *testing.T) {
 	pub := []byte("-----BEGIN PUBLIC KEY-----\nMFk...\n-----END PUBLIC KEY-----\n")
 	exp, err := policyFor(writeTestManifest(t, tdxManifest()), pub, nil)
@@ -24,7 +26,9 @@ func TestPolicyForSeedMatchesGuestConvention(t *testing.T) {
 	}
 
 	keyDigest := sha512.Sum384(pub)
-	want := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	seed := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
+	modeDynamic := sha512.Sum384([]byte("c8s/rtmr3/mode/dynamic/v1"))
+	want := sha512.Sum384(append(seed[:], modeDynamic[:]...))
 	if hex.EncodeToString(exp.rtmr3[:]) != hex.EncodeToString(want[:]) {
 		t.Errorf("expected RTMR[3] = %x, want %x", exp.rtmr3, want)
 	}

--- a/internal/cmds/getkubeconfig/release.go
+++ b/internal/cmds/getkubeconfig/release.go
@@ -52,25 +52,16 @@ func (id *clientIdentity) csrPEM() ([]byte, error) {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der}), nil
 }
 
-// requestCredential mints an operator-signed JWT bound to the exact request
-// body, POSTs the CSR to the cred-release endpoint, and returns the issued
-// cert + cluster CA. httpClient is the (RA-TLS or plain) transport to :8443;
-// operatorKeyPEM is the operator PRIVATE key that authorizes the release.
+// requestCredential POSTs the CSR to the cred-release endpoint and returns
+// the issued cert + cluster CA. httpClient is the (RA-TLS or plain) transport
+// to :8443. operatorKeyPEM is the operator PRIVATE key that authorizes the
+// release; it signs a JWT bound to the exact request body. nil sends no
+// Authorization header at all, the static-mode wire form: a static
+// cred-release checks no operator token and refuses nothing on its absence.
 func requestCredential(ctx context.Context, httpClient *http.Client, baseURL string, operatorKeyPEM, csrPEM []byte) (*credrelease.ReleaseResponse, error) {
-	signer, err := operatorauth.NewSignerFromKeyPEM(operatorKeyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("operator key: %w", err)
-	}
-
 	body, err := json.Marshal(credrelease.ReleaseRequest{CSRPEM: string(csrPEM)})
 	if err != nil {
 		return nil, err
-	}
-
-	// The JWT binds method/path/body (pbh) — must match exactly what we send.
-	authz, err := signer.Authorization(http.MethodPost, credrelease.ReleasePath, body)
-	if err != nil {
-		return nil, fmt.Errorf("sign operator token: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+credrelease.ReleasePath, bytes.NewReader(body))
@@ -78,7 +69,18 @@ func requestCredential(ctx context.Context, httpClient *http.Client, baseURL str
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", authz)
+	if operatorKeyPEM != nil {
+		signer, err := operatorauth.NewSignerFromKeyPEM(operatorKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("operator key: %w", err)
+		}
+		// The JWT binds method/path/body (pbh) — must match exactly what we send.
+		authz, err := signer.Authorization(http.MethodPost, credrelease.ReleasePath, body)
+		if err != nil {
+			return nil, fmt.Errorf("sign operator token: %w", err)
+		}
+		req.Header.Set("Authorization", authz)
+	}
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -33,7 +33,8 @@ type Config struct {
 	ImageManifestPath string
 	// WorkloadImages are the digest-pinned image refs the node's measurer is
 	// expected to have extended into RTMR[3], in first-extend order. Empty
-	// means the register must equal the bare operator-key seed.
+	// means the register must equal the operator-key seed extended by the
+	// dynamic mode event alone.
 	WorkloadImages []string
 	// ContextName names the kubeconfig cluster/context/user.
 	ContextName string
@@ -69,8 +70,9 @@ func Run(ctx context.Context, cfg Config) error {
 
 	// 1. Trust gate: attest the node and enforce the full measured identity —
 	//    the image tuple (MRTD, RTMR[1], RTMR[2]) from the manifest plus the
-	//    RTMR[3] chain seeded by THIS key and extended by the expected
-	//    workload images — with no host trust and not TOFU. Everything
+	//    RTMR[3] chain seeded by THIS key, extended by the dynamic mode event
+	//    and then by the expected workload images — with no host trust and
+	//    not TOFU. Everything
 	//    downstream depends on it.
 	attestCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	if err := attestAndVerify(attestCtx, cfg.AttestURL, exp); err != nil {

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -24,8 +24,15 @@ type Config struct {
 	// (e.g. https://<node>:6443).
 	APIServerURL string
 	// OperatorKeyPath is the operator ECDSA PRIVATE key (PEM). Its public half
-	// was bound into the node's RTMR[3] at launch.
+	// was bound into the node's RTMR[3] at launch. Empty under
+	// StaticAllowlistPath.
 	OperatorKeyPath string
+	// StaticAllowlistPath is the policy bundle a static node booted with (a
+	// directory, or the static-allowlist.json alone). RTMR[3] is then pinned
+	// to ForStaticAllowlist of its index, and the release carries no operator
+	// token: a static cred-release serves any caller, and this client still
+	// attests the node it talks to.
+	StaticAllowlistPath string
 	// ImageManifestPath is the build-artifact manifest carrying the expected
 	// guest image's full TDX tuple (mrtd, rtmr1, rtmr2). Required: without it
 	// the gate would rest on RTMR[3] alone, which the untrusted host can
@@ -55,17 +62,31 @@ type Config struct {
 // Run executes the client flow: attest + RTMR[3] gate, then CSR -> cred-release
 // -> kubeconfig.
 func Run(ctx context.Context, cfg Config) error {
-	keyPEM, err := os.ReadFile(cfg.OperatorKeyPath)
-	if err != nil {
-		return fmt.Errorf("read operator key: %w", err)
-	}
-	pubPEM, err := publicKeyPEMFromPrivate(keyPEM)
-	if err != nil {
-		return fmt.Errorf("derive operator public key: %w", err)
-	}
-	exp, err := policyFor(cfg.ImageManifestPath, pubPEM, cfg.WorkloadImages)
-	if err != nil {
-		return err
+	var keyPEM []byte
+	var exp measuredPolicy
+	if cfg.StaticAllowlistPath != "" {
+		if cfg.OperatorKeyPath != "" || len(cfg.WorkloadImages) > 0 {
+			return fmt.Errorf("--static-allowlist cannot be combined with --operator-key or --workload-image: a static node has no operator key and no workload extends")
+		}
+		var err error
+		exp, err = policyForStatic(cfg.ImageManifestPath, cfg.StaticAllowlistPath)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		keyPEM, err = os.ReadFile(cfg.OperatorKeyPath)
+		if err != nil {
+			return fmt.Errorf("read operator key: %w", err)
+		}
+		pubPEM, err := publicKeyPEMFromPrivate(keyPEM)
+		if err != nil {
+			return fmt.Errorf("derive operator public key: %w", err)
+		}
+		exp, err = policyFor(cfg.ImageManifestPath, pubPEM, cfg.WorkloadImages)
+		if err != nil {
+			return err
+		}
 	}
 
 	// 1. Trust gate: attest the node and enforce the full measured identity —
@@ -125,7 +146,7 @@ func Run(ctx context.Context, cfg Config) error {
 	if err := os.WriteFile(cfg.OutPath, kc, 0o600); err != nil {
 		return fmt.Errorf("write kubeconfig: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "wrote %s (context %q) — attested: image tuple + operator-key chain verified\n", cfg.OutPath, cfg.ContextName)
+	fmt.Fprintf(os.Stderr, "wrote %s (context %q) — attested: %s\n", cfg.OutPath, cfg.ContextName, exp.attestedSummary())
 	return nil
 }
 

--- a/internal/cmds/getkubeconfig/static.go
+++ b/internal/cmds/getkubeconfig/static.go
@@ -1,0 +1,56 @@
+package getkubeconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// staticRTMR3Meaning names the chain a static node's register pins.
+const staticRTMR3Meaning = "static mode event + policy bundle index"
+
+// staticPolicy pins the image tuple and the static register: a node sealed
+// to the bundle extended the static mode event and then the bundle index,
+// and nothing after. There is no operator key and no workload chain.
+func staticPolicy(pins runtimemeasure.ImagePins, rtmr3 [runtimemeasure.Size]byte) measuredPolicy {
+	return measuredPolicy{
+		platform:     teetypes.PlatformTDX,
+		pins:         pins,
+		rtmr3:        rtmr3,
+		chainMeaning: staticRTMR3Meaning,
+	}
+}
+
+// policyForStatic builds the trust gate for a static node from the TDX image
+// manifest and the bundle it booted with. The bundle's static-allowlist.json
+// is linted first (allowlist.LintSealed): the node refused to boot anything
+// unsealed, so a bundle that fails here can only be the wrong file.
+func policyForStatic(manifestPath, bundlePath string) (measuredPolicy, error) {
+	pins, err := runtimemeasure.LoadImageManifest(manifestPath)
+	if err != nil {
+		return measuredPolicy{}, fmt.Errorf("--image-manifest: %w (a static allowlist needs a TDX manifest: only TDX has the register the policy is measured into)", err)
+	}
+	bundle, err := policybundle.Load(bundlePath)
+	if err != nil {
+		return measuredPolicy{}, fmt.Errorf("--static-allowlist: %w", err)
+	}
+	if err := allowlist.LintSealed(bundle.Members[policybundle.MemberStaticAllowlist]); err != nil {
+		return measuredPolicy{}, fmt.Errorf("--static-allowlist %s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	return staticPolicy(pins, bundle.RTMR3()), nil
+}
+
+// VerifyStaticNode attests the node behind attestURL and requires the static
+// tuple: the manifest's image registers and RTMR[3] equal to rtmr3, the
+// register a node sealed to the expected bundle reports. It is the gate
+// `c8s install --static-allowlist` runs against every node before rendering
+// the chart, and the same gate get-kubeconfig runs before releasing a
+// credential.
+func VerifyStaticNode(ctx context.Context, attestURL string, pins runtimemeasure.ImagePins, rtmr3 [runtimemeasure.Size]byte) error {
+	return attestAndVerify(ctx, attestURL, staticPolicy(pins, rtmr3))
+}

--- a/internal/cmds/getkubeconfig/static_test.go
+++ b/internal/cmds/getkubeconfig/static_test.go
@@ -1,0 +1,254 @@
+package getkubeconfig
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/credrelease"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// writeStaticBundle writes a one-member bundle directory holding a sealed
+// static-allowlist.json and returns its path and the member bytes.
+func writeStaticBundle(t *testing.T) (string, []byte) {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{
+		"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+		"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},
+		"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, policybundle.MemberStaticAllowlist), doc, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, doc
+}
+
+// staticRegister recomputes the static register by hand from the convention
+// in pkg/runtimemeasure — deliberately without the helpers the code under
+// test calls, so the two cannot agree by construction:
+// Extend(Extend(Zero, SHA-384("c8s/rtmr3/mode/static/v1")),
+// SHA-384("c8s/rtmr3/policy/v1:" + index)), index = {"static-allowlist.json":
+// "sha256:<hex of member>"}.
+func staticRegister(member []byte) []byte {
+	sum := sha256.Sum256(member)
+	index := `{"static-allowlist.json":"sha256:` + hex.EncodeToString(sum[:]) + `"}`
+	mode := sha512.Sum384([]byte("c8s/rtmr3/mode/static/v1"))
+	h := sha512.New384()
+	h.Write(make([]byte, 48))
+	h.Write(mode[:])
+	afterMode := h.Sum(nil)
+	policy := sha512.Sum384([]byte("c8s/rtmr3/policy/v1:" + index))
+	h = sha512.New384()
+	h.Write(afterMode)
+	h.Write(policy[:])
+	return h.Sum(nil)
+}
+
+func TestPolicyForStaticPinsTheBundleRegister(t *testing.T) {
+	dir, member := writeStaticBundle(t)
+	exp, err := policyForStatic(writeTestManifest(t, tdxManifest()), dir)
+	if err != nil {
+		t.Fatalf("policyForStatic: %v", err)
+	}
+	if got, want := hex.EncodeToString(exp.rtmr3[:]), hex.EncodeToString(staticRegister(member)); got != want {
+		t.Errorf("policyForStatic rtmr3 = %s, want %s", got, want)
+	}
+	if hex.EncodeToString(exp.pins.MRTD[:]) != testMRTDHex {
+		t.Errorf("policyForStatic MRTD = %x, want the manifest's %s", exp.pins.MRTD, testMRTDHex)
+	}
+	if exp.chainMeaning != staticRTMR3Meaning {
+		t.Errorf("chainMeaning = %q, want %q", exp.chainMeaning, staticRTMR3Meaning)
+	}
+
+	// The loose file is the same one-member bundle.
+	loose, err := policyForStatic(writeTestManifest(t, tdxManifest()), filepath.Join(dir, policybundle.MemberStaticAllowlist))
+	if err != nil {
+		t.Fatalf("policyForStatic(file): %v", err)
+	}
+	if loose.rtmr3 != exp.rtmr3 {
+		t.Errorf("policyForStatic(file) rtmr3 = %x, want the directory's %x", loose.rtmr3, exp.rtmr3)
+	}
+}
+
+func TestPolicyForStaticErrors(t *testing.T) {
+	dir, member := writeStaticBundle(t)
+	unsealed := t.TempDir()
+	if err := os.WriteFile(filepath.Join(unsealed, policybundle.MemberStaticAllowlist), append(member, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name     string
+		manifest string
+		bundle   string
+		want     string
+	}{
+		{"snp manifest", writeTestManifest(t, snpManifest()), dir, "TDX manifest"},
+		{"iso refused", writeTestManifest(t, tdxManifest()), filepath.Join(dir, "policydata.iso"), "ISO images cannot be read here"},
+		{"missing bundle", writeTestManifest(t, tdxManifest()), filepath.Join(dir, "absent"), "--static-allowlist"},
+		{"unsealed member", writeTestManifest(t, tdxManifest()), unsealed, "not its canonical form"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := policyForStatic(tc.manifest, tc.bundle)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("policyForStatic(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+// staticReleaseHandler is releaseHandler for a static cred-release: the
+// request must carry NO Authorization header — the static server checks no
+// operator token, and a client that still sent one would be asserting a key
+// the node never measured.
+func staticReleaseHandler(t *testing.T, respBody string) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != credrelease.ReleasePath {
+			t.Errorf("release path = %s, want %s", r.URL.Path, credrelease.ReleasePath)
+		}
+		if _, set := r.Header["Authorization"]; set {
+			t.Errorf("static release sent Authorization %q, want no header at all", r.Header.Get("Authorization"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req credrelease.ReleaseRequest
+		if err := json.Unmarshal(body, &req); err != nil || !strings.Contains(req.CSRPEM, "CERTIFICATE REQUEST") {
+			t.Errorf("release body %q: %v", body, err)
+		}
+		fmt.Fprint(w, respBody)
+	})
+}
+
+// TestRunStaticEndToEnd drives the static flow: bundle-derived gate, RA-TLS
+// dial pinned to the same policy, JWT-less release, kubeconfig on disk.
+func TestRunStaticEndToEnd(t *testing.T) {
+	dir, _ := writeStaticBundle(t)
+	manifest := writeTestManifest(t, tdxManifest())
+	exp, err := policyForStatic(manifest, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stubVerify(t, verifiedResultFor(exp), nil)
+	release := newAttestedTLSServer(t, staticReleaseHandler(t, goodRelease))
+	out := filepath.Join(t.TempDir(), "kubeconfig")
+
+	err = execCmd(t,
+		"--attest-url", newAttestStub(t).URL+"/attest",
+		"--release-url", release.URL,
+		"--apiserver-url", "https://node:6443",
+		"--static-allowlist", dir,
+		"--image-manifest", manifest,
+		"--out", out,
+		"--timeout", "10s")
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	kc, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "client-certificate-data: " + base64.StdEncoding.EncodeToString([]byte("CERTPEM")); !strings.Contains(string(kc), want) {
+		t.Errorf("kubeconfig missing %q", want)
+	}
+}
+
+// A node whose register is the dynamic operator-key shape — the same image,
+// not sealed — must be refused before any credential request.
+func TestRunStaticRejectsUnsealedNode(t *testing.T) {
+	dir, _ := writeStaticBundle(t)
+	manifest := writeTestManifest(t, tdxManifest())
+	exp, err := policyForStatic(manifest, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := verifiedResultFor(exp)
+	dynamic := testPolicy(t, operatorPub(t))
+	res.Claims.PlatformData["rtmr_3"] = hex.EncodeToString(dynamic.rtmr3[:])
+	stubVerify(t, res, nil)
+
+	cfg := Config{
+		AttestURL:           newAttestStub(t).URL + "/attest",
+		ReleaseBaseURL:      "https://127.0.0.1:1",
+		APIServerURL:        "https://node:6443",
+		StaticAllowlistPath: dir,
+		ImageManifestPath:   manifest,
+		OutPath:             filepath.Join(t.TempDir(), "kc"),
+		Timeout:             5 * time.Second,
+	}
+	err = Run(context.Background(), cfg)
+	if err == nil || !strings.Contains(err.Error(), "RTMR[3] mismatch ("+staticRTMR3Meaning+")") {
+		t.Fatalf("Run = %v, want an RTMR[3] mismatch naming the static chain", err)
+	}
+}
+
+func TestStaticFlagConflicts(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"with operator key", []string{"--static-allowlist", "b", "--operator-key", "k.pem"}, "none of the others can be"},
+		{"with workload image", []string{"--static-allowlist", "b", "--workload-image", "sha256:00"}, "none of the others can be"},
+		{"without image manifest", []string{"--static-allowlist", "b"}, "--image-manifest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := execCmd(t, append([]string{"--node", "127.0.0.1", "--out", "kc"}, tc.args...)...)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Execute(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+	// Run itself refuses the pair too, for callers that build Config directly.
+	err := Run(context.Background(), Config{StaticAllowlistPath: "b", OperatorKeyPath: "k", ImageManifestPath: "m", OutPath: "o"})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("Run(static + operator key) = %v, want a refusal", err)
+	}
+}
+
+// Every policy names what it bound beyond the image tuple: the status line
+// interpolates it, and an empty phrase there would report a chain nobody
+// checked.
+func TestAttestedSummaryNamesEveryChain(t *testing.T) {
+	dir, _ := writeStaticBundle(t)
+	static, err := policyForStatic(writeTestManifest(t, tdxManifest()), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snp, err := policyFor(writeTestManifest(t, snpManifest()), operatorPub(t), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		exp  measuredPolicy
+		want string
+	}{
+		{"tdx operator key", testPolicy(t, operatorPub(t)), "image tuple + operator-key + dynamic mode event + workload chain verified"},
+		{"tdx static", static, "image tuple + " + staticRTMR3Meaning + " verified"},
+		{"snp operator key", snp, "image tuple + operator-key HOSTDATA binding verified"},
+	} {
+		if got := tc.exp.attestedSummary(); got != tc.want {
+			t.Errorf("attestedSummary(%s) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -48,11 +48,17 @@ type measuredPolicy struct {
 	platform teetypes.PlatformType
 
 	pins runtimemeasure.ImagePins
-	// rtmr3 = FromDigestsSeeded(ForDynamic(ForOperatorKey(pubPEM)), workload
-	// digests): the operator-key seed, the dynamic mode event the node image
-	// extends before containerd, then the workload extends. Equal to
-	// ForDynamic(seed) when no workload images are expected. TDX only.
+	// rtmr3 is the expected runtime register, TDX only. On an operator-key
+	// boot: FromDigestsSeeded(ForDynamic(ForOperatorKey(pubPEM)), workload
+	// digests) — the operator-key seed, the dynamic mode event the node image
+	// extends before containerd, then the workload extends (ForDynamic(seed)
+	// alone when no workload images are expected). On a static boot:
+	// ForStaticAllowlist(bundle index).
 	rtmr3 [runtimemeasure.Size]byte
+	// chainMeaning names, for diagnostics, what binds the operator to the
+	// node beyond the image tuple: the RTMR[3] chain on TDX, the HOSTDATA
+	// binding on SEV-SNP.
+	chainMeaning string
 
 	// SNP: the pinned per-SMP launch digests plus the operator-key binding
 	// committed as HOSTDATA at launch. No runtime-extend register, so there
@@ -92,9 +98,10 @@ func snpPolicy(pins runtimemeasure.SNPImagePins, operatorPubPEM []byte, workload
 		return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
 	}
 	return measuredPolicy{
-		platform: teetypes.PlatformSNP,
-		snpPins:  pins,
-		hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
+		platform:     teetypes.PlatformSNP,
+		snpPins:      pins,
+		hostData:     runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
+		chainMeaning: "operator-key HOSTDATA binding",
 	}, nil
 }
 
@@ -122,9 +129,10 @@ func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadIma
 		digests = append(digests, d)
 	}
 	return measuredPolicy{
-		platform: teetypes.PlatformTDX,
-		pins:     pins,
-		rtmr3:    runtimemeasure.FromDigestsSeeded(runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(operatorPubPEM)), digests),
+		platform:     teetypes.PlatformTDX,
+		pins:         pins,
+		rtmr3:        runtimemeasure.FromDigestsSeeded(runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(operatorPubPEM)), digests),
+		chainMeaning: "operator-key + dynamic mode event + workload chain",
 	}, nil
 }
 
@@ -212,7 +220,7 @@ func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy)
 	}{
 		{1, "guest kernel", exp.pins.RTMR1},
 		{2, "guest rootfs", exp.pins.RTMR2},
-		{3, "operator-key + dynamic mode event + workload chain", exp.rtmr3},
+		{3, exp.chainMeaning, exp.rtmr3},
 	} {
 		got, err := res.Claims.RTMR(reg.idx)
 		if err != nil {
@@ -354,4 +362,10 @@ func verifySNPEvidence(env teetypes.AttestationEvidence, expectedReportData []by
 		return nil, err
 	}
 	return res, nil
+}
+
+// attestedSummary is the one-line account of what the gate proved, for the
+// final status line.
+func (p measuredPolicy) attestedSummary() string {
+	return "image tuple + " + p.chainMeaning + " verified"
 }

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -1,8 +1,9 @@
 // Package getkubeconfig implements the operator-side client (B4 client) that
 // obtains a kube credential from a measured CVM: it attests the node,
 // confirms the full measured identity — on TDX the image tuple (MRTD,
-// RTMR[1], RTMR[2]) plus the RTMR[3] chain seeded by the operator's key and
-// extended by the expected workload images; on SEV-SNP the pinned per-SMP
+// RTMR[1], RTMR[2]) plus the RTMR[3] chain seeded by the operator's key,
+// extended by the dynamic mode event and then by the expected workload
+// images; on SEV-SNP the pinned per-SMP
 // launch digest plus the operator-key HOSTDATA binding — then exchanges a CSR
 // for a short-lived kube client cert over the cred-release endpoint and
 // assembles a kubeconfig.
@@ -38,7 +39,7 @@ var verifyEnvelope = teeverify.Verify
 // credential flows: the TDX image tuple from one provenanced build-artifact
 // manifest, and the expected RTMR[3] chain. RTMR[3] alone is not an identity
 // gate — the untrusted host stages the operator key, so it can boot ANY image
-// and reproduce the bare operator-key register — which is why the image tuple
+// and reproduce the operator-key/mode register — which is why the image tuple
 // anchors the policy and RTMR[3] then binds the key and workload set.
 type measuredPolicy struct {
 	// platform is the TEE this policy gates, inferred from the manifest's
@@ -47,9 +48,10 @@ type measuredPolicy struct {
 	platform teetypes.PlatformType
 
 	pins runtimemeasure.ImagePins
-	// rtmr3 = FromDigestsSeeded(ForOperatorKey(pubPEM), workload digests):
-	// equal to the bare operator-key seed only when no workload images are
-	// expected. TDX only.
+	// rtmr3 = FromDigestsSeeded(ForDynamic(ForOperatorKey(pubPEM)), workload
+	// digests): the operator-key seed, the dynamic mode event the node image
+	// extends before containerd, then the workload extends. Equal to
+	// ForDynamic(seed) when no workload images are expected. TDX only.
 	rtmr3 [runtimemeasure.Size]byte
 
 	// SNP: the pinned per-SMP launch digests plus the operator-key binding
@@ -96,8 +98,9 @@ func snpPolicy(pins runtimemeasure.SNPImagePins, operatorPubPEM []byte, workload
 	}, nil
 }
 
-// tdxPolicy pins the image tuple and the RTMR[3] chain: the operator-key seed
-// extended, in first-extend order, by each digest-pinned workload image.
+// tdxPolicy pins the image tuple and the RTMR[3] chain: the operator-key seed,
+// the dynamic mode event, then each digest-pinned workload image in
+// first-extend order.
 func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadImages []string) (measuredPolicy, error) {
 	digests := make([]string, 0, len(workloadImages))
 	seen := make(map[string]string, len(workloadImages))
@@ -121,7 +124,7 @@ func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadIma
 	return measuredPolicy{
 		platform: teetypes.PlatformTDX,
 		pins:     pins,
-		rtmr3:    runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(operatorPubPEM), digests),
+		rtmr3:    runtimemeasure.FromDigestsSeeded(runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(operatorPubPEM)), digests),
 	}, nil
 }
 
@@ -188,7 +191,7 @@ func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy)
 
 // checkMeasuredIdentity asserts the verified claims match the full policy:
 // MRTD against the launch digest, RTMR[1]/[2] against the image tuple,
-// RTMR[3] against the operator-key/workload chain. The compares are over the
+// RTMR[3] against the operator-key/mode/workload chain. The compares are over the
 // claims attestation-go extracted from the signature-verified quote body.
 // Absent or malformed claims fail closed.
 func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy) error {
@@ -209,7 +212,7 @@ func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy)
 	}{
 		{1, "guest kernel", exp.pins.RTMR1},
 		{2, "guest rootfs", exp.pins.RTMR2},
-		{3, "operator-key + workload chain", exp.rtmr3},
+		{3, "operator-key + dynamic mode event + workload chain", exp.rtmr3},
 	} {
 		got, err := res.Claims.RTMR(reg.idx)
 		if err != nil {

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -3,10 +3,9 @@
 // confirms the full measured identity — on TDX the image tuple (MRTD,
 // RTMR[1], RTMR[2]) plus the RTMR[3] chain seeded by the operator's key,
 // extended by the dynamic mode event and then by the expected workload
-// images; on SEV-SNP the pinned per-SMP
-// launch digest plus the operator-key HOSTDATA binding — then exchanges a CSR
-// for a short-lived kube client cert over the cred-release endpoint and
-// assembles a kubeconfig.
+// images; on SEV-SNP the pinned per-SMP launch digest plus the operator-key
+// HOSTDATA binding — then exchanges a CSR for a short-lived kube client cert
+// over the cred-release endpoint and assembles a kubeconfig.
 package getkubeconfig
 
 import (

--- a/internal/cmds/getsecret/cmd_test.go
+++ b/internal/cmds/getsecret/cmd_test.go
@@ -39,6 +39,8 @@ func TestNewCmdDefaults(t *testing.T) {
 		"key":       "/run/c8s/certs/tls.key",
 		"out-dir":   "/run/c8s/secrets",
 		"file-mode": "0640",
+
+		"cds-pins-from-own-quote": "false",
 	} {
 		if got := cmd.Flags().Lookup(flag).DefValue; got != want {
 			t.Fatalf("--%s default = %q, want %q", flag, got, want)

--- a/internal/cmds/getsecret/run.go
+++ b/internal/cmds/getsecret/run.go
@@ -72,7 +72,7 @@ func run(cfg config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	pins, err := cfg.ParsePins()
+	pins, err := cfg.CDSPins(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmds/getvolume/run.go
+++ b/internal/cmds/getvolume/run.go
@@ -78,7 +78,7 @@ func run(cfg config) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	pins, err := cfg.ParsePins()
+	pins, err := cfg.CDSPins(ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmds/nri-image-policy/config.go
+++ b/internal/cmds/nri-image-policy/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ type config struct {
 	Plugin         pluginConfig         `yaml:"plugin"`
 	Allowlist      allowlistConfig      `yaml:"allowlist"`
 	Containerd     containerdConfig     `yaml:"containerd"`
+	Runtime        runtimeConfig        `yaml:"runtime"`
 	Policy         policyConfig         `yaml:"policy"`
 	Logging        loggingConfig        `yaml:"logging"`
 	WorkloadClaims workloadClaimsConfig `yaml:"workload_claims"`
@@ -66,7 +68,27 @@ type workloadClaimsConfig struct {
 type allowlistConfig struct {
 	AlwaysAllow map[string]string `yaml:"always_allow"`
 	Pull        pullConfig        `yaml:"pull"`
+	// PolicyDir is the tmpfs directory c8s-policy-measure fills at boot
+	// (docs/static-allowlist.md). Set, the plugin reads <PolicyDir>/mode
+	// and refuses to start unless it says static or dynamic; static seals
+	// the plugin to the bundle in that directory. Empty keeps the pull and
+	// always_allow behaviour with no mode check, which is what a
+	// chart-installed plugin on a host without the measured unit needs.
+	PolicyDir string `yaml:"policy_dir"`
 }
+
+// runtimeConfig describes what the plugin requires of containerd.
+type runtimeConfig struct {
+	// RequireFailClosed, in sealed mode, refuses a containerd whose version
+	// lacks FailClosedRuntimeMarker: without the nri fix a request that times
+	// out is admitted, so a sealed node needs the patched build.
+	RequireFailClosed bool `yaml:"require_fail_closed"`
+}
+
+// FailClosedRuntimeMarker is the build-metadata suffix a containerd built with
+// node-guest-image/c8s/patches/containerd-nri-fail-closed.patch reports as its
+// version. Configure compares the runtime version against it in sealed mode.
+const FailClosedRuntimeMarker = "+c8s.nri-failclosed"
 
 // pullConfig configures the CDS polling source.
 type pullConfig struct {
@@ -264,6 +286,12 @@ func (c *config) Validate() error {
 	}
 	if len(c.Policy.ExemptNamespaces) > 0 && c.Policy.ExemptSnapshotPath == "" {
 		return fmt.Errorf("policy.exempt_namespaces requires policy.exempt_snapshot_path: the captured digest set must persist across restarts")
+	}
+	if d := c.Allowlist.PolicyDir; d != "" && !path.IsAbs(d) {
+		return fmt.Errorf("allowlist.policy_dir %q must be an absolute path", d)
+	}
+	if c.Runtime.RequireFailClosed && c.Allowlist.PolicyDir == "" {
+		return fmt.Errorf("runtime.require_fail_closed needs allowlist.policy_dir: the check runs in sealed mode only")
 	}
 	return validateLabelRules(c.Policy.LabelRules)
 }

--- a/internal/cmds/nri-image-policy/config_test.go
+++ b/internal/cmds/nri-image-policy/config_test.go
@@ -602,3 +602,31 @@ func TestAllowlistPullHTTPClientRejectsBadRTMRs(t *testing.T) {
 		t.Fatalf("err = %v, want an RTMR parse failure", err)
 	}
 }
+
+func TestValidate_PolicyDirAndRuntime(t *testing.T) {
+	base := func() *config {
+		return &config{Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "a"}}, Policy: policyConfig{Mode: ModeFailClosed}}
+	}
+	for _, tc := range []struct {
+		name    string
+		mutate  func(c *config)
+		wantErr string
+	}{
+		{"absolute policy dir", func(c *config) { c.Allowlist.PolicyDir = "/run/confai/policy" }, ""},
+		{"relative policy dir", func(c *config) { c.Allowlist.PolicyDir = "policy" }, "must be an absolute path"},
+		{"require_fail_closed needs a policy dir", func(c *config) { c.Runtime.RequireFailClosed = true }, "needs allowlist.policy_dir"},
+		{"require_fail_closed with a policy dir", func(c *config) {
+			c.Allowlist.PolicyDir = "/run/confai/policy"
+			c.Runtime.RequireFailClosed = true
+		}, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := base()
+			tc.mutate(c)
+			err := c.Validate()
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("Validate(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cmds/nri-image-policy/image_policy_template_test.go
+++ b/internal/cmds/nri-image-policy/image_policy_template_test.go
@@ -54,6 +54,21 @@ func TestNodeImageBootConfig_LoadsAndFloorsSystemImages(t *testing.T) {
 		t.Fatalf("the rendered node-image boot config does not load: %v", err)
 	}
 
+	// The sealed-mode keys are rendered unconditionally: the measured config
+	// decides the mode from the policy dir, never from a file's presence.
+	if cfg.Allowlist.PolicyDir != "/run/confai/policy" {
+		t.Errorf("allowlist.policy_dir = %q, want /run/confai/policy", cfg.Allowlist.PolicyDir)
+	}
+	if cfg.Allowlist.Pull.AttestationApiURL != "unix:///run/confai/attestation-api.sock" {
+		t.Errorf("allowlist.pull.attestation_api_url = %q, want the measured unix socket", cfg.Allowlist.Pull.AttestationApiURL)
+	}
+	if cfg.Runtime.RequireFailClosed {
+		t.Error("runtime.require_fail_closed is true, but the image pipeline does not ship the patched containerd yet")
+	}
+	if !strings.Contains(rendered, "require_fail_closed: false") {
+		t.Error("runtime.require_fail_closed must be rendered explicitly so flipping it is a one-line change")
+	}
+
 	// The full RKE2 system floor: every digest systemfloor derives from the
 	// pinned airgap bundles and baked manifests. A regen for an RKE2 pin bump
 	// rewrites these — update the pins with it. Pinning the whole set, not a

--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -1,7 +1,10 @@
 // Package nriimagepolicy is an NRI plugin that validates container images
 // against a digest allowlist. Every plugin polls a remote CDS service (pull
 // mode) for the allowlist, with a bootstrap file on disk (always_allow) as the
-// cold-boot baseline.
+// cold-boot baseline. On a static boot (allowlist.policy_dir holds
+// mode=static) it is sealed instead: it admits only what the measured policy
+// bundle describes, pulls nothing, and powers the node off on any fatal
+// condition (sealed.go, sealed_plugin.go).
 package nriimagepolicy
 
 import (
@@ -28,7 +31,9 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
@@ -45,7 +50,10 @@ var (
 	errPluginDied                  = errors.New("NRI plugin died during allowlist init")
 )
 
-func startupSourceMode(cfg *config) string {
+func startupSourceMode(cfg *config, sealed *sealedPolicy) string {
+	if sealed != nil {
+		return "sealed"
+	}
 	if cfg.PullEnabled() {
 		return "pull"
 	}
@@ -89,10 +97,16 @@ func Run(args []string) error {
 	}
 	slog.SetDefault(logger)
 
+	sealed, err := openPolicyMode(cfg, logger)
+	if err != nil {
+		return err
+	}
+	pull := cfg.PullEnabled() && sealed == nil
+
 	logger.Info("starting nri-image-policy",
 		"version", version.Version,
 		"config", *configPath,
-		"mode", startupSourceMode(cfg),
+		"mode", startupSourceMode(cfg, sealed),
 	)
 
 	logger.Debug("initializing containerd resolver",
@@ -107,11 +121,22 @@ func Run(args []string) error {
 
 	auditLogger := audit.NewLogger()
 
+	// A sealed store starts empty and holds the bundle alone: no floor, no
+	// pull, so nothing the control plane serves can enter the index.
 	bootstrap := alwaysAllowAllowlist(cfg.Allowlist.AlwaysAllow)
 	store := newPolicyStore(bootstrap)
+	var pins ratls.Pins
+	if sealed != nil {
+		bootstrap = nil
+		store = newPolicyStore(nil)
+		store.apply(sealed.doc, 0)
+		protectFromOOM(logger)
+	} else if pins, err = configuredPins(cfg.Allowlist.Pull); err != nil {
+		return err
+	}
 
 	var wlClient allowlistclient.Client
-	if cfg.PullEnabled() {
+	if pull {
 		logger.Info("initializing allowlist client", "url", cfg.Allowlist.Pull.URL)
 		httpClient, err := allowlistPullHTTPClient(cfg.Allowlist.Pull)
 		if err != nil {
@@ -120,7 +145,7 @@ func Run(args []string) error {
 		wlClient = allowlistclient.NewClientWithHTTP(cfg.Allowlist.Pull.URL, httpClient)
 	}
 
-	plugin, err := newPlugin(cfg, resolver, store, auditLogger, logger)
+	plugin, err := newPlugin(cfg, resolver, store, sealed, auditLogger, logger)
 	if err != nil {
 		return fmt.Errorf("create plugin: %w", err)
 	}
@@ -157,8 +182,18 @@ func Run(args []string) error {
 		pluginErrCh <- plugin.Run(ctx)
 	}()
 
+	// The stub is registering by now. The own-quote round trip can outlast
+	// containerd's plugin_registration_timeout (10s on the node image), and
+	// a plugin that misses registration is killed and dropped, never powered
+	// off. Admission needs no pins; only the digests endpoint waits.
+	if sealed != nil {
+		if pins, err = pinOwnTuple(ctx, cfg.Allowlist.Pull.AttestationApiURL, sealed.rtmr3); err != nil {
+			return sealedFatal(logger, fmt.Errorf("pin CDS to the node's own tuple: %w", err))
+		}
+	}
+
 	if plugin.inventory != nil {
-		signer, err := sandboxTokenSigner(cfg, logger)
+		signer, err := sandboxTokenSigner(cfg, logger, pull || sealed != nil)
 		if err != nil {
 			return err
 		}
@@ -170,15 +205,19 @@ func Run(args []string) error {
 		// plugin (required_plugins), so exiting takes container creation down
 		// node-wide. A missing digests endpoint only degrades issuance — CDS
 		// refuses tokens it cannot check — which is the cheaper failure.
+		// Sealed mode has no cheaper failure: the node is either whole or off.
 		if signer != nil {
-			if err := startSandboxDigests(ctx, logger, cfg, plugin.inventory, signer); err != nil {
+			if err := startSandboxDigests(ctx, logger, cfg, plugin.inventory, signer, pins); err != nil {
+				if sealed != nil {
+					return sealedFatal(logger, fmt.Errorf("start sandbox-digests endpoint: %w", err))
+				}
 				logger.Error("sandbox-digests endpoint disabled; CDS will refuse requests carrying a sandbox token", "error", err)
 			}
 		}
 	}
 
 	var initialETag string
-	if cfg.PullEnabled() {
+	if pull {
 		initialETag, err = pullInitial(ctx, pullArgs{
 			client:      wlClient,
 			store:       store,
@@ -214,7 +253,7 @@ func Run(args []string) error {
 	plugin.SetReady()
 	logger.Info("plugin ready")
 
-	if cfg.PullEnabled() {
+	if pull {
 		go runPullLoop(ctx, pullLoopArgs{
 			client:   wlClient,
 			store:    store,
@@ -241,22 +280,82 @@ func Run(args []string) error {
 	return nil
 }
 
+// openPolicyMode reads the boot mode c8s-policy-measure recorded when the
+// config names a policy dir. static returns the sealed policy the register
+// commits to; dynamic proves the register carries the dynamic chain (on TDX,
+// the only platform with a register) and returns nil. A missing or foreign
+// mode, a register that disagrees with the mode, and a sealed load that
+// fails all power the node off: with a policy dir configured, the measured
+// unit wrote the mode before containerd started, so a disagreement now is
+// tampering, not a misconfiguration.
+func openPolicyMode(cfg *config, logger *slog.Logger) (*sealedPolicy, error) {
+	dir := cfg.Allowlist.PolicyDir
+	if dir == "" {
+		return nil, nil
+	}
+	state, err := policybundle.ReadDir(dir)
+	if err != nil {
+		return nil, sealedFatal(logger, fmt.Errorf("policy state in %s: %w", dir, err))
+	}
+	if state.Mode == policybundle.DynamicMode {
+		if cfg.NormalizedPlatform() == ratls.NormalizePlatform(string(types.PlatformTdx)) {
+			if err := checkDynamicRegister(operatorPubkeyPath); err != nil {
+				return nil, sealedFatal(logger, fmt.Errorf("dynamic boot: %w", err))
+			}
+		}
+		return nil, nil
+	}
+	sealed, err := loadSealed(state.Bundle)
+	if err != nil {
+		return nil, sealedFatal(logger, fmt.Errorf("sealed load from %s: %w", dir, err))
+	}
+	sealed.hostIP, _ = nodeIP(cfg)
+	host, err := os.Hostname()
+	if err != nil {
+		return nil, sealedFatal(logger, fmt.Errorf("read hostname: %w", err))
+	}
+	sealed.nodeName = kubeletNodeName(host)
+	logger.Info("sealed to the measured policy bundle", "policy_dir", dir, "rtmr3", fmt.Sprintf("%x", sealed.rtmr3[:]),
+		"workloads", len(sealed.doc.Workloads), "host_ip", sealed.hostIP, "node_name", sealed.nodeName)
+	return sealed, nil
+}
+
+// sealedFatal powers the node off for a startup failure in sealed mode and
+// returns the error for the exit path, should the power-off not land.
+func sealedFatal(logger *slog.Logger, err error) error {
+	logger.Error("sealed image policy: fatal at startup, powering the node off", "error", err)
+	if perr := poweroff(); perr != nil {
+		logger.Error("power-off failed", "error", perr)
+	}
+	return err
+}
+
+// configuredPins parses the CDS pins the config carries; empty pins accept
+// any attested CDS, which every dynamic boot starts from.
+func configuredPins(cfg pullConfig) (ratls.Pins, error) {
+	measurements, err := ratls.ParseHexMeasurementsList(cfg.CDSMeasurements)
+	if err != nil {
+		return ratls.Pins{}, fmt.Errorf("parse CDS measurements: %w", err)
+	}
+	rtmrs, err := ratls.ParseRTMRPins(cfg.CDSRTMRs)
+	if err != nil {
+		return ratls.Pins{}, fmt.Errorf("parse CDS RTMR pins: %w", err)
+	}
+	return ratls.Pins{Measurements: measurements, RTMRs: rtmrs}, nil
+}
+
 // allowlistPullHTTPClient builds the RA-TLS client for the CDS pull. The pull
 // URL is always https (enforced by config.Validate), so this always verifies
 // the CDS attestation handshake.
 func allowlistPullHTTPClient(cfg pullConfig) (*http.Client, error) {
-	measurements, err := ratls.ParseHexMeasurementsList(cfg.CDSMeasurements)
+	pins, err := configuredPins(cfg)
 	if err != nil {
-		return nil, fmt.Errorf("parse CDS measurements: %w", err)
+		return nil, err
 	}
-	if len(measurements) == 0 {
+	if len(pins.Measurements) == 0 {
 		slog.Warn("allowlist.pull.cds_measurements not set; nri-image-policy accepts any RA-TLS-attested CDS measurement")
 	}
-	rtmrs, err := ratls.ParseRTMRPins(cfg.CDSRTMRs)
-	if err != nil {
-		return nil, fmt.Errorf("parse CDS RTMR pins: %w", err)
-	}
-	client, err := ratls.NewVerifyingHTTPClient(ratls.Pins{Measurements: measurements, RTMRs: rtmrs}, cfg.AttestationApiURL)
+	client, err := ratls.NewVerifyingHTTPClient(pins, cfg.AttestationApiURL)
 	if err != nil {
 		return nil, fmt.Errorf("CDS RA-TLS client: %w", err)
 	}
@@ -493,11 +592,12 @@ func startHealthServer(ctx context.Context, cfg healthServerConfig) error {
 
 // sandboxTokenSigner builds the inventory's sandbox-token signer. The key needs
 // no credential of its own: CDS reads it from this inventory's digests endpoint
-// on a privileged port, which is what establishes whose key it is. Without pull
-// config there is no CDS in the picture at all, so tokens are disabled and
-// get-cert issues without a sandbox ID.
-func sandboxTokenSigner(cfg *config, logger *slog.Logger) (*workloadclaims.SandboxTokenSigner, error) {
-	if !cfg.PullEnabled() {
+// on a privileged port, which is what establishes whose key it is. enabled is
+// false when there is no CDS in the picture at all (no pull config on a
+// dynamic boot); tokens are then disabled and get-cert issues without a
+// sandbox ID.
+func sandboxTokenSigner(cfg *config, logger *slog.Logger, enabled bool) (*workloadclaims.SandboxTokenSigner, error) {
+	if !enabled {
 		logger.Warn("admission inventory has no CDS pull config; sandbox tokens disabled")
 		return nil, nil
 	}
@@ -526,9 +626,7 @@ func digestsAdvertiseHost(cfg *config) (string, error) {
 	// can only fail closed, never redirect.
 	host := cfg.WorkloadClaims.AdvertiseHost
 	if host == "" {
-		if b, err := os.ReadFile(filepath.Join(cfg.WorkloadClaims.SocketDir, NodeIPFile)); err == nil {
-			host = strings.TrimSpace(string(b))
-		}
+		host, _ = nodeIP(cfg)
 	}
 	if host == "" {
 		host = strings.TrimSpace(os.Getenv("C8S_SANDBOX_DIGESTS_ADVERTISE_HOST"))
@@ -540,18 +638,11 @@ func digestsAdvertiseHost(cfg *config) (string, error) {
 }
 
 // startSandboxDigests serves the CDS-facing digests endpoint over
-// mutually-attested RA-TLS (docs/ratls.md, "Sandbox identity").
-func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *config, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner) error {
-	measurements, err := ratls.ParseHexMeasurementsList(cfg.Allowlist.Pull.CDSMeasurements)
-	if err != nil {
-		return fmt.Errorf("parse CDS measurements: %w", err)
-	}
-	if len(measurements) == 0 {
+// mutually-attested RA-TLS (docs/ratls.md, "Sandbox identity"), accepting
+// only a CDS peer matching pins.
+func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *config, inventory *admissionInventory, signer *workloadclaims.SandboxTokenSigner, pins ratls.Pins) error {
+	if len(pins.Measurements) == 0 && len(pins.Entries) == 0 {
 		logger.Warn("allowlist.pull.cds_measurements not set: the sandbox-digests endpoint answers ANY RA-TLS-attested caller, so any TEE on the network can read what this node runs. UNSAFE outside development.")
-	}
-	rtmrs, err := ratls.ParseRTMRPins(cfg.Allowlist.Pull.CDSRTMRs)
-	if err != nil {
-		return fmt.Errorf("parse CDS RTMR pins: %w", err)
 	}
 	attestationApiURL := cfg.Allowlist.Pull.AttestationApiURL
 	// The attest func is platform-agnostic despite its name (see its doc
@@ -559,7 +650,7 @@ func startSandboxDigests(ctx context.Context, logger *slog.Logger, cfg *config, 
 	return workloadclaims.StartDigestsEndpoint(ctx, logger, inventory, signer.PublicKeyDER(),
 		cfg.NormalizedPlatform(),
 		attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), attestationApiURL),
-		attestationApiURL, ratls.Pins{Measurements: measurements, RTMRs: rtmrs})
+		attestationApiURL, pins)
 }
 
 // startAdmissionInventory serves the node-CVM token socket (docs/ratls.md).

--- a/internal/cmds/nri-image-policy/main.go
+++ b/internal/cmds/nri-image-policy/main.go
@@ -101,7 +101,7 @@ func Run(args []string) error {
 	if err != nil {
 		return err
 	}
-	pull := cfg.PullEnabled() && sealed == nil
+	store, bootstrap, pull := startupPolicy(cfg, sealed)
 
 	logger.Info("starting nri-image-policy",
 		"version", version.Version,
@@ -121,15 +121,8 @@ func Run(args []string) error {
 
 	auditLogger := audit.NewLogger()
 
-	// A sealed store starts empty and holds the bundle alone: no floor, no
-	// pull, so nothing the control plane serves can enter the index.
-	bootstrap := alwaysAllowAllowlist(cfg.Allowlist.AlwaysAllow)
-	store := newPolicyStore(bootstrap)
 	var pins ratls.Pins
 	if sealed != nil {
-		bootstrap = nil
-		store = newPolicyStore(nil)
-		store.apply(sealed.doc, 0)
 		protectFromOOM(logger)
 	} else if pins, err = configuredPins(cfg.Allowlist.Pull); err != nil {
 		return err
@@ -318,6 +311,20 @@ func openPolicyMode(cfg *config, logger *slog.Logger) (*sealedPolicy, error) {
 	logger.Info("sealed to the measured policy bundle", "policy_dir", dir, "rtmr3", fmt.Sprintf("%x", sealed.rtmr3[:]),
 		"workloads", len(sealed.doc.Workloads), "host_ip", sealed.hostIP, "node_name", sealed.nodeName)
 	return sealed, nil
+}
+
+// startupPolicy chooses what the index starts from and whether the pull
+// loop runs. A sealed store starts empty and holds the measured bundle
+// alone: no always_allow floor, no pull, so nothing the control plane serves
+// can enter the index.
+func startupPolicy(cfg *config, sealed *sealedPolicy) (store *policyStore, bootstrap *allowlist.Allowlist, pull bool) {
+	if sealed != nil {
+		store = newPolicyStore(nil)
+		store.apply(sealed.doc, 0)
+		return store, nil, false
+	}
+	bootstrap = alwaysAllowAllowlist(cfg.Allowlist.AlwaysAllow)
+	return newPolicyStore(bootstrap), bootstrap, cfg.PullEnabled()
 }
 
 // sealedFatal powers the node off for a startup failure in sealed mode and

--- a/internal/cmds/nri-image-policy/observe.go
+++ b/internal/cmds/nri-image-policy/observe.go
@@ -21,10 +21,6 @@ import (
 // sources of the binds it adds to every container.
 const criSandboxDir = "/io.containerd.grpc.v1.cri/sandboxes/"
 
-// localPathProvisionerRoot is where local-path-storage keeps hostPath-type
-// persistent volumes on the node image (local-path-storage.yaml).
-const localPathProvisionerRoot = "/opt/local-path-provisioner/"
-
 // hostDevShm is the bind source containerd's CRI uses for /dev/shm when the
 // pod shares the node's IPC namespace (container_create.go: NamespaceMode_NODE).
 const hostDevShm = "/dev/shm"
@@ -77,7 +73,7 @@ func (o observer) observe(pod *api.PodSandbox, ctr *api.Container, digest string
 		if m.GetType() != "bind" {
 			continue
 		}
-		src := runPath(m.GetSource())
+		src := allowlist.BindSource(m.GetSource())
 		obs.Mounts[path.Clean(m.GetDestination())] = allowlist.MountSource{
 			Path:  src,
 			Class: o.classify(src, pod.GetUid(), ctr.GetPodSandboxId(), hostIPC),
@@ -151,18 +147,21 @@ func (o observer) sources(pod *api.PodSandbox) map[string]string {
 // there. hostIPC says the container shares the node's IPC namespace:
 // containerd then binds the node's /dev/shm in place of the sandbox's, and
 // render emits the same platform rule for both.
+//
+// Only CSI volumes are pvc. A local volume (kubernetes.io~local-volume) is
+// bound from whatever host directory its PersistentVolume names, which the
+// operator chooses, so it is a host path with a kubelet-shaped source and
+// stays outside the reviewed classes.
 func (o observer) classify(source, podUID, sandboxID string, hostIPC bool) string {
 	switch {
-	case underDir(source, policybundle.NodeStateDir):
+	case allowlist.UnderDir(source, policybundle.NodeStateDir):
 		return allowlist.SourceNodeState
-	case underDir(source, o.platformDir):
+	case allowlist.UnderDir(source, o.platformDir):
 		return allowlist.SourcePlatform
 	case sandboxID != "" && strings.Contains(source, criSandboxDir+sandboxID+"/"):
 		return allowlist.SourcePlatform
 	case hostIPC && source == hostDevShm:
 		return allowlist.SourcePlatform
-	case strings.HasPrefix(source, localPathProvisionerRoot):
-		return allowlist.SourcePVC
 	}
 	if podUID == "" {
 		return allowlist.SourceHostPath
@@ -188,7 +187,7 @@ func (o observer) classify(source, podUID, sandboxID string, hostIPC bool) strin
 			return allowlist.SourceServiceAccountToken
 		}
 		return "projected"
-	case "kubernetes.io~csi", "kubernetes.io~local-volume":
+	case "kubernetes.io~csi":
 		return allowlist.SourcePVC
 	case "kubernetes.io~configmap":
 		return "configMap"
@@ -283,21 +282,6 @@ func hostNamespaces(namespaces []*api.LinuxNamespace) []string {
 func hooksPresent(h *api.Hooks) bool {
 	return len(h.GetPrestart())+len(h.GetCreateRuntime())+len(h.GetCreateContainer())+
 		len(h.GetStartContainer())+len(h.GetPoststart())+len(h.GetPoststop()) > 0
-}
-
-func underDir(p, dir string) bool {
-	return dir != "" && (p == dir || strings.HasPrefix(p, dir+"/"))
-}
-
-// runPath is a bind source as the runtime records it: cleaned, with /var/run
-// mapped to /run as on the node image (the same mapping render applies to
-// rule sources).
-func runPath(p string) string {
-	p = path.Clean(p)
-	if p == "/var/run" || strings.HasPrefix(p, "/var/run/") {
-		return "/run" + strings.TrimPrefix(p, "/var/run")
-	}
-	return p
 }
 
 // cdiSpec is the part of a CDI spec file the device explanation reads

--- a/internal/cmds/nri-image-policy/observe.go
+++ b/internal/cmds/nri-image-policy/observe.go
@@ -1,0 +1,392 @@
+package nriimagepolicy
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/nri/pkg/api"
+	"gopkg.in/yaml.v3"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// criSandboxDir is the path segment under containerd's state directory
+// where the CRI keeps a sandbox's hostname, resolv.conf and shm: the
+// sources of the binds it adds to every container.
+const criSandboxDir = "/io.containerd.grpc.v1.cri/sandboxes/"
+
+// localPathProvisionerRoot is where local-path-storage keeps hostPath-type
+// persistent volumes on the node image (local-path-storage.yaml).
+const localPathProvisionerRoot = "/opt/local-path-provisioner/"
+
+// hostDevShm is the bind source containerd's CRI uses for /dev/shm when the
+// pod shares the node's IPC namespace (container_create.go: NamespaceMode_NODE).
+const hostDevShm = "/dev/shm"
+
+// defaultCDISpecDirs are where the CDI registry reads device specs from.
+var defaultCDISpecDirs = []string{"/etc/cdi", "/var/run/cdi"}
+
+// containerdDefaultCapabilities is the capability set containerd gives a
+// container with no adds (pkg/oci defaultUnixCaps); a rule lists only what is
+// beyond it.
+var containerdDefaultCapabilities = map[string]bool{
+	"CAP_CHOWN": true, "CAP_DAC_OVERRIDE": true, "CAP_FSETID": true, "CAP_FOWNER": true,
+	"CAP_MKNOD": true, "CAP_NET_RAW": true, "CAP_SETGID": true, "CAP_SETUID": true,
+	"CAP_SETFCAP": true, "CAP_SETPCAP": true, "CAP_NET_BIND_SERVICE": true,
+	"CAP_SYS_CHROOT": true, "CAP_KILL": true, "CAP_AUDIT_WRITE": true,
+}
+
+// observer turns NRI messages and OCI specs into allowlist.Observations. Its
+// fields are the node facts no message carries.
+type observer struct {
+	// platformDir is the plugin's own socket directory as the runtime binds
+	// it (workload_claims.socket_dir with /var/run mapped to /run): binds
+	// from it are the platform's, not the operator's.
+	platformDir string
+	hostIP      string
+	nodeName    string
+	// cdiDeviceNodes resolves CDI device names to the device node paths
+	// their specs inject, so those nodes are not reported as operator-added
+	// devices. nil treats every device as unexplained.
+	cdiDeviceNodes func(names []string) ([]string, error)
+}
+
+// observe builds the observation for one container from what the NRI
+// message carries. digest is the resolved image digest. Capabilities,
+// masked paths and no_new_privileges are not in the message; observeSpec
+// adds them from the stored OCI spec.
+func (o observer) observe(pod *api.PodSandbox, ctr *api.Container, digest string) allowlist.Observation {
+	obs := allowlist.Observation{
+		Digest:         digest,
+		Argv:           ctr.GetArgs(),
+		Env:            envMap(ctr.GetEnv()),
+		Mounts:         map[string]allowlist.MountSource{},
+		HostNamespaces: hostNamespaces(ctr.GetLinux().GetNamespaces()),
+		Hooks:          hooksPresent(ctr.GetHooks()),
+		Privileged:     sysfsWritable(nriMounts(ctr.GetMounts())),
+		Sources:        o.sources(pod),
+	}
+	hostIPC := slices.Contains(obs.HostNamespaces, allowlist.HostNamespaceIPC)
+	for _, m := range ctr.GetMounts() {
+		if m.GetType() != "bind" {
+			continue
+		}
+		src := runPath(m.GetSource())
+		obs.Mounts[path.Clean(m.GetDestination())] = allowlist.MountSource{
+			Path:  src,
+			Class: o.classify(src, pod.GetUid(), ctr.GetPodSandboxId(), hostIPC),
+		}
+	}
+	var devices []string
+	for _, d := range ctr.GetLinux().GetDevices() {
+		devices = append(devices, d.GetPath())
+	}
+	obs.Devices = o.unexplainedDevices(devices, ctr.GetCDIDevices())
+	return obs
+}
+
+// observeSpec fills in what only the stored OCI spec carries. The mount
+// list is re-read from the spec too, so the privileged inference is made
+// from the same source as the capabilities.
+func observeSpec(obs allowlist.Observation, spec *oci.Spec) allowlist.Observation {
+	var mounts []mountView
+	for _, m := range spec.Mounts {
+		mounts = append(mounts, mountView{kind: m.Type, destination: m.Destination, options: m.Options})
+	}
+	obs.Privileged = sysfsWritable(mounts)
+	obs.Capabilities = nil
+	if spec.Process != nil && spec.Process.Capabilities != nil {
+		for _, c := range spec.Process.Capabilities.Bounding {
+			if !containerdDefaultCapabilities[c] {
+				obs.Capabilities = append(obs.Capabilities, c)
+			}
+		}
+		slices.Sort(obs.Capabilities)
+	}
+	// A privileged container has no masked paths by construction; its rule
+	// says so through privileged, not unmaskedProc.
+	obs.UnmaskedProc = !obs.Privileged && (spec.Linux == nil || len(spec.Linux.MaskedPaths) == 0)
+	return obs
+}
+
+// specSecurity summarizes the spec fields no rule expresses yet, for the
+// deny log a reviewer completes rules from.
+func specSecurity(spec *oci.Spec) []any {
+	seccomp := "unconfined"
+	if spec.Linux != nil && spec.Linux.Seccomp != nil {
+		seccomp = string(spec.Linux.Seccomp.DefaultAction)
+	}
+	noNewPrivs := spec.Process != nil && spec.Process.NoNewPrivileges
+	return []any{"seccomp", seccomp, "no_new_privileges", noNewPrivs}
+}
+
+// sources are the pod-field values env From rules compare against.
+func (o observer) sources(pod *api.PodSandbox) map[string]string {
+	s := map[string]string{
+		allowlist.FromPodName:      pod.GetName(),
+		allowlist.FromPodNamespace: pod.GetNamespace(),
+		allowlist.FromPodUID:       pod.GetUid(),
+		allowlist.FromHostIP:       o.hostIP,
+		allowlist.FromNodeName:     o.nodeName,
+	}
+	if ips := pod.GetIps(); len(ips) > 0 {
+		s[allowlist.FromPodIP] = ips[0]
+	}
+	return s
+}
+
+// classify names the source class of a bind for Index.Admit: one of the
+// reviewed classes when the kubelet or the platform put it there, the
+// kubelet plugin name for a volume type the schema does not review, and
+// hostPath for everything else. The plugin socket dir is platform; the
+// measured image's state dir (policybundle.NodeStateDir: the policy dir and
+// the attestation socket) is nodeState, a class of its own, so the platform
+// rule every container carries for /etc/hosts cannot admit the socket bound
+// there. hostIPC says the container shares the node's IPC namespace:
+// containerd then binds the node's /dev/shm in place of the sandbox's, and
+// render emits the same platform rule for both.
+func (o observer) classify(source, podUID, sandboxID string, hostIPC bool) string {
+	switch {
+	case underDir(source, policybundle.NodeStateDir):
+		return allowlist.SourceNodeState
+	case underDir(source, o.platformDir):
+		return allowlist.SourcePlatform
+	case sandboxID != "" && strings.Contains(source, criSandboxDir+sandboxID+"/"):
+		return allowlist.SourcePlatform
+	case hostIPC && source == hostDevShm:
+		return allowlist.SourcePlatform
+	case strings.HasPrefix(source, localPathProvisionerRoot):
+		return allowlist.SourcePVC
+	}
+	if podUID == "" {
+		return allowlist.SourceHostPath
+	}
+	rest, ok := strings.CutPrefix(source, allowlist.KubeletVolumesRoot+podUID+"/")
+	if !ok {
+		return allowlist.SourceHostPath
+	}
+	switch {
+	case rest == "etc-hosts", strings.HasPrefix(rest, "containers/"):
+		return allowlist.SourcePlatform
+	}
+	volume, ok := strings.CutPrefix(rest, "volumes/")
+	if !ok {
+		return allowlist.SourceHostPath
+	}
+	plugin, name, _ := strings.Cut(volume, "/")
+	switch plugin {
+	case "kubernetes.io~empty-dir":
+		return allowlist.SourceEmptyDir
+	case "kubernetes.io~projected":
+		if strings.HasPrefix(name, "kube-api-access-") {
+			return allowlist.SourceServiceAccountToken
+		}
+		return "projected"
+	case "kubernetes.io~csi", "kubernetes.io~local-volume":
+		return allowlist.SourcePVC
+	case "kubernetes.io~configmap":
+		return "configMap"
+	case "kubernetes.io~downward-api":
+		return "downwardAPI"
+	}
+	return strings.TrimPrefix(plugin, "kubernetes.io~")
+}
+
+// unexplainedDevices drops the device nodes the container's CDI devices
+// inject. A CDI lookup failure leaves every device unexplained: the rule
+// then has to list them, which is the safe direction.
+func (o observer) unexplainedDevices(devices []string, cdi []*api.CDIDevice) []string {
+	if len(devices) == 0 {
+		return nil
+	}
+	explained := map[string]bool{}
+	if len(cdi) > 0 && o.cdiDeviceNodes != nil {
+		names := make([]string, 0, len(cdi))
+		for _, d := range cdi {
+			names = append(names, d.GetName())
+		}
+		if nodes, err := o.cdiDeviceNodes(names); err == nil {
+			for _, n := range nodes {
+				explained[n] = true
+			}
+		}
+	}
+	var out []string
+	for _, d := range devices {
+		if !explained[d] {
+			out = append(out, d)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// mountView is the part of a mount the privileged inference reads, shared
+// between the NRI and OCI mount types.
+type mountView struct {
+	kind, destination string
+	options           []string
+}
+
+func nriMounts(ms []*api.Mount) []mountView {
+	out := make([]mountView, 0, len(ms))
+	for _, m := range ms {
+		out = append(out, mountView{kind: m.GetType(), destination: m.GetDestination(), options: m.GetOptions()})
+	}
+	return out
+}
+
+// sysfsWritable reports a writable /sys: containerd mounts sysfs read-only
+// for every container and drops "ro" only through oci.WithPrivileged, so it
+// is the privileged marker both the NRI message and the spec carry.
+func sysfsWritable(mounts []mountView) bool {
+	for _, m := range mounts {
+		if m.kind == "sysfs" && m.destination == "/sys" && !slices.Contains(m.options, "ro") {
+			return true
+		}
+	}
+	return false
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, e := range env {
+		name, value, _ := strings.Cut(e, "=")
+		out[name] = value
+	}
+	return out
+}
+
+// hostNamespaces lists the namespaces the spec does not create: an absent
+// entry means the container shares the node's.
+func hostNamespaces(namespaces []*api.LinuxNamespace) []string {
+	present := map[string]bool{}
+	for _, ns := range namespaces {
+		present[ns.GetType()] = true
+	}
+	var out []string
+	for spec, rule := range map[string]string{"network": allowlist.HostNamespaceNet, "pid": allowlist.HostNamespacePID, "ipc": allowlist.HostNamespaceIPC} {
+		if !present[spec] {
+			out = append(out, rule)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+func hooksPresent(h *api.Hooks) bool {
+	return len(h.GetPrestart())+len(h.GetCreateRuntime())+len(h.GetCreateContainer())+
+		len(h.GetStartContainer())+len(h.GetPoststart())+len(h.GetPoststop()) > 0
+}
+
+func underDir(p, dir string) bool {
+	return dir != "" && (p == dir || strings.HasPrefix(p, dir+"/"))
+}
+
+// runPath is a bind source as the runtime records it: cleaned, with /var/run
+// mapped to /run as on the node image (the same mapping render applies to
+// rule sources).
+func runPath(p string) string {
+	p = path.Clean(p)
+	if p == "/var/run" || strings.HasPrefix(p, "/var/run/") {
+		return "/run" + strings.TrimPrefix(p, "/var/run")
+	}
+	return p
+}
+
+// cdiSpec is the part of a CDI spec file the device explanation reads
+// (tags.cncf.io/container-device-interface, spec v0.x): the kind and, per
+// device, the device nodes its edits inject.
+type cdiSpec struct {
+	Kind           string          `yaml:"kind"`
+	ContainerEdits cdiEdits        `yaml:"containerEdits"`
+	Devices        []cdiSpecDevice `yaml:"devices"`
+}
+
+type cdiSpecDevice struct {
+	Name           string   `yaml:"name"`
+	ContainerEdits cdiEdits `yaml:"containerEdits"`
+}
+
+type cdiEdits struct {
+	DeviceNodes []struct {
+		Path string `yaml:"path"`
+	} `yaml:"deviceNodes"`
+}
+
+// cdiDeviceNodesFrom returns a resolver over the spec files in dirs. Every
+// spec file is read on each call; CDI specs change when a device plugin
+// regenerates them and the plugin has no watcher.
+func cdiDeviceNodesFrom(dirs []string) func(names []string) ([]string, error) {
+	return func(names []string) ([]string, error) {
+		specs, err := readCDISpecs(dirs)
+		if err != nil {
+			return nil, err
+		}
+		var nodes []string
+		for _, name := range names {
+			kind, device, ok := strings.Cut(name, "=")
+			if !ok {
+				return nil, fmt.Errorf("CDI device %q is not <kind>=<name>", name)
+			}
+			found := false
+			for _, s := range specs {
+				if s.Kind != kind {
+					continue
+				}
+				for _, d := range s.Devices {
+					if d.Name != device {
+						continue
+					}
+					found = true
+					for _, n := range s.ContainerEdits.DeviceNodes {
+						nodes = append(nodes, n.Path)
+					}
+					for _, n := range d.ContainerEdits.DeviceNodes {
+						nodes = append(nodes, n.Path)
+					}
+				}
+			}
+			if !found {
+				return nil, fmt.Errorf("CDI device %q is in no spec under %s", name, strings.Join(dirs, ", "))
+			}
+		}
+		return nodes, nil
+	}
+}
+
+func readCDISpecs(dirs []string) ([]cdiSpec, error) {
+	var specs []cdiSpec
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("read CDI specs: %w", err)
+		}
+		for _, e := range entries {
+			ext := filepath.Ext(e.Name())
+			if !e.Type().IsRegular() || (ext != ".json" && ext != ".yaml" && ext != ".yml") {
+				continue
+			}
+			b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				return nil, fmt.Errorf("read CDI spec: %w", err)
+			}
+			var s cdiSpec
+			// YAML is a superset of JSON, so one decoder covers both file forms.
+			if err := yaml.Unmarshal(b, &s); err != nil {
+				return nil, fmt.Errorf("parse CDI spec %s: %w", e.Name(), err)
+			}
+			specs = append(specs, s)
+		}
+	}
+	return specs, nil
+}

--- a/internal/cmds/nri-image-policy/observe_test.go
+++ b/internal/cmds/nri-image-policy/observe_test.go
@@ -52,8 +52,8 @@ func TestClassify(t *testing.T) {
 		{"service account token", podRoot + "volumes/kubernetes.io~projected/kube-api-access-x7z9q", allowlist.SourceServiceAccountToken},
 		{"other projected", podRoot + "volumes/kubernetes.io~projected/certs", "projected"},
 		{"csi pvc", podRoot + "volumes/kubernetes.io~csi/pvc-1/mount", allowlist.SourcePVC},
-		{"local pv", podRoot + "volumes/kubernetes.io~local-volume/pv-1", allowlist.SourcePVC},
-		{"local-path pv", localPathProvisionerRoot + "pvc-1_default_data", allowlist.SourcePVC},
+		{"local pv is an operator-chosen host directory", podRoot + "volumes/kubernetes.io~local-volume/pv-1", "local-volume"},
+		{"local-path pv", "/opt/local-path-provisioner/pvc-1_default_data", allowlist.SourceHostPath},
 		{"configMap", podRoot + "volumes/kubernetes.io~configmap/cfg", "configMap"},
 		{"secret", podRoot + "volumes/kubernetes.io~secret/tls", "secret"},
 		{"downwardAPI", podRoot + "volumes/kubernetes.io~downward-api/info", "downwardAPI"},
@@ -278,19 +278,6 @@ func TestSpecSecurity(t *testing.T) {
 	}
 	if got := specSecurity(&oci.Spec{}); !reflect.DeepEqual(got, []any{"seccomp", "unconfined", "no_new_privileges", false}) {
 		t.Fatalf("specSecurity(empty) = %v, want unconfined, false", got)
-	}
-}
-
-func TestRunPath(t *testing.T) {
-	for in, want := range map[string]string{
-		"/var/run/nri-image-policy/": "/run/nri-image-policy",
-		"/var/run":                   "/run",
-		"/var/runner/x":              "/var/runner/x",
-		"/lib/modules/../modules":    "/lib/modules",
-	} {
-		if got := runPath(in); got != want {
-			t.Errorf("runPath(%q) = %q, want %q", in, got, want)
-		}
 	}
 }
 

--- a/internal/cmds/nri-image-policy/observe_test.go
+++ b/internal/cmds/nri-image-policy/observe_test.go
@@ -1,0 +1,351 @@
+package nriimagepolicy
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/nri/pkg/api"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+const (
+	testPlatformDir  = "/run/nri-image-policy"
+	testSandboxState = "/run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/" + testSandboxID + "/"
+)
+
+func testObserver() observer {
+	return observer{platformDir: testPlatformDir, hostIP: "10.0.0.7", nodeName: "node-a"}
+}
+
+func bind(dest, src string) *api.Mount {
+	return &api.Mount{Destination: dest, Type: "bind", Source: src, Options: []string{"rbind", "rprivate", "rw"}}
+}
+
+// ownNamespaces are the namespaces a pod container gets with no host sharing.
+func ownNamespaces() []*api.LinuxNamespace {
+	return []*api.LinuxNamespace{
+		{Type: "network", Path: "/var/run/netns/cni-1"}, {Type: "pid"}, {Type: "ipc", Path: "/proc/1/ns/ipc"},
+		{Type: "uts", Path: "/proc/1/ns/uts"}, {Type: "mount"},
+	}
+}
+
+func sysfsMount(options ...string) *api.Mount {
+	return &api.Mount{Destination: "/sys", Type: "sysfs", Source: "sysfs", Options: options}
+}
+
+func TestClassify(t *testing.T) {
+	podRoot := allowlist.KubeletVolumesRoot + testPodUID + "/"
+	for _, tc := range []struct {
+		name, source, want string
+	}{
+		{"emptyDir", podRoot + "volumes/kubernetes.io~empty-dir/scratch", allowlist.SourceEmptyDir},
+		{"memory emptyDir", podRoot + "volumes/kubernetes.io~empty-dir/c8s-certs", allowlist.SourceEmptyDir},
+		{"service account token", podRoot + "volumes/kubernetes.io~projected/kube-api-access-x7z9q", allowlist.SourceServiceAccountToken},
+		{"other projected", podRoot + "volumes/kubernetes.io~projected/certs", "projected"},
+		{"csi pvc", podRoot + "volumes/kubernetes.io~csi/pvc-1/mount", allowlist.SourcePVC},
+		{"local pv", podRoot + "volumes/kubernetes.io~local-volume/pv-1", allowlist.SourcePVC},
+		{"local-path pv", localPathProvisionerRoot + "pvc-1_default_data", allowlist.SourcePVC},
+		{"configMap", podRoot + "volumes/kubernetes.io~configmap/cfg", "configMap"},
+		{"secret", podRoot + "volumes/kubernetes.io~secret/tls", "secret"},
+		{"downwardAPI", podRoot + "volumes/kubernetes.io~downward-api/info", "downwardAPI"},
+		{"unknown kubelet plugin", podRoot + "volumes/kubernetes.io~nfs/share", "nfs"},
+		{"kubelet etc-hosts", podRoot + "etc-hosts", allowlist.SourcePlatform},
+		{"termination log", podRoot + "containers/app/1a2b3c", allowlist.SourcePlatform},
+		{"cri hostname", testSandboxState + "hostname", allowlist.SourcePlatform},
+		{"cri resolv.conf", testSandboxState + "resolv.conf", allowlist.SourcePlatform},
+		{"cri shm", testSandboxState + "shm", allowlist.SourcePlatform},
+		{"another sandbox's shm", "/run/k3s/containerd/io.containerd.grpc.v1.cri/sandboxes/other/shm", allowlist.SourceHostPath},
+		{"plugin socket dir", testPlatformDir, allowlist.SourcePlatform},
+		{"plugin socket dir file", testPlatformDir + "/inventory.sock", allowlist.SourcePlatform},
+		{"plugin socket dir sibling", testPlatformDir + "-evil/x", allowlist.SourceHostPath},
+		{"node state dir", policybundle.NodeStateDir, allowlist.SourceNodeState},
+		{"attestation socket", policybundle.NodeStateDir + "/attestation-api.sock", allowlist.SourceNodeState},
+		{"policy dir member", policybundle.DefaultPolicyDir + "/static-allowlist.json", allowlist.SourceNodeState},
+		{"node state dir sibling", policybundle.NodeStateDir + "-evil/attestation-api.sock", allowlist.SourceHostPath},
+		{"another pod's emptyDir", allowlist.KubeletVolumesRoot + "other-uid/volumes/kubernetes.io~empty-dir/x", allowlist.SourceHostPath},
+		{"pod dir outside volumes", podRoot + "plugins/x", allowlist.SourceHostPath},
+		{"host path", "/lib/modules", allowlist.SourceHostPath},
+		{"host dev shm", "/dev/shm", allowlist.SourceHostPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testObserver().classify(tc.source, testPodUID, testSandboxID, false); got != tc.want {
+				t.Fatalf("classify(%s) = %q, want %q", tc.source, got, tc.want)
+			}
+		})
+	}
+	t.Run("no pod uid classifies kubelet volumes as hostPath", func(t *testing.T) {
+		if got := testObserver().classify(podRoot+"volumes/kubernetes.io~empty-dir/x", "", testSandboxID, false); got != allowlist.SourceHostPath {
+			t.Fatalf("classify(emptyDir, no uid) = %q, want hostPath", got)
+		}
+	})
+	// containerd binds the node's /dev/shm for a pod that shares the node's
+	// IPC namespace; render emits a platform rule for it, like the sandbox's.
+	for _, tc := range []struct {
+		name, source, want string
+	}{
+		{"host dev shm under host ipc", "/dev/shm", allowlist.SourcePlatform},
+		{"path under host dev shm under host ipc", "/dev/shm/x", allowlist.SourceHostPath},
+		{"host path under host ipc", "/lib/modules", allowlist.SourceHostPath},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := testObserver().classify(tc.source, testPodUID, testSandboxID, true); got != tc.want {
+				t.Fatalf("classify(%s, hostIPC) = %q, want %q", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+// The rule render emits for a pod with hostIPC (a platform rule for /dev/shm
+// plus the ipc host namespace) must admit what containerd binds for it: the
+// node's /dev/shm, with no ipc namespace entry in the spec.
+func TestObserve_HostIPCShmAdmittedByRenderedRule(t *testing.T) {
+	rule := allowlist.Container{
+		Digest:  mustDigest(t, pushDigestA),
+		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/app"}},
+		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"serve"}},
+		Env: allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH"},
+			Values: map[string]allowlist.EnvValue{"PATH": {Value: str("/bin")}}},
+		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: []string{"/dev/shm"},
+			Rules: map[string]allowlist.MountRule{"/dev/shm": {Source: allowlist.SourcePlatform}}},
+		Privileges: &allowlist.Privileges{HostNamespaces: []string{allowlist.HostNamespaceIPC}, Review: "shares the node's IPC namespace"},
+	}
+	raw, err := json.Marshal(&allowlist.Allowlist{Schema: allowlist.Schema, Digests: map[string]string{},
+		Workloads: map[string]allowlist.Workload{"shm": {Containers: []allowlist.Container{rule}}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := allowlist.LintSealed(mustCanonical(t, raw)); err != nil {
+		t.Fatalf("rendered-shape rule is not sealed: %v", err)
+	}
+	doc, err := allowlist.ParseJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	index := doc.BuildIndex()
+
+	container := func(namespaces []*api.LinuxNamespace) *api.Container {
+		return &api.Container{
+			Id: "shm-ctr", PodSandboxId: testSandboxID, Name: "app",
+			Args:   []string{"/app", "serve"},
+			Env:    []string{"PATH=/bin"},
+			Mounts: []*api.Mount{sysfsMount("ro"), bind("/dev/shm", "/dev/shm")},
+			Linux:  &api.LinuxContainer{Namespaces: namespaces},
+		}
+	}
+	withoutIPC := []*api.LinuxNamespace{{Type: "network", Path: "/var/run/netns/cni-1"}, {Type: "pid"}, {Type: "uts"}, {Type: "mount"}}
+	pod := &api.PodSandbox{Id: testSandboxID, Name: "shm-0", Namespace: "tenant", Uid: testPodUID}
+	if _, ok := index.Admit(testObserver().observe(pod, container(withoutIPC), pushDigestA)); !ok {
+		t.Fatal("Admit(hostIPC container) = false, want the rendered platform rule to admit the node's /dev/shm")
+	}
+	if _, ok := index.Admit(testObserver().observe(pod, container(ownNamespaces()), pushDigestA)); ok {
+		t.Fatal("Admit(own-IPC container binding the node's /dev/shm) = true, want a deny")
+	}
+}
+
+func mustCanonical(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	doc, err := allowlist.ParseJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := doc.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return canonical
+}
+
+func TestObserve(t *testing.T) {
+	podRoot := allowlist.KubeletVolumesRoot + testPodUID + "/"
+	pod := &api.PodSandbox{Id: testSandboxID, Name: "web-0", Namespace: "tenant", Uid: testPodUID, Ips: []string{"10.42.0.9", "fd00::9"}}
+	ctr := &api.Container{
+		Id: "ctr-1", PodSandboxId: testSandboxID, Name: "app",
+		Args: []string{"/app", "serve"},
+		Env:  []string{"PATH=/bin", "EMPTY=", "NOEQ", "KEY=a=b"},
+		Mounts: []*api.Mount{
+			{Destination: "/proc", Type: "proc", Source: "proc"},
+			sysfsMount("nosuid", "noexec", "nodev", "ro"),
+			bind("/etc/hosts", podRoot+"etc-hosts"),
+			bind("/data/", podRoot+"volumes/kubernetes.io~empty-dir/data"),
+			bind("/run/c8s/workload-claims", "/var/run/nri-image-policy"),
+			bind("/host/modules", "/lib/modules/"),
+		},
+		Linux: &api.LinuxContainer{
+			Namespaces: []*api.LinuxNamespace{{Type: "network", Path: "/var/run/netns/x"}, {Type: "uts"}, {Type: "mount"}},
+			Devices:    []*api.LinuxDevice{{Path: "/dev/nvidia0"}, {Path: "/dev/kvm"}, {Path: "/dev/nvidiactl"}},
+		},
+		CDIDevices: []*api.CDIDevice{{Name: "nvidia.com/gpu=0"}},
+	}
+	o := testObserver()
+	o.cdiDeviceNodes = func(names []string) ([]string, error) {
+		if !reflect.DeepEqual(names, []string{"nvidia.com/gpu=0"}) {
+			t.Fatalf("cdiDeviceNodes(%v), want [nvidia.com/gpu=0]", names)
+		}
+		return []string{"/dev/nvidia0", "/dev/nvidiactl"}, nil
+	}
+
+	got := o.observe(pod, ctr, pushDigestA)
+	want := allowlist.Observation{
+		Digest: pushDigestA,
+		Argv:   []string{"/app", "serve"},
+		Env:    map[string]string{"PATH": "/bin", "EMPTY": "", "NOEQ": "", "KEY": "a=b"},
+		Mounts: map[string]allowlist.MountSource{
+			"/etc/hosts":               {Path: podRoot + "etc-hosts", Class: allowlist.SourcePlatform},
+			"/data":                    {Path: podRoot + "volumes/kubernetes.io~empty-dir/data", Class: allowlist.SourceEmptyDir},
+			"/run/c8s/workload-claims": {Path: "/run/nri-image-policy", Class: allowlist.SourcePlatform},
+			"/host/modules":            {Path: "/lib/modules", Class: allowlist.SourceHostPath},
+		},
+		HostNamespaces: []string{allowlist.HostNamespaceIPC, allowlist.HostNamespacePID},
+		Devices:        []string{"/dev/kvm"},
+		Sources: map[string]string{
+			allowlist.FromPodIP: "10.42.0.9", allowlist.FromPodName: "web-0", allowlist.FromPodNamespace: "tenant",
+			allowlist.FromPodUID: testPodUID, allowlist.FromHostIP: "10.0.0.7", allowlist.FromNodeName: "node-a",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("observe() = %+v\nwant %+v", got, want)
+	}
+
+	t.Run("cdi lookup failure leaves every device unexplained", func(t *testing.T) {
+		o.cdiDeviceNodes = func([]string) ([]string, error) { return nil, errors.New("no specs") }
+		if got := o.observe(pod, ctr, pushDigestA).Devices; !reflect.DeepEqual(got, []string{"/dev/kvm", "/dev/nvidia0", "/dev/nvidiactl"}) {
+			t.Fatalf("Devices = %v, want all three", got)
+		}
+	})
+	t.Run("no ips leaves podIP unset", func(t *testing.T) {
+		if _, ok := o.observe(&api.PodSandbox{}, ctr, pushDigestA).Sources[allowlist.FromPodIP]; ok {
+			t.Fatal("podIP present for a sandbox without IPs")
+		}
+	})
+	t.Run("hooks, writable sysfs and full namespaces", func(t *testing.T) {
+		c := &api.Container{
+			Mounts: []*api.Mount{sysfsMount("nosuid", "noexec", "nodev")},
+			Hooks:  &api.Hooks{CreateRuntime: []*api.Hook{{Path: "/usr/bin/nvidia-cdi-hook"}}},
+			Linux:  &api.LinuxContainer{Namespaces: ownNamespaces()},
+		}
+		got := o.observe(pod, c, pushDigestA)
+		if !got.Hooks || !got.Privileged || got.HostNamespaces != nil {
+			t.Fatalf("observe(hooks, rw sysfs) = hooks %v, privileged %v, host namespaces %v; want true, true, none", got.Hooks, got.Privileged, got.HostNamespaces)
+		}
+	})
+}
+
+func TestObserveSpec(t *testing.T) {
+	ro := specs.Mount{Destination: "/sys", Type: "sysfs", Options: []string{"ro"}}
+	rw := specs.Mount{Destination: "/sys", Type: "sysfs", Options: []string{"rw"}}
+	caps := func(extra ...string) *specs.LinuxCapabilities {
+		bounding := append([]string{"CAP_CHOWN", "CAP_KILL", "CAP_NET_BIND_SERVICE"}, extra...)
+		return &specs.LinuxCapabilities{Bounding: bounding, Effective: bounding, Permitted: bounding}
+	}
+	for _, tc := range []struct {
+		name string
+		spec *oci.Spec
+		want allowlist.Observation
+	}{
+		{"ordinary", &oci.Spec{Mounts: []specs.Mount{ro}, Process: &specs.Process{Capabilities: caps()},
+			Linux: &specs.Linux{MaskedPaths: []string{"/proc/kcore"}}}, allowlist.Observation{}},
+		{"added capabilities", &oci.Spec{Mounts: []specs.Mount{ro}, Process: &specs.Process{Capabilities: caps("CAP_SYS_ADMIN", "CAP_NET_ADMIN")},
+			Linux: &specs.Linux{MaskedPaths: []string{"/proc/kcore"}}}, allowlist.Observation{Capabilities: []string{"CAP_NET_ADMIN", "CAP_SYS_ADMIN"}}},
+		{"unmasked proc", &oci.Spec{Mounts: []specs.Mount{ro}, Process: &specs.Process{Capabilities: caps()}, Linux: &specs.Linux{}},
+			allowlist.Observation{UnmaskedProc: true}},
+		{"privileged", &oci.Spec{Mounts: []specs.Mount{rw}, Process: &specs.Process{Capabilities: caps("CAP_SYS_ADMIN")}, Linux: &specs.Linux{}},
+			allowlist.Observation{Privileged: true, Capabilities: []string{"CAP_SYS_ADMIN"}}},
+		{"no process block", &oci.Spec{Mounts: []specs.Mount{ro}, Linux: &specs.Linux{MaskedPaths: []string{"/proc/kcore"}}}, allowlist.Observation{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := observeSpec(allowlist.Observation{Capabilities: []string{"stale"}}, tc.spec)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("observeSpec(%s) = %+v, want %+v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSpecSecurity(t *testing.T) {
+	got := specSecurity(&oci.Spec{Process: &specs.Process{NoNewPrivileges: true},
+		Linux: &specs.Linux{Seccomp: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno}}})
+	if want := []any{"seccomp", "SCMP_ACT_ERRNO", "no_new_privileges", true}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("specSecurity(confined) = %v, want %v", got, want)
+	}
+	if got := specSecurity(&oci.Spec{}); !reflect.DeepEqual(got, []any{"seccomp", "unconfined", "no_new_privileges", false}) {
+		t.Fatalf("specSecurity(empty) = %v, want unconfined, false", got)
+	}
+}
+
+func TestRunPath(t *testing.T) {
+	for in, want := range map[string]string{
+		"/var/run/nri-image-policy/": "/run/nri-image-policy",
+		"/var/run":                   "/run",
+		"/var/runner/x":              "/var/runner/x",
+		"/lib/modules/../modules":    "/lib/modules",
+	} {
+		if got := runPath(in); got != want {
+			t.Errorf("runPath(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCDIDeviceNodesFrom(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("nvidia.yaml", `
+cdiVersion: 0.6.0
+kind: nvidia.com/gpu
+containerEdits:
+  deviceNodes:
+    - path: /dev/nvidiactl
+devices:
+  - name: "0"
+    containerEdits:
+      deviceNodes:
+        - path: /dev/nvidia0
+  - name: all
+    containerEdits:
+      deviceNodes:
+        - path: /dev/nvidia0
+        - path: /dev/nvidia1
+`)
+	write("vfio.json", `{"cdiVersion":"0.6.0","kind":"example.com/vfio","devices":[{"name":"a","containerEdits":{"deviceNodes":[{"path":"/dev/vfio/1"}]}}]}`)
+	write("README.txt", "not a spec")
+	resolve := cdiDeviceNodesFrom([]string{dir, filepath.Join(dir, "absent")})
+	for _, tc := range []struct {
+		name    string
+		names   []string
+		want    []string
+		wantErr string
+	}{
+		{"gpu 0 with kind-level edits", []string{"nvidia.com/gpu=0"}, []string{"/dev/nvidiactl", "/dev/nvidia0"}, ""},
+		{"two devices", []string{"nvidia.com/gpu=all", "example.com/vfio=a"}, []string{"/dev/nvidiactl", "/dev/nvidia0", "/dev/nvidia1", "/dev/vfio/1"}, ""},
+		{"unknown device", []string{"nvidia.com/gpu=9"}, nil, "in no spec"},
+		{"malformed name", []string{"nvidia.com/gpu"}, nil, "not <kind>=<name>"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolve(tc.names)
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("cdiDeviceNodes(%v) = %v, want error containing %q", tc.names, err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("cdiDeviceNodes(%v) = %v, want %v", tc.names, got, tc.want)
+			}
+		})
+	}
+	t.Run("malformed spec file is an error", func(t *testing.T) {
+		write("broken.yaml", "kind: [")
+		if _, err := resolve([]string{"nvidia.com/gpu=0"}); err == nil || !strings.Contains(err.Error(), "parse CDI spec broken.yaml") {
+			t.Fatalf("cdiDeviceNodes(broken spec dir) = %v, want a parse error", err)
+		}
+	})
+}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -6,9 +6,11 @@ import (
 	"log/slog"
 	"os"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nri/pkg/api"
 	"github.com/containerd/nri/pkg/stub"
 	"k8s.io/apimachinery/pkg/labels"
@@ -94,6 +96,7 @@ func (s *policyStore) apply(pulled *allowlist.Allowlist, version uint64) bool {
 type containerdOps interface {
 	Resolve(ctx context.Context, imageRef string) (string, error)
 	StopContainer(ctx context.Context, containerID string) error
+	Spec(ctx context.Context, containerID string) (*oci.Spec, error)
 }
 
 // plugin implements the NRI plugin interface for image policy enforcement.
@@ -105,6 +108,16 @@ type plugin struct {
 	logger     *slog.Logger
 	ready      atomic.Bool
 	containerd containerdOps
+
+	// sealed is non-nil on a static boot: admission then runs the sealed
+	// hooks (sealed_plugin.go) against the measured bundle and nothing
+	// else. observer builds their observations, verdicts carries the
+	// PostCreateContainer decision to StartContainer, and poweroff is what a
+	// fatal condition calls.
+	sealed   *sealedPolicy
+	observer observer
+	verdicts verdictCache
+	poweroff func() error
 
 	// exempt admits an exempt namespace's containers by the digest set captured
 	// running in it, not by the namespace name. nil ⇔ not opted in
@@ -129,6 +142,7 @@ func newPlugin(
 	cfg *config,
 	ctrd containerdOps,
 	store *policyStore,
+	sealed *sealedPolicy,
 	auditLogger *audit.Logger,
 	logger *slog.Logger,
 ) (*plugin, error) {
@@ -138,6 +152,16 @@ func newPlugin(
 		audit:      auditLogger,
 		logger:     logger,
 		containerd: ctrd,
+		sealed:     sealed,
+		poweroff:   poweroff,
+	}
+	if sealed != nil {
+		p.observer = observer{
+			platformDir:    runPath(cfg.WorkloadClaims.SocketDir),
+			hostIP:         sealed.hostIP,
+			nodeName:       sealed.nodeName,
+			cdiDeviceNodes: cdiDeviceNodesFrom(defaultCDISpecDirs),
+		}
 	}
 	if cfg.WorkloadClaims.SocketDir != "" {
 		procRoot := cfg.WorkloadClaims.ProcRoot
@@ -195,15 +219,27 @@ func (p *plugin) Run(ctx context.Context) error {
 	return p.stub.Run(ctx)
 }
 
-// Configure is called when the plugin is registered with the runtime.
+// Configure is called when the plugin is registered with the runtime. In
+// sealed mode it also subscribes the post-create and start hooks and, when
+// the config requires it, refuses a containerd without the fail-closed fix:
+// returning an error fails registration, and Run exits.
 func (p *plugin) Configure(ctx context.Context, config, runtime, version string) (api.EventMask, error) {
 	p.logger.Info("plugin configured",
 		"runtime", runtime,
 		"version", version,
+		"sealed", p.sealed != nil,
 	)
 
 	var mask api.EventMask
 	mask.Set(api.Event_CREATE_CONTAINER)
+	if p.sealed != nil {
+		if p.cfg.Runtime.RequireFailClosed && !strings.Contains(version, FailClosedRuntimeMarker) {
+			return 0, fmt.Errorf("sealed mode requires a containerd built with the NRI fail-closed fix (version containing %q), got %s %s", FailClosedRuntimeMarker, runtime, version)
+		}
+		mask.Set(api.Event_POST_CREATE_CONTAINER)
+		mask.Set(api.Event_START_CONTAINER)
+		mask.Set(api.Event_REMOVE_CONTAINER)
+	}
 	if p.inventory != nil {
 		// The inventory needs eviction on stop to stay correct across pod churn,
 		// and the pod-sandbox lifecycle to keep its sandbox set (the /sandbox
@@ -222,6 +258,7 @@ func (p *plugin) RemoveContainer(ctx context.Context, pod *api.PodSandbox, ctr *
 	if p.inventory != nil {
 		p.inventory.remove(ctr.GetId())
 	}
+	p.verdicts.drop(ctr.GetId())
 	return nil
 }
 
@@ -582,6 +619,10 @@ func (p *plugin) captureExempt(ctx context.Context, pods []*api.PodSandbox, ctrs
 func (p *plugin) Synchronize(ctx context.Context, pods []*api.PodSandbox, ctrs []*api.Container) ([]*api.ContainerUpdate, error) {
 	cfg := p.cfg
 
+	if p.sealed != nil {
+		return p.sealedSynchronize(pods, ctrs)
+	}
+
 	// Seed the inventory's sandbox set now, even when the container check is
 	// deferred: sandbox existence needs no allowlist.
 	if p.inventory != nil {
@@ -718,6 +759,15 @@ func (p *plugin) admitWhileInitializing(ctx context.Context, cfg *config, pod *a
 func (p *plugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
 	cfg := p.cfg
 	imageRef := ctr.GetAnnotations()[annotationImageName]
+
+	// Sealed admission needs no readiness: the index is loaded before the
+	// stub registers, and there is no audit mode to pass through.
+	if p.sealed != nil {
+		if err := p.sealedCreate(ctx, pod, ctr); err != nil {
+			return nil, nil, err
+		}
+		return nil, nil, nil
+	}
 
 	if !p.Ready() {
 		if err := p.admitWhileInitializing(ctx, cfg, pod, ctr, imageRef); err != nil {

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -157,7 +157,7 @@ func newPlugin(
 	}
 	if sealed != nil {
 		p.observer = observer{
-			platformDir:    runPath(cfg.WorkloadClaims.SocketDir),
+			platformDir:    allowlist.BindSource(cfg.WorkloadClaims.SocketDir),
 			hostIP:         sealed.hostIP,
 			nodeName:       sealed.nodeName,
 			cdiDeviceNodes: cdiDeviceNodesFrom(defaultCDISpecDirs),

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/audit"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nri/pkg/api"
 )
 
@@ -35,6 +36,14 @@ func newTestPlugin(cfg *config) *plugin {
 type fakeContainerd struct {
 	resolve func(ctx context.Context, imageRef string) (string, error)
 	stop    func(ctx context.Context, containerID string) error
+	spec    func(ctx context.Context, containerID string) (*oci.Spec, error)
+}
+
+func (f *fakeContainerd) Spec(ctx context.Context, containerID string) (*oci.Spec, error) {
+	if f.spec == nil {
+		panic("unexpected containerd spec load")
+	}
+	return f.spec(ctx, containerID)
 }
 
 func (f *fakeContainerd) Resolve(ctx context.Context, imageRef string) (string, error) {

--- a/internal/cmds/nri-image-policy/refresh_test.go
+++ b/internal/cmds/nri-image-policy/refresh_test.go
@@ -144,7 +144,7 @@ func TestStartupSourceMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := startupSourceMode(tt.cfg); got != tt.want {
+			if got := startupSourceMode(tt.cfg, nil); got != tt.want {
 				t.Fatalf("startupSourceMode() = %q, want %q", got, tt.want)
 			}
 		})

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -393,8 +393,9 @@ logging:
 // serves the peer end, so registration blocks until its timeout rather than
 // failing on connect. The socket stays up for the whole test: the stub holds a
 // dup of the adopted end, and closing the peer end would make registration fail
-// immediately and restore the race.
-func holdNRISocket(t *testing.T) {
+// immediately and restore the race. The returned peer reads what the stub
+// sends, so a test can tell when registration has started.
+func holdNRISocket(t *testing.T) net.Conn {
 	t.Helper()
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
@@ -403,8 +404,19 @@ func holdNRISocket(t *testing.T) {
 	// nri's NewFdConn dups the adopted descriptor and closes the original, so
 	// fds[0] belongs to the stub from here on and its number is recycled: the
 	// test owns only the peer end.
-	t.Cleanup(func() { _ = syscall.Close(fds[1]) })
+	peerFile := os.NewFile(uintptr(fds[1]), "nri-peer")
+	peer, err := net.FileConn(peerFile)
+	if err != nil {
+		t.Fatalf("peer conn: %v", err)
+	}
+	// peerFile stays referenced until cleanup: its finalizer would otherwise
+	// close the peer end mid-test.
+	t.Cleanup(func() {
+		_ = peer.Close()
+		_ = peerFile.Close()
+	})
 	t.Setenv(api.PluginSocketEnvVar, strconv.Itoa(fds[0]))
+	return peer
 }
 
 // --- allowlistPullHTTPClient ------------------------------------------------
@@ -511,7 +523,7 @@ func TestNewPlugin_WorkloadClaimsWiring(t *testing.T) {
 				Policy:         policyConfig{Mode: ModeFailClosed},
 				WorkloadClaims: workloadClaimsConfig{SocketDir: tc.socketDir, ProcRoot: tc.procRoot},
 			}
-			p, err := newPlugin(cfg, &fakeContainerd{}, store, audit.NewLogger(), discardLogger())
+			p, err := newPlugin(cfg, &fakeContainerd{}, store, nil, audit.NewLogger(), discardLogger())
 			if err != nil {
 				t.Fatalf("newPlugin: %v", err)
 			}

--- a/internal/cmds/nri-image-policy/sealed.go
+++ b/internal/cmds/nri-image-policy/sealed.go
@@ -1,0 +1,168 @@
+package nriimagepolicy
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// operatorPubkeyPath is where the measured initrd stages the operator public
+// key on a dynamic boot; the same path cred-release reads. A var so tests
+// point it at a temp file.
+var operatorPubkeyPath = "/etc/confai/operator-pubkey"
+
+// poweroff powers the node off after a sealed-mode fatal condition. The plugin
+// is a containerd child, not a unit, so no FailureAction= applies to it. A var
+// so tests inject a recorder instead of powering off the test host.
+var poweroff = systemPoweroff
+
+// selfAttestTimeout bounds the own-quote round trip at startup; the socket
+// is local, so a slow answer means the verifier is not serving. It exceeds
+// containerd's plugin_registration_timeout, so Run registers the stub before
+// it attests (see pinOwnTuple).
+const selfAttestTimeout = 30 * time.Second
+
+// pinOwnTuple derives the CDS pins from the node's own quote. A var so tests
+// observe when Run calls it relative to stub registration.
+var pinOwnTuple = ownTuplePins
+
+// sealedPolicy is what a static boot pins the plugin to: the linted document,
+// the register that commits to it, and the values env From rules resolve
+// against that no NRI message carries.
+type sealedPolicy struct {
+	doc   *allowlist.Allowlist
+	rtmr3 [runtimemeasure.Size]byte
+	// hostIP is what nri-node-ip.service wrote for this node; nodeName is
+	// the node name the kubelet derives from the hostname. The kubelet
+	// injects both through fieldRefs.
+	hostIP   string
+	nodeName string
+}
+
+// nodeIP is the address the node-ip file under workload_claims.socket_dir
+// holds: nri-node-ip.service writes it on the node image, the chart's
+// installer elsewhere. false when no socket dir is configured or the file is
+// absent; the file's only readers fall back to another source then.
+func nodeIP(cfg *config) (string, bool) {
+	if cfg.WorkloadClaims.SocketDir == "" {
+		return "", false
+	}
+	b, err := os.ReadFile(filepath.Join(cfg.WorkloadClaims.SocketDir, NodeIPFile))
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(b)), true
+}
+
+// kubeletNodeName is the node name the kubelet (and RKE2, which passes it
+// as hostname-override) forms from the kernel hostname: trimmed and
+// lowercased, so a spec.nodeName fieldRef injects that form.
+func kubeletNodeName(hostname string) string {
+	return strings.ToLower(strings.TrimSpace(hostname))
+}
+
+// systemPoweroff asks systemd first, which flushes journals, and falls back
+// to the syscall when systemd is not answering.
+func systemPoweroff() error {
+	if err := exec.Command("systemctl", "poweroff", "--force", "--force").Run(); err == nil {
+		return nil
+	}
+	unix.Sync()
+	return unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF)
+}
+
+// loadSealed proves the running register commits to exactly the bundle
+// policybundle.ReadDir found (members re-indexed against the digest file):
+// strict parse and sealed lint of the allowlist member, then sysfs RTMR[3]
+// must equal ForStaticAllowlist(index).
+func loadSealed(bundle policybundle.Bundle) (*sealedPolicy, error) {
+	raw := bundle.Members[policybundle.MemberStaticAllowlist]
+	if err := allowlist.LintSealed(raw); err != nil {
+		return nil, fmt.Errorf("%s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	doc, err := allowlist.ParseJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	own, err := tdxrtmr.Read(3)
+	if err != nil {
+		return nil, err
+	}
+	want := bundle.RTMR3()
+	if own != want {
+		return nil, fmt.Errorf("RTMR[3] is %s, want %s = ForStaticAllowlist(index) (was the bundle replaced after the measurement?)",
+			hex.EncodeToString(own[:]), hex.EncodeToString(want[:]))
+	}
+	return &sealedPolicy{doc: doc, rtmr3: own}, nil
+}
+
+// checkDynamicRegister proves a dynamic boot left RTMR[3] at ForDynamic(seed):
+// the node plugin never extends the register itself, so anything else means
+// the static events, or something foreign, went in. The seed is the
+// initrd-staged operator key when one was launched with, else Zero.
+func checkDynamicRegister(pubkeyPath string) error {
+	seed := runtimemeasure.Zero
+	pub, err := os.ReadFile(pubkeyPath)
+	switch {
+	case err == nil && len(pub) > 0:
+		seed = runtimemeasure.ForOperatorKey(pub)
+	case err != nil && !errors.Is(err, os.ErrNotExist):
+		return fmt.Errorf("read operator pubkey: %w", err)
+	}
+	own, err := tdxrtmr.Read(3)
+	if err != nil {
+		return err
+	}
+	if want := runtimemeasure.ForDynamic(seed); own != want {
+		return fmt.Errorf("RTMR[3] is %s, want %s = ForDynamic(seed) on a dynamic boot", hex.EncodeToString(own[:]), hex.EncodeToString(want[:]))
+	}
+	return nil
+}
+
+// ownTuplePins pins the CDS peer to this node's own image tuple {MRTD,
+// RTMR1, RTMR2, RTMR3} as the attestation-api reports it from a fresh quote,
+// so no installer writes pins into the measured config. The reported RTMR[3]
+// must be the one the sealed load proved, or the verifier is not looking at
+// this node.
+func ownTuplePins(ctx context.Context, attestationAPIURL string, rtmr3 [runtimemeasure.Size]byte) (ratls.Pins, error) {
+	ctx, cancel := context.WithTimeout(ctx, selfAttestTimeout)
+	defer cancel()
+
+	entry, err := attestationclient.NewClient(attestationAPIURL).OwnTupleEntry(ctx)
+	if err != nil {
+		return ratls.Pins{}, err
+	}
+	if got := entry.RTMRs[3]; !bytes.Equal(got, rtmr3[:]) {
+		return ratls.Pins{}, fmt.Errorf("the verifier reports RTMR[3] %x, the sealed register is %x", got, rtmr3[:])
+	}
+	return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+}
+
+// oomScoreAdjPath is where the plugin lowers its own OOM score in sealed
+// mode: containerd launches it with no unit to carry OOMScoreAdjust=, and a
+// plugin the kernel kills mid-request admits that request. A var for tests.
+var oomScoreAdjPath = "/proc/self/oom_score_adj"
+
+func protectFromOOM(logger *slog.Logger) {
+	if err := os.WriteFile(oomScoreAdjPath, []byte("-1000\n"), 0); err != nil {
+		logger.Warn("cannot lower the plugin's OOM score; an OOM kill mid-request admits that request", "path", oomScoreAdjPath, "error", err)
+	}
+}

--- a/internal/cmds/nri-image-policy/sealed.go
+++ b/internal/cmds/nri-image-policy/sealed.go
@@ -11,37 +11,30 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
-	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
 
-// operatorPubkeyPath is where the measured initrd stages the operator public
-// key on a dynamic boot; the same path cred-release reads. A var so tests
-// point it at a temp file.
-var operatorPubkeyPath = "/etc/confai/operator-pubkey"
+// operatorPubkeyPath is the initrd-staged operator key of a dynamic boot. A
+// var so tests point it at a temp file.
+var operatorPubkeyPath = policybundle.OperatorPubkeyPath
 
 // poweroff powers the node off after a sealed-mode fatal condition. The plugin
 // is a containerd child, not a unit, so no FailureAction= applies to it. A var
 // so tests inject a recorder instead of powering off the test host.
 var poweroff = systemPoweroff
 
-// selfAttestTimeout bounds the own-quote round trip at startup; the socket
-// is local, so a slow answer means the verifier is not serving. It exceeds
-// containerd's plugin_registration_timeout, so Run registers the stub before
-// it attests (see pinOwnTuple).
-const selfAttestTimeout = 30 * time.Second
-
 // pinOwnTuple derives the CDS pins from the node's own quote. A var so tests
-// observe when Run calls it relative to stub registration.
+// observe when Run calls it relative to stub registration: the round trip
+// (attestationclient.OwnTupleTimeout) can outlast containerd's
+// plugin_registration_timeout, so Run registers the stub first.
 var pinOwnTuple = ownTuplePins
 
 // sealedPolicy is what a static boot pins the plugin to: the linted document,
@@ -137,23 +130,19 @@ func checkDynamicRegister(pubkeyPath string) error {
 	return nil
 }
 
-// ownTuplePins pins the CDS peer to this node's own image tuple {MRTD,
-// RTMR1, RTMR2, RTMR3} as the attestation-api reports it from a fresh quote,
-// so no installer writes pins into the measured config. The reported RTMR[3]
-// must be the one the sealed load proved, or the verifier is not looking at
-// this node.
+// ownTuplePins pins the CDS peer to this node's own image tuple, so no
+// installer writes pins into the measured config. The reported RTMR[3] must
+// be the one the sealed load proved, or the verifier is not looking at this
+// node.
 func ownTuplePins(ctx context.Context, attestationAPIURL string, rtmr3 [runtimemeasure.Size]byte) (ratls.Pins, error) {
-	ctx, cancel := context.WithTimeout(ctx, selfAttestTimeout)
-	defer cancel()
-
-	entry, err := attestationclient.NewClient(attestationAPIURL).OwnTupleEntry(ctx)
+	pins, err := ratls.OwnTuplePins(ctx, attestationclient.NewClient(attestationAPIURL))
 	if err != nil {
 		return ratls.Pins{}, err
 	}
-	if got := entry.RTMRs[3]; !bytes.Equal(got, rtmr3[:]) {
+	if got := pins.Entries[0].RTMRs[3]; !bytes.Equal(got, rtmr3[:]) {
 		return ratls.Pins{}, fmt.Errorf("the verifier reports RTMR[3] %x, the sealed register is %x", got, rtmr3[:])
 	}
-	return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+	return pins, nil
 }
 
 // oomScoreAdjPath is where the plugin lowers its own OOM score in sealed

--- a/internal/cmds/nri-image-policy/sealed_plugin.go
+++ b/internal/cmds/nri-image-policy/sealed_plugin.go
@@ -1,0 +1,251 @@
+package nriimagepolicy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/containerd/nri/pkg/api"
+
+	"github.com/confidential-dot-ai/c8s/internal/audit"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// sealedHookTimeout is the plugin's own deadline for a sealed-mode hook,
+// below containerd's plugin_request_timeout (2s on the node image). nri
+// v0.12.2 admits a request whose plugin call times out; answering first with
+// a deny closes that window until the patched containerd ships. A var so
+// tests shrink it.
+var sealedHookTimeout = 1500 * time.Millisecond
+
+// errSealedFatal is what a sealed hook returns after asking for power-off, so
+// containerd also drops the request should the power-off not land.
+var errSealedFatal = errors.New("sealed image policy: fatal condition, node is powering off")
+
+// sealedVerdict is the decision PostCreateContainer cached for StartContainer.
+type sealedVerdict struct {
+	denied bool
+	reason string
+}
+
+// verdictCache keeps per-container verdicts between hooks, keyed by
+// container ID. RemoveContainer evicts.
+type verdictCache struct {
+	mu sync.Mutex
+	m  map[string]sealedVerdict
+}
+
+func (c *verdictCache) put(id string, v sealedVerdict) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.m == nil {
+		c.m = map[string]sealedVerdict{}
+	}
+	c.m[id] = v
+}
+
+func (c *verdictCache) get(id string) (sealedVerdict, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	v, ok := c.m[id]
+	return v, ok
+}
+
+func (c *verdictCache) drop(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.m, id)
+}
+
+// fatal handles a sealed-mode condition the node must not survive: log,
+// power off, and return the error the hook answers with.
+func (p *plugin) fatal(reason string, args ...any) error {
+	p.logger.Error("sealed image policy: fatal, powering the node off: "+reason, args...)
+	if err := p.poweroff(); err != nil {
+		p.logger.Error("power-off failed", "error", err)
+	}
+	return errSealedFatal
+}
+
+// sealedSynchronize refuses a node that already runs containers: containerd
+// starts after the measured unit and this plugin registers before the first
+// create, so anything present ran unchecked and stopping it now is too late.
+func (p *plugin) sealedSynchronize(pods []*api.PodSandbox, ctrs []*api.Container) ([]*api.ContainerUpdate, error) {
+	if len(ctrs) > 0 {
+		podByID := make(map[string]*api.PodSandbox, len(pods))
+		for _, pod := range pods {
+			podByID[pod.GetId()] = pod
+		}
+		for _, ctr := range ctrs {
+			pod := podByID[ctr.GetPodSandboxId()]
+			p.logger.Error("container present before the sealed plugin registered",
+				"namespace", pod.GetNamespace(), "pod", pod.GetName(), "container", ctr.GetName(),
+				"image", ctr.GetAnnotations()[annotationImageName], "id", ctr.GetId())
+		}
+		return nil, p.fatal("containers were running at Synchronize", "containers", len(ctrs))
+	}
+	if p.inventory != nil {
+		for _, pod := range pods {
+			p.inventory.recordSandbox(pod.GetId())
+		}
+	}
+	p.logger.Info("sealed: no containers at Synchronize", "pods", len(pods))
+	return nil, nil
+}
+
+// withinDeadline runs check under sealedHookTimeout and answers a deny when
+// it does not finish in time, so the runtime always hears a verdict before
+// its own timeout admits the request. A check that finishes after the deny
+// keeps running to its end, so callers keep side effects out of it and act
+// on the returned verdict instead.
+func (p *plugin) withinDeadline(ctx context.Context, hook string, check func(ctx context.Context) error) error {
+	ctx, cancel := context.WithTimeout(ctx, sealedHookTimeout)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- check(ctx) }()
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		p.logger.Error("sealed hook did not answer in time; denying", "hook", hook, "timeout", sealedHookTimeout)
+		return fmt.Errorf("image policy %s did not complete within %s", hook, sealedHookTimeout)
+	}
+}
+
+// sealedCreate is the sealed CreateContainer: everything the NRI message
+// carries is matched against a complete rule, and OCI hooks are refused here
+// because runc runs them at create, before StartContainer could deny.
+func (p *plugin) sealedCreate(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	imageRef := ctr.GetAnnotations()[annotationImageName]
+	var digest string
+	err := p.withinDeadline(ctx, "CreateContainer", func(ctx context.Context) error {
+		if verdict, reason := p.checkLabels(p.cfg, pod.GetNamespace(), pod.GetName(), ctr.GetName(), pod.GetLabels()); verdict == verdictDeny {
+			return errors.New(reason)
+		}
+		obs, err := p.sealedObservation(ctx, pod, ctr, imageRef)
+		if err != nil {
+			return err
+		}
+		digest = obs.Digest
+		return p.sealedAdmit(pod, ctr, imageRef, obs, "CreateContainer")
+	})
+	if err != nil {
+		return err
+	}
+	// Recorded only for a delivered admission: a check that admits after
+	// the deadline describes a container the runtime never created.
+	p.recordDigest(ctr, digest)
+	return nil
+}
+
+// PostCreateContainer evaluates the stored OCI spec, which carries what the
+// NRI message lacks, and caches the verdict for StartContainer. containerd
+// ignores this hook's error, so the deny lands at start; the round trip to
+// containerd happens here, where a slow answer only delays.
+func (p *plugin) PostCreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	if p.sealed == nil {
+		return nil
+	}
+	err := p.withinDeadline(ctx, "PostCreateContainer", func(ctx context.Context) error {
+		return p.evaluateSpec(ctx, pod, ctr, "PostCreateContainer")
+	})
+	p.verdicts.put(ctr.GetId(), sealedVerdict{denied: err != nil, reason: errString(err)})
+	return err
+}
+
+// StartContainer answers from the PostCreateContainer verdict: containerd
+// deletes the created task on error before the entrypoint runs. A container
+// with no cached verdict is evaluated here, and a failure to evaluate is a
+// deny.
+func (p *plugin) StartContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	if p.sealed == nil {
+		return nil
+	}
+	if v, ok := p.verdicts.get(ctr.GetId()); ok {
+		if v.denied {
+			return errors.New(v.reason)
+		}
+		return nil
+	}
+	p.logger.Warn("no cached verdict at StartContainer; evaluating the spec now", "container", ctr.GetName())
+	err := p.withinDeadline(ctx, "StartContainer", func(ctx context.Context) error {
+		return p.evaluateSpec(ctx, pod, ctr, "StartContainer")
+	})
+	p.verdicts.put(ctr.GetId(), sealedVerdict{denied: err != nil, reason: errString(err)})
+	return err
+}
+
+// evaluateSpec re-observes the container from the message and the stored
+// spec together and matches the result.
+func (p *plugin) evaluateSpec(ctx context.Context, pod *api.PodSandbox, ctr *api.Container, hook string) error {
+	imageRef := ctr.GetAnnotations()[annotationImageName]
+	obs, err := p.sealedObservation(ctx, pod, ctr, imageRef)
+	if err != nil {
+		return err
+	}
+	spec, err := p.containerd.Spec(ctx, ctr.GetId())
+	if err != nil {
+		p.logger.Error("cannot load the OCI spec; denying", "container", ctr.GetName(), "error", err)
+		return fmt.Errorf("image policy cannot load the OCI spec of %s", imageRef)
+	}
+	obs = observeSpec(obs, spec)
+	return p.sealedAdmit(pod, ctr, imageRef, obs, hook, specSecurity(spec)...)
+}
+
+// sealedObservation resolves the digest and builds the observation. A
+// missing annotation or an unresolvable reference is a deny: the sealed
+// document admits nothing without a digest.
+func (p *plugin) sealedObservation(ctx context.Context, pod *api.PodSandbox, ctr *api.Container, imageRef string) (allowlist.Observation, error) {
+	if imageRef == "" {
+		return allowlist.Observation{}, errors.New("container has no image annotation")
+	}
+	digest := extractDigest(imageRef)
+	if digest == "" {
+		resolved, err := p.containerd.Resolve(ctx, imageRef)
+		if err != nil {
+			return allowlist.Observation{}, fmt.Errorf("cannot resolve digest for %s: %v", imageRef, err)
+		}
+		digest = resolved
+	}
+	return p.observer.observe(pod, ctr, digest), nil
+}
+
+// sealedAdmit matches an observation and logs the whole of it on a deny,
+// which is how a reviewer completes a floor rule from a dynamic node. The
+// returned reason names only the image (see checkImage).
+func (p *plugin) sealedAdmit(pod *api.PodSandbox, ctr *api.Container, imageRef string, obs allowlist.Observation, hook string, extra ...any) error {
+	snap := p.policy.current()
+	if snap == nil || snap.index == nil {
+		return fmt.Errorf("no allowlist available for %s", imageRef)
+	}
+	event := audit.Event{
+		Namespace: pod.GetNamespace(), Pod: pod.GetName(), Container: ctr.GetName(), Image: imageRef,
+	}
+	rule, ok := snap.index.Admit(obs)
+	if !ok {
+		p.logger.Warn("sealed: container not admitted",
+			append([]any{
+				"hook", hook, "namespace", pod.GetNamespace(), "pod", pod.GetName(), "container", ctr.GetName(),
+				"image", imageRef, "digest", obs.Digest, "argv", obs.Argv, "env", obs.Env, "mounts", obs.Mounts,
+				"host_namespaces", obs.HostNamespaces, "devices", obs.Devices, "capabilities", obs.Capabilities,
+				"hooks", obs.Hooks, "privileged", obs.Privileged, "unmasked_proc", obs.UnmaskedProc, "sources", obs.Sources,
+			}, extra...)...)
+		event.Action, event.Reason = "deny", "sealed_not_admitted"
+		p.audit.Log(event)
+		return fmt.Errorf("container not admitted by the sealed allowlist: %s", imageRef)
+	}
+	p.logger.Info("sealed: container admitted", "hook", hook, "rule", rule,
+		"namespace", pod.GetNamespace(), "pod", pod.GetName(), "container", ctr.GetName(), "image", imageRef)
+	event.Action, event.Reason, event.Rule = "allow", "sealed_verified", rule
+	p.audit.Log(event)
+	return nil
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/cmds/nri-image-policy/sealed_plugin_test.go
+++ b/internal/cmds/nri-image-policy/sealed_plugin_test.go
@@ -155,7 +155,8 @@ func TestSealedCreateContainer_PrivilegedEntry(t *testing.T) {
 	ctr := &api.Container{
 		Id: "cni", PodSandboxId: testSandboxID, Name: "agent",
 		Annotations: map[string]string{annotationImageName: "registry/cni@" + pushDigestB},
-		Args:        []string{"/agent", "--anything"},
+		Args:        []string{"/agent"},
+		Env:         []string{"PATH=/bin"},
 		Mounts:      []*api.Mount{sysfsMount("nosuid"), bind("/host/modules", "/lib/modules/6.12/kernel")},
 		Linux: &api.LinuxContainer{Namespaces: []*api.LinuxNamespace{{Type: "pid"}, {Type: "ipc"}},
 			Devices: []*api.LinuxDevice{{Path: "/dev/kvm"}}},
@@ -166,6 +167,11 @@ func TestSealedCreateContainer_PrivilegedEntry(t *testing.T) {
 	ctr.Mounts = append(ctr.Mounts, bind("/host/etc", "/etc"))
 	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
 		t.Fatal("CreateContainer(privileged entry, hostPath outside hostPaths) admitted")
+	}
+	ctr.Mounts = ctr.Mounts[:2]
+	ctr.Args = []string{"/bin/sh", "-c", "id"}
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+		t.Fatal("CreateContainer(privileged entry, other argv) admitted: a privileged image with an open argv is a shell on the node")
 	}
 }
 

--- a/internal/cmds/nri-image-policy/sealed_plugin_test.go
+++ b/internal/cmds/nri-image-policy/sealed_plugin_test.go
@@ -1,0 +1,434 @@
+package nriimagepolicy
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/nri/pkg/api"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/confidential-dot-ai/c8s/internal/audit"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// sealedPlugin is a plugin sealed to sealedDocument with a poweroff recorder.
+func sealedPlugin(t *testing.T, cfg *config) (*plugin, *atomic.Int32) {
+	t.Helper()
+	doc, _ := sealedDocument(t)
+	if cfg == nil {
+		cfg = &config{Policy: policyConfig{Mode: ModeFailClosed, EnforceExisting: true, DenyMissingAnnotation: true}}
+	}
+	if err := validateLabelRules(cfg.Policy.LabelRules); err != nil {
+		t.Fatal(err)
+	}
+	store := newPolicyStore(nil)
+	store.apply(doc, 0)
+	var calls atomic.Int32
+	p := &plugin{
+		cfg:        cfg,
+		policy:     store,
+		audit:      audit.NewLogger(),
+		logger:     discardLogger(),
+		containerd: &fakeContainerd{},
+		sealed:     &sealedPolicy{doc: doc, hostIP: "10.0.0.7", nodeName: "node-a"},
+		observer:   testObserver(),
+		poweroff:   func() error { calls.Add(1); return nil },
+	}
+	return p, &calls
+}
+
+// webPod and webContainer are the pod and container the web rule admits.
+func webPod() *api.PodSandbox {
+	return &api.PodSandbox{Id: testSandboxID, Name: "web-0", Namespace: "tenant", Uid: testPodUID, Ips: []string{"10.42.0.9"}}
+}
+
+func webContainer(image string) *api.Container {
+	podRoot := allowlist.KubeletVolumesRoot + testPodUID + "/"
+	return &api.Container{
+		Id: "web-ctr", PodSandboxId: testSandboxID, Name: "app",
+		Annotations: map[string]string{annotationImageName: image},
+		Args:        []string{"/app", "serve"},
+		Env:         []string{"PATH=/bin", "POD_NAME=web-0", "NODE=node-a"},
+		Mounts: []*api.Mount{
+			sysfsMount("nosuid", "noexec", "nodev", "ro"),
+			bind("/etc/hosts", podRoot+"etc-hosts"),
+			bind("/data", podRoot+"volumes/kubernetes.io~empty-dir/data"),
+			bind("/var/run/secrets/kubernetes.io/serviceaccount", podRoot+"volumes/kubernetes.io~projected/kube-api-access-abc"),
+		},
+		Linux: &api.LinuxContainer{Namespaces: ownNamespaces()},
+	}
+}
+
+// webSpec is the stored OCI spec of an admitted web container.
+func webSpec() *oci.Spec {
+	bounding := []string{"CAP_CHOWN", "CAP_KILL"}
+	return &oci.Spec{
+		Mounts:  []specs.Mount{{Destination: "/sys", Type: "sysfs", Options: []string{"ro"}}},
+		Process: &specs.Process{Capabilities: &specs.LinuxCapabilities{Bounding: bounding}, NoNewPrivileges: true},
+		Linux:   &specs.Linux{MaskedPaths: []string{"/proc/kcore"}},
+	}
+}
+
+func specReturning(spec *oci.Spec, err error) func(context.Context, string) (*oci.Spec, error) {
+	return func(context.Context, string) (*oci.Spec, error) { return spec, err }
+}
+
+func TestSealedCreateContainer(t *testing.T) {
+	image := "registry/web@" + pushDigestA
+	for _, tc := range []struct {
+		name    string
+		pod     func() *api.PodSandbox
+		ctr     func() *api.Container
+		cfg     *config
+		wantErr string
+	}{
+		{"admitted", webPod, func() *api.Container { return webContainer(image) }, nil, ""},
+		{"no annotation", webPod, func() *api.Container { return webContainer("") }, nil, "no image annotation"},
+		{"unlisted digest", webPod, func() *api.Container { return webContainer("registry/web@" + pushDigestC) }, nil, "not admitted by the sealed allowlist"},
+		{"argv drift", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Args = append(c.Args, "--debug")
+			return c
+		}, nil, "not admitted"},
+		{"env value drift", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Env[0] = "PATH=/bin:/evil"
+			return c
+		}, nil, "not admitted"},
+		{"from-source drift", func() *api.PodSandbox {
+			p := webPod()
+			p.Name = "web-1"
+			return p
+		}, func() *api.Container { return webContainer(image) }, nil, "not admitted"},
+		{"configMap mount", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Mounts = append(c.Mounts, bind("/etc/app", allowlist.KubeletVolumesRoot+testPodUID+"/volumes/kubernetes.io~configmap/cfg"))
+			return c
+		}, nil, "not admitted"},
+		{"host pid namespace", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Linux.Namespaces = []*api.LinuxNamespace{{Type: "network"}, {Type: "ipc"}}
+			return c
+		}, nil, "not admitted"},
+		{"hooks", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Hooks = &api.Hooks{Prestart: []*api.Hook{{Path: "/hook"}}}
+			return c
+		}, nil, "not admitted"},
+		{"device", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Linux.Devices = []*api.LinuxDevice{{Path: "/dev/kvm"}}
+			return c
+		}, nil, "not admitted"},
+		{"privileged", webPod, func() *api.Container {
+			c := webContainer(image)
+			c.Mounts[0] = sysfsMount("nosuid")
+			return c
+		}, nil, "not admitted"},
+		{"label rule denies first", webPod, func() *api.Container { return webContainer(image) },
+			&config{Policy: policyConfig{Mode: ModeFailClosed, LabelRules: []labelRule{{Name: "tenant",
+				MatchExpressions: []labelExpression{{Key: "tenant", Operator: OpExists}}}}}}, `label rule "tenant" denied`},
+		{"audit mode does not pass through", webPod, func() *api.Container { return webContainer("registry/web@" + pushDigestC) },
+			&config{Policy: policyConfig{Mode: ModeAudit}}, "not admitted"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _ := sealedPlugin(t, tc.cfg)
+			_, _, err := p.CreateContainer(context.Background(), tc.pod(), tc.ctr())
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("CreateContainer(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+			if err != nil && strings.Contains(err.Error(), "--debug") {
+				t.Fatalf("CreateContainer(%s) error %q leaks argv", tc.name, err)
+			}
+		})
+	}
+}
+
+func TestSealedCreateContainer_PrivilegedEntry(t *testing.T) {
+	p, _ := sealedPlugin(t, nil)
+	pod := &api.PodSandbox{Id: testSandboxID, Name: "cni-x", Namespace: "kube-system", Uid: testPodUID}
+	ctr := &api.Container{
+		Id: "cni", PodSandboxId: testSandboxID, Name: "agent",
+		Annotations: map[string]string{annotationImageName: "registry/cni@" + pushDigestB},
+		Args:        []string{"/agent", "--anything"},
+		Mounts:      []*api.Mount{sysfsMount("nosuid"), bind("/host/modules", "/lib/modules/6.12/kernel")},
+		Linux: &api.LinuxContainer{Namespaces: []*api.LinuxNamespace{{Type: "pid"}, {Type: "ipc"}},
+			Devices: []*api.LinuxDevice{{Path: "/dev/kvm"}}},
+	}
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+		t.Fatalf("CreateContainer(privileged entry) = %v, want admitted", err)
+	}
+	ctr.Mounts = append(ctr.Mounts, bind("/host/etc", "/etc"))
+	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+		t.Fatal("CreateContainer(privileged entry, hostPath outside hostPaths) admitted")
+	}
+}
+
+func TestSealedCreateContainer_ResolvesTags(t *testing.T) {
+	p, _ := sealedPlugin(t, nil)
+	fake := p.containerd.(*fakeContainerd)
+	fake.resolve = func(_ context.Context, ref string) (string, error) {
+		if ref != "registry/web:v1" {
+			t.Fatalf("Resolve(%q), want registry/web:v1", ref)
+		}
+		return pushDigestA, nil
+	}
+	if _, _, err := p.CreateContainer(context.Background(), webPod(), webContainer("registry/web:v1")); err != nil {
+		t.Fatalf("CreateContainer(tag) = %v, want admitted through resolution", err)
+	}
+	fake.resolve = func(context.Context, string) (string, error) { return "", errors.New("not pulled") }
+	if _, _, err := p.CreateContainer(context.Background(), webPod(), webContainer("registry/web:v1")); err == nil || !strings.Contains(err.Error(), "cannot resolve digest") {
+		t.Fatalf("CreateContainer(unresolvable tag) = %v, want a resolve denial", err)
+	}
+}
+
+func TestSealedCreateContainer_RecordsForInventory(t *testing.T) {
+	p, _ := sealedPlugin(t, nil)
+	p.inventory = newAdmissionInventory(t.TempDir())
+	if _, _, err := p.CreateContainer(context.Background(), webPod(), webContainer("registry/web@"+pushDigestA)); err != nil {
+		t.Fatal(err)
+	}
+	if rec, ok := p.inventory.containers["web-ctr"]; !ok || rec.digest != pushDigestA {
+		t.Fatalf("inventory record = %+v, %v; want digest %s", rec, ok, pushDigestA)
+	}
+	if _, _, err := p.CreateContainer(context.Background(), webPod(), webContainer("registry/web@"+pushDigestC)); err == nil {
+		t.Fatal("denied container admitted")
+	}
+	if len(p.inventory.containers) != 1 {
+		t.Fatalf("denied container recorded: %d records", len(p.inventory.containers))
+	}
+}
+
+// A check that admits after the deadline describes a container the runtime
+// never created (it heard the deny), so the inventory must not record it.
+func TestSealedCreateContainer_LateAdmissionIsNotRecorded(t *testing.T) {
+	prev := sealedHookTimeout
+	sealedHookTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { sealedHookTimeout = prev })
+
+	p, _ := sealedPlugin(t, nil)
+	p.inventory = newAdmissionInventory(t.TempDir())
+	release := make(chan struct{})
+	resolved := make(chan struct{}, 2)
+	p.containerd.(*fakeContainerd).resolve = func(context.Context, string) (string, error) {
+		<-release
+		resolved <- struct{}{}
+		return pushDigestA, nil
+	}
+	_, _, err := p.CreateContainer(context.Background(), webPod(), webContainer("registry/web:v1"))
+	if err == nil || !strings.Contains(err.Error(), "CreateContainer did not complete within") {
+		t.Fatalf("CreateContainer(slow resolve) = %v, want a timeout denial", err)
+	}
+	close(release)
+	<-resolved
+	// The late check admits right after resolving; give it time to act.
+	time.Sleep(50 * time.Millisecond)
+	if n := len(p.inventory.containers); n != 0 {
+		t.Fatalf("late admission recorded %d containers, want 0", n)
+	}
+}
+
+func TestSealedHooks_TimeoutDenies(t *testing.T) {
+	prev := sealedHookTimeout
+	sealedHookTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { sealedHookTimeout = prev })
+
+	p, _ := sealedPlugin(t, nil)
+	fake := p.containerd.(*fakeContainerd)
+	fake.resolve = func(ctx context.Context, _ string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	fake.spec = func(ctx context.Context, _ string) (*oci.Spec, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	pod, ctr := webPod(), webContainer("registry/web:v1")
+	start := time.Now()
+	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	if err == nil || !strings.Contains(err.Error(), "CreateContainer did not complete within") {
+		t.Fatalf("CreateContainer(slow resolve) = %v, want a timeout denial", err)
+	}
+	if err := p.StartContainer(context.Background(), pod, webContainer("registry/web@"+pushDigestA)); err == nil || !strings.Contains(err.Error(), "StartContainer did not complete within") {
+		t.Fatalf("StartContainer(slow spec) = %v, want a timeout denial", err)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("hooks took %s, want well under the runtime's 2s", elapsed)
+	}
+}
+
+func TestSealedPostCreateAndStart(t *testing.T) {
+	image := "registry/web@" + pushDigestA
+	privileged := webSpec()
+	privileged.Mounts[0].Options = nil
+	extraCaps := webSpec()
+	extraCaps.Process.Capabilities.Bounding = append(extraCaps.Process.Capabilities.Bounding, "CAP_SYS_ADMIN")
+	unmasked := webSpec()
+	unmasked.Linux.MaskedPaths = nil
+	for _, tc := range []struct {
+		name    string
+		spec    *oci.Spec
+		specErr error
+		wantErr string
+	}{
+		{"spec matches", webSpec(), nil, ""},
+		{"spec adds a capability", extraCaps, nil, "not admitted"},
+		{"spec is privileged", privileged, nil, "not admitted"},
+		{"spec unmasks proc", unmasked, nil, "not admitted"},
+		{"spec cannot be loaded", nil, errors.New("gone"), "cannot load the OCI spec"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _ := sealedPlugin(t, nil)
+			fake := p.containerd.(*fakeContainerd)
+			loads := 0
+			fake.spec = func(context.Context, string) (*oci.Spec, error) { loads++; return tc.spec, tc.specErr }
+			pod, ctr := webPod(), webContainer(image)
+
+			postErr := p.PostCreateContainer(context.Background(), pod, ctr)
+			startErr := p.StartContainer(context.Background(), pod, ctr)
+			if (tc.wantErr == "") != (startErr == nil) || (startErr != nil && !strings.Contains(startErr.Error(), tc.wantErr)) {
+				t.Fatalf("StartContainer(%s) = %v, want error containing %q", tc.name, startErr, tc.wantErr)
+			}
+			if (postErr == nil) != (startErr == nil) {
+				t.Fatalf("PostCreateContainer(%s) = %v but StartContainer = %v", tc.name, postErr, startErr)
+			}
+			if loads != 1 {
+				t.Fatalf("StartContainer(%s) loaded the spec again: %d loads, want the cached verdict", tc.name, loads)
+			}
+
+			// Eviction forgets the verdict; the next start re-evaluates.
+			if err := p.RemoveContainer(context.Background(), pod, ctr); err != nil {
+				t.Fatal(err)
+			}
+			if _, ok := p.verdicts.get(ctr.GetId()); ok {
+				t.Fatal("RemoveContainer left the verdict cached")
+			}
+			if err := p.StartContainer(context.Background(), pod, ctr); loads != 2 || (err == nil) != (startErr == nil) {
+				t.Fatalf("StartContainer(%s) after eviction = %v with %d loads, want a re-evaluation", tc.name, err, loads)
+			}
+		})
+	}
+}
+
+func TestSealedPostCreateAndStart_DenyIsCachedNotRecomputed(t *testing.T) {
+	p, _ := sealedPlugin(t, nil)
+	fake := p.containerd.(*fakeContainerd)
+	fake.spec = specReturning(webSpec(), nil)
+	pod, ctr := webPod(), webContainer("registry/web@"+pushDigestC)
+	if err := p.PostCreateContainer(context.Background(), pod, ctr); err == nil {
+		t.Fatal("PostCreateContainer admitted an unlisted digest")
+	}
+	// A container whose message changed after create still gets the cached
+	// deny: the verdict follows the ID.
+	if err := p.StartContainer(context.Background(), pod, webContainer("registry/web@"+pushDigestA)); err == nil || !strings.Contains(err.Error(), "not admitted") {
+		t.Fatalf("StartContainer(cached deny) = %v, want the cached denial", err)
+	}
+}
+
+func TestSealedHooks_DynamicPluginIsUntouched(t *testing.T) {
+	p := floorPlugin(t)
+	if err := p.PostCreateContainer(context.Background(), webPod(), webContainer("x")); err != nil {
+		t.Fatalf("PostCreateContainer(dynamic) = %v, want nil", err)
+	}
+	if err := p.StartContainer(context.Background(), webPod(), webContainer("x")); err != nil {
+		t.Fatalf("StartContainer(dynamic) = %v, want nil", err)
+	}
+}
+
+func TestSealedSynchronize(t *testing.T) {
+	t.Run("no containers seeds the inventory", func(t *testing.T) {
+		p, calls := sealedPlugin(t, nil)
+		p.inventory = newAdmissionInventory(t.TempDir())
+		if _, err := p.Synchronize(context.Background(), []*api.PodSandbox{webPod()}, nil); err != nil {
+			t.Fatalf("Synchronize(no containers) = %v, want nil", err)
+		}
+		if _, _, known, _ := p.inventory.DigestsForSandbox(testSandboxID); !known {
+			t.Fatal("sandbox not seeded")
+		}
+		if calls.Load() != 0 {
+			t.Fatal("powered off with no containers")
+		}
+	})
+	t.Run("a running container powers the node off", func(t *testing.T) {
+		p, calls := sealedPlugin(t, nil)
+		_, err := p.Synchronize(context.Background(), []*api.PodSandbox{webPod()}, []*api.Container{webContainer("registry/web@" + pushDigestA)})
+		if !errors.Is(err, errSealedFatal) {
+			t.Fatalf("Synchronize(running container) = %v, want errSealedFatal", err)
+		}
+		if calls.Load() != 1 {
+			t.Fatalf("poweroff called %d times, want 1", calls.Load())
+		}
+	})
+	t.Run("power-off failure still returns the fatal error", func(t *testing.T) {
+		p, _ := sealedPlugin(t, nil)
+		p.poweroff = func() error { return errors.New("no systemd") }
+		if _, err := p.Synchronize(context.Background(), nil, []*api.Container{webContainer("x")}); !errors.Is(err, errSealedFatal) {
+			t.Fatalf("Synchronize(orphan container, poweroff fails) = %v, want errSealedFatal", err)
+		}
+	})
+}
+
+func TestSealedConfigure(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		require   bool
+		version   string
+		inventory bool
+		wantErr   bool
+	}{
+		{"marker not required", false, "v2.3.4", false, false},
+		{"marker required and present", true, "v2.3.4+c8s.nri-failclosed", false, false},
+		{"marker required and absent", true, "v2.3.4", false, true},
+		{"marker required, inventory on", true, "v2.3.4+c8s.nri-failclosed.1", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, _ := sealedPlugin(t, &config{Runtime: runtimeConfig{RequireFailClosed: tc.require}, Policy: policyConfig{Mode: ModeFailClosed}})
+			if tc.inventory {
+				p.inventory = newAdmissionInventory(t.TempDir())
+			}
+			mask, err := p.Configure(context.Background(), "", "containerd", tc.version)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Configure(%s) = %v, want error %v", tc.name, err, tc.wantErr)
+			}
+			if err != nil {
+				if !strings.Contains(err.Error(), FailClosedRuntimeMarker) {
+					t.Fatalf("Configure(%s) error %q does not name the marker", tc.name, err)
+				}
+				return
+			}
+			for _, ev := range []api.Event{api.Event_CREATE_CONTAINER, api.Event_POST_CREATE_CONTAINER, api.Event_START_CONTAINER, api.Event_REMOVE_CONTAINER} {
+				if !mask.IsSet(ev) {
+					t.Errorf("Configure(%s) did not subscribe %s", tc.name, ev)
+				}
+			}
+			if mask.IsSet(api.Event_RUN_POD_SANDBOX) != tc.inventory {
+				t.Errorf("Configure(%s) pod-sandbox subscription = %v, want %v", tc.name, mask.IsSet(api.Event_RUN_POD_SANDBOX), tc.inventory)
+			}
+		})
+	}
+}
+
+func TestVerdictCache(t *testing.T) {
+	var c verdictCache
+	if _, ok := c.get("a"); ok {
+		t.Fatal("empty cache answered")
+	}
+	c.put("a", sealedVerdict{denied: true, reason: "no"})
+	c.put("b", sealedVerdict{})
+	if v, ok := c.get("a"); !ok || !v.denied || v.reason != "no" {
+		t.Fatalf("get(a) = %+v, %v; want the stored deny", v, ok)
+	}
+	c.drop("a")
+	c.drop("never-stored")
+	if _, ok := c.get("a"); ok {
+		t.Fatal("drop(a) left the verdict")
+	}
+	if v, ok := c.get("b"); !ok || v.denied {
+		t.Fatalf("get(b) = %+v, %v; want the stored allow", v, ok)
+	}
+}

--- a/internal/cmds/nri-image-policy/sealed_test.go
+++ b/internal/cmds/nri-image-policy/sealed_test.go
@@ -1,0 +1,456 @@
+package nriimagepolicy
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	testPodUID    = "11111111-2222-3333-4444-555555555555"
+	testSandboxID = "sandbox0123"
+)
+
+func str(s string) *string { return &s }
+
+// sealedDocument is a complete sealed document with one unprivileged web
+// entry (pushDigestA) and one privileged node-TCB entry (pushDigestB), in the
+// canonical bytes a node measures.
+func sealedDocument(t *testing.T) (*allowlist.Allowlist, []byte) {
+	t.Helper()
+	web := allowlist.Container{
+		Digest:  mustDigest(t, pushDigestA),
+		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/app"}},
+		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"serve"}},
+		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact,
+			Destinations: []string{"/etc/hosts", "/data", "/var/run/secrets/kubernetes.io/serviceaccount"},
+			Rules: map[string]allowlist.MountRule{
+				"/etc/hosts": {Source: allowlist.SourcePlatform},
+				"/data":      {Source: allowlist.SourceEmptyDir},
+				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: allowlist.SourceServiceAccountToken},
+			}},
+		Env: allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH", "POD_NAME", "NODE"},
+			Values: map[string]allowlist.EnvValue{
+				"PATH":     {Value: str("/bin")},
+				"POD_NAME": {From: allowlist.FromPodName},
+				"NODE":     {From: allowlist.FromNodeName},
+			}},
+	}
+	agent := allowlist.Container{
+		Digest:  mustDigest(t, pushDigestB),
+		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+		Privileges: &allowlist.Privileges{Privileged: true, HostNamespaces: []string{allowlist.HostNamespaceNet},
+			HostPaths: []string{"/lib/modules/"}, Review: "node TCB: the CNI agent"},
+	}
+	raw, err := json.Marshal(&allowlist.Allowlist{Schema: allowlist.Schema, Digests: map[string]string{}, Workloads: map[string]allowlist.Workload{
+		"web":   {Containers: []allowlist.Container{web}},
+		"agent": {Containers: []allowlist.Container{agent}},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := allowlist.ParseJSON(raw)
+	if err != nil {
+		t.Fatalf("parse fixture: %v", err)
+	}
+	canonical, err := doc.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := allowlist.LintSealed(canonical); err != nil {
+		t.Fatalf("fixture is not sealed: %v", err)
+	}
+	return doc, canonical
+}
+
+// writeRegister points tdxrtmr at a temp sysfs root holding RTMR[3] = value.
+func writeRegister(t *testing.T, value [runtimemeasure.Size]byte) {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "rtmr3:sha384"), value[:], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prev := tdxrtmr.SysfsRoot
+	tdxrtmr.SysfsRoot = root
+	t.Cleanup(func() { tdxrtmr.SysfsRoot = prev })
+}
+
+// writePolicyDir lays out what c8s-policy-measure writes for a static boot
+// and sets the register to match; mutate edits the files before the load.
+func writePolicyDir(t *testing.T, doc []byte) (dir string, bundle policybundle.Bundle) {
+	t.Helper()
+	dir = t.TempDir()
+	bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := bundle.IndexDigest()
+	for name, content := range map[string]string{
+		policybundle.ModeFile:              policybundle.StaticMode + "\n",
+		policybundle.DigestFile:            hex.EncodeToString(digest[:]) + "\n",
+		policybundle.MemberStaticAllowlist: string(doc),
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o444); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeRegister(t, bundle.RTMR3())
+	return dir, bundle
+}
+
+// overwrite replaces a read-only policy file the way a tampering host would.
+func overwrite(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// recordPoweroff swaps the package poweroff for a counter.
+func recordPoweroff(t *testing.T) *atomic.Int32 {
+	t.Helper()
+	var calls atomic.Int32
+	prev := poweroff
+	poweroff = func() error { calls.Add(1); return nil }
+	t.Cleanup(func() { poweroff = prev })
+	return &calls
+}
+
+// loadSealed takes the bundle policybundle.ReadDir already re-indexed, so
+// these cases mutate the member bytes and the register, not the directory.
+func TestLoadSealed(t *testing.T) {
+	_, doc := sealedDocument(t)
+	for _, tc := range []struct {
+		name    string
+		member  []byte
+		mutate  func(t *testing.T)
+		wantErr string
+	}{
+		{"valid", doc, nil, ""},
+		{"member not canonical", append(append([]byte{}, doc...), '\n'), nil, "not its canonical form"},
+		{"member not sealed", []byte(`{"schema":"c8s.allowlist/v1","digests":{"` + pushDigestA + `":"a"},"workloads":{}}`), nil, "digests must be empty"},
+		{"member not json", []byte("{"), nil, "decode allowlist"},
+		{"register mismatch", doc, func(t *testing.T) {
+			writeRegister(t, runtimemeasure.ForDynamic(runtimemeasure.Zero))
+		}, "RTMR[3] is"},
+		{"register unreadable", doc, func(t *testing.T) {
+			tdxrtmr.SysfsRoot = t.TempDir()
+		}, "is this a TDX guest"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: tc.member})
+			if err != nil {
+				t.Fatal(err)
+			}
+			writeRegister(t, bundle.RTMR3())
+			if tc.mutate != nil {
+				tc.mutate(t)
+			}
+			sealed, err := loadSealed(bundle)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("loadSealed(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadSealed(%s) = %v, want nil", tc.name, err)
+			}
+			want := bundle.RTMR3()
+			if sealed.rtmr3 != want || len(sealed.doc.Workloads) != 2 {
+				t.Fatalf("loadSealed(%s) = rtmr3 %x, %d workloads; want %x, 2", tc.name, sealed.rtmr3[:4], len(sealed.doc.Workloads), want[:4])
+			}
+		})
+	}
+}
+
+func TestCheckDynamicRegister(t *testing.T) {
+	pub := []byte("-----BEGIN PUBLIC KEY-----\nMFkw\n-----END PUBLIC KEY-----\n")
+	for _, tc := range []struct {
+		name     string
+		pubkey   *[]byte
+		register [runtimemeasure.Size]byte
+		wantErr  string
+	}{
+		{"no key, chained zero", nil, runtimemeasure.ForDynamic(runtimemeasure.Zero), ""},
+		{"key, chained key", &pub, runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pub)), ""},
+		{"key, bare seed", &pub, runtimemeasure.ForOperatorKey(pub), "ForDynamic(seed)"},
+		{"no key, static register", nil, runtimemeasure.ForStaticAllowlist([]byte("{}")), "ForDynamic(seed)"},
+		{"empty key file reads as no key", new([]byte), runtimemeasure.ForDynamic(runtimemeasure.Zero), ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "operator-pubkey")
+			if tc.pubkey != nil {
+				if err := os.WriteFile(path, *tc.pubkey, 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			writeRegister(t, tc.register)
+			err := checkDynamicRegister(path)
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("checkDynamicRegister(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+		})
+	}
+	t.Run("unreadable key file", func(t *testing.T) {
+		writeRegister(t, runtimemeasure.ForDynamic(runtimemeasure.Zero))
+		if err := checkDynamicRegister(t.TempDir()); err == nil || !strings.Contains(err.Error(), "read operator pubkey") {
+			t.Fatalf("checkDynamicRegister(dir) = %v, want a read error", err)
+		}
+	})
+}
+
+func TestOwnTuplePins_SocketAbsentIsAnError(t *testing.T) {
+	_, err := ownTuplePins(t.Context(), "unix://"+filepath.Join(t.TempDir(), "absent.sock"), runtimemeasure.Zero)
+	if err == nil || !strings.Contains(err.Error(), "attest self") {
+		t.Fatalf("ownTuplePins(absent socket) = %v, want an attest error", err)
+	}
+}
+
+func hexReg(b byte) string { return strings.Repeat(hex.EncodeToString([]byte{b}), runtimemeasure.Size) }
+
+// TestOwnTuplePins covers the plugin's own rule over the shared tuple
+// derivation: the verifier's RTMR[3] must be the sealed register. The
+// verdict checks themselves are pkg/attestationclient's.
+func TestOwnTuplePins(t *testing.T) {
+	var sealed [runtimemeasure.Size]byte
+	copy(sealed[:], bytes.Repeat([]byte{0x33}, runtimemeasure.Size))
+	good := testattest.TDXVerdict(hexReg(0x11), map[int]string{0: hexReg(0x00), 1: hexReg(0x21), 2: hexReg(0x22), 3: hex.EncodeToString(sealed[:])})
+	foreign := testattest.TDXVerdict(hexReg(0x11), map[int]string{0: hexReg(0x00), 1: hexReg(0x21), 2: hexReg(0x22), 3: hexReg(0x44)})
+	unsigned := good
+	unsigned.SignatureValid = false
+	for _, tc := range []struct {
+		name    string
+		verdict testattest.Verdict
+		wantErr string
+	}{
+		{"own tuple", good, ""},
+		{"foreign RTMR[3]", foreign, "the verifier reports RTMR[3]"},
+		{"signature invalid", unsigned, "verify self-report"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub, url := testattest.NewUnix(t)
+			stub.SetPlatform(types.PlatformTdx)
+			stub.SetVerdict(tc.verdict)
+			pins, err := ownTuplePins(t.Context(), url, sealed)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ownTuplePins(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ownTuplePins(%s) = %v, want nil", tc.name, err)
+			}
+			if len(pins.Entries) != 1 || len(pins.Measurements) != 0 || len(pins.RTMRs) != 0 {
+				t.Fatalf("ownTuplePins(%s) = %+v, want exactly one entry and no loose pins", tc.name, pins)
+			}
+			entry := pins.Entries[0]
+			if hex.EncodeToString(entry.Digest) != hexReg(0x11) || len(entry.RTMRs) != 3 || !bytes.Equal(entry.RTMRs[3], sealed[:]) {
+				t.Fatalf("ownTuplePins(%s) entry = digest %x, %d RTMRs, RTMR[3] %x; want %s, 3, the sealed register", tc.name, entry.Digest, len(entry.RTMRs), entry.RTMRs[3], hexReg(0x11))
+			}
+		})
+	}
+}
+
+func TestNodeIP(t *testing.T) {
+	withFile := t.TempDir()
+	if err := os.WriteFile(filepath.Join(withFile, NodeIPFile), []byte(" 10.0.0.7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, socketDir, want string
+		wantOK                bool
+	}{
+		{"no socket dir", "", "", false},
+		{"file absent", t.TempDir(), "", false},
+		{"file present", withFile, "10.0.0.7", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &config{WorkloadClaims: workloadClaimsConfig{SocketDir: tc.socketDir}}
+			if got, ok := nodeIP(cfg); got != tc.want || ok != tc.wantOK {
+				t.Fatalf("nodeIP(%s) = %q, %v, want %q, %v", tc.name, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestKubeletNodeName(t *testing.T) {
+	for in, want := range map[string]string{
+		"Node-A":     "node-a",
+		" node-b \n": "node-b",
+		"node-c":     "node-c",
+	} {
+		if got := kubeletNodeName(in); got != want {
+			t.Errorf("kubeletNodeName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestProtectFromOOM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "oom_score_adj")
+	if err := os.WriteFile(path, []byte("0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	prev := oomScoreAdjPath
+	oomScoreAdjPath = path
+	t.Cleanup(func() { oomScoreAdjPath = prev })
+	protectFromOOM(discardLogger())
+	if b, _ := os.ReadFile(path); strings.TrimSpace(string(b)) != "-1000" {
+		t.Fatalf("oom_score_adj = %q, want -1000", b)
+	}
+	// An unwritable path only logs.
+	oomScoreAdjPath = filepath.Join(t.TempDir(), "missing", "oom_score_adj")
+	protectFromOOM(discardLogger())
+}
+
+// --- Run: policy mode at startup ---
+
+func sealedConfigYAML(t *testing.T, policyDir, platform string) string {
+	t.Helper()
+	dir := t.TempDir()
+	return fmt.Sprintf(`
+platform: %s
+plugin:
+  health_addr: unix://%s/health.sock
+containerd:
+  socket: %s/ctr.sock
+allowlist:
+  policy_dir: %s
+  always_allow:
+    "%s": image-a
+  pull:
+    attestation_api_url: unix://%s/attestation-api.sock
+policy:
+  mode: fail-closed
+  enforce_existing: false
+logging:
+  level: error
+`, platform, dir, dir, policyDir, pushDigestA, dir)
+}
+
+func TestRun_PolicyMode(t *testing.T) {
+	_, doc := sealedDocument(t)
+	for _, tc := range []struct {
+		name         string
+		platform     string
+		layout       func(t *testing.T) string
+		wantErr      string
+		wantPoweroff int32
+	}{
+		{"mode file missing powers off", "snp", func(t *testing.T) string { return t.TempDir() }, "policy mode", 1},
+		{"foreign mode powers off", "snp", func(t *testing.T) string {
+			dir := t.TempDir()
+			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("audit\n"))
+			return dir
+		}, `holds "audit"`, 1},
+		{"dynamic on snp skips the register and reaches registration", "snp", func(t *testing.T) string {
+			dir := t.TempDir()
+			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("dynamic\n"))
+			return dir
+		}, "plugin: ", 0},
+		{"dynamic on tdx with a foreign register powers off", "tdx", func(t *testing.T) string {
+			dir := t.TempDir()
+			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("dynamic\n"))
+			writeRegister(t, runtimemeasure.ForStaticAllowlist([]byte("{}")))
+			prev := operatorPubkeyPath
+			operatorPubkeyPath = filepath.Join(dir, "no-such-key")
+			t.Cleanup(func() { operatorPubkeyPath = prev })
+			return dir
+		}, "dynamic boot: RTMR[3]", 1},
+		{"static with a broken bundle powers off", "tdx", func(t *testing.T) string {
+			dir, _ := writePolicyDir(t, doc)
+			os.Remove(filepath.Join(dir, policybundle.DigestFile))
+			return dir
+		}, "policy digest", 1},
+		{"static with no verifier socket powers off", "tdx", func(t *testing.T) string {
+			dir, _ := writePolicyDir(t, doc)
+			return dir
+		}, "pin CDS to the node's own tuple", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := recordPoweroff(t)
+			prevOOM := oomScoreAdjPath
+			oomScoreAdjPath = filepath.Join(t.TempDir(), "oom_score_adj")
+			t.Cleanup(func() { oomScoreAdjPath = prevOOM })
+			policyDir := tc.layout(t)
+			err := runWithDeadline(t, 20*time.Second, []string{"-config", writeConfigYAML(t, sealedConfigYAML(t, policyDir, tc.platform))})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Run(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+			if got := calls.Load(); got != tc.wantPoweroff {
+				t.Fatalf("Run(%s) powered off %d times, want %d", tc.name, got, tc.wantPoweroff)
+			}
+		})
+	}
+}
+
+// The own-quote round trip may outlast containerd's registration window, so
+// Run must have the stub registering before it attests: the registration
+// request is on the wire by the time the pin function runs.
+func TestRun_SealedRegistersBeforeSelfAttest(t *testing.T) {
+	_, doc := sealedDocument(t)
+	policyDir, _ := writePolicyDir(t, doc)
+	calls := recordPoweroff(t)
+	prevOOM := oomScoreAdjPath
+	oomScoreAdjPath = filepath.Join(t.TempDir(), "oom_score_adj")
+	t.Cleanup(func() { oomScoreAdjPath = prevOOM })
+	peer := holdNRISocket(t)
+
+	registered := make(chan error, 1)
+	prev := pinOwnTuple
+	pinOwnTuple = func(context.Context, string, [runtimemeasure.Size]byte) (ratls.Pins, error) {
+		_ = peer.SetReadDeadline(time.Now().Add(5 * time.Second))
+		_, err := peer.Read(make([]byte, 1))
+		registered <- err
+		return ratls.Pins{}, errors.New("verifier down")
+	}
+	t.Cleanup(func() { pinOwnTuple = prev })
+
+	err := runWithDeadline(t, 20*time.Second, []string{"-config", writeConfigYAML(t, sealedConfigYAML(t, policyDir, "tdx"))})
+	if err == nil || !strings.Contains(err.Error(), "verifier down") {
+		t.Fatalf("Run(sealed, verifier down) = %v, want the pin error", err)
+	}
+	select {
+	case err := <-registered:
+		if err != nil {
+			t.Fatalf("no registration request reached the runtime before the self-attestation: %v", err)
+		}
+	default:
+		t.Fatal("Run returned without attesting")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("Run(sealed, verifier down) powered off %d times, want 1", got)
+	}
+}
+
+func TestSealedFatal_ReportsPoweroffFailure(t *testing.T) {
+	prev := poweroff
+	poweroff = func() error { return errors.New("no systemd") }
+	t.Cleanup(func() { poweroff = prev })
+	cause := errors.New("bundle gone")
+	if err := sealedFatal(discardLogger(), cause); !errors.Is(err, cause) {
+		t.Fatalf("sealedFatal(cause) = %v, want the cause back", err)
+	}
+}

--- a/internal/cmds/nri-image-policy/sealed_test.go
+++ b/internal/cmds/nri-image-policy/sealed_test.go
@@ -44,7 +44,7 @@ func sealedDocument(t *testing.T) (*allowlist.Allowlist, []byte) {
 			Rules: map[string]allowlist.MountRule{
 				"/etc/hosts": {Source: allowlist.SourcePlatform},
 				"/data":      {Source: allowlist.SourceEmptyDir},
-				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: allowlist.SourceServiceAccountToken},
+				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: allowlist.SourceServiceAccountToken, Review: "the app reads nothing there"},
 			}},
 		Env: allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH", "POD_NAME", "NODE"},
 			Values: map[string]allowlist.EnvValue{
@@ -55,8 +55,12 @@ func sealedDocument(t *testing.T) (*allowlist.Allowlist, []byte) {
 	}
 	agent := allowlist.Container{
 		Digest:  mustDigest(t, pushDigestB),
-		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
-		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/agent"}},
+		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyDeny},
+		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: []string{"/host/modules"},
+			Rules: map[string]allowlist.MountRule{"/host/modules": {Source: allowlist.SourceHostPath, Path: "/lib/modules/"}}},
+		Env: allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH"},
+			Values: map[string]allowlist.EnvValue{"PATH": {Value: str("/bin")}}},
 		Privileges: &allowlist.Privileges{Privileged: true, HostNamespaces: []string{allowlist.HostNamespaceNet},
 			HostPaths: []string{"/lib/modules/"}, Review: "node TCB: the CNI agent"},
 	}
@@ -341,13 +345,51 @@ allowlist:
   always_allow:
     "%s": image-a
   pull:
+    url: https://cds.example:8443
     attestation_api_url: unix://%s/attestation-api.sock
 policy:
   mode: fail-closed
   enforce_existing: false
 logging:
   level: error
-`, platform, dir, dir, policyDir, pushDigestA, dir)
+`, platform, dir, dir, policyDir, pushDigestC, dir)
+}
+
+// A sealed store holds the measured bundle alone: the config's always_allow
+// floor and pull URL, which the baked image-policy.yaml carries for dynamic
+// boots, must not reach the index or start the pull loop.
+func TestStartupPolicy(t *testing.T) {
+	doc, _ := sealedDocument(t)
+	cfg, err := loadConfig(writeConfigYAML(t, sealedConfigYAML(t, t.TempDir(), "tdx")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.PullEnabled() || len(cfg.Allowlist.AlwaysAllow) != 1 {
+		t.Fatalf("fixture config: pull %v, always_allow %d; want a pull URL and one floor digest", cfg.PullEnabled(), len(cfg.Allowlist.AlwaysAllow))
+	}
+	for _, tc := range []struct {
+		name          string
+		sealed        *sealedPolicy
+		wantFloor     bool
+		wantBootstrap bool
+		wantPull      bool
+	}{
+		{"sealed", &sealedPolicy{doc: doc}, false, false, false},
+		{"dynamic", nil, true, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store, bootstrap, pull := startupPolicy(cfg, tc.sealed)
+			if got := store.current().index.AdmitsDigest(pushDigestC); got != tc.wantFloor {
+				t.Errorf("startupPolicy(%s) index admits the always_allow digest = %v, want %v", tc.name, got, tc.wantFloor)
+			}
+			if (bootstrap != nil) != tc.wantBootstrap || pull != tc.wantPull {
+				t.Errorf("startupPolicy(%s) = bootstrap %v, pull %v; want bootstrap %v, pull %v", tc.name, bootstrap != nil, pull, tc.wantBootstrap, tc.wantPull)
+			}
+			if tc.sealed != nil && !store.current().index.AdmitsDigest(pushDigestA) {
+				t.Errorf("startupPolicy(%s) index lacks the bundle's own digest", tc.name)
+			}
+		})
+	}
 }
 
 func TestRun_PolicyMode(t *testing.T) {
@@ -365,11 +407,6 @@ func TestRun_PolicyMode(t *testing.T) {
 			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("audit\n"))
 			return dir
 		}, `holds "audit"`, 1},
-		{"dynamic on snp skips the register and reaches registration", "snp", func(t *testing.T) string {
-			dir := t.TempDir()
-			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("dynamic\n"))
-			return dir
-		}, "plugin: ", 0},
 		{"dynamic on tdx with a foreign register powers off", "tdx", func(t *testing.T) string {
 			dir := t.TempDir()
 			overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("dynamic\n"))
@@ -403,6 +440,25 @@ func TestRun_PolicyMode(t *testing.T) {
 				t.Fatalf("Run(%s) powered off %d times, want %d", tc.name, got, tc.wantPoweroff)
 			}
 		})
+	}
+}
+
+// A dynamic boot on SEV-SNP has no register to check: Run must not read
+// sysfs (a foreign RTMR[3] there is ignored) and must get as far as NRI
+// registration. With the config's pull URL in force on a dynamic boot, the
+// plugin dies registering (no NRI socket here) during the initial pull,
+// which Run reports as errPluginDied.
+func TestRun_DynamicOnSNPSkipsRegister(t *testing.T) {
+	calls := recordPoweroff(t)
+	dir := t.TempDir()
+	overwrite(t, filepath.Join(dir, policybundle.ModeFile), []byte("dynamic\n"))
+	writeRegister(t, runtimemeasure.ForStaticAllowlist([]byte("{}")))
+	err := runWithDeadline(t, 20*time.Second, []string{"-config", writeConfigYAML(t, sealedConfigYAML(t, dir, "snp"))})
+	if !errors.Is(err, errPluginDied) {
+		t.Fatalf("Run(dynamic on snp) = %v, want %v from NRI registration", err, errPluginDied)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("Run(dynamic on snp) powered off %d times, want 0", got)
 	}
 }
 

--- a/internal/cmds/policydisk/cmd.go
+++ b/internal/cmds/policydisk/cmd.go
@@ -1,0 +1,203 @@
+// Package policydisk implements `c8s policy-disk`: it builds the policydata
+// ISO a static-allowlist node boots with from the reviewed bundle members,
+// and prints the index digest and RTMR[3] the node will report so the
+// reviewer can pin them before the node exists.
+package policydisk
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// VolumeLabel is the ISO9660 volume label the node image looks the policy
+// bundle up by (/dev/disk/by-label/policydata).
+const VolumeLabel = "policydata"
+
+// isoTools are the ISO9660 authoring tools tried in order; the first on PATH
+// wins. They share the option set the node image's own test harness uses.
+var isoTools = []string{"xorrisofs", "genisoimage", "mkisofs"}
+
+// Config is what one run takes.
+type Config struct {
+	// Members are the files that make up the bundle; each becomes a member
+	// named by its basename.
+	Members []string
+	// Output is the ISO path to write.
+	Output string
+	// KubeVirtSecret, when set, names a Secret to emit on stdout that KubeVirt
+	// turns into the same disk (a secret volume with volumeLabel policydata).
+	KubeVirtSecret string
+}
+
+// NewCmd returns the cobra subcommand.
+func NewCmd() *cobra.Command {
+	var cfg Config
+	cmd := &cobra.Command{
+		Use:   "policy-disk --member <file>... -o <iso>",
+		Short: "Build the policydata disk a static-allowlist node boots with",
+		Long: `Builds the policydata ISO from the reviewed bundle members and prints the
+index digest and the RTMR[3] a node sealed to it reports. static-allowlist.json
+is required and is linted as a sealed document first: its bytes are what the
+node measures, so it must be canonical and complete.
+
+Attach the ISO to the node at launch with volume label policydata (libvirt:
+a CD-ROM device). On KubeVirt pass --kubevirt-secret <name>: the command then
+writes a Secret holding the members, plus the volume to add to the
+VirtualMachine, to stdout, and the digest lines to stderr.
+
+Requires xorrisofs, genisoimage or mkisofs on PATH.`,
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return Run(cmd.Context(), cfg, cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+	}
+	f := cmd.Flags()
+	f.StringArrayVar(&cfg.Members, "member", nil, "bundle member file; repeatable. The basename is the member name and static-allowlist.json is required")
+	f.StringVarP(&cfg.Output, "output", "o", "", "ISO path to write (required)")
+	f.StringVar(&cfg.KubeVirtSecret, "kubevirt-secret", "", "also write a Secret of this name holding the members, and the KubeVirt volume that mounts it as the policydata disk, to stdout")
+	_ = cmd.MarkFlagRequired("member")
+	_ = cmd.MarkFlagRequired("output")
+	return cmd
+}
+
+// Run builds the bundle, writes the ISO and prints the measurements. The
+// digest lines go to stdout, or to stderr when the KubeVirt manifest takes
+// stdout, so `> volume.yaml` captures exactly one document stream.
+func Run(ctx context.Context, cfg Config, stdout, stderr io.Writer) error {
+	bundle, err := loadMembers(cfg.Members)
+	if err != nil {
+		return err
+	}
+	if err := pkgallowlist.LintSealed(bundle.Members[policybundle.MemberStaticAllowlist]); err != nil {
+		return fmt.Errorf("%s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	tool, err := findISOTool()
+	if err != nil {
+		return err
+	}
+	if err := writeISO(ctx, tool, bundle, cfg.Output); err != nil {
+		return err
+	}
+
+	report := stdout
+	if cfg.KubeVirtSecret != "" {
+		report = stderr
+		manifest, err := kubeVirtManifest(cfg.KubeVirtSecret, bundle)
+		if err != nil {
+			return err
+		}
+		if _, err := stdout.Write(manifest); err != nil {
+			return err
+		}
+	}
+	digest := bundle.IndexDigest()
+	rtmr3 := bundle.RTMR3()
+	fmt.Fprintf(report, "index-digest: sha256:%s\n", hex.EncodeToString(digest[:]))
+	fmt.Fprintf(report, "rtmr3: %s\n", hex.EncodeToString(rtmr3[:]))
+	return nil
+}
+
+// loadMembers reads each member file under the bundle's own bounds. Two
+// paths with one basename would silently drop one, so that is an error.
+func loadMembers(paths []string) (policybundle.Bundle, error) {
+	members := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		name := filepath.Base(path)
+		if _, dup := members[name]; dup {
+			return policybundle.Bundle{}, fmt.Errorf("--member %s: a member named %q was already given", path, name)
+		}
+		f, err := os.Open(path)
+		if err != nil {
+			return policybundle.Bundle{}, fmt.Errorf("--member: %w", err)
+		}
+		data, err := io.ReadAll(io.LimitReader(f, policybundle.MaxMemberSize+1))
+		f.Close()
+		if err != nil {
+			return policybundle.Bundle{}, fmt.Errorf("--member %s: %w", path, err)
+		}
+		members[name] = data
+	}
+	return policybundle.FromMembers(members)
+}
+
+// findISOTool returns the first ISO authoring tool on PATH.
+func findISOTool() (string, error) {
+	for _, tool := range isoTools {
+		if path, err := exec.LookPath(tool); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("no ISO9660 tool on PATH: install one of %s", strings.Join(isoTools, ", "))
+}
+
+// writeISO stages the members in a temporary directory and runs the tool
+// over it, so members given from different directories land flat under
+// their bundle names. Joliet and Rock Ridge are both written: the node
+// mounts iso9660 and reads the names the index was computed over.
+func writeISO(ctx context.Context, tool string, bundle policybundle.Bundle, out string) error {
+	stage, err := os.MkdirTemp("", "policydata-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(stage)
+	for name, data := range bundle.Members {
+		if err := os.WriteFile(filepath.Join(stage, name), data, 0o444); err != nil {
+			return fmt.Errorf("stage %s: %w", name, err)
+		}
+	}
+	cmd := exec.CommandContext(ctx, tool, "-V", VolumeLabel, "-J", "-R", "-o", out, stage)
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%s: %w\n%s", filepath.Base(tool), err, strings.TrimSpace(output.String()))
+	}
+	return nil
+}
+
+// kubeVirtManifest renders the Secret KubeVirt serves as the policydata disk
+// and, as comments after it, the disk and volume entries the VirtualMachine
+// needs. Comments keep `kubectl apply -f` to the one document it can apply.
+func kubeVirtManifest(name string, bundle policybundle.Bundle) ([]byte, error) {
+	secret := corev1.Secret{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Data:       bundle.Members,
+	}
+	doc, err := sigsyaml.Marshal(secret)
+	if err != nil {
+		return nil, fmt.Errorf("encode secret: %w", err)
+	}
+	var b bytes.Buffer
+	b.Write(doc)
+	fmt.Fprintf(&b, `---
+# Add to the VirtualMachine's spec.template.spec (no opkeydata disk: a static
+# node has no operator key):
+#   domain.devices.disks:
+#     - name: %[1]s
+#       disk:
+#         bus: virtio
+#   volumes:
+#     - name: %[1]s
+#       secret:
+#         secretName: %[2]s
+#         volumeLabel: %[1]s
+`, VolumeLabel, name)
+	return b.Bytes(), nil
+}

--- a/internal/cmds/policydisk/cmd.go
+++ b/internal/cmds/policydisk/cmd.go
@@ -114,8 +114,8 @@ func Run(ctx context.Context, cfg Config, stdout, stderr io.Writer) error {
 	return nil
 }
 
-// loadMembers reads each member file under the bundle's own bounds. Two
-// paths with one basename would silently drop one, so that is an error.
+// loadMembers reads each member file. Two paths with one basename would
+// silently drop one, so that is an error.
 func loadMembers(paths []string) (policybundle.Bundle, error) {
 	members := make(map[string][]byte, len(paths))
 	for _, path := range paths {
@@ -123,14 +123,9 @@ func loadMembers(paths []string) (policybundle.Bundle, error) {
 		if _, dup := members[name]; dup {
 			return policybundle.Bundle{}, fmt.Errorf("--member %s: a member named %q was already given", path, name)
 		}
-		f, err := os.Open(path)
+		data, err := policybundle.ReadMember(path)
 		if err != nil {
 			return policybundle.Bundle{}, fmt.Errorf("--member: %w", err)
-		}
-		data, err := io.ReadAll(io.LimitReader(f, policybundle.MaxMemberSize+1))
-		f.Close()
-		if err != nil {
-			return policybundle.Bundle{}, fmt.Errorf("--member %s: %w", path, err)
 		}
 		members[name] = data
 	}

--- a/internal/cmds/policydisk/cmd_test.go
+++ b/internal/cmds/policydisk/cmd_test.go
@@ -20,6 +20,14 @@ import (
 
 // sealedDoc is a complete one-entry sealed allowlist in canonical bytes, the
 // only shape the member lint accepts.
+// goldenIndexDigest and goldenRTMR3 are IndexDigest and RTMR3 of the
+// one-member bundle holding sealedDoc, frozen so a change to what
+// policy-disk prints fails here rather than on a node.
+const (
+	goldenIndexDigest = "a9fcb41b544900137e2c78a784149e94e45ecc3ce1e17e385f471f876f124343"
+	goldenRTMR3       = "37f566599428ed639fac1e806a3c1dc0e18b3cd5a4443ed1f0bcd8b9098971d70be1bd83daf104409e9a9802025874c5"
+)
+
 func sealedDoc(t *testing.T) []byte {
 	t.Helper()
 	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{
@@ -76,14 +84,19 @@ func TestRunWritesISOAndPrintsMeasurements(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
+	// Frozen for sealedDoc: the two lines are what a reviewer pastes into
+	// launch tooling, so they are held to fixed vectors, not recomputed
+	// through the helpers Run itself calls.
+	want := "index-digest: sha256:" + goldenIndexDigest + "\nrtmr3: " + goldenRTMR3 + "\n"
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
 	bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: doc})
 	if err != nil {
 		t.Fatal(err)
 	}
-	digest, rtmr3 := bundle.IndexDigest(), bundle.RTMR3()
-	want := "index-digest: sha256:" + hex.EncodeToString(digest[:]) + "\nrtmr3: " + hex.EncodeToString(rtmr3[:]) + "\n"
-	if stdout.String() != want {
-		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	if digest, rtmr3 := bundle.IndexDigest(), bundle.RTMR3(); hex.EncodeToString(digest[:]) != goldenIndexDigest || hex.EncodeToString(rtmr3[:]) != goldenRTMR3 {
+		t.Errorf("policybundle derives %x / %x for sealedDoc, want the frozen %s / %s", digest, rtmr3, goldenIndexDigest, goldenRTMR3)
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr = %q, want empty without --kubevirt-secret", stderr.String())

--- a/internal/cmds/policydisk/cmd_test.go
+++ b/internal/cmds/policydisk/cmd_test.go
@@ -1,0 +1,242 @@
+package policydisk
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// sealedDoc is a complete one-entry sealed allowlist in canonical bytes, the
+// only shape the member lint accepts.
+func sealedDoc(t *testing.T) []byte {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{
+		"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+		"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},
+		"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func writeFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// stubISOTool puts a fake ISO tool named name on PATH. It records its argv
+// and the staged directory listing, and creates the -o output.
+func stubISOTool(t *testing.T, name string) (argvLog, stagedLog string) {
+	t.Helper()
+	bin := t.TempDir()
+	argvLog = filepath.Join(bin, name+".argv")
+	stagedLog = filepath.Join(bin, name+".staged")
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' \"$*\" > '" + argvLog + "'\n" +
+		"out=''\nwhile [ $# -gt 1 ]; do if [ \"$1\" = -o ]; then out=$2; fi; shift; done\n" +
+		"ls -1 \"$1\" > '" + stagedLog + "'\n" +
+		": > \"$out\"\n"
+	if err := os.WriteFile(filepath.Join(bin, name), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin+":"+os.Getenv("PATH"))
+	return argvLog, stagedLog
+}
+
+func TestRunWritesISOAndPrintsMeasurements(t *testing.T) {
+	argvLog, stagedLog := stubISOTool(t, "xorrisofs")
+	doc := sealedDoc(t)
+	member := writeFile(t, t.TempDir(), "static-allowlist.json", doc)
+	out := filepath.Join(t.TempDir(), "policydata.iso")
+
+	var stdout, stderr bytes.Buffer
+	if err := Run(context.Background(), Config{Members: []string{member}, Output: out}, &stdout, &stderr); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, rtmr3 := bundle.IndexDigest(), bundle.RTMR3()
+	want := "index-digest: sha256:" + hex.EncodeToString(digest[:]) + "\nrtmr3: " + hex.EncodeToString(rtmr3[:]) + "\n"
+	if stdout.String() != want {
+		t.Errorf("stdout = %q, want %q", stdout.String(), want)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty without --kubevirt-secret", stderr.String())
+	}
+
+	argv, err := os.ReadFile(argvLog)
+	if err != nil {
+		t.Fatalf("the ISO tool was not run: %v", err)
+	}
+	if !strings.HasPrefix(string(argv), "-V policydata -J -R -o "+out+" ") {
+		t.Errorf("ISO tool argv = %q, want -V policydata -J -R -o %s <stage dir>", argv, out)
+	}
+	staged, _ := os.ReadFile(stagedLog)
+	if strings.TrimSpace(string(staged)) != policybundle.MemberStaticAllowlist {
+		t.Errorf("staged dir lists %q, want exactly %s", staged, policybundle.MemberStaticAllowlist)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Errorf("output ISO not created: %v", err)
+	}
+}
+
+// The member name is the basename: a file reviewed under another name is
+// staged and indexed as static-allowlist.json only when it is called that.
+func TestRunKubeVirtSecret(t *testing.T) {
+	stubISOTool(t, "genisoimage")
+	doc := sealedDoc(t)
+	member := writeFile(t, t.TempDir(), "static-allowlist.json", doc)
+
+	var stdout, stderr bytes.Buffer
+	cfg := Config{Members: []string{member}, Output: filepath.Join(t.TempDir(), "p.iso"), KubeVirtSecret: "vm-policy"}
+	if err := Run(context.Background(), cfg, &stdout, &stderr); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if !strings.HasPrefix(stderr.String(), "index-digest: sha256:") || !strings.Contains(stderr.String(), "\nrtmr3: ") {
+		t.Errorf("stderr = %q, want the digest lines moved off stdout", stderr.String())
+	}
+	docs := strings.SplitN(stdout.String(), "\n---\n", 2)
+	if len(docs) != 2 {
+		t.Fatalf("stdout = %q, want a Secret document followed by the volume notes", stdout.String())
+	}
+	var secret corev1.Secret
+	if err := sigsyaml.Unmarshal([]byte(docs[0]), &secret); err != nil {
+		t.Fatalf("decode Secret: %v\n%s", err, docs[0])
+	}
+	if secret.Kind != "Secret" || secret.Name != "vm-policy" {
+		t.Errorf("Secret = %s/%s, want Secret/vm-policy", secret.Kind, secret.Name)
+	}
+	if got := secret.Data[policybundle.MemberStaticAllowlist]; !bytes.Equal(got, doc) {
+		t.Errorf("Secret data[%s] differs from the member bytes", policybundle.MemberStaticAllowlist)
+	}
+	for _, want := range []string{"secretName: vm-policy", "volumeLabel: policydata", "bus: virtio"} {
+		if !strings.Contains(docs[1], want) {
+			t.Errorf("volume notes missing %q:\n%s", want, docs[1])
+		}
+	}
+	for _, line := range strings.Split(strings.TrimSpace(docs[1]), "\n") {
+		if !strings.HasPrefix(line, "#") {
+			t.Errorf("volume notes line %q is not a comment; kubectl apply would read it as a second document", line)
+		}
+	}
+}
+
+func TestRunErrors(t *testing.T) {
+	dir := t.TempDir()
+	doc := sealedDoc(t)
+	sealed := writeFile(t, dir, "static-allowlist.json", doc)
+	if err := os.MkdirAll(filepath.Join(dir, "x"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	unsealed := writeFile(t, filepath.Join(dir, "x"), "static-allowlist.json", append(slices.Clone(doc), '\n'))
+	if err := os.MkdirAll(filepath.Join(dir, "y"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nullDigests := writeFile(t, filepath.Join(dir, "y"), "static-allowlist.json", bytes.Replace(doc, []byte(`"digests":{}`), []byte(`"digests":null`), 1))
+	routes := writeFile(t, dir, "routes.json", []byte("{}"))
+	renamed := writeFile(t, dir, "reviewed.json", doc)
+
+	for _, tc := range []struct {
+		name    string
+		members []string
+		tool    string
+		want    string
+	}{
+		{"no static-allowlist.json", []string{routes}, "xorrisofs", "no static-allowlist.json member"},
+		{"renamed member", []string{renamed}, "xorrisofs", "no static-allowlist.json member"},
+		{"unknown member", []string{sealed, routes}, "xorrisofs", `member "routes.json" is unknown`},
+		{"non-canonical member", []string{unsealed}, "xorrisofs", "not its canonical form"},
+		{"digests null", []string{nullDigests}, "xorrisofs", `"digests" must be {}`},
+		{"duplicate basename", []string{sealed, unsealed}, "xorrisofs", "already given"},
+		{"missing file", []string{filepath.Join(dir, "absent.json")}, "xorrisofs", "--member"},
+		{"no ISO tool", []string{sealed}, "", "install one of xorrisofs, genisoimage, mkisofs"},
+		{"ISO tool fails", []string{sealed}, "failing", "mkisofs: exit status 3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			switch tc.tool {
+			case "":
+				t.Setenv("PATH", t.TempDir())
+			case "failing":
+				bin := t.TempDir()
+				if err := os.WriteFile(filepath.Join(bin, "mkisofs"), []byte("#!/bin/sh\necho no space; exit 3\n"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				t.Setenv("PATH", bin)
+			default:
+				stubISOTool(t, tc.tool)
+			}
+			var stdout, stderr bytes.Buffer
+			err := Run(context.Background(), Config{Members: tc.members, Output: filepath.Join(t.TempDir(), "p.iso")}, &stdout, &stderr)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Run(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("Run(%s) printed %q before failing", tc.name, stdout.String())
+			}
+		})
+	}
+}
+
+// The first tool on PATH in the documented order wins, whatever else is
+// installed.
+func TestFindISOToolOrder(t *testing.T) {
+	bin := t.TempDir()
+	for _, name := range []string{"mkisofs", "genisoimage"} {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", bin)
+	got, err := findISOTool()
+	if err != nil {
+		t.Fatalf("findISOTool: %v", err)
+	}
+	if filepath.Base(got) != "genisoimage" {
+		t.Errorf("findISOTool() = %s, want genisoimage ahead of mkisofs", got)
+	}
+}
+
+func TestNewCmdFlags(t *testing.T) {
+	cmd := NewCmd()
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	cmd.SetArgs([]string{"-o", "x.iso"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), `"member"`) {
+		t.Fatalf("Execute without --member = %v, want the required-flag error", err)
+	}
+	for _, name := range []string{"member", "output", "kubevirt-secret"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("missing --%s flag", name)
+		}
+	}
+	if !slices.Contains(isoTools, "xorrisofs") {
+		t.Error("xorrisofs must stay a supported tool")
+	}
+}

--- a/internal/cmds/policymeasure/cmd.go
+++ b/internal/cmds/policymeasure/cmd.go
@@ -1,0 +1,76 @@
+// Package policymeasure implements `c8s policy-measure`, the measured
+// c8s-policy-measure.service that runs on every node boot before RKE2 and
+// commits the boot's policy mode to RTMR[3]: ModeDynamic on a boot without
+// a policydata disk, ModeStatic followed by the policy event on a boot with
+// one. The mode is explicit and written to <policy-dir>/mode last, so every
+// static consumer (cred-release, the NRI plugin, CDS) reads a mode the
+// register already commits to and never infers one from a file's presence.
+package policymeasure
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// Launch disks and the staged key. The unit passes none of them, so the
+// binary defaults are the contract; the policy directory itself is
+// policybundle.DefaultPolicyDir, shared with every reader.
+const (
+	// DefaultOpkeyDisk is the operator-key launch ISO; its presence on a
+	// static boot is fatal.
+	DefaultOpkeyDisk = "/dev/disk/by-label/opkeydata"
+	// DefaultPolicyDisk is the policy bundle launch ISO.
+	DefaultPolicyDisk = "/dev/disk/by-label/policydata"
+	// DefaultOperatorPubkey is where the confos initrd stages the operator
+	// public key it measured into RTMR[3] (cred-release reads the same file).
+	DefaultOperatorPubkey = "/etc/confai/operator-pubkey"
+)
+
+// Config is the measurer's input.
+type Config struct {
+	// Platform is the TEE platform ("tdx" or "snp"). Only TDX has a runtime
+	// register; SNP boots are always dynamic.
+	Platform string
+	// PolicyDir receives mode, digest and the members.
+	PolicyDir string
+	// OpkeyDisk and PolicyDisk are the launch ISOs, by label.
+	OpkeyDisk  string
+	PolicyDisk string
+	// OperatorPubkey is the initrd-staged operator key, if any.
+	OperatorPubkey string
+}
+
+// NewCmd builds the `policy-measure` subcommand. It is run by the node
+// image's c8s-policy-measure.service, whose FailureAction powers the node
+// off on any non-zero exit.
+func NewCmd() *cobra.Command {
+	var cfg Config
+	cmd := &cobra.Command{
+		Use:   "policy-measure",
+		Short: "Commit the boot's policy mode (and static allowlist bundle) to RTMR[3]",
+		Long: "policy-measure runs once per boot, before containerd, and extends\n" +
+			"the policy mode event into TDX RTMR[3]. Without a policydata disk it\n" +
+			"extends ModeDynamic and writes mode=dynamic. With one it refuses an\n" +
+			"operator key, reads the bundle read-only, lints static-allowlist.json\n" +
+			"as a sealed document, publishes the members and their index digest\n" +
+			"under --policy-dir, extends ModeStatic and the policy event, checks\n" +
+			"the register reads back as ForStaticAllowlist(index), and writes\n" +
+			"mode=static last. Any failure exits non-zero.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return Run(cfg)
+		},
+	}
+	f := cmd.Flags()
+	f.StringVar(&cfg.Platform, "platform", "", "TEE platform: tdx or snp (required)")
+	f.StringVar(&cfg.PolicyDir, "policy-dir", policybundle.DefaultPolicyDir, "tmpfs directory that receives mode, digest and the bundle members")
+	f.StringVar(&cfg.OpkeyDisk, "opkey-disk", DefaultOpkeyDisk, "operator-key launch ISO; fatal when present on a static boot")
+	f.StringVar(&cfg.PolicyDisk, "policy-disk", DefaultPolicyDisk, "policy bundle launch ISO; absent means a dynamic boot")
+	f.StringVar(&cfg.OperatorPubkey, "operator-pubkey", DefaultOperatorPubkey, "initrd-staged operator public key; its RTMR[3] seed must match the register")
+	// No default: the baked unit always passes the flag explicitly.
+	_ = cmd.MarkFlagRequired("platform")
+	return cmd
+}

--- a/internal/cmds/policymeasure/cmd.go
+++ b/internal/cmds/policymeasure/cmd.go
@@ -22,9 +22,9 @@ const (
 	DefaultOpkeyDisk = "/dev/disk/by-label/opkeydata"
 	// DefaultPolicyDisk is the policy bundle launch ISO.
 	DefaultPolicyDisk = "/dev/disk/by-label/policydata"
-	// DefaultOperatorPubkey is where the confos initrd stages the operator
-	// public key it measured into RTMR[3] (cred-release reads the same file).
-	DefaultOperatorPubkey = "/etc/confai/operator-pubkey"
+	// DefaultOperatorPubkey is the initrd-staged operator key every
+	// dynamic-boot reader shares.
+	DefaultOperatorPubkey = policybundle.OperatorPubkeyPath
 )
 
 // Config is the measurer's input.

--- a/internal/cmds/policymeasure/cmd_test.go
+++ b/internal/cmds/policymeasure/cmd_test.go
@@ -1,0 +1,38 @@
+package policymeasure
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCmdDefaults(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "policy-measure" {
+		t.Fatalf("Use = %q, want policy-measure", cmd.Use)
+	}
+	flags := cmd.Flags()
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{"platform", ""},
+		{"policy-dir", "/run/confai/policy"},
+		{"opkey-disk", "/dev/disk/by-label/opkeydata"},
+		{"policy-disk", "/dev/disk/by-label/policydata"},
+		{"operator-pubkey", "/etc/confai/operator-pubkey"},
+	} {
+		flag := flags.Lookup(tc.name)
+		if flag == nil {
+			t.Errorf("flag %q not registered", tc.name)
+			continue
+		}
+		if flag.DefValue != tc.want {
+			t.Errorf("flag %q default = %q, want %q", tc.name, flag.DefValue, tc.want)
+		}
+	}
+	// Omitting --platform is a usage error, not a tdx default.
+	if pf := flags.Lookup("platform"); pf == nil || pf.Annotations[cobra.BashCompOneRequiredFlag] == nil {
+		t.Error("--platform is not marked required")
+	}
+}

--- a/internal/cmds/policymeasure/mount_linux.go
+++ b/internal/cmds/policymeasure/mount_linux.go
@@ -1,0 +1,15 @@
+package policymeasure
+
+import "golang.org/x/sys/unix"
+
+// mountISO and unmountISO attach the policydata ISO read-only, with device
+// nodes, setuid bits and execution refused: the disk is host-controlled
+// data, never code. Vars so tests substitute a directory copy.
+var (
+	mountISO = func(dev, target string) error {
+		return unix.Mount(dev, target, "iso9660", unix.MS_RDONLY|unix.MS_NODEV|unix.MS_NOSUID|unix.MS_NOEXEC, "")
+	}
+	unmountISO = func(target string) error {
+		return unix.Unmount(target, 0)
+	}
+)

--- a/internal/cmds/policymeasure/mount_other.go
+++ b/internal/cmds/policymeasure/mount_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package policymeasure
+
+import "errors"
+
+// The command only ever runs inside the Linux node image; the CLI build for
+// other platforms carries the subcommand but cannot mount a disk.
+var (
+	mountISO = func(dev, target string) error {
+		return errors.New("policy-measure: mounting the policydata ISO needs Linux")
+	}
+	unmountISO = func(target string) error { return nil }
+)

--- a/internal/cmds/policymeasure/node_image_test.go
+++ b/internal/cmds/policymeasure/node_image_test.go
@@ -1,0 +1,252 @@
+package policymeasure
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/cmds/attestproxy"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// The node image wires this command and its siblings through files nothing
+// else ties to the binary: the measurer unit, the socket unit, the preset
+// that creates their RequiredBy links, the tmpfiles that create /run/confai,
+// and the sync hook that renders the platform drop-in. Load them here so a
+// drift between a unit and the binary fails `go test`.
+const (
+	nodeImageDir      = "../../../node-guest-image/c8s"
+	measureService    = nodeImageDir + "/mkosi.extra/etc/systemd/system/c8s-policy-measure.service"
+	socketService     = nodeImageDir + "/mkosi.extra/etc/systemd/system/c8s-attest-socket.service"
+	nodeImagePreset   = nodeImageDir + "/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset"
+	nodeImageTmpfiles = nodeImageDir + "/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf"
+	nodeImageSync     = nodeImageDir + "/mkosi.sync"
+
+	attestationSocket = "/run/confai/attestation-api.sock"
+	rke2Pair          = "rke2-server.service rke2-agent.service"
+)
+
+// unitFile reads a unit with continuation lines joined, refusing the
+// backslash-then-whitespace form systemd does not treat as a continuation.
+func unitFile(t *testing.T, path string) string {
+	t.Helper()
+	unit, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if regexp.MustCompile(`\\[ \t]+\n`).Match(unit) {
+		t.Fatalf("%s has a backslash followed by whitespace: not a systemd continuation", path)
+	}
+	return strings.ReplaceAll(string(unit), "\\\n", " ")
+}
+
+// directives returns every value of name= in the unit, in order.
+func directives(unit, name string) []string {
+	var values []string
+	for _, line := range strings.Split(unit, "\n") {
+		if v, ok := strings.CutPrefix(line, name+"="); ok {
+			values = append(values, strings.TrimSpace(v))
+		}
+	}
+	return values
+}
+
+// execStart returns the single ExecStart's argv.
+func execStart(t *testing.T, unit, path string) []string {
+	t.Helper()
+	values := directives(unit, "ExecStart")
+	if len(values) != 1 {
+		t.Fatalf("%s ExecStart directive count = %d, want exactly 1", path, len(values))
+	}
+	return strings.Fields(values[0])
+}
+
+func TestNodeImagePolicyMeasureService(t *testing.T) {
+	unit := unitFile(t, measureService)
+	args := execStart(t, unit, measureService)
+	if len(args) < 2 || args[0] != "/usr/local/bin/c8s" || args[1] != "policy-measure" {
+		t.Fatalf("ExecStart = %q, want /usr/local/bin/c8s policy-measure ...", args)
+	}
+	// The platform is the only environment expansion: anything else would
+	// let a drop-in's Environment= repoint a disk or the policy dir.
+	var flagArgs []string
+	for _, arg := range args[2:] {
+		if arg == "--platform=${POLICY_PLATFORM}" {
+			continue
+		}
+		if strings.Contains(arg, "$") {
+			t.Errorf("ExecStart argument %q expands the environment", arg)
+		}
+		flagArgs = append(flagArgs, arg)
+	}
+	if !slices.Contains(args, "--platform=${POLICY_PLATFORM}") {
+		t.Error("ExecStart does not pass --platform=${POLICY_PLATFORM}")
+	}
+	// Every path is the binary default: the consumers (cred-release, the
+	// plugin, CDS) build on those defaults, not on the unit.
+	flags := NewCmd().Flags()
+	if err := flags.Parse(flagArgs); err != nil {
+		t.Fatalf("parse baked ExecStart flags: %v", err)
+	}
+	for _, name := range []string{"policy-dir", "opkey-disk", "policy-disk", "operator-pubkey"} {
+		if flags.Changed(name) {
+			t.Errorf("ExecStart overrides --%s; the consumers assume the binary default", name)
+		}
+	}
+
+	for _, tc := range []struct {
+		directive string
+		want      string
+	}{
+		{"Before", rke2Pair},
+		{"RequiredBy", rke2Pair},
+		{"FailureAction", "poweroff-force"},
+		{"RestrictAddressFamilies", "AF_UNIX"},
+		{"Type", "oneshot"},
+		{"RemainAfterExit", "yes"},
+	} {
+		if got := directives(unit, tc.directive); !slices.Contains(got, tc.want) {
+			t.Errorf("c8s-policy-measure.service %s = %q, want %q", tc.directive, got, tc.want)
+		}
+	}
+	// The unit always runs: the mode is measured on every boot.
+	if got := directives(unit, "ConditionPathExists"); len(got) != 0 {
+		t.Errorf("c8s-policy-measure.service has ConditionPathExists=%q; the measurer must run on every boot", got)
+	}
+	// Mounting the ISO and extending the register need the kernel
+	// interfaces these settings would remove.
+	for _, forbidden := range []string{"ProtectKernelTunables", "PrivateDevices", "CapabilityBoundingSet"} {
+		if got := directives(unit, forbidden); len(got) != 0 {
+			t.Errorf("c8s-policy-measure.service sets %s=%q, which breaks the mount or the sysfs extend", forbidden, got)
+		}
+	}
+	if rw := directives(unit, "ReadWritePaths"); !slices.Contains(rw, filepath.Dir(policybundle.DefaultPolicyDir)) {
+		t.Errorf("ReadWritePaths = %q, want %s (the policy dir and the ISO mountpoint)", rw, filepath.Dir(policybundle.DefaultPolicyDir))
+	}
+	requireOptionalReadOnlyPath(t, unit, "c8s-policy-measure.service", filepath.Dir(DefaultOperatorPubkey))
+}
+
+// requireOptionalReadOnlyPath asserts that dir appears in ReadOnlyPaths= only
+// with the `-` prefix. The confos initrd creates /etc/confai only on an
+// opkeydata boot; without the prefix systemd fails the unit's mount
+// namespace setup on every other boot, before ExecStart runs.
+func requireOptionalReadOnlyPath(t *testing.T, unit, name, dir string) {
+	t.Helper()
+	var paths []string
+	for _, value := range directives(unit, "ReadOnlyPaths") {
+		paths = append(paths, strings.Fields(value)...)
+	}
+	if slices.Contains(paths, dir) {
+		t.Errorf("%s ReadOnlyPaths = %q, want -%s: the initrd creates %s only on an opkeydata boot", name, paths, dir, dir)
+	}
+	if !slices.Contains(paths, "-"+dir) {
+		t.Errorf("%s ReadOnlyPaths = %q, want -%s", name, paths, dir)
+	}
+}
+
+func TestNodeImageAttestSocketService(t *testing.T) {
+	unit := unitFile(t, socketService)
+	args := execStart(t, unit, socketService)
+	if len(args) < 2 || args[0] != "/usr/local/bin/c8s" || args[1] != "attest-proxy" {
+		t.Fatalf("ExecStart = %q, want /usr/local/bin/c8s attest-proxy ...", args)
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, "$") {
+			t.Errorf("ExecStart argument %q expands the environment", arg)
+		}
+	}
+	flags := attestproxy.NewCmd().Flags()
+	if err := flags.Parse(args[2:]); err != nil {
+		t.Fatalf("parse baked ExecStart flags: %v", err)
+	}
+	if socket, _ := flags.GetString("socket"); socket != attestationSocket {
+		t.Errorf("baked --socket = %q, want %q", socket, attestationSocket)
+	}
+	if filepath.Dir(attestationSocket) != filepath.Dir(policybundle.DefaultPolicyDir) {
+		t.Errorf("socket dir %s and policy dir parent %s differ; tmpfiles creates one /run/confai", filepath.Dir(attestationSocket), filepath.Dir(policybundle.DefaultPolicyDir))
+	}
+	// The literal in the unit must be the constant the chart hands CDS as a
+	// supplementary group, or the CDS pod cannot connect.
+	if gid, _ := flags.GetInt("socket-gid"); gid != workloadclaims.InventorySocketGID {
+		t.Errorf("baked --socket-gid = %d, want workloadclaims.InventorySocketGID %d", gid, workloadclaims.InventorySocketGID)
+	}
+	if !slices.Contains(args, strconv.Itoa(workloadclaims.InventorySocketGID)) {
+		t.Errorf("ExecStart does not spell out --socket-gid %d", workloadclaims.InventorySocketGID)
+	}
+	if upstream, _ := flags.GetString("upstream"); upstream != "http://127.0.0.1:8400" {
+		t.Errorf("baked --upstream = %q, want the confos attestation-api at http://127.0.0.1:8400", upstream)
+	}
+	for _, tc := range []struct {
+		directive string
+		want      string
+	}{
+		{"After", "attestation-api.service"},
+		{"Requires", "attestation-api.service"},
+		{"Before", rke2Pair},
+		{"RequiredBy", rke2Pair},
+	} {
+		if got := directives(unit, tc.directive); !slices.Contains(got, tc.want) {
+			t.Errorf("c8s-attest-socket.service %s = %q, want %q", tc.directive, got, tc.want)
+		}
+	}
+	// The vsock fence: serves AF_UNIX, dials loopback AF_INET, nothing else.
+	if got := directives(unit, "RestrictAddressFamilies"); !slices.Contains(got, "AF_UNIX AF_INET") {
+		t.Errorf("RestrictAddressFamilies = %q, want AF_UNIX AF_INET", got)
+	}
+	if got := directives(unit, "User"); len(got) != 0 {
+		t.Errorf("User=%q; the socket must be root-owned for attestationclient's owner check", got)
+	}
+	// Before= on a simple unit orders only the fork. The plugin self-attests
+	// over the socket once at startup, so the unit must not count as started
+	// until a probe through the socket reaches attestation-api.
+	post := directives(unit, "ExecStartPost")
+	if len(post) != 1 || !strings.Contains(post[0], "attest-proxy healthcheck --socket "+attestationSocket) {
+		t.Errorf("ExecStartPost = %q, want one readiness gate running attest-proxy healthcheck --socket %s", post, attestationSocket)
+	}
+	if got := directives(unit, "TimeoutStartSec"); len(got) != 1 {
+		t.Errorf("TimeoutStartSec = %q, want one bound on the readiness gate", got)
+	}
+}
+
+func TestNodeImagePresetTmpfilesAndSync(t *testing.T) {
+	preset, err := os.ReadFile(filepath.Clean(nodeImagePreset))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unit := range []string{"c8s-policy-measure.service", "c8s-attest-socket.service", "cred-release.service"} {
+		if !slices.Contains(strings.Split(string(preset), "\n"), "enable "+unit) {
+			t.Errorf("50-rke2.preset does not enable %s; without it the RequiredBy links are never created", unit)
+		}
+	}
+
+	tmpfiles, err := os.ReadFile(filepath.Clean(nodeImageTmpfiles))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range []string{filepath.Dir(policybundle.DefaultPolicyDir), policybundle.DefaultPolicyDir} {
+		if !regexp.MustCompile(`(?m)^d ` + regexp.QuoteMeta(dir) + ` 0755 root root`).Match(tmpfiles) {
+			t.Errorf("confos-rke2.conf does not create %s 0755 root root", dir)
+		}
+	}
+	// tmpfiles, not RuntimeDirectory=: a unit restart must not remove the
+	// other unit's files under /run/confai.
+	for _, path := range []string{measureService, socketService} {
+		if got := directives(unitFile(t, path), "RuntimeDirectory"); len(got) != 0 {
+			t.Errorf("%s sets RuntimeDirectory=%q, which is removed on stop", path, got)
+		}
+	}
+
+	sync, err := os.ReadFile(filepath.Clean(nodeImageSync))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sync), "Environment=POLICY_PLATFORM=") ||
+		!strings.Contains(string(sync), "c8s-policy-measure.service.d/10-platform.conf") {
+		t.Error("mkosi.sync does not render the c8s-policy-measure platform drop-in (Environment=POLICY_PLATFORM=)")
+	}
+}

--- a/internal/cmds/policymeasure/policydir.go
+++ b/internal/cmds/policymeasure/policydir.go
@@ -1,0 +1,118 @@
+package policymeasure
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+)
+
+// writeFile publishes data at dir/name, 0444, through a rename so a
+// consumer never reads a partial file. A member name never starts with a
+// dot, so the temp name cannot collide with one.
+func writeFile(dir, name string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, "."+name+".*")
+	if err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	if err := tmp.Chmod(0o444); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	if err := os.Rename(tmpPath, filepath.Join(dir, name)); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	return nil
+}
+
+// writeMode publishes the verdict; it is the last write of a run.
+func writeMode(dir, mode string) error {
+	return writeFile(dir, policybundle.ModeFile, []byte(mode+"\n"))
+}
+
+// refuseMeasured fails when dir already carries a verdict: a second run in
+// the same boot would extend the register again and leave a mode that no
+// longer matches it.
+func refuseMeasured(dir string) error {
+	_, err := os.Stat(filepath.Join(dir, policybundle.ModeFile))
+	if err == nil {
+		return fmt.Errorf("%s already exists: the policy mode was measured earlier this boot", filepath.Join(dir, policybundle.ModeFile))
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("policy dir: %w", err)
+	}
+	return nil
+}
+
+// readBundleDisk mounts the policydata ISO read-only under mountRoot, reads
+// every member once, and unmounts. Entries starting with ".." are the
+// KubeVirt AtomicWriter's versioned directory and its ..data link (the same
+// skip rke2-role.sh applies to joindata); everything else must be a regular
+// file within the bundle bounds.
+func readBundleDisk(dev, mountRoot string) (members map[string][]byte, err error) {
+	target, err := os.MkdirTemp(mountRoot, "policydata-*")
+	if err != nil {
+		return nil, fmt.Errorf("policydata mountpoint: %w", err)
+	}
+	defer os.Remove(target)
+	if err := mountISO(dev, target); err != nil {
+		return nil, fmt.Errorf("mount %s: %w", dev, err)
+	}
+	defer func() {
+		if uerr := unmountISO(target); uerr != nil && err == nil {
+			err = fmt.Errorf("unmount %s: %w", dev, uerr)
+		}
+	}()
+
+	entries, err := os.ReadDir(target)
+	if err != nil {
+		return nil, fmt.Errorf("policydata: %w", err)
+	}
+	members = make(map[string][]byte)
+	for _, e := range entries {
+		name := e.Name()
+		if strings.HasPrefix(name, "..") {
+			continue
+		}
+		if !e.Type().IsRegular() {
+			return nil, fmt.Errorf("policydata: %s is not a regular file; a bundle is a flat set of files", name)
+		}
+		if len(members) == policybundle.MaxMembers {
+			return nil, fmt.Errorf("policydata has more than %d members", policybundle.MaxMembers)
+		}
+		data, err := policybundle.ReadMember(filepath.Join(target, name))
+		if err != nil {
+			return nil, err
+		}
+		members[name] = data
+	}
+	return members, nil
+}
+
+// exists reports whether path is present; any other stat failure is an
+// error so a disk that cannot be examined is never taken for an absent one.
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, fmt.Errorf("stat %s: %w", path, err)
+}

--- a/internal/cmds/policymeasure/run.go
+++ b/internal/cmds/policymeasure/run.go
@@ -75,9 +75,8 @@ func Run(cfg Config) error {
 }
 
 // launchSeed returns the register the initrd left: ForOperatorKey of the
-// staged pubkey, or Zero when no key was staged. The design admits either
-// value on its own; tying them together refuses a staged key the initrd
-// did not measure (a pubkey file written after boot).
+// staged pubkey, or Zero when no key was staged. Requiring the two to agree
+// refuses a pubkey file written after boot that the initrd never measured.
 func launchSeed(pubkeyPath string) ([runtimemeasure.Size]byte, error) {
 	pub, err := os.ReadFile(pubkeyPath)
 	if errors.Is(err, os.ErrNotExist) {

--- a/internal/cmds/policymeasure/run.go
+++ b/internal/cmds/policymeasure/run.go
@@ -1,0 +1,160 @@
+package policymeasure
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// extendRTMR3 is the register extend; a var so tests substitute a fake that
+// folds into the sysfs fixture (a plain file cannot fold on write).
+var extendRTMR3 = func(event [runtimemeasure.Size]byte) error {
+	return tdxrtmr.Extend(3, event)
+}
+
+// Run measures the boot's policy mode. Every failure is returned; the unit's
+// FailureAction turns it into a power-off.
+func Run(cfg Config) error {
+	platform := ratls.NormalizePlatform(cfg.Platform)
+	if platform == "" {
+		return errors.New("--platform is required")
+	}
+	if err := ratls.ValidatePlatform(platform); err != nil {
+		return fmt.Errorf("--platform: %w", err)
+	}
+	if err := os.MkdirAll(cfg.PolicyDir, 0o755); err != nil {
+		return fmt.Errorf("policy dir: %w", err)
+	}
+	if err := refuseMeasured(cfg.PolicyDir); err != nil {
+		return err
+	}
+	policyAttached, err := exists(cfg.PolicyDisk)
+	if err != nil {
+		return err
+	}
+
+	// Only TDX has a runtime register. An SNP boot is always dynamic, and a
+	// policydata disk it cannot measure is refused rather than ignored, or
+	// the launcher would believe the node is sealed.
+	if platform != "tdx" {
+		if policyAttached {
+			return fmt.Errorf("policydata disk %s is attached but platform %s has no runtime register to measure it into: static mode is TDX-only", cfg.PolicyDisk, platform)
+		}
+		return writeMode(cfg.PolicyDir, policybundle.DynamicMode)
+	}
+
+	seed, err := launchSeed(cfg.OperatorPubkey)
+	if err != nil {
+		return err
+	}
+	reg, err := tdxrtmr.Read(3)
+	if err != nil {
+		return err
+	}
+	if reg != seed {
+		return fmt.Errorf("RTMR[3] is %s before the mode event, want %s (Zero, or ForOperatorKey of %s when staged): the register was extended before this unit ran",
+			hex.EncodeToString(reg[:]), hex.EncodeToString(seed[:]), cfg.OperatorPubkey)
+	}
+
+	if !policyAttached {
+		want := runtimemeasure.ForDynamic(seed)
+		if err := extendAndVerify([][runtimemeasure.Size]byte{runtimemeasure.ModeDynamic}, want); err != nil {
+			return err
+		}
+		return writeMode(cfg.PolicyDir, policybundle.DynamicMode)
+	}
+	return measureStatic(cfg, seed)
+}
+
+// launchSeed returns the register the initrd left: ForOperatorKey of the
+// staged pubkey, or Zero when no key was staged. The design admits either
+// value on its own; tying them together refuses a staged key the initrd
+// did not measure (a pubkey file written after boot).
+func launchSeed(pubkeyPath string) ([runtimemeasure.Size]byte, error) {
+	pub, err := os.ReadFile(pubkeyPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return runtimemeasure.Zero, nil
+	}
+	if err != nil {
+		return runtimemeasure.Zero, fmt.Errorf("operator pubkey: %w", err)
+	}
+	if len(pub) == 0 {
+		return runtimemeasure.Zero, fmt.Errorf("operator pubkey %s is empty", pubkeyPath)
+	}
+	return runtimemeasure.ForOperatorKey(pub), nil
+}
+
+// measureStatic is the static branch: the register must be Zero (a static
+// node has no operator key), the bundle is read off the disk and linted,
+// the members and digest are published, then the two events are extended
+// and the register must read back as the bundle's RTMR3. mode is written
+// last so a consumer that finds mode=static finds every other file too.
+func measureStatic(cfg Config, seed [runtimemeasure.Size]byte) error {
+	opkeyAttached, err := exists(cfg.OpkeyDisk)
+	if err != nil {
+		return err
+	}
+	if opkeyAttached {
+		return fmt.Errorf("both %s and %s are attached: a static node has no operator key", cfg.PolicyDisk, cfg.OpkeyDisk)
+	}
+	if seed != runtimemeasure.Zero {
+		return fmt.Errorf("operator pubkey %s is staged on a static boot: a static node has no operator key", cfg.OperatorPubkey)
+	}
+
+	members, err := readBundleDisk(cfg.PolicyDisk, filepath.Dir(cfg.PolicyDir))
+	if err != nil {
+		return err
+	}
+	bundle, err := policybundle.FromMembers(members)
+	if err != nil {
+		return err
+	}
+	// LintSealed parses strictly (unknown fields refused) and requires the
+	// bytes to be canonical, so what is measured is what was reviewed.
+	if err := allowlist.LintSealed(bundle.Members[policybundle.MemberStaticAllowlist]); err != nil {
+		return fmt.Errorf("%s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+
+	for name, data := range bundle.Members {
+		if err := writeFile(cfg.PolicyDir, name, data); err != nil {
+			return err
+		}
+	}
+	sum := bundle.IndexDigest()
+	if err := writeFile(cfg.PolicyDir, policybundle.DigestFile, []byte(hex.EncodeToString(sum[:]))); err != nil {
+		return err
+	}
+
+	events := [][runtimemeasure.Size]byte{runtimemeasure.ModeStatic, runtimemeasure.PolicyEvent(bundle.Index())}
+	if err := extendAndVerify(events, bundle.RTMR3()); err != nil {
+		return err
+	}
+	return writeMode(cfg.PolicyDir, policybundle.StaticMode)
+}
+
+// extendAndVerify folds events into RTMR[3] and reads the register back:
+// the value the verifiers recompute must be what the hardware holds, not
+// what this process believes it wrote.
+func extendAndVerify(events [][runtimemeasure.Size]byte, want [runtimemeasure.Size]byte) error {
+	for _, ev := range events {
+		if err := extendRTMR3(ev); err != nil {
+			return err
+		}
+	}
+	got, err := tdxrtmr.Read(3)
+	if err != nil {
+		return fmt.Errorf("read back RTMR[3]: %w", err)
+	}
+	if got != want {
+		return fmt.Errorf("RTMR[3] reads back as %s after the mode event, want %s", hex.EncodeToString(got[:]), hex.EncodeToString(want[:]))
+	}
+	return nil
+}

--- a/internal/cmds/policymeasure/run_test.go
+++ b/internal/cmds/policymeasure/run_test.go
@@ -1,0 +1,428 @@
+package policymeasure
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+const digestA = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+// sealedAllowlist is a canonical document LintSealed accepts.
+func sealedAllowlist(t *testing.T) []byte {
+	t.Helper()
+	doc := `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{"digest":"` + digestA + `",` +
+		`"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
+		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
+		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`
+	al, err := allowlist.ParseJSON([]byte(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonical, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return canonical
+}
+
+// fixture is one boot: a fake sysfs, fake disks (directories the fake
+// mount copies from), a policy dir, and recorders for the extends and
+// unmounts that happened.
+type fixture struct {
+	cfg      Config
+	sysfs    string
+	extended [][runtimemeasure.Size]byte
+	mounted  []string
+	unmounts int
+}
+
+func newFixture(t *testing.T) *fixture {
+	t.Helper()
+	root := t.TempDir()
+	fx := &fixture{
+		sysfs: filepath.Join(root, "sysfs"),
+		cfg: Config{
+			Platform:       "tdx",
+			PolicyDir:      filepath.Join(root, "run", "confai", "policy"),
+			OpkeyDisk:      filepath.Join(root, "disks", "opkeydata"),
+			PolicyDisk:     filepath.Join(root, "disks", "policydata"),
+			OperatorPubkey: filepath.Join(root, "etc", "operator-pubkey"),
+		},
+	}
+	for _, d := range []string{fx.sysfs, filepath.Dir(fx.cfg.PolicyDir), filepath.Join(root, "disks"), filepath.Join(root, "etc")} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	origRoot, origExtend, origMount, origUnmount := tdxrtmr.SysfsRoot, extendRTMR3, mountISO, unmountISO
+	tdxrtmr.SysfsRoot = fx.sysfs
+	// The fake sysfs node folds like the TSM node does.
+	extendRTMR3 = func(event [runtimemeasure.Size]byte) error {
+		fx.extended = append(fx.extended, event)
+		reg, err := tdxrtmr.Read(3)
+		if err != nil {
+			return err
+		}
+		next := runtimemeasure.Extend(reg, event)
+		return os.WriteFile(tdxrtmr.Path(3), next[:], 0o600)
+	}
+	// A "disk" is a directory; mounting copies its entries into the target.
+	mountISO = func(dev, target string) error {
+		fx.mounted = append(fx.mounted, target)
+		entries, err := os.ReadDir(dev)
+		if err != nil {
+			return err
+		}
+		for _, e := range entries {
+			src, dst := filepath.Join(dev, e.Name()), filepath.Join(target, e.Name())
+			switch {
+			case e.Type()&os.ModeSymlink != 0:
+				link, err := os.Readlink(src)
+				if err != nil {
+					return err
+				}
+				if err := os.Symlink(link, dst); err != nil {
+					return err
+				}
+			case e.IsDir():
+				if err := os.Mkdir(dst, 0o755); err != nil {
+					return err
+				}
+			default:
+				data, err := os.ReadFile(src)
+				if err != nil {
+					return err
+				}
+				if err := os.WriteFile(dst, data, 0o444); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	unmountISO = func(target string) error {
+		fx.unmounts++
+		return os.RemoveAll(target)
+	}
+	t.Cleanup(func() {
+		tdxrtmr.SysfsRoot, extendRTMR3, mountISO, unmountISO = origRoot, origExtend, origMount, origUnmount
+	})
+	return fx
+}
+
+func (fx *fixture) setRegister(t *testing.T, reg [runtimemeasure.Size]byte) {
+	t.Helper()
+	if err := os.WriteFile(tdxrtmr.Path(3), reg[:], 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (fx *fixture) register(t *testing.T) [runtimemeasure.Size]byte {
+	t.Helper()
+	reg, err := tdxrtmr.Read(3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return reg
+}
+
+// attachPolicy builds the policydata "disk" from members; a value of nil
+// makes a subdirectory instead of a file.
+func (fx *fixture) attachPolicy(t *testing.T, members map[string][]byte) {
+	t.Helper()
+	if err := os.Mkdir(fx.cfg.PolicyDisk, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, data := range members {
+		path := filepath.Join(fx.cfg.PolicyDisk, name)
+		if data == nil {
+			if err := os.Mkdir(path, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func (fx *fixture) stageOperatorKey(t *testing.T) []byte {
+	t.Helper()
+	pub := []byte("-----BEGIN PUBLIC KEY-----\noperator\n-----END PUBLIC KEY-----\n")
+	if err := os.WriteFile(fx.cfg.OperatorPubkey, pub, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return pub
+}
+
+func (fx *fixture) readPolicy(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(fx.cfg.PolicyDir, name))
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return data
+}
+
+func (fx *fixture) policyFileAbsent(t *testing.T, name string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(fx.cfg.PolicyDir, name)); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("os.Stat(%s/%s) = %v, want not-exist", fx.cfg.PolicyDir, name, err)
+	}
+}
+
+func TestRunDynamic(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		stage func(t *testing.T, fx *fixture) (seed [runtimemeasure.Size]byte)
+	}{
+		{"no operator key", func(t *testing.T, fx *fixture) [runtimemeasure.Size]byte {
+			fx.setRegister(t, runtimemeasure.Zero)
+			return runtimemeasure.Zero
+		}},
+		{"operator key measured by the initrd", func(t *testing.T, fx *fixture) [runtimemeasure.Size]byte {
+			seed := runtimemeasure.ForOperatorKey(fx.stageOperatorKey(t))
+			fx.setRegister(t, seed)
+			return seed
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			seed := tc.stage(t, fx)
+			if err := Run(fx.cfg); err != nil {
+				t.Fatalf("Run(dynamic) = %v, want nil", err)
+			}
+			if got, want := fx.register(t), runtimemeasure.ForDynamic(seed); got != want {
+				t.Errorf("RTMR[3] after Run = %x, want ForDynamic(seed) %x", got, want)
+			}
+			if got := string(fx.readPolicy(t, policybundle.ModeFile)); got != "dynamic\n" {
+				t.Errorf("mode = %q, want %q", got, "dynamic\n")
+			}
+			fx.policyFileAbsent(t, policybundle.DigestFile)
+			fx.policyFileAbsent(t, policybundle.MemberStaticAllowlist)
+			if len(fx.mounted) != 0 {
+				t.Errorf("mounted %v on a dynamic boot, want nothing", fx.mounted)
+			}
+		})
+	}
+}
+
+func TestRunStatic(t *testing.T) {
+	fx := newFixture(t)
+	fx.setRegister(t, runtimemeasure.Zero)
+	doc := sealedAllowlist(t)
+	fx.attachPolicy(t, map[string][]byte{
+		policybundle.MemberStaticAllowlist: doc,
+		// KubeVirt's AtomicWriter layout: a versioned directory and a link.
+		"..2026_09_03": nil,
+	})
+	if err := os.Symlink("..2026_09_03", filepath.Join(fx.cfg.PolicyDisk, "..data")); err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := policybundle.FromMembers(map[string][]byte{policybundle.MemberStaticAllowlist: doc})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Run(fx.cfg); err != nil {
+		t.Fatalf("Run(static) = %v, want nil", err)
+	}
+	if got, want := fx.register(t), bundle.RTMR3(); got != want {
+		t.Errorf("RTMR[3] after Run = %x, want bundle RTMR3 %x", got, want)
+	}
+	if want := [][runtimemeasure.Size]byte{runtimemeasure.ModeStatic, runtimemeasure.PolicyEvent(bundle.Index())}; len(fx.extended) != 2 || fx.extended[0] != want[0] || fx.extended[1] != want[1] {
+		t.Errorf("extended events = %x, want ModeStatic then PolicyEvent(index)", fx.extended)
+	}
+	if got := string(fx.readPolicy(t, policybundle.ModeFile)); got != "static\n" {
+		t.Errorf("mode = %q, want %q", got, "static\n")
+	}
+	sum := bundle.IndexDigest()
+	if got, want := string(fx.readPolicy(t, policybundle.DigestFile)), hex.EncodeToString(sum[:]); got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+	if got := fx.readPolicy(t, policybundle.MemberStaticAllowlist); !bytes.Equal(got, doc) {
+		t.Errorf("published member differs from the attached bytes")
+	}
+	for _, name := range []string{policybundle.ModeFile, policybundle.DigestFile, policybundle.MemberStaticAllowlist} {
+		info, err := os.Stat(filepath.Join(fx.cfg.PolicyDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o444 {
+			t.Errorf("%s mode = %o, want 0444", name, info.Mode().Perm())
+		}
+	}
+	if fx.unmounts != 1 {
+		t.Errorf("unmounts = %d, want 1", fx.unmounts)
+	}
+	if entries, _ := os.ReadDir(filepath.Dir(fx.cfg.PolicyDir)); len(entries) != 1 {
+		t.Errorf("mountpoint left behind under %s: %v", filepath.Dir(fx.cfg.PolicyDir), entries)
+	}
+
+	state, err := policybundle.ReadDir(fx.cfg.PolicyDir)
+	if err != nil {
+		t.Fatalf("policybundle.ReadDir after Run = %v, want nil", err)
+	}
+	if state.Mode != policybundle.StaticMode || state.Bundle.RTMR3() != bundle.RTMR3() {
+		t.Errorf("policybundle.ReadDir = %+v, want static with the measured bundle", state)
+	}
+}
+
+func TestRunSNP(t *testing.T) {
+	t.Run("dynamic without touching a register", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.cfg.Platform = "snp"
+		// No sysfs node at all: SNP has none, and the run must not need one.
+		if err := Run(fx.cfg); err != nil {
+			t.Fatalf("Run(snp) = %v, want nil", err)
+		}
+		if got := string(fx.readPolicy(t, policybundle.ModeFile)); got != "dynamic\n" {
+			t.Errorf("mode = %q, want %q", got, "dynamic\n")
+		}
+		if len(fx.extended) != 0 {
+			t.Errorf("extended %d events on SNP, want 0", len(fx.extended))
+		}
+	})
+	t.Run("policydata attached is fatal", func(t *testing.T) {
+		fx := newFixture(t)
+		fx.cfg.Platform = "sev-snp"
+		fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: sealedAllowlist(t)})
+		err := Run(fx.cfg)
+		if err == nil || !strings.Contains(err.Error(), "TDX-only") {
+			t.Fatalf("Run(snp, policydata) = %v, want TDX-only error", err)
+		}
+		fx.policyFileAbsent(t, policybundle.ModeFile)
+	})
+}
+
+// TestRunFailsClosed walks every refusal. Each case leaves no mode file, so
+// a consumer ordered after the unit cannot find a verdict the register does
+// not back.
+func TestRunFailsClosed(t *testing.T) {
+	staticBoot := func(t *testing.T, fx *fixture) {
+		fx.setRegister(t, runtimemeasure.Zero)
+		fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: sealedAllowlist(t)})
+	}
+	for _, tc := range []struct {
+		name  string
+		stage func(t *testing.T, fx *fixture)
+		want  string
+	}{
+		{"platform missing", func(t *testing.T, fx *fixture) { fx.cfg.Platform = "" }, "--platform is required"},
+		{"platform unknown", func(t *testing.T, fx *fixture) { fx.cfg.Platform = "sgx" }, "--platform"},
+		{"sysfs register absent", func(t *testing.T, fx *fixture) {}, "is this a TDX guest"},
+		{"register already extended", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.ForDynamic(runtimemeasure.Zero))
+		}, "before the mode event"},
+		{"operator key staged but not measured", func(t *testing.T, fx *fixture) {
+			fx.stageOperatorKey(t)
+			fx.setRegister(t, runtimemeasure.Zero)
+		}, "before the mode event"},
+		{"operator key file empty", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			if err := os.WriteFile(fx.cfg.OperatorPubkey, nil, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "is empty"},
+		{"already measured this boot", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			if err := os.MkdirAll(fx.cfg.PolicyDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := writeMode(fx.cfg.PolicyDir, policybundle.DynamicMode); err != nil {
+				t.Fatal(err)
+			}
+		}, "measured earlier this boot"},
+		{"dynamic extend fails", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			extendRTMR3 = func([runtimemeasure.Size]byte) error { return errors.New("EACCES") }
+		}, "EACCES"},
+		{"dynamic read-back mismatch", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			extendRTMR3 = func([runtimemeasure.Size]byte) error { return nil } // the node ignored the write
+		}, "reads back as"},
+		{"static with opkeydata attached", func(t *testing.T, fx *fixture) {
+			staticBoot(t, fx)
+			if err := os.WriteFile(fx.cfg.OpkeyDisk, []byte("iso"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}, "a static node has no operator key"},
+		{"static with an operator key measured", func(t *testing.T, fx *fixture) {
+			seed := runtimemeasure.ForOperatorKey(fx.stageOperatorKey(t))
+			fx.setRegister(t, seed)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: sealedAllowlist(t)})
+		}, "a static node has no operator key"},
+		{"mount fails", func(t *testing.T, fx *fixture) {
+			staticBoot(t, fx)
+			mountISO = func(string, string) error { return errors.New("EINVAL: not an iso9660 image") }
+		}, "mount"},
+		{"unmount fails", func(t *testing.T, fx *fixture) {
+			staticBoot(t, fx)
+			unmountISO = func(string) error { return errors.New("EBUSY") }
+		}, "unmount"},
+		{"bundle without static-allowlist.json", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{"README": []byte("x")})
+		}, "no static-allowlist.json member"},
+		{"unknown member", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: sealedAllowlist(t), "routes.json": []byte("{}")})
+		}, "is unknown"},
+		{"subdirectory on the disk", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: sealedAllowlist(t), "sub": nil})
+		}, "not a regular file"},
+		{"member over the size bound", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: bytes.Repeat([]byte("{"), policybundle.MaxMemberSize+1)})
+		}, "over"},
+		{"allowlist not sealed", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			doc := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"web":{"initContainers":null,"containers":[{"digest":"` + digestA + `","command":{"policy":"any"},"args":{"policy":"any"},"mounts":{"policy":"any"},"env":{"policy":"any"}}]}}}`
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: []byte(doc)})
+		}, "sealed allowlist"},
+		{"allowlist not canonical", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: append(sealedAllowlist(t), '\n')})
+		}, "canonical"},
+		{"allowlist not JSON", func(t *testing.T, fx *fixture) {
+			fx.setRegister(t, runtimemeasure.Zero)
+			fx.attachPolicy(t, map[string][]byte{policybundle.MemberStaticAllowlist: []byte("not json")})
+		}, "static-allowlist.json"},
+		{"static extend fails", func(t *testing.T, fx *fixture) {
+			staticBoot(t, fx)
+			extendRTMR3 = func([runtimemeasure.Size]byte) error { return errors.New("EACCES") }
+		}, "EACCES"},
+		{"static read-back mismatch", func(t *testing.T, fx *fixture) {
+			staticBoot(t, fx)
+			extendRTMR3 = func([runtimemeasure.Size]byte) error { return nil }
+		}, "reads back as"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fx := newFixture(t)
+			tc.stage(t, fx)
+			err := Run(fx.cfg)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Run(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+			if tc.name != "already measured this boot" {
+				fx.policyFileAbsent(t, policybundle.ModeFile)
+			}
+			if fx.unmounts != len(fx.mounted) && !strings.Contains(tc.name, "unmount") {
+				t.Errorf("mounted %d, unmounted %d: the disk stays mounted after a failure", len(fx.mounted), fx.unmounts)
+			}
+		})
+	}
+}

--- a/internal/cmds/policymeasure/run_test.go
+++ b/internal/cmds/policymeasure/run_test.go
@@ -367,7 +367,7 @@ func TestRunFailsClosed(t *testing.T) {
 		{"mount fails", func(t *testing.T, fx *fixture) {
 			staticBoot(t, fx)
 			mountISO = func(string, string) error { return errors.New("EINVAL: not an iso9660 image") }
-		}, "mount"},
+		}, filepath.Join("disks", "policydata") + ": EINVAL"},
 		{"unmount fails", func(t *testing.T, fx *fixture) {
 			staticBoot(t, fx)
 			unmountISO = func(string) error { return errors.New("EBUSY") }

--- a/internal/cmds/rtmr3measurer/measurer.go
+++ b/internal/cmds/rtmr3measurer/measurer.go
@@ -27,12 +27,9 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/kataspec"
+	"github.com/confidential-dot-ai/c8s/internal/tdxrtmr"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
-
-// rtmr3Sysfs is the kernel TSM node backing extendSysfs/readRegisterSysfs.
-// A var (not const) only so tests can point it at a temp file.
-var rtmr3Sysfs = "/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384"
 
 const (
 	watchDir = "/run/kata-containers"
@@ -81,8 +78,8 @@ func newMeasurer(logger *slog.Logger) *measurer {
 		logger:             logger,
 		watchDir:           watchDir,
 		statePath:          statePath,
-		extend:             extendSysfs,
-		readRegister:       readRegisterSysfs,
+		extend:             func(event [runtimemeasure.Size]byte) error { return tdxrtmr.Extend(3, event) },
+		readRegister:       func() ([runtimemeasure.Size]byte, error) { return tdxrtmr.Read(3) },
 		seenCids:           map[string]struct{}{},
 		measuredDigests:    map[string]struct{}{},
 		configReadDeadline: 2 * time.Second,
@@ -94,7 +91,7 @@ func newMeasurer(logger *slog.Logger) *measurer {
 func Run(_ []string) error {
 	m := newMeasurer(slog.Default())
 	m.logger.Info("rtmr3-measurer starting",
-		"watch_dir", m.watchDir, "state", m.statePath, "sysfs", rtmr3Sysfs)
+		"watch_dir", m.watchDir, "state", m.statePath, "sysfs", tdxrtmr.Path(3))
 	if err := m.loadState(); err != nil {
 		return err
 	}
@@ -315,27 +312,4 @@ func (m *measurer) readConfig(path string) (*ociSpec, error) {
 		}
 		time.Sleep(m.configReadInterval)
 	}
-}
-
-// extendSysfs performs TDG.MR.RTMR.EXTEND via the kernel TSM sysfs write:
-// RTMR3 = SHA384(RTMR3 ‖ event). Needs mainline >= 6.16.
-func extendSysfs(event [runtimemeasure.Size]byte) error {
-	if err := os.WriteFile(rtmr3Sysfs, event[:], 0); err != nil {
-		return fmt.Errorf("write %s: %w", rtmr3Sysfs, err)
-	}
-	return nil
-}
-
-// readRegisterSysfs reads the current RTMR[3] value from the same node.
-func readRegisterSysfs() ([runtimemeasure.Size]byte, error) {
-	var reg [runtimemeasure.Size]byte
-	b, err := os.ReadFile(rtmr3Sysfs)
-	if err != nil {
-		return reg, err
-	}
-	if len(b) != runtimemeasure.Size {
-		return reg, fmt.Errorf("read %s: got %d bytes, want %d", rtmr3Sysfs, len(b), runtimemeasure.Size)
-	}
-	copy(reg[:], b)
-	return reg, nil
 }

--- a/internal/cmds/rtmr3measurer/measurer_errors_test.go
+++ b/internal/cmds/rtmr3measurer/measurer_errors_test.go
@@ -3,7 +3,6 @@
 package rtmr3measurer
 
 import (
-	"bytes"
 	"errors"
 	"log/slog"
 	"os"
@@ -214,37 +213,5 @@ func TestUnrecordLastRewriteFailureIsLoggedNotFatal(t *testing.T) {
 	m.unrecordLast("sha256:" + hexA)
 	if len(m.measuredOrder) != 0 {
 		t.Fatalf("measuredOrder = %v, want empty even when the rewrite fails", m.measuredOrder)
-	}
-}
-
-// The real sysfs helpers, pointed at a temp file standing in for the TSM node.
-func TestSysfsExtendAndReadRegister(t *testing.T) {
-	orig := rtmr3Sysfs
-	t.Cleanup(func() { rtmr3Sysfs = orig })
-
-	node := filepath.Join(t.TempDir(), "rtmr3:sha384")
-	if err := os.WriteFile(node, make([]byte, runtimemeasure.Size), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	rtmr3Sysfs = node
-
-	event := runtimemeasure.Event("sha256:" + hexA)
-	if err := extendSysfs(event); err != nil {
-		t.Fatalf("extendSysfs: %v", err)
-	}
-	got, err := readRegisterSysfs()
-	if err != nil {
-		t.Fatalf("readRegisterSysfs: %v", err)
-	}
-	if !bytes.Equal(got[:], event[:]) {
-		t.Fatal("readRegisterSysfs did not return the written event bytes")
-	}
-
-	// Wrong-size node contents are rejected, not silently truncated.
-	if err := os.WriteFile(node, []byte("short"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := readRegisterSysfs(); err == nil {
-		t.Fatal("readRegisterSysfs = nil error, want size mismatch error")
 	}
 }

--- a/internal/cmds/sidecar/measurements_test.go
+++ b/internal/cmds/sidecar/measurements_test.go
@@ -4,52 +4,115 @@ import (
 	"encoding/hex"
 	"strings"
 	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
 func measurementHex() string { return strings.Repeat(hex.EncodeToString([]byte{0xab}), 48) }
 
 // Empty measurements accept any RA-TLS-attested CDS, so dropping the flag is
 // how a host points a sidecar at a CDS it runs. Under kata it writes the argv.
-func TestParsePinsRefusesAnUnpinnedCDSInsideAKataGuest(t *testing.T) {
+func TestCDSPinsRefusesAnUnpinnedCDSInsideAKataGuest(t *testing.T) {
 	cfg := Config{WorkloadClaimsGuest: true}
-	if _, err := cfg.ParsePins(); err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
+	if _, err := cfg.CDSPins(t.Context()); err == nil || !strings.Contains(err.Error(), "--measurements is empty") {
 		t.Fatalf("error = %v, want a refusal to use an unpinned CDS", err)
 	}
 }
 
 // Outside kata "no pinning" is a supported development shape.
-func TestParsePinsWarnsOutsideAKataGuest(t *testing.T) {
+func TestCDSPinsWarnsOutsideAKataGuest(t *testing.T) {
 	cfg := Config{}
-	got, err := cfg.ParsePins()
+	got, err := cfg.CDSPins(t.Context())
 	if err != nil {
-		t.Fatalf("ParsePins: %v", err)
+		t.Fatalf("CDSPins: %v", err)
 	}
 	if len(got.Measurements) != 0 {
 		t.Fatalf("parsed %d measurements, want none", len(got.Measurements))
 	}
 }
 
-func TestParsePinsAcceptsAPinnedCDSInsideAKataGuest(t *testing.T) {
+func TestCDSPinsAcceptsAPinnedCDSInsideAKataGuest(t *testing.T) {
 	cfg := Config{Measurements: []string{measurementHex()}, WorkloadClaimsGuest: true}
-	got, err := cfg.ParsePins()
+	got, err := cfg.CDSPins(t.Context())
 	if err != nil {
-		t.Fatalf("ParsePins: %v", err)
+		t.Fatalf("CDSPins: %v", err)
 	}
 	if len(got.Measurements) != 1 {
 		t.Fatalf("parsed %d measurements, want 1", len(got.Measurements))
 	}
 }
 
-func TestParsePinsRejectsMalformedHex(t *testing.T) {
+func TestCDSPinsRejectsMalformedHex(t *testing.T) {
 	cfg := Config{Measurements: []string{"zz"}}
-	if _, err := cfg.ParsePins(); err == nil || !strings.Contains(err.Error(), "--measurements") {
+	if _, err := cfg.CDSPins(t.Context()); err == nil || !strings.Contains(err.Error(), "--measurements") {
 		t.Fatalf("error = %v, want a parse error naming the flag", err)
 	}
 }
 
-func TestParsePinsRejectsMalformedRTMR(t *testing.T) {
+func TestCDSPinsRejectsMalformedRTMR(t *testing.T) {
 	cfg := Config{Measurements: []string{measurementHex()}, RTMRs: []string{"1=zz"}}
-	if _, err := cfg.ParsePins(); err == nil || !strings.Contains(err.Error(), "--rtmrs") {
+	if _, err := cfg.CDSPins(t.Context()); err == nil || !strings.Contains(err.Error(), "--rtmrs") {
 		t.Fatalf("error = %v, want a parse error naming the flag", err)
+	}
+}
+
+// A sealed node's sidecar takes its CDS pins from its own quote: the flat
+// flags would put a cluster-specific digest into an argv the bundle measures.
+func TestCDSPinsFromOwnQuote(t *testing.T) {
+	reg := func(b byte) string { return strings.Repeat(hex.EncodeToString([]byte{b}), 48) }
+	stub, url := testattest.NewUnix(t)
+	stub.SetPlatform(types.PlatformTdx)
+	stub.SetVerdict(testattest.TDXVerdict(reg(0x11), map[int]string{0: reg(0), 1: reg(0x21), 2: reg(0x22), 3: reg(0x33)}))
+	cfg := Config{AttestationApiURL: url, CDSPinsFromOwnQuote: true}
+	got, err := cfg.CDSPins(t.Context())
+	if err != nil {
+		t.Fatalf("CDSPins(own quote) = %v, want nil", err)
+	}
+	if len(got.Entries) != 1 || len(got.Measurements) != 0 || len(got.RTMRs) != 0 {
+		t.Fatalf("CDSPins(own quote) = %+v, want exactly one entry and no loose pins", got)
+	}
+	if e := got.Entries[0]; hex.EncodeToString(e.Digest) != reg(0x11) || hex.EncodeToString(e.RTMRs[3]) != reg(0x33) {
+		t.Fatalf("CDSPins(own quote) entry = %x / RTMR[3] %x, want the quote's tuple", e.Digest, e.RTMRs[3])
+	}
+}
+
+func TestCDSPinsFromOwnQuoteNeedsAVerifier(t *testing.T) {
+	stub, url := testattest.NewUnix(t)
+	stub.SetVerdict(testattest.PassingVerdict(strings.Repeat("11", 48))) // snp: no registers
+	cfg := Config{AttestationApiURL: url, CDSPinsFromOwnQuote: true}
+	if _, err := cfg.CDSPins(t.Context()); err == nil || !strings.Contains(err.Error(), "--cds-pins-from-own-quote") {
+		t.Fatalf("CDSPins(snp verifier) = %v, want a failure naming the flag", err)
+	}
+}
+
+// The own-quote flag and the flat pins are two answers to one question, and
+// the quote is only trustworthy from the node's own verifier.
+func TestValidateOwnQuoteFlagRules(t *testing.T) {
+	base := Config{CDSURL: "https://cds:8443", Attempts: 1, RetryInterval: 1, RequestTimeout: 1, InventoryTimeout: 1, CDSPinsFromOwnQuote: true}
+	for _, tc := range []struct {
+		name    string
+		edit    func(c *Config)
+		wantErr string
+	}{
+		{"unix verifier", func(c *Config) { c.AttestationApiURL = "unix:///run/confai/attestation-api.sock" }, ""},
+		{"with measurements", func(c *Config) {
+			c.AttestationApiURL = "unix:///run/confai/attestation-api.sock"
+			c.Measurements = []string{measurementHex()}
+		}, "replaces --measurements"},
+		{"with rtmrs", func(c *Config) {
+			c.AttestationApiURL = "unix:///run/confai/attestation-api.sock"
+			c.RTMRs = []string{"1=" + measurementHex()}
+		}, "replaces --measurements"},
+		{"network verifier", func(c *Config) { c.AttestationApiURL = "http://127.0.0.1:8400" }, "unix://"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := base
+			tc.edit(&cfg)
+			err := cfg.Validate()
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("Validate(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -17,9 +17,16 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
+
+// ownQuoteTimeout bounds the self-attestation round trip that derives the
+// CDS pins at start; the verifier is a local socket, so a slow answer means
+// it is not serving.
+const ownQuoteTimeout = 30 * time.Second
 
 // Config is the release plumbing every sidecar needs. The webhook renders all
 // of it; each command adds its own fields for what it fetches and where it
@@ -29,6 +36,14 @@ type Config struct {
 	AttestationApiURL string
 	Measurements      []string
 	RTMRs             []string
+
+	// CDSPinsFromOwnQuote pins CDS to this node's own image tuple, read
+	// from a fresh quote of this pod at start, instead of Measurements and
+	// RTMRs. A sealed node's sidecar argv is in the measured bundle, so it
+	// cannot carry a digest that depends on the bundle; the node's own quote
+	// carries the same tuple with RTMR[3] included, so a CDS on an unsealed
+	// node of the same image is refused.
+	CDSPinsFromOwnQuote bool
 
 	CertPath string
 	KeyPath  string
@@ -65,6 +80,7 @@ func BindFlags(f *pflag.FlagSet, cfg *Config) {
 	f.StringVar(&cfg.AttestationApiURL, "attestation-api-url", "", "local attestation-api used to verify CDS's RA-TLS certificate")
 	f.StringSliceVar(&cfg.Measurements, "measurements", nil, "SHA-384 hex launch measurement(s) CDS must present (repeatable; empty pins none, UNSAFE)")
 	f.StringSliceVar(&cfg.RTMRs, "rtmrs", nil, "TDX RTMR pin(s) <index>=<sha384-hex> CDS must additionally satisfy (repeatable; ignored when CDS presents SNP evidence, empty pins no registers)")
+	f.BoolVar(&cfg.CDSPinsFromOwnQuote, "cds-pins-from-own-quote", false, "pin CDS to this node's own image tuple {MRTD, RTMR[1..3]}, taken from a fresh quote of this pod verified over the unix --attestation-api-url at start, instead of --measurements and --rtmrs (static allowlist nodes, where the argv is sealed)")
 	f.StringVar(&cfg.CertPath, "cert", "/run/c8s/certs/tls.crt", "the pod's CDS-issued certificate, presented to CDS")
 	f.StringVar(&cfg.KeyPath, "key", "/run/c8s/certs/tls.key", "private key for --cert")
 	f.IntVar(&cfg.Attempts, "attempts", 60, "how many times to try before failing; release is refused until every main container is running, so retries are expected")
@@ -90,6 +106,14 @@ func (c *Config) Validate() error {
 	if err := cmdsutil.ValidateAttestationAPIURL("--attestation-api-url", c.AttestationApiURL); err != nil {
 		return err
 	}
+	if c.CDSPinsFromOwnQuote {
+		if len(c.Measurements) > 0 || len(c.RTMRs) > 0 {
+			return fmt.Errorf("--cds-pins-from-own-quote replaces --measurements and --rtmrs; pass one form of CDS pin")
+		}
+		if !strings.HasPrefix(c.AttestationApiURL, "unix://") {
+			return fmt.Errorf("--cds-pins-from-own-quote requires a unix:// --attestation-api-url: the pins come from the node's own verifier, and a network endpoint is one the control plane can substitute")
+		}
+	}
 	if c.Attempts <= 0 {
 		return fmt.Errorf("--attempts must be positive")
 	}
@@ -99,14 +123,25 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// ParsePins decodes --measurements and --rtmrs, refusing an empty measurement
-// pin inside a kata guest and warning outside one.
-func (c *Config) ParsePins() (ratls.Pins, error) {
-	measurements, err := ratls.ParseHexMeasurementsList(c.Measurements)
+// CDSPins is what the sidecar holds CDS's RA-TLS certificate to: the node's
+// own tuple under --cds-pins-from-own-quote, else --measurements and
+// --rtmrs decoded, refusing an empty measurement pin inside a kata guest and
+// warning outside one.
+func (c *Config) CDSPins(ctx context.Context) (ratls.Pins, error) {
+	if c.CDSPinsFromOwnQuote {
+		ctx, cancel := context.WithTimeout(ctx, ownQuoteTimeout)
+		defer cancel()
+		entry, err := attestationclient.NewClient(c.AttestationApiURL).OwnTupleEntry(ctx)
+		if err != nil {
+			return ratls.Pins{}, fmt.Errorf("--cds-pins-from-own-quote: %w", err)
+		}
+		return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+	}
+	launch, err := ratls.ParseHexMeasurementsList(c.Measurements)
 	if err != nil {
 		return ratls.Pins{}, fmt.Errorf("--measurements: %w", err)
 	}
-	if err := cmdsutil.CheckCDSPinned(len(measurements), c.WorkloadClaimsGuest,
+	if err := cmdsutil.CheckCDSPinned(len(launch), c.WorkloadClaimsGuest,
 		"--measurements empty: the CDS this sidecar hands its sandbox token to is not pinned to a launch measurement. UNSAFE outside development."); err != nil {
 		return ratls.Pins{}, err
 	}
@@ -114,7 +149,7 @@ func (c *Config) ParsePins() (ratls.Pins, error) {
 	if err != nil {
 		return ratls.Pins{}, fmt.Errorf("--rtmrs: %w", err)
 	}
-	return ratls.Pins{Measurements: measurements, RTMRs: rtmrs}, nil
+	return ratls.Pins{Measurements: launch, RTMRs: rtmrs}, nil
 }
 
 // Terminal marks a non-nil error no later attempt can clear, so Retry stops on

--- a/internal/cmds/sidecar/sidecar.go
+++ b/internal/cmds/sidecar/sidecar.go
@@ -18,15 +18,9 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
-	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
-
-// ownQuoteTimeout bounds the self-attestation round trip that derives the
-// CDS pins at start; the verifier is a local socket, so a slow answer means
-// it is not serving.
-const ownQuoteTimeout = 30 * time.Second
 
 // Config is the release plumbing every sidecar needs. The webhook renders all
 // of it; each command adds its own fields for what it fetches and where it
@@ -129,13 +123,11 @@ func (c *Config) Validate() error {
 // warning outside one.
 func (c *Config) CDSPins(ctx context.Context) (ratls.Pins, error) {
 	if c.CDSPinsFromOwnQuote {
-		ctx, cancel := context.WithTimeout(ctx, ownQuoteTimeout)
-		defer cancel()
-		entry, err := attestationclient.NewClient(c.AttestationApiURL).OwnTupleEntry(ctx)
+		pins, err := ratls.OwnTuplePins(ctx, attestationclient.NewClient(c.AttestationApiURL))
 		if err != nil {
 			return ratls.Pins{}, fmt.Errorf("--cds-pins-from-own-quote: %w", err)
 		}
-		return ratls.Pins{Entries: []measurements.Entry{entry}}, nil
+		return pins, nil
 	}
 	launch, err := ratls.ParseHexMeasurementsList(c.Measurements)
 	if err != nil {

--- a/internal/cmds/verify/operatorpkey_test.go
+++ b/internal/cmds/verify/operatorpkey_test.go
@@ -61,17 +61,25 @@ func operatorKeypair(t *testing.T) (pubPath string, keyPaths []string, pubPEM []
 	return pubPath, keyPaths, pubPEM
 }
 
-// operatorSeed recomputes the register an initrd leaves behind —
-// SHA-384(0x00*48 ‖ SHA-384(pubkey)) — straight from the convention documented
-// in pkg/runtimemeasure, deliberately WITHOUT calling the helper the code under
-// test calls. Comparing that helper against itself would pin nothing; this is
-// the arithmetic an operator would otherwise have to do by hand, which is the
-// chore --operator-pkey exists to remove.
+// operatorSeed recomputes the register a dynamic operator-key boot leaves
+// behind — the initrd's seed SHA-384(0x00*48 ‖ SHA-384(pubkey)) extended by
+// the node image's mode event SHA-384("c8s/rtmr3/mode/dynamic/v1") — straight
+// from the convention documented in pkg/runtimemeasure, deliberately WITHOUT
+// calling the helpers the code under test calls. Comparing those helpers
+// against themselves would pin nothing; this is the arithmetic an operator
+// would otherwise have to do by hand, which is the chore --operator-pkey
+// exists to remove.
 func operatorSeed(pubPEM []byte) []byte {
 	inner := sha512.Sum384(pubPEM)
 	h := sha512.New384()
 	h.Write(make([]byte, 48))
 	h.Write(inner[:])
+	seed := h.Sum(nil)
+
+	mode := sha512.Sum384([]byte("c8s/rtmr3/mode/dynamic/v1"))
+	h = sha512.New384()
+	h.Write(seed)
+	h.Write(mode[:])
 	return h.Sum(nil)
 }
 
@@ -85,7 +93,7 @@ func TestOperatorPkeyDerivesTheRTMR3Pin(t *testing.T) {
 	cfg := config{imageManifest: writeTestManifest(t), operatorPubkey: pubPath}
 	plan := mustPlan(t, cfg)
 	if !bytes.Equal(plan.pins.rtmr3, want) {
-		t.Fatalf("derived RTMR[3] = %x, want the bare operator-key seed %x", plan.pins.rtmr3, want)
+		t.Fatalf("derived RTMR[3] = %x, want the dynamic-mode operator-key register %x", plan.pins.rtmr3, want)
 	}
 
 	// The hex an operator computes by hand and the key file must be two ways of

--- a/internal/cmds/verify/staticallowlist_test.go
+++ b/internal/cmds/verify/staticallowlist_test.go
@@ -1,0 +1,307 @@
+package verify
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+
+	"github.com/confidential-dot-ai/c8s/internal/allowlist"
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+// staticBundle writes a bundle directory holding a sealed one-entry
+// static-allowlist.json (workload "web") and returns its path and the exact
+// member bytes.
+func staticBundle(t *testing.T) (string, []byte) {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{"web":{"containers":[{
+		"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111",
+		"command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},
+		"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},
+		"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}]}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, policybundle.MemberStaticAllowlist), member, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return dir, member
+}
+
+// staticRegister recomputes the static register straight from the convention
+// in pkg/runtimemeasure, deliberately WITHOUT the helpers the code under test
+// calls: Extend(Extend(Zero, SHA-384("c8s/rtmr3/mode/static/v1")),
+// SHA-384("c8s/rtmr3/policy/v1:" + index)) with index the sorted, unspaced
+// JSON {"static-allowlist.json": "sha256:<hex of the member>"}.
+func staticRegister(member []byte) []byte {
+	sum := sha256.Sum256(member)
+	index := `{"static-allowlist.json":"sha256:` + hex.EncodeToString(sum[:]) + `"}`
+	mode := sha512.Sum384([]byte("c8s/rtmr3/mode/static/v1"))
+	h := sha512.New384()
+	h.Write(make([]byte, 48))
+	h.Write(mode[:])
+	afterMode := h.Sum(nil)
+	policy := sha512.Sum384([]byte("c8s/rtmr3/policy/v1:" + index))
+	h = sha512.New384()
+	h.Write(afterMode)
+	h.Write(policy[:])
+	return h.Sum(nil)
+}
+
+// staticConfig is the minimal valid invocation: the bundle, the manifest, and
+// the workload/mesh-CA pair the stamp check needs.
+func staticConfig(t *testing.T, bundle string) config {
+	t.Helper()
+	_, caPath := caSignedWorkloadLeaf(t, nil)
+	return config{imageManifest: writeTestManifest(t), staticAllowlist: bundle, workload: "web", meshCA: caPath}
+}
+
+func TestStaticAllowlistDerivesTheRTMR3Pin(t *testing.T) {
+	dir, member := staticBundle(t)
+	want := staticRegister(member)
+
+	cfg := staticConfig(t, dir)
+	plan := mustPlan(t, cfg)
+	if !bytes.Equal(plan.pins.rtmr3, want) {
+		t.Fatalf("derived RTMR[3] = %x, want the static register %x", plan.pins.rtmr3, want)
+	}
+	if plan.static == nil {
+		t.Fatal("plan carries no bundle; the stamp check would have nothing to hold the leaf to")
+	}
+
+	// The loose member is the same one-member bundle.
+	loose := staticConfig(t, filepath.Join(dir, policybundle.MemberStaticAllowlist))
+	if got := mustPlan(t, loose).pins.rtmr3; !bytes.Equal(got, want) {
+		t.Errorf("loose file RTMR[3] = %x, want the directory's %x", got, want)
+	}
+
+	// End to end: a sealed node verifies, the verdict names the register and
+	// the bundle it came from.
+	regHex := hex.EncodeToString(want)
+	rtmrs := map[string]any{"rtmr_1": testRTMR1, "rtmr_2": testRTMR2, "rtmr_3": regHex}
+	oc := newOutcome(cfg, &evidence{platform: "tdx"}, tdxResult(testMRTD, rtmrs), nil, plan)
+	if !oc.Verified {
+		t.Fatalf("a sealed node must verify: %s", oc.Error)
+	}
+	if len(oc.RTMRsPinned) != 3 || oc.RTMRsPinned[2] != "3:"+regHex {
+		t.Errorf("RTMRsPinned = %v, want RTMR[3] reported as %s", oc.RTMRsPinned, regHex)
+	}
+	sum := sha256.Sum256([]byte(`{"static-allowlist.json":"sha256:` + func() string { s := sha256.Sum256(member); return hex.EncodeToString(s[:]) }() + `"}`))
+	if want := "sha256:" + hex.EncodeToString(sum[:]); oc.StaticPolicyDigest != want {
+		t.Errorf("StaticPolicyDigest = %q, want the index digest %q", oc.StaticPolicyDigest, want)
+	}
+	var text strings.Builder
+	renderText(cfg, oc, &text)
+	if !strings.Contains(text.String(), "static policy: "+oc.StaticPolicyDigest) {
+		t.Errorf("text verdict does not name the static policy:\n%s", text.String())
+	}
+}
+
+// The pin fills the same slot as --operator-pkey and inherits its rules: a
+// different register fails, an absent claim fails closed, SNP is a policy
+// error naming this flag.
+func TestStaticAllowlistPinEnforcedLikeOperatorPkey(t *testing.T) {
+	dir, _ := staticBundle(t)
+	cfg := staticConfig(t, dir)
+	plan := mustPlan(t, cfg)
+
+	t.Run("an unsealed node of the same image fails", func(t *testing.T) {
+		pubPath, _, _ := operatorKeypair(t)
+		dynamic := mustPlan(t, config{imageManifest: writeTestManifest(t), operatorPubkey: pubPath})
+		rtmrs := map[string]any{"rtmr_1": testRTMR1, "rtmr_2": testRTMR2, "rtmr_3": hex.EncodeToString(dynamic.pins.rtmr3)}
+		oc := newOutcome(cfg, &evidence{platform: "tdx"}, tdxResult(testMRTD, rtmrs), nil, plan)
+		if oc.Verified || !strings.Contains(oc.Error, "RTMR[3]") {
+			t.Errorf("a dynamic-mode node must fail the static pin: %+v", oc)
+		}
+	})
+	t.Run("a node sealed to another bundle fails", func(t *testing.T) {
+		other, _ := staticBundle(t)
+		otherMember := filepath.Join(other, policybundle.MemberStaticAllowlist)
+		data, _ := os.ReadFile(otherMember)
+		// Same document, one byte of whitespace more: the node measures bytes.
+		if err := os.WriteFile(otherMember, append(data, '\n'), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		reg := staticRegister(append(data, '\n'))
+		rtmrs := map[string]any{"rtmr_1": testRTMR1, "rtmr_2": testRTMR2, "rtmr_3": hex.EncodeToString(reg)}
+		oc := newOutcome(cfg, &evidence{platform: "tdx"}, tdxResult(testMRTD, rtmrs), nil, plan)
+		if oc.Verified || !strings.Contains(oc.Error, "RTMR[3]") {
+			t.Errorf("a node sealed to other bytes must fail: %+v", oc)
+		}
+	})
+	t.Run("an absent claim fails closed", func(t *testing.T) {
+		rtmrs := map[string]any{"rtmr_1": testRTMR1, "rtmr_2": testRTMR2}
+		oc := newOutcome(cfg, &evidence{platform: "tdx"}, tdxResult(testMRTD, rtmrs), nil, plan)
+		if oc.Verified || !strings.Contains(oc.Error, "carry no rtmr_3") {
+			t.Errorf("an unreportable register must fail closed: %+v", oc)
+		}
+	})
+	t.Run("SNP evidence is a policy error", func(t *testing.T) {
+		result := &teetypes.VerificationResult{
+			SignatureValid: true,
+			Platform:       teetypes.PlatformSNP,
+			Claims:         teetypes.Claims{LaunchDigest: strings.Repeat("ab", 48)},
+		}
+		oc := newOutcome(cfg, &evidence{platform: "snp"}, result, nil, plan)
+		if oc.Verified || !strings.Contains(oc.Error, "--static-allowlist") {
+			t.Errorf("SNP has no runtime registers; the pin must be a named policy error: %+v", oc)
+		}
+	})
+}
+
+// cdsStamp is the policy digest CDS puts in every leaf: SHA-256 of the
+// canonical document its store serves after being seeded from member. The
+// store is the real one, so the test fails if seeding ever re-serializes a
+// sealed member differently from the bytes the node measured.
+func cdsStamp(t *testing.T, member []byte) []byte {
+	t.Helper()
+	al, err := pkgallowlist.ParseJSON(member)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := allowlist.OpenInMemory()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	if _, err := store.SeedWorkloads(al.Workloads); err != nil {
+		t.Fatal(err)
+	}
+	served, _, err := store.LoadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := served.CanonicalDigest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+// The bundle member is the allowlist the stamp is held to: the leaf's stamped
+// digest must be SHA-256 of the measured bytes and the stamped name must
+// resolve in it, exactly as --allowlist would have checked a held file. The
+// stamp comes from CDS's own store round trip, not from hashing the member,
+// so the check proves the two sides agree on the bytes.
+func TestStaticAllowlistHoldsTheStamp(t *testing.T) {
+	dir, member := staticBundle(t)
+	stamp := cdsStamp(t, member)
+	if measured := sha256.Sum256(member); !bytes.Equal(stamp, measured[:]) {
+		t.Fatalf("CDS would stamp %x but the node measured %x: the member is not in the store's form", stamp, measured)
+	}
+	cfg := staticConfig(t, dir)
+	plan := mustPlan(t, cfg)
+	held, err := heldFromBundle(plan.static)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(held.raw, member) {
+		t.Fatal("held bytes differ from the member; the digest compare would hash a re-serialization")
+	}
+
+	run := func(matched *ratls.MatchedWorkload) Outcome {
+		t.Helper()
+		leaf, caPath := caSignedWorkloadLeaf(t, matched)
+		cfg := cfg
+		cfg.meshCA = caPath
+		oc := Outcome{Verified: true}
+		applySandboxPolicy(&oc, cfg, &evidence{leaf: leaf, workload: matched}, operatorKeysReport{}, &verifyPlan{}, measurementsReport{})
+		applyWorkloadPolicy(&oc, cfg, &evidence{leaf: leaf, workload: matched}, held)
+		return oc
+	}
+	if oc := run(&ratls.MatchedWorkload{Name: "web", AllowlistVersion: "1", AllowlistDigest: stamp}); !oc.Verified {
+		t.Errorf("a leaf stamped with the bundle's digest must verify: %s", oc.Error)
+	}
+	other := sha256.Sum256(append(bytes.Clone(member), '\n'))
+	if oc := run(&ratls.MatchedWorkload{Name: "web", AllowlistVersion: "1", AllowlistDigest: other[:]}); oc.Verified || !strings.Contains(oc.Error, "allowlist_digest_mismatch") || !strings.Contains(oc.Error, "held --static-allowlist bytes") || strings.Contains(oc.Error, "--allowlist bytes") {
+		t.Errorf("a leaf stamped with another policy's digest must fail naming --static-allowlist: %+v", oc)
+	}
+	if oc := run(&ratls.MatchedWorkload{Name: "other", AllowlistVersion: "1", AllowlistDigest: stamp}); oc.Verified || !strings.Contains(oc.Error, "workload_name_mismatch") {
+		t.Errorf("a leaf stamped for another entry must fail: %+v", oc)
+	}
+}
+
+func TestStaticAllowlistFlagErrors(t *testing.T) {
+	dir, member := staticBundle(t)
+	manifest := writeTestManifest(t)
+	pubPath, _, _ := operatorKeypair(t)
+	_, caPath := caSignedWorkloadLeaf(t, nil)
+	unsealed := t.TempDir()
+	if err := os.WriteFile(filepath.Join(unsealed, policybundle.MemberStaticAllowlist), append(member, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nullDigests := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nullDigests, policybundle.MemberStaticAllowlist), bytes.Replace(member, []byte(`"digests":{}`), []byte(`"digests":null`), 1), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := config{imageManifest: manifest, staticAllowlist: dir, workload: "web", meshCA: caPath}
+	with := func(mutate func(c *config)) config {
+		c := valid
+		mutate(&c)
+		return c
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  config
+		want []string
+	}{
+		{"with --operator-pkey", with(func(c *config) { c.operatorPubkey = pubPath }),
+			[]string{"--operator-pkey", "--static-allowlist", "name the register once"}},
+		{"with --expected-rtmr3", with(func(c *config) { c.expectedRTMR3Hex = testRTMR3 }),
+			[]string{"--expected-rtmr3", "--static-allowlist", "name the register once"}},
+		{"with --rtmr 3=", with(func(c *config) { c.rtmrs = []string{"3=" + testRTMR3} }),
+			[]string{"--rtmr 3=", "--static-allowlist", "name the register once"}},
+		{"without --image-manifest", with(func(c *config) { c.imageManifest = "" }),
+			[]string{"--static-allowlist requires --image-manifest"}},
+		{"without --workload", with(func(c *config) { c.workload = "" }),
+			[]string{"--static-allowlist requires --workload"}},
+		{"without --mesh-ca", with(func(c *config) { c.meshCA = "" }),
+			[]string{"--workload requires --mesh-ca"}},
+		{"with --allowlist", with(func(c *config) { c.allowlistFile = filepath.Join(dir, policybundle.MemberStaticAllowlist) }),
+			[]string{"--allowlist cannot be combined with --static-allowlist"}},
+		{"iso image", with(func(c *config) { c.staticAllowlist = filepath.Join(dir, "policydata.iso") }),
+			[]string{"--static-allowlist", "ISO images cannot be read here"}},
+		{"missing bundle", with(func(c *config) { c.staticAllowlist = filepath.Join(dir, "absent") }),
+			[]string{"--static-allowlist"}},
+		{"member not sealed", with(func(c *config) { c.staticAllowlist = unsealed }),
+			[]string{"--static-allowlist static-allowlist.json", "not its canonical form"}},
+		{"member not in the store's form", with(func(c *config) { c.staticAllowlist = nullDigests }),
+			[]string{"--static-allowlist static-allowlist.json", `"digests" must be {}`}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := buildPolicy(tc.cfg)
+			if err == nil {
+				t.Fatal("want a usage error")
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to contain %q", err, want)
+				}
+			}
+			var out, errOut strings.Builder
+			if code := run(context.Background(), tc.cfg, &out, &errOut); code != exitUsage {
+				t.Errorf("run code = %d, want %d; stderr: %s", code, exitUsage, errOut.String())
+			}
+		})
+	}
+
+	if plan := mustPlan(t, valid); !bytes.Equal(plan.pins.rtmr3, staticRegister(member)) {
+		t.Error("the valid case must still resolve the derived pin")
+	}
+}

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -30,6 +30,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/pkg/initdata"
 	measurementspkg "github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
@@ -113,6 +114,7 @@ type config struct {
 	imageManifest      string
 	expectedRTMR3Hex   string
 	operatorPubkey     string
+	staticAllowlist    string
 	rtmrs              []string
 	operatorKeys       string
 	measurementsConfig string
@@ -206,6 +208,7 @@ responder chose).`,
 	f.StringVar(&cfg.imageManifest, "image-manifest", "", "build-artifact manifest of the expected TDX guest image (JSON object with mrtd, rtmr1, rtmr2, each 96 lowercase hex chars, published with the image build); all three registers are pinned exactly against this one manifest, so the guest kernel and rootfs are verified rather than only the firmware. Since it pins MRTD exactly it replaces --measurements/--measurements-file rather than combining with them. TDX evidence only — with SNP evidence this is a policy error")
 	f.StringVar(&cfg.expectedRTMR3Hex, "expected-rtmr3", "", "DEPRECATED, prefer --rtmr 3=<sha384-hex>: identical pin under identical rules, one flag for every register. Retained so existing invocations keep working")
 	f.StringVar(&cfg.operatorPubkey, "operator-pkey", "", "path to the operator PUBLIC key PEM (the verbatim file bytes the guest initrd hashed, as written by `openssl ec -pubout`) — derives and pins RTMR[3] as the dynamic-mode register of an operator-key boot: the seed SHA-384(0x00*48 ‖ SHA-384(pubkey)) extended by the dynamic mode event SHA-384(\"c8s/rtmr3/mode/dynamic/v1\"), so the register need not be computed by hand. Mutually exclusive with --expected-rtmr3, and like it a deployment property, NOT a cluster identity, so it requires --image-manifest. That value is what a node with no per-workload RTMR[3] extends reports, which today is every node (the workload measurer ships only inside the kata guest image). TDX evidence only — with SNP evidence this is a policy error")
+	f.StringVar(&cfg.staticAllowlist, "static-allowlist", "", "policy bundle a static-allowlist node booted with (a directory of members, or the static-allowlist.json alone): derives and pins RTMR[3] as the static register Extend(Extend(Zero, SHA-384(\"c8s/rtmr3/mode/static/v1\")), SHA-384(\"c8s/rtmr3/policy/v1:\" + bundle index)), and holds the leaf's matched-workload stamp to the bundle's own document. Requires --image-manifest (the register proves nothing under an unpinned image), --workload and --mesh-ca (the stamp is CA-vouched; the mesh CA carries no evidence of its own yet). Mutually exclusive with --operator-pkey, --expected-rtmr3, --rtmr 3= and --allowlist. TDX evidence only")
 	f.StringSliceVar(&cfg.rtmrs, "rtmr", nil, "expected TDX runtime measurement register(s) as <index>=<sha384-hex> (repeatable). RTMR[1] pins the guest kernel and RTMR[2] the kernel command line carrying the dm-verity root hash: these ARE the image, so pinning them by hand cannot be combined with --image-manifest, which pins the same two plus the MRTD from one provenanced build. RTMR[3] is the operator-key/mode/workload chain extended inside whatever image the host booted, so --rtmr 3= REQUIRES --image-manifest — alone it would read as proof of identity while proving none. RTMR[0] is not pinnable. TDX evidence only — with SNP evidence any pin here is a policy error")
 	f.StringVar(&cfg.measurementsConfig, "measurements-config", "", "measurements config listing the VM images this cluster runs. Pins the target to those images, and for kind=cds also fails unless the set the target serves at /measurements is exactly the same. Cannot be combined with --measurements, --measurements-file or --image-manifest")
 	f.StringVar(&cfg.operatorKeys, "operator-keys", "", "PEM bundle of expected operator public keys; verification fails unless the key set the attested target serves at /operator-keys matches it (kind=cds targets)")
@@ -256,6 +259,13 @@ func run(ctx context.Context, cfg config, out, errOut io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(errOut, "error: %v\n", err)
 		return exitUsage
+	}
+	if plan.static != nil {
+		held, err = heldFromBundle(plan.static)
+		if err != nil {
+			fmt.Fprintf(errOut, "error: %v\n", err)
+			return exitUsage
+		}
 	}
 
 	if cfg.url == "" && cfg.fromFile == "" {
@@ -496,6 +506,9 @@ type verifyPlan struct {
 	// refValues is the parsed --measurements-config, empty when unset. It
 	// both pins the target and is compared against what the target serves.
 	refValues measurementspkg.ReferenceValues
+	// static is the --static-allowlist bundle, nil when unset. Its member is
+	// the allowlist the leaf's stamp is held to, read once with the pins.
+	static *policybundle.Bundle
 }
 
 // buildPolicy parses the measurement allowlist, resolves the register pins and
@@ -576,6 +589,15 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 		return nil, fmt.Errorf("%s requires --image-manifest: RTMR[3] records events extended into a guest whose image the untrusted host selects, so pinning it without pinning the image proves nothing about what is running", rtmr3FlagUsed(cfg))
 	}
 
+	if cfg.staticAllowlist != "" {
+		if cfg.allowlistFile != "" {
+			return nil, fmt.Errorf("--allowlist cannot be combined with --static-allowlist: the bundle's static-allowlist.json is the document the stamp is held to")
+		}
+		if cfg.workload == "" {
+			return nil, fmt.Errorf("--static-allowlist requires --workload: the static register proves the node runs only the bundle; which entry this target is comes from the leaf's stamp, and the stamp is checked only against a named entry")
+		}
+	}
+
 	if _, err := expectedOperatorKeysDigest(cfg); err != nil {
 		return nil, err
 	}
@@ -635,6 +657,7 @@ func buildPolicy(cfg config) (*verifyPlan, error) {
 		meshCA:       caPool,
 		initDataHash: initDataHash,
 		refValues:    refValues,
+		static:       pins.static,
 	}, nil
 }
 
@@ -676,6 +699,9 @@ type rtmrPins struct {
 	// localverify.Verify, whose Params carries no registers). Setting the
 	// policy field alone made the flag a silent no-op.
 	manual map[int][]byte
+	// static is the --static-allowlist bundle rtmr3 was derived from, so the
+	// allowlist the stamp is held to is the one that produced the pin.
+	static *policybundle.Bundle
 }
 
 func (p rtmrPins) any() bool {
@@ -699,6 +725,8 @@ func allowlistFlagsUsed(cfg config) string {
 // slot, so the shared rules must be able to blame the right one.
 func rtmr3FlagUsed(cfg config) string {
 	switch {
+	case cfg.staticAllowlist != "":
+		return "--static-allowlist"
 	case cfg.operatorPubkey != "":
 		return "--operator-pkey"
 	case cfg.expectedRTMR3Hex != "":
@@ -729,6 +757,9 @@ func resolveRTMRPins(cfg config) (rtmrPins, error) {
 	}
 	if cfg.operatorPubkey != "" {
 		rtmr3Flags = append(rtmr3Flags, "--operator-pkey")
+	}
+	if cfg.staticAllowlist != "" {
+		rtmr3Flags = append(rtmr3Flags, "--static-allowlist")
 	}
 	if len(rtmr3Flags) > 1 {
 		return rtmrPins{}, fmt.Errorf("%s all pin RTMR[3]: name the register once", strings.Join(rtmr3Flags, " and "))
@@ -769,6 +800,24 @@ func resolveRTMRPins(cfg config) (rtmrPins, error) {
 		// inspects them.
 		reg := runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pubPEM))
 		pins.rtmr3 = reg[:]
+	}
+	if cfg.staticAllowlist != "" {
+		bundle, err := policybundle.Load(cfg.staticAllowlist)
+		if err != nil {
+			return rtmrPins{}, fmt.Errorf("--static-allowlist: %w", err)
+		}
+		// A node refuses to boot a member that is not sealed, so a bundle
+		// failing here is the wrong file, reported as such rather than as a
+		// register mismatch no node can explain.
+		if err := pkgallowlist.LintSealed(bundle.Members[policybundle.MemberStaticAllowlist]); err != nil {
+			return rtmrPins{}, fmt.Errorf("--static-allowlist %s: %w", policybundle.MemberStaticAllowlist, err)
+		}
+		// Derived by the shared convention package, like --operator-pkey: the
+		// measurer, cred-release, install and get-kubeconfig all go through
+		// ForStaticAllowlist over the same index.
+		reg := bundle.RTMR3()
+		pins.rtmr3 = reg[:]
+		pins.static = &bundle
 	}
 	if v, ok := manual[3]; ok {
 		pins.rtmr3 = v
@@ -851,12 +900,14 @@ func expectedOperatorKeysDigest(cfg config) ([]byte, error) {
 	return operatorauth.KeySetDigest(keys)
 }
 
-// heldAllowlist is the --allowlist file: the exact bytes (which are what gets
-// hashed — no reserialization, per the canonical-bytes rule) and the parsed
-// document the stamped name resolves against.
+// heldAllowlist is the allowlist a stamp is held to: the exact bytes (which
+// are what gets hashed — no reserialization, per the canonical-bytes rule),
+// the parsed document the stamped name resolves against, and the flag that
+// supplied it, for the mismatch text.
 type heldAllowlist struct {
-	raw []byte
-	doc *pkgallowlist.Allowlist
+	raw  []byte
+	doc  *pkgallowlist.Allowlist
+	flag string
 }
 
 // loadHeldAllowlist reads --allowlist once, or returns nil when the flag is
@@ -874,7 +925,20 @@ func loadHeldAllowlist(path string) (*heldAllowlist, error) {
 	if err != nil {
 		return nil, fmt.Errorf("--allowlist: %w", err)
 	}
-	return &heldAllowlist{raw: data, doc: doc}, nil
+	return &heldAllowlist{raw: data, doc: doc, flag: "--allowlist"}, nil
+}
+
+// heldFromBundle holds the --static-allowlist member the way --allowlist
+// holds a file: the leaf's stamped policy digest must be SHA-256 of these
+// exact bytes, and the node measured the same bytes, so a passing verdict ties
+// the stamp to the register.
+func heldFromBundle(bundle *policybundle.Bundle) (*heldAllowlist, error) {
+	raw := bundle.Members[policybundle.MemberStaticAllowlist]
+	doc, err := pkgallowlist.ParseJSON(raw)
+	if err != nil {
+		return nil, fmt.Errorf("--static-allowlist %s: %w", policybundle.MemberStaticAllowlist, err)
+	}
+	return &heldAllowlist{raw: raw, doc: doc, flag: "--static-allowlist"}, nil
 }
 
 // meshCAPool loads the mesh CA bundle used to authenticate a leaf's sandbox ID.
@@ -1020,6 +1084,9 @@ type Outcome struct {
 	// rootfs are unverified, and without RTMR[3] the runtime chain is. A
 	// verdict that proves neither must not look like one that proves both.
 	RTMRsPinned []string `json:"rtmrs_pinned,omitempty"`
+	// StaticPolicyDigest is the --static-allowlist bundle's index digest, the
+	// value RTMR[3] was derived from, on a verified static verdict.
+	StaticPolicyDigest string `json:"static_policy_digest,omitempty"`
 
 	// Warnings are policy gaps in an otherwise passing verdict — verified
 	// true, but with named limits a relying party should read.
@@ -1226,7 +1293,7 @@ func applyWorkloadPolicy(oc *Outcome, cfg config, ev *evidence, held *heldAllowl
 	if held != nil {
 		digest := sha256.Sum256(held.raw)
 		if !bytes.Equal(digest[:], ev.workload.AllowlistDigest) {
-			fail("allowlist_digest_mismatch: stamped policy digest %x does not match SHA-256 %x of the held --allowlist bytes", ev.workload.AllowlistDigest, digest[:])
+			fail("allowlist_digest_mismatch: stamped policy digest %x does not match SHA-256 %x of the held %s bytes", ev.workload.AllowlistDigest, digest[:], held.flag)
 			return
 		}
 		if _, ok := held.doc.Workloads[ev.workload.Name]; !ok {
@@ -1279,7 +1346,7 @@ func newOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, v
 	// evidence an MRTD/RTMR pin cannot be enforced at all, and reporting a
 	// register mismatch would obscure that the policy was inapplicable.
 	if plan.pins.any() && !isTDX(oc.Platform) {
-		oc.Error = fmt.Sprintf("an RTMR pin (--image-manifest / --expected-rtmr3 / --operator-pkey) is set but the evidence platform is %q: runtime measurement registers exist only on TDX, so this policy cannot be enforced against %q evidence", oc.Platform, oc.Platform)
+		oc.Error = fmt.Sprintf("an RTMR pin (--image-manifest / --expected-rtmr3 / --operator-pkey / --static-allowlist / --rtmr) is set but the evidence platform is %q: runtime measurement registers exist only on TDX, so this policy cannot be enforced against %q evidence", oc.Platform, oc.Platform)
 		return oc
 	}
 	if !enforceMinTCB(&oc, cfg, result) {
@@ -1316,6 +1383,10 @@ func newOutcome(cfg config, ev *evidence, result *teetypes.VerificationResult, v
 		return oc
 	}
 	oc.Verified = true
+	if plan.static != nil {
+		digest := plan.static.IndexDigest()
+		oc.StaticPolicyDigest = "sha256:" + hex.EncodeToString(digest[:])
+	}
 
 	// What decides between rejecting an MRTD-only TDX verdict and warning
 	// about it is whether an operator-pinned CA anchor (--mesh-ca) stands next
@@ -1447,7 +1518,7 @@ func rtmrMeaning(idx int) string {
 	case 2:
 		return "guest command line / dm-verity root hash"
 	case 3:
-		return "runtime operator-key/mode/workload chain"
+		return "runtime chain: operator-key seed then the dynamic mode event and workloads, or the static mode event then the policy"
 	default:
 		return "runtime measurement register"
 	}
@@ -1552,6 +1623,9 @@ func renderText(cfg config, oc Outcome, out io.Writer) {
 	for _, p := range oc.RTMRsPinned {
 		idx, hexVal, _ := strings.Cut(p, ":")
 		fmt.Fprintf(out, "  RTMR[%s]:      %s (matched)\n", idx, hexVal)
+	}
+	if oc.StaticPolicyDigest != "" {
+		fmt.Fprintf(out, "  static policy: %s (bundle index digest; RTMR[3] derived from it)\n", oc.StaticPolicyDigest)
 	}
 	if oc.InitDataNote != "" {
 		if oc.InitData != "" {

--- a/internal/cmds/verify/verify.go
+++ b/internal/cmds/verify/verify.go
@@ -205,8 +205,8 @@ responder chose).`,
 	f.StringVar(&cfg.measurementsFile, "measurements-file", "", "file of allowed launch measurements, one hex digest per line; feeds the same allowlist as --measurements and is likewise mutually exclusive with --image-manifest")
 	f.StringVar(&cfg.imageManifest, "image-manifest", "", "build-artifact manifest of the expected TDX guest image (JSON object with mrtd, rtmr1, rtmr2, each 96 lowercase hex chars, published with the image build); all three registers are pinned exactly against this one manifest, so the guest kernel and rootfs are verified rather than only the firmware. Since it pins MRTD exactly it replaces --measurements/--measurements-file rather than combining with them. TDX evidence only — with SNP evidence this is a policy error")
 	f.StringVar(&cfg.expectedRTMR3Hex, "expected-rtmr3", "", "DEPRECATED, prefer --rtmr 3=<sha384-hex>: identical pin under identical rules, one flag for every register. Retained so existing invocations keep working")
-	f.StringVar(&cfg.operatorPubkey, "operator-pkey", "", "path to the operator PUBLIC key PEM (the verbatim file bytes the guest initrd hashed, as written by `openssl ec -pubout`) — derives and pins RTMR[3] as the bare operator-key seed, SHA-384(0x00*48 ‖ SHA-384(pubkey)), so the register need not be computed by hand. Mutually exclusive with --expected-rtmr3, and like it a deployment property, NOT a cluster identity, so it requires --image-manifest. The bare seed is the value a node with no per-workload RTMR[3] extends reports, which today is every node (the workload measurer ships only inside the kata guest image). TDX evidence only — with SNP evidence this is a policy error")
-	f.StringSliceVar(&cfg.rtmrs, "rtmr", nil, "expected TDX runtime measurement register(s) as <index>=<sha384-hex> (repeatable). RTMR[1] pins the guest kernel and RTMR[2] the kernel command line carrying the dm-verity root hash: these ARE the image, so pinning them by hand cannot be combined with --image-manifest, which pins the same two plus the MRTD from one provenanced build. RTMR[3] is the operator-key/workload chain extended inside whatever image the host booted, so --rtmr 3= REQUIRES --image-manifest — alone it would read as proof of identity while proving none. RTMR[0] is not pinnable. TDX evidence only — with SNP evidence any pin here is a policy error")
+	f.StringVar(&cfg.operatorPubkey, "operator-pkey", "", "path to the operator PUBLIC key PEM (the verbatim file bytes the guest initrd hashed, as written by `openssl ec -pubout`) — derives and pins RTMR[3] as the dynamic-mode register of an operator-key boot: the seed SHA-384(0x00*48 ‖ SHA-384(pubkey)) extended by the dynamic mode event SHA-384(\"c8s/rtmr3/mode/dynamic/v1\"), so the register need not be computed by hand. Mutually exclusive with --expected-rtmr3, and like it a deployment property, NOT a cluster identity, so it requires --image-manifest. That value is what a node with no per-workload RTMR[3] extends reports, which today is every node (the workload measurer ships only inside the kata guest image). TDX evidence only — with SNP evidence this is a policy error")
+	f.StringSliceVar(&cfg.rtmrs, "rtmr", nil, "expected TDX runtime measurement register(s) as <index>=<sha384-hex> (repeatable). RTMR[1] pins the guest kernel and RTMR[2] the kernel command line carrying the dm-verity root hash: these ARE the image, so pinning them by hand cannot be combined with --image-manifest, which pins the same two plus the MRTD from one provenanced build. RTMR[3] is the operator-key/mode/workload chain extended inside whatever image the host booted, so --rtmr 3= REQUIRES --image-manifest — alone it would read as proof of identity while proving none. RTMR[0] is not pinnable. TDX evidence only — with SNP evidence any pin here is a policy error")
 	f.StringVar(&cfg.measurementsConfig, "measurements-config", "", "measurements config listing the VM images this cluster runs. Pins the target to those images, and for kind=cds also fails unless the set the target serves at /measurements is exactly the same. Cannot be combined with --measurements, --measurements-file or --image-manifest")
 	f.StringVar(&cfg.operatorKeys, "operator-keys", "", "PEM bundle of expected operator public keys; verification fails unless the key set the attested target serves at /operator-keys matches it (kind=cds targets)")
 	f.StringVar(&cfg.sandboxID, "sandbox-id", "", "expected CRI pod sandbox ID on the target's leaf; requires --mesh-ca, since CDS's signature on the leaf is what vouches for the ID (docs/ratls.md)")
@@ -761,13 +761,14 @@ func resolveRTMRPins(cfg config) (rtmrPins, error) {
 		if err := checkOperatorPublicKeyPEM(pubPEM); err != nil {
 			return rtmrPins{}, fmt.Errorf("--operator-pkey %s: %w", cfg.operatorPubkey, err)
 		}
-		// The seed is derived by the shared convention package, never
-		// recomputed here: the initrd, cred-release and get-kubeconfig all go
-		// through ForOperatorKey, and a second implementation of the same
-		// arithmetic is a second thing to drift. It hashes the file bytes
-		// verbatim — the check above only inspects them.
-		seed := runtimemeasure.ForOperatorKey(pubPEM)
-		pins.rtmr3 = seed[:]
+		// The register is derived by the shared convention package, never
+		// recomputed here: the initrd, the node image, cred-release and
+		// get-kubeconfig all go through ForOperatorKey and ForDynamic, and a
+		// second implementation of the same arithmetic is a second thing to
+		// drift. It hashes the file bytes verbatim — the check above only
+		// inspects them.
+		reg := runtimemeasure.ForDynamic(runtimemeasure.ForOperatorKey(pubPEM))
+		pins.rtmr3 = reg[:]
 	}
 	if v, ok := manual[3]; ok {
 		pins.rtmr3 = v
@@ -1423,7 +1424,7 @@ func applyRTMRPins(oc *Outcome, pins rtmrPins, result *teetypes.VerificationResu
 			return false
 		}
 	}
-	if pins.rtmr3 != nil && !check(3, "runtime operator-key/workload chain", pins.rtmr3) {
+	if pins.rtmr3 != nil && !check(3, rtmrMeaning(3), pins.rtmr3) {
 		return false
 	}
 	// Ascending index, so a target missing several pinned registers always
@@ -1446,7 +1447,7 @@ func rtmrMeaning(idx int) string {
 	case 2:
 		return "guest command line / dm-verity root hash"
 	case 3:
-		return "runtime operator-key/workload chain"
+		return "runtime operator-key/mode/workload chain"
 	default:
 		return "runtime measurement register"
 	}

--- a/internal/containerd/resolver.go
+++ b/internal/containerd/resolver.go
@@ -1,4 +1,6 @@
-// Package containerd provides tag-to-digest resolution via the containerd image store.
+// Package containerd is the plugin's view of the containerd daemon: image
+// tag-to-digest resolution, killing a container, and loading the OCI spec
+// containerd stored for a container.
 package containerd
 
 import (
@@ -10,6 +12,7 @@ import (
 
 	containerdclient "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	"github.com/distribution/reference"
 	"google.golang.org/grpc/codes"
@@ -91,6 +94,27 @@ func (r *Resolver) StopContainer(ctx context.Context, containerID string) error 
 	}
 
 	return nil
+}
+
+// Spec returns the OCI spec containerd stored for a container: the
+// authoritative process capabilities, masked and read-only paths, seccomp and
+// no_new_privileges, which the NRI container message does not carry.
+func (r *Resolver) Spec(ctx context.Context, containerID string) (*oci.Spec, error) {
+	nsCtx := namespaces.WithNamespace(ctx, r.namespace)
+
+	var container containerdclient.Container
+	if err := r.withReconnect(func() error {
+		var err error
+		container, err = r.client.LoadContainer(nsCtx, containerID)
+		return err
+	}); err != nil {
+		return nil, fmt.Errorf("load container %s: %w", containerID, err)
+	}
+	spec, err := container.Spec(nsCtx)
+	if err != nil {
+		return nil, fmt.Errorf("load spec of %s: %w", containerID, err)
+	}
+	return spec, nil
 }
 
 // withReconnect runs op; if it fails because the containerd connection is

--- a/internal/containerd/resolver_fake_server_test.go
+++ b/internal/containerd/resolver_fake_server_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -76,18 +77,22 @@ type fakeContainers struct {
 	containersapi.UnimplementedContainersServer
 
 	knownID string
+	// spec is the JSON OCI spec Get returns for knownID; nil returns none.
+	spec []byte
 }
 
 func (f *fakeContainers) Get(_ context.Context, req *containersapi.GetContainerRequest) (*containersapi.GetContainerResponse, error) {
 	if req.ID != f.knownID {
 		return nil, status.Errorf(codes.NotFound, "container %q: not found", req.ID)
 	}
-	return &containersapi.GetContainerResponse{
-		Container: &containersapi.Container{
-			ID:      req.ID,
-			Runtime: &containersapi.Container_Runtime{Name: "io.containerd.runc.v2"},
-		},
-	}, nil
+	c := &containersapi.Container{
+		ID:      req.ID,
+		Runtime: &containersapi.Container_Runtime{Name: "io.containerd.runc.v2"},
+	}
+	if f.spec != nil {
+		c.Spec = &anypb.Any{TypeUrl: "types.containerd.io/opencontainers/runtime-spec/1/Spec", Value: f.spec}
+	}
+	return &containersapi.GetContainerResponse{Container: c}, nil
 }
 
 // fakeTasks is a minimal tasks service whose Get/Kill behavior is scriptable.
@@ -373,6 +378,47 @@ func TestStopContainer(t *testing.T) {
 		}
 		if want := "kill task for " + containerID; !strings.Contains(err.Error(), want) {
 			t.Fatalf("error %q does not contain %q", err, want)
+		}
+	})
+}
+
+func TestSpec(t *testing.T) {
+	const containerID = "abc123"
+	specJSON := []byte(`{"ociVersion":"1.1.0","process":{"args":["/bin/sh"],"noNewPrivileges":true,"capabilities":{"bounding":["CAP_CHOWN","CAP_NET_ADMIN"]}},"linux":{"maskedPaths":["/proc/kcore"]}}`)
+
+	t.Run("returns the stored spec", func(t *testing.T) {
+		socket := startFakeContainerd(t, nil, &fakeContainers{knownID: containerID, spec: specJSON}, &fakeTasks{})
+		r := newTestResolver(t, socket)
+
+		spec, err := r.Spec(context.Background(), containerID)
+		if err != nil {
+			t.Fatalf("Spec(%s) = %v, want nil error", containerID, err)
+		}
+		if got, want := spec.Process.Capabilities.Bounding, []string{"CAP_CHOWN", "CAP_NET_ADMIN"}; strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Fatalf("Spec(%s).Process.Capabilities.Bounding = %v, want %v", containerID, got, want)
+		}
+		if !spec.Process.NoNewPrivileges || len(spec.Linux.MaskedPaths) != 1 {
+			t.Fatalf("Spec(%s) = noNewPrivileges %v, maskedPaths %v; want true, 1 path", containerID, spec.Process.NoNewPrivileges, spec.Linux.MaskedPaths)
+		}
+	})
+
+	t.Run("unknown container fails at load", func(t *testing.T) {
+		socket := startFakeContainerd(t, nil, &fakeContainers{knownID: containerID, spec: specJSON}, &fakeTasks{})
+		r := newTestResolver(t, socket)
+
+		_, err := r.Spec(context.Background(), "no-such-id")
+		if err == nil || !strings.Contains(err.Error(), "load container no-such-id") {
+			t.Fatalf("Spec(no-such-id) = %v, want a load container error", err)
+		}
+	})
+
+	t.Run("malformed spec is an error", func(t *testing.T) {
+		socket := startFakeContainerd(t, nil, &fakeContainers{knownID: containerID, spec: []byte("{")}, &fakeTasks{})
+		r := newTestResolver(t, socket)
+
+		_, err := r.Spec(context.Background(), containerID)
+		if err == nil || !strings.Contains(err.Error(), "load spec of "+containerID) {
+			t.Fatalf("Spec(%s) = %v, want a load spec error", containerID, err)
 		}
 	})
 }

--- a/internal/controller/runner.go
+++ b/internal/controller/runner.go
@@ -108,6 +108,12 @@ type Options struct {
 	// WorkloadClaimsGuest selects the kata shape: the inventory is reached on
 	// the guest's loopback address, so no socket is mounted.
 	WorkloadClaimsGuest bool
+
+	// StaticAllowlist selects the sealed node shape for the injected
+	// sidecars; AttestationSocketDir is the node's attestation socket
+	// directory they mount. See webhook.Config.
+	StaticAllowlist      bool
+	AttestationSocketDir string
 }
 
 var scheme = runtime.NewScheme()
@@ -280,6 +286,8 @@ func setupManager(ctx context.Context, mgr manager.Manager, dc serverResourcesFo
 			KataGuestReadyGate:    opts.KataGuestReadyGate,
 			WorkloadClaimsHostDir: opts.WorkloadClaimsHostDir,
 			WorkloadClaimsGuest:   opts.WorkloadClaimsGuest,
+			StaticAllowlist:       opts.StaticAllowlist,
+			AttestationSocketDir:  opts.AttestationSocketDir,
 		}); err != nil {
 			return fmt.Errorf("register webhook: %w", err)
 		}

--- a/internal/crane/crane.go
+++ b/internal/crane/crane.go
@@ -52,7 +52,7 @@ func Digest(ctx context.Context, ref string) (string, error) {
 }
 
 // Config returns the parsed OCI image config for a reference via
-// `crane config <ref>`, exposing the image's baked Entrypoint and Cmd.
+// `crane config <ref>`, exposing the image's baked Entrypoint, Cmd and Env.
 func Config(ctx context.Context, ref string) (*ImageConfig, error) {
 	out, err := run(ctx, "config", ref)
 	if err != nil {
@@ -99,6 +99,7 @@ type ImageConfig struct {
 	Config struct {
 		Entrypoint []string `json:"Entrypoint"`
 		Cmd        []string `json:"Cmd"`
+		Env        []string `json:"Env"`
 	} `json:"config"`
 }
 

--- a/internal/crane/crane_test.go
+++ b/internal/crane/crane_test.go
@@ -38,6 +38,9 @@ func TestConfig(t *testing.T) {
 	if len(cfg.Config.Cmd) != 2 || cfg.Config.Cmd[0] != "serve" || cfg.Config.Cmd[1] != "--port=1" {
 		t.Fatalf("cmd = %v", cfg.Config.Cmd)
 	}
+	if len(cfg.Config.Env) != 2 || cfg.Config.Env[0] != "PATH=/usr/bin:/bin" {
+		t.Fatalf("env = %v, want the stub's two entries", cfg.Config.Env)
+	}
 	if _, err := Config(context.Background(), "registry.example.com/badjson:v1"); err == nil || !strings.Contains(err.Error(), "parse crane config") {
 		t.Fatalf("expected a config parse error, got %v", err)
 	}

--- a/internal/crane/cranetest/cranetest.go
+++ b/internal/crane/cranetest/cranetest.go
@@ -18,8 +18,8 @@ const (
 
 // Install prepends a crane stub to PATH: digest resolves any ref to DigA
 // (refs containing "unresolvable" fail with MANIFEST_UNKNOWN), config serves
-// a fixed image config (refs containing "badjson" serve garbage), and
-// manifest fails for DigB refs.
+// a fixed image config with Entrypoint, Cmd and Env (refs containing
+// "badjson" serve garbage), and manifest fails for DigB refs.
 func Install(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
@@ -34,7 +34,7 @@ digest)
 config)
   case "$ref" in
   *badjson*) echo "not json" ;;
-  *) echo '{"config":{"Entrypoint":["/bin/app"],"Cmd":["serve","--port=1"]}}' ;;
+  *) echo '{"config":{"Entrypoint":["/bin/app"],"Cmd":["serve","--port=1"],"Env":["PATH=/usr/bin:/bin","APP_MODE=prod"]}}' ;;
   esac ;;
 manifest)
   case "$ref" in

--- a/internal/helmchart/c8s/templates/_helpers.tpl
+++ b/internal/helmchart/c8s/templates/_helpers.tpl
@@ -301,11 +301,16 @@ a floating tag would be root on every GPU node — so the digest is what's used.
 
 {{- /*
 c8s.attestationApiURL — the attestation-api endpoint injected into the operator
-and CDS. Three shapes:
+and CDS. Four shapes:
 
   - kata.enabled: the kata-guest-base image bakes an in-guest attestation-service
     on loopback, and the consumers (the operator's get-cert sidecars and CDS) run
     INSIDE the CVM, so they dial 127.0.0.1 — not the (absent) host Service.
+  - otherwise, when staticAllowlist.enabled: the node image serves the
+    attestation-api on <staticAllowlist.attestationSocketDir>/attestation-api.sock
+    (c8s-attest-socket.service). Every consumer dials that socket and no
+    HOST_IP env is rendered, so no chart value and no per-pod expansion can
+    pick another verifier; the sealed rules pin the argv as rendered.
   - otherwise, when attestationApi.enabled=true (the chart DaemonSet shape —
     the raw-values default, kept by gke/aks installs): the on-node Unix socket
     its attest-proxy sidecar serves
@@ -328,7 +333,7 @@ and CDS. Three shapes:
 {{- define "c8s.attestationApiURL" -}}
 {{- if .Values.kata.enabled -}}
 http://127.0.0.1:{{ .Values.attestationApi.port }}
-{{- else if .Values.attestationApi.enabled -}}
+{{- else if or .Values.staticAllowlist.enabled .Values.attestationApi.enabled -}}
 unix://{{ include "c8s.attestationApiSocket" . }}
 {{- else -}}
 http://$(HOST_IP):{{ .Values.attestationApi.port }}
@@ -336,22 +341,39 @@ http://$(HOST_IP):{{ .Values.attestationApi.port }}
 {{- end -}}
 
 {{- /*
-c8s.attestationApiSocket — the node-local socket the attest-proxy sidecar
-serves the attestation-api on. It lives in the admission inventory's socket
-directory: the one hostPath the deny-host-namespaces policy admits into a cw
-pod (read-only) and the one the webhook mounts into get-cert sidecars.
+c8s.attestationApiSocketDir — the node directory holding the attestation-api
+socket: under a static allowlist the node image's own
+(staticAllowlist.attestationSocketDir, served by c8s-attest-socket.service),
+otherwise the admission inventory's socket directory, where the chart's
+attest-proxy sidecar serves it.
 */ -}}
-{{- define "c8s.attestationApiSocket" -}}
-{{ .Values.nriImagePolicy.hostPaths.runtimeDir }}/attestation-api.sock
+{{- define "c8s.attestationApiSocketDir" -}}
+{{- if .Values.staticAllowlist.enabled -}}
+{{ .Values.staticAllowlist.attestationSocketDir }}
+{{- else -}}
+{{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+{{- end -}}
 {{- end -}}
 
 {{- /*
-c8s.attestationApiHostSocket — "true" when consumers reach the chart-managed
-attestation-api over the on-node Unix socket, i.e. the DaemonSet renders and
-the in-guest (kata) endpoint does not apply.
+c8s.attestationApiSocket — the node-local socket consumers verify evidence
+through. In the chart-managed shape it lives in the admission inventory's
+socket directory: the one hostPath the deny-host-namespaces policy admits
+into a cw pod (read-only) and the one the webhook mounts into get-cert
+sidecars.
+*/ -}}
+{{- define "c8s.attestationApiSocket" -}}
+{{ include "c8s.attestationApiSocketDir" . }}/attestation-api.sock
+{{- end -}}
+
+{{- /*
+c8s.attestationApiHostSocket — "true" when consumers reach the attestation-api
+over an on-node Unix socket: the chart DaemonSet renders and the in-guest
+(kata) endpoint does not apply, or the node image serves the socket itself
+(staticAllowlist.enabled).
 */ -}}
 {{- define "c8s.attestationApiHostSocket" -}}
-{{- if and .Values.attestationApi.enabled (not .Values.kata.enabled) -}}true{{- end -}}
+{{- if or .Values.staticAllowlist.enabled (and .Values.attestationApi.enabled (not .Values.kata.enabled)) -}}true{{- end -}}
 {{- end -}}
 
 {{- /*
@@ -365,15 +387,18 @@ DirectoryOrCreate so a consumer scheduled before the DaemonSet does not wedge
 {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
 - name: attestation-api-socket
   hostPath:
-    path: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
-    type: DirectoryOrCreate
+    path: {{ include "c8s.attestationApiSocketDir" . }}
+    {{- /* The static socket directory is the node image's own: a node
+           missing it did not boot the measured image, and a pod must not
+           create it. */}}
+    type: {{ ternary "Directory" "DirectoryOrCreate" .Values.staticAllowlist.enabled }}
 {{- end }}
 {{- end -}}
 
 {{- define "c8s.attestationApiSocketMount" -}}
 {{- if eq (include "c8s.attestationApiHostSocket" .) "true" }}
 - name: attestation-api-socket
-  mountPath: {{ .Values.nriImagePolicy.hostPaths.runtimeDir }}
+  mountPath: {{ include "c8s.attestationApiSocketDir" . }}
   readOnly: true
 {{- end }}
 {{- end -}}
@@ -386,7 +411,7 @@ pod-netns consumers reach the node-baked host attestation-api via the node's
 own IP. Empty in every other shape.
 */ -}}
 {{- define "c8s.attestationApiHostIPEnv" -}}
-{{- if and (not .Values.kata.enabled) (not .Values.attestationApi.enabled) (eq .Values.attestationApi.cvmMode "node") -}}
+{{- if and (not .Values.kata.enabled) (not .Values.attestationApi.enabled) (not .Values.staticAllowlist.enabled) (eq .Values.attestationApi.cvmMode "node") -}}
 - name: HOST_IP
   valueFrom:
     fieldRef:
@@ -469,6 +494,12 @@ Caller passes a dict:
     - --renew-interval={{ .renewInterval }}
     - --reload-nginx={{ default "false" .reloadNginx }}
     - --continue-on-initial-error
+    {{- if $root.Values.staticAllowlist.enabled }}
+    # Sealed node: pin CDS to this node's own tuple (RTMR[3] included) from a
+    # quote over the mounted socket, so a CDS on an unsealed node of the same
+    # image is refused and the argv carries no per-cluster digest.
+    - --cds-pins-from-own-quote
+    {{- end }}
     {{- range .extraArgs }}
     - {{ . }}
     {{- end }}
@@ -710,10 +741,32 @@ cache_max_entries = 1024
       until an operator hand-runs `c8s allowlist add`. The cvmMode arm also
       covers a node install that leaves the installer off entirely.
   Gating on nriImagePolicy.enabled alone dropped the seed under both pod and
-  node mode.
+  node mode. Under a static allowlist the seed is the measured bundle member
+  on the node (c8s.staticSeedPath), never a chart ConfigMap.
 */}}
 {{- define "c8s.serveAllowlistSeed" -}}
-{{- or .Values.nriImagePolicy.enabled .Values.kata.enabled (eq .Values.attestationApi.cvmMode "node") -}}
+{{- and (not .Values.staticAllowlist.enabled) (or .Values.nriImagePolicy.enabled .Values.kata.enabled (eq .Values.attestationApi.cvmMode "node")) -}}
+{{- end -}}
+
+{{/*
+  c8s.staticPodSpec — pod-spec fields every c8s pod carries under a static
+  allowlist. The sealed rules pin every environment variable, and the kubelet
+  adds one per Service in the namespace unless enableServiceLinks is false;
+  the API server's own KUBERNETES_* set is added regardless and is what the
+  rules list. Empty otherwise.
+*/}}
+{{- define "c8s.staticPodSpec" -}}
+{{- if .Values.staticAllowlist.enabled -}}
+enableServiceLinks: false
+{{- end -}}
+{{- end -}}
+
+{{/*
+  c8s.staticSeedPath — the bundle member a static CDS seeds from: the file
+  c8s-policy-measure published and measured.
+*/}}
+{{- define "c8s.staticSeedPath" -}}
+{{ .Values.staticAllowlist.policyDir }}/static-allowlist.json
 {{- end -}}
 
 {{/*

--- a/internal/helmchart/c8s/templates/attestation-api.yaml
+++ b/internal/helmchart/c8s/templates/attestation-api.yaml
@@ -44,6 +44,9 @@ spec:
       annotations:
         checksum/config: {{ include "c8s.attestationApiConfig" (dict "root" .) | sha256sum }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.attestationApiName" . }}
       tolerations:
         - operator: Exists

--- a/internal/helmchart/c8s/templates/cds.yaml
+++ b/internal/helmchart/c8s/templates/cds.yaml
@@ -96,6 +96,9 @@ spec:
         checksum/measurements-config: {{ .Values.cds.measurementsConfig | sha256sum }}
         {{- end }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- if .Values.kata.enabled }}
       # Run the trust root inside a confidential VM. Its mesh CA and EAR signing
       # keys live only in SEV-SNP-encrypted guest memory, and peers verify cds's
@@ -133,6 +136,11 @@ spec:
         runAsNonRoot: false
       {{- else }}
 {{ toYaml .Values.podSecurityContext | indent 8 }}
+        {{- if .Values.staticAllowlist.enabled }}
+        # workloadclaims.InventorySocketGID: the node's attestation socket is
+        # root-owned 0660 and group-owned by it, so uid 65532 can connect.
+        supplementalGroups: [65532]
+        {{- end }}
       {{- end }}
       containers:
         - name: cds
@@ -145,7 +153,14 @@ spec:
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
             - --allowlist-db={{ .Values.cds.allowlistDB }}
             - --allowlist-persistent={{ .Values.cds.persistence.enabled }}
-            {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
+            {{- if .Values.staticAllowlist.enabled }}
+            # The node measured this bundle into RTMR[3] at boot; CDS refuses
+            # to start unless its own evidence carries that register
+            # (validations.yaml, kind=static_allowlist_*).
+            - --static-allowlist
+            - --policy-dir={{ .Values.staticAllowlist.policyDir }}
+            - --allowlist-seed={{ include "c8s.staticSeedPath" . }}
+            {{- else if eq (include "c8s.serveAllowlistSeed" .) "true" }}
             - --allowlist-seed=/etc/cds/allowlist-seed.json
             {{- end }}
             - --ear-issuer={{ .Values.cds.earIssuer }}
@@ -245,7 +260,11 @@ spec:
             - name: data
               mountPath: /data
             {{- include "c8s.attestationApiSocketMount" . | nindent 12 }}
-            {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
+            {{- if .Values.staticAllowlist.enabled }}
+            - name: policy-dir
+              mountPath: {{ .Values.staticAllowlist.policyDir }}
+              readOnly: true
+            {{- else if eq (include "c8s.serveAllowlistSeed" .) "true" }}
             - name: allowlist-seed
               mountPath: /etc/cds
               readOnly: true
@@ -282,7 +301,15 @@ spec:
           emptyDir: {}
           {{- end }}
         {{- include "c8s.attestationApiSocketVolume" . | nindent 8 }}
-        {{- if eq (include "c8s.serveAllowlistSeed" .) "true" }}
+        {{- if .Values.staticAllowlist.enabled }}
+        # Directory, not DirectoryOrCreate: a node without the measurer's
+        # output did not boot the measured image, and CDS must not start
+        # against an empty directory a pod created.
+        - name: policy-dir
+          hostPath:
+            path: {{ .Values.staticAllowlist.policyDir }}
+            type: Directory
+        {{- else if eq (include "c8s.serveAllowlistSeed" .) "true" }}
         - name: allowlist-seed
           configMap:
             name: {{ include "c8s.cdsName" . }}-allowlist-seed

--- a/internal/helmchart/c8s/templates/host-namespace-policy.yaml
+++ b/internal/helmchart/c8s/templates/host-namespace-policy.yaml
@@ -16,7 +16,9 @@ with kube-system and any operator-supplied additions.
 One hostPath is carved out: the webhook injects a read-only mount of the
 inventory socket directory (nriImagePolicy.hostPaths.runtimeDir) into every
 CW pod's cert sidecar, so the policy admits exactly that dir, type Directory,
-with every referencing mount readOnly.
+with every referencing mount readOnly. Under a static allowlist the CDS pod
+reads the node's policy directory and attestation socket directory the same
+way, so those two are carved out on the same terms.
 */}}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -69,7 +71,11 @@ spec:
     - expression: >-
         !has(object.spec.volumes) ||
         object.spec.volumes.all(v, !has(v.hostPath) ||
-          (v.hostPath.path == {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }} &&
+          ((v.hostPath.path == {{ .Values.nriImagePolicy.hostPaths.runtimeDir | quote }}
+            {{- if .Values.staticAllowlist.enabled }} ||
+            v.hostPath.path == {{ .Values.staticAllowlist.policyDir | quote }} ||
+            v.hostPath.path == {{ .Values.staticAllowlist.attestationSocketDir | quote }}
+            {{- end }}) &&
            has(v.hostPath.type) && v.hostPath.type == 'Directory' &&
            object.spec.containers.all(c, !has(c.volumeMounts) ||
              c.volumeMounts.all(m, m.name != v.name || (has(m.readOnly) && m.readOnly == true))) &&

--- a/internal/helmchart/c8s/templates/kata-image-puller-nvidia.yaml
+++ b/internal/helmchart/c8s/templates/kata-image-puller-nvidia.yaml
@@ -41,6 +41,9 @@ spec:
       annotations:
         checksum/config: {{ printf "%s|%s" .Values.kata.guestImage.repository (include "c8s.kataGuestImageNvidiaTag" .) | sha256sum }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.kataName" . }}-image-puller
       nodeSelector:
         kubernetes.io/os: linux

--- a/internal/helmchart/c8s/templates/kata-image-puller.yaml
+++ b/internal/helmchart/c8s/templates/kata-image-puller.yaml
@@ -71,6 +71,9 @@ spec:
         # the ConfigMap and rolls the DaemonSet.
         checksum/config: {{ printf "%s|%s" .Values.kata.guestImage.repository (include "c8s.kataGuestImageTag" .) | sha256sum }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.kataName" . }}-image-puller
       # Same node selector / tolerations as kata-deploy (templates/kata.yaml).
       # The puller must land on every node kata-deploy lands on so the

--- a/internal/helmchart/c8s/templates/kata-sandbox-device-plugin.yaml
+++ b/internal/helmchart/c8s/templates/kata-sandbox-device-plugin.yaml
@@ -54,6 +54,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: kata-sandbox-device-plugin
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.kataName" . }}-sandbox-device-plugin
       hostPID: true
       priorityClassName: system-node-critical

--- a/internal/helmchart/c8s/templates/kata.yaml
+++ b/internal/helmchart/c8s/templates/kata.yaml
@@ -109,6 +109,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: kata-deploy
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.kataName" . }}
       # hostPID: kata-deploy nsenters into PID 1 to restart the runtime.
       hostPID: true

--- a/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/nri-image-policy-installer-daemonset.yaml
@@ -38,6 +38,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       hostPID: true
       {{- with .Values.nriImagePolicy.priorityClassName }}
       priorityClassName: {{ . }}

--- a/internal/helmchart/c8s/templates/nri-image-policy-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/nri-image-policy-uninstall-hook.yaml
@@ -27,6 +27,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       hostPID: true
       {{- with .Values.nriImagePolicy.priorityClassName }}
       priorityClassName: {{ . }}

--- a/internal/helmchart/c8s/templates/operator.yaml
+++ b/internal/helmchart/c8s/templates/operator.yaml
@@ -34,6 +34,9 @@ spec:
         {{- end }}
       {{- end }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       serviceAccountName: {{ include "c8s.operatorName" . }}
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}
@@ -60,8 +63,18 @@ spec:
             - --attestation-api-url={{ include "c8s.attestationApiURL" . }}
             {{- /* The same measurements CDS is pinned to elsewhere: the
                    injected secret fetcher verifies CDS before handing it a
-                   sandbox token and taking a value back. */}}
-            {{- if .Values.cds.measurementsConfig }}
+                   sandbox token and taking a value back. Under a static
+                   allowlist the operator forwards no pins: the sidecars'
+                   argv is a rule in the measured bundle, so it cannot carry
+                   a digest derived from that bundle. Instead each sidecar
+                   pins CDS to the tuple of its own quote, taken over the
+                   node's attestation socket (--cds-pins-from-own-quote),
+                   which carries RTMR[3] and so refuses a CDS on an unsealed
+                   node of the same image. */}}
+            {{- if .Values.staticAllowlist.enabled }}
+            - --static-allowlist
+            - --attestation-socket-dir={{ .Values.staticAllowlist.attestationSocketDir }}
+            {{- else if .Values.cds.measurementsConfig }}
             - --measurements-config=/etc/c8s-measurements/cds.json
             {{- else }}
             {{- range .Values.cds.measurements }}
@@ -122,7 +135,7 @@ spec:
             # this emptyDir rather than the immutable image.
             - name: tmp
               mountPath: /tmp
-            {{- if .Values.cds.measurementsConfig }}
+            {{- if and .Values.cds.measurementsConfig (not .Values.staticAllowlist.enabled) }}
             - name: measurements-config
               mountPath: /etc/c8s-measurements
               readOnly: true
@@ -130,7 +143,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if .Values.cds.measurementsConfig }}
+        {{- if and .Values.cds.measurementsConfig (not .Values.staticAllowlist.enabled) }}
         - name: measurements-config
           configMap:
             name: {{ include "c8s.fullname" . }}-measurements

--- a/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/ratls-mesh-daemonset.yaml
@@ -62,6 +62,9 @@ spec:
         prometheus.io/port: {{ .Values.ratlsMesh.ports.health | quote }}
         prometheus.io/path: "/metrics"
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- with .Values.ratlsMesh.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
+++ b/internal/helmchart/c8s/templates/tls-lb-deployment.yaml
@@ -73,6 +73,9 @@ spec:
         checksum/measurements-config: {{ .Values.cds.measurementsConfig | sha256sum }}
         {{- end }}
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       {{- if .Values.kata.enabled }}
       # Chart-managed mesh component: the webhook excludes the release
       # namespace, so the chart pins the RuntimeClass directly (same pattern as

--- a/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
+++ b/internal/helmchart/c8s/templates/tls-lb-helpers.tpl
@@ -524,7 +524,7 @@ list.
 {{- $mounts = append $mounts (printf "- name: discovery\n  mountPath: %s" .Values.tlsLb.discovery.mountPath) -}}
 {{- end -}}
 {{- if eq (include "c8s.attestationApiHostSocket" .) "true" -}}
-{{- $mounts = append $mounts (printf "- name: attestation-api-socket\n  mountPath: %s\n  readOnly: true" .Values.nriImagePolicy.hostPaths.runtimeDir) -}}
+{{- $mounts = append $mounts (printf "- name: attestation-api-socket\n  mountPath: %s\n  readOnly: true" (include "c8s.attestationApiSocketDir" .)) -}}
 {{- end -}}
 {{- $extraArgs := include "tls-lb.getCertCommonArgs" . | fromYamlArray -}}
 {{- if .Values.tlsLb.attest.expectedWorkload -}}

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -2,6 +2,41 @@
 {{- $nri := .Values.nriImagePolicy -}}
 {{- $nriCDSURL := tpl (include "c8s.nriCDSURL" .) . -}}
 {{- /*
+Static allowlist: the node measured its policy bundle into RTMR[3] and CDS
+serves only that. Every shape below would let something outside the bundle
+in — operator writes, a store outliving the reseed, a chart-installed plugin
+beside the baked sealed one, a chart-deployed verifier beside the node's,
+a platform with no runtime register, a pod shape whose plugin does not seal
+— or leave CDS with no tuple to hold itself and every requester to.
+*/ -}}
+{{- if .Values.staticAllowlist.enabled }}
+{{- if ne .Values.attestationApi.cvmMode "node" }}
+{{- fail (printf "VALIDATION_ERROR kind=static_allowlist_requires_node: staticAllowlist.enabled needs attestationApi.cvmMode=node (got %q): the policy bundle is measured by the node image's c8s-policy-measure unit — use `c8s install --cvm-mode=node --static-allowlist <bundle>`" .Values.attestationApi.cvmMode) -}}
+{{- end }}
+{{- if or (not .Values.attestationApi.teeDevices.tdxGuest) (ne (.Values.cds.ratlsPlatform | toString) "tdx") }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_requires_tdx: staticAllowlist.enabled needs a TDX platform (attestationApi.teeDevices.tdxGuest=true and cds.ratlsPlatform=tdx): the policy is measured into RTMR[3], which only TDX has — use `c8s install --hardware-platform=tdx`" -}}
+{{- end }}
+{{- if .Values.cds.operatorKeys }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_no_operator_keys: staticAllowlist.enabled cannot be combined with cds.operatorKeys: the allowlist is sealed at boot and takes no operator writes — drop --operator-keys" -}}
+{{- end }}
+{{- if .Values.cds.persistence.enabled }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_no_persistence: staticAllowlist.enabled cannot be combined with cds.persistence.enabled: every CDS start reseeds from the measured bundle, and a persisted store could add entries to it — set cds.persistence.enabled=false" -}}
+{{- end }}
+{{- if .Values.kata.enabled }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_no_kata: staticAllowlist.enabled cannot be combined with kata.enabled: the sealed plugin runs on the node, not inside per-pod guests — use --cvm-mode=node" -}}
+{{- end }}
+{{- if .Values.attestationApi.enabled }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_no_chart_attestation_api: staticAllowlist.enabled cannot be combined with attestationApi.enabled: the node image serves the attestation socket under staticAllowlist.attestationSocketDir (c8s-attest-socket.service) and every consumer dials it, so a chart-deployed verifier would be a second one nothing dials — set attestationApi.enabled=false" -}}
+{{- end }}
+{{- if .Values.nriImagePolicy.enabled }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_no_host_nri: staticAllowlist.enabled cannot be combined with nriImagePolicy.enabled: the node image bakes the sealed plugin and its pins come from the node's own quote — set nriImagePolicy.enabled=false" -}}
+{{- end }}
+{{- if not .Values.cds.measurementsConfig }}
+{{- fail "VALIDATION_ERROR kind=static_allowlist_requires_measurements_config: staticAllowlist.enabled needs cds.measurementsConfig carrying the static entry (MRTD, RTMR[1], RTMR[2], RTMR[3]); `c8s install --static-allowlist <bundle> --image-manifest <manifest>` computes it" -}}
+{{- end }}
+{{- end }}
+
+{{- /*
   Helm silently ignores values keys the chart no longer reads, so a values
   file carried over from a release that still had tee-proxy would drop its
   settings (hostPort opt-out, upstream) without a trace. Fail loud instead.
@@ -199,3 +234,4 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+

--- a/internal/helmchart/c8s/templates/validations.yaml
+++ b/internal/helmchart/c8s/templates/validations.yaml
@@ -234,4 +234,3 @@ a platform with no runtime register, a pod shape whose plugin does not seal
 {{- end -}}
 {{- end -}}
 {{- end -}}
-

--- a/internal/helmchart/c8s/templates/volumed-daemonset.yaml
+++ b/internal/helmchart/c8s/templates/volumed-daemonset.yaml
@@ -37,6 +37,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       # SO_PEERCRED reports a peer's PID in the reader's PID namespace, so a
       # caller in another pod resolves to 0 without this.
       hostPID: true

--- a/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
+++ b/internal/helmchart/c8s/templates/volumed-uninstall-hook.yaml
@@ -45,6 +45,9 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      {{- with (include "c8s.staticPodSpec" .) }}
+      {{- . | nindent 6 }}
+      {{- end }}
       automountServiceAccountToken: false
       {{- with .Values.volumed.priorityClassName }}
       priorityClassName: {{ . }}

--- a/internal/helmchart/c8s/values.schema.json
+++ b/internal/helmchart/c8s/values.schema.json
@@ -564,6 +564,18 @@
     "podSecurityContext": {},
     "teeProxy": {
       "$comment": "Removed component, listed only so validations.yaml can answer with the migration message rather than a generic unknown-key refusal."
+    },
+    "staticAllowlist": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {},
+        "policyDir": {},
+        "attestationSocketDir": {}
+      }
     }
   },
   "additionalProperties": false

--- a/internal/helmchart/c8s/values.yaml
+++ b/internal/helmchart/c8s/values.yaml
@@ -319,6 +319,29 @@ cds:
       cpu: 500m
       memory: 256Mi
 
+## Static allowlist (docs/static-allowlist.md): the node booted a policy
+## bundle and measured it into RTMR[3], so CDS serves that bundle and nothing
+## else. `c8s install --static-allowlist <bundle> --image-manifest <manifest>`
+## sets everything here and computes cds.measurementsConfig: one entry pinning
+## MRTD, RTMR[1], RTMR[2] and RTMR[3] = ForStaticAllowlist(bundle index), which
+## /attest requires of every requester and CDS requires of itself at start.
+## Requires attestationApi.cvmMode=node, a TDX platform, nriImagePolicy.enabled
+## =false (the node image bakes the sealed plugin), no cds.operatorKeys, no
+## cds.persistence and no kata (validations.yaml, kind=static_allowlist_*).
+## Every c8s pod then sets enableServiceLinks: false, so its environment is
+## the one the sealed rules list.
+staticAllowlist:
+  enabled: false
+  ## Where c8s-policy-measure publishes the boot's mode, the bundle digest and
+  ## the members; CDS mounts it read-only and seeds from
+  ## <policyDir>/static-allowlist.json.
+  policyDir: /run/confai/policy
+  ## Directory holding the node's attestation-api unix socket
+  ## (attestation-api.sock, served by c8s-attest-socket.service). Every c8s
+  ## pod that verifies evidence dials it there instead of the node IP, so no
+  ## chart value can point it at another verifier.
+  attestationSocketDir: /run/confai
+
 ## DaemonSet running the attestation-api image from github.com/confidential-dot-ai/attestation-rs.
 attestationApi:
   ## Render the host-side attestation-api DaemonSet. Disable on

--- a/internal/helmchart/chart_test.go
+++ b/internal/helmchart/chart_test.go
@@ -7434,7 +7434,7 @@ func TestChartIptablesSyncNamesNoClusterDNS(t *testing.T) {
 
 // schemaCoveredPaths are the values subtrees values.schema.json seals: the
 // component blocks the docs tell operators to write by hand.
-var schemaCoveredPaths = []string{"cds", "nriImagePolicy", "tlsLb", "volumed"}
+var schemaCoveredPaths = []string{"cds", "nriImagePolicy", "tlsLb", "volumed", "staticAllowlist"}
 
 // readChartFile decodes a file from the chart directory. JSON is a subset of
 // YAML, so one decoder serves values.yaml and values.schema.json alike.
@@ -7932,5 +7932,289 @@ func TestChartNoRTMRPinsRendersNoFlags(t *testing.T) {
 	meshArgs := renderedDaemonSetContainer(t, out, "c8s-ratls-mesh", "ratls-mesh").Args
 	if slices.Contains(meshArgs, "--rtmrs") || slices.Contains(meshArgs, "--cds-rtmrs") {
 		t.Fatalf("unpinned render emitted RTMR flags\nargs: %v", meshArgs)
+	}
+}
+
+// staticMeasurementsConfig is a static entry document: the image tuple plus
+// the RTMR[3] a node sealed to the bundle reports, as `c8s install
+// --static-allowlist` computes it.
+const staticMeasurementsConfig = `{"schema_version":"1","tee":"tdx","measurements":[{"name":"static-allowlist",` +
+	`"mrtd":"1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a",` +
+	`"rtmr":[null,"2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b2b",` +
+	`"3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c3c",` +
+	`"4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d"]}]}`
+
+// staticAllowlistArgs is the value set `c8s install --cvm-mode=node
+// --hardware-platform=tdx --static-allowlist <bundle> --image-manifest <m>`
+// emits, with the measurements config written to a file the way --set-file
+// carries it.
+func staticAllowlistArgs(t *testing.T, extra ...string) []string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cds.json")
+	if err := os.WriteFile(path, []byte(staticMeasurementsConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return append([]string{
+		"--set", "staticAllowlist.enabled=true",
+		"--set-string", "attestationApi.cvmMode=node",
+		"--set", "attestationApi.enabled=false",
+		"--set", "attestationApi.teeDevices.sevGuest=false",
+		"--set", "attestationApi.teeDevices.tdxGuest=true",
+		"--set-string", "cds.ratlsPlatform=tdx",
+		"--set-string", "ratlsMesh.platform=tdx",
+		"--set", "nriImagePolicy.enabled=false",
+		"--set", "nriImagePolicy.baked=true",
+		"--set", "cds.persistence.enabled=false",
+		"--set-file", "cds.measurementsConfig=" + path,
+		"--set", "tlsLb.attest.enabled=true",
+	}, extra...)
+}
+
+// TestChartStaticAllowlistCDS pins the CDS pod shape under a static allowlist:
+// the seed is the measured bundle member on the node (hostPath, read-only),
+// the verifier is the node's own unix socket (no HOST_IP anywhere), no
+// operator keys and no persistent store, and the group that lets uid 65532
+// open the root-owned socket.
+func TestChartStaticAllowlistCDS(t *testing.T) {
+	out, err := helmTemplate(t, staticAllowlistArgs(t)...)
+	if err != nil {
+		t.Fatalf("helm template (static allowlist): %v\n%s", err, out)
+	}
+
+	dep := renderedDeployment(t, out, "c8s-cds")
+	spec := dep.Spec.Template.Spec
+	cds, ok := findContainer(spec.Containers, "cds")
+	if !ok {
+		t.Fatal("cds container missing")
+	}
+	assertContainerArgs(t, cds,
+		"--static-allowlist",
+		"--policy-dir=/run/confai/policy",
+		"--allowlist-seed=/run/confai/policy/static-allowlist.json",
+		"--attestation-api-url=unix:///run/confai/attestation-api.sock",
+		"--allowlist-persistent=false",
+		"--measurements-config=/etc/c8s-measurements/cds.json",
+		"--ratls-platform=tdx",
+	)
+	assertContainerNoArgPrefix(t, "cds", cds.Args, "--operator-keys")
+	assertContainerNoArgPrefix(t, "cds", cds.Args, "--rtmrs")
+	if hasHostIPEnv(cds) {
+		t.Errorf("cds carries the HOST_IP downward-API env; the static verifier is the unix socket: %+v", cds.Env)
+	}
+
+	assertPodVolume(t, &spec, "policy-dir", func(v corev1.Volume) bool {
+		return v.HostPath != nil && v.HostPath.Path == "/run/confai/policy" && v.HostPath.Type != nil && *v.HostPath.Type == corev1.HostPathDirectory
+	})
+	assertPodVolume(t, &spec, "attestation-api-socket", func(v corev1.Volume) bool {
+		return v.HostPath != nil && v.HostPath.Path == "/run/confai" && v.HostPath.Type != nil && *v.HostPath.Type == corev1.HostPathDirectory
+	})
+	for _, name := range []string{"policy-dir", "attestation-api-socket"} {
+		m, ok := containerVolumeMount(cds, name)
+		if !ok {
+			t.Errorf("cds mounts no %s volume", name)
+			continue
+		}
+		if !m.ReadOnly {
+			t.Errorf("cds %s mount is writable; a hostPath into the node TCB must be read-only", name)
+		}
+	}
+	for _, v := range spec.Volumes {
+		switch {
+		case v.Name == "allowlist-seed":
+			t.Error("cds still mounts the chart's allowlist-seed ConfigMap; the seed must be the measured member")
+		case v.PersistentVolumeClaim != nil:
+			t.Error("cds mounts a PVC; a persisted store could outlive the reseed")
+		}
+	}
+	if renderedManifestHasNamedKind(t, out, "ConfigMap", "c8s-cds-allowlist-seed") {
+		t.Error("the chart renders an allowlist-seed ConfigMap under a static allowlist")
+	}
+	if spec.SecurityContext == nil || !slices.Contains(spec.SecurityContext.SupplementalGroups, 65532) {
+		t.Errorf("cds pod lacks supplementalGroups [65532] (workloadclaims.InventorySocketGID), so uid 65532 cannot open the root-owned attestation socket: %+v", spec.SecurityContext)
+	}
+}
+
+// TestChartStaticAllowlistPods pins what the sealed rules rely on across every
+// c8s pod: enableServiceLinks false (the kubelet would otherwise add an env var
+// per Service, which no exact rule can list) and no argv reaching the verifier
+// through $(HOST_IP), which expands to a per-node value no exact rule can pin.
+func TestChartStaticAllowlistPods(t *testing.T) {
+	out, err := helmTemplate(t, staticAllowlistArgs(t, "--set", "volumed.enabled=true")...)
+	if err != nil {
+		t.Fatalf("helm template (static allowlist): %v\n%s", err, out)
+	}
+	pods := renderedPodSpecs(t, out)
+	if len(pods) == 0 {
+		t.Fatal("no pod-bearing manifests rendered")
+	}
+	for _, p := range pods {
+		if p.spec.EnableServiceLinks == nil || *p.spec.EnableServiceLinks {
+			t.Errorf("%s %s: enableServiceLinks is not false", p.kind, p.name)
+		}
+		for _, c := range slices.Concat(p.spec.InitContainers, p.spec.Containers) {
+			for _, arg := range slices.Concat(c.Command, c.Args) {
+				if strings.Contains(arg, "$(HOST_IP)") {
+					t.Errorf("%s %s container %s argv %q expands $(HOST_IP); the static verifier is the unix socket", p.kind, p.name, c.Name, arg)
+				}
+			}
+		}
+	}
+
+	// The operator forwards its CDS pins into the sidecars' argv, which the
+	// bundle measures, so under a static allowlist it gets none: the
+	// sidecars pin CDS from their own quote over the node socket instead.
+	operator := renderedOperatorArgs(t, out)
+	for _, want := range []string{"--static-allowlist", "--attestation-socket-dir=/run/confai"} {
+		if !slices.Contains(operator, want) {
+			t.Errorf("operator args %v lack %s", operator, want)
+		}
+	}
+	for _, prefix := range []string{"--measurements-config", "--cds-measurements", "--cds-rtmrs"} {
+		assertContainerNoArgPrefix(t, "operator", operator, prefix)
+	}
+	for _, v := range renderedDeployment(t, out, "c8s-operator").Spec.Template.Spec.Volumes {
+		if v.Name == "measurements-config" {
+			t.Error("the operator mounts the measurements ConfigMap under a static allowlist")
+		}
+	}
+	plain, err := helmTemplate(t, "--set", "cds.measurements[0]="+strings.Repeat("ab", 48))
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, plain)
+	}
+	if args := renderedOperatorArgs(t, plain); slices.Contains(args, "--static-allowlist") || !slices.Contains(args, "--cds-measurements="+strings.Repeat("ab", 48)) {
+		t.Errorf("default render operator args = %v, want the flat pin and no --static-allowlist", args)
+	}
+}
+
+// TestChartStaticAllowlistSocketConsumers: every pod that verifies evidence
+// dials the node's socket under a static allowlist, mounted from the node
+// image's own directory rather than the chart plugin's runtime dir.
+func TestChartStaticAllowlistSocketConsumers(t *testing.T) {
+	out, err := helmTemplate(t, staticAllowlistArgs(t)...)
+	if err != nil {
+		t.Fatalf("helm template (static allowlist): %v\n%s", err, out)
+	}
+	const socketURL = "--attestation-api-url=unix:///run/confai/attestation-api.sock"
+	for _, c := range []corev1.Container{
+		tlsLBGetCertContainer(t, out, "c8s-cert"),
+		renderedDeploymentContainer(t, out, "c8s-tls-lb", "cds-attest"),
+		renderedDeploymentContainer(t, out, "c8s-tls-lb", "allowlist-proxy"),
+	} {
+		assertContainerArgs(t, c, socketURL)
+		if m, ok := containerVolumeMount(c, "attestation-api-socket"); !ok || m.MountPath != "/run/confai" || !m.ReadOnly {
+			t.Errorf("tls-lb %s: attestation-api-socket mount = %+v, want /run/confai read-only", c.Name, m)
+		}
+	}
+	// The mesh leaf tls-lb serves is issued by a CDS pinned to this node's
+	// own tuple, RTMR[3] included, not to any RA-TLS-attested peer.
+	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
+	assertContainerArgs(t, cert, "--cds-pins-from-own-quote")
+	assertContainerNoArgPrefix(t, cert.Name, cert.Args, "--cds-measurements")
+	assertContainerNoArgPrefix(t, cert.Name, cert.Args, "--cds-rtmrs")
+	mesh := findRATLSMeshDaemonSet(t, out)
+	assertPodVolume(t, &mesh.Spec.Template.Spec, "attestation-api-socket", func(v corev1.Volume) bool {
+		return v.HostPath != nil && v.HostPath.Path == "/run/confai"
+	})
+}
+
+// The deny-host-namespaces VAP admits exactly the hostPaths c8s pods need;
+// the two the static CDS reads are carved out only when static mode is on.
+func TestChartStaticAllowlistVAPCarveOuts(t *testing.T) {
+	hostPathExpr := func(t *testing.T, out string) string {
+		t.Helper()
+		var vap admissionregv1.ValidatingAdmissionPolicy
+		if !findDoc(t, out, "ValidatingAdmissionPolicy", "c8s-deny-host-namespaces", &vap) {
+			t.Fatal("ValidatingAdmissionPolicy c8s-deny-host-namespaces not rendered")
+		}
+		for _, v := range vap.Spec.Validations {
+			if strings.Contains(v.Expression, "hostPath") {
+				return v.Expression
+			}
+		}
+		t.Fatal("no hostPath validation in c8s-deny-host-namespaces")
+		return ""
+	}
+	static, err := helmTemplate(t, staticAllowlistArgs(t)...)
+	if err != nil {
+		t.Fatalf("helm template (static allowlist): %v\n%s", err, static)
+	}
+	expr := hostPathExpr(t, static)
+	for _, want := range []string{`"/var/run/nri-image-policy"`, `"/run/confai/policy"`, `"/run/confai"`, `'Directory'`, "m.readOnly"} {
+		if !strings.Contains(expr, want) {
+			t.Errorf("static hostPath validation missing %s; expression=%q", want, expr)
+		}
+	}
+	plain, err := helmTemplate(t)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, plain)
+	}
+	if expr := hostPathExpr(t, plain); strings.Contains(expr, "/run/confai") {
+		t.Errorf("default render carves out the static hostPaths; expression=%q", expr)
+	}
+}
+
+// Non-static node mode is untouched: the HOST_IP arm and the ConfigMap seed
+// stay exactly as TestChartNodeModeAttestationApiURLUsesHostIP and
+// TestChartServesAllowlistSeedInNodeMode pin them. This test guards the one
+// thing they cannot: that leaving staticAllowlist at its default renders no
+// static flag at all.
+func TestChartStaticAllowlistOffByDefault(t *testing.T) {
+	out, err := helmTemplate(t,
+		"--set-string", "attestationApi.cvmMode=node",
+		"--set", "attestationApi.enabled=false",
+		"--set", "nriImagePolicy.enabled=false",
+	)
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, out)
+	}
+	cds := renderedDeploymentContainer(t, out, "c8s-cds", "cds")
+	assertContainerNoArgPrefix(t, "cds", cds.Args, "--static-allowlist")
+	assertContainerNoArgPrefix(t, "cds", cds.Args, "--policy-dir")
+	cert := tlsLBGetCertContainer(t, out, "c8s-cert")
+	assertContainerNoArgPrefix(t, cert.Name, cert.Args, "--cds-pins-from-own-quote")
+	for _, p := range renderedPodSpecs(t, out) {
+		if p.spec.EnableServiceLinks != nil {
+			t.Errorf("%s %s sets enableServiceLinks outside static mode", p.kind, p.name)
+		}
+	}
+}
+
+// One fail per shape a static allowlist cannot coexist with.
+func TestChartStaticAllowlistFails(t *testing.T) {
+	keysPath := filepath.Join(t.TempDir(), "keys.pem")
+	if err := os.WriteFile(keysPath, []byte("-----BEGIN PUBLIC KEY-----\nMFkw\n-----END PUBLIC KEY-----\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name string
+		args []string
+		kind string
+	}{
+		{"gke cvm mode", []string{"--set-string", "attestationApi.cvmMode=gke"}, "static_allowlist_requires_node"},
+		{"snp platform", []string{"--set", "attestationApi.teeDevices.tdxGuest=false", "--set", "attestationApi.teeDevices.sevGuest=true"}, "static_allowlist_requires_tdx"},
+		{"cds ratls platform snp", []string{"--set-string", "cds.ratlsPlatform=snp"}, "static_allowlist_requires_tdx"},
+		{"operator keys", []string{"--set-file", "cds.operatorKeys=" + keysPath}, "static_allowlist_no_operator_keys"},
+		{"persistence", []string{"--set", "cds.persistence.enabled=true"}, "static_allowlist_no_persistence"},
+		{"kata", []string{"--set", "kata.enabled=true"}, "static_allowlist_no_kata"},
+		{"chart nri plugin", []string{"--set", "nriImagePolicy.enabled=true"}, "static_allowlist_no_host_nri"},
+		{"chart attestation-api", []string{"--set", "attestationApi.enabled=true"}, "static_allowlist_no_chart_attestation_api"},
+		// helm applies --set-file after --set-string whatever the argv order,
+		// so the file pair is dropped rather than overridden.
+		{"no measurements config", nil, "static_allowlist_requires_measurements_config"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			args := staticAllowlistArgs(t, tc.args...)
+			if tc.kind == "static_allowlist_requires_measurements_config" {
+				i := slices.IndexFunc(args, func(a string) bool { return strings.HasPrefix(a, "cds.measurementsConfig=") })
+				args = slices.Delete(args, i-1, i+1)
+			}
+			out, err := helmTemplate(t, args...)
+			if err == nil {
+				t.Fatalf("helm template rendered; want a %s failure", tc.kind)
+			}
+			if got := parseValidationErrorKind(out); got != tc.kind {
+				t.Fatalf("validation error kind = %q, want %q\n%s", got, tc.kind, out)
+			}
+		})
 	}
 }

--- a/internal/tdxrtmr/tdxrtmr.go
+++ b/internal/tdxrtmr/tdxrtmr.go
@@ -1,0 +1,67 @@
+// Package tdxrtmr reads and extends the TDX runtime measurement registers
+// through the kernel TSM sysfs nodes (mainline >= 6.16):
+// /sys/devices/virtual/misc/tdx_guest/measurements/rtmr<N>:sha384. A read
+// returns the raw 48-byte register; a write of 48 bytes performs
+// TDG.MR.RTMR.EXTEND. Every in-guest c8s component that touches a register
+// (cred-release, policy-measure, the NRI plugin, the kata workload measurer)
+// goes through this package so the sysfs contract lives in one place. The
+// arithmetic the register commits is pkg/runtimemeasure.
+package tdxrtmr
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// SysfsRoot is the directory holding the rtmr<N>:sha384 nodes. A var so
+// tests point it at a temp dir.
+var SysfsRoot = "/sys/devices/virtual/misc/tdx_guest/measurements"
+
+// Path returns the sysfs node of register index under SysfsRoot.
+func Path(index int) string {
+	return filepath.Join(SysfsRoot, fmt.Sprintf("rtmr%d:sha384", index))
+}
+
+// Read returns the current value of RTMR[index] (0..3). A node that is
+// absent or not exactly 48 bytes is an error, never a truncated value.
+func Read(index int) ([runtimemeasure.Size]byte, error) {
+	var reg [runtimemeasure.Size]byte
+	if index < 0 || index > 3 {
+		return reg, fmt.Errorf("RTMR[%d] does not exist: TDX has RTMR[0..3]", index)
+	}
+	path := Path(index)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return reg, fmt.Errorf("read %s: %w (is this a TDX guest with runtime measurement?)", path, err)
+	}
+	if len(b) != runtimemeasure.Size {
+		return reg, fmt.Errorf("read %s: got %d bytes, want %d", path, len(b), runtimemeasure.Size)
+	}
+	copy(reg[:], b)
+	return reg, nil
+}
+
+// Extend folds event into RTMR[index]: RTMR = SHA384(RTMR ‖ event). Only
+// RTMR[2] and RTMR[3] are guest-extendable; the TDX module owns 0 and 1 and
+// the kernel exposes them read-only, so other indices are refused here rather
+// than by an opaque EACCES.
+func Extend(index int, event [runtimemeasure.Size]byte) error {
+	if index != 2 && index != 3 {
+		return fmt.Errorf("RTMR[%d] is not guest-extendable: only RTMR[2] and RTMR[3] are", index)
+	}
+	path := Path(index)
+	// No O_CREATE: a mis-pointed SysfsRoot or a kernel without the TSM node
+	// must fail, not leave a regular file that reads back as a register.
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return fmt.Errorf("extend %s: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write(event[:]); err != nil {
+		return fmt.Errorf("extend %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/tdxrtmr/tdxrtmr_test.go
+++ b/internal/tdxrtmr/tdxrtmr_test.go
@@ -1,0 +1,124 @@
+package tdxrtmr
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// fakeSysfs points SysfsRoot at a temp dir for the test and returns it.
+func fakeSysfs(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := SysfsRoot
+	SysfsRoot = dir
+	t.Cleanup(func() { SysfsRoot = orig })
+	return dir
+}
+
+func TestPath(t *testing.T) {
+	dir := fakeSysfs(t)
+	if got, want := Path(3), filepath.Join(dir, "rtmr3:sha384"); got != want {
+		t.Errorf("Path(3) = %q, want %q", got, want)
+	}
+}
+
+func TestRead(t *testing.T) {
+	value := runtimemeasure.Event("sha256:" + strings.Repeat("ab", 32))
+	for _, tc := range []struct {
+		name  string
+		index int
+		node  []byte // nil: no node written
+		want  string // "" = must succeed with value
+	}{
+		{"rtmr3", 3, value[:], ""},
+		{"rtmr0", 0, value[:], ""},
+		{"short node", 3, value[:47], "got 47 bytes, want 48"},
+		{"long node", 3, append(value[:], 0), "got 49 bytes, want 48"},
+		{"missing node", 3, nil, "is this a TDX guest"},
+		{"index too high", 4, value[:], "does not exist"},
+		{"negative index", -1, value[:], "does not exist"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := fakeSysfs(t)
+			if tc.node != nil {
+				name := "rtmr3:sha384"
+				if tc.index >= 0 && tc.index <= 3 {
+					name = filepath.Base(Path(tc.index))
+				}
+				if err := os.WriteFile(filepath.Join(dir, name), tc.node, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got, err := Read(tc.index)
+			if tc.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("Read(%d) error = %v, want it to contain %q", tc.index, err, tc.want)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Read(%d): %v", tc.index, err)
+			}
+			if got != value {
+				t.Errorf("Read(%d) = %x, want %x", tc.index, got, value)
+			}
+		})
+	}
+}
+
+func TestExtend(t *testing.T) {
+	event := runtimemeasure.ModeDynamic
+	for _, tc := range []struct {
+		name  string
+		index int
+		node  bool // create the node first
+		want  string
+	}{
+		{"rtmr3", 3, true, ""},
+		{"rtmr2", 2, true, ""},
+		{"rtmr1 is firmware-owned", 1, true, "not guest-extendable"},
+		{"rtmr0 is firmware-owned", 0, true, "not guest-extendable"},
+		{"index too high", 4, true, "not guest-extendable"},
+		{"missing node under an existing root", 3, false, "extend "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := fakeSysfs(t)
+			if tc.node {
+				if err := os.WriteFile(filepath.Join(dir, filepath.Base(Path(tc.index))), make([]byte, runtimemeasure.Size), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			err := Extend(tc.index, event)
+			if tc.want != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("Extend(%d) error = %v, want it to contain %q", tc.index, err, tc.want)
+				}
+				// A failed extend must leave no file behind: a created node
+				// would read back as a register on the next call.
+				if !tc.node {
+					if _, statErr := os.Stat(Path(tc.index)); !os.IsNotExist(statErr) {
+						t.Errorf("os.Stat(%s) after a failed Extend = %v, want not-exist", Path(tc.index), statErr)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Extend(%d): %v", tc.index, err)
+			}
+			// The fake node records the last event written; the real TSM node
+			// folds it. Either way the bytes that reached the node are the event.
+			got, err := os.ReadFile(Path(tc.index))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, event[:]) {
+				t.Errorf("node after Extend(%d) = %x, want %x", tc.index, got, event)
+			}
+		})
+	}
+}

--- a/internal/testattest/testattest.go
+++ b/internal/testattest/testattest.go
@@ -20,9 +20,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -52,6 +56,18 @@ func PassingVerdict(launchDigest string) Verdict {
 		ReportDataMatch: &match,
 		Claims:          types.Claims{LaunchDigest: launchDigest},
 	}
+}
+
+// TDXVerdict is PassingVerdict for TDX evidence: mrtd is the launch digest
+// and each register is reported as the real api does, hex under
+// claims.platform_data rtmr_<index>.
+func TDXVerdict(mrtd string, rtmrs map[int]string) Verdict {
+	v := PassingVerdict(mrtd)
+	v.Claims.PlatformData = map[string]any{}
+	for i, reg := range rtmrs {
+		v.Claims.PlatformData[fmt.Sprintf("rtmr_%d", i)] = reg
+	}
+	return v
 }
 
 // ErrorReply is an error response from the attestation-api. A non-empty Code
@@ -92,12 +108,46 @@ type Stub struct {
 // New starts a stub attestation-api, closed at test cleanup.
 func New(t testing.TB) *Stub {
 	t.Helper()
+	s := newStub()
+	s.Start()
+	t.Cleanup(s.Close)
+	return s
+}
+
+// NewUnix starts a stub attestation-api on a unix socket, the transport
+// callers that only accept a node-local verifier dial, and returns its
+// unix:// URL. The socket is owned by the test process and not
+// world-writable, as attestationclient requires. It lives under a short temp
+// path: a unix path is capped at 108 bytes and t.TempDir() names can exceed
+// it.
+func NewUnix(t testing.TB) (*Stub, string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "testattest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	socket := filepath.Join(dir, "attestation-api.sock")
+	l, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(socket, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	s := newStub()
+	s.Listener = l
+	s.Start()
+	t.Cleanup(s.Close)
+	return s, "unix://" + socket
+}
+
+func newStub() *Stub {
 	s := &Stub{verdict: PassingVerdict(""), platform: types.PlatformSnp}
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /attest", s.handleAttest)
 	mux.HandleFunc("POST /verify", s.handleVerify)
-	s.Server = httptest.NewServer(mux)
-	t.Cleanup(s.Close)
+	s.Server = httptest.NewUnstartedServer(mux)
 	return s
 }
 

--- a/internal/webhook/mutate_test.go
+++ b/internal/webhook/mutate_test.go
@@ -1,0 +1,75 @@
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Mutate is the whole admission decision without HTTP, so a tool that
+// renders rules for injected containers sees what a cluster runs.
+func TestMutate(t *testing.T) {
+	cfg := Config{
+		GetCertImage:          "ghcr.io/confidential-dot-ai/c8s-operator:test",
+		CDSURL:                "https://cds.c8s-system.svc:8443",
+		WorkloadClaimsHostDir: "/run/c8s",
+	}
+	for _, tc := range []struct {
+		name        string
+		pod         corev1.Pod
+		wantID      string
+		wantInit    int
+		wantErr     string
+		wantMutated bool
+	}{
+		{
+			name:    "passthrough without annotation",
+			pod:     corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}}},
+			wantErr: "",
+		},
+		{
+			name: "injects the cert containers and a namespace-derived SAN",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationWorkload: "api"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+			},
+			wantID: "api", wantInit: 2, wantMutated: true,
+		},
+		{
+			name: "refuses hostNetwork",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{AnnotationWorkload: "api"}},
+				Spec:       corev1.PodSpec{HostNetwork: true, Containers: []corev1.Container{{Name: "app"}}},
+			},
+			wantErr: "must not set hostNetwork",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := tc.pod
+			res, err := Mutate(&pod, "tenant", cfg)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("Mutate(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Mutate(%s) = %v, want nil", tc.name, err)
+			}
+			if res.WorkloadID != tc.wantID || res.Mutated() != tc.wantMutated {
+				t.Errorf("Mutate(%s) = %+v, want workload %q mutated=%v", tc.name, res, tc.wantID, tc.wantMutated)
+			}
+			if len(pod.Spec.InitContainers) != tc.wantInit {
+				t.Errorf("Mutate(%s) left %d init containers, want %d", tc.name, len(pod.Spec.InitContainers), tc.wantInit)
+			}
+			if tc.wantMutated {
+				args := strings.Join(pod.Spec.InitContainers[0].Args, " ")
+				if want := "--san=" + workloadSAN("api", "tenant") + " "; !strings.Contains(args+" ", want) {
+					t.Errorf("c8s-cert args = %q, want %q (the SAN comes from the request namespace)", args, strings.TrimSpace(want))
+				}
+			}
+		})
+	}
+}

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/volume"
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/policybundle"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -262,7 +263,27 @@ type Config struct {
 	// rather than a mounted socket, so no volume is injected. Mutually
 	// exclusive with WorkloadClaimsHostDir — the chart sets exactly one.
 	WorkloadClaimsGuest bool
+
+	// StaticAllowlist selects the sealed node shape: the injected sidecars
+	// mount AttestationSocketDir read-only at its own path, dial the
+	// verifier there and pin CDS to the tuple of their own quote
+	// (--cds-pins-from-own-quote) instead of CDSMeasurements and CDSRTMRs.
+	// The sidecar argv is a rule in the measured bundle, so it cannot carry
+	// a digest that depends on the bundle; the node's quote carries the
+	// same tuple with RTMR[3], so a CDS on an unsealed node is refused.
+	StaticAllowlist bool
+
+	// AttestationSocketDir is the node directory holding attestation-api.sock
+	// under StaticAllowlist; empty means DefaultAttestationSocketDir.
+	AttestationSocketDir string
 }
+
+// DefaultAttestationSocketDir is where the node image serves the
+// attestation-api socket on a sealed node (c8s-attest-socket.service).
+const DefaultAttestationSocketDir = policybundle.NodeStateDir
+
+// attestationSocketName is the socket file under AttestationSocketDir.
+const attestationSocketName = "attestation-api.sock"
 
 // Register wires the pod mutator onto the manager's webhook server.
 func Register(mgr ctrl.Manager, cfg Config) error {
@@ -1054,6 +1075,11 @@ func mutatePod(pod *corev1.Pod, inj *injection, cfg Config) {
 		// connect fails closed and the pod hangs on its initial cert.
 		ensureSupplementalGroup(pod, workloadclaims.InventorySocketGID)
 	}
+	if vol, ok := attestationSocketVolume(cfg); ok {
+		ensureVolume(pod, vol)
+		// c8s-attest-socket.service serves the socket with the same group.
+		ensureSupplementalGroup(pod, workloadclaims.InventorySocketGID)
+	}
 
 	mountAll(pod, corev1.VolumeMount{
 		Name:      effective.Cert.Volume,
@@ -1147,14 +1173,9 @@ func certContainer(inj *injection, cfg Config) corev1.Container {
 		args = append(args, "--reload-watch="+path)
 	}
 	args = append(args, discoveryArgs(inj.Discovery)...)
-	// get-cert names this one --cds-measurements and takes it comma-joined,
-	// where the secret and volume fetchers take a repeatable --measurements.
-	if joined := strings.Join(cfg.CDSMeasurements, ","); joined != "" {
-		args = append(args, "--cds-measurements="+joined)
-	}
-	if joined := strings.Join(cfg.CDSRTMRs, ","); joined != "" {
-		args = append(args, "--cds-rtmrs="+joined)
-	}
+	// get-cert names these --cds-measurements and --cds-rtmrs and takes them
+	// comma-joined, where the secret and volume fetchers repeat --measurements.
+	args = append(args, cfg.cdsPinArgs("--cds-measurements", "--cds-rtmrs", true)...)
 	// get-cert redeems a sandbox token from the node's inventory: over the
 	// mounted socket on node-CVM, or the guest's loopback address under kata,
 	// where policy-monitor is in the same guest and there is nothing to mount.
@@ -1176,7 +1197,7 @@ func certContainer(inj *injection, cfg Config) corev1.Container {
 		RestartPolicy:   &always,
 		Args:            args,
 		Env:             getCertEnv(inj),
-		VolumeMounts:    append(getCertVolumeMounts(inj, true), workloadClaimsMounts(cfg)...),
+		VolumeMounts:    append(getCertVolumeMounts(inj, true), nodeSocketMounts(cfg)...),
 		SecurityContext: getCertSecurityContext(inj),
 		// The workload is gated on the initial cert by the c8s-cert-wait
 		// init container (certWaitContainer), not a startupProbe here: a
@@ -1350,6 +1371,12 @@ func (cfg Config) withDefaults() Config {
 	if cfg.HardwarePlatform == "" {
 		cfg.HardwarePlatform = HardwarePlatformSNP
 	}
+	if cfg.AttestationSocketDir == "" {
+		cfg.AttestationSocketDir = DefaultAttestationSocketDir
+	}
+	// The dir is written verbatim into the sidecars' mounts and argv, which
+	// the sealed rule names in clean form.
+	cfg.AttestationSocketDir = filepath.Clean(cfg.AttestationSocketDir)
 	return cfg
 }
 
@@ -1577,12 +1604,7 @@ func volumeContainer(inj *injection, cfg Config) corev1.Container {
 	for _, spec := range inj.Volumes.Specs {
 		args = append(args, "--volume="+spec)
 	}
-	for _, m := range cfg.CDSMeasurements {
-		args = append(args, "--measurements="+m)
-	}
-	for _, r := range cfg.CDSRTMRs {
-		args = append(args, "--rtmrs="+r)
-	}
+	args = append(args, cfg.cdsPinArgs("--measurements", "--rtmrs", false)...)
 	// Under kata both the inventory and volumed are inside this guest, on
 	// compiled loopback ports, with nothing mounted to reach them by.
 	if cfg.WorkloadClaimsGuest {
@@ -1599,7 +1621,7 @@ func volumeContainer(inj *injection, cfg Config) corev1.Container {
 		Env:             getCertEnv(inj),
 		// It reads the leaf and talks to the node agent's socket; the volumes
 		// themselves are mounted into the workload, not into this.
-		VolumeMounts:    append(getCertVolumeMounts(inj, false), workloadClaimsMounts(cfg)...),
+		VolumeMounts:    append(getCertVolumeMounts(inj, false), nodeSocketMounts(cfg)...),
 		SecurityContext: getCertSecurityContext(inj),
 	}
 }
@@ -1623,12 +1645,7 @@ func secretContainer(inj *injection, cfg Config) corev1.Container {
 	for _, spec := range inj.Secrets.Specs {
 		args = append(args, "--secret="+spec)
 	}
-	for _, m := range cfg.CDSMeasurements {
-		args = append(args, "--measurements="+m)
-	}
-	for _, r := range cfg.CDSRTMRs {
-		args = append(args, "--rtmrs="+r)
-	}
+	args = append(args, cfg.cdsPinArgs("--measurements", "--rtmrs", false)...)
 	// Unlike get-cert the token is not optional here, so only the shape is
 	// selected: the mounted socket on node-CVM, guest loopback under kata.
 	if cfg.WorkloadClaimsGuest {
@@ -1651,7 +1668,7 @@ func secretContainer(inj *injection, cfg Config) corev1.Container {
 				Name:      secretsVolumeName,
 				MountPath: inj.Secrets.Dir,
 			}),
-			workloadClaimsMounts(cfg)...),
+			nodeSocketMounts(cfg)...),
 		SecurityContext: getCertSecurityContext(inj),
 	}
 }
@@ -1686,10 +1703,77 @@ func workloadClaimsVolume(cfg Config) (corev1.Volume, bool) {
 	}, true
 }
 
-// sidecarAttestationApiURL rebases a unix:// attestation-api endpoint under
-// the inventory's host directory onto the sidecar's mount of that directory
-// (workloadClaimsMounts); every other shape passes through verbatim.
+// cdsPinArgs is how a sidecar is told which CDS to trust: the own-quote flag
+// under a static allowlist, else the flat pins under the flag names the
+// command takes, comma-joined or repeated.
+func (cfg Config) cdsPinArgs(measurementsFlag, rtmrsFlag string, joined bool) []string {
+	if cfg.StaticAllowlist {
+		return []string{"--cds-pins-from-own-quote"}
+	}
+	var args []string
+	if joined {
+		if v := strings.Join(cfg.CDSMeasurements, ","); v != "" {
+			args = append(args, measurementsFlag+"="+v)
+		}
+		if v := strings.Join(cfg.CDSRTMRs, ","); v != "" {
+			args = append(args, rtmrsFlag+"="+v)
+		}
+		return args
+	}
+	for _, m := range cfg.CDSMeasurements {
+		args = append(args, measurementsFlag+"="+m)
+	}
+	for _, r := range cfg.CDSRTMRs {
+		args = append(args, rtmrsFlag+"="+r)
+	}
+	return args
+}
+
+// attestationSocketVolumeName is the injected volume that mounts the sealed
+// node's attestation socket directory into the sidecars.
+const attestationSocketVolumeName = "c8s-attestation-socket"
+
+// attestationSocketVolume is the read-only hostPath over the node's
+// attestation socket directory, under a static allowlist only. Type
+// Directory: the directory is the measured image's own, and a pod must not
+// create it on a node that lacks it.
+func attestationSocketVolume(cfg Config) (corev1.Volume, bool) {
+	if !cfg.StaticAllowlist {
+		return corev1.Volume{}, false
+	}
+	hpType := corev1.HostPathDirectory
+	return corev1.Volume{
+		Name: attestationSocketVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{Path: cfg.AttestationSocketDir, Type: &hpType},
+		},
+	}, true
+}
+
+// nodeSocketMounts are the sidecar mounts of the node's socket directories:
+// the inventory's (node-CVM) and, under a static allowlist, the attestation
+// socket's at its own path, so the URL in the sealed argv is the host path.
+func nodeSocketMounts(cfg Config) []corev1.VolumeMount {
+	mounts := workloadClaimsMounts(cfg)
+	if cfg.StaticAllowlist {
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      attestationSocketVolumeName,
+			MountPath: cfg.AttestationSocketDir,
+			ReadOnly:  true,
+		})
+	}
+	return mounts
+}
+
+// sidecarAttestationApiURL is the verifier a sidecar dials: under a static
+// allowlist the node's socket at the path it is mounted on (whatever the
+// operator's own URL); otherwise a unix:// endpoint under the inventory's
+// host directory rebased onto the sidecar's mount of that directory
+// (workloadClaimsMounts), and every other shape verbatim.
 func (cfg Config) sidecarAttestationApiURL() string {
+	if cfg.StaticAllowlist {
+		return "unix://" + filepath.Join(cfg.AttestationSocketDir, attestationSocketName)
+	}
 	hostPrefix := "unix://" + cfg.WorkloadClaimsHostDir + "/"
 	if cfg.WorkloadClaimsHostDir == "" || !strings.HasPrefix(cfg.AttestationApiURL, hostPrefix) {
 		return cfg.AttestationApiURL

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -676,12 +676,64 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Allowed("ephemeral container mounts no reserved c8s volume")
 	}
 
-	if err := validateWorkloadLabel(pod); err != nil {
+	// req.Namespace, not pod.Namespace: template-created pods reach
+	// admission with an empty metadata.namespace.
+	result, err := Mutate(pod, req.Namespace, m.cfg)
+	if err != nil {
+		var internal internalError
+		if errors.As(err, &internal) {
+			return admission.Errored(http.StatusInternalServerError, err)
+		}
 		return admission.Errored(http.StatusBadRequest, err)
+	}
+	if !result.Mutated() {
+		return admission.Allowed("no c8s annotation — passthrough")
+	}
+	if result.WorkloadID != "" {
+		l.Info("injecting c8s get-cert containers", "workload", result.WorkloadID)
+	}
+	if result.KataClass != "" {
+		l.Info("injecting kata runtimeClassName", "runtimeClass", result.KataClass)
+	}
+
+	raw, err := json.Marshal(pod)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	return admission.PatchResponseFromRaw(req.Object.Raw, raw)
+}
+
+// MutationResult says what Mutate changed: the workload whose get-cert
+// containers were injected, and the kata runtime class set, each empty when
+// that mutation did not apply.
+type MutationResult struct {
+	WorkloadID string
+	KataClass  string
+}
+
+// Mutated reports whether the pod changed at all.
+func (r MutationResult) Mutated() bool { return r.WorkloadID != "" || r.KataClass != "" }
+
+// internalError marks a failure that is the operator's, not the pod
+// author's, so Handle answers 500 instead of 400.
+type internalError struct{ err error }
+
+func (e internalError) Error() string { return e.err.Error() }
+func (e internalError) Unwrap() error { return e.err }
+
+// Mutate applies the c8s pod mutation in place, exactly as the admission
+// webhook does for a pod created in namespace: get-cert injection for a pod
+// carrying the confidential.ai/cw annotation and kata class injection under
+// KataEnforce. It is the whole decision, so a tool rendering rules for
+// injected containers sees the same containers a cluster runs. An error
+// means the pod is refused.
+func Mutate(pod *corev1.Pod, namespace string, cfg Config) (MutationResult, error) {
+	if err := validateWorkloadLabel(pod); err != nil {
+		return MutationResult{}, err
 	}
 	inj, err := parseAnnotations(pod)
 	if err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
+		return MutationResult{}, err
 	}
 	// A hostNetwork pod shares the node IP, so it cannot be a mesh endpoint
 	// and the cw inbound guard (which keys on distinct pod IPs) cannot cover
@@ -689,33 +741,31 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// no interception and no drop. Reject the contradictory combination at
 	// admission rather than let it onboard silently unprotected.
 	if inj != nil && pod.Spec.HostNetwork {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
+		return MutationResult{}, fmt.Errorf(
 			"%w: %s pods must not set hostNetwork — a hostNetwork pod shares the node IP and cannot be mesh-intercepted or protected by the cw inbound guard",
-			errInvalidInjectionAnnotation, AnnotationWorkload))
+			errInvalidInjectionAnnotation, AnnotationWorkload)
 	}
 	// The fetcher redeems a sandbox token from an inventory: the mounted
 	// nri-image-policy socket on node-CVM, or policy-monitor on guest loopback
 	// under kata. An operator with neither has nothing to point it at, so
 	// injecting would produce a Running pod whose fetcher CrashLoops while the
 	// workload blocks forever on a file that never lands. Refuse at admission.
-	if inj != nil && len(inj.Secrets.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
+	if inj != nil && len(inj.Secrets.Specs) > 0 && cfg.WorkloadClaimsHostDir == "" && !cfg.WorkloadClaimsGuest {
+		return MutationResult{}, fmt.Errorf(
 			"%w: %s needs an admission inventory, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/secrets.md",
-			errInvalidInjectionAnnotation, AnnotationSecrets))
+			errInvalidInjectionAnnotation, AnnotationSecrets)
 	}
 	// Same for volumes: the fetcher hands the key to volumed, over the mounted
 	// socket directory on node-CVM or on guest loopback under kata. An operator
 	// with neither shape has no daemon to hand it to, so the workload would wait
 	// on a mount that can never land (docs/volumes.md).
-	if inj != nil && len(inj.Volumes.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
+	if inj != nil && len(inj.Volumes.Specs) > 0 && cfg.WorkloadClaimsHostDir == "" && !cfg.WorkloadClaimsGuest {
+		return MutationResult{}, fmt.Errorf(
 			"%w: %s needs a volume daemon, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/volumes.md",
-			errInvalidInjectionAnnotation, AnnotationVolumes))
+			errInvalidInjectionAnnotation, AnnotationVolumes)
 	}
 	if inj != nil && inj.SAN == "" {
-		// req.Namespace, not pod.Namespace: template-created pods reach
-		// admission with an empty metadata.namespace.
-		inj.SAN = workloadSAN(inj.WorkloadID, req.Namespace)
+		inj.SAN = workloadSAN(inj.WorkloadID, namespace)
 	}
 
 	// confidential.ai/cw drives both get-cert injection and confidential
@@ -731,20 +781,20 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// Injection is idempotent by reconstruction (mutatePod rebuilds the sidecar
 	// every call), so it no longer keys off the confidential.ai/c8s-injected
 	// marker: an author cannot skip injection by pre-setting it.
-	getCertNeeded := inj != nil && m.cfg.GetCertImage != ""
-	kataClass := kataRuntimeClassFor(pod, m.cfg)
+	getCertNeeded := inj != nil && cfg.GetCertImage != ""
+	kataClass := kataRuntimeClassFor(pod, cfg)
 
 	// Covers a pod that set its own runtimeClassName too: injection skips it,
 	// but the shim still honors the annotations. Host-namespace pods are
 	// exempt like they are from class injection (kataIncompatible).
-	if m.cfg.KataEnforce && !kataIncompatible(pod) {
+	if cfg.KataEnforce && !kataIncompatible(pod) {
 		if err := rejectKataHypervisorAnnotations(pod); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+			return MutationResult{}, err
 		}
 	}
 
 	if inj == nil && kataClass == "" {
-		return admission.Allowed("no c8s annotation — passthrough")
+		return MutationResult{}, nil
 	}
 
 	// Only the webhook may place a container under the reserved c8s-cert name.
@@ -753,41 +803,41 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// integrity is name-based.
 	if inj != nil {
 		if err := rejectReservedCertContainer(pod); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+			return MutationResult{}, err
 		}
 	}
 
+	var result MutationResult
 	if getCertNeeded {
 		// ensureVolume keeps a pre-declared same-named volume rather than
 		// overwriting it, so a pod that declares the reserved cert volume as a
 		// hostPath/PVC/disk-backed emptyDir would have its private keys written
 		// to persistent, host-visible storage outside the TEE memory boundary.
 		// Reject anything but the expected memory-backed emptyDir.
-		if err := rejectReservedCertVolume(pod, inj.withDefaults(m.cfg).Cert.Volume); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+		if err := rejectReservedCertVolume(pod, inj.withDefaults(cfg).Cert.Volume); err != nil {
+			return MutationResult{}, err
 		}
 		// Same reasoning for the released secrets: a hostPath here would write
 		// them to host-visible storage.
 		if err := rejectReservedSecretsVolume(pod); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+			return MutationResult{}, err
 		}
-		if err := rejectReservedVolumeVolume(pod, m.cfg.WorkloadClaimsGuest); err != nil {
-			return admission.Errored(http.StatusBadRequest, err)
+		if err := rejectReservedVolumeVolume(pod, cfg.WorkloadClaimsGuest); err != nil {
+			return MutationResult{}, err
 		}
-		l.Info("injecting c8s get-cert containers", "workload", inj.WorkloadID)
-		mutatePod(pod, inj, m.cfg)
+		mutatePod(pod, inj, cfg)
+		result.WorkloadID = inj.WorkloadID
 	}
 	if kataClass != "" {
-		l.Info("injecting kata runtimeClassName", "runtimeClass", kataClass)
 		pod.Spec.RuntimeClassName = &kataClass
-		if m.cfg.KataGuestReadyGate {
+		if cfg.KataGuestReadyGate {
 			requireGuestReadyNode(pod)
 		}
-		if err := stampInitData(pod, kataClass, m.cfg.CDSMeasurements, m.cfg.CDSRTMRs); err != nil {
+		if err := stampInitData(pod, kataClass, cfg.CDSMeasurements, cfg.CDSRTMRs); err != nil {
 			if errors.Is(err, errInvalidInjectionAnnotation) {
-				return admission.Errored(http.StatusBadRequest, err)
+				return MutationResult{}, err
 			}
-			return admission.Errored(http.StatusInternalServerError, err)
+			return MutationResult{}, internalError{err}
 		}
 		// Stamp AnnotationInjected here too — mutatePod only runs when
 		// get-cert is needed, but a kata-only mutation is still a mutation
@@ -797,13 +847,9 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 			pod.Annotations = map[string]string{}
 		}
 		pod.Annotations[AnnotationInjected] = "true"
+		result.KataClass = kataClass
 	}
-
-	raw, err := json.Marshal(pod)
-	if err != nil {
-		return admission.Errored(http.StatusInternalServerError, err)
-	}
-	return admission.PatchResponseFromRaw(req.Object.Raw, raw)
+	return result, nil
 }
 
 // workloadServiceNamePrefix marks the operator-managed headless Service inside

--- a/internal/webhook/static_allowlist_test.go
+++ b/internal/webhook/static_allowlist_test.go
@@ -1,0 +1,92 @@
+package webhook
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Under a static allowlist every injected sidecar pins CDS from its own
+// quote and reaches the verifier over the node's socket, mounted read-only
+// at its own path so the sealed argv names the host path. The flat pins the
+// operator may still hold are not forwarded: they would put a per-cluster
+// digest into an argv the bundle measures.
+func TestStaticAllowlist_SidecarsPinFromOwnQuote(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		socketDir string
+		wantDir   string
+	}{
+		{"default socket dir", "", DefaultAttestationSocketDir},
+		{"custom socket dir", "/run/node-attest", "/run/node-attest"},
+		{"trailing slash", "/run/confai/", "/run/confai"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := newInjectablePod()
+			mutatePod(pod, &injection{
+				WorkloadID: "api",
+				Secrets:    secretsSpec{Specs: []string{"DB=/api/db"}, Dir: "/run/c8s/secrets"},
+				Volumes:    volumesSpec{Specs: []string{"data=/api/data"}, Dir: "/mnt"},
+			}, Config{
+				GetCertImage:          "img",
+				CDSURL:                "https://cds:8443",
+				AttestationApiURL:     "unix:///var/run/nri-image-policy/attestation-api.sock",
+				CDSMeasurements:       []string{strings.Repeat("ab", 48)},
+				CDSRTMRs:              []string{"1=" + strings.Repeat("cd", 48)},
+				WorkloadClaimsHostDir: "/var/run/nri-image-policy",
+				StaticAllowlist:       true,
+				AttestationSocketDir:  tc.socketDir,
+			})
+
+			vol := findVolume(pod, attestationSocketVolumeName)
+			if vol == nil || vol.HostPath == nil || vol.HostPath.Path != tc.wantDir || vol.HostPath.Type == nil || *vol.HostPath.Type != corev1.HostPathDirectory {
+				t.Fatalf("attestation socket volume = %#v, want hostPath %s of type Directory", vol, tc.wantDir)
+			}
+			if pod.Spec.SecurityContext == nil || !slices.Contains(pod.Spec.SecurityContext.SupplementalGroups, workloadclaims.InventorySocketGID) {
+				t.Fatalf("pod lacks supplemental group %d for the root-owned socket: %+v", workloadclaims.InventorySocketGID, pod.Spec.SecurityContext)
+			}
+			wantURL := "--attestation-api-url=unix://" + tc.wantDir + "/attestation-api.sock"
+			for _, name := range []string{reservedCertContainerName, reservedSecretContainerName, reservedVolumeContainerName} {
+				c := containerNamed(pod, name)
+				if c == nil {
+					t.Fatalf("no %s container injected", name)
+				}
+				if !hasArg(c.Args, "--cds-pins-from-own-quote") || !hasArg(c.Args, wantURL) {
+					t.Errorf("%s args = %v, want --cds-pins-from-own-quote and %s", name, c.Args, wantURL)
+				}
+				for _, arg := range c.Args {
+					for _, flat := range []string{"--cds-measurements=", "--cds-rtmrs=", "--measurements=", "--rtmrs="} {
+						if strings.HasPrefix(arg, flat) {
+							t.Errorf("%s forwards the flat pin %q under a static allowlist", name, arg)
+						}
+					}
+				}
+				i := slices.IndexFunc(c.VolumeMounts, func(m corev1.VolumeMount) bool { return m.Name == attestationSocketVolumeName })
+				if i < 0 || c.VolumeMounts[i].MountPath != tc.wantDir || !c.VolumeMounts[i].ReadOnly {
+					t.Errorf("%s attestation socket mount = %+v, want %s read-only", name, c.VolumeMounts, tc.wantDir)
+				}
+			}
+		})
+	}
+}
+
+// Off by default: no socket volume, and the flat pins keep flowing.
+func TestStaticAllowlist_OffKeepsFlatPins(t *testing.T) {
+	pod := newInjectablePod()
+	mutatePod(pod, &injection{WorkloadID: "api"}, Config{
+		GetCertImage:      "img",
+		CDSURL:            "https://cds:8443",
+		AttestationApiURL: "http://as:8400",
+		CDSMeasurements:   []string{strings.Repeat("ab", 48)},
+	})
+	if findVolume(pod, attestationSocketVolumeName) != nil {
+		t.Fatal("the attestation socket volume is injected without a static allowlist")
+	}
+	cert := containerNamed(pod, reservedCertContainerName)
+	if hasArg(cert.Args, "--cds-pins-from-own-quote") || !hasArg(cert.Args, "--cds-measurements="+strings.Repeat("ab", 48)) {
+		t.Fatalf("c8s-cert args = %v, want the flat pin and no own-quote flag", cert.Args)
+	}
+}

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -14,18 +14,20 @@ Layout:
   it must stay `c8s`.
 - Platform: the profile is platform-neutral; `build` requires
   `C8S_PLATFORM` (`tdx`|`snp`, no default) and `c8s/mkosi.sync` renders the
-  **entire** tdx/snp divergence — three files — from it: cred-release's
-  `Environment=CRED_PLATFORM` drop-in, the node's self-label
+  **entire** tdx/snp divergence — four files — from it: cred-release's
+  `Environment=CRED_PLATFORM` drop-in, c8s-policy-measure's
+  `Environment=POLICY_PLATFORM` drop-in, the node's self-label
   (`confidential.ai/tdx` / `confidential.ai/sev-snp`, the k8s vocabulary
   `c8s install --hardware-platform` selects on), and the NRI floor's
   `platform:`. The sync refuses to render a missing/invalid value, so the
-  fail-closed gate is at **build** time; `--platform=${CRED_PLATFORM}` in
-  the unit is boot-time defense in depth (cred-release opens no quote
-  device — quotes come from attestation-api over HTTP, the operator-key
-  RTMR read is sysfs). The guest kernel carries both TEEs' symbols via
-  confos `kernel/required.config`, so the images differ only by those
-  three rendered files — which keeps a one-image-serves-both design
-  (boot-time platform probe, confos `--platform both`) evaluable later.
+  fail-closed gate is at **build** time; `--platform=${CRED_PLATFORM}` and
+  `--platform=${POLICY_PLATFORM}` in the units are boot-time defense in
+  depth (neither opens a quote device — quotes come from attestation-api
+  over HTTP, the RTMR reads and extends are sysfs). The guest kernel
+  carries both TEEs' symbols via confos `kernel/required.config`, so the
+  images differ only by those four rendered files — which keeps a
+  one-image-serves-both design (boot-time platform probe, confos
+  `--platform both`) evaluable later.
   NOTE: the operator credential-release flow itself is TDX-only today
   (RTMR[3] binding; SNP has no runtime-extend equivalent) — an SNP image
   boots and attests, but operator flows fail closed pending an SNP
@@ -76,6 +78,26 @@ The other disks are optional; each is owned by one unit under
   see [operator.md]). The baked `cred-release-rbac` RKE2 AddOn binds the
   issued certificate's group to `cluster-admin` through ordinary RBAC;
   identity, TTL and revocation are documented in [operator.md].
+- label `policydata` — an ISO carrying the policy bundle: a flat set of
+  JSON members, `static-allowlist.json` required (`c8s policy-disk` builds
+  it). Its presence makes the boot **static** (`c8s-policy-measure.service`,
+  see [static-allowlist.md]): `opkeydata` must be absent, the bundle is
+  linted sealed, and RTMR[3] commits to the bundle index. KubeVirt attaches
+  it as `secret: {secretName: <name>, volumeLabel: policydata}` on a virtio
+  disk; libvirt as a CD-ROM built with `mkisofs -V policydata`. TDX only:
+  an SNP node with the disk attached powers off.
+
+Every boot runs `c8s-policy-measure.service` before RKE2. It extends the
+mode event into RTMR[3] (`ModeDynamic`, or `ModeStatic` then the policy
+event), publishes the verdict as `/run/confai/policy/mode` (`static` or
+`dynamic`, written last) and, on a static boot, the bundle members and their
+index digest beside it. `c8s-attest-socket.service` fronts the confos
+`attestation-api.service` on `/run/confai/attestation-api.sock`
+(root-owned, group 65532) so the baked NRI plugin config and the static CDS
+pin a verifier the control plane cannot repoint. In static mode
+`cred-release.service` starts without an operator key: RTMR[3] must equal
+the value recomputed from the published bundle, and any attested caller
+receives the operator credential (see [operator.md]).
 
 Migration state (see [#264] for the full plan):
 
@@ -98,3 +120,4 @@ Migration state (see [#264] for the full plan):
 [confidential-os-builder]: https://github.com/confidential-dot-ai/confidential-os-builder
 [#264]: https://github.com/confidential-dot-ai/c8s/issues/264
 [operator.md]: ../docs/operator.md
+[static-allowlist.md]: ../docs/static-allowlist.md

--- a/node-guest-image/c8s/image-policy.yaml.in
+++ b/node-guest-image/c8s/image-policy.yaml.in
@@ -58,6 +58,12 @@ workload_claims:
   advertise_host: ""
 
 allowlist:
+  # Where c8s-policy-measure.service records the boot mode and, on a static
+  # boot, the measured policy bundle (docs/static-allowlist.md). The plugin
+  # reads <policy_dir>/mode at start: "dynamic" keeps the floor and pull
+  # below, "static" seals the plugin to the bundle and ignores them, anything
+  # else is fatal.
+  policy_dir: "/run/confai/policy"
   # Cold-boot floor. The first two entries resolve from C8S_REF by mkosi.sync:
   #   - the plugin's own image (self-allow), and
   #   - CDS, so it can start against this fail-closed plugin and then serve the
@@ -106,10 +112,12 @@ allowlist:
     url: "https://127.0.0.1:30808"
     interval: "30s"
     timeout: "30s"
-    # The BAKED attestation-api (attest/attest-gpu profile, host service on
-    # :8400). The plugin runs in the host netns as a containerd child, so
-    # loopback reaches it.
-    attestation_api_url: "http://127.0.0.1:8400"
+    # The BAKED attestation-api behind the unix front door
+    # c8s-attest-socket.service serves (c8s attest-proxy in the measured
+    # image). A socket path, not a routable address, so nothing the control
+    # plane configures can point the plugin at another verifier; in static
+    # mode the CDS pins come from the node's own quote over it.
+    attestation_api_url: "unix:///run/confai/attestation-api.sock"
     # `c8s install --measurements` / `--measurements-config` writes these; see
     # TRUST POSTURE above. Empty = accept any RA-TLS-attested CDS measurement
     # (logged), which is what every boot starts from.
@@ -118,6 +126,13 @@ allowlist:
 containerd:
   socket: "/run/k3s/containerd/containerd.sock"
   namespace: "k8s.io"
+
+runtime:
+  # In static mode, require a containerd whose version carries the
+  # +c8s.nri-failclosed build marker (the containerd/nri fail-closed patch
+  # under patches/). Flip to true once the image pipeline ships that
+  # containerd; until then the plugin's own 1.5 s deadline is the mitigation.
+  require_fail_closed: false
 
 policy:
   mode: "fail-closed"

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-attest-socket.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-attest-socket.service
@@ -1,0 +1,51 @@
+# Node-local attestation verifier socket. attestation-api (from the confos
+# attest profile) listens on http://127.0.0.1:8400 only; this unit fronts it
+# with `c8s attest-proxy` on /run/confai/attestation-api.sock so the baked
+# NRI plugin config and the static-mode CDS argv can pin a verifier URL that
+# no chart value, pod restart or control-plane action can repoint. Root owns
+# the socket (0660); the group lets CDS (uid 65532, given that supplementary
+# group by the chart in static mode) connect. The verdict stays unsigned:
+# the socket is what makes it immutable to the control plane.
+[Unit]
+Description=attestation-api on the node-local unix socket
+Documentation=https://github.com/confidential-dot-ai/c8s
+After=attestation-api.service
+Requires=attestation-api.service
+# Up before containerd: the sealed NRI plugin self-attests over the socket
+# once at startup and powers the node off on failure. Before= on a simple
+# unit only orders the fork, so the ExecStartPost readiness gate below is
+# what makes "started" mean "serving": rke2 waits until a health probe
+# through the socket and the proxy reaches attestation-api.
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=simple
+# --socket-gid is pkg/workloadclaims.InventorySocketGID; policymeasure's
+# node_image_test.go pins the literal to the constant.
+ExecStart=/usr/local/bin/c8s attest-proxy \
+    --socket /run/confai/attestation-api.sock \
+    --upstream http://127.0.0.1:8400 \
+    --socket-gid 65532
+# Readiness gate (see Before= above): the probe dials the socket the way a
+# consumer does (owner and mode checks included) and proxies GET /health to
+# attestation-api, so one passing probe covers socket, proxy and upstream.
+# Bounded to 30 s; a failure fails the start and Restart= tries again.
+ExecStartPost=/bin/sh -c 'for _ in $(seq 1 30); do /usr/local/bin/c8s attest-proxy healthcheck --socket /run/confai/attestation-api.sock && exit 0; sleep 1; done; exit 1'
+TimeoutStartSec=60
+Restart=on-failure
+RestartSec=2
+# Serves a unix socket, dials loopback TCP. Nothing else.
+ProtectSystem=strict
+ReadWritePaths=/run/confai
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+NoNewPrivileges=yes
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).
+RestrictAddressFamilies=AF_UNIX AF_INET
+
+[Install]
+WantedBy=multi-user.target
+# Preset creates the .requires links: no verifier socket, no containers.
+RequiredBy=rke2-server.service rke2-agent.service

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-policy-measure.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-policy-measure.service
@@ -1,0 +1,53 @@
+# Commit the boot's policy mode to RTMR[3] before RKE2 starts containerd.
+# Every boot extends a mode event: ModeDynamic without a policydata disk,
+# ModeStatic plus the bundle's policy event with one. Without that, a
+# dynamic node (where cluster-admin is node root through any privileged pod)
+# could write the static events itself and pass every static check.
+# /run/confai/policy/mode is written last, so a static consumer
+# (cred-release, the NRI plugin, CDS) only ever reads a verdict the register
+# already backs. No ConditionPathExists: the unit always runs.
+[Unit]
+Description=Measure the policy mode (and static allowlist bundle) into RTMR[3]
+# The launch ISOs may still be settling; the ExecStartPre below waits for
+# udev so a late policydata device is not misread as a dynamic boot.
+After=systemd-udevd.service
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStartPre=-/usr/bin/udevadm settle --timeout=10
+# ${POLICY_PLATFORM} comes from a drop-in the c8s sync hook renders from
+# the build's required C8S_PLATFORM (same mechanism as cred-release's
+# CRED_PLATFORM). The `=` form matters: with the variable unset systemd
+# would elide a bare word, but --platform= expands to an empty value, which
+# the command rejects — fail closed, never a default. On snp the command
+# writes mode=dynamic and touches no register; a policydata disk is fatal.
+ExecStart=/usr/local/bin/c8s policy-measure --platform=${POLICY_PLATFORM}
+TimeoutStartSec=60
+# Fail closed: a node whose mode event did not land must not run
+# containers. A powered-off node does not flap.
+FailureAction=poweroff-force
+
+# Mounts the policydata ISO itself (CAP_SYS_ADMIN, /dev/disk/by-label),
+# extends the register through sysfs and writes /run/confai/policy, so it
+# cannot take cred-release's ProtectKernelTunables/PrivateDevices. Everything
+# else stays read-only; the private mount namespace keeps the ISO mount out
+# of the host view. The initrd creates /etc/confai only on an opkeydata
+# boot, so the `-` prefix is what lets a keyless or static boot start at all:
+# without it systemd fails the namespace setup (226/NAMESPACE) and this
+# unit's FailureAction powers the node off before the command runs.
+ProtectSystem=strict
+ReadOnlyPaths=-/etc/confai
+ReadWritePaths=/run/confai
+ProtectHome=yes
+PrivateTmp=yes
+NoNewPrivileges=yes
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).
+RestrictAddressFamilies=AF_UNIX
+
+[Install]
+WantedBy=multi-user.target
+# Preset creates the .requires links, so rke2 cannot start while this unit
+# is failing or has not run.
+RequiredBy=rke2-server.service rke2-agent.service

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/cred-release.service
@@ -6,30 +6,37 @@ Documentation=https://github.com/confidential-dot-ai/c8s
 # not spin. 5 tries in 5 min, then give up until the next boot.
 StartLimitIntervalSec=300
 StartLimitBurst=5
-# Needs the RKE2 client-CA (to sign operator certs) and the attestation-api
-# (to fetch the RA-TLS serving cert's quote from :8400). rke2-server
-# creates /var/lib/rancher/rke2/server/tls/client-ca.* only once it has
-# initialised, so we order after it and gate on the key existing (the Exec
-# startpre below), rather than racing a half-initialised control plane.
-After=network-online.target rke2-role.service rke2-server.service attestation-api.service
+# Needs the RKE2 client-CA (to sign operator certs), the attestation-api
+# (to fetch the RA-TLS serving cert's quote from :8400) and the policy mode
+# c8s-policy-measure wrote (static or dynamic). rke2-server creates
+# /var/lib/rancher/rke2/server/tls/client-ca.* only once it has initialised,
+# so we order after it and gate on the key existing (the Exec startpre
+# below), rather than racing a half-initialised control plane.
+After=network-online.target rke2-role.service rke2-server.service attestation-api.service c8s-policy-measure.service
 Wants=network-online.target
-Requires=rke2-role.service attestation-api.service
-# Only run on operator boots. A VM launched without --operator-key has no
-# opkeydata disk; the condition makes systemd SKIP the unit (not fail it), so
-# there's no restart-loop on non-operator nodes. The launcher attaches the
-# disk with ISO label "opkeydata".
-ConditionPathExists=/dev/disk/by-label/opkeydata
+Requires=rke2-role.service attestation-api.service c8s-policy-measure.service
+# Only run on operator or static boots. A VM launched with neither an
+# operator key (ISO label "opkeydata") nor a policy bundle (ISO label
+# "policydata") has nothing to release; the `|` conditions OR each other,
+# and make systemd SKIP the unit (not fail it), so there's no restart-loop
+# on such nodes. Which of the two applies is decided by the policy mode, not
+# by the disk: c8s-policy-measure refuses a boot with both.
+ConditionPathExists=|/dev/disk/by-label/opkeydata
+ConditionPathExists=|/dev/disk/by-label/policydata
 # Server role only: agent nodes have no client CA to sign with.
 ConditionPathExists=/run/confos/role-server
 
 [Service]
 Type=simple
-# The operator key is bound into the platform's launch identity (TDX: the
-# initrd extends its hash into RTMR[3]; SNP: the launcher commits its sha256
-# as HOSTDATA); the service verifies the on-disk pubkey against that binding
-# via the local attestation-api and refuses (exits non-zero) if it was
-# substituted.
-# Non-operator boots never reach here (ConditionPathExists skips the unit).
+# Dynamic mode: the operator key is bound into the platform's launch
+# identity (TDX: the initrd extends its hash into RTMR[3]; SNP: the launcher
+# commits its sha256 as HOSTDATA); the service verifies the on-disk pubkey
+# against that binding via the local attestation-api and refuses (exits
+# non-zero) if it was substituted. Static mode: there is no operator key and
+# no token check; RTMR[3] must equal the bundle-derived value recomputed
+# from /run/confai/policy, and any attested caller gets the credential
+# (cluster-admin is the adversary the static design already assumes).
+# Keyless dynamic boots never reach here (ConditionPathExists skips the unit).
 # Waits bounded (10 min) rather than failing fast: on a slow first boot the
 # CA can take minutes to appear, and 5 quick ExecStartPre failures 10s apart
 # would exhaust StartLimitBurst in under a minute and give up until reboot.
@@ -50,16 +57,21 @@ ExecStart=/usr/local/bin/c8s cred-release \
     --listen :8443 \
     --attestation-api-url http://127.0.0.1:8400 \
     --platform=${CRED_PLATFORM} \
+    --policy-dir /run/confai/policy \
     --cert-ttl 1h \
     --cert-org c8s:node-operators \
     --cert-cn operator
 Restart=on-failure
 RestartSec=10
-# Reads the initrd-staged operator pubkey (/etc/confai), the RKE2 client-CA
-# key, and (ExecStartPre only) the RKE2 admin kubeconfig. Writes only the
-# kubectl cache under /run. Keep the rest of the FS read-only.
+# Reads the initrd-staged operator pubkey (/etc/confai), the policy mode and
+# bundle (/run/confai/policy), the RKE2 client-CA key, and (ExecStartPre
+# only) the RKE2 admin kubeconfig. Writes only the kubectl cache under /run.
+# Keep the rest of the FS read-only. /etc/confai exists only on an opkeydata
+# boot (the initrd creates it while staging the pubkey); the `-` prefix
+# keeps a static boot, which has no operator key, from failing at namespace
+# setup before the command runs.
 ProtectSystem=strict
-ReadOnlyPaths=/etc/confai /var/lib/rancher/rke2/server/tls
+ReadOnlyPaths=-/etc/confai /run/confai/policy /var/lib/rancher/rke2/server/tls
 ReadWritePaths=/run
 ProtectHome=yes
 NoNewPrivileges=yes

--- a/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
+++ b/node-guest-image/c8s/mkosi.extra/etc/tmpfiles.d/confos-rke2.conf
@@ -13,3 +13,9 @@ d /run/nri-image-policy 0755 root root - -
 # writes the role fragment there.
 d /run/confos 0755 root root - -
 d /etc/rancher/rke2/config.yaml.d 0755 root root - -
+# c8s-policy-measure writes the policy mode, digest and bundle members under
+# /run/confai/policy; c8s-attest-socket serves /run/confai/attestation-api.sock.
+# Both are tmpfs paths the units expect to exist; tmpfiles rather than
+# RuntimeDirectory= so a restart of one unit never removes the other's files.
+d /run/confai 0755 root root - -
+d /run/confai/policy 0755 root root - -

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -26,6 +26,13 @@ enable gpu-cc-enforce.service
 # Fail closed when the initrd fell back to the tmpfs rootfs upper; RequiredBy
 # the rke2 pair so a scratch-less node powers off instead of flapping.
 enable scratch-enforce.service
+# Commit the policy mode (dynamic, or static plus the bundle) to RTMR[3]
+# before containerd; RequiredBy the rke2 pair so a node whose mode event did
+# not land powers off instead of running containers.
+enable c8s-policy-measure.service
+# attestation-api on the node-local unix socket the NRI plugin and static
+# CDS pin; RequiredBy the rke2 pair so no container runs without a verifier.
+enable c8s-attest-socket.service
 # Role dispatch + the role-gated rke2 pair.
 enable rke2-role.service
 enable rke2-server.service
@@ -35,6 +42,6 @@ enable rke2-agent.service
 # CVM's masquerade NAT.
 enable systemd-timesyncd.service
 # Attested operator credential release. Enabled always, but its
-# ConditionPathExists on the opkeydata disk means it only starts on operator
-# boots — a no-op on nodes launched without --operator-key.
+# ConditionPathExists on the opkeydata|policydata disks means it only starts
+# on operator or static boots — a no-op on keyless dynamic nodes.
 enable cred-release.service

--- a/node-guest-image/c8s/mkosi.sync
+++ b/node-guest-image/c8s/mkosi.sync
@@ -75,11 +75,11 @@ case "$PLATFORM" in
     *) echo "c8s sync: FATAL platform sync-input must be tdx or snp, got '${PLATFORM}'" >&2; exit 1 ;;
 esac
 
-# Platform drop-ins rendered from the one sync-input: cred-release's
-# platform and the node self-label; the NRI floor's platform: is substituted
-# below together with the digests. Rendered paths must stay disjoint from
-# the profile's mkosi.extra tree (copy precedence between the two is
-# undocumented; today every rendered path is a new file).
+# Platform drop-ins rendered from the one sync-input: cred-release's and
+# c8s-policy-measure's platform and the node self-label; the NRI floor's
+# platform: is substituted below together with the digests. Rendered paths
+# must stay disjoint from the profile's mkosi.extra tree (copy precedence
+# between the two is undocumented; today every rendered path is a new file).
 #
 # The label key is the one consumer with its own vocabulary: the chart
 # selector and c8s install use confidential.ai/sev-snp (NOT /snp — nothing
@@ -90,9 +90,12 @@ case "$PLATFORM" in
     *)   LABEL_PLATFORM=$PLATFORM ;;
 esac
 mkdir -p "$STAGE_DIR/etc/systemd/system/cred-release.service.d" \
+         "$STAGE_DIR/etc/systemd/system/c8s-policy-measure.service.d" \
          "$STAGE_DIR/etc/rancher/rke2/config.yaml.d"
 printf '[Service]\nEnvironment=CRED_PLATFORM=%s\n' "$PLATFORM" \
     > "$STAGE_DIR/etc/systemd/system/cred-release.service.d/10-platform.conf"
+printf '[Service]\nEnvironment=POLICY_PLATFORM=%s\n' "$PLATFORM" \
+    > "$STAGE_DIR/etc/systemd/system/c8s-policy-measure.service.d/10-platform.conf"
 printf '# Self-label so `c8s install --hardware-platform %s` finds this node.\nnode-label:\n  - confidential.ai/%s=true\n' "$LABEL_PLATFORM" "$LABEL_PLATFORM" \
     > "$STAGE_DIR/etc/rancher/rke2/config.yaml.d/50-platform.yaml"
 

--- a/node-guest-image/c8s/patches/README.md
+++ b/node-guest-image/c8s/patches/README.md
@@ -1,0 +1,63 @@
+# containerd patches for the node image
+
+The node image runs the containerd that RKE2 unpacks from its `rke2-runtime`
+airgap image; nothing in this repo builds containerd. The patches here are
+the source-level fixes the image pipeline must build into that containerd
+before static mode can require them.
+
+## containerd-nri-fail-closed.patch
+
+Against `github.com/containerd/nri` `v0.12.2`, `pkg/adaptation`. In
+v0.12.2 `Adaptation.CreateContainer` registers a plugin with the validators
+before the plugin replies, and a fatal reply error (`context.DeadlineExceeded`,
+`ttrpc.ErrClosed`) becomes a nil reply. The default validator's
+`required_plugins` therefore refuses every later request, but the request
+that timed out is admitted, and two seconds of a privileged container is
+enough to read CDS memory. The patch:
+
+1. registers a plugin with the validators only after a successful reply, so a
+   plugin closed on a fatal error is not present for that request;
+2. returns a globally required plugin's fatal error as the error of
+   `CreateContainer`, `PostCreateContainer` and `StartContainer`;
+3. fails `PostCreateContainer` and `StartContainer` while a globally required
+   plugin is absent. Upstream drops a closed plugin from its list after every
+   request, so without this a container admitted at `CreateContainer` starts
+   with no plugin present once the plugin has died, whatever verdict it
+   cached for `StartContainer`.
+
+Required plugins are the `required_plugins` of the default validator's
+config (the node image sets `["nri-image-policy"]` in
+`config-v3.toml.d/nri-image-policy.toml`). `CreateContainer` keeps the
+validator's own presence check, toleration annotations included; per-pod
+required plugins declared by annotation are covered by point 1 at
+`CreateContainer` only.
+
+### How the image pipeline applies it
+
+The pipeline builds containerd with a `replace` for the nri module:
+
+```sh
+git clone --branch v0.12.2 https://github.com/containerd/nri
+patch -p1 -d nri < containerd-nri-fail-closed.patch
+# in the containerd checkout RKE2's rke2-runtime image is built from:
+go mod edit -replace github.com/containerd/nri=../nri
+```
+
+and sets the version marker the plugin checks:
+
+```sh
+make VERSION="$(git describe --tags)+c8s.nri-failclosed"
+```
+
+`containerd --version` must then report a version containing
+`+c8s.nri-failclosed` (`FailClosedRuntimeMarker` in the NRI plugin). In
+sealed mode with `runtime.require_fail_closed: true` in
+`image-policy.yaml.in`, the plugin exits when the marker is absent; the baked
+template keeps the key `false` until the patched containerd ships.
+
+### Checking the patch
+
+```sh
+cp -r "$(go env GOMODCACHE)/github.com/containerd/nri@v0.12.2" nri && chmod -R u+w nri
+patch --dry-run -p1 -d nri < containerd-nri-fail-closed.patch
+```

--- a/node-guest-image/c8s/patches/containerd-nri-fail-closed.patch
+++ b/node-guest-image/c8s/patches/containerd-nri-fail-closed.patch
@@ -1,0 +1,139 @@
+containerd/nri v0.12.2: fail closed on a required plugin's fatal error.
+
+Upstream registers every plugin with the validators before it replies and
+turns a fatal reply error (request timeout, connection loss) into a nil
+reply, so the request that timed out is admitted while later ones are
+refused. Closed plugins are then dropped from the plugin list, so a later
+PostCreateContainer or StartContainer for a container the plugin admitted
+runs with no required plugin and no error. This registers a plugin only
+after a successful reply, makes a globally required plugin's fatal error
+the error of CreateContainer, PostCreateContainer and StartContainer, and
+fails PostCreateContainer and StartContainer while a globally required
+plugin is absent. See README.md in this directory.
+
+--- a/pkg/adaptation/adaptation.go
++++ b/pkg/adaptation/adaptation.go
+@@ -72,6 +72,7 @@
+ 	listener    net.Listener
+ 	plugins     []*plugin
+ 	validators  []*plugin
++	required    map[string]struct{}
+ 	builtin     []*builtin.BuiltinPlugin
+ 	syncLock    sync.RWMutex
+ 	wasmService *api.PluginPlugin
+@@ -154,6 +155,12 @@
+ 	return func(r *Adaptation) error {
+ 		if plugin := validator.GetDefaultValidator(cfg); plugin != nil {
+ 			r.builtin = append([]*builtin.BuiltinPlugin{plugin}, r.builtin...)
++			if r.required == nil {
++				r.required = map[string]struct{}{}
++			}
++			for _, name := range cfg.RequiredPlugins {
++				r.required[name] = struct{}{}
++			}
+ 		}
+ 		return nil
+ 	}
+@@ -339,13 +346,19 @@
+ 	}
+ 
+ 	for _, plugin := range r.plugins {
+-		if validate != nil {
+-			validate.AddPlugin(plugin.base, plugin.idx)
+-		}
+ 		rpl, err := plugin.createContainer(ctx, req)
+ 		if err != nil {
+ 			return nil, err
+ 		}
++		if err := r.requiredPluginFailed(plugin, "CreateContainer"); err != nil {
++			return nil, err
++		}
++		// Register the plugin with the validators only after it replied: a
++		// plugin closed on a fatal error (request timeout, connection loss)
++		// did not process this request and must not count as present.
++		if validate != nil && !plugin.isClosed() {
++			validate.AddPlugin(plugin.base, plugin.idx)
++		}
+ 		err = result.apply(rpl, plugin.name())
+ 		if err != nil {
+ 			return nil, err
+@@ -361,11 +374,17 @@
+ 	defer r.Unlock()
+ 	defer r.removeClosedPlugins()
+ 
++	if err := r.requiredPluginMissing("PostCreateContainer"); err != nil {
++		return err
++	}
+ 	for _, plugin := range r.plugins {
+ 		_, err := plugin.postCreateContainer(ctx, req)
+ 		if err != nil {
+ 			return err
+ 		}
++		if err := r.requiredPluginFailed(plugin, "PostCreateContainer"); err != nil {
++			return err
++		}
+ 	}
+ 
+ 	return nil
+@@ -377,11 +396,17 @@
+ 	defer r.Unlock()
+ 	defer r.removeClosedPlugins()
+ 
++	if err := r.requiredPluginMissing("StartContainer"); err != nil {
++		return err
++	}
+ 	for _, plugin := range r.plugins {
+ 		_, err := plugin.startContainer(ctx, req)
+ 		if err != nil {
+ 			return err
+ 		}
++		if err := r.requiredPluginFailed(plugin, "StartContainer"); err != nil {
++			return err
++		}
+ 	}
+ 
+ 	return nil
+@@ -482,6 +507,43 @@
+ 	return r.updateFn(ctx, req)
+ }
+ 
++// requiredPluginFailed reports a globally required plugin that was closed
++// while handling op (a fatal error: request timeout, connection loss). The
++// plugin wrapper turns such an error into a nil reply so the request goes
++// on without the plugin; for a required plugin that silence must fail the
++// request instead, or the container the plugin never saw is admitted.
++func (r *Adaptation) requiredPluginFailed(p *plugin, op string) error {
++	if !p.isClosed() {
++		return nil
++	}
++	if _, ok := r.required[p.base]; !ok {
++		return nil
++	}
++	return fmt.Errorf("required plugin %q failed to handle %s and was closed", p.name(), op)
++}
++
++// requiredPluginMissing reports a globally required plugin with no open
++// entry in r.plugins. removeClosedPlugins drops a plugin closed on a fatal
++// error, so a later lifecycle request for a container that plugin admitted
++// would otherwise run with no required plugin and no error. CreateContainer
++// needs no such check: the default validator refuses a missing required
++// plugin there, with its toleration annotations.
++func (r *Adaptation) requiredPluginMissing(op string) error {
++	for name := range r.required {
++		present := false
++		for _, p := range r.plugins {
++			if p.base == name && !p.isClosed() {
++				present = true
++				break
++			}
++		}
++		if !present {
++			return fmt.Errorf("required plugin %q is not present to handle %s", name, op)
++		}
++	}
++	return nil
++}
++
+ // Validate requested container adjustments.
+ func (r *Adaptation) validateContainerAdjustment(ctx context.Context, req *ValidateContainerAdjustmentRequest, result *result) (*CreateContainerResponse, error) {
+ 	rpl := result.createContainerResponse()

--- a/node-guest-image/c8s/systemfloor/main.go
+++ b/node-guest-image/c8s/systemfloor/main.go
@@ -30,10 +30,11 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"regexp"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/containerd/containerd/v2/core/content"
@@ -171,14 +172,8 @@ func render(entries []entry) string {
 		seen[e.digest] = true
 		byRef[e.ref] = e.digest
 	}
-	refs := make([]string, 0, len(byRef))
-	for r := range byRef {
-		refs = append(refs, r)
-	}
-	sort.Strings(refs)
-
 	var b strings.Builder
-	for _, r := range refs {
+	for _, r := range slices.Sorted(maps.Keys(byRef)) {
 		fmt.Fprintf(&b, "    %q: %q\n", byRef[r], r)
 	}
 	return b.String()
@@ -197,11 +192,7 @@ func floorFile(entries []entry) ([]byte, error) {
 		seen[e.digest] = true
 		byRef[e.ref] = e
 	}
-	refs := make([]string, 0, len(byRef))
-	for r := range byRef {
-		refs = append(refs, r)
-	}
-	sort.Strings(refs)
+	refs := slices.Sorted(maps.Keys(byRef))
 	floor := allowlist.SystemFloor{Schema: allowlist.SystemFloorSchema, Images: make([]allowlist.SystemFloorImage, 0, len(refs))}
 	for _, r := range refs {
 		e := byRef[r]

--- a/node-guest-image/c8s/systemfloor/main.go
+++ b/node-guest-image/c8s/systemfloor/main.go
@@ -17,7 +17,10 @@
 //
 // prints the always_allow block. With -template pointing at
 // image-policy.yaml.in, -check reports drift and -write rewrites the block
-// between the BEGIN/END markers in place.
+// between the BEGIN/END markers in place. -floor writes system-floor.json,
+// the rule skeleton `c8s allowlist render --sealed --system-floor` consumes:
+// one image per entry with the argv its config bakes, and empty env, mounts
+// and review for the reviewer to complete.
 package main
 
 import (
@@ -37,14 +40,22 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
 	localcontent "github.com/containerd/containerd/v2/plugins/content/local"
+	"github.com/containerd/platforms"
 	"github.com/klauspost/compress/zstd"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/confidential-dot-ai/c8s/internal/crane"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
 
-// entry is one floor line: a digest admitted under an image reference.
+// entry is one floor line: a digest admitted under an image reference, with
+// the argv the image config bakes (known for bundle images; fetched for
+// manifest refs only when -floor asks for it).
 type entry struct {
-	digest string
-	ref    string
+	digest     string
+	ref        string
+	entrypoint []string
+	cmd        []string
 }
 
 // bundleEntries imports a docker-archive airgap bundle the way containerd's
@@ -103,9 +114,31 @@ func importEntries(r io.Reader) ([]entry, error) {
 		if name == "" {
 			continue
 		}
-		out = append(out, entry{digest: m.Digest.String(), ref: name})
+		e := entry{digest: m.Digest.String(), ref: name}
+		if e.entrypoint, e.cmd, err = imageArgv(store, m); err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		out = append(out, e)
 	}
 	return out, nil
+}
+
+// imageArgv reads the imported image's config blob for its Entrypoint and Cmd.
+func imageArgv(store content.Store, desc ocispec.Descriptor) (entrypoint, cmd []string, err error) {
+	ctx := context.Background()
+	configDesc, err := images.Config(ctx, store, desc, platforms.Default())
+	if err != nil {
+		return nil, nil, fmt.Errorf("config descriptor: %w", err)
+	}
+	blob, err := content.ReadBlob(ctx, store, configDesc)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read config: %w", err)
+	}
+	var img ocispec.Image
+	if err := json.Unmarshal(blob, &img); err != nil {
+		return nil, nil, fmt.Errorf("parse config: %w", err)
+	}
+	return img.Config.Entrypoint, img.Config.Cmd, nil
 }
 
 // imageRefRE matches an `image:` value pinned by digest.
@@ -149,6 +182,60 @@ func render(entries []entry) string {
 		fmt.Fprintf(&b, "    %q: %q\n", byRef[r], r)
 	}
 	return b.String()
+}
+
+// floorFile renders the system-floor.json skeleton: one image per entry,
+// sorted by reference and deduped by digest like render, with the config
+// argv and everything the build cannot see left for the reviewer.
+func floorFile(entries []entry) ([]byte, error) {
+	byRef := make(map[string]entry, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if seen[e.digest] {
+			continue
+		}
+		seen[e.digest] = true
+		byRef[e.ref] = e
+	}
+	refs := make([]string, 0, len(byRef))
+	for r := range byRef {
+		refs = append(refs, r)
+	}
+	sort.Strings(refs)
+	floor := allowlist.SystemFloor{Schema: allowlist.SystemFloorSchema, Images: make([]allowlist.SystemFloorImage, 0, len(refs))}
+	for _, r := range refs {
+		e := byRef[r]
+		floor.Images = append(floor.Images, allowlist.SystemFloorImage{
+			Ref:        e.ref,
+			Digest:     e.digest,
+			Entrypoint: e.entrypoint,
+			Cmd:        e.cmd,
+			Env:        map[string]allowlist.EnvValue{},
+			Mounts:     map[string]allowlist.MountRule{},
+			Privileges: &allowlist.Privileges{},
+		})
+	}
+	return json.MarshalIndent(floor, "", "  ")
+}
+
+// resolveManifestArgv fills the config argv of manifest-sourced entries from
+// the registry; bundle entries already carry theirs.
+func resolveManifestArgv(entries []entry) error {
+	if err := crane.Require(); err != nil {
+		return fmt.Errorf("-floor needs the config of manifest-pinned images: %w", err)
+	}
+	for i := range entries {
+		e := &entries[i]
+		if e.entrypoint != nil || e.cmd != nil {
+			continue
+		}
+		cfg, err := crane.Config(context.Background(), e.ref)
+		if err != nil {
+			return err
+		}
+		e.entrypoint, e.cmd = cfg.Config.Entrypoint, cfg.Config.Cmd
+	}
+	return nil
 }
 
 const (
@@ -199,13 +286,14 @@ func main() {
 func run(args []string, stdout io.Writer) error {
 	fs := flag.NewFlagSet("systemfloor", flag.ContinueOnError)
 	var bundles, manifests stringList
-	var templatePath string
+	var templatePath, floorPath string
 	var check, write bool
 	fs.Var(&bundles, "bundle", "RKE2 airgap image bundle (*.tar.zst); repeatable")
 	fs.Var(&manifests, "manifest", "YAML manifest to scan for digest-pinned image refs; repeatable")
 	fs.StringVar(&templatePath, "template", "", "image-policy.yaml.in to splice the block into")
 	fs.BoolVar(&check, "check", false, "exit non-zero when the template block is stale")
 	fs.BoolVar(&write, "write", false, "rewrite the template block in place")
+	fs.StringVar(&floorPath, "floor", "", "write the system-floor.json rule skeleton here (manifest refs are resolved through crane)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -230,6 +318,20 @@ func run(args []string, stdout io.Writer) error {
 	}
 	if len(entries) == 0 {
 		return fmt.Errorf("no images found in the inputs")
+	}
+	if floorPath != "" {
+		if len(manifests) > 0 {
+			if err := resolveManifestArgv(entries); err != nil {
+				return err
+			}
+		}
+		floor, err := floorFile(entries)
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(floorPath, append(floor, '\n'), 0o644); err != nil {
+			return err
+		}
 	}
 	block := render(entries)
 

--- a/node-guest-image/c8s/systemfloor/main_test.go
+++ b/node-guest-image/c8s/systemfloor/main_test.go
@@ -10,7 +10,28 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
 )
+
+// writeZstdBundle compresses the synthetic bundle the way RKE2 ships its
+// airgap images, for tests that go through bundleEntries.
+func writeZstdBundle(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(writeSyntheticBundle(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "bundle.tar.zst")
+	if err := os.WriteFile(path, enc.EncodeAll(raw, nil), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
 
 // writeSyntheticBundle builds a minimal deterministic docker-archive bundle:
 // one image, one layer, fixed bytes and zeroed tar metadata.
@@ -155,5 +176,77 @@ func TestSplice_ReplacesBetweenMarkers(t *testing.T) {
 	}
 	if _, err := splice("no markers", "x"); err == nil {
 		t.Fatal("missing markers must error")
+	}
+}
+
+// The -floor skeleton carries the config argv the bundle bakes and leaves
+// env, mounts and the review empty for the reviewer.
+func TestFloorFile_SkeletonFromBundle(t *testing.T) {
+	entries, err := bundleEntries(writeZstdBundle(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := entries[0].entrypoint; len(got) != 1 || got[0] != "/bin/fixture" {
+		t.Fatalf("bundle entry entrypoint = %v, want [/bin/fixture]", got)
+	}
+	out, err := floorFile(append(entries, entry{digest: entries[0].digest, ref: "example.com/library/fixture:alias"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{
+  "schema": "c8s.system-floor/v1",
+  "images": [
+    {
+      "ref": "example.com/library/fixture:1.2.3",
+      "digest": "sha256:087f0ac20596efe1fa93dad0f2467e5ad1b6f84bb57a3e8d5dd5c196f9708b33",
+      "entrypoint": [
+        "/bin/fixture"
+      ],
+      "cmd": null,
+      "env": {},
+      "mounts": {},
+      "privileges": {
+        "review": ""
+      }
+    }
+  ]
+}`
+	if string(out) != want {
+		t.Fatalf("floorFile =\n%s\nwant\n%s", out, want)
+	}
+}
+
+func TestRun_WritesFloor(t *testing.T) {
+	bundle := writeZstdBundle(t)
+	floor := filepath.Join(t.TempDir(), "system-floor.json")
+	var stdout bytes.Buffer
+	if err := run([]string{"-bundle", bundle, "-floor", floor}, &stdout); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(floor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"ref": "example.com/library/fixture:1.2.3"`) || !strings.HasSuffix(string(data), "}\n") {
+		t.Fatalf("system-floor.json =\n%s", data)
+	}
+	if !strings.Contains(stdout.String(), `"sha256:087f0ac2`) {
+		t.Fatalf("stdout lost the YAML block:\n%s", stdout.String())
+	}
+}
+
+// Manifest refs have no bundle to read a config from; -floor needs crane.
+func TestRun_FloorWithManifestNeedsCrane(t *testing.T) {
+	manifest := filepath.Join(t.TempDir(), "m.yaml")
+	if err := os.WriteFile(manifest, []byte("image: rancher/x:1@sha256:1eba82e9c386038b4af6d69cca7519fac738c28c42735ed48ce70c882ad0d80f\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", "")
+	err := run([]string{"-manifest", manifest, "-floor", filepath.Join(t.TempDir(), "f.json")}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "crane") {
+		t.Fatalf("run(-floor with manifest, no crane) = %v, want a crane error", err)
+	}
+	if err := run([]string{"-manifest", manifest}, &bytes.Buffer{}); err != nil {
+		t.Fatalf("run(-manifest without -floor) = %v, want nil (crane not needed)", err)
 	}
 }

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -80,14 +80,18 @@ type Container struct {
 // workload: host namespaces, extra capabilities, devices, host bind sources,
 // an unmasked /proc, or full privilege. A sealed document requires Review to
 // say why the entry is acceptable; the reviewer, not the tool, is the
-// authority on a privileged pod.
+// authority on a privileged pod. It does not loosen the argv, env or mount
+// rules: a sealed entry pins those exactly whether privileged or not.
 //
 // Capabilities lists capabilities beyond the runtime's default set, in OCI
 // form (CAP_NET_ADMIN); Privileged implies all of them and every device, so
-// those lists are not matched for a privileged entry. HostPaths lists host bind sources admitted for
-// classes outside the reviewed mount classes (hostPath, configMap, secret,
+// those lists are not matched for a privileged entry.
+//
+// HostPaths lists the host bind sources the entry may take for classes
+// outside the reviewed mount classes (hostPath, configMap, secret,
 // projected); an entry ending in "/" admits the subtree, and the kubelet's
-// own volumes live under KubeletVolumesRoot.
+// own volumes live under KubeletVolumesRoot. Each hostPath mount rule binds
+// one of them to its destination through MountRule.Path.
 type Privileges struct {
 	Privileged     bool     `json:"privileged,omitempty"`
 	HostNamespaces []string `json:"hostNamespaces,omitempty"`
@@ -144,12 +148,21 @@ type MountPolicy struct {
 	Rules        map[string]MountRule `json:"rules,omitempty"`
 }
 
-// MountRule is the reviewed source class of one bind destination. Review is
-// required for a pvc source (why operator-supplied contents at that path
-// cannot steer the workload) and for a nodeState source (why this entry may
-// reach the node's attestation socket or policy directory).
+// MountRule is the reviewed source class of one bind destination.
+//
+// Path is the host source a hostPath rule admits at this destination, as the
+// runtime binds it: the path itself, or a subtree when it ends in "/". A
+// sealed document requires it on every hostPath rule, so a listed source
+// cannot be bound at another rule's destination; other sources take none.
+//
+// Review is required for a pvc source (why operator-supplied contents at
+// that path cannot steer the workload), for a serviceAccountToken source
+// (the kubelet's volume name is not reserved, so why operator-chosen files
+// there cannot steer it either) and for a nodeState source (why this entry
+// may reach the node's attestation socket or policy directory).
 type MountRule struct {
 	Source string `json:"source"`
+	Path   string `json:"path,omitempty"`
 	Review string `json:"review,omitempty"`
 }
 
@@ -422,6 +435,12 @@ func normalizeMounts(p *MountPolicy) error {
 			default:
 				return fmt.Errorf("rule %q: unknown source %q (want %s, %s, %s, %s, %s or %s)", d, r.Source,
 					SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceNodeState, SourceHostPath)
+			}
+			if r.Path != "" && r.Source != SourceHostPath {
+				return fmt.Errorf("rule %q: path is only for a %s source", d, SourceHostPath)
+			}
+			if r.Path != "" && !path.IsAbs(r.Path) {
+				return fmt.Errorf("rule %q: path %q is not an absolute path", d, r.Path)
 			}
 		}
 	default:

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -145,22 +145,27 @@ type MountPolicy struct {
 }
 
 // MountRule is the reviewed source class of one bind destination. Review is
-// required for a pvc source: it names why operator-supplied contents at that
-// path cannot steer the workload.
+// required for a pvc source (why operator-supplied contents at that path
+// cannot steer the workload) and for a nodeState source (why this entry may
+// reach the node's attestation socket or policy directory).
 type MountRule struct {
 	Source string `json:"source"`
 	Review string `json:"review,omitempty"`
 }
 
 // Mount source classes. The first four are what a pod spec and the kubelet
-// put there; SourceHostPath marks a destination whose content the node
-// supplies (hostPath, configMap, secret, projected) and is admitted only
-// through Privileges.HostPaths.
+// put there. SourceNodeState is a bind from the measured image's state
+// directory (the attestation socket and the policy directory); it is its
+// own class, not platform, so a platform rule at /etc/hosts can never admit
+// the socket bound there. SourceHostPath marks a destination whose content
+// the node supplies (hostPath, configMap, secret, projected) and is admitted
+// only through Privileges.HostPaths.
 const (
 	SourceEmptyDir            = "emptyDir"
 	SourceServiceAccountToken = "serviceAccountToken"
 	SourcePVC                 = "pvc"
 	SourcePlatform            = "platform"
+	SourceNodeState           = "nodeState"
 	SourceHostPath            = "hostPath"
 )
 
@@ -413,10 +418,10 @@ func normalizeMounts(p *MountPolicy) error {
 		}
 		for d, r := range p.Rules {
 			switch r.Source {
-			case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceHostPath:
+			case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceNodeState, SourceHostPath:
 			default:
-				return fmt.Errorf("rule %q: unknown source %q (want %s, %s, %s, %s or %s)", d, r.Source,
-					SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceHostPath)
+				return fmt.Errorf("rule %q: unknown source %q (want %s, %s, %s, %s, %s or %s)", d, r.Source,
+					SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceNodeState, SourceHostPath)
 			}
 		}
 	default:

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -63,14 +63,52 @@ type Workload struct {
 }
 
 // Container binds a digest to the process policy permitted for it.
+//
+// Privileges is nil for an ordinary workload container. A pointer so a
+// document written before the field existed canonicalizes to the same bytes.
 type Container struct {
-	Digest  types.Digest `json:"digest"`
-	Image   string       `json:"image,omitempty"`
-	Command ArgvPolicy   `json:"command"`
-	Args    ArgvPolicy   `json:"args"`
-	Mounts  MountPolicy  `json:"mounts,omitempty"`
-	Env     EnvPolicy    `json:"env,omitempty"`
+	Digest     types.Digest `json:"digest"`
+	Image      string       `json:"image,omitempty"`
+	Command    ArgvPolicy   `json:"command"`
+	Args       ArgvPolicy   `json:"args"`
+	Mounts     MountPolicy  `json:"mounts,omitempty"`
+	Env        EnvPolicy    `json:"env,omitempty"`
+	Privileges *Privileges  `json:"privileges,omitempty"`
 }
+
+// Privileges declares what a node-TCB container may hold beyond an ordinary
+// workload: host namespaces, extra capabilities, devices, host bind sources,
+// an unmasked /proc, or full privilege. A sealed document requires Review to
+// say why the entry is acceptable; the reviewer, not the tool, is the
+// authority on a privileged pod.
+//
+// Capabilities lists capabilities beyond the runtime's default set, in OCI
+// form (CAP_NET_ADMIN); Privileged implies all of them and every device, so
+// those lists are not matched for a privileged entry. HostPaths lists host bind sources admitted for
+// classes outside the reviewed mount classes (hostPath, configMap, secret,
+// projected); an entry ending in "/" admits the subtree, and the kubelet's
+// own volumes live under KubeletVolumesRoot.
+type Privileges struct {
+	Privileged     bool     `json:"privileged,omitempty"`
+	HostNamespaces []string `json:"hostNamespaces,omitempty"`
+	Capabilities   []string `json:"capabilities,omitempty"`
+	Devices        []string `json:"devices,omitempty"`
+	HostPaths      []string `json:"hostPaths,omitempty"`
+	UnmaskedProc   bool     `json:"unmaskedProc,omitempty"`
+	Review         string   `json:"review"`
+}
+
+// Host namespaces a Privileges entry may share with the node.
+const (
+	HostNamespaceNet = "net"
+	HostNamespacePID = "pid"
+	HostNamespaceIPC = "ipc"
+)
+
+// KubeletVolumesRoot is where the kubelet materializes configMap, secret and
+// projected volumes (<root><pod uid>/volumes/kubernetes.io~<plugin>/<name>).
+// A Privileges.HostPaths entry naming it admits every such volume.
+const KubeletVolumesRoot = "/var/lib/kubelet/pods/"
 
 // ArgvPolicy governs part of a container's effective argv (the OCI process.args
 // a pod actually runs), mirroring the Kubernetes command/args split: Command is
@@ -96,19 +134,67 @@ type ArgvPolicy struct {
 // Any leaves them unconstrained, and is what an absent policy means — unlike
 // argv, a Deny default would refuse every real pod, since the base set is never
 // empty.
+//
+// Rules, keyed by destination, classify what may be bound there. A sealed
+// document (Index.Admit) requires one per destination; dynamic enforcers
+// ignore them. When present the key set must equal Destinations.
 type MountPolicy struct {
-	Policy       string   `json:"policy"`
-	Destinations []string `json:"destinations,omitempty"`
+	Policy       string               `json:"policy"`
+	Destinations []string             `json:"destinations,omitempty"`
+	Rules        map[string]MountRule `json:"rules,omitempty"`
 }
 
-// EnvPolicy governs the environment variable NAMES a container may run with.
-// Values are not matched: they carry secrets, and an allowlist is served to
-// every enforcer. Exact requires every name to appear in Names; Any, the
-// default, leaves them unconstrained.
-type EnvPolicy struct {
-	Policy string   `json:"policy"`
-	Names  []string `json:"names,omitempty"`
+// MountRule is the reviewed source class of one bind destination. Review is
+// required for a pvc source: it names why operator-supplied contents at that
+// path cannot steer the workload.
+type MountRule struct {
+	Source string `json:"source"`
+	Review string `json:"review,omitempty"`
 }
+
+// Mount source classes. The first four are what a pod spec and the kubelet
+// put there; SourceHostPath marks a destination whose content the node
+// supplies (hostPath, configMap, secret, projected) and is admitted only
+// through Privileges.HostPaths.
+const (
+	SourceEmptyDir            = "emptyDir"
+	SourceServiceAccountToken = "serviceAccountToken"
+	SourcePVC                 = "pvc"
+	SourcePlatform            = "platform"
+	SourceHostPath            = "hostPath"
+)
+
+// EnvPolicy governs the environment variable NAMES a container may run with,
+// and, in a sealed document, their values.
+//
+// Dynamic enforcers match names only: values carry secrets there, and the
+// allowlist is served to every enforcer. A sealed document is reviewed and
+// measured, not secret, so Values pins each name to a literal or to a pod
+// field (Index.Admit). When present the key set must equal Names.
+type EnvPolicy struct {
+	Policy string              `json:"policy"`
+	Names  []string            `json:"names,omitempty"`
+	Values map[string]EnvValue `json:"values,omitempty"`
+}
+
+// EnvValue pins one environment variable: Value matches byte-exact, From
+// matches the pod field the enforcer reports under that name. Exactly one is
+// set.
+type EnvValue struct {
+	Value *string `json:"value,omitempty"`
+	From  string  `json:"from,omitempty"`
+}
+
+// From sources an EnvValue may name. They are what the kubelet's fieldRef
+// injects and what the NRI PodSandbox (or the node) can report.
+const (
+	FromPodIP        = "podIP"
+	FromPodName      = "podName"
+	FromPodNamespace = "podNamespace"
+	FromPodUID       = "podUID"
+	FromHostIP       = "hostIP"
+	FromNodeName     = "nodeName"
+)
 
 // SecretsPolicy grants secret-store read/write globs to a whole workload entry.
 // The subject is the entry, not a container: the value is delivered on a volume
@@ -285,6 +371,9 @@ func normalizeContainers(workload, field string, cs []Container) error {
 		if err := normalizeEnv(&c.Env); err != nil {
 			return fmt.Errorf("workload %q %s %s env: %w", workload, field, c.Digest, err)
 		}
+		if err := normalizePrivileges(c.Privileges); err != nil {
+			return fmt.Errorf("workload %q %s %s privileges: %w", workload, field, c.Digest, err)
+		}
 	}
 	return nil
 }
@@ -299,8 +388,12 @@ func normalizeMounts(p *MountPolicy) error {
 		if len(p.Destinations) != 0 {
 			return fmt.Errorf("any policy takes no destinations")
 		}
+		if len(p.Rules) != 0 {
+			return fmt.Errorf("any policy takes no rules")
+		}
 		p.Policy = PolicyAny
 		p.Destinations = nil
+		p.Rules = nil
 	case PolicyExact:
 		if len(p.Destinations) == 0 {
 			return fmt.Errorf("exact policy requires at least one destination")
@@ -311,8 +404,44 @@ func normalizeMounts(p *MountPolicy) error {
 			}
 		}
 		p.Destinations = sortedUnique(p.Destinations)
+		if len(p.Rules) == 0 {
+			p.Rules = nil
+			break
+		}
+		if err := requireSameKeys(p.Rules, p.Destinations, "rule", "destination"); err != nil {
+			return err
+		}
+		for d, r := range p.Rules {
+			switch r.Source {
+			case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceHostPath:
+			default:
+				return fmt.Errorf("rule %q: unknown source %q (want %s, %s, %s, %s or %s)", d, r.Source,
+					SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceHostPath)
+			}
+		}
 	default:
 		return fmt.Errorf("unknown mount policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// requireSameKeys checks that a rule map covers exactly the listed names:
+// a name without a rule is a gap the reviewer never saw, and a rule for an
+// unlisted name is a typo that would otherwise pin nothing.
+func requireSameKeys[V any](rules map[string]V, names []string, ruleWord, nameWord string) error {
+	listed := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		listed[n] = struct{}{}
+	}
+	for k := range rules {
+		if _, ok := listed[k]; !ok {
+			return fmt.Errorf("%s for %q names no listed %s", ruleWord, k, nameWord)
+		}
+	}
+	for _, n := range names {
+		if _, ok := rules[n]; !ok {
+			return fmt.Errorf("%s %q has no %s", nameWord, n, ruleWord)
+		}
 	}
 	return nil
 }
@@ -325,8 +454,12 @@ func normalizeEnv(p *EnvPolicy) error {
 		if len(p.Names) != 0 {
 			return fmt.Errorf("any policy takes no names")
 		}
+		if len(p.Values) != 0 {
+			return fmt.Errorf("any policy takes no values")
+		}
 		p.Policy = PolicyAny
 		p.Names = nil
+		p.Values = nil
 	case PolicyExact:
 		if len(p.Names) == 0 {
 			return fmt.Errorf("exact policy requires at least one name")
@@ -337,10 +470,87 @@ func normalizeEnv(p *EnvPolicy) error {
 			}
 		}
 		p.Names = sortedUnique(p.Names)
+		if len(p.Values) == 0 {
+			p.Values = nil
+			break
+		}
+		if err := requireSameKeys(p.Values, p.Names, "value", "name"); err != nil {
+			return err
+		}
+		for n, v := range p.Values {
+			if err := v.validate(); err != nil {
+				return fmt.Errorf("value for %q: %w", n, err)
+			}
+		}
 	default:
 		return fmt.Errorf("unknown env policy %q (want any or exact)", p.Policy)
 	}
 	return nil
+}
+
+func (v EnvValue) validate() error {
+	switch {
+	case v.Value != nil && v.From != "":
+		return fmt.Errorf("value and from are mutually exclusive")
+	case v.Value == nil && v.From == "":
+		return fmt.Errorf("one of value or from is required")
+	case v.From != "" && !validFromSource(v.From):
+		return fmt.Errorf("unknown from source %q (want %s, %s, %s, %s, %s or %s)", v.From,
+			FromPodIP, FromPodName, FromPodNamespace, FromPodUID, FromHostIP, FromNodeName)
+	}
+	return nil
+}
+
+func validFromSource(from string) bool {
+	switch from {
+	case FromPodIP, FromPodName, FromPodNamespace, FromPodUID, FromHostIP, FromNodeName:
+		return true
+	}
+	return false
+}
+
+// normalizePrivileges validates a privileges block in place. A nil block is
+// the ordinary, unprivileged container. An empty non-nil block is kept: its
+// presence is the reviewer's declaration that the entry is node TCB, and the
+// sealed lint then insists on the review text.
+func normalizePrivileges(p *Privileges) error {
+	if p == nil {
+		return nil
+	}
+	for _, ns := range p.HostNamespaces {
+		switch ns {
+		case HostNamespaceNet, HostNamespacePID, HostNamespaceIPC:
+		default:
+			return fmt.Errorf("unknown host namespace %q (want %s, %s or %s)", ns, HostNamespaceNet, HostNamespacePID, HostNamespaceIPC)
+		}
+	}
+	for _, c := range p.Capabilities {
+		if !strings.HasPrefix(c, "CAP_") || strings.ToUpper(c) != c {
+			return fmt.Errorf("capability %q is not in OCI form (CAP_NAME)", c)
+		}
+	}
+	for _, d := range p.Devices {
+		if !path.IsAbs(d) {
+			return fmt.Errorf("device %q is not an absolute path", d)
+		}
+	}
+	for _, h := range p.HostPaths {
+		if !path.IsAbs(h) {
+			return fmt.Errorf("host path %q is not an absolute path", h)
+		}
+	}
+	p.HostNamespaces = emptyToNil(sortedUnique(p.HostNamespaces))
+	p.Capabilities = emptyToNil(sortedUnique(p.Capabilities))
+	p.Devices = emptyToNil(sortedUnique(p.Devices))
+	p.HostPaths = emptyToNil(sortedUnique(p.HostPaths))
+	return nil
+}
+
+func emptyToNil(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	return in
 }
 
 // sortedUnique makes a list a function of its content, so Canonical does not
@@ -466,8 +676,9 @@ func sortContainers(cs []Container) {
 	})
 }
 
+// policyKey renders every policy field; Image is informational and stays out.
 func policyKey(c Container) string {
-	b, _ := json.Marshal([]any{c.Command, c.Args})
+	b, _ := json.Marshal([]any{c.Command, c.Args, c.Mounts, c.Env, c.Privileges})
 	return string(b)
 }
 

--- a/pkg/allowlist/allowlist_test.go
+++ b/pkg/allowlist/allowlist_test.go
@@ -160,6 +160,27 @@ func TestSortContainers_StableOnFullTie(t *testing.T) {
 	}
 }
 
+// policyKey covers mounts, env and privileges, so two same-digest containers
+// that tie on argv are ordered by those fields. This pins the order (and the
+// bytes) so a change here is a deliberate canonical-form break.
+func TestSortContainers_TiedArgvOrderedByPolicy(t *testing.T) {
+	envZ := `{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"exact","names":["Z"]}}`
+	envA := `{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"exact","names":["A"]}}`
+	want := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"w":{"initContainers":null,"containers":[` + envA + `,` + envZ + `]}}}`
+	for _, tc := range []struct{ name, doc string }{
+		{"A first", `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[` + envA + `,` + envZ + `]}}}`},
+		{"Z first", `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[` + envZ + `,` + envA + `]}}}`},
+	} {
+		got, err := mustParse(t, tc.doc).Canonical()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != want {
+			t.Errorf("Canonical(%s) =\n%s\nwant\n%s", tc.name, got, want)
+		}
+	}
+}
+
 func TestValidWorkloadName(t *testing.T) {
 	for _, tc := range []struct {
 		name string

--- a/pkg/allowlist/paths.go
+++ b/pkg/allowlist/paths.go
@@ -1,0 +1,25 @@
+package allowlist
+
+import (
+	"path"
+	"strings"
+)
+
+// UnderDir reports whether p is dir or lies under it. dir is a cleaned
+// absolute path without a trailing slash; an empty dir contains nothing.
+func UnderDir(p, dir string) bool {
+	return dir != "" && (p == dir || strings.HasPrefix(p, dir+"/"))
+}
+
+// BindSource is a bind source as the runtime records it: cleaned, with
+// /var/run mapped to /run as on the node image, where /var/run is a symlink
+// containerd resolves. render writes rule sources in this form and the
+// sealed plugin compares observed sources in it, so a trailing slash in a
+// pod spec never becomes a subtree grant by accident.
+func BindSource(p string) string {
+	p = path.Clean(p)
+	if p == "/var/run" || strings.HasPrefix(p, "/var/run/") {
+		return "/run" + strings.TrimPrefix(p, "/var/run")
+	}
+	return p
+}

--- a/pkg/allowlist/paths_test.go
+++ b/pkg/allowlist/paths_test.go
@@ -1,0 +1,37 @@
+package allowlist
+
+import "testing"
+
+func TestBindSource(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"/etc/cni/net.d/", "/etc/cni/net.d"},
+		{"/var/run/nri-image-policy", "/run/nri-image-policy"},
+		{"/var/run/nri-image-policy/", "/run/nri-image-policy"},
+		{"/var/run", "/run"},
+		{"/var/runtime", "/var/runtime"},
+		{"/var/runner/x", "/var/runner/x"},
+		{"/dev/../etc", "/etc"},
+		{"/lib/modules/../modules", "/lib/modules"},
+	} {
+		if got := BindSource(tc.in); got != tc.want {
+			t.Errorf("BindSource(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestUnderDir(t *testing.T) {
+	for _, tc := range []struct {
+		p, dir string
+		want   bool
+	}{
+		{"/run/confai", "/run/confai", true},
+		{"/run/confai/policy", "/run/confai", true},
+		{"/run/confai-evil/x", "/run/confai", false},
+		{"/run", "/run/confai", false},
+		{"/anything", "", false},
+	} {
+		if got := UnderDir(tc.p, tc.dir); got != tc.want {
+			t.Errorf("UnderDir(%q, %q) = %v, want %v", tc.p, tc.dir, got, tc.want)
+		}
+	}
+}

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -1,12 +1,27 @@
 package allowlist
 
-import "github.com/confidential-dot-ai/c8s/pkg/types"
+import (
+	"fmt"
+	"sort"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
 
 // Index answers admission queries for enforcers in O(1). Build it once from a
 // normalized Allowlist.
 type Index struct {
 	floor    map[string]bool
 	byDigest map[string][]Container
+	// rules keeps the entry each container came from, in entry-name order,
+	// so Admit can name the rule that admitted an observation.
+	rules map[string][]indexedRule
+}
+
+// indexedRule is one container rule with its position in the document, the
+// name a sealed enforcer reports for it.
+type indexedRule struct {
+	name      string
+	container Container
 }
 
 // BuildIndex projects an Allowlist into an admission index.
@@ -14,19 +29,30 @@ func (a *Allowlist) BuildIndex() *Index {
 	idx := &Index{
 		floor:    make(map[string]bool, len(a.Digests)),
 		byDigest: map[string][]Container{},
+		rules:    map[string][]indexedRule{},
 	}
 	for d := range a.Digests {
 		idx.floor[d] = true
 	}
-	for _, w := range a.Workloads {
-		for _, c := range w.InitContainers {
-			idx.byDigest[c.Digest.String()] = append(idx.byDigest[c.Digest.String()], c)
-		}
-		for _, c := range w.Containers {
-			idx.byDigest[c.Digest.String()] = append(idx.byDigest[c.Digest.String()], c)
-		}
+	names := make([]string, 0, len(a.Workloads))
+	for name := range a.Workloads {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		w := a.Workloads[name]
+		idx.add(name, "initContainers", w.InitContainers)
+		idx.add(name, "containers", w.Containers)
 	}
 	return idx
+}
+
+func (i *Index) add(entry, field string, cs []Container) {
+	for n, c := range cs {
+		d := c.Digest.String()
+		i.byDigest[d] = append(i.byDigest[d], c)
+		i.rules[d] = append(i.rules[d], indexedRule{name: fmt.Sprintf("%s/%s[%d]", entry, field, n), container: c})
+	}
 }
 
 // AdmitsDigest reports whether an image with this digest may run at all — as a

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -2,7 +2,8 @@ package allowlist
 
 import (
 	"fmt"
-	"sort"
+	"maps"
+	"slices"
 
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -34,12 +35,7 @@ func (a *Allowlist) BuildIndex() *Index {
 	for d := range a.Digests {
 		idx.floor[d] = true
 	}
-	names := make([]string, 0, len(a.Workloads))
-	for name := range a.Workloads {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range slices.Sorted(maps.Keys(a.Workloads)) {
 		w := a.Workloads[name]
 		idx.add(name, "initContainers", w.InitContainers)
 		idx.add(name, "containers", w.Containers)

--- a/pkg/allowlist/sealed.go
+++ b/pkg/allowlist/sealed.go
@@ -1,0 +1,285 @@
+package allowlist
+
+import (
+	"bytes"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// Observation is one container as a sealed enforcer sees it at create time.
+// Every field is authoritative: unlike RunningContainer there is no
+// "unobserved" state, because the sealed enforcer reads the whole OCI spec.
+//
+// Env maps name to value. Mounts maps each bind destination to its source.
+// HostNamespaces lists the namespaces shared with the node (HostNamespace*).
+// Capabilities lists capabilities beyond the runtime's default set, in OCI
+// form. Hooks reports whether the spec carries any OCI hook. Sources carries
+// the pod-field values env From rules resolve against, keyed by From*.
+type Observation struct {
+	Digest         string
+	Argv           []string
+	Env            map[string]string
+	Mounts         map[string]MountSource
+	HostNamespaces []string
+	Devices        []string
+	Capabilities   []string
+	Hooks          bool
+	Privileged     bool
+	UnmaskedProc   bool
+	Sources        map[string]string
+}
+
+// MountSource is where one bind destination's content comes from: the host
+// path the runtime binds and the class the enforcer assigned it (Source*, or
+// any other string for a source it could not classify).
+type MountSource struct {
+	Path  string
+	Class string
+}
+
+// Admit reports whether a sealed document admits an observation and names
+// the rule that did ("<entry>/<list>[<index>]"). There is no floor and no
+// vacuity: the digest must be listed, and every observed field must satisfy
+// the rule. Hooks are never admitted.
+func (i *Index) Admit(obs Observation) (rule string, ok bool) {
+	d, err := types.ParseDigest(obs.Digest)
+	if err != nil || obs.Hooks {
+		return "", false
+	}
+	for _, r := range i.rules[d.String()] {
+		if r.container.admitsSealed(obs) {
+			return r.name, true
+		}
+	}
+	return "", false
+}
+
+func (c Container) admitsSealed(obs Observation) bool {
+	rest, ok := c.Command.matchCommand(obs.Argv)
+	if !ok || !c.Args.matchArgs(rest) {
+		return false
+	}
+	if !c.Env.admitsValues(obs.Env, obs.Sources) || !c.Mounts.admitsSources(obs.Mounts, c.Privileges) {
+		return false
+	}
+	p := c.Privileges
+	if p == nil {
+		p = &Privileges{}
+	}
+	if obs.Privileged && !p.Privileged {
+		return false
+	}
+	if obs.UnmaskedProc && !p.UnmaskedProc {
+		return false
+	}
+	if !subset(obs.HostNamespaces, p.HostNamespaces) {
+		return false
+	}
+	// A privileged container holds every capability and every device; the
+	// review string covers that, so the lists are not compared.
+	return p.Privileged || (subset(obs.Devices, p.Devices) && subset(obs.Capabilities, p.Capabilities))
+}
+
+// admitsValues checks names as admits does, then each value against its
+// rule: byte-exact for a literal, equal to the reported pod field for From.
+func (p EnvPolicy) admitsValues(env, sources map[string]string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	allowed := make(map[string]struct{}, len(p.Names))
+	for _, n := range p.Names {
+		allowed[n] = struct{}{}
+	}
+	for name, value := range env {
+		if _, ok := allowed[name]; !ok {
+			return false
+		}
+		rule, ok := p.Values[name]
+		if !ok {
+			continue
+		}
+		switch {
+		case rule.Value != nil:
+			if *rule.Value != value {
+				return false
+			}
+		default:
+			want, ok := sources[rule.From]
+			if !ok || want != value {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// admitsSources checks every observed bind against the destination list and
+// its rule's class. A source outside the reviewed classes is admitted only
+// through the entry's Privileges.HostPaths, whatever the mount policy says.
+func (p MountPolicy) admitsSources(mounts map[string]MountSource, priv *Privileges) bool {
+	allowed := make(map[string]struct{}, len(p.Destinations))
+	for _, d := range p.Destinations {
+		allowed[d] = struct{}{}
+	}
+	for dest, src := range mounts {
+		if !reviewedClass(src.Class) && (priv == nil || !hostPathAdmitted(priv.HostPaths, src.Path)) {
+			return false
+		}
+		if p.Policy != PolicyExact {
+			continue
+		}
+		if _, ok := allowed[dest]; !ok {
+			return false
+		}
+		rule, ok := p.Rules[dest]
+		if !ok {
+			continue
+		}
+		if rule.Source == SourceHostPath {
+			if reviewedClass(src.Class) {
+				return false
+			}
+			continue
+		}
+		if rule.Source != src.Class {
+			return false
+		}
+	}
+	return true
+}
+
+func reviewedClass(class string) bool {
+	switch class {
+	case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform:
+		return true
+	}
+	return false
+}
+
+// hostPathAdmitted matches a bind source against the reviewed host paths: an
+// entry without a trailing slash is the path itself, one with a trailing
+// slash is a subtree. The source is cleaned first so ".." cannot escape a
+// subtree; callers need not clean it.
+func hostPathAdmitted(hostPaths []string, source string) bool {
+	source = path.Clean(source)
+	for _, h := range hostPaths {
+		if h == source || (strings.HasSuffix(h, "/") && strings.HasPrefix(source, h)) {
+			return true
+		}
+	}
+	return false
+}
+
+func subset(observed, allowed []string) bool {
+	set := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		set[a] = struct{}{}
+	}
+	for _, o := range observed {
+		if _, ok := set[o]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// LintSealed reports whether doc is a complete sealed document: the bytes a
+// node measures, with a rule for everything a sealed enforcer observes. It
+// is what the node plugin runs at boot and what `c8s allowlist lint --sealed`
+// prints, so the two cannot disagree.
+func LintSealed(doc []byte) error {
+	findings, err := SealedFindings(doc)
+	if err != nil {
+		return err
+	}
+	if len(findings) > 0 {
+		return fmt.Errorf("sealed allowlist: %s", strings.Join(findings, "; "))
+	}
+	return nil
+}
+
+// SealedFindings parses doc strictly and returns every way it falls short
+// of a sealed document, one message each. A parse failure is the error.
+func SealedFindings(doc []byte) ([]string, error) {
+	al, err := ParseJSON(doc)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := al.Canonical()
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	if !bytes.Equal(canonical, doc) {
+		out = append(out, "document bytes are not its canonical form; the measured bytes must be what the reviewer read (rewrite it with `c8s allowlist export` and review again)")
+	}
+	return append(out, al.sealedFindings()...), nil
+}
+
+func (a *Allowlist) sealedFindings() []string {
+	var out []string
+	if len(a.Digests) > 0 {
+		out = append(out, "digests must be empty: a sealed document admits nothing by digest alone")
+	}
+	names := make([]string, 0, len(a.Workloads))
+	for name := range a.Workloads {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		w := a.Workloads[name]
+		for i, c := range w.InitContainers {
+			out = append(out, c.sealedFindings(fmt.Sprintf("workload %q initContainers[%d] %s", name, i, c.Digest))...)
+		}
+		for i, c := range w.Containers {
+			out = append(out, c.sealedFindings(fmt.Sprintf("workload %q containers[%d] %s", name, i, c.Digest))...)
+		}
+	}
+	return out
+}
+
+func (c Container) sealedFindings(where string) []string {
+	var out []string
+	add := func(format string, args ...any) {
+		out = append(out, where+": "+fmt.Sprintf(format, args...))
+	}
+	if c.Privileges != nil && c.Privileges.Review == "" {
+		add("privileges.review is empty; say why this node-TCB entry is acceptable")
+	}
+	if c.Privileges == nil {
+		if c.Command.Policy != PolicyExact {
+			add("command must be exact for an unprivileged entry")
+		}
+		if c.Args.Policy == PolicyAny {
+			add("args must be exact or deny for an unprivileged entry")
+		}
+		if c.Mounts.Policy != PolicyExact {
+			add("mounts must be exact for an unprivileged entry")
+		}
+		if c.Env.Policy != PolicyExact {
+			add("env must be exact for an unprivileged entry")
+		}
+	}
+	if c.Env.Policy == PolicyExact && c.Env.Values == nil {
+		add("env names carry no values; every name needs a value or from rule")
+	}
+	if c.Mounts.Policy == PolicyExact {
+		if c.Mounts.Rules == nil {
+			add("mount destinations carry no rules; every destination needs a source class")
+		}
+		for _, d := range c.Mounts.Destinations {
+			r := c.Mounts.Rules[d]
+			if r.Source == SourcePVC && r.Review == "" {
+				add("mount %q is a pvc without a review; say why its contents cannot steer the workload", d)
+			}
+			if r.Source == SourceHostPath && c.Privileges == nil {
+				add("mount %q is a hostPath on an unprivileged entry; list its host source under privileges.hostPaths", d)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/allowlist/sealed.go
+++ b/pkg/allowlist/sealed.go
@@ -3,8 +3,9 @@ package allowlist
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"path"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -44,7 +45,10 @@ type MountSource struct {
 // Admit reports whether a sealed document admits an observation and names
 // the rule that did ("<entry>/<list>[<index>]"). There is no floor and no
 // vacuity: the digest must be listed, and every observed field must satisfy
-// the rule. Hooks are never admitted.
+// a rule that pins it exactly. Hooks are never admitted, and neither is a
+// rule with an open argv, env or mount policy, whatever its privileges: the
+// lint refuses those, and Admit refuses them again in case a document
+// reached it another way.
 func (i *Index) Admit(obs Observation) (rule string, ok bool) {
 	d, err := types.ParseDigest(obs.Digest)
 	if err != nil || obs.Hooks {
@@ -59,6 +63,9 @@ func (i *Index) Admit(obs Observation) (rule string, ok bool) {
 }
 
 func (c Container) admitsSealed(obs Observation) bool {
+	if !c.pinsExactly() {
+		return false
+	}
 	rest, ok := c.Command.matchCommand(obs.Argv)
 	if !ok || !c.Args.matchArgs(rest) {
 		return false
@@ -82,6 +89,14 @@ func (c Container) admitsSealed(obs Observation) bool {
 	// A privileged container holds every capability and every device; the
 	// review string covers that, so the lists are not compared.
 	return p.Privileged || (subset(obs.Devices, p.Devices) && subset(obs.Capabilities, p.Capabilities))
+}
+
+// pinsExactly reports whether every policy of the rule is one a sealed
+// document accepts: exact argv (args may also be deny), exact env, exact
+// mounts.
+func (c Container) pinsExactly() bool {
+	return c.Command.Policy == PolicyExact && c.Args.Policy != PolicyAny &&
+		c.Env.Policy == PolicyExact && c.Mounts.Policy == PolicyExact
 }
 
 // admitsValues checks names as admits does, then each value against its
@@ -119,33 +134,24 @@ func (p EnvPolicy) admitsValues(env, sources map[string]string) bool {
 
 // admitsSources checks every observed bind against the destination list and
 // its rule's class. A source outside the reviewed classes is admitted only
-// through the entry's Privileges.HostPaths, whatever the mount policy says.
+// at a hostPath rule's destination, from the source that rule's Path names,
+// and only when the entry's Privileges.HostPaths lists it too.
 func (p MountPolicy) admitsSources(mounts map[string]MountSource, priv *Privileges) bool {
-	allowed := make(map[string]struct{}, len(p.Destinations))
-	for _, d := range p.Destinations {
-		allowed[d] = struct{}{}
-	}
 	for dest, src := range mounts {
-		if !reviewedClass(src.Class) && (priv == nil || !hostPathAdmitted(priv.HostPaths, src.Path)) {
-			return false
-		}
-		if p.Policy != PolicyExact {
-			continue
-		}
-		if _, ok := allowed[dest]; !ok {
-			return false
-		}
 		rule, ok := p.Rules[dest]
 		if !ok {
-			continue
+			return false
 		}
-		if rule.Source == SourceHostPath {
-			if reviewedClass(src.Class) {
+		if rule.Source != SourceHostPath {
+			if rule.Source != src.Class {
 				return false
 			}
 			continue
 		}
-		if rule.Source != src.Class {
+		if reviewedClass(src.Class) || rule.Path == "" || priv == nil {
+			return false
+		}
+		if !hostPathAdmitted([]string{rule.Path}, src.Path) || !hostPathAdmitted(priv.HostPaths, src.Path) {
 			return false
 		}
 	}
@@ -160,7 +166,7 @@ func reviewedClass(class string) bool {
 	return false
 }
 
-// hostPathAdmitted matches a bind source against the reviewed host paths: an
+// hostPathAdmitted matches a bind source against reviewed host paths: an
 // entry without a trailing slash is the path itself, one with a trailing
 // slash is a subtree. The source is cleaned first so ".." cannot escape a
 // subtree; callers need not clean it.
@@ -168,6 +174,19 @@ func hostPathAdmitted(hostPaths []string, source string) bool {
 	source = path.Clean(source)
 	for _, h := range hostPaths {
 		if h == source || (strings.HasSuffix(h, "/") && strings.HasPrefix(source, h)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostPathCovered reports whether a rule's Path (itself an exact path or a
+// trailing-slash subtree) lies within the reviewed host paths: an exact
+// grant covers only itself, a subtree grant covers every path and subtree
+// under it.
+func hostPathCovered(hostPaths []string, rulePath string) bool {
+	for _, h := range hostPaths {
+		if h == rulePath || (strings.HasSuffix(h, "/") && strings.HasPrefix(rulePath, h)) {
 			return true
 		}
 	}
@@ -239,12 +258,7 @@ func (a *Allowlist) sealedFindings() []string {
 	if a.Workloads == nil {
 		out = append(out, `"workloads" must be an object (not null or absent): `+storeForm)
 	}
-	names := make([]string, 0, len(a.Workloads))
-	for name := range a.Workloads {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range slices.Sorted(maps.Keys(a.Workloads)) {
 		w := a.Workloads[name]
 		for i, c := range w.InitContainers {
 			out = append(out, c.sealedFindings(fmt.Sprintf("workload %q initContainers[%d] %s", name, i, c.Digest))...)
@@ -264,37 +278,53 @@ func (c Container) sealedFindings(where string) []string {
 	if c.Privileges != nil && c.Privileges.Review == "" {
 		add("privileges.review is empty; say why this node-TCB entry is acceptable")
 	}
-	if c.Privileges == nil {
-		if c.Command.Policy != PolicyExact {
-			add("command must be exact for an unprivileged entry")
-		}
-		if c.Args.Policy == PolicyAny {
-			add("args must be exact or deny for an unprivileged entry")
-		}
-		if c.Mounts.Policy != PolicyExact {
-			add("mounts must be exact for an unprivileged entry")
-		}
-		if c.Env.Policy != PolicyExact {
-			add("env must be exact for an unprivileged entry")
-		}
+	// A privileged entry gets no open policy: an open argv on a node-TCB
+	// image is a shell on the node for whoever can create pods, and open env
+	// or mounts steer a fixed argv (LD_PRELOAD from an operator volume).
+	if c.Command.Policy != PolicyExact {
+		add("command must be exact; a node-TCB entry whose argv cannot be pinned cannot be sealed")
+	}
+	if c.Args.Policy == PolicyAny {
+		add("args must be exact or deny")
+	}
+	if c.Mounts.Policy != PolicyExact {
+		add("mounts must be exact")
+	}
+	if c.Env.Policy != PolicyExact {
+		add("env must be exact")
 	}
 	if c.Env.Policy == PolicyExact && c.Env.Values == nil {
 		add("env names carry no values; every name needs a value or from rule")
 	}
-	if c.Mounts.Policy == PolicyExact {
-		if c.Mounts.Rules == nil {
-			add("mount destinations carry no rules; every destination needs a source class")
-		}
-		for _, d := range c.Mounts.Destinations {
-			r := c.Mounts.Rules[d]
-			if r.Source == SourcePVC && r.Review == "" {
+	if c.Mounts.Policy != PolicyExact {
+		return out
+	}
+	if c.Mounts.Rules == nil {
+		add("mount destinations carry no rules; every destination needs a source class")
+	}
+	for _, d := range c.Mounts.Destinations {
+		r := c.Mounts.Rules[d]
+		switch r.Source {
+		case SourcePVC:
+			if r.Review == "" {
 				add("mount %q is a pvc without a review; say why its contents cannot steer the workload", d)
 			}
-			if r.Source == SourceNodeState && r.Review == "" {
+		case SourceServiceAccountToken:
+			if r.Review == "" {
+				add("mount %q is a serviceAccountToken bind without a review; the kube-api-access-* volume name is not reserved, so say why operator-chosen files at that path cannot steer the workload", d)
+			}
+		case SourceNodeState:
+			if r.Review == "" {
 				add("mount %q is a nodeState bind without a review; say why this entry may reach the node's attestation socket or policy directory", d)
 			}
-			if r.Source == SourceHostPath && c.Privileges == nil {
+		case SourceHostPath:
+			switch {
+			case c.Privileges == nil:
 				add("mount %q is a hostPath on an unprivileged entry; list its host source under privileges.hostPaths", d)
+			case r.Path == "":
+				add("mount %q is a hostPath rule without a path; name the host source it admits", d)
+			case !hostPathCovered(c.Privileges.HostPaths, r.Path):
+				add("mount %q admits host source %q, which privileges.hostPaths does not cover", d, r.Path)
 			}
 		}
 	}

--- a/pkg/allowlist/sealed.go
+++ b/pkg/allowlist/sealed.go
@@ -154,7 +154,7 @@ func (p MountPolicy) admitsSources(mounts map[string]MountSource, priv *Privileg
 
 func reviewedClass(class string) bool {
 	switch class {
-	case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform:
+	case SourceEmptyDir, SourceServiceAccountToken, SourcePVC, SourcePlatform, SourceNodeState:
 		return true
 	}
 	return false
@@ -220,10 +220,24 @@ func SealedFindings(doc []byte) ([]string, error) {
 	return append(out, al.sealedFindings()...), nil
 }
 
+// storeForm is why a sealed document spells its empty maps as {}: CDS seeds
+// its store from the member and stamps every leaf with the digest of the
+// document the store serves back, which always carries "digests":{} and a
+// "workloads" object. A null or absent map canonicalizes to null, so it
+// would be measured under one digest and stamped under another, and no
+// verifier holding the bundle could match the stamp.
+const storeForm = "CDS stamps leaves with the digest of the document its store serves, which carries both as objects; `c8s allowlist render --sealed` writes that form"
+
 func (a *Allowlist) sealedFindings() []string {
 	var out []string
 	if len(a.Digests) > 0 {
 		out = append(out, "digests must be empty: a sealed document admits nothing by digest alone")
+	}
+	if a.Digests == nil {
+		out = append(out, `"digests" must be {} (not null or absent): `+storeForm)
+	}
+	if a.Workloads == nil {
+		out = append(out, `"workloads" must be an object (not null or absent): `+storeForm)
 	}
 	names := make([]string, 0, len(a.Workloads))
 	for name := range a.Workloads {
@@ -275,6 +289,9 @@ func (c Container) sealedFindings(where string) []string {
 			r := c.Mounts.Rules[d]
 			if r.Source == SourcePVC && r.Review == "" {
 				add("mount %q is a pvc without a review; say why its contents cannot steer the workload", d)
+			}
+			if r.Source == SourceNodeState && r.Review == "" {
+				add("mount %q is a nodeState bind without a review; say why this entry may reach the node's attestation socket or policy directory", d)
 			}
 			if r.Source == SourceHostPath && c.Privileges == nil {
 				add("mount %q is a hostPath on an unprivileged entry; list its host source under privileges.hostPaths", d)

--- a/pkg/allowlist/sealed_test.go
+++ b/pkg/allowlist/sealed_test.go
@@ -15,10 +15,11 @@ func sealedContainer(t *testing.T) Container {
 		Command: ArgvPolicy{Policy: PolicyExact, Argv: []string{"/app"}},
 		Args:    ArgvPolicy{Policy: PolicyExact, Argv: []string{"serve"}},
 		Mounts: MountPolicy{Policy: PolicyExact,
-			Destinations: []string{"/etc/hosts", "/data", "/var/run/secrets/kubernetes.io/serviceaccount"},
+			Destinations: []string{"/etc/hosts", "/data", "/run/confai", "/var/run/secrets/kubernetes.io/serviceaccount"},
 			Rules: map[string]MountRule{
-				"/etc/hosts": {Source: SourcePlatform},
-				"/data":      {Source: SourcePVC, Review: "opaque blob store; the app never executes its contents"},
+				"/etc/hosts":  {Source: SourcePlatform},
+				"/data":       {Source: SourcePVC, Review: "opaque blob store; the app never executes its contents"},
+				"/run/confai": {Source: SourceNodeState, Review: "c8s sidecar; attests over the node socket"},
 				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: SourceServiceAccountToken},
 			}},
 		Env: EnvPolicy{Policy: PolicyExact, Names: []string{"PATH", "HOSTNAME"},
@@ -36,8 +37,9 @@ func sealedObservation() Observation {
 		Argv:   []string{"/app", "serve"},
 		Env:    map[string]string{"PATH": "/bin", "HOSTNAME": "web-0"},
 		Mounts: map[string]MountSource{
-			"/etc/hosts": {Path: "/var/lib/kubelet/pods/u/etc-hosts", Class: SourcePlatform},
-			"/data":      {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~csi/pvc-1/mount", Class: SourcePVC},
+			"/etc/hosts":  {Path: "/var/lib/kubelet/pods/u/etc-hosts", Class: SourcePlatform},
+			"/data":       {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~csi/pvc-1/mount", Class: SourcePVC},
+			"/run/confai": {Path: "/run/confai", Class: SourceNodeState},
 			"/var/run/secrets/kubernetes.io/serviceaccount": {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~projected/kube-api-access-x", Class: SourceServiceAccountToken},
 		},
 		Sources: map[string]string{FromPodName: "web-0"},
@@ -63,6 +65,15 @@ func TestIndexAdmit(t *testing.T) {
 		{"undeclared env name", func(o *Observation) { o.Env["LD_PRELOAD"] = "/x.so" }, "", false},
 		{"undeclared mount", func(o *Observation) { o.Mounts["/x"] = MountSource{Path: "/tmp/x", Class: SourceEmptyDir} }, "", false},
 		{"mount class drift", func(o *Observation) { o.Mounts["/data"] = MountSource{Path: "/etc", Class: SourceHostPath} }, "", false},
+		{"node state bind where a platform rule stands", func(o *Observation) {
+			o.Mounts["/etc/hosts"] = MountSource{Path: "/run/confai/attestation-api.sock", Class: SourceNodeState}
+		}, "", false},
+		{"platform bind where a nodeState rule stands", func(o *Observation) {
+			o.Mounts["/run/confai"] = MountSource{Path: "/var/lib/kubelet/pods/u/etc-hosts", Class: SourcePlatform}
+		}, "", false},
+		{"hostPath bind where a nodeState rule stands", func(o *Observation) {
+			o.Mounts["/run/confai"] = MountSource{Path: "/run/confai-evil", Class: SourceHostPath}
+		}, "", false},
 		{"configMap at a declared destination", func(o *Observation) {
 			o.Mounts["/etc/hosts"] = MountSource{Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~configmap/c", Class: "configMap"}
 		}, "", false},
@@ -285,7 +296,7 @@ func TestAdmitsContainerIgnoresSealedFields(t *testing.T) {
 
 func sealedDoc(t *testing.T, workloads string) []byte {
 	t.Helper()
-	al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{`+workloads+`}}`)
+	al := mustParse(t, `{"schema":"c8s.allowlist/v1","digests":{},"workloads":{`+workloads+`}}`)
 	b, err := al.Canonical()
 	if err != nil {
 		t.Fatal(err)
@@ -305,13 +316,18 @@ func TestLintSealed(t *testing.T) {
 		{"complete unprivileged entry", sealedDoc(t, `"w":{"containers":[`+complete+`]}`), ""},
 		{"privileged entry with review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true,"review":"node TCB"}}]}`), ""},
 		{"non-canonical bytes", append(sealedDoc(t, `"w":{"containers":[`+complete+`]}`), '\n'), "not its canonical form"},
-		{"floor digest", []byte(`{"schema":"c8s.allowlist/v1","digests":{"` + digestC + `":"x"},"workloads":null}`), "digests must be empty"},
+		{"floor digest", []byte(`{"schema":"c8s.allowlist/v1","digests":{"` + digestC + `":"x"},"workloads":{}}`), "digests must be empty"},
+		{"digests null", []byte(`{"schema":"c8s.allowlist/v1","digests":null,"workloads":{}}`), `"digests" must be {}`},
+		{"workloads null", []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":null}`), `"workloads" must be an object`},
+		{"store form with no entries", []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{}}`), ""},
 		{"command any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "command must be exact"},
 		{"args any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"any"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "args must be exact or deny"},
 		{"mounts any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "mounts must be exact"},
 		{"env any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}}}]}`), "env must be exact"},
 		{"env without values", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"]}}]}`), "carry no values"},
 		{"mounts without rules", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"]},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "carry no rules"},
+		{"nodeState with review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/run/confai"],"rules":{"/run/confai":{"source":"nodeState","review":"c8s sidecar"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), ""},
+		{"nodeState without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/run/confai"],"rules":{"/run/confai":{"source":"nodeState"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "nodeState bind without a review"},
 		{"pvc without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"pvc"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "pvc without a review"},
 		{"hostPath rule on unprivileged entry", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"hostPath"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "hostPath on an unprivileged entry"},
 		{"privileged without review", sealedDoc(t, `"w":{"initContainers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true}}]}`), "privileges.review is empty"},

--- a/pkg/allowlist/sealed_test.go
+++ b/pkg/allowlist/sealed_test.go
@@ -20,7 +20,7 @@ func sealedContainer(t *testing.T) Container {
 				"/etc/hosts":  {Source: SourcePlatform},
 				"/data":       {Source: SourcePVC, Review: "opaque blob store; the app never executes its contents"},
 				"/run/confai": {Source: SourceNodeState, Review: "c8s sidecar; attests over the node socket"},
-				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: SourceServiceAccountToken},
+				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: SourceServiceAccountToken, Review: "the app reads nothing there"},
 			}},
 		Env: EnvPolicy{Policy: PolicyExact, Names: []string{"PATH", "HOSTNAME"},
 			Values: map[string]EnvValue{"PATH": {Value: str("/bin")}, "HOSTNAME": {From: FromPodName}}},
@@ -99,20 +99,23 @@ func TestIndexAdmit_Privileged(t *testing.T) {
 	cs := []Container{{
 		Digest:  mustDigest(t, digestB),
 		Command: ArgvPolicy{Policy: PolicyExact, Argv: []string{"/cilium-agent"}},
-		Args:    ArgvPolicy{Policy: PolicyAny},
+		Args:    ArgvPolicy{Policy: PolicyExact, Argv: []string{"--config-dir=/tmp/cm"}},
 		Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/host/etc/cni", "/run/cilium", "/tmp/cm"},
 			Rules: map[string]MountRule{
-				"/host/etc/cni": {Source: SourceHostPath},
+				"/host/etc/cni": {Source: SourceHostPath, Path: "/etc/cni/net.d"},
 				"/run/cilium":   {Source: SourceEmptyDir},
-				"/tmp/cm":       {Source: SourceHostPath},
+				"/tmp/cm":       {Source: SourceHostPath, Path: KubeletVolumesRoot},
 			}},
+		Env: EnvPolicy{Policy: PolicyExact, Names: []string{"NODE"}, Values: map[string]EnvValue{"NODE": {From: FromNodeName}}},
 		Privileges: &Privileges{HostNamespaces: []string{HostNamespaceNet},
 			Capabilities: []string{"CAP_NET_ADMIN"}, HostPaths: []string{"/etc/cni/net.d", KubeletVolumesRoot},
 			Review: "CNI agent; node TCB"},
 	}, {
 		Digest:     mustDigest(t, digestC),
-		Command:    ArgvPolicy{Policy: PolicyAny},
-		Args:       ArgvPolicy{Policy: PolicyAny},
+		Command:    ArgvPolicy{Policy: PolicyExact, Argv: []string{"/device-plugin"}},
+		Args:       ArgvPolicy{Policy: PolicyDeny},
+		Mounts:     MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts"}, Rules: map[string]MountRule{"/etc/hosts": {Source: SourcePlatform}}},
+		Env:        EnvPolicy{Policy: PolicyExact, Names: []string{"PATH"}, Values: map[string]EnvValue{"PATH": {Value: str("/bin")}}},
 		Privileges: &Privileges{Privileged: true, Review: "device plugin; node TCB"},
 	}}
 	if err := normalizeContainers("cni", "containers", cs); err != nil {
@@ -122,8 +125,9 @@ func TestIndexAdmit_Privileged(t *testing.T) {
 	idx := al.BuildIndex()
 	base := func() Observation {
 		return Observation{
-			Digest: digestB, Argv: []string{"/cilium-agent", "--any-args"},
-			Env:            map[string]string{"ANY": "thing"},
+			Digest: digestB, Argv: []string{"/cilium-agent", "--config-dir=/tmp/cm"},
+			Env:            map[string]string{"NODE": "node-a"},
+			Sources:        map[string]string{FromNodeName: "node-a"},
 			HostNamespaces: []string{HostNamespaceNet},
 			Capabilities:   []string{"CAP_NET_ADMIN"},
 			Mounts: map[string]MountSource{
@@ -140,6 +144,9 @@ func TestIndexAdmit_Privileged(t *testing.T) {
 	}{
 		{"declared privileges and host paths", func(*Observation) {}, true},
 		{"hostPath outside hostPaths", func(o *Observation) { o.Mounts["/host/etc/cni"] = MountSource{Path: "/", Class: SourceHostPath} }, false},
+		{"listed source at another rule's destination", func(o *Observation) {
+			o.Mounts["/host/etc/cni"] = MountSource{Path: KubeletVolumesRoot + "u/volumes/kubernetes.io~secret/s", Class: "secret"}
+		}, false},
 		{"subtree entry admits a path under it", func(o *Observation) {
 			o.Mounts["/tmp/cm"] = MountSource{Path: KubeletVolumesRoot + "u/volumes/kubernetes.io~secret/s", Class: "secret"}
 		}, true},
@@ -150,11 +157,15 @@ func TestIndexAdmit_Privileged(t *testing.T) {
 			o.Mounts["/host/etc/cni"] = MountSource{Path: "/etc/../etc/cni/net.d", Class: SourceHostPath}
 		}, true},
 		{"emptyDir where a hostPath rule stands", func(o *Observation) { o.Mounts["/tmp/cm"] = MountSource{Path: "/x", Class: SourceEmptyDir} }, false},
+		{"other argv on a privileged image", func(o *Observation) { o.Argv = []string{"/bin/sh", "-c", "id"} }, false},
+		{"undeclared env on a privileged image", func(o *Observation) { o.Env["LD_PRELOAD"] = "/tmp/cm/x.so" }, false},
 		{"undeclared host namespace", func(o *Observation) { o.HostNamespaces = append(o.HostNamespaces, HostNamespacePID) }, false},
 		{"undeclared capability", func(o *Observation) { o.Capabilities = append(o.Capabilities, "CAP_SYS_ADMIN") }, false},
 		{"privileged without a privileged rule", func(o *Observation) { o.Privileged = true }, false},
 		{"privileged rule admits every capability and device", func(o *Observation) {
-			*o = Observation{Digest: digestC, Privileged: true, Capabilities: []string{"CAP_SYS_ADMIN"}, Devices: []string{"/dev/vfio/1"}}
+			*o = Observation{Digest: digestC, Argv: []string{"/device-plugin"}, Env: map[string]string{"PATH": "/bin"},
+				Mounts:     map[string]MountSource{"/etc/hosts": {Path: "/var/lib/kubelet/pods/u/etc-hosts", Class: SourcePlatform}},
+				Privileged: true, Capabilities: []string{"CAP_SYS_ADMIN"}, Devices: []string{"/dev/vfio/1"}}
 		}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -162,6 +173,36 @@ func TestIndexAdmit_Privileged(t *testing.T) {
 			tc.mutate(&obs)
 			if _, ok := idx.Admit(obs); ok != tc.wantOK {
 				t.Errorf("Admit(%s) = %v, want %v", tc.name, ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// A rule with an open policy admits nothing, privileged or not: the lint
+// refuses such a document, and Admit does not rely on the lint having run.
+func TestIndexAdmit_RefusesOpenPolicies(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(c *Container)
+	}{
+		{"command any", func(c *Container) { c.Command = ArgvPolicy{Policy: PolicyAny} }},
+		{"args any", func(c *Container) { c.Args = ArgvPolicy{Policy: PolicyAny} }},
+		{"env any", func(c *Container) { c.Env = EnvPolicy{Policy: PolicyAny} }},
+		{"mounts any", func(c *Container) { c.Mounts = MountPolicy{Policy: PolicyAny} }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := sealedContainer(t)
+			c.Privileges = &Privileges{Privileged: true, Review: "node TCB"}
+			tc.edit(&c)
+			cs := []Container{c}
+			if err := normalizeContainers("web", "containers", cs); err != nil {
+				t.Fatal(err)
+			}
+			al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{"web": {Containers: cs}}}
+			obs := sealedObservation()
+			obs.Privileged = true
+			if rule, ok := al.BuildIndex().Admit(obs); ok {
+				t.Errorf("Admit(%s) = (%q, true), want refusal", tc.name, rule)
 			}
 		})
 	}
@@ -204,6 +245,10 @@ func TestSealedFieldValidation(t *testing.T) {
 		{"mount destination without rule", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a", "/b"},
 			Rules: map[string]MountRule{"/a": {Source: SourceEmptyDir}}}}, `"/b" has no rule`},
 		{"mount any with rules", Container{Mounts: MountPolicy{Policy: PolicyAny, Rules: map[string]MountRule{"/a": {Source: SourceEmptyDir}}}}, "takes no rules"},
+		{"mount path on a reviewed source", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a"},
+			Rules: map[string]MountRule{"/a": {Source: SourceEmptyDir, Path: "/x"}}}}, "path is only for a hostPath source"},
+		{"mount relative path", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a"},
+			Rules: map[string]MountRule{"/a": {Source: SourceHostPath, Path: "etc"}}}}, "not an absolute path"},
 		{"privileges unknown namespace", Container{Privileges: &Privileges{HostNamespaces: []string{"uts"}}}, "unknown host namespace"},
 		{"privileges capability not OCI form", Container{Privileges: &Privileges{Capabilities: []string{"NET_ADMIN"}}}, "not in OCI form"},
 		{"privileges relative device", Container{Privileges: &Privileges{Devices: []string{"dev/null"}}}, "not an absolute path"},
@@ -270,7 +315,7 @@ func TestCanonical_ExistingDocumentBytesUnchanged(t *testing.T) {
 }
 
 func TestCanonical_NewFieldsRoundTrip(t *testing.T) {
-	doc := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"w":{"initContainers":null,"containers":[{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a","/b"],"rules":{"/a":{"source":"emptyDir"},"/b":{"source":"pvc","review":"why"}}},"env":{"policy":"exact","names":["A","B"],"values":{"A":{"value":""},"B":{"from":"podIP"}}},"privileges":{"privileged":true,"hostNamespaces":["net"],"capabilities":["CAP_NET_ADMIN"],"devices":["/dev/x"],"hostPaths":["/etc/"],"unmaskedProc":true,"review":"r"}}]}}}`
+	doc := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"w":{"initContainers":null,"containers":[{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a","/b","/c"],"rules":{"/a":{"source":"emptyDir"},"/b":{"source":"pvc","review":"why"},"/c":{"source":"hostPath","path":"/etc/"}}},"env":{"policy":"exact","names":["A","B"],"values":{"A":{"value":""},"B":{"from":"podIP"}}},"privileges":{"privileged":true,"hostNamespaces":["net"],"capabilities":["CAP_NET_ADMIN"],"devices":["/dev/x"],"hostPaths":["/etc/"],"unmaskedProc":true,"review":"r"}}]}}}`
 	al := mustParse(t, doc)
 	got, err := al.Canonical()
 	if err != nil {
@@ -308,13 +353,28 @@ func TestLintSealed(t *testing.T) {
 	complete := `{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
 		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
 		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}`
+	// privileged pins everything complete does and binds one host path.
+	privileged := func(rule, hostPaths string) string {
+		return `{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/agent"]},"args":{"policy":"deny"},` +
+			`"mounts":{"policy":"exact","destinations":["/host/cni"],"rules":{"/host/cni":` + rule + `}},` +
+			`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}},` +
+			`"privileges":{"privileged":true,"hostPaths":` + hostPaths + `,"review":"node TCB"}}`
+	}
 	for _, tc := range []struct {
 		name string
 		doc  []byte
 		want string // "" for clean
 	}{
 		{"complete unprivileged entry", sealedDoc(t, `"w":{"containers":[`+complete+`]}`), ""},
-		{"privileged entry with review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true,"review":"node TCB"}}]}`), ""},
+		{"privileged entry with a bound host path", sealedDoc(t, `"w":{"containers":[`+privileged(`{"source":"hostPath","path":"/etc/cni/net.d"}`, `["/etc/cni/net.d"]`)+`]}`), ""},
+		{"privileged entry with a subtree host path", sealedDoc(t, `"w":{"containers":[`+privileged(`{"source":"hostPath","path":"/etc/cni/"}`, `["/etc/"]`)+`]}`), ""},
+		{"hostPath rule without a path", sealedDoc(t, `"w":{"containers":[`+privileged(`{"source":"hostPath"}`, `["/etc/cni/net.d"]`)+`]}`), "hostPath rule without a path"},
+		{"hostPath path outside hostPaths", sealedDoc(t, `"w":{"containers":[`+privileged(`{"source":"hostPath","path":"/etc/cni/net.d"}`, `["/opt/cni/"]`)+`]}`), "privileges.hostPaths does not cover"},
+		{"hostPath subtree under an exact grant", sealedDoc(t, `"w":{"containers":[`+privileged(`{"source":"hostPath","path":"/etc/cni/"}`, `["/etc/cni"]`)+`]}`), "privileges.hostPaths does not cover"},
+		{"privileged entry with an open argv", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}},"privileges":{"privileged":true,"review":"node TCB"}}]}`), "command must be exact"},
+		{"privileged entry with open env and mounts", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"privileges":{"privileged":true,"review":"node TCB"}}]}`), "env must be exact"},
+		{"serviceAccountToken with review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/var/run/secrets/kubernetes.io/serviceaccount"],"rules":{"/var/run/secrets/kubernetes.io/serviceaccount":{"source":"serviceAccountToken","review":"reads nothing there"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), ""},
+		{"serviceAccountToken without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/var/run/secrets/kubernetes.io/serviceaccount"],"rules":{"/var/run/secrets/kubernetes.io/serviceaccount":{"source":"serviceAccountToken"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "serviceAccountToken bind without a review"},
 		{"non-canonical bytes", append(sealedDoc(t, `"w":{"containers":[`+complete+`]}`), '\n'), "not its canonical form"},
 		{"floor digest", []byte(`{"schema":"c8s.allowlist/v1","digests":{"` + digestC + `":"x"},"workloads":{}}`), "digests must be empty"},
 		{"digests null", []byte(`{"schema":"c8s.allowlist/v1","digests":null,"workloads":{}}`), `"digests" must be {}`},
@@ -330,7 +390,7 @@ func TestLintSealed(t *testing.T) {
 		{"nodeState without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/run/confai"],"rules":{"/run/confai":{"source":"nodeState"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "nodeState bind without a review"},
 		{"pvc without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"pvc"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "pvc without a review"},
 		{"hostPath rule on unprivileged entry", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"hostPath"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "hostPath on an unprivileged entry"},
-		{"privileged without review", sealedDoc(t, `"w":{"initContainers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true}}]}`), "privileges.review is empty"},
+		{"privileged without review", sealedDoc(t, `"w":{"initContainers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}},"privileges":{"privileged":true}}]}`), "privileges.review is empty"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := LintSealed(tc.doc)

--- a/pkg/allowlist/sealed_test.go
+++ b/pkg/allowlist/sealed_test.go
@@ -1,0 +1,335 @@
+package allowlist
+
+import (
+	"strings"
+	"testing"
+)
+
+func str(s string) *string { return &s }
+
+// sealedContainer is a complete rule for an unprivileged web server.
+func sealedContainer(t *testing.T) Container {
+	t.Helper()
+	cs := []Container{{
+		Digest:  mustDigest(t, digestA),
+		Command: ArgvPolicy{Policy: PolicyExact, Argv: []string{"/app"}},
+		Args:    ArgvPolicy{Policy: PolicyExact, Argv: []string{"serve"}},
+		Mounts: MountPolicy{Policy: PolicyExact,
+			Destinations: []string{"/etc/hosts", "/data", "/var/run/secrets/kubernetes.io/serviceaccount"},
+			Rules: map[string]MountRule{
+				"/etc/hosts": {Source: SourcePlatform},
+				"/data":      {Source: SourcePVC, Review: "opaque blob store; the app never executes its contents"},
+				"/var/run/secrets/kubernetes.io/serviceaccount": {Source: SourceServiceAccountToken},
+			}},
+		Env: EnvPolicy{Policy: PolicyExact, Names: []string{"PATH", "HOSTNAME"},
+			Values: map[string]EnvValue{"PATH": {Value: str("/bin")}, "HOSTNAME": {From: FromPodName}}},
+	}}
+	if err := normalizeContainers("web", "containers", cs); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return cs[0]
+}
+
+func sealedObservation() Observation {
+	return Observation{
+		Digest: digestA,
+		Argv:   []string{"/app", "serve"},
+		Env:    map[string]string{"PATH": "/bin", "HOSTNAME": "web-0"},
+		Mounts: map[string]MountSource{
+			"/etc/hosts": {Path: "/var/lib/kubelet/pods/u/etc-hosts", Class: SourcePlatform},
+			"/data":      {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~csi/pvc-1/mount", Class: SourcePVC},
+			"/var/run/secrets/kubernetes.io/serviceaccount": {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~projected/kube-api-access-x", Class: SourceServiceAccountToken},
+		},
+		Sources: map[string]string{FromPodName: "web-0"},
+	}
+}
+
+func TestIndexAdmit(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{"web": {Containers: []Container{sealedContainer(t)}}}}
+	idx := al.BuildIndex()
+	for _, tc := range []struct {
+		name     string
+		mutate   func(o *Observation)
+		wantRule string
+		wantOK   bool
+	}{
+		{"complete match", func(*Observation) {}, "web/containers[0]", true},
+		{"no env at all is a subset", func(o *Observation) { o.Env = nil }, "web/containers[0]", true},
+		{"unknown digest", func(o *Observation) { o.Digest = digestB }, "", false},
+		{"argv drift", func(o *Observation) { o.Argv = []string{"/app", "serve", "--debug"} }, "", false},
+		{"env value drift", func(o *Observation) { o.Env["PATH"] = "/bin:/evil" }, "", false},
+		{"env from-source drift", func(o *Observation) { o.Env["HOSTNAME"] = "other" }, "", false},
+		{"env from-source missing", func(o *Observation) { o.Sources = nil }, "", false},
+		{"undeclared env name", func(o *Observation) { o.Env["LD_PRELOAD"] = "/x.so" }, "", false},
+		{"undeclared mount", func(o *Observation) { o.Mounts["/x"] = MountSource{Path: "/tmp/x", Class: SourceEmptyDir} }, "", false},
+		{"mount class drift", func(o *Observation) { o.Mounts["/data"] = MountSource{Path: "/etc", Class: SourceHostPath} }, "", false},
+		{"configMap at a declared destination", func(o *Observation) {
+			o.Mounts["/etc/hosts"] = MountSource{Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~configmap/c", Class: "configMap"}
+		}, "", false},
+		{"hooks present", func(o *Observation) { o.Hooks = true }, "", false},
+		{"privileged", func(o *Observation) { o.Privileged = true }, "", false},
+		{"host namespace", func(o *Observation) { o.HostNamespaces = []string{HostNamespaceNet} }, "", false},
+		{"device", func(o *Observation) { o.Devices = []string{"/dev/tdx_guest"} }, "", false},
+		{"capability", func(o *Observation) { o.Capabilities = []string{"CAP_NET_ADMIN"} }, "", false},
+		{"unmasked proc", func(o *Observation) { o.UnmaskedProc = true }, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := sealedObservation()
+			tc.mutate(&obs)
+			rule, ok := idx.Admit(obs)
+			if rule != tc.wantRule || ok != tc.wantOK {
+				t.Errorf("Admit(%s) = (%q, %v), want (%q, %v)", tc.name, rule, ok, tc.wantRule, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestIndexAdmit_Privileged(t *testing.T) {
+	cs := []Container{{
+		Digest:  mustDigest(t, digestB),
+		Command: ArgvPolicy{Policy: PolicyExact, Argv: []string{"/cilium-agent"}},
+		Args:    ArgvPolicy{Policy: PolicyAny},
+		Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/host/etc/cni", "/run/cilium", "/tmp/cm"},
+			Rules: map[string]MountRule{
+				"/host/etc/cni": {Source: SourceHostPath},
+				"/run/cilium":   {Source: SourceEmptyDir},
+				"/tmp/cm":       {Source: SourceHostPath},
+			}},
+		Privileges: &Privileges{HostNamespaces: []string{HostNamespaceNet},
+			Capabilities: []string{"CAP_NET_ADMIN"}, HostPaths: []string{"/etc/cni/net.d", KubeletVolumesRoot},
+			Review: "CNI agent; node TCB"},
+	}, {
+		Digest:     mustDigest(t, digestC),
+		Command:    ArgvPolicy{Policy: PolicyAny},
+		Args:       ArgvPolicy{Policy: PolicyAny},
+		Privileges: &Privileges{Privileged: true, Review: "device plugin; node TCB"},
+	}}
+	if err := normalizeContainers("cni", "containers", cs); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{"cni": {Containers: cs}}}
+	idx := al.BuildIndex()
+	base := func() Observation {
+		return Observation{
+			Digest: digestB, Argv: []string{"/cilium-agent", "--any-args"},
+			Env:            map[string]string{"ANY": "thing"},
+			HostNamespaces: []string{HostNamespaceNet},
+			Capabilities:   []string{"CAP_NET_ADMIN"},
+			Mounts: map[string]MountSource{
+				"/host/etc/cni": {Path: "/etc/cni/net.d", Class: SourceHostPath},
+				"/run/cilium":   {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~empty-dir/run", Class: SourceEmptyDir},
+				"/tmp/cm":       {Path: "/var/lib/kubelet/pods/u/volumes/kubernetes.io~configmap/cm", Class: "configMap"},
+			},
+		}
+	}
+	for _, tc := range []struct {
+		name   string
+		mutate func(o *Observation)
+		wantOK bool
+	}{
+		{"declared privileges and host paths", func(*Observation) {}, true},
+		{"hostPath outside hostPaths", func(o *Observation) { o.Mounts["/host/etc/cni"] = MountSource{Path: "/", Class: SourceHostPath} }, false},
+		{"subtree entry admits a path under it", func(o *Observation) {
+			o.Mounts["/tmp/cm"] = MountSource{Path: KubeletVolumesRoot + "u/volumes/kubernetes.io~secret/s", Class: "secret"}
+		}, true},
+		{"subtree entry refuses a traversal out of it", func(o *Observation) {
+			o.Mounts["/tmp/cm"] = MountSource{Path: KubeletVolumesRoot + "../../../../etc/shadow", Class: "secret"}
+		}, false},
+		{"exact entry matches the cleaned source", func(o *Observation) {
+			o.Mounts["/host/etc/cni"] = MountSource{Path: "/etc/../etc/cni/net.d", Class: SourceHostPath}
+		}, true},
+		{"emptyDir where a hostPath rule stands", func(o *Observation) { o.Mounts["/tmp/cm"] = MountSource{Path: "/x", Class: SourceEmptyDir} }, false},
+		{"undeclared host namespace", func(o *Observation) { o.HostNamespaces = append(o.HostNamespaces, HostNamespacePID) }, false},
+		{"undeclared capability", func(o *Observation) { o.Capabilities = append(o.Capabilities, "CAP_SYS_ADMIN") }, false},
+		{"privileged without a privileged rule", func(o *Observation) { o.Privileged = true }, false},
+		{"privileged rule admits every capability and device", func(o *Observation) {
+			*o = Observation{Digest: digestC, Privileged: true, Capabilities: []string{"CAP_SYS_ADMIN"}, Devices: []string{"/dev/vfio/1"}}
+		}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			obs := base()
+			tc.mutate(&obs)
+			if _, ok := idx.Admit(obs); ok != tc.wantOK {
+				t.Errorf("Admit(%s) = %v, want %v", tc.name, ok, tc.wantOK)
+			}
+		})
+	}
+}
+
+// A floor digest admits nothing through Admit: sealed mode has no digest-only
+// path, whatever the dynamic index says about the same document.
+func TestIndexAdmit_IgnoresFloor(t *testing.T) {
+	al := mustParse(t, `{"schema":"c8s.allowlist/v1","digests":{"`+digestA+`":"base"}}`)
+	idx := al.BuildIndex()
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA}) {
+		t.Fatal("AdmitsContainer(floor digest) = false, want true")
+	}
+	if rule, ok := idx.Admit(Observation{Digest: digestA}); ok {
+		t.Errorf("Admit(floor digest) = (%q, true), want refusal", rule)
+	}
+}
+
+func TestSealedFieldValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    Container
+		want string
+	}{
+		{"env value and from together", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"A"},
+			Values: map[string]EnvValue{"A": {Value: str("x"), From: FromPodIP}}}}, "mutually exclusive"},
+		{"env value neither", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"A"},
+			Values: map[string]EnvValue{"A": {}}}}, "one of value or from"},
+		{"env unknown from", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"A"},
+			Values: map[string]EnvValue{"A": {From: "moon"}}}}, "unknown from source"},
+		{"env value for unlisted name", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"A"},
+			Values: map[string]EnvValue{"B": {Value: str("x")}}}}, "names no listed name"},
+		{"env name without value", Container{Env: EnvPolicy{Policy: PolicyExact, Names: []string{"A", "B"},
+			Values: map[string]EnvValue{"A": {Value: str("x")}}}}, `"B" has no value`},
+		{"env any with values", Container{Env: EnvPolicy{Policy: PolicyAny, Values: map[string]EnvValue{"A": {From: FromPodIP}}}}, "takes no values"},
+		{"mount unknown source", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a"},
+			Rules: map[string]MountRule{"/a": {Source: "nfs"}}}}, "unknown source"},
+		{"mount rule for unlisted destination", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a"},
+			Rules: map[string]MountRule{"/b": {Source: SourceEmptyDir}}}}, "names no listed destination"},
+		{"mount destination without rule", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"/a", "/b"},
+			Rules: map[string]MountRule{"/a": {Source: SourceEmptyDir}}}}, `"/b" has no rule`},
+		{"mount any with rules", Container{Mounts: MountPolicy{Policy: PolicyAny, Rules: map[string]MountRule{"/a": {Source: SourceEmptyDir}}}}, "takes no rules"},
+		{"privileges unknown namespace", Container{Privileges: &Privileges{HostNamespaces: []string{"uts"}}}, "unknown host namespace"},
+		{"privileges capability not OCI form", Container{Privileges: &Privileges{Capabilities: []string{"NET_ADMIN"}}}, "not in OCI form"},
+		{"privileges relative device", Container{Privileges: &Privileges{Devices: []string{"dev/null"}}}, "not an absolute path"},
+		{"privileges relative host path", Container{Privileges: &Privileges{HostPaths: []string{"etc"}}}, "not an absolute path"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c
+			c.Digest = mustDigest(t, digestA)
+			err := normalizeContainers("w", "containers", []Container{c})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("normalizeContainers(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestPrivilegesNormalizeSortsAndKeepsEmptyBlock(t *testing.T) {
+	cs := []Container{{Digest: mustDigest(t, digestA), Privileges: &Privileges{
+		HostNamespaces: []string{HostNamespacePID, HostNamespaceNet, HostNamespaceNet},
+		Capabilities:   []string{"CAP_SYS_ADMIN", "CAP_NET_ADMIN"},
+	}}, {Digest: mustDigest(t, digestA), Privileges: &Privileges{}}}
+	if err := normalizeContainers("w", "containers", cs); err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Join(cs[0].Privileges.HostNamespaces, ","); got != "net,pid" {
+		t.Errorf("HostNamespaces = %q, want %q", got, "net,pid")
+	}
+	if got := strings.Join(cs[0].Privileges.Capabilities, ","); got != "CAP_NET_ADMIN,CAP_SYS_ADMIN" {
+		t.Errorf("Capabilities = %q, want %q", got, "CAP_NET_ADMIN,CAP_SYS_ADMIN")
+	}
+	if cs[1].Privileges == nil {
+		t.Error("an empty privileges block was dropped; it marks the entry as node TCB")
+	}
+}
+
+// Two same-digest containers that tie on argv but differ in env must
+// canonicalize identically whichever order they were written in.
+func TestPolicyKeyCoversEveryField(t *testing.T) {
+	a := `{"digest":"` + digestA + `","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","names":["A"]}}`
+	b := `{"digest":"` + digestA + `","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","names":["B"]}}`
+	ab := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[`+a+`,`+b+`]}}}`)
+	ba := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[`+b+`,`+a+`]}}}`)
+	x, _ := ab.Canonical()
+	y, _ := ba.Canonical()
+	if string(x) != string(y) {
+		t.Errorf("Canonical(ab) = %s\nCanonical(ba) = %s, want equal", x, y)
+	}
+}
+
+// existingDocument is a pre-sealed-schema document already in canonical form.
+// Its bytes are stamped into issued leaves and hashed by verify --allowlist,
+// so the schema additions must not move them.
+const existingDocument = `{"schema":"c8s.allowlist/v1","digests":{"` + digestC + `":"registry.example/base@` + digestC + `"},"workloads":{"web":{"label":"registry.example/web:1","initContainers":[{"digest":"` + digestB + `","command":{"policy":"exact","argv":["/init"]},"args":{"policy":"deny"},"mounts":{"policy":"any"},"env":{"policy":"any"}}],"containers":[{"digest":"` + digestA + `","image":"registry.example/web@` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"exact","argv":["serve"]},"mounts":{"policy":"exact","destinations":["/data","/etc/hosts"]},"env":{"policy":"exact","names":["HOME","PATH"]}}],"secrets":{"policy":"allow","read":["/web/**"]}},"worker":{"initContainers":null,"containers":[{"digest":"` + digestA + `","command":{"policy":"any"},"args":{"policy":"any"},"mounts":{"policy":"any"},"env":{"policy":"any"}}]}}}`
+
+func TestCanonical_ExistingDocumentBytesUnchanged(t *testing.T) {
+	al := mustParse(t, existingDocument)
+	got, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != existingDocument {
+		t.Errorf("Canonical(existing) =\n%s\nwant\n%s", got, existingDocument)
+	}
+}
+
+func TestCanonical_NewFieldsRoundTrip(t *testing.T) {
+	doc := `{"schema":"c8s.allowlist/v1","digests":null,"workloads":{"w":{"initContainers":null,"containers":[{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a","/b"],"rules":{"/a":{"source":"emptyDir"},"/b":{"source":"pvc","review":"why"}}},"env":{"policy":"exact","names":["A","B"],"values":{"A":{"value":""},"B":{"from":"podIP"}}},"privileges":{"privileged":true,"hostNamespaces":["net"],"capabilities":["CAP_NET_ADMIN"],"devices":["/dev/x"],"hostPaths":["/etc/"],"unmaskedProc":true,"review":"r"}}]}}}`
+	al := mustParse(t, doc)
+	got, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != doc {
+		t.Errorf("Canonical(new fields) =\n%s\nwant\n%s", got, doc)
+	}
+	if _, err := ParseServedJSON([]byte(doc)); err != nil {
+		t.Errorf("ParseServedJSON(new fields) = %v, want nil", err)
+	}
+}
+
+// The dynamic path (AdmitsContainer) keeps ignoring values, rules and
+// privileges: its enforcers never observe them.
+func TestAdmitsContainerIgnoresSealedFields(t *testing.T) {
+	al := &Allowlist{Schema: Schema, Workloads: map[string]Workload{"web": {Containers: []Container{sealedContainer(t)}}}}
+	idx := al.BuildIndex()
+	if !idx.AdmitsContainer(RunningContainer{Digest: digestA, Argv: []string{"/app", "serve"}, EnvNames: []string{"PATH"}, BindMounts: []string{"/data"}}) {
+		t.Error("AdmitsContainer(names only) = false, want true")
+	}
+}
+
+func sealedDoc(t *testing.T, workloads string) []byte {
+	t.Helper()
+	al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{`+workloads+`}}`)
+	b, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}
+
+func TestLintSealed(t *testing.T) {
+	complete := `{"digest":"` + digestA + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},` +
+		`"mounts":{"policy":"exact","destinations":["/etc/hosts"],"rules":{"/etc/hosts":{"source":"platform"}}},` +
+		`"env":{"policy":"exact","names":["PATH"],"values":{"PATH":{"value":"/bin"}}}}`
+	for _, tc := range []struct {
+		name string
+		doc  []byte
+		want string // "" for clean
+	}{
+		{"complete unprivileged entry", sealedDoc(t, `"w":{"containers":[`+complete+`]}`), ""},
+		{"privileged entry with review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true,"review":"node TCB"}}]}`), ""},
+		{"non-canonical bytes", append(sealedDoc(t, `"w":{"containers":[`+complete+`]}`), '\n'), "not its canonical form"},
+		{"floor digest", []byte(`{"schema":"c8s.allowlist/v1","digests":{"` + digestC + `":"x"},"workloads":null}`), "digests must be empty"},
+		{"command any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "command must be exact"},
+		{"args any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"any"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "args must be exact or deny"},
+		{"mounts any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "mounts must be exact"},
+		{"env any", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}}}]}`), "env must be exact"},
+		{"env without values", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"emptyDir"}}},"env":{"policy":"exact","names":["A"]}}]}`), "carry no values"},
+		{"mounts without rules", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"]},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "carry no rules"},
+		{"pvc without review", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"pvc"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "pvc without a review"},
+		{"hostPath rule on unprivileged entry", sealedDoc(t, `"w":{"containers":[{"digest":"`+digestA+`","command":{"policy":"exact","argv":["/a"]},"args":{"policy":"deny"},"mounts":{"policy":"exact","destinations":["/a"],"rules":{"/a":{"source":"hostPath"}}},"env":{"policy":"exact","names":["A"],"values":{"A":{"value":"x"}}}}]}`), "hostPath on an unprivileged entry"},
+		{"privileged without review", sealedDoc(t, `"w":{"initContainers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"privileges":{"privileged":true}}]}`), "privileges.review is empty"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := LintSealed(tc.doc)
+			switch {
+			case tc.want == "" && err != nil:
+				t.Errorf("LintSealed(%s) = %v, want nil", tc.name, err)
+			case tc.want != "" && (err == nil || !strings.Contains(err.Error(), tc.want)):
+				t.Errorf("LintSealed(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestLintSealed_ParseError(t *testing.T) {
+	if err := LintSealed([]byte(`{"schema":"other"}`)); err == nil || !strings.Contains(err.Error(), "unknown schema") {
+		t.Errorf("LintSealed(bad schema) = %v, want unknown schema error", err)
+	}
+}

--- a/pkg/allowlist/systemfloor.go
+++ b/pkg/allowlist/systemfloor.go
@@ -27,10 +27,10 @@ type SystemFloor struct {
 }
 
 // SystemFloorImage is one system image and its rule skeleton. Env keys and
-// Mounts keys become the exact names and destinations of the rendered rule.
-// The skeleton carries an empty Privileges block; the reviewer completes it
-// for a node-TCB image or sets it to null for an unprivileged one, whose
-// env and mounts must then be exact.
+// Mounts keys become the exact names and destinations of the rendered rule;
+// both must be complete before the document seals, privileged or not. The
+// skeleton carries an empty Privileges block; the reviewer completes it for
+// a node-TCB image or sets it to null for an unprivileged one.
 type SystemFloorImage struct {
 	Ref        string               `json:"ref"`
 	Digest     string               `json:"digest"`
@@ -146,7 +146,8 @@ func ArgvRule(argv []string) ArgvPolicy {
 }
 
 // EnvRules builds an exact env policy from name-keyed rules; an empty map is
-// the unconstrained policy, which only a privileged entry may keep.
+// the unconstrained policy, which LintSealed refuses until the reviewer
+// completes it.
 func EnvRules(values map[string]EnvValue) EnvPolicy {
 	if len(values) == 0 {
 		return EnvPolicy{Policy: PolicyAny}
@@ -160,7 +161,8 @@ func EnvRules(values map[string]EnvValue) EnvPolicy {
 }
 
 // MountRules builds an exact mount policy from destination-keyed rules; an
-// empty map is the unconstrained policy.
+// empty map is the unconstrained policy, which LintSealed refuses until the
+// reviewer completes it.
 func MountRules(rules map[string]MountRule) MountPolicy {
 	if len(rules) == 0 {
 		return MountPolicy{Policy: PolicyAny}

--- a/pkg/allowlist/systemfloor.go
+++ b/pkg/allowlist/systemfloor.go
@@ -1,0 +1,174 @@
+package allowlist
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/distribution/reference"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// SystemFloorSchema identifies the system-floor file the node image build
+// emits next to its manifest.
+const SystemFloorSchema = "c8s.system-floor/v1"
+
+// SystemFloor lists the node image's system images (RKE2 static pods, CNI,
+// DNS) with what the build can see of them: the image config. The build
+// cannot see the argv, env and mounts the static pod manifests give them, so
+// Env and Mounts start empty and Privileges.Review starts blank; the reviewer
+// completes them from a dynamic node's observations before the document
+// passes LintSealed.
+type SystemFloor struct {
+	Schema string             `json:"schema"`
+	Images []SystemFloorImage `json:"images"`
+}
+
+// SystemFloorImage is one system image and its rule skeleton. Env keys and
+// Mounts keys become the exact names and destinations of the rendered rule.
+// The skeleton carries an empty Privileges block; the reviewer completes it
+// for a node-TCB image or sets it to null for an unprivileged one, whose
+// env and mounts must then be exact.
+type SystemFloorImage struct {
+	Ref        string               `json:"ref"`
+	Digest     string               `json:"digest"`
+	Entrypoint []string             `json:"entrypoint"`
+	Cmd        []string             `json:"cmd"`
+	Env        map[string]EnvValue  `json:"env"`
+	Mounts     map[string]MountRule `json:"mounts"`
+	Privileges *Privileges          `json:"privileges"`
+}
+
+// ParseSystemFloor decodes a system-floor file, rejecting unknown fields.
+func ParseSystemFloor(data []byte) (*SystemFloor, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var f SystemFloor
+	if err := dec.Decode(&f); err != nil {
+		return nil, fmt.Errorf("decode system floor: %w", err)
+	}
+	if f.Schema != SystemFloorSchema {
+		return nil, fmt.Errorf("system floor: unknown schema %q (expected %q)", f.Schema, SystemFloorSchema)
+	}
+	return &f, nil
+}
+
+// Workloads renders one entry per image, named "system-<repo base>-<tag>".
+// The argv rule pins the image config verbatim; a static pod that overrides
+// it is the reviewer's edit.
+func (f *SystemFloor) Workloads() (map[string]Workload, error) {
+	out := make(map[string]Workload, len(f.Images))
+	for _, img := range f.Images {
+		name, err := systemEntryName(img.Ref)
+		if err != nil {
+			return nil, err
+		}
+		if _, dup := out[name]; dup {
+			return nil, fmt.Errorf("system floor: images %q and another share the entry name %q", img.Ref, name)
+		}
+		c, err := img.container()
+		if err != nil {
+			return nil, fmt.Errorf("system floor image %q: %w", img.Ref, err)
+		}
+		out[name] = Workload{Label: img.Ref, Containers: []Container{c}}
+	}
+	return out, nil
+}
+
+func (img SystemFloorImage) container() (Container, error) {
+	digest, err := types.ParseDigest(img.Digest)
+	if err != nil {
+		return Container{}, err
+	}
+	named, err := reference.ParseDockerRef(img.Ref)
+	if err != nil {
+		return Container{}, fmt.Errorf("ref: %w", err)
+	}
+	c := Container{
+		Digest:     digest,
+		Image:      reference.TrimNamed(named).String() + "@" + digest.String(),
+		Command:    ArgvRule(img.Entrypoint),
+		Args:       ArgvRule(img.Cmd),
+		Mounts:     MountRules(img.Mounts),
+		Env:        EnvRules(img.Env),
+		Privileges: img.Privileges,
+	}
+	if c.Command.Policy == PolicyDeny && c.Args.Policy == PolicyExact {
+		// An image with only a Cmd runs it as its argv; the same shape a
+		// pod template with args and no command produces.
+		c.Command, c.Args = c.Args, ArgvPolicy{Policy: PolicyDeny}
+	}
+	return c, nil
+}
+
+// systemEntryName derives an entry name from an image reference:
+// "system-<repository basename>-<tag>", squeezed to the entry grammar.
+func systemEntryName(ref string) (string, error) {
+	named, err := reference.ParseDockerRef(ref)
+	if err != nil {
+		return "", fmt.Errorf("system floor image %q: %w", ref, err)
+	}
+	base := reference.Path(reference.TrimNamed(named))
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	name := "system-" + sanitizeEntryName(base)
+	if tagged, ok := named.(reference.Tagged); ok {
+		name += "-" + sanitizeEntryName(tagged.Tag())
+	}
+	if len(name) > MaxWorkloadNameLen {
+		name = name[:MaxWorkloadNameLen]
+	}
+	return name, nil
+}
+
+func sanitizeEntryName(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}
+
+// ArgvRule pins an argv exactly, or denies it when there is nothing to pin.
+func ArgvRule(argv []string) ArgvPolicy {
+	if len(argv) == 0 {
+		return ArgvPolicy{Policy: PolicyDeny}
+	}
+	return ArgvPolicy{Policy: PolicyExact, Argv: argv}
+}
+
+// EnvRules builds an exact env policy from name-keyed rules; an empty map is
+// the unconstrained policy, which only a privileged entry may keep.
+func EnvRules(values map[string]EnvValue) EnvPolicy {
+	if len(values) == 0 {
+		return EnvPolicy{Policy: PolicyAny}
+	}
+	p := EnvPolicy{Policy: PolicyExact, Values: make(map[string]EnvValue, len(values))}
+	for name, v := range values {
+		p.Names = append(p.Names, name)
+		p.Values[name] = v
+	}
+	return p
+}
+
+// MountRules builds an exact mount policy from destination-keyed rules; an
+// empty map is the unconstrained policy.
+func MountRules(rules map[string]MountRule) MountPolicy {
+	if len(rules) == 0 {
+		return MountPolicy{Policy: PolicyAny}
+	}
+	p := MountPolicy{Policy: PolicyExact, Rules: make(map[string]MountRule, len(rules))}
+	for dest, r := range rules {
+		p.Destinations = append(p.Destinations, dest)
+		p.Rules[dest] = r
+	}
+	return p
+}

--- a/pkg/allowlist/systemfloor_test.go
+++ b/pkg/allowlist/systemfloor_test.go
@@ -1,0 +1,136 @@
+package allowlist
+
+import (
+	"strings"
+	"testing"
+)
+
+const floorDoc = `{"schema":"c8s.system-floor/v1","images":[
+ {"ref":"docker.io/rancher/hardened-kubernetes:v1.33.3-rke2r1-build20250723","digest":"` + digestA + `","entrypoint":["/usr/local/bin/kube-apiserver"],"cmd":null,"env":{},"mounts":{},"privileges":{"review":""}},
+ {"ref":"docker.io/rancher/mirrored-pause:3.6","digest":"` + digestB + `","entrypoint":null,"cmd":["/pause"],"env":{"PATH":{"value":"/bin"}},"mounts":{"/etc/hosts":{"source":"platform"}},"privileges":{"hostNamespaces":["net"],"review":"sandbox"}},
+ {"ref":"docker.io/rancher/mirrored-coredns-coredns:1.12.1","digest":"` + digestC + `","entrypoint":["/coredns"],"cmd":null,"env":{},"mounts":{},"privileges":null}
+]}`
+
+func TestSystemFloorWorkloads(t *testing.T) {
+	f, err := ParseSystemFloor([]byte(floorDoc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ws, err := f.Workloads()
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, ok := ws["system-hardened-kubernetes-v1.33.3-rke2r1-build20250723"]
+	if !ok {
+		t.Fatalf("Workloads() names = %v, want the kube-apiserver entry", keys(ws))
+	}
+	c := api.Containers[0]
+	if c.Image != "docker.io/rancher/hardened-kubernetes@"+digestA {
+		t.Errorf("Image = %q, want repo@digest", c.Image)
+	}
+	if c.Command.Policy != PolicyExact || c.Command.Argv[0] != "/usr/local/bin/kube-apiserver" || c.Args.Policy != PolicyDeny {
+		t.Errorf("argv rule = %+v/%+v, want exact entrypoint and deny args", c.Command, c.Args)
+	}
+	if c.Privileges == nil || c.Privileges.Review != "" || c.Env.Policy != PolicyAny || c.Mounts.Policy != PolicyAny {
+		t.Errorf("skeleton = %+v, want empty privileges and unconstrained env/mounts", c)
+	}
+
+	pause := ws["system-mirrored-pause-3.6"].Containers[0]
+	if pause.Command.Policy != PolicyExact || pause.Command.Argv[0] != "/pause" || pause.Args.Policy != PolicyDeny {
+		t.Errorf("cmd-only image argv rule = %+v/%+v, want the cmd as the command", pause.Command, pause.Args)
+	}
+	if pause.Env.Policy != PolicyExact || pause.Env.Values["PATH"].Value == nil || pause.Mounts.Rules["/etc/hosts"].Source != SourcePlatform {
+		t.Errorf("completed rule = env %+v mounts %+v, want exact policies from the keys", pause.Env, pause.Mounts)
+	}
+
+	dns := ws["system-mirrored-coredns-coredns-1.12.1"].Containers[0]
+	if dns.Privileges != nil {
+		t.Errorf("privileges null -> %+v, want nil (an unprivileged system image)", dns.Privileges)
+	}
+
+	al := &Allowlist{Schema: Schema, Workloads: ws}
+	b, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseJSON(b); err != nil {
+		t.Errorf("ParseJSON(Canonical(floor workloads)) = %v, want nil", err)
+	}
+}
+
+// A reviewer who nulls privileges owes exact env and mounts: the sealed lint
+// holds an unprivileged floor entry to the same rule as any workload.
+func TestSystemFloorWorkloads_UnprivilegedNeedsCompleteRule(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		images string
+		want   []string
+	}{
+		{"privileged with review passes with empty env and mounts",
+			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{},"mounts":{},"privileges":{"review":"node TCB"}}]`, nil},
+		{"unprivileged with empty env and mounts",
+			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{},"mounts":{},"privileges":null}]`, []string{"mounts must be exact", "env must be exact"}},
+		{"unprivileged with complete rules",
+			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{"PATH":{"value":"/bin"}},"mounts":{"/etc/hosts":{"source":"platform"}},"privileges":null}]`, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := ParseSystemFloor([]byte(`{"schema":"c8s.system-floor/v1","images":` + tc.images + `}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			ws, err := f.Workloads()
+			if err != nil {
+				t.Fatal(err)
+			}
+			doc, err := (&Allowlist{Schema: Schema, Workloads: ws}).Canonical()
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = LintSealed(doc)
+			if len(tc.want) == 0 && err != nil {
+				t.Fatalf("LintSealed(%s) = %v, want nil", tc.name, err)
+			}
+			for _, w := range tc.want {
+				if err == nil || !strings.Contains(err.Error(), w) {
+					t.Errorf("LintSealed(%s) = %v, want error containing %q", tc.name, err, w)
+				}
+			}
+		})
+	}
+}
+
+func TestParseSystemFloorRejects(t *testing.T) {
+	for _, tc := range []struct{ name, doc, want string }{
+		{"schema", `{"schema":"x","images":[]}`, "unknown schema"},
+		{"unknown field", `{"schema":"c8s.system-floor/v1","images":[],"extra":1}`, "unknown field"},
+	} {
+		_, err := ParseSystemFloor([]byte(tc.doc))
+		if err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("ParseSystemFloor(%s) = %v, want error containing %q", tc.name, err, tc.want)
+		}
+	}
+}
+
+func TestSystemFloorWorkloads_Rejects(t *testing.T) {
+	for _, tc := range []struct{ name, images, want string }{
+		{"bad digest", `[{"ref":"a/b:1","digest":"sha256:zz","privileges":{"review":""}}]`, "digest"},
+		{"bad ref", `[{"ref":"A B","digest":"` + digestA + `","privileges":{"review":""}}]`, "ref"},
+		{"duplicate name", `[{"ref":"a/b:1","digest":"` + digestA + `","privileges":{"review":""}},{"ref":"c/b:1","digest":"` + digestB + `","privileges":{"review":""}}]`, "share the entry name"},
+	} {
+		f, err := ParseSystemFloor([]byte(`{"schema":"c8s.system-floor/v1","images":` + tc.images + `}`))
+		if err != nil {
+			t.Fatalf("%s: parse: %v", tc.name, err)
+		}
+		if _, err := f.Workloads(); err == nil || !strings.Contains(err.Error(), tc.want) {
+			t.Errorf("Workloads(%s) = %v, want error containing %q", tc.name, err, tc.want)
+		}
+	}
+}
+
+func keys(m map[string]Workload) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/pkg/allowlist/systemfloor_test.go
+++ b/pkg/allowlist/systemfloor_test.go
@@ -58,16 +58,19 @@ func TestSystemFloorWorkloads(t *testing.T) {
 	}
 }
 
-// A reviewer who nulls privileges owes exact env and mounts: the sealed lint
-// holds an unprivileged floor entry to the same rule as any workload.
-func TestSystemFloorWorkloads_UnprivilegedNeedsCompleteRule(t *testing.T) {
+// The skeleton's empty env and mounts owe completion whatever the
+// privileges say: the sealed lint holds a floor entry to the same rule as
+// any workload.
+func TestSystemFloorWorkloads_NeedsCompleteRule(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		images string
 		want   []string
 	}{
-		{"privileged with review passes with empty env and mounts",
-			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{},"mounts":{},"privileges":{"review":"node TCB"}}]`, nil},
+		{"privileged with empty env and mounts",
+			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{},"mounts":{},"privileges":{"review":"node TCB"}}]`, []string{"mounts must be exact", "env must be exact"}},
+		{"privileged with complete rules",
+			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{"PATH":{"value":"/bin"}},"mounts":{"/etc/hosts":{"source":"platform"}},"privileges":{"review":"node TCB"}}]`, nil},
 		{"unprivileged with empty env and mounts",
 			`[{"ref":"a/b:1","digest":"` + digestA + `","entrypoint":["/b"],"env":{},"mounts":{},"privileges":null}]`, []string{"mounts must be exact", "env must be exact"}},
 		{"unprivileged with complete rules",

--- a/pkg/allowlist/systemfloor_test.go
+++ b/pkg/allowlist/systemfloor_test.go
@@ -82,7 +82,7 @@ func TestSystemFloorWorkloads_UnprivilegedNeedsCompleteRule(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			doc, err := (&Allowlist{Schema: Schema, Workloads: ws}).Canonical()
+			doc, err := (&Allowlist{Schema: Schema, Digests: map[string]string{}, Workloads: ws}).Canonical()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/attestationclient/client.go
+++ b/pkg/attestationclient/client.go
@@ -25,6 +25,10 @@ const maxErrorBodyBytes = 8 << 10
 // ever answers.
 const requestTimeout = 60 * time.Second
 
+// unixBaseURL is the placeholder host of a client whose transport dials a
+// Unix socket; the host is never resolved.
+const unixBaseURL = "http://unix"
+
 // Client is an HTTP client for the external attestation-api.
 type Client struct {
 	baseURL    string
@@ -43,7 +47,7 @@ type Client struct {
 func NewClient(baseURL string) Client {
 	if socket, ok := strings.CutPrefix(baseURL, "unix://"); ok {
 		return Client{
-			baseURL:    "http://unix",
+			baseURL:    unixBaseURL,
 			httpClient: &http.Client{Transport: unixSocketTransport(socket), Timeout: requestTimeout},
 		}
 	}
@@ -107,7 +111,7 @@ func NewClientWithHTTP(baseURL string, httpClient *http.Client) Client {
 		c := *httpClient
 		c.Transport = unixSocketTransport(socket)
 		return Client{
-			baseURL:    "http://unix",
+			baseURL:    unixBaseURL,
 			httpClient: &c,
 		}
 	}

--- a/pkg/attestationclient/owntuple.go
+++ b/pkg/attestationclient/owntuple.go
@@ -1,0 +1,72 @@
+package attestationclient
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// OwnTupleEntry attests the calling TD through c and returns the image tuple
+// the verifier reports for it: MRTD as the digest and RTMR[1..3]. The
+// evidence is bound to a fresh nonce and its verdict enforced (signature and
+// REPORTDATA), so the tuple is this TD's now, not a replay. A peer pinned to
+// the entry is accepted only when it runs the same image with the same
+// runtime chain, which lets a sealed node pin CDS without any per-cluster
+// digest in its own configuration. Non-TDX evidence is refused: only TDX
+// carries the registers.
+func (c Client) OwnTupleEntry(ctx context.Context) (measurements.Entry, error) {
+	// The tuple is trusted as this node's because the verifier is the node's
+	// own; a routable endpoint is one the control plane can substitute.
+	if c.baseURL != unixBaseURL {
+		return measurements.Entry{}, errors.New("OwnTupleEntry needs a unix:// verifier: a network endpoint is one the control plane can substitute")
+	}
+	// The attester takes the 48-byte prefix and zero-extends it into the
+	// 64-byte REPORTDATA the verifier compares.
+	var reportData [64]byte
+	if _, err := rand.Read(reportData[:sha512.Size384]); err != nil {
+		return measurements.Entry{}, fmt.Errorf("self-attest nonce: %w", err)
+	}
+	resp, err := c.Attest(ctx, types.AttestRequest{
+		ReportData: types.NewBase64Bytes(reportData[:sha512.Size384]),
+		Platform:   types.PlatformAuto,
+	})
+	if err != nil {
+		return measurements.Entry{}, fmt.Errorf("attest self: %w", err)
+	}
+	if !TDXPlatform(resp.Platform) {
+		return measurements.Entry{}, fmt.Errorf("attestation-api reports platform %q, want TDX: only TDX evidence carries the runtime registers", resp.Platform)
+	}
+	verified, err := c.VerifyEvidence(ctx, types.AttestationEvidence(resp), EvidencePolicy{ExpectedReportData: reportData})
+	if err != nil {
+		return measurements.Entry{}, fmt.Errorf("verify self-report: %w", err)
+	}
+	return tupleEntry(verified)
+}
+
+// tupleEntry reads the MRTD and RTMR[1..3] out of a verified self-report,
+// from the claims EnforceEntries later matches a peer's evidence against.
+// RTMR[0] is left unpinned: it carries the TD HOB and varies with the VM's
+// vCPU and memory shape.
+func tupleEntry(resp types.VerifyResponse) (measurements.Entry, error) {
+	mrtd, err := launchDigest(resp)
+	if err != nil {
+		return measurements.Entry{}, fmt.Errorf("self-report launch digest: %w", err)
+	}
+	entry := measurements.Entry{Name: "own-tuple", Digest: mrtd, RTMRs: map[int][]byte{}}
+	reported := reportedRTMRs(resp)
+	for i := 1; i <= 3; i++ {
+		reg, err := hex.DecodeString(strings.TrimSpace(reported[i]))
+		if err != nil || len(reg) != launchMeasurementSize {
+			return measurements.Entry{}, fmt.Errorf("self-report rtmr_%d %q is not %d hex bytes", i, reported[i], launchMeasurementSize)
+		}
+		entry.RTMRs[i] = reg
+	}
+	return entry, nil
+}

--- a/pkg/attestationclient/owntuple.go
+++ b/pkg/attestationclient/owntuple.go
@@ -8,10 +8,16 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
+
+// OwnTupleTimeout bounds one OwnTupleEntry round trip for every caller that
+// self-attests at start (the sidecars, CDS, the sealed NRI plugin): the
+// verifier is a local socket, so a slow answer means it is not serving.
+const OwnTupleTimeout = 30 * time.Second
 
 // OwnTupleEntry attests the calling TD through c and returns the image tuple
 // the verifier reports for it: MRTD as the digest and RTMR[1..3]. The

--- a/pkg/attestationclient/owntuple_test.go
+++ b/pkg/attestationclient/owntuple_test.go
@@ -1,0 +1,140 @@
+package attestationclient
+
+import (
+	"bytes"
+	"encoding/hex"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func hexReg(b byte) string {
+	return strings.Repeat(hex.EncodeToString([]byte{b}), launchMeasurementSize)
+}
+
+func TestOwnTupleEntry(t *testing.T) {
+	good := testattest.TDXVerdict(hexReg(0x11), map[int]string{0: hexReg(0x00), 1: hexReg(0x21), 2: hexReg(0x22), 3: hexReg(0x33)})
+	with := func(edit func(v *testattest.Verdict)) testattest.Verdict {
+		v := good
+		v.Claims.PlatformData = map[string]any{}
+		for k, reg := range good.Claims.PlatformData {
+			v.Claims.PlatformData[k] = reg
+		}
+		edit(&v)
+		return v
+	}
+	for _, tc := range []struct {
+		name     string
+		platform types.Platform
+		verdict  testattest.Verdict
+		wantErr  string
+	}{
+		{"own tuple", types.PlatformTdx, good, ""},
+		{"snp evidence", types.PlatformSnp, good, "want TDX"},
+		{"signature invalid", types.PlatformTdx, with(func(v *testattest.Verdict) { v.SignatureValid = false }), "verify self-report"},
+		{"report data mismatch", types.PlatformTdx, with(func(v *testattest.Verdict) { f := false; v.ReportDataMatch = &f }), "verify self-report"},
+		{"report data unchecked", types.PlatformTdx, with(func(v *testattest.Verdict) { v.ReportDataMatch = nil }), "verify self-report"},
+		{"launch digest short", types.PlatformTdx, with(func(v *testattest.Verdict) { v.Claims.LaunchDigest = "abcd" }), "verify self-report"},
+		{"launch digest missing", types.PlatformTdx, with(func(v *testattest.Verdict) { v.Claims.LaunchDigest = "" }), "launch digest"},
+		{"rtmr_3 missing", types.PlatformTdx, with(func(v *testattest.Verdict) { delete(v.Claims.PlatformData, "rtmr_3") }), "rtmr_3"},
+		{"rtmr_1 not a string", types.PlatformTdx, with(func(v *testattest.Verdict) { v.Claims.PlatformData["rtmr_1"] = 7 }), "rtmr_1"},
+		{"rtmr_2 short", types.PlatformTdx, with(func(v *testattest.Verdict) { v.Claims.PlatformData["rtmr_2"] = "abcd" }), "rtmr_2"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			stub, url := testattest.NewUnix(t)
+			stub.SetPlatform(tc.platform)
+			stub.SetVerdict(tc.verdict)
+			entry, err := NewClient(url).OwnTupleEntry(t.Context())
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("OwnTupleEntry(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("OwnTupleEntry(%s) = %v, want nil", tc.name, err)
+			}
+			if hex.EncodeToString(entry.Digest) != hexReg(0x11) || len(entry.RTMRs) != 3 {
+				t.Fatalf("OwnTupleEntry(%s) = digest %x, %d RTMRs; want %s, 3", tc.name, entry.Digest, len(entry.RTMRs), hexReg(0x11))
+			}
+			for i, want := range map[int]byte{1: 0x21, 2: 0x22, 3: 0x33} {
+				if !bytes.Equal(entry.RTMRs[i], bytes.Repeat([]byte{want}, launchMeasurementSize)) {
+					t.Errorf("OwnTupleEntry(%s) RTMR[%d] = %x, want %s", tc.name, i, entry.RTMRs[i], hexReg(want))
+				}
+			}
+			attests, verifies := stub.AttestRequests(), stub.VerifyRequests()
+			if len(attests) != 1 || len(verifies) != 1 {
+				t.Fatalf("attest/verify requests = %d/%d, want 1/1", len(attests), len(verifies))
+			}
+			if verifies[0].Params == nil || verifies[0].Params.ExpectedReportData == nil {
+				t.Fatal("self-report verified without an expected report_data: the verdict would be replayable")
+			}
+			if got := verifies[0].Params.ExpectedReportData.Bytes(); !bytes.Equal(got[:launchMeasurementSize], attests[0].ReportData.Bytes()) || len(got) != 64 {
+				t.Fatalf("verify expected report_data = %x (%d bytes), want the attested nonce zero-extended to 64", got, len(got))
+			}
+		})
+	}
+}
+
+func TestOwnTupleEntry_SocketAbsentIsAnError(t *testing.T) {
+	_, err := NewClient("unix://" + filepath.Join(t.TempDir(), "absent.sock")).OwnTupleEntry(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "attest self") {
+		t.Fatalf("OwnTupleEntry(absent socket) = %v, want an attest error", err)
+	}
+}
+
+// The tuple is only this node's when the verifier is the node's own socket;
+// refusal happens before any request so a network stub is never dialed.
+func TestOwnTupleEntry_NetworkVerifierRefused(t *testing.T) {
+	stub := testattest.New(t)
+	stub.SetPlatform(types.PlatformTdx)
+	stub.SetVerdict(testattest.TDXVerdict(hexReg(0x11), map[int]string{1: hexReg(0x21), 2: hexReg(0x22), 3: hexReg(0x33)}))
+	for _, tc := range []struct {
+		name   string
+		client Client
+	}{
+		{"NewClient", NewClient(stub.URL)},
+		{"NewClientWithHTTP", NewClientWithHTTP(stub.URL, &http.Client{})},
+	} {
+		_, err := tc.client.OwnTupleEntry(t.Context())
+		if err == nil || !strings.Contains(err.Error(), "unix://") {
+			t.Errorf("OwnTupleEntry(%s over http) = %v, want an error naming unix://", tc.name, err)
+		}
+	}
+	if n := len(stub.AttestRequests()); n != 0 {
+		t.Fatalf("attest requests over the network verifier = %d, want 0", n)
+	}
+}
+
+func TestTupleEntry(t *testing.T) {
+	reg := hexReg(0xab)
+	valid := map[string]any{"rtmr_0": reg, "rtmr_1": reg, "rtmr_2": reg, "rtmr_3": reg}
+	for _, tc := range []struct {
+		name    string
+		digest  string
+		data    map[string]any
+		wantErr string
+	}{
+		{"complete", reg, valid, ""},
+		{"digest upper case", strings.ToUpper(reg), valid, ""},
+		{"digest short", "abcd", valid, "launch digest"},
+		{"digest missing", "", valid, "launch digest"},
+		{"rtmr missing", reg, map[string]any{"rtmr_1": reg, "rtmr_2": reg}, "rtmr_3"},
+		{"rtmr not a string", reg, map[string]any{"rtmr_1": reg, "rtmr_2": reg, "rtmr_3": 7}, "rtmr_3"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := types.VerifyResponse{Result: types.VerificationResult{Claims: types.Claims{LaunchDigest: tc.digest, PlatformData: tc.data}}}
+			entry, err := tupleEntry(resp)
+			if (tc.wantErr == "") != (err == nil) || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("tupleEntry(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+			}
+			if err == nil && (len(entry.RTMRs) != 3 || hex.EncodeToString(entry.Digest) != reg) {
+				t.Fatalf("tupleEntry(%s) = %d RTMRs, digest %x; want 3, %s", tc.name, len(entry.RTMRs), entry.Digest, reg)
+			}
+		})
+	}
+}

--- a/pkg/measurements/static.go
+++ b/pkg/measurements/static.go
@@ -1,0 +1,48 @@
+package measurements
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// StaticEntryName names the one image a static-allowlist cluster accepts.
+const StaticEntryName = "static-allowlist"
+
+// StaticReferenceValues builds the reference values a static-allowlist cluster
+// pins: one TDX entry carrying the image tuple from the build manifest and the
+// RTMR[3] a node sealed to the policy bundle reports. Every register is
+// pinned, so a pod on an unsealed node of the same image, or on a node sealed
+// to another bundle, matches nothing.
+func StaticReferenceValues(pins runtimemeasure.ImagePins, rtmr3 [runtimemeasure.Size]byte) ReferenceValues {
+	return ReferenceValues{TEE: TEETDX, Entries: []Entry{{
+		Name:   StaticEntryName,
+		Digest: bytes.Clone(pins.MRTD[:]),
+		RTMRs: map[int][]byte{
+			1: bytes.Clone(pins.RTMR1[:]),
+			2: bytes.Clone(pins.RTMR2[:]),
+			3: bytes.Clone(rtmr3[:]),
+		},
+	}}}
+}
+
+// StaticEntry returns the entry a static-allowlist consumer enforces: the set
+// must declare TDX and hold exactly one entry pinning RTMR[1], RTMR[2] and
+// RTMR[3]. Anything looser would let a second image, or an unsealed node of
+// the same image, through the static gate.
+func (s ReferenceValues) StaticEntry() (Entry, error) {
+	if s.TEE != TEETDX {
+		return Entry{}, fmt.Errorf("static allowlist needs tee %q, config declares %q", TEETDX, s.TEE)
+	}
+	if len(s.Entries) != 1 {
+		return Entry{}, fmt.Errorf("static allowlist needs exactly one measurements entry, config has %d", len(s.Entries))
+	}
+	e := s.Entries[0]
+	for _, idx := range []int{1, 2, 3} {
+		if len(e.RTMRs[idx]) != DigestSize {
+			return Entry{}, fmt.Errorf("static allowlist entry %q must pin RTMR[%d]", e.Name, idx)
+		}
+	}
+	return e, nil
+}

--- a/pkg/measurements/static_test.go
+++ b/pkg/measurements/static_test.go
@@ -1,0 +1,81 @@
+package measurements
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+func staticFixture() (runtimemeasure.ImagePins, [runtimemeasure.Size]byte) {
+	var pins runtimemeasure.ImagePins
+	var rtmr3 [runtimemeasure.Size]byte
+	for i := range runtimemeasure.Size {
+		pins.MRTD[i], pins.RTMR1[i], pins.RTMR2[i], rtmr3[i] = 0xa1, 0xb2, 0xc3, 0xd4
+	}
+	return pins, rtmr3
+}
+
+// The static entry must survive the file format: what install writes is what
+// CDS loads, register for register.
+func TestStaticReferenceValuesRoundTrip(t *testing.T) {
+	pins, rtmr3 := staticFixture()
+	set := StaticReferenceValues(pins, rtmr3)
+
+	doc, err := Format(set)
+	if err != nil {
+		t.Fatalf("Format: %v", err)
+	}
+	parsed, err := Parse(doc)
+	if err != nil {
+		t.Fatalf("Parse(Format(static)) = %v, want nil\n%s", err, doc)
+	}
+	entry, err := parsed.StaticEntry()
+	if err != nil {
+		t.Fatalf("StaticEntry() = %v, want nil", err)
+	}
+	if entry.Name != StaticEntryName {
+		t.Errorf("Name = %q, want %q", entry.Name, StaticEntryName)
+	}
+	if !bytes.Equal(entry.Digest, pins.MRTD[:]) {
+		t.Errorf("Digest = %x, want MRTD %x", entry.Digest, pins.MRTD)
+	}
+	for idx, want := range map[int][]byte{1: pins.RTMR1[:], 2: pins.RTMR2[:], 3: rtmr3[:]} {
+		if !bytes.Equal(entry.RTMRs[idx], want) {
+			t.Errorf("RTMRs[%d] = %x, want %x", idx, entry.RTMRs[idx], want)
+		}
+	}
+	if _, ok := entry.RTMRs[0]; ok {
+		t.Error("RTMRs[0] pinned; it varies with the VM shape and must stay unpinned")
+	}
+}
+
+func TestStaticEntryRejectsLooserSets(t *testing.T) {
+	pins, rtmr3 := staticFixture()
+	complete := StaticReferenceValues(pins, rtmr3)
+	without := func(idx int) ReferenceValues {
+		s := StaticReferenceValues(pins, rtmr3)
+		delete(s.Entries[0].RTMRs, idx)
+		return s
+	}
+	for _, tc := range []struct {
+		name string
+		set  ReferenceValues
+		want string
+	}{
+		{"snp", ReferenceValues{TEE: TEESNP, Entries: complete.Entries}, `needs tee "tdx"`},
+		{"empty", ReferenceValues{TEE: TEETDX}, "exactly one measurements entry"},
+		{"two entries", ReferenceValues{TEE: TEETDX, Entries: append(complete.Entries, complete.Entries[0])}, "exactly one measurements entry"},
+		{"no rtmr1", without(1), "must pin RTMR[1]"},
+		{"no rtmr2", without(2), "must pin RTMR[2]"},
+		{"no rtmr3", without(3), "must pin RTMR[3]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.set.StaticEntry()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("StaticEntry(%s) = %v, want error containing %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/policybundle/bundle.go
+++ b/pkg/policybundle/bundle.go
@@ -68,7 +68,7 @@ func Load(path string) (Bundle, error) {
 		if !info.Mode().IsRegular() {
 			return Bundle{}, fmt.Errorf("policy bundle: %s is not a regular file", path)
 		}
-		data, err := readMember(path)
+		data, err := ReadMember(path)
 		if err != nil {
 			return Bundle{}, err
 		}
@@ -91,7 +91,7 @@ func Load(path string) (Bundle, error) {
 		if !e.Type().IsRegular() {
 			return Bundle{}, fmt.Errorf("policy bundle: %s is not a regular file", member)
 		}
-		data, err := readMember(member)
+		data, err := ReadMember(member)
 		if err != nil {
 			return Bundle{}, err
 		}
@@ -100,10 +100,11 @@ func Load(path string) (Bundle, error) {
 	return FromMembers(members)
 }
 
-// readMember bounds the read itself, not a Stat size, so a file that grows
-// after Stat or a node whose Stat size is not its content is still refused
-// past MaxMemberSize instead of buffered.
-func readMember(path string) ([]byte, error) {
+// ReadMember reads one member file. The bound applies to the read itself,
+// not a Stat size, so a file that grows after Stat or a node whose Stat
+// size is not its content is still refused past MaxMemberSize instead of
+// buffered. The node's measurer reads the policydata disk through it.
+func ReadMember(path string) ([]byte, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("policy bundle: %w", err)

--- a/pkg/policybundle/bundle.go
+++ b/pkg/policybundle/bundle.go
@@ -1,0 +1,173 @@
+// Package policybundle loads and indexes a policy bundle: the flat set of
+// JSON documents a static-allowlist node boots with (the policydata disk).
+// The bundle's index — one "sha256:<hex>" per member over its raw bytes — is
+// what the node measures into RTMR[3] (runtimemeasure.ForStaticAllowlist),
+// so the node, the installer and every verifier recompute it through this
+// package. The index digests the member bytes exactly as attached: a member
+// that differs by one byte is a different bundle.
+package policybundle
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"maps"
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+)
+
+// MemberStaticAllowlist is the one required member: the sealed
+// c8s.allowlist/v1 document the node enforces.
+const MemberStaticAllowlist = "static-allowlist.json"
+
+// Bounds the node's measurer enforces when it reads the bundle off an
+// untrusted disk; Load and FromMembers apply the same bounds so a bundle the
+// client accepts is one the node accepts.
+const (
+	MaxMembers    = 64
+	MaxMemberSize = 8 << 20
+)
+
+// knownMembers lists every member name a consumer exists for. An unknown
+// name is refused rather than measured: a member nothing reads would still
+// change RTMR[3], and a reviewer cannot review what nothing enforces.
+var knownMembers = map[string]bool{
+	MemberStaticAllowlist: true,
+}
+
+var memberNameRe = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+// Bundle is a validated policy bundle. Members holds the raw bytes of every
+// member, keyed by name, exactly as attached to the node.
+type Bundle struct {
+	Members map[string][]byte
+}
+
+// Load reads a bundle from a directory (every regular file is a member, no
+// subdirectories) or from a single file, which becomes the one member
+// MemberStaticAllowlist whatever its basename. An ISO image is refused: no
+// ISO9660 reader exists here, so pass the directory the image was built
+// from.
+func Load(path string) (Bundle, error) {
+	if strings.EqualFold(filepath.Ext(path), ".iso") {
+		return Bundle{}, fmt.Errorf("%s: ISO images cannot be read here; pass the directory the image was built from (or the static-allowlist.json alone)", path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("policy bundle: %w", err)
+	}
+	if !info.IsDir() {
+		if !info.Mode().IsRegular() {
+			return Bundle{}, fmt.Errorf("policy bundle: %s is not a regular file", path)
+		}
+		data, err := readMember(path)
+		if err != nil {
+			return Bundle{}, err
+		}
+		return FromMembers(map[string][]byte{MemberStaticAllowlist: data})
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("policy bundle: %w", err)
+	}
+	if len(entries) > MaxMembers {
+		return Bundle{}, fmt.Errorf("policy bundle %s has %d entries, max %d", path, len(entries), MaxMembers)
+	}
+	members := make(map[string][]byte, len(entries))
+	for _, e := range entries {
+		member := filepath.Join(path, e.Name())
+		if e.IsDir() {
+			return Bundle{}, fmt.Errorf("policy bundle: %s is a directory; a bundle is flat", member)
+		}
+		if !e.Type().IsRegular() {
+			return Bundle{}, fmt.Errorf("policy bundle: %s is not a regular file", member)
+		}
+		data, err := readMember(member)
+		if err != nil {
+			return Bundle{}, err
+		}
+		members[e.Name()] = data
+	}
+	return FromMembers(members)
+}
+
+// readMember bounds the read itself, not a Stat size, so a file that grows
+// after Stat or a node whose Stat size is not its content is still refused
+// past MaxMemberSize instead of buffered.
+func readMember(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("policy bundle: %w", err)
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, MaxMemberSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("policy bundle: read %s: %w", path, err)
+	}
+	if len(data) > MaxMemberSize {
+		return nil, fmt.Errorf("policy bundle member %s is over %d bytes", path, MaxMemberSize)
+	}
+	return data, nil
+}
+
+// FromMembers validates an in-memory member set: MemberStaticAllowlist
+// present, every name well-formed and known, every member within
+// MaxMemberSize, at most MaxMembers. The returned Bundle owns copies of the
+// input.
+func FromMembers(m map[string][]byte) (Bundle, error) {
+	if len(m) > MaxMembers {
+		return Bundle{}, fmt.Errorf("policy bundle has %d members, max %d", len(m), MaxMembers)
+	}
+	if _, ok := m[MemberStaticAllowlist]; !ok {
+		return Bundle{}, fmt.Errorf("policy bundle has no %s member", MemberStaticAllowlist)
+	}
+	members := make(map[string][]byte, len(m))
+	for _, name := range slices.Sorted(maps.Keys(m)) {
+		if !memberNameRe.MatchString(name) {
+			return Bundle{}, fmt.Errorf("policy bundle member name %q is invalid: want %s", name, memberNameRe)
+		}
+		if !knownMembers[name] {
+			return Bundle{}, fmt.Errorf("policy bundle member %q is unknown: no consumer exists for it (known: %s)", name, strings.Join(slices.Sorted(maps.Keys(knownMembers)), ", "))
+		}
+		if len(m[name]) > MaxMemberSize {
+			return Bundle{}, fmt.Errorf("policy bundle member %s is %d bytes, max %d", name, len(m[name]), MaxMemberSize)
+		}
+		members[name] = bytes.Clone(m[name])
+	}
+	return Bundle{Members: members}, nil
+}
+
+// Index returns the canonical index document the node measures: the
+// encoding/json form of map[string]string{name: "sha256:<hex>"} — keys
+// sorted, no whitespace — over the raw bytes of every member.
+func (b Bundle) Index() []byte {
+	index := make(map[string]string, len(b.Members))
+	for name, data := range b.Members {
+		sum := sha256.Sum256(data)
+		index[name] = "sha256:" + hex.EncodeToString(sum[:])
+	}
+	// A map[string]string always marshals: no error can occur here.
+	out, _ := json.Marshal(index)
+	return out
+}
+
+// IndexDigest is SHA-256 of Index(): the value the node writes to
+// <policy-dir>/digest and `c8s policy-disk` prints.
+func (b Bundle) IndexDigest() [32]byte {
+	return sha256.Sum256(b.Index())
+}
+
+// RTMR3 is the register a node sealed to this bundle reports:
+// runtimemeasure.ForStaticAllowlist(Index()).
+func (b Bundle) RTMR3() [runtimemeasure.Size]byte {
+	return runtimemeasure.ForStaticAllowlist(b.Index())
+}

--- a/pkg/policybundle/bundle_test.go
+++ b/pkg/policybundle/bundle_test.go
@@ -1,0 +1,290 @@
+package policybundle
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
+	"golang.org/x/sys/unix"
+)
+
+// goldenMember is a minimal member whose index bytes are frozen below. A
+// change to the index encoding changes RTMR[3] on every static node, so a
+// failure here is a contract break, not a test to update.
+var goldenMember = []byte("{}\n")
+
+const (
+	goldenIndex       = `{"static-allowlist.json":"sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356"}`
+	goldenIndexDigest = "c2ac7a5e7197eb736507b69fffc9d1f5e24ebf38f709a3226a6f8bb10ffa8749"
+	goldenRTMR3       = "2e2286ab174b1ef0777157d810ac762c4c1915524e113a467b651cbaea41b89e1ac80388fabae89f8108c66e3685ae1e"
+)
+
+func mustBundle(t *testing.T, m map[string][]byte) Bundle {
+	t.Helper()
+	b, err := FromMembers(m)
+	if err != nil {
+		t.Fatalf("FromMembers(%v): %v", keys(m), err)
+	}
+	return b
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestIndexGolden(t *testing.T) {
+	b := mustBundle(t, map[string][]byte{MemberStaticAllowlist: goldenMember})
+	if got := string(b.Index()); got != goldenIndex {
+		t.Errorf("Index() = %s, want %s", got, goldenIndex)
+	}
+	d := b.IndexDigest()
+	if got := hex.EncodeToString(d[:]); got != goldenIndexDigest {
+		t.Errorf("IndexDigest() = %s, want %s", got, goldenIndexDigest)
+	}
+	r := b.RTMR3()
+	if got := hex.EncodeToString(r[:]); got != goldenRTMR3 {
+		t.Errorf("RTMR3() = %s, want %s", got, goldenRTMR3)
+	}
+}
+
+// Key order and the multi-member layout, frozen with a hand-built Bundle:
+// FromMembers cannot build one today (only one member name is known), yet
+// every static node and verifier depends on the sorted, whitespace-free form.
+func TestIndexGoldenMultiMember(t *testing.T) {
+	b := Bundle{Members: map[string][]byte{
+		"z.json":              []byte("z"),
+		MemberStaticAllowlist: goldenMember,
+		"a.json":              []byte("a"),
+	}}
+	const want = `{"a.json":"sha256:ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb",` +
+		`"static-allowlist.json":"sha256:ca3d163bab055381827226140568f3bef7eaac187cebd76878e0b63e9e442356",` +
+		`"z.json":"sha256:594e519ae499312b29433b7dd8a97ff068defcba9755b6d5d00e84c524d67b06"}`
+	if got := string(b.Index()); got != want {
+		t.Errorf("Index() = %s, want %s", got, want)
+	}
+}
+
+// The index is derived from Index() alone, so the three accessors cannot
+// disagree.
+func TestIndexDerivations(t *testing.T) {
+	b := mustBundle(t, map[string][]byte{MemberStaticAllowlist: []byte(`{"apiVersion":"c8s.allowlist/v1"}`)})
+	index := b.Index()
+	if want := sha256.Sum256(index); b.IndexDigest() != want {
+		t.Errorf("IndexDigest() = %x, want sha256(Index()) = %x", b.IndexDigest(), want)
+	}
+	if want := runtimemeasure.ForStaticAllowlist(index); b.RTMR3() != want {
+		t.Errorf("RTMR3() = %x, want ForStaticAllowlist(Index()) = %x", b.RTMR3(), want)
+	}
+}
+
+// The index digests the raw bytes: whitespace-only differences in a member
+// are different bundles, because the node enforces the bytes it measured.
+func TestIndexIsOverRawBytes(t *testing.T) {
+	a := mustBundle(t, map[string][]byte{MemberStaticAllowlist: []byte("{}")})
+	b := mustBundle(t, map[string][]byte{MemberStaticAllowlist: []byte("{ }")})
+	if bytes.Equal(a.Index(), b.Index()) {
+		t.Error("Index() must differ for members that differ by a byte")
+	}
+	if a.RTMR3() == b.RTMR3() {
+		t.Error("RTMR3() must differ for members that differ by a byte")
+	}
+}
+
+func TestFromMembersOwnsCopies(t *testing.T) {
+	in := map[string][]byte{MemberStaticAllowlist: []byte("{}")}
+	b := mustBundle(t, in)
+	in[MemberStaticAllowlist][0] = '['
+	if got := string(b.Members[MemberStaticAllowlist]); got != "{}" {
+		t.Errorf("Members[%s] = %q after mutating the input, want %q", MemberStaticAllowlist, got, "{}")
+	}
+}
+
+func TestFromMembersErrors(t *testing.T) {
+	ok := []byte("{}")
+	tooMany := make(map[string][]byte, MaxMembers+1)
+	tooMany[MemberStaticAllowlist] = ok
+	for i := 0; len(tooMany) <= MaxMembers; i++ {
+		tooMany["m"+strings.Repeat("x", i)] = ok
+	}
+	for _, tc := range []struct {
+		name string
+		in   map[string][]byte
+		want string
+	}{
+		{"nil", nil, "no static-allowlist.json member"},
+		{"required member missing", map[string][]byte{"routes.json": ok}, "no static-allowlist.json member"},
+		{"unknown member", map[string][]byte{MemberStaticAllowlist: ok, "routes.json": ok}, `member "routes.json" is unknown`},
+		{"name with slash", map[string][]byte{MemberStaticAllowlist: ok, "a/b.json": ok}, `"a/b.json" is invalid`},
+		{"name starting with dot", map[string][]byte{MemberStaticAllowlist: ok, ".hidden": ok}, `".hidden" is invalid`},
+		{"name too long", map[string][]byte{MemberStaticAllowlist: ok, strings.Repeat("a", 129): ok}, "is invalid"},
+		{"empty name", map[string][]byte{MemberStaticAllowlist: ok, "": ok}, `"" is invalid`},
+		{"name with space", map[string][]byte{MemberStaticAllowlist: ok, "a b": ok}, `"a b" is invalid`},
+		{"oversize member", map[string][]byte{MemberStaticAllowlist: make([]byte, MaxMemberSize+1)}, "max 8388608"},
+		{"too many members", tooMany, "max 64"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := FromMembers(tc.in)
+			if err == nil {
+				t.Fatalf("FromMembers(%s) = nil error, want %q", tc.name, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("FromMembers(%s) error = %q, want it to contain %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}
+
+// The name rule at its boundaries. Only one member name is known today, so
+// the rule is tested directly: an unknown but well-formed name must fail on
+// the known-set check, not the name check.
+func TestMemberNameRule(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ok   bool
+	}{
+		{MemberStaticAllowlist, true},
+		{"a", true},
+		{"A1_b-c.d", true},
+		{strings.Repeat("a", 128), true},
+		{strings.Repeat("a", 129), false},
+		{"", false},
+		{".hidden", false},
+		{"-dash", false},
+		{"_under", false},
+		{"a/b", false},
+		{"a b", false},
+		{"ü.json", false},
+	} {
+		if got := memberNameRe.MatchString(tc.name); got != tc.ok {
+			t.Errorf("memberNameRe.MatchString(%q) = %v, want %v", tc.name, got, tc.ok)
+		}
+	}
+	_, err := FromMembers(map[string][]byte{MemberStaticAllowlist: []byte("{}"), "routes.json": []byte("{}")})
+	if err == nil || !strings.Contains(err.Error(), "is unknown") {
+		t.Errorf("FromMembers with a well-formed unknown name: err = %v, want an unknown-member error", err)
+	}
+}
+
+func TestFromMembersAcceptsMaxMemberSize(t *testing.T) {
+	b := mustBundle(t, map[string][]byte{MemberStaticAllowlist: make([]byte, MaxMemberSize)})
+	if got := len(b.Members[MemberStaticAllowlist]); got != MaxMemberSize {
+		t.Errorf("len(Members[%s]) = %d, want %d", MemberStaticAllowlist, got, MaxMemberSize)
+	}
+}
+
+func writeFile(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, MemberStaticAllowlist), goldenMember)
+	b, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load(dir): %v", err)
+	}
+	if got := string(b.Index()); got != goldenIndex {
+		t.Errorf("Load(dir).Index() = %s, want %s", got, goldenIndex)
+	}
+}
+
+// A lone file is a one-member bundle named MemberStaticAllowlist, whatever
+// its basename, so `verify --static-allowlist ./my-policy.json` works.
+func TestLoadSingleFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "my-policy.json")
+	writeFile(t, path, goldenMember)
+	b, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load(file): %v", err)
+	}
+	if got := string(b.Index()); got != goldenIndex {
+		t.Errorf("Load(file).Index() = %s, want %s", got, goldenIndex)
+	}
+	if _, ok := b.Members[MemberStaticAllowlist]; !ok || len(b.Members) != 1 {
+		t.Errorf("Load(file).Members = %v, want exactly [%s]", keys(b.Members), MemberStaticAllowlist)
+	}
+}
+
+func TestLoadErrors(t *testing.T) {
+	root := t.TempDir()
+	mk := func(name string, stage func(dir string)) string {
+		dir := filepath.Join(root, name)
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(dir, MemberStaticAllowlist), goldenMember)
+		stage(dir)
+		return dir
+	}
+	withSubdir := mk("subdir", func(dir string) {
+		if err := os.Mkdir(filepath.Join(dir, "nested"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	})
+	withSymlink := mk("symlink", func(dir string) {
+		if err := os.Symlink(filepath.Join(dir, MemberStaticAllowlist), filepath.Join(dir, "link.json")); err != nil {
+			t.Fatal(err)
+		}
+	})
+	withUnknown := mk("unknown", func(dir string) { writeFile(t, filepath.Join(dir, "routes.json"), []byte("{}")) })
+	withOversize := mk("oversize", func(dir string) {
+		writeFile(t, filepath.Join(dir, MemberStaticAllowlist), make([]byte, MaxMemberSize+1))
+	})
+	withTooMany := mk("toomany", func(dir string) {
+		for i := range MaxMembers {
+			writeFile(t, filepath.Join(dir, "m"+strings.Repeat("x", i)), []byte("{}"))
+		}
+	})
+	empty := mk("empty", func(dir string) { os.Remove(filepath.Join(dir, MemberStaticAllowlist)) })
+	iso := filepath.Join(root, "policydata.iso")
+	writeFile(t, iso, []byte("not really an iso"))
+	oversizeFile := filepath.Join(root, "big.json")
+	writeFile(t, oversizeFile, make([]byte, MaxMemberSize+1))
+	// A FIFO has Stat size 0 and never reaches EOF: Load must refuse it from
+	// the mode alone, before any read that would block.
+	fifo := filepath.Join(root, "policy.fifo")
+	if err := unix.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		path string
+		want string
+	}{
+		{"iso refused", iso, "ISO images cannot be read here"},
+		{"iso refused even when absent", filepath.Join(root, "missing.ISO"), "ISO images cannot be read here"},
+		{"missing path", filepath.Join(root, "absent"), "no such file"},
+		{"subdirectory", withSubdir, "is a directory; a bundle is flat"},
+		{"symlink member", withSymlink, "is not a regular file"},
+		{"unknown member", withUnknown, `"routes.json" is unknown`},
+		{"oversize member", withOversize, "over 8388608 bytes"},
+		{"too many entries", withTooMany, "max 64"},
+		{"required member missing", empty, "no static-allowlist.json member"},
+		{"oversize single file", oversizeFile, "over 8388608 bytes"},
+		{"fifo single file", fifo, "is not a regular file"},
+		{"device node single file", "/dev/zero", "is not a regular file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Load(tc.path)
+			if err == nil {
+				t.Fatalf("Load(%s) = nil error, want %q", tc.name, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Load(%s) error = %q, want it to contain %q", tc.name, err, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/policybundle/state.go
+++ b/pkg/policybundle/state.go
@@ -1,0 +1,98 @@
+package policybundle
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Node-side paths. c8s-policy-measure writes the policy directory once per
+// boot; cred-release, the NRI plugin and CDS read it through ReadDir.
+const (
+	// NodeStateDir is the tmpfs the measured image keeps its boot state in:
+	// the policy directory and the attestation-api unix socket. Binds from
+	// it classify as allowlist.SourceNodeState.
+	NodeStateDir = "/run/confai"
+	// DefaultPolicyDir holds ModeFile (always), DigestFile and one file per
+	// bundle member (static boots only).
+	DefaultPolicyDir = NodeStateDir + "/policy"
+
+	// ModeFile holds StaticMode or DynamicMode plus a newline; the measurer
+	// writes it last, so a reader that finds it finds every other file too.
+	ModeFile = "mode"
+	// DigestFile holds the lowercase hex of the bundle's IndexDigest.
+	DigestFile = "digest"
+
+	// StaticMode and DynamicMode are the two values ModeFile carries.
+	StaticMode  = "static"
+	DynamicMode = "dynamic"
+)
+
+// State is what a consumer reads back from the policy directory.
+type State struct {
+	// Mode is StaticMode or DynamicMode.
+	Mode string
+	// Bundle is the attached bundle, re-indexed from the member files;
+	// ReadDir checked its IndexDigest against DigestFile. Zero on a dynamic
+	// boot.
+	Bundle Bundle
+}
+
+// ReadDir loads the measurer's output from dir. A missing or unknown mode
+// is an error, never a default: a consumer that starts without the
+// measurer's verdict must not guess one. On a static boot every other
+// regular file is a member, read under the Load bounds, and the members'
+// index digest must equal DigestFile, so a member rewritten after the
+// measurement is refused before any register comparison.
+func ReadDir(dir string) (State, error) {
+	raw, err := os.ReadFile(filepath.Join(dir, ModeFile))
+	if err != nil {
+		return State{}, fmt.Errorf("policy mode: %w (did c8s-policy-measure.service run?)", err)
+	}
+	mode := strings.TrimSpace(string(raw))
+	switch mode {
+	case DynamicMode:
+		return State{Mode: mode}, nil
+	case StaticMode:
+	default:
+		return State{}, fmt.Errorf("%s holds %q: the policy mode is neither %s nor %s", filepath.Join(dir, ModeFile), mode, StaticMode, DynamicMode)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return State{}, fmt.Errorf("policy dir: %w", err)
+	}
+	if len(entries) > MaxMembers+2 {
+		return State{}, fmt.Errorf("policy dir %s has %d entries, max %d members", dir, len(entries), MaxMembers)
+	}
+	members := make(map[string][]byte, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if name == ModeFile || name == DigestFile {
+			continue
+		}
+		if !e.Type().IsRegular() {
+			return State{}, fmt.Errorf("policy dir: %s is not a regular file", filepath.Join(dir, name))
+		}
+		data, err := ReadMember(filepath.Join(dir, name))
+		if err != nil {
+			return State{}, err
+		}
+		members[name] = data
+	}
+	bundle, err := FromMembers(members)
+	if err != nil {
+		return State{}, err
+	}
+	recorded, err := os.ReadFile(filepath.Join(dir, DigestFile))
+	if err != nil {
+		return State{}, fmt.Errorf("policy digest: %w", err)
+	}
+	sum := bundle.IndexDigest()
+	if got := strings.TrimSpace(string(recorded)); got != hex.EncodeToString(sum[:]) {
+		return State{}, fmt.Errorf("policy dir %s: members index to %x, %s says %s", dir, sum, DigestFile, got)
+	}
+	return State{Mode: mode, Bundle: bundle}, nil
+}

--- a/pkg/policybundle/state.go
+++ b/pkg/policybundle/state.go
@@ -28,6 +28,13 @@ const (
 	// StaticMode and DynamicMode are the two values ModeFile carries.
 	StaticMode  = "static"
 	DynamicMode = "dynamic"
+
+	// OperatorPubkeyPath is where the measured initrd stages the operator
+	// public key it read off the opkeydata disk and hashed into RTMR[3] on a
+	// dynamic boot. The initrd is the single measured reader of that disk;
+	// c8s-policy-measure, cred-release and the NRI plugin read the staged
+	// file.
+	OperatorPubkeyPath = "/etc/confai/operator-pubkey"
 )
 
 // State is what a consumer reads back from the policy directory.

--- a/pkg/policybundle/state_test.go
+++ b/pkg/policybundle/state_test.go
@@ -1,0 +1,89 @@
+package policybundle
+
+import (
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadDir(t *testing.T) {
+	doc := []byte(`{"schema":"c8s.allowlist/v1","digests":{},"workloads":{}}`)
+	bundle := mustBundle(t, map[string][]byte{MemberStaticAllowlist: doc})
+	sum := bundle.IndexDigest()
+	digest := hex.EncodeToString(sum[:])
+	static := func(extra map[string][]byte) map[string][]byte {
+		files := map[string][]byte{ModeFile: []byte("static\n"), DigestFile: []byte(digest), MemberStaticAllowlist: doc}
+		for name, data := range extra {
+			files[name] = data
+		}
+		return files
+	}
+	for _, tc := range []struct {
+		name     string
+		files    map[string][]byte
+		wantMode string
+		wantErr  string
+	}{
+		{"dynamic", map[string][]byte{ModeFile: []byte("dynamic\n")}, DynamicMode, ""},
+		{"dynamic without newline", map[string][]byte{ModeFile: []byte("dynamic")}, DynamicMode, ""},
+		{"static", static(nil), StaticMode, ""},
+		{"static with a newline after the digest", static(map[string][]byte{DigestFile: []byte(digest + "\n")}), StaticMode, ""},
+		{"mode missing", map[string][]byte{}, "", "did c8s-policy-measure.service run"},
+		{"mode unknown", map[string][]byte{ModeFile: []byte("sealed\n")}, "", `holds "sealed"`},
+		{"mode empty", map[string][]byte{ModeFile: []byte("")}, "", `holds ""`},
+		{"static without members", map[string][]byte{ModeFile: []byte("static\n"), DigestFile: []byte(digest)}, "", "no static-allowlist.json member"},
+		{"static without digest", map[string][]byte{ModeFile: []byte("static\n"), MemberStaticAllowlist: doc}, "", "policy digest"},
+		{"digest rewritten", static(map[string][]byte{DigestFile: []byte(strings.Repeat("0", 64))}), "", "members index to"},
+		{"member rewritten after measurement", static(map[string][]byte{MemberStaticAllowlist: append(doc, ' ')}), "", "members index to"},
+		{"unknown member added", static(map[string][]byte{"extra.json": []byte("{}")}), "", `member "extra.json" is unknown`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for name, data := range tc.files {
+				writeFile(t, filepath.Join(dir, name), data)
+			}
+			state, err := ReadDir(dir)
+			if tc.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("ReadDir(%s) = %v, want error containing %q", tc.name, err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ReadDir(%s) = %v, want nil", tc.name, err)
+			}
+			if state.Mode != tc.wantMode {
+				t.Errorf("ReadDir(%s).Mode = %q, want %q", tc.name, state.Mode, tc.wantMode)
+			}
+			if tc.wantMode == DynamicMode {
+				if state.Bundle.Members != nil {
+					t.Errorf("ReadDir(%s) = %+v, want no bundle on a dynamic boot", tc.name, state)
+				}
+				return
+			}
+			if state.Bundle.IndexDigest() != sum || state.Bundle.RTMR3() != bundle.RTMR3() {
+				t.Errorf("ReadDir(%s) = digest %x, RTMR3 %x; want %s and the measured bundle's register", tc.name, state.Bundle.IndexDigest(), state.Bundle.RTMR3(), digest)
+			}
+		})
+	}
+	t.Run("non-regular entry", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ModeFile), []byte("static\n"))
+		if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := ReadDir(dir); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+			t.Fatalf("ReadDir(subdir) = %v, want not-a-regular-file error", err)
+		}
+	})
+	t.Run("oversized member", func(t *testing.T) {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, ModeFile), []byte("static\n"))
+		writeFile(t, filepath.Join(dir, MemberStaticAllowlist), make([]byte, MaxMemberSize+1))
+		if _, err := ReadDir(dir); err == nil || !strings.Contains(err.Error(), "over") {
+			t.Fatalf("ReadDir(oversized) = %v, want a size error", err)
+		}
+	})
+}

--- a/pkg/ratls/owntuple.go
+++ b/pkg/ratls/owntuple.go
@@ -1,0 +1,23 @@
+package ratls
+
+import (
+	"context"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/measurements"
+)
+
+// OwnTuplePins holds a peer to this node's own image tuple {MRTD, RTMR1,
+// RTMR2, RTMR3}, read from a fresh quote through client.OwnTupleEntry under
+// attestationclient.OwnTupleTimeout. A sealed node's argv carries no
+// per-cluster digest, and the tuple includes RTMR[3], so a peer on an
+// unsealed node of the same image is refused.
+func OwnTuplePins(ctx context.Context, client attestationclient.Client) (Pins, error) {
+	ctx, cancel := context.WithTimeout(ctx, attestationclient.OwnTupleTimeout)
+	defer cancel()
+	entry, err := client.OwnTupleEntry(ctx)
+	if err != nil {
+		return Pins{}, err
+	}
+	return Pins{Entries: []measurements.Entry{entry}}, nil
+}

--- a/pkg/ratls/owntuple_test.go
+++ b/pkg/ratls/owntuple_test.go
@@ -1,0 +1,41 @@
+package ratls
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/internal/testattest"
+	"github.com/confidential-dot-ai/c8s/pkg/attestationclient"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func TestOwnTuplePins(t *testing.T) {
+	reg := func(b byte) string { return strings.Repeat(hex.EncodeToString([]byte{b}), 48) }
+	stub, url := testattest.NewUnix(t)
+	stub.SetPlatform(types.PlatformTdx)
+	stub.SetVerdict(testattest.TDXVerdict(reg(0x11), map[int]string{0: reg(0x00), 1: reg(0x21), 2: reg(0x22), 3: reg(0x33)}))
+
+	pins, err := OwnTuplePins(t.Context(), attestationclient.NewClient(url))
+	if err != nil {
+		t.Fatalf("OwnTuplePins() = %v, want nil", err)
+	}
+	if len(pins.Entries) != 1 || len(pins.Measurements) != 0 || len(pins.RTMRs) != 0 {
+		t.Fatalf("OwnTuplePins() = %+v, want exactly one entry and no loose pins", pins)
+	}
+	entry := pins.Entries[0]
+	if hex.EncodeToString(entry.Digest) != reg(0x11) || len(entry.RTMRs) != 3 || !bytes.Equal(entry.RTMRs[3], bytes.Repeat([]byte{0x33}, 48)) {
+		t.Fatalf("OwnTuplePins() entry = digest %x, %d RTMRs; want MRTD %s and RTMR[1..3]", entry.Digest, len(entry.RTMRs), reg(0x11))
+	}
+
+	// The round trip runs under the caller's context: a cancelled caller is
+	// not held to OwnTupleTimeout.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if _, err := OwnTuplePins(ctx, attestationclient.NewClient(url)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("OwnTuplePins(cancelled) = %v, want %v", err, context.Canceled)
+	}
+}

--- a/pkg/runtimemeasure/runtimemeasure.go
+++ b/pkg/runtimemeasure/runtimemeasure.go
@@ -1,37 +1,47 @@
 // Package runtimemeasure pins the c8s conventions for runtime measurement:
 // what a guest extends into its runtime measurement register after launch,
 // and in what order. It is the single source of truth shared by the in-guest
-// measurer, the guest initrd's operator-key binding, and any verifier that
-// recomputes the expected register value — every side MUST build on this
-// package so the conventions cannot drift.
+// measurer, the guest initrd's operator-key binding, the node's policy
+// measurer, and any verifier that recomputes the expected register value —
+// every side MUST build on this package so the conventions cannot drift.
 //
 // Runtime measurement is the counterpart to launch measurement. A launch
 // measurement (MRTD on Intel TDX, the launch digest on AMD SEV-SNP) covers
 // what booted and is fixed at launch. A runtime measurement register is
 // hardware-append-only and records what happened afterwards, so it can carry
 // identity a launch measurement cannot: which key the node was launched to
-// trust, and which workloads it admitted.
+// trust, which mode the node runs in, and which workloads it admitted.
 //
-// c8s extends two distinct kinds of value, in this order:
+// A node's register takes one of two shapes, selected by an explicit mode
+// event that the measured node image extends before containerd starts:
 //
-//   - the operator-key seed, written once by the measured initrd before
-//     switch_root (ForOperatorKey), then
-//   - zero or more per-workload image extends chained on top (Event).
+//   - dynamic: [operator-key seed] → ModeDynamic → [workload extends]. The
+//     seed is written once by the measured initrd before switch_root
+//     (ForOperatorKey) and is absent (the register stays Zero) on a node
+//     launched without an operator key. ForDynamic(seed) is the register after
+//     the mode event; per-workload image extends (Event) chain on top.
+//   - static: Zero → ModeStatic → PolicyEvent(index). There is no operator-key
+//     seed and no workload extend: the register commits the policy bundle the
+//     node booted with (ForStaticAllowlist) and nothing else.
 //
-// A verifier cannot interpret the register without knowing the seed, so a
-// node launched with an operator key must be verified with
-// FromDigestsSeeded(ForOperatorKey(pub), …) rather than FromDigests.
+// The mode event is what keeps the two shapes apart: without it a dynamic
+// node, where cluster-admin is node root, could extend the static events
+// itself and pass a static verifier. A verifier cannot interpret the register
+// without knowing the shape, so a dynamic node launched with an operator key
+// must be verified with FromDigestsSeeded(ForDynamic(ForOperatorKey(pub)), …)
+// rather than FromDigests.
 //
 // This package is deliberately vendor-neutral: it is arithmetic over digests
 // and says nothing about where the register lives. The register-backed
 // convention above runs on Intel TDX RTMR[3]. SEV-SNP has no runtime-extend
 // register, so on SNP only the operator-key half of the convention exists:
 // the launcher commits the key digest into the report's immutable HOSTDATA
-// field at launch (HostDataForOperatorKey), and per-workload extends do not
-// exist — FromDigestsSeeded/Event remain TDX-only. The code that reads or
-// writes the TDX register is TDX-specific (internal/cmds/rtmr3measurer,
-// credrelease, the guest initrd) while the convention it implements is not.
-// See docs/kata-guest-base.md "Per-workload RTMR[3] measurement".
+// field at launch (HostDataForOperatorKey), and mode events and per-workload
+// extends do not exist — FromDigestsSeeded/Event/ForDynamic/ForStaticAllowlist
+// remain TDX-only. The code that reads or writes the TDX register is
+// TDX-specific (internal/tdxrtmr and its callers, the guest initrd) while the
+// convention it implements is not. See docs/kata-guest-base.md "Per-workload
+// RTMR[3] measurement".
 package runtimemeasure
 
 import (
@@ -76,9 +86,10 @@ func FromDigests(canonicalDigests []string) [Size]byte {
 }
 
 // FromDigestsSeeded is FromDigests starting from an arbitrary register
-// value, so per-workload extends can chain onto an operator-key seed:
+// value, so per-workload extends can chain onto the dynamic-mode register of
+// an operator-key-bound node:
 //
-//	FromDigestsSeeded(ForOperatorKey(pub), digests)
+//	FromDigestsSeeded(ForDynamic(ForOperatorKey(pub)), digests)
 func FromDigestsSeeded(seed [Size]byte, canonicalDigests []string) [Size]byte {
 	reg := seed
 	for _, d := range canonicalDigests {
@@ -87,16 +98,17 @@ func FromDigestsSeeded(seed [Size]byte, canonicalDigests []string) [Size]byte {
 	return reg
 }
 
-// ForOperatorKey computes the register value as it reads back on a node
-// launched with an operator key and no per-workload extends:
+// ForOperatorKey computes the operator-key seed: the register value as it
+// reads back at switch_root on a node launched with an operator key, before
+// the node image extends the mode event:
 //
 //	reg = SHA384( 0x00*48 ‖ SHA384(pubkey) )
 //
 // The guest initrd hashes the operator public key off the opkeydata disk and
 // extends that digest into the register before switch_root, so the operator
-// can verify offline that the node trusts only their key. cred-release
-// re-derives the same value to confirm the staged on-disk pubkey is the
-// measured one.
+// can verify offline that the node trusts only their key. The node image then
+// extends ModeDynamic (see ForDynamic); cred-release and every verifier
+// compare against that chained value, never the bare seed.
 //
 // pubkey is the EXACT bytes the initrd hashed — the pubkey file verbatim, as
 // written by `openssl ec -pubout` (PKIX PEM text, armor and trailing newline
@@ -105,6 +117,55 @@ func FromDigestsSeeded(seed [Size]byte, canonicalDigests []string) [Size]byte {
 // through unmodified rather than round-tripping through a PEM parser.
 func ForOperatorKey(pubkey []byte) [Size]byte {
 	return Extend(Zero, sha512.Sum384(pubkey))
+}
+
+// Mode events. Each is the SHA-384 of a fixed ASCII label (not Event, which
+// takes a canonical image digest), so a label collision with an image digest
+// or a policy event is impossible: the label namespaces are disjoint.
+var (
+	// ModeStatic is the event a static-allowlist node extends first. Label:
+	// "c8s/rtmr3/mode/static/v1".
+	ModeStatic = sha512.Sum384([]byte("c8s/rtmr3/mode/static/v1"))
+	// ModeDynamic is the event a dynamic node extends on top of the
+	// operator-key seed (or Zero). Label: "c8s/rtmr3/mode/dynamic/v1".
+	ModeDynamic = sha512.Sum384([]byte("c8s/rtmr3/mode/dynamic/v1"))
+)
+
+// policyEventPrefix namespaces the policy event so its preimage can never be
+// a mode label or an image digest string.
+const policyEventPrefix = "c8s/rtmr3/policy/v1:"
+
+// PolicyEvent maps a policy-bundle index to its measurement event:
+// SHA384("c8s/rtmr3/policy/v1:" ‖ index). index is the bundle's canonical
+// index document — the bytes pkg/policybundle Bundle.Index returns:
+// encoding/json of map[string]string{name: "sha256:<hex>"} (keys sorted, no
+// whitespace) — and is hashed verbatim.
+func PolicyEvent(index []byte) [Size]byte {
+	h := sha512.New384()
+	h.Write([]byte(policyEventPrefix))
+	h.Write(index)
+	var out [Size]byte
+	copy(out[:], h.Sum(nil))
+	return out
+}
+
+// ForStaticAllowlist computes the register of a static-allowlist node:
+//
+//	reg = Extend(Extend(Zero, ModeStatic), PolicyEvent(index))
+//
+// A static node has no operator-key seed and runs no workload measurer, so
+// the register equals this value for the life of the guest.
+func ForStaticAllowlist(index []byte) [Size]byte {
+	return Extend(Extend(Zero, ModeStatic), PolicyEvent(index))
+}
+
+// ForDynamic computes the register of a dynamic node after the node image
+// extends the mode event: Extend(seed, ModeDynamic). seed is
+// ForOperatorKey(pub) on a node launched with an operator key and Zero
+// otherwise. Per-workload extends, where a measurer runs, chain on top via
+// FromDigestsSeeded.
+func ForDynamic(seed [Size]byte) [Size]byte {
+	return Extend(seed, ModeDynamic)
 }
 
 // HostDataSize is the byte length of the SNP HOSTDATA field, and so of the

--- a/pkg/runtimemeasure/runtimemeasure_test.go
+++ b/pkg/runtimemeasure/runtimemeasure_test.go
@@ -20,9 +20,19 @@ Ln7t8a7OvDkCwGUhGYtOC2MGQ08BTMRqi2Q306MP5Xh9TnKAf0I/5QOglA==
 -----END PUBLIC KEY-----
 `
 
+// testPolicyIndex is a fixed one-member bundle index in the exact bytes
+// pkg/policybundle Bundle.Index emits.
+const testPolicyIndex = `{"static-allowlist.json":"` + digestA + `"}`
+
 // Golden vectors pin the convention. If any of these change, the measurer
 // and every verifier disagree on RTMR[3] — treat a failure here as a
 // breaking change to the attestation contract, not a test to update.
+//
+// The mode and policy vectors (ModeStatic, ModeDynamic, PolicyEvent,
+// ForStaticAllowlist, ForDynamic) are convention-only: they freeze the
+// arithmetic this package defines but have not yet been read back from a TDX
+// register the node image extended. Only the ForOperatorKey vector is
+// hardware-confirmed.
 func TestConventionGoldenVectors(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -42,6 +52,21 @@ func TestConventionGoldenVectors(t *testing.T) {
 		{"FromDigestsSeeded(ForOperatorKey(testPEM),[A,B])",
 			FromDigestsSeeded(ForOperatorKey([]byte(testOperatorPubPEM)), []string{digestA, digestB}),
 			"ed90ff0e91dd3dd4304808ca32436d0cd6db768381ca0c7e20b1ff375b3e15d8515f3ca97009d73a253a4266386c6a14"},
+		{"ModeStatic", ModeStatic,
+			"12813c78721a5788b78367c000aa545f1ad0fae5e6e4a395667bc58107650dcb29ef16a5924fe4742e5ffd025f6b3922"},
+		{"ModeDynamic", ModeDynamic,
+			"68e13aefc7235604c7ef71cea8ec756ac8ee7cd51bdc6af94fec37e1630c27c779da2b83f7cccadd844b4a47cef1f0bc"},
+		{"PolicyEvent(index)", PolicyEvent([]byte(testPolicyIndex)),
+			"50b4872872e3582e7a1e3a148ede580becaa38e87c5f1ce6594797dd32897a09d232aabfa653fa9e466d20cbf5359a15"},
+		{"ForStaticAllowlist(index)", ForStaticAllowlist([]byte(testPolicyIndex)),
+			"b30937601377eb061f127d4c3f33bbc90db1deee88944929981351956ba79674257bb2543a4e440a11c0da3497360d2d"},
+		{"ForDynamic(Zero)", ForDynamic(Zero),
+			"1390f0b7af0b4261547cb9d4354a01d55008a388075bc4770be7eeb3826e4d16829c439dfded8a4935842e1c42c2b78e"},
+		{"ForDynamic(ForOperatorKey(testPEM))", ForDynamic(ForOperatorKey([]byte(testOperatorPubPEM))),
+			"8c4bd74149be7c77487beff0a5f503bdf774eefe9430e8a682f8f9ede15874d6fb810f9e0a35da705a7faedf37a4487d"},
+		{"FromDigestsSeeded(ForDynamic(ForOperatorKey(testPEM)),[A,B])",
+			FromDigestsSeeded(ForDynamic(ForOperatorKey([]byte(testOperatorPubPEM))), []string{digestA, digestB}),
+			"4ef4d0fabc6bb99cf309f3a691a34ee2a0a4e79b1f1dec1ae005b760a1a455113691873c3ba487b08f0be5807281ecc4"},
 	} {
 		if got := hex.EncodeToString(tc.got[:]); got != tc.want {
 			t.Errorf("%s = %s, want %s", tc.name, got, tc.want)
@@ -122,6 +147,67 @@ func TestFromDigestsSeededChainsOntoOperatorKey(t *testing.T) {
 	}
 	if got == FromDigests([]string{digestA}) {
 		t.Error("seeded and unseeded results must differ, else the seed is being ignored")
+	}
+}
+
+// The mode events are plain SHA-384 of their labels, not Event() of them:
+// the label namespaces must stay disjoint from image digests.
+func TestModeEventsAreLabelDigests(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		got   [Size]byte
+		label string
+	}{
+		{"ModeStatic", ModeStatic, "c8s/rtmr3/mode/static/v1"},
+		{"ModeDynamic", ModeDynamic, "c8s/rtmr3/mode/dynamic/v1"},
+	} {
+		if want := sha512.Sum384([]byte(tc.label)); tc.got != want {
+			t.Errorf("%s = %x, want SHA384(%q) = %x", tc.name, tc.got, tc.label, want)
+		}
+	}
+	if ModeStatic == ModeDynamic {
+		t.Error("ModeStatic == ModeDynamic; the two shapes would be indistinguishable")
+	}
+}
+
+// ForStaticAllowlist is exactly two extends from Zero over the mode event and
+// the prefixed index digest, so a verifier can recompute it from the bundle.
+func TestForStaticAllowlistComposition(t *testing.T) {
+	index := []byte(testPolicyIndex)
+	policy := sha512.Sum384(append([]byte("c8s/rtmr3/policy/v1:"), index...))
+	if want := Extend(Extend(Zero, ModeStatic), policy); ForStaticAllowlist(index) != want {
+		t.Errorf("ForStaticAllowlist(index) = %x, want %x", ForStaticAllowlist(index), want)
+	}
+	if PolicyEvent(index) != policy {
+		t.Errorf("PolicyEvent(index) = %x, want %x", PolicyEvent(index), policy)
+	}
+
+	changed := append([]byte(nil), index...)
+	changed[len(changed)-3] ^= 0x01
+	if ForStaticAllowlist(changed) == ForStaticAllowlist(index) {
+		t.Error("a one-byte index change must change ForStaticAllowlist")
+	}
+	if ForStaticAllowlist(index) == ForDynamic(Zero) {
+		t.Error("a static register must never equal a dynamic one")
+	}
+}
+
+// ForDynamic is one extend of the mode event onto the seed, so workload
+// extends chain onto it exactly as they chained onto the bare seed before.
+func TestForDynamicComposition(t *testing.T) {
+	seed := ForOperatorKey([]byte(testOperatorPubPEM))
+	if got, want := ForDynamic(seed), Extend(seed, ModeDynamic); got != want {
+		t.Errorf("ForDynamic(seed) = %x, want %x", got, want)
+	}
+	if ForDynamic(seed) == ForDynamic(Zero) {
+		t.Error("ForDynamic must depend on the seed")
+	}
+	if ForDynamic(seed) == seed {
+		t.Error("ForDynamic must not equal the bare seed; the mode event is load-bearing")
+	}
+	got := FromDigestsSeeded(ForDynamic(seed), []string{digestA})
+	if want := Extend(ForDynamic(seed), Event(digestA)); got != want {
+		t.Errorf("FromDigestsSeeded(ForDynamic(seed), [A]) = %x, want %x", got, want)
 	}
 }
 

--- a/test/e2e/static/build-bundle.sh
+++ b/test/e2e/static/build-bundle.sh
@@ -22,6 +22,12 @@
 # when that pin moves: a stale entry fails step 3 here (entry names carry the
 # tag), a wrong one shows up as a sealed node whose system pods never start.
 #
+# A sealed document has no open argv, env or mounts, privileged or not, so
+# every floor entry in reviews.json needs the env values and mount rules (and
+# the argv, where the static pod manifest overrides the image config) observed
+# on a dynamic node of the same image: the sealed plugin's deny log prints one
+# observation per refused container. A floor entry without them fails step 3.
+#
 # Needs c8s, helm, crane, jq, yq, go and one of xorrisofs, genisoimage or
 # mkisofs on PATH, registry access for the image configs, and:
 #   E2E_IMAGE_MANIFEST  manifest.json of the node image (tdx.mrtd/rtmr1/rtmr2)

--- a/test/e2e/static/build-bundle.sh
+++ b/test/e2e/static/build-bundle.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Builds the policy bundle the static lane boots, from the published image
+# evidence and the fixtures beside this script, and proves the bundle is the
+# fixed point of the install that consumes it:
+#
+#   1. `c8s render-values` computes the dynamic node-mode values install
+#      would apply at E2E_IMAGE_TAG; static-overlay.yaml adds what
+#      `c8s install --static-allowlist` sets on top.
+#   2. `c8s allowlist render --sealed` turns those values, the image's
+#      system-floor.json and workloads/demo-nginx.yaml into rules.
+#   3. complete/ applies reviews.json (the lane's reviewer) and lints.
+#   4. `c8s render-values --static-allowlist <bundle>` is rendered again and
+#      must reproduce the bundle byte for byte, so the values install derives
+#      from the bundle are the values the bundle was rendered from.
+#   5. `c8s policy-disk` writes the ISO, the KubeVirt Secret and the expected
+#      RTMR[3], which is cross-checked against lib.sh's shell arithmetic.
+#
+# REVIEWER'S COMPLETION. system-floor.json only names each RKE2 image and its
+# image-config argv; what the static pods bind, share and run is completed by
+# reviews.json, which cannot be verified on the runner. It is written for the
+# RKE2 bundle pinned in node-guest-image/c8s/mkosi.sync and MUST be refreshed
+# when that pin moves: a stale entry fails step 3 here (entry names carry the
+# tag), a wrong one shows up as a sealed node whose system pods never start.
+#
+# Needs c8s, helm, crane, jq, yq, go and one of xorrisofs, genisoimage or
+# mkisofs on PATH, registry access for the image configs, and:
+#   E2E_IMAGE_MANIFEST  manifest.json of the node image (tdx.mrtd/rtmr1/rtmr2)
+#   E2E_SYSTEM_FLOOR    system-floor.json published beside it
+#   E2E_IMAGE_TAG       component image tag the bundle names (the c8s ref paired with the image)
+#   E2E_OUT             output directory
+# Optional:
+#   E2E_POLICYDATA_SECRET  KubeVirt Secret name to emit (default c8s-policydata)
+#   E2E_C8S_SRC            c8s checkout holding complete/ (default: the one this script is in)
+#
+# Writes under E2E_OUT: bundle/static-allowlist.json (the one-member bundle
+# directory every c8s --static-allowlist flag takes), policydata.iso,
+# policydata-secret.yaml, rtmr3, index-digest, values.yaml and the render
+# report.
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+here=$(cd "$(dirname "$0")" && pwd)
+: "${E2E_IMAGE_MANIFEST:?manifest.json of the node image}"
+: "${E2E_SYSTEM_FLOOR:?system-floor.json of the node image}"
+: "${E2E_IMAGE_TAG:?component image tag}"
+: "${E2E_OUT:?output directory}"
+secret=${E2E_POLICYDATA_SECRET:-c8s-policydata}
+src=${E2E_C8S_SRC:-$(cd "$here/../../.." && pwd)}
+
+for tool in c8s helm crane jq yq go; do
+  command -v "$tool" >/dev/null || fail "$tool is not on PATH"
+done
+command -v xorrisofs >/dev/null || command -v genisoimage >/dev/null || command -v mkisofs >/dev/null \
+  || fail "no ISO9660 tool on PATH (xorrisofs, genisoimage or mkisofs)"
+
+mkdir -p "$E2E_OUT/bundle"
+mrtd=$(jq -r '.tdx.mrtd // empty' "$E2E_IMAGE_MANIFEST")
+rtmr1=$(jq -r '.tdx.rtmr1 // empty' "$E2E_IMAGE_MANIFEST")
+rtmr2=$(jq -r '.tdx.rtmr2 // empty' "$E2E_IMAGE_MANIFEST")
+[ -n "$mrtd" ] && [ -n "$rtmr1" ] && [ -n "$rtmr2" ] || fail "$E2E_IMAGE_MANIFEST carries no TDX tuple"
+
+# render-values takes the same flags install does, minus the cluster.
+values_flags=(--cvm-mode node --hardware-platform tdx --single-node --distro rke2)
+
+# render_bundle <values.yaml> <out.json>: rules from the chart, the floor and
+# the sample workload, completed by the reviewer fixture.
+render_bundle() {
+  c8s allowlist render --sealed \
+    --system-floor "$E2E_SYSTEM_FLOOR" \
+    --chart-values "$1" \
+    --workloads "$here/workloads/demo-nginx.yaml" \
+    --report "$E2E_OUT/render-report.txt" > "$E2E_OUT/rendered.json" \
+    || fail "c8s allowlist render --sealed failed (see $E2E_OUT/render-report.txt)"
+  (cd "$src" && go run ./test/e2e/static/complete -reviews "$here/reviews.json" "$E2E_OUT/rendered.json") > "$2" \
+    || fail "reviews.json does not complete the rendered document"
+}
+
+# 1. Values as install computes them, plus the static overlay. The
+# measurements entry is a placeholder here: its RTMR[3] is what the bundle
+# determines, and the chart only carries the file, so the rules do not
+# depend on it.
+c8s render-values "${values_flags[@]}" --image-tag "$E2E_IMAGE_TAG" \
+  --measurements "$mrtd" --rtmrs "1=$rtmr1,2=$rtmr2" > "$E2E_OUT/values-base.yaml" \
+  || fail "c8s render-values failed"
+MC=$(jq -cn --arg m "$mrtd" --arg r1 "$rtmr1" --arg r2 "$rtmr2" --arg z "$(printf '%096d' 0)" \
+  '{schema_version:"1",tee:"tdx",measurements:[{name:"static-allowlist",mrtd:$m,rtmr:[null,$r1,$r2,$z]}]}')
+export MC
+cp "$here/static-overlay.yaml" "$E2E_OUT/values-overlay.yaml"
+yq -i '.cds.measurementsConfig = strenv(MC) | .ratlsMesh.measurementsConfig = strenv(MC)' "$E2E_OUT/values-overlay.yaml"
+yq eval-all 'select(fileIndex == 0) * select(fileIndex == 1)' \
+  "$E2E_OUT/values-base.yaml" "$E2E_OUT/values-overlay.yaml" > "$E2E_OUT/values.yaml"
+echo "ok: chart values rendered for tag $E2E_IMAGE_TAG"
+
+# 2 + 3. Render and complete.
+render_bundle "$E2E_OUT/values.yaml" "$E2E_OUT/bundle/static-allowlist.json"
+c8s allowlist lint --sealed "$E2E_OUT/bundle/static-allowlist.json" >/dev/null \
+  || fail "the completed bundle does not lint as sealed"
+echo "ok: bundle rendered and linted ($(jq '.workloads | length' "$E2E_OUT/bundle/static-allowlist.json") entries)"
+
+# 4. Fixed point: the values install derives from this bundle must render
+# this bundle again.
+c8s render-values "${values_flags[@]}" \
+  --static-allowlist "$E2E_OUT/bundle" --image-manifest "$E2E_IMAGE_MANIFEST" > "$E2E_OUT/values-from-bundle.yaml" \
+  || fail "c8s render-values --static-allowlist refused the bundle"
+render_bundle "$E2E_OUT/values-from-bundle.yaml" "$E2E_OUT/static-allowlist.from-bundle.json"
+if ! cmp -s "$E2E_OUT/bundle/static-allowlist.json" "$E2E_OUT/static-allowlist.from-bundle.json"; then
+  diff <(jq -S . "$E2E_OUT/bundle/static-allowlist.json") <(jq -S . "$E2E_OUT/static-allowlist.from-bundle.json") || true
+  fail "the bundle is not a fixed point of its own install: static-overlay.yaml no longer matches what c8s install --static-allowlist sets"
+fi
+echo "ok: bundle is the fixed point of c8s render-values --static-allowlist"
+
+# 5. Disk, Secret and the expected register.
+c8s policy-disk --member "$E2E_OUT/bundle/static-allowlist.json" -o "$E2E_OUT/policydata.iso" \
+  --kubevirt-secret "$secret" > "$E2E_OUT/policydata-secret.yaml" 2> "$E2E_OUT/policy-disk.txt" \
+  || fail "c8s policy-disk failed: $(cat "$E2E_OUT/policy-disk.txt")"
+awk '$1 == "rtmr3:" { print $2 }' "$E2E_OUT/policy-disk.txt" > "$E2E_OUT/rtmr3"
+awk '$1 == "index-digest:" { print $2 }' "$E2E_OUT/policy-disk.txt" > "$E2E_OUT/index-digest"
+[ -s "$E2E_OUT/rtmr3" ] && [ -s "$E2E_OUT/index-digest" ] || fail "policy-disk printed no rtmr3/index-digest lines: $(cat "$E2E_OUT/policy-disk.txt")"
+want=$(static_rtmr3_hex "$E2E_OUT/bundle/static-allowlist.json")
+[ "$(cat "$E2E_OUT/rtmr3")" = "$want" ] \
+  || fail "policy-disk rtmr3 $(cat "$E2E_OUT/rtmr3") differs from lib.sh's ForStaticAllowlist $want; the shell arithmetic forge-rtmr3.sh relies on is wrong"
+echo "ok: policydata.iso written; RTMR[3] $(cut -c1-16 "$E2E_OUT/rtmr3")... index $(cut -c1-23 "$E2E_OUT/index-digest")..."
+
+echo "PASS: policy bundle built under $E2E_OUT"

--- a/test/e2e/static/complete/main.go
+++ b/test/e2e/static/complete/main.go
@@ -1,0 +1,224 @@
+// Command complete finishes the sealed allowlist the static e2e lane renders.
+// `c8s allowlist render --sealed` leaves every review empty and pins each
+// system-floor image to the argv its image config bakes, because only a
+// reviewer who observed the node can say more. The lane's reviewer is the
+// checked-in test/e2e/static/reviews.json: this command applies it, drops
+// the floor images the node never runs, and prints the canonical document
+// once it passes the same LintSealed a node runs at boot.
+//
+//	go run ./test/e2e/static/complete -reviews reviews.json rendered.json > static-allowlist.json
+//
+// Every name in the reviews file must exist in the document and every floor
+// entry in the document must be reviewed or dropped, so an RKE2 or chart
+// bump fails here, on the runner, rather than as a node that never converges.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// floorPrefix is what pkg/allowlist SystemFloor.Workloads names its entries.
+const floorPrefix = "system-"
+
+// Reviews is the reviewer's completion of a rendered document.
+type Reviews struct {
+	// Entries carries review strings for chart and workload entries, keyed
+	// by entry name.
+	Entries map[string]EntryReview `json:"entries"`
+	// Floor completes system-floor entries as node TCB, keyed by entry name.
+	Floor map[string]FloorReview `json:"floor"`
+	// Drop lists floor entries that get no rule: the sealed node denies them.
+	Drop []string `json:"drop"`
+}
+
+// EntryReview fills the review slots of one entry. Privileges goes to every
+// container that carries a privileges block; Mounts goes to every container
+// whose rule at that destination is a pvc or nodeState bind.
+type EntryReview struct {
+	Privileges string            `json:"privileges,omitempty"`
+	Mounts     map[string]string `json:"mounts,omitempty"`
+}
+
+// FloorReview replaces a floor entry's privileges with the reviewed block.
+// Argv "any" lifts the image-config argv pin, for a static pod whose
+// manifest overrides it; empty keeps the pin.
+type FloorReview struct {
+	Privileges allowlist.Privileges `json:"privileges"`
+	Argv       string               `json:"argv,omitempty"`
+}
+
+func main() {
+	reviewsPath := flag.String("reviews", "", "reviews file (required)")
+	flag.Parse()
+	if *reviewsPath == "" || flag.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "usage: complete -reviews FILE <rendered.json|->")
+		os.Exit(2)
+	}
+	if err := run(*reviewsPath, flag.Arg(0), os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, "complete:", err)
+		os.Exit(1)
+	}
+}
+
+func run(reviewsPath, docPath string, out io.Writer) error {
+	reviews, err := loadReviews(reviewsPath)
+	if err != nil {
+		return err
+	}
+	var doc []byte
+	if docPath == "-" {
+		doc, err = io.ReadAll(os.Stdin)
+	} else {
+		doc, err = os.ReadFile(docPath)
+	}
+	if err != nil {
+		return err
+	}
+	completed, err := complete(doc, reviews)
+	if err != nil {
+		return err
+	}
+	_, err = out.Write(completed)
+	return err
+}
+
+func loadReviews(path string) (Reviews, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Reviews{}, err
+	}
+	var r Reviews
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&r); err != nil {
+		return Reviews{}, fmt.Errorf("%s: %w", path, err)
+	}
+	return r, nil
+}
+
+// complete applies reviews to doc and returns the canonical bytes of a
+// document LintSealed accepts. Names the reviews file mentions must exist,
+// and every floor entry must be reviewed or dropped.
+func complete(doc []byte, r Reviews) ([]byte, error) {
+	al, err := allowlist.ParseJSON(doc)
+	if err != nil {
+		return nil, err
+	}
+	var errs []error
+	for _, name := range r.Drop {
+		if _, ok := al.Workloads[name]; !ok {
+			errs = append(errs, fmt.Errorf("drop: entry %q is not in the document", name))
+			continue
+		}
+		delete(al.Workloads, name)
+	}
+	for name, fr := range r.Floor {
+		w, ok := al.Workloads[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("floor: entry %q is not in the document", name))
+			continue
+		}
+		if fr.Argv != "" && fr.Argv != allowlist.PolicyAny {
+			errs = append(errs, fmt.Errorf("floor: entry %q: argv must be %q or empty, got %q", name, allowlist.PolicyAny, fr.Argv))
+			continue
+		}
+		for _, list := range [][]allowlist.Container{w.InitContainers, w.Containers} {
+			for i := range list {
+				priv := fr.Privileges
+				list[i].Privileges = &priv
+				if fr.Argv == allowlist.PolicyAny {
+					list[i].Command = allowlist.ArgvPolicy{Policy: allowlist.PolicyAny}
+					list[i].Args = allowlist.ArgvPolicy{Policy: allowlist.PolicyAny}
+				}
+			}
+		}
+	}
+	for name, er := range r.Entries {
+		w, ok := al.Workloads[name]
+		if !ok {
+			errs = append(errs, fmt.Errorf("entries: entry %q is not in the document", name))
+			continue
+		}
+		errs = append(errs, applyEntryReview(name, w, er)...)
+	}
+	for name := range al.Workloads {
+		if !strings.HasPrefix(name, floorPrefix) {
+			continue
+		}
+		if _, ok := r.Floor[name]; ok || slices.Contains(r.Drop, name) {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("floor entry %q is neither reviewed under \"floor\" nor listed under \"drop\"; the RKE2 pin moved, refresh the reviews file", name))
+	}
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	return canonicalize(al)
+}
+
+// canonicalize round-trips the edited document through ParseJSON so the
+// reviewed lists come out normalized (sorted, deduplicated) the way any
+// reader of the bytes would write them; LintSealed then holds the bytes to
+// that form.
+func canonicalize(al *allowlist.Allowlist) ([]byte, error) {
+	edited, err := al.Canonical()
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := allowlist.ParseJSON(edited)
+	if err != nil {
+		return nil, err
+	}
+	canonical, err := normalized.Canonical()
+	if err != nil {
+		return nil, err
+	}
+	if err := allowlist.LintSealed(canonical); err != nil {
+		return nil, err
+	}
+	return canonical, nil
+}
+
+// applyEntryReview writes the entry's review strings and reports a review
+// with no slot to land in, which means the chart no longer needs it.
+func applyEntryReview(name string, w allowlist.Workload, er EntryReview) []error {
+	var errs []error
+	containers := slices.Concat(w.InitContainers, w.Containers)
+	if er.Privileges != "" {
+		hit := false
+		for _, c := range containers {
+			if c.Privileges != nil {
+				c.Privileges.Review = er.Privileges
+				hit = true
+			}
+		}
+		if !hit {
+			errs = append(errs, fmt.Errorf("entries: %q carries a privileges review but no container has a privileges block", name))
+		}
+	}
+	for dest, review := range er.Mounts {
+		hit := false
+		for _, c := range containers {
+			rule, ok := c.Mounts.Rules[dest]
+			if !ok || (rule.Source != allowlist.SourcePVC && rule.Source != allowlist.SourceNodeState) {
+				continue
+			}
+			rule.Review = review
+			c.Mounts.Rules[dest] = rule
+			hit = true
+		}
+		if !hit {
+			errs = append(errs, fmt.Errorf("entries: %q reviews mount %q but no container binds a pvc or nodeState source there", name, dest))
+		}
+	}
+	return errs
+}

--- a/test/e2e/static/complete/main.go
+++ b/test/e2e/static/complete/main.go
@@ -1,10 +1,14 @@
 // Command complete finishes the sealed allowlist the static e2e lane renders.
 // `c8s allowlist render --sealed` leaves every review empty and pins each
-// system-floor image to the argv its image config bakes, because only a
-// reviewer who observed the node can say more. The lane's reviewer is the
-// checked-in test/e2e/static/reviews.json: this command applies it, drops
-// the floor images the node never runs, and prints the canonical document
-// once it passes the same LintSealed a node runs at boot.
+// system-floor image to the argv its image config bakes with no env and no
+// mounts, because only a reviewer who observed the node can say more. The
+// lane's reviewer is the checked-in test/e2e/static/reviews.json: this
+// command applies it, drops the floor images the node never runs, and
+// prints the canonical document once it passes the same LintSealed a node
+// runs at boot. A floor entry the reviews file leaves without env and
+// mounts fails that lint: a sealed document has no open policy, privileged
+// or not, so the floor must be completed from a dynamic node's observation
+// (the sealed plugin's deny log prints one per refused container).
 //
 //	go run ./test/e2e/static/complete -reviews reviews.json rendered.json > static-allowlist.json
 //
@@ -42,18 +46,24 @@ type Reviews struct {
 
 // EntryReview fills the review slots of one entry. Privileges goes to every
 // container that carries a privileges block; Mounts goes to every container
-// whose rule at that destination is a pvc or nodeState bind.
+// whose rule at that destination is a pvc, serviceAccountToken or nodeState
+// bind.
 type EntryReview struct {
 	Privileges string            `json:"privileges,omitempty"`
 	Mounts     map[string]string `json:"mounts,omitempty"`
 }
 
-// FloorReview replaces a floor entry's privileges with the reviewed block.
-// Argv "any" lifts the image-config argv pin, for a static pod whose
-// manifest overrides it; empty keeps the pin.
+// FloorReview completes a floor entry from the reviewer's observation of a
+// dynamic node: the reviewed privileges block, the env values and mount
+// rules the skeleton left empty, and, when the static pod manifest overrides
+// the image config, the argv. Command and Args unset keep the image-config
+// pin; Env and Mounts unset leave the entry open, which the lint refuses.
 type FloorReview struct {
-	Privileges allowlist.Privileges `json:"privileges"`
-	Argv       string               `json:"argv,omitempty"`
+	Privileges allowlist.Privileges           `json:"privileges"`
+	Command    []string                       `json:"command,omitempty"`
+	Args       []string                       `json:"args,omitempty"`
+	Env        map[string]allowlist.EnvValue  `json:"env,omitempty"`
+	Mounts     map[string]allowlist.MountRule `json:"mounts,omitempty"`
 }
 
 func main() {
@@ -127,18 +137,19 @@ func complete(doc []byte, r Reviews) ([]byte, error) {
 			errs = append(errs, fmt.Errorf("floor: entry %q is not in the document", name))
 			continue
 		}
-		if fr.Argv != "" && fr.Argv != allowlist.PolicyAny {
-			errs = append(errs, fmt.Errorf("floor: entry %q: argv must be %q or empty, got %q", name, allowlist.PolicyAny, fr.Argv))
+		if len(fr.Command) == 0 && len(fr.Args) != 0 {
+			errs = append(errs, fmt.Errorf("floor: entry %q: args without command; an observed argv is given as command plus args", name))
 			continue
 		}
 		for _, list := range [][]allowlist.Container{w.InitContainers, w.Containers} {
 			for i := range list {
 				priv := fr.Privileges
 				list[i].Privileges = &priv
-				if fr.Argv == allowlist.PolicyAny {
-					list[i].Command = allowlist.ArgvPolicy{Policy: allowlist.PolicyAny}
-					list[i].Args = allowlist.ArgvPolicy{Policy: allowlist.PolicyAny}
+				if len(fr.Command) != 0 {
+					list[i].Command, list[i].Args = allowlist.ArgvRule(fr.Command), allowlist.ArgvRule(fr.Args)
 				}
+				list[i].Env = allowlist.EnvRules(fr.Env)
+				list[i].Mounts = allowlist.MountRules(fr.Mounts)
 			}
 		}
 	}
@@ -209,7 +220,7 @@ func applyEntryReview(name string, w allowlist.Workload, er EntryReview) []error
 		hit := false
 		for _, c := range containers {
 			rule, ok := c.Mounts.Rules[dest]
-			if !ok || (rule.Source != allowlist.SourcePVC && rule.Source != allowlist.SourceNodeState) {
+			if !ok || !reviewedMount(rule.Source) {
 				continue
 			}
 			rule.Review = review
@@ -217,8 +228,17 @@ func applyEntryReview(name string, w allowlist.Workload, er EntryReview) []error
 			hit = true
 		}
 		if !hit {
-			errs = append(errs, fmt.Errorf("entries: %q reviews mount %q but no container binds a pvc or nodeState source there", name, dest))
+			errs = append(errs, fmt.Errorf("entries: %q reviews mount %q but no container binds a pvc, serviceAccountToken or nodeState source there", name, dest))
 		}
 	}
 	return errs
+}
+
+// reviewedMount reports the source classes whose rule carries a review.
+func reviewedMount(source string) bool {
+	switch source {
+	case allowlist.SourcePVC, allowlist.SourceServiceAccountToken, allowlist.SourceNodeState:
+		return true
+	}
+	return false
 }

--- a/test/e2e/static/complete/main_test.go
+++ b/test/e2e/static/complete/main_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+const (
+	appDigest   = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+	floorDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+	dropDigest  = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+)
+
+func str(s string) *string { return &s }
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// rendered is the shape `render --sealed` leaves behind: an unprivileged
+// workload whose nodeState bind has no review, and two floor entries pinned
+// to their image-config argv with an empty review.
+func rendered(t *testing.T) []byte {
+	t.Helper()
+	app := allowlist.Container{
+		Digest:  mustDigest(t, appDigest),
+		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/app"}},
+		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyDeny},
+		Env:     allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH"}, Values: map[string]allowlist.EnvValue{"PATH": {Value: str("/bin")}}},
+		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: []string{"/etc/hosts", "/run/confai"}, Rules: map[string]allowlist.MountRule{
+			"/etc/hosts":  {Source: allowlist.SourcePlatform},
+			"/run/confai": {Source: allowlist.SourceNodeState},
+		}},
+	}
+	floor := func(d string) allowlist.Container {
+		return allowlist.Container{
+			Digest:     mustDigest(t, d),
+			Command:    allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/agent"}},
+			Args:       allowlist.ArgvPolicy{Policy: allowlist.PolicyDeny},
+			Env:        allowlist.EnvPolicy{Policy: allowlist.PolicyAny},
+			Mounts:     allowlist.MountPolicy{Policy: allowlist.PolicyAny},
+			Privileges: &allowlist.Privileges{},
+		}
+	}
+	al := allowlist.Allowlist{
+		Schema:  allowlist.Schema,
+		Digests: map[string]string{},
+		Workloads: map[string]allowlist.Workload{
+			"app":          {Containers: []allowlist.Container{app}},
+			"system-agent": {Containers: []allowlist.Container{floor(floorDigest)}},
+			"system-spare": {Containers: []allowlist.Container{floor(dropDigest)}},
+		},
+	}
+	doc, err := al.Canonical()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return doc
+}
+
+func fullReviews() Reviews {
+	return Reviews{
+		Entries: map[string]EntryReview{"app": {Mounts: map[string]string{"/run/confai": "dials the node verifier"}}},
+		Floor: map[string]FloorReview{"system-agent": {
+			// Unsorted on purpose: the output must be the normalized form.
+			Privileges: allowlist.Privileges{Privileged: true, HostNamespaces: []string{"pid", "net"}, HostPaths: []string{"/sys/fs/bpf", "/proc"}, Review: "node TCB"},
+			Argv:       "any",
+		}},
+		Drop: []string{"system-spare"},
+	}
+}
+
+func TestComplete(t *testing.T) {
+	doc := rendered(t)
+	out, err := complete(doc, fullReviews())
+	if err != nil {
+		t.Fatalf("complete() error = %v", err)
+	}
+	if err := allowlist.LintSealed(out); err != nil {
+		t.Fatalf("LintSealed(complete()) = %v, want nil", err)
+	}
+	al, err := allowlist.ParseJSON(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := al.Workloads["system-spare"]; ok {
+		t.Errorf("complete() kept dropped entry system-spare")
+	}
+	agent := al.Workloads["system-agent"].Containers[0]
+	if agent.Command.Policy != allowlist.PolicyAny || agent.Args.Policy != allowlist.PolicyAny {
+		t.Errorf("system-agent argv = %s/%s, want any/any", agent.Command.Policy, agent.Args.Policy)
+	}
+	if !agent.Privileges.Privileged || agent.Privileges.Review != "node TCB" {
+		t.Errorf("system-agent privileges = %+v, want the reviewed block", agent.Privileges)
+	}
+	if got := agent.Privileges.HostNamespaces; len(got) != 2 || got[0] != "net" || got[1] != "pid" {
+		t.Errorf("system-agent hostNamespaces = %v, want the sorted [net pid]", got)
+	}
+	if got := al.Workloads["app"].Containers[0].Mounts.Rules["/run/confai"].Review; got != "dials the node verifier" {
+		t.Errorf("app /run/confai review = %q, want the reviewed string", got)
+	}
+}
+
+func TestCompleteErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		edit func(r *Reviews)
+		want string
+	}{
+		{"unreviewed floor entry", func(r *Reviews) { delete(r.Floor, "system-agent") }, `floor entry "system-agent" is neither reviewed`},
+		{"unknown drop", func(r *Reviews) { r.Drop = append(r.Drop, "system-gone") }, `drop: entry "system-gone" is not in the document`},
+		{"unknown floor", func(r *Reviews) { r.Floor["system-gone"] = r.Floor["system-agent"] }, `floor: entry "system-gone" is not in the document`},
+		{"unknown entry", func(r *Reviews) { r.Entries["gone"] = EntryReview{Privileges: "x"} }, `entries: entry "gone" is not in the document`},
+		{"privileges review without a slot", func(r *Reviews) { r.Entries["app"] = EntryReview{Privileges: "x"} }, `no container has a privileges block`},
+		{"mount review without a slot", func(r *Reviews) { r.Entries["app"] = EntryReview{Mounts: map[string]string{"/etc/hosts": "x"}} }, `no container binds a pvc or nodeState source`},
+		{"bad argv policy", func(r *Reviews) {
+			fr := r.Floor["system-agent"]
+			fr.Argv = "exact"
+			r.Floor["system-agent"] = fr
+		}, `argv must be "any" or empty`},
+		{"empty floor review fails lint", func(r *Reviews) {
+			fr := r.Floor["system-agent"]
+			fr.Privileges.Review = ""
+			r.Floor["system-agent"] = fr
+		}, `privileges.review is empty`},
+		{"missing mount review fails lint", func(r *Reviews) { delete(r.Entries, "app") }, `nodeState bind without a review`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := fullReviews()
+			tc.edit(&r)
+			_, err := complete(rendered(t), r)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("complete() error = %v, want it to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunReadsFilesAndWritesCanonicalBytes(t *testing.T) {
+	dir := t.TempDir()
+	docPath := filepath.Join(dir, "rendered.json")
+	if err := os.WriteFile(docPath, rendered(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	reviewsPath := filepath.Join(dir, "reviews.json")
+	reviews := `{"entries":{"app":{"mounts":{"/run/confai":"dials the node verifier"}}},` +
+		`"floor":{"system-agent":{"privileges":{"privileged":true,"review":"node TCB"},"argv":"any"}},"drop":["system-spare"]}`
+	if err := os.WriteFile(reviewsPath, []byte(reviews), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	if err := run(reviewsPath, docPath, &out); err != nil {
+		t.Fatalf("run() error = %v", err)
+	}
+	if strings.HasSuffix(out.String(), "\n") {
+		t.Errorf("run() output ends with a newline; the node measures canonical bytes, which carry none")
+	}
+	if err := allowlist.LintSealed([]byte(out.String())); err != nil {
+		t.Errorf("LintSealed(run()) = %v, want nil", err)
+	}
+}
+
+func TestLoadReviewsRejectsUnknownFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "reviews.json")
+	if err := os.WriteFile(path, []byte(`{"entries":{},"floor":{},"drop":[],"extra":1}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadReviews(path); err == nil || !strings.Contains(err.Error(), "extra") {
+		t.Fatalf("loadReviews() error = %v, want an unknown-field error naming extra", err)
+	}
+}

--- a/test/e2e/static/complete/main_test.go
+++ b/test/e2e/static/complete/main_test.go
@@ -28,8 +28,9 @@ func mustDigest(t *testing.T, s string) types.Digest {
 }
 
 // rendered is the shape `render --sealed` leaves behind: an unprivileged
-// workload whose nodeState bind has no review, and two floor entries pinned
-// to their image-config argv with an empty review.
+// workload whose nodeState and token binds have no review, and two floor
+// entries pinned to their image-config argv with open env and mounts and
+// an empty review.
 func rendered(t *testing.T) []byte {
 	t.Helper()
 	app := allowlist.Container{
@@ -37,9 +38,10 @@ func rendered(t *testing.T) []byte {
 		Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: []string{"/app"}},
 		Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyDeny},
 		Env:     allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{"PATH"}, Values: map[string]allowlist.EnvValue{"PATH": {Value: str("/bin")}}},
-		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: []string{"/etc/hosts", "/run/confai"}, Rules: map[string]allowlist.MountRule{
+		Mounts: allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: []string{"/etc/hosts", "/run/confai", "/var/run/secrets/kubernetes.io/serviceaccount"}, Rules: map[string]allowlist.MountRule{
 			"/etc/hosts":  {Source: allowlist.SourcePlatform},
 			"/run/confai": {Source: allowlist.SourceNodeState},
+			"/var/run/secrets/kubernetes.io/serviceaccount": {Source: allowlist.SourceServiceAccountToken},
 		}},
 	}
 	floor := func(d string) allowlist.Container {
@@ -70,11 +72,20 @@ func rendered(t *testing.T) []byte {
 
 func fullReviews() Reviews {
 	return Reviews{
-		Entries: map[string]EntryReview{"app": {Mounts: map[string]string{"/run/confai": "dials the node verifier"}}},
+		Entries: map[string]EntryReview{"app": {Mounts: map[string]string{
+			"/run/confai": "dials the node verifier",
+			"/var/run/secrets/kubernetes.io/serviceaccount": "reads nothing there",
+		}}},
 		Floor: map[string]FloorReview{"system-agent": {
 			// Unsorted on purpose: the output must be the normalized form.
 			Privileges: allowlist.Privileges{Privileged: true, HostNamespaces: []string{"pid", "net"}, HostPaths: []string{"/sys/fs/bpf", "/proc"}, Review: "node TCB"},
-			Argv:       "any",
+			Command:    []string{"/agent"},
+			Args:       []string{"--config-dir=/tmp/cm"},
+			Env:        map[string]allowlist.EnvValue{"PATH": {Value: str("/bin")}, "NODE": {From: allowlist.FromNodeName}},
+			Mounts: map[string]allowlist.MountRule{
+				"/etc/hosts": {Source: allowlist.SourcePlatform},
+				"/host/bpf":  {Source: allowlist.SourceHostPath, Path: "/sys/fs/bpf"},
+			},
 		}},
 		Drop: []string{"system-spare"},
 	}
@@ -97,8 +108,14 @@ func TestComplete(t *testing.T) {
 		t.Errorf("complete() kept dropped entry system-spare")
 	}
 	agent := al.Workloads["system-agent"].Containers[0]
-	if agent.Command.Policy != allowlist.PolicyAny || agent.Args.Policy != allowlist.PolicyAny {
-		t.Errorf("system-agent argv = %s/%s, want any/any", agent.Command.Policy, agent.Args.Policy)
+	if got := strings.Join(append(agent.Command.Argv, agent.Args.Argv...), " "); agent.Command.Policy != allowlist.PolicyExact || agent.Args.Policy != allowlist.PolicyExact || got != "/agent --config-dir=/tmp/cm" {
+		t.Errorf("system-agent argv = %s/%s %q, want the observed argv pinned exactly", agent.Command.Policy, agent.Args.Policy, got)
+	}
+	if got := agent.Env.Values["NODE"].From; got != allowlist.FromNodeName {
+		t.Errorf("system-agent env NODE = %+v, want from nodeName", agent.Env.Values["NODE"])
+	}
+	if got := agent.Mounts.Rules["/host/bpf"]; got.Source != allowlist.SourceHostPath || got.Path != "/sys/fs/bpf" {
+		t.Errorf("system-agent mount /host/bpf = %+v, want the observed hostPath bound to /sys/fs/bpf", got)
 	}
 	if !agent.Privileges.Privileged || agent.Privileges.Review != "node TCB" {
 		t.Errorf("system-agent privileges = %+v, want the reviewed block", agent.Privileges)
@@ -122,18 +139,36 @@ func TestCompleteErrors(t *testing.T) {
 		{"unknown floor", func(r *Reviews) { r.Floor["system-gone"] = r.Floor["system-agent"] }, `floor: entry "system-gone" is not in the document`},
 		{"unknown entry", func(r *Reviews) { r.Entries["gone"] = EntryReview{Privileges: "x"} }, `entries: entry "gone" is not in the document`},
 		{"privileges review without a slot", func(r *Reviews) { r.Entries["app"] = EntryReview{Privileges: "x"} }, `no container has a privileges block`},
-		{"mount review without a slot", func(r *Reviews) { r.Entries["app"] = EntryReview{Mounts: map[string]string{"/etc/hosts": "x"}} }, `no container binds a pvc or nodeState source`},
-		{"bad argv policy", func(r *Reviews) {
+		{"mount review without a slot", func(r *Reviews) { r.Entries["app"] = EntryReview{Mounts: map[string]string{"/etc/hosts": "x"}} }, `no container binds a pvc, serviceAccountToken or nodeState source`},
+		{"args without command", func(r *Reviews) {
 			fr := r.Floor["system-agent"]
-			fr.Argv = "exact"
+			fr.Command = nil
 			r.Floor["system-agent"] = fr
-		}, `argv must be "any" or empty`},
+		}, `args without command`},
+		{"floor without env fails lint", func(r *Reviews) {
+			fr := r.Floor["system-agent"]
+			fr.Env = nil
+			r.Floor["system-agent"] = fr
+		}, `env must be exact`},
+		{"floor without mounts fails lint", func(r *Reviews) {
+			fr := r.Floor["system-agent"]
+			fr.Mounts = nil
+			r.Floor["system-agent"] = fr
+		}, `mounts must be exact`},
+		{"floor host path outside hostPaths fails lint", func(r *Reviews) {
+			fr := r.Floor["system-agent"]
+			fr.Privileges.HostPaths = []string{"/proc"}
+			r.Floor["system-agent"] = fr
+		}, `privileges.hostPaths does not cover`},
 		{"empty floor review fails lint", func(r *Reviews) {
 			fr := r.Floor["system-agent"]
 			fr.Privileges.Review = ""
 			r.Floor["system-agent"] = fr
 		}, `privileges.review is empty`},
 		{"missing mount review fails lint", func(r *Reviews) { delete(r.Entries, "app") }, `nodeState bind without a review`},
+		{"missing token review fails lint", func(r *Reviews) {
+			r.Entries["app"] = EntryReview{Mounts: map[string]string{"/run/confai": "dials the node verifier"}}
+		}, `serviceAccountToken bind without a review`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -154,8 +189,9 @@ func TestRunReadsFilesAndWritesCanonicalBytes(t *testing.T) {
 		t.Fatal(err)
 	}
 	reviewsPath := filepath.Join(dir, "reviews.json")
-	reviews := `{"entries":{"app":{"mounts":{"/run/confai":"dials the node verifier"}}},` +
-		`"floor":{"system-agent":{"privileges":{"privileged":true,"review":"node TCB"},"argv":"any"}},"drop":["system-spare"]}`
+	reviews := `{"entries":{"app":{"mounts":{"/run/confai":"dials the node verifier","/var/run/secrets/kubernetes.io/serviceaccount":"reads nothing there"}}},` +
+		`"floor":{"system-agent":{"privileges":{"privileged":true,"review":"node TCB"},` +
+		`"env":{"PATH":{"value":"/bin"}},"mounts":{"/etc/hosts":{"source":"platform"}}}},"drop":["system-spare"]}`
 	if err := os.WriteFile(reviewsPath, []byte(reviews), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/static/cvm.sh
+++ b/test/e2e/static/cvm.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# KubeVirt lifecycle of one TDX node CVM for the static lane, run from the
+# host-side launcher runner (its SA is scoped to the image namespace):
+#
+#   cvm.sh create NAME          scratch PVC, bait cloud-init Secret and the VM
+#   cvm.sh wait-running NAME    waits for the VMI and prints its address
+#   cvm.sh assert-tdx NAME      qemu was launched with -object tdx-guest
+#   cvm.sh wait-services ADDR   attestation-api :8400 (tdx), apiserver :6443, cred-release :8443
+#   cvm.sh wait-stopped NAME SECONDS  the guest powered itself off
+#   cvm.sh delete NAME          the VM, its Secrets and its scratch PVC
+#
+# The VM is the vendored tdx-metal-e2e.yml one (root disk read-only on the
+# shared PVC, scratch disk with serial confai-scratch, bait cidata disk,
+# launchSecurity tdx), with the launch attachments chosen by env:
+#   NS                   namespace (required)
+#   rootPvc              the shared node image PVC (required for create)
+#   CVM_OPKEY_SECRET     Secret attached as the opkeydata disk (dynamic boot)
+#   CVM_POLICYDATA_SECRET Secret attached as the policydata disk (static boot)
+#   CVM_RUN_STRATEGY     Always (default) or RerunOnFailure. Under
+#                        RerunOnFailure a guest power-off leaves the VMI
+#                        Succeeded, the VM controller then deletes the VMI
+#                        and the VM reports Stopped; wait-stopped accepts
+#                        either observation.
+#   CVM_MEMORY           guest memory (default 16Gi)
+#   GITHUB_RUN_ID, GITHUB_REPOSITORY, GITHUB_SERVER_URL  reaper labels (optional)
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+: "${NS:?KubeVirt namespace}"
+cmd=${1:-}
+name=${2:-}
+[ -n "$cmd" ] && [ -n "$name" ] || fail "usage: cvm.sh <create|wait-running|assert-tdx|wait-services|wait-stopped|delete> <name|addr> [seconds]"
+
+create() {
+  : "${rootPvc:?node image PVC}"
+  local run_id=${GITHUB_RUN_ID:-} repo=${GITHUB_REPOSITORY:-} server=${GITHUB_SERVER_URL:-}
+  local strategy=${CVM_RUN_STRATEGY:-Always} memory=${CVM_MEMORY:-16Gi}
+  local disks="" volumes=""
+  if [ -n "${CVM_OPKEY_SECRET:-}" ]; then
+    disks+=$'            - name: opkey\n              disk: {bus: virtio}\n'
+    volumes+="        - name: opkey"$'\n'"          secret: {secretName: $CVM_OPKEY_SECRET, volumeLabel: opkeydata}"$'\n'
+  fi
+  if [ -n "${CVM_POLICYDATA_SECRET:-}" ]; then
+    disks+=$'            - name: policydata\n              disk: {bus: virtio}\n'
+    volumes+="        - name: policydata"$'\n'"          secret: {secretName: $CVM_POLICYDATA_SECRET, volumeLabel: policydata}"$'\n'
+  fi
+  kubectl apply -f - <<EOF_VM
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $name-scratch
+  namespace: $NS
+  labels: {ci.confidential.ai/managed: "true"}
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: {requests: {storage: 80Gi}}
+  storageClassName: local-path
+---
+apiVersion: v1
+kind: Secret
+metadata: {name: $name-cloudinit, namespace: $NS}
+type: Opaque
+# Bait, not configuration: the node image disables cloud-init, so this host
+# disk must be inert (the cidata tripwire asserts it).
+stringData:
+  userdata: |
+    #cloud-config
+    hostname: cidata-bait
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: $name
+  namespace: $NS
+  labels:
+    ci.confidential.ai/managed: "true"
+    ci.confidential.ai/run-id: "$run_id"
+  annotations:
+    ci.confidential.ai/repo: "$repo"
+    ci.confidential.ai/run-url: "$server/$repo/actions/runs/$run_id"
+spec:
+  runStrategy: $strategy
+  template:
+    metadata:
+      labels: {kubevirt.io/domain: $name}
+    spec:
+      nodeSelector:
+        kubevirt.io/tdx: "true"
+      domain:
+        cpu:
+          # host-passthrough is mandatory: QEMU rejects a named model for TDX.
+          model: host-passthrough
+          cores: 4
+        devices:
+          autoattachVSOCK: true
+          disks:
+            - name: rootdisk
+              # dm-verity rootfs, never written; readonly takes a shared qemu
+              # lock so concurrent CVMs on the same PVC coexist.
+              disk: {bus: virtio, readonly: true}
+            - name: scratch
+              disk: {bus: virtio}
+              # The initrd keys the encrypted overlay off this exact serial.
+              serial: confai-scratch
+$disks            - name: cloudinit
+              disk: {bus: virtio}
+          interfaces: [{name: default, masquerade: {}}]
+          rng: {}
+        firmware: {bootloader: {efi: {secureBoot: false}}}
+        launchSecurity: {tdx: {}}
+        memory: {guest: $memory}
+        resources: {requests: {memory: $memory}}
+      networks: [{name: default, pod: {}}]
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim: {claimName: $rootPvc}
+        - name: scratch
+          persistentVolumeClaim: {claimName: $name-scratch}
+$volumes        - name: cloudinit
+          cloudInitNoCloud: {secretRef: {name: $name-cloudinit}}
+EOF_VM
+}
+
+wait_running() {
+  local phase="" ip=""
+  for _ in $(seq 1 60); do
+    phase=$(kubectl -n "$NS" get vmi "$name" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    [ "$phase" = Running ] && break
+    sleep 5
+  done
+  if [ "$phase" != Running ]; then
+    kubectl -n "$NS" describe vmi "$name" 2>&1 | tail -25 >&2 || true
+    fail "VMI $name not Running (phase=${phase:-none}). 'Insufficient devices.kubevirt.io/tdx' means virt-handler latched 0: rollout restart daemonset/virt-handler -n kubevirt"
+  fi
+  ip=$(kubectl -n "$NS" get vmi "$name" -o jsonpath='{.status.interfaces[0].ipAddress}')
+  [ -n "$ip" ] || fail "VMI $name has no guest address"
+  echo "VMI $name Running at $ip" >&2
+  printf '%s' "$ip"
+}
+
+assert_tdx() {
+  local pod count
+  pod=$(kubectl -n "$NS" get pods -l kubevirt.io/domain="$name" -o name | head -1)
+  [ -n "$pod" ] || fail "no virt-launcher pod for $name"
+  # shellcheck disable=SC2016  # the substitution runs in the launcher pod
+  count=$(kubectl -n "$NS" exec "$pod" -c compute -- \
+    bash -c 'tr "\0" "\n" < /proc/$(pgrep -f qemu-system | head -1)/cmdline | grep -c "tdx-guest"' || true)
+  [ "${count:-0}" -ge 1 ] || fail "qemu for $name has no tdx-guest object: not a genuine trust domain"
+  echo "ok: $name launched with -object tdx-guest"
+}
+
+wait_services() {
+  local addr=$name health="" code=""
+  for _ in $(seq 1 90); do
+    health=$(curl -s --connect-timeout 2 --max-time 4 "http://$addr:8400/health" 2>/dev/null || true)
+    [ -n "$health" ] && { echo "attestation-api: $health"; break; }
+    sleep 10
+  done
+  grep -q '"platform":"tdx"' <<<"$health" || fail "attestation-api at $addr did not report platform=tdx"
+  for _ in $(seq 1 60); do
+    code=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$addr:6443/livez" 2>/dev/null || true)
+    case "$code" in 200|401|403) echo "kube-apiserver: HTTP $code"; break ;; esac
+    sleep 5
+  done
+  case "$code" in 200|401|403) ;; *) fail "kube-apiserver at $addr:6443 did not answer" ;; esac
+  for _ in $(seq 1 60); do
+    code=$(curl -sk --max-time 4 -o /dev/null -w '%{http_code}' "https://$addr:8443/" 2>/dev/null || true)
+    [ -n "$code" ] && [ "$code" != 000 ] && { echo "cred-release: HTTP $code"; break; }
+    sleep 5
+  done
+  [ -n "$code" ] && [ "$code" != 000 ] || fail "cred-release at $addr:8443 did not answer"
+}
+
+wait_stopped() {
+  local budget=${3:?seconds to wait} phase="" seen="" vmstatus="" waited=0
+  while [ "$waited" -lt "$budget" ]; do
+    phase=$(kubectl -n "$NS" get vmi "$name" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+    [ -n "$phase" ] && seen=1
+    case "$phase" in
+      Succeeded) echo "ok: $name powered itself off after ${waited}s (VMI Succeeded)"; return 0 ;;
+      Failed)
+        kubectl -n "$NS" describe vmi "$name" | tail -25
+        fail "$name crashed (VMI Failed) rather than powering off" ;;
+      "")
+        # RerunOnFailure deletes a Succeeded VMI and leaves the VM Stopped,
+        # often between two polls. A fresh VM is also Stopped before its
+        # VMI exists, hence the seen guard.
+        vmstatus=$(kubectl -n "$NS" get vm "$name" -o jsonpath='{.status.printableStatus}' 2>/dev/null || true)
+        if [ -n "$seen" ] && [ "$vmstatus" = Stopped ]; then
+          echo "ok: $name powered itself off after ${waited}s (VM Stopped, VMI reaped)"; return 0
+        fi ;;
+    esac
+    sleep 10
+    waited=$((waited + 10))
+  done
+  kubectl -n "$NS" describe vm "$name" | tail -25
+  fail "$name is still ${phase:-absent} (VM ${vmstatus:-unknown}) after ${budget}s; the guest did not power off"
+}
+
+delete() {
+  set +e
+  kubectl -n "$NS" delete vm "$name" --ignore-not-found --wait=true --timeout=120s
+  kubectl -n "$NS" delete secret "$name-cloudinit" "${CVM_OPKEY_SECRET:-$name-opkey}" "${CVM_POLICYDATA_SECRET:-$name-policydata}" --ignore-not-found
+  kubectl -n "$NS" delete pvc "$name-scratch" --ignore-not-found --wait=false
+  set -e
+}
+
+case "$cmd" in
+  create) create ;;
+  wait-running) wait_running ;;
+  assert-tdx) assert_tdx ;;
+  wait-services) wait_services ;;
+  wait-stopped) wait_stopped "$@" ;;
+  delete) delete ;;
+  *) fail "unknown command $cmd" ;;
+esac

--- a/test/e2e/static/debug-refused.sh
+++ b/test/e2e/static/debug-refused.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Live-cluster check that the two ways into a running container are shut on
+# a sealed node: `kubectl exec` is refused by the kubelet (the locked image
+# runs it with enable-debugging-handlers=false), and `kubectl debug`, which
+# the kubelet flag does not cover because an ephemeral container is created
+# like any other, is refused by the sealed allowlist at container creation.
+# The debug image is one the node already holds (busybox from the RKE2
+# bundle), so what refuses it is the absence of a rule, not a pull.
+#
+# Needs kubectl pointed at a static-allowlist cluster with the demo-nginx
+# workload from workload.sh running. Optional:
+#   E2E_TARGET_POD   pod to exec into and attach the ephemeral container to
+#                    (default: the first demo-nginx pod in default)
+#   E2E_DEBUG_IMAGE  ephemeral container image (default busybox:1.38.0)
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+ns=default
+target=${E2E_TARGET_POD:-$(kubectl -n "$ns" get pods -l app=demo-nginx -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)}
+[ -n "$target" ] || fail "no demo-nginx pod in $ns to target; run workload.sh first or set E2E_TARGET_POD"
+image=${E2E_DEBUG_IMAGE:-busybox:1.38.0}
+probe=sealed-debug-probe
+
+expect_deny "kubectl exec into $target" "Debug endpoints are disabled" -- \
+  kubectl -n "$ns" exec "$target" -c nginx -- true
+
+# No -it: the command returns once the API server accepts the ephemeral
+# container; the kubelet's verdict lands in the pod status.
+kubectl -n "$ns" debug "$target" --image="$image" --container="$probe" -- sleep 3600 >/dev/null \
+  || fail "kubectl debug was rejected by the API server; the check needs the ephemeral container to reach the kubelet"
+wait_container_denied "$ns" "$target" ephemeralContainerStatuses "$probe"
+
+echo "PASS: kubectl exec and kubectl debug are refused on the sealed node"

--- a/test/e2e/static/forge-rtmr3.sh
+++ b/test/e2e/static/forge-rtmr3.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Live check that the mode event keeps a dynamic node from posing as a
+# sealed one. On a dynamic node cluster-admin is node root: a privileged
+# copy of Cilium (admitted there by the floor on its digest alone) extends
+# RTMR[3] with the very events a static boot extends, the static mode event
+# and the policy event of the reviewed bundle. Because the register already
+# holds the operator-key seed and the dynamic mode event, the result is
+# Extend(Extend(ForDynamic(seed), ModeStatic), PolicyEvent(index)), never
+# ForStaticAllowlist(index), and `c8s verify --static-allowlist` keeps
+# failing on RTMR[3].
+#
+# The register is read through verify's own error text ("RTMR[3] (...) is
+# <got>, expected <want>"), so each step asserts the exact value: before the
+# forge it must be ForDynamic(ForOperatorKey(pub)), which is the dynamic-boot
+# assertion of the lane, and after it the forged chain above.
+#
+# Needs c8s, curl, jq and openssl on PATH, kubectl pointed at the dynamic
+# node's cluster, and:
+#   E2E_LB_URL          the dynamic node's tls-lb front door, https://<node>:443
+#   E2E_IMAGE_MANIFEST  manifest.json of the node image
+#   E2E_BUNDLE          the static bundle directory (the one the sealed node booted)
+#   E2E_OPERATOR_PUB    the operator public key file the dynamic node booted with,
+#                       byte for byte (the initrd hashed the file as attached)
+# Optional:
+#   E2E_WORKLOAD        entry name passed to --workload (default c8s-tls-lb; verify
+#                       fails on RTMR[3] before it reads the stamp)
+#   E2E_OUT             where to keep the verify outputs (default: a temp dir)
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+: "${E2E_LB_URL:?tls-lb URL of the dynamic node}"
+: "${E2E_IMAGE_MANIFEST:?manifest.json of the node image}"
+: "${E2E_BUNDLE:?static bundle directory}"
+: "${E2E_OPERATOR_PUB:?operator public key the dynamic node booted with}"
+workload=${E2E_WORKLOAD:-c8s-tls-lb}
+out=${E2E_OUT:-$(mktemp -d)}
+mkdir -p "$out"
+# kube-system: the chart's host-namespace admission policy denies the pod's
+# hostPath volume in every other namespace.
+ns=kube-system
+pod=rtmr3-forge
+
+member="$E2E_BUNDLE/static-allowlist.json"
+[ -f "$member" ] || fail "$member is missing"
+static=$(static_rtmr3_hex "$member")
+dynamic=$(dynamic_rtmr3_hex "$E2E_OPERATOR_PUB")
+mode_static=$(mode_static_hex)
+policy=$(policy_event_hex "$(bundle_index "$member")")
+forged=$(extend_hex "$(extend_hex "$dynamic" "$mode_static")" "$policy")
+echo "static register:  $static"
+echo "dynamic register: $dynamic"
+echo "forged register:  $forged"
+
+cleanup() {
+  local rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  kubectl -n "$ns" delete pod "$pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+fetched=""
+for _ in $(seq 1 30); do
+  if curl -fsk --max-time 10 "$E2E_LB_URL/.well-known/mesh-ca.pem" -o "$out/mesh-ca.pem" && grep -q 'BEGIN CERTIFICATE' "$out/mesh-ca.pem"; then
+    fetched=1; break
+  fi
+  sleep 5
+done
+[ -n "$fetched" ] || fail "no mesh CA served at $E2E_LB_URL/.well-known/mesh-ca.pem"
+
+# reported_rtmr3 <label>: runs the static verifier against the dynamic node,
+# requires the policy failure (exit 2) to be the RTMR[3] pin with the static
+# register as the expectation, and prints the register the node reported.
+reported_rtmr3() {
+  local rc=0 err got want
+  c8s verify "$E2E_LB_URL" --kind lb \
+    --image-manifest "$E2E_IMAGE_MANIFEST" \
+    --static-allowlist "$E2E_BUNDLE" \
+    --workload "$workload" \
+    --mesh-ca "$out/mesh-ca.pem" \
+    -o json > "$out/verify-$1.json" || rc=$?
+  [ "$rc" -eq 2 ] || fail "$1: c8s verify --static-allowlist against the dynamic node exited $rc, want 2 (policy failed): $(cat "$out/verify-$1.json")"
+  err=$(jq -r '.error // ""' "$out/verify-$1.json")
+  got=$(sed -nE 's/^RTMR\[3\] \(.*\) is ([0-9a-f]{96}), expected ([0-9a-f]{96})$/\1/p' <<<"$err")
+  want=$(sed -nE 's/^RTMR\[3\] \(.*\) is ([0-9a-f]{96}), expected ([0-9a-f]{96})$/\2/p' <<<"$err")
+  [ -n "$got" ] || fail "$1: verify failed, but not on the RTMR[3] pin: $err"
+  [ "$want" = "$static" ] || fail "$1: verify expects RTMR[3] $want, but the bundle derives $static"
+  printf '%s' "$got"
+}
+
+got=$(reported_rtmr3 before)
+[ "$got" = "$dynamic" ] || fail "before the forge the dynamic node reports RTMR[3] $got, want ForDynamic(ForOperatorKey(pub)) $dynamic"
+echo "ok: dynamic node reports the operator-key seed extended by the dynamic mode event; the static verifier refuses it"
+
+# Two 48-byte writes, in the order a static boot extends them. dd holds each
+# to a single write, which is what the tdx_guest sysfs node accepts.
+sysfs=/host/sys/devices/virtual/misc/tdx_guest/measurements/rtmr3:sha384
+script=$(printf "printf '%s' | dd of=%s bs=48 count=1 2>/dev/null && printf '%s' | dd of=%s bs=48 count=1 2>/dev/null" \
+  "$(hex2octal "$mode_static")" "$sysfs" "$(hex2octal "$policy")" "$sysfs")
+cilium_copy_manifest "$ns" "$pod" "$(cilium_image)" "$(jq -Rn --arg s "$script" '$s')" | kubectl apply -f - >/dev/null
+phase=""
+for _ in $(seq 1 60); do
+  phase=$(kubectl -n "$ns" get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+  case "$phase" in Succeeded|Failed) break ;; esac
+  sleep 2
+done
+if [ "$phase" != Succeeded ]; then
+  kubectl -n "$ns" describe pod "$pod" | tail -25
+  fail "the privileged cilium copy did not run to completion on the dynamic node (phase ${phase:-none}); the floor no longer admits it, or the sysfs write failed"
+fi
+echo "ok: privileged pod on the dynamic node extended RTMR[3] with the static events"
+
+got=$(reported_rtmr3 after)
+[ "$got" = "$forged" ] || fail "after the forge the dynamic node reports RTMR[3] $got, want the forged chain $forged"
+echo "ok: the register carries the forged chain and the static verifier still refuses it"
+
+echo "PASS: a dynamic node cannot forge the static register; the mode event keeps the two shapes apart"

--- a/test/e2e/static/image-artifacts.sh
+++ b/test/e2e/static/image-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Fetches the node image's published evidence for the static lane: the
+# manifest.json whose mrtd+rtmr1+rtmr2 match the booted build, and the
+# system-floor.json the same build emitted beside it. Both ship as layers of
+# the oras artifact that sits next to the CDI image (c8s-image.yml).
+#
+# The CM's 'image' may be a tag or a digest. A digest carries no name, so it
+# is resolved back to the sibling tag that points at it; without that the
+# only candidate left would be the floating dev tag. Candidates are matched
+# on the whole tuple: two builds sharing a firmware have the same MRTD while
+# their kernels, and so their RTMR[1], differ.
+#
+# Needs crane and jq on PATH, and:
+#   image      node image reference (tag or digest) from the refs ConfigMap
+#   mrtd, rtmr1, rtmr2   the tuple the ConfigMap pins
+#   E2E_OUT    directory to write image-manifest.json and system-floor.json to
+# Optional:
+#   imageTag   oras tag published beside the image, when it cannot be derived
+#   REFS_CM    ConfigMap name, for the error text
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+: "${image:?node image reference}"
+: "${mrtd:?MRTD the ConfigMap pins}"
+: "${rtmr1:?RTMR[1] the ConfigMap pins}"
+: "${rtmr2:?RTMR[2] the ConfigMap pins}"
+: "${E2E_OUT:?output directory}"
+refs_cm=${REFS_CM:-tdx-rke2-image-refs}
+mkdir -p "$E2E_OUT"
+
+repo="${image%%@*}"; repo="${repo%%:*}"
+cands="${imageTag:-}"
+case "$image" in
+  *@*)
+    want="${image#*@}"
+    for t in $(crane ls "$repo" 2>/dev/null | grep -E -- '-cdi(-[0-9a-f]+)?$'); do
+      [ "$(crane digest "$repo:$t" 2>/dev/null)" = "$want" ] || continue
+      cands="$cands $t"; break
+    done
+    ;;
+  *-cdi*) cands="$cands ${image#*:}" ;;
+esac
+# shellcheck disable=SC2086  # deliberate split: cands is a word list
+cands="$(printf '%s\n' ${cands} | sed 's/-cdi//' | awk 'NF && !seen[$0]++')"
+[ -n "$cands" ] || fail "cannot derive an oras tag from image '$image'. Set 'imageTag' in $refs_cm to the tag published beside it"
+
+layer_digest() {
+  crane manifest "$1" 2>/dev/null \
+    | jq -r --arg title "$2" '.layers[]|select(.annotations["org.opencontainers.image.title"]==$title)|.digest'
+}
+
+oras_ref=""
+for t in $cands; do
+  d=$(layer_digest "$repo:$t" manifest.json) || true
+  [ -n "$d" ] || { echo "  $t: no manifest.json layer"; continue; }
+  crane blob "$repo@$d" > "$E2E_OUT/candidate-manifest.json" 2>/dev/null || continue
+  m=$(jq -r '.tdx.mrtd // empty' "$E2E_OUT/candidate-manifest.json")
+  m1=$(jq -r '.tdx.rtmr1 // empty' "$E2E_OUT/candidate-manifest.json")
+  m2=$(jq -r '.tdx.rtmr2 // empty' "$E2E_OUT/candidate-manifest.json")
+  if [ "$m" = "$mrtd" ] && [ "$m1" = "$rtmr1" ] && [ "$m2" = "$rtmr2" ]; then
+    mv "$E2E_OUT/candidate-manifest.json" "$E2E_OUT/image-manifest.json"
+    oras_ref="$repo:$t"; break
+  fi
+  echo "  $t: tuple mismatch (mrtd ${m:0:16}/${mrtd:0:16} rtmr1 ${m1:0:16}/${rtmr1:0:16} rtmr2 ${m2:0:16}/${rtmr2:0:16})"
+done
+rm -f "$E2E_OUT/candidate-manifest.json"
+[ -n "$oras_ref" ] || fail "no oras artifact among [$cands] publishes a manifest.json whose mrtd+rtmr1+rtmr2 matches the build this CVM boots. Set 'imageTag' in $refs_cm to the tag published beside the pinned image"
+echo "ok: manifest from $oras_ref"
+
+# The floor is the same build's, never another tag's: the RKE2 bundle pin,
+# and so every system digest, is part of what the tuple measures.
+d=$(layer_digest "$oras_ref" system-floor.json) || true
+[ -n "$d" ] || fail "$oras_ref publishes no system-floor.json layer: the image was built before c8s-image.yml emitted the floor skeleton; rebuild and re-seed $refs_cm"
+crane blob "$oras_ref@$d" > "$E2E_OUT/system-floor.json" || fail "cannot fetch system-floor.json from $oras_ref"
+jq -e '.schema == "c8s.system-floor/v1"' "$E2E_OUT/system-floor.json" >/dev/null \
+  || fail "system-floor.json from $oras_ref is not a c8s.system-floor/v1 document"
+echo "ok: system floor from $oras_ref ($(jq '.images | length' "$E2E_OUT/system-floor.json") images)"
+
+echo "PASS: image evidence fetched into $E2E_OUT"

--- a/test/e2e/static/lib.sh
+++ b/test/e2e/static/lib.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Shared helpers for the static-allowlist e2e checks under test/e2e/static/.
+# Source it after `set -euo pipefail`:
+#
+#   . "$(dirname "$0")/lib.sh"
+#
+# It pulls in test/e2e/lib.sh (fail) and adds the sealed-plugin denial
+# probe, expect_deny, and the RTMR[3] arithmetic of pkg/runtimemeasure in
+# shell (SHA-384 over openssl), so the lane can predict a register from the
+# host without a Go toolchain on the assertion path.
+# shellcheck disable=SC1091  # resolved relative to this file at run time
+. "$(dirname "${BASH_SOURCE[0]}")/../lib.sh"
+
+# sealed_denied is the waiting message the sealed plugin leaves on a refused
+# container (internal/cmds/nri-image-policy/sealed_plugin.go sealedAdmit).
+# shellcheck disable=SC2034  # read by the scripts that source this file
+sealed_denied='container not admitted by the sealed allowlist'
+
+# expect_deny <description> <expected-substring> -- <command...>
+# Runs the command, requires it to fail, and requires the output to contain
+# <expected-substring> so the check proves which guard fired.
+expect_deny() {
+  (( $# >= 3 )) || fail "expect_deny: usage: expect_deny <description> <expected-substring> -- <command...>"
+  [[ $3 == -- ]] || fail "expect_deny: expected '--' before the command, got '$3'"
+  local what=$1 want=$2
+  shift 3
+  (( $# > 0 )) || fail "expect_deny: missing command after '--'"
+  local out
+  if out=$("$@" 2>&1); then
+    fail "$what was admitted; want denial matching '$want'. output: $out"
+  fi
+  grep -q -- "$want" <<<"$out" \
+    || fail "$what was denied, but not by the expected guard (want '$want'): $out"
+  echo "ok: $what denied"
+}
+
+# wait_container_denied <namespace> <pod> <status-list> <container>
+# Polls the container's waiting message in .status.<status-list>
+# (containerStatuses, initContainerStatuses or ephemeralContainerStatuses)
+# until the sealed plugin's denial appears. A container that starts instead
+# is a security regression.
+wait_container_denied() {
+  local ns=$1 pod=$2 list=$3 name=$4 msg="" state=""
+  for _ in $(seq 1 "${E2E_DENY_WAIT:-90}"); do
+    msg=$(kubectl -n "$ns" get pod "$pod" \
+      -o jsonpath="{.status.${list}[?(@.name==\"${name}\")].state.waiting.message}" 2>/dev/null || true)
+    case "$msg" in *"$sealed_denied"*) echo "ok: $pod/$name refused by the sealed allowlist"; return 0 ;; esac
+    state=$(kubectl -n "$ns" get pod "$pod" \
+      -o jsonpath="{.status.${list}[?(@.name==\"${name}\")].state}" 2>/dev/null || true)
+    case "$state" in
+      *running*|*terminated*)
+        kubectl -n "$ns" describe pod "$pod" | tail -25
+        fail "SECURITY REGRESSION: $pod/$name ran on a sealed node (state: $state)" ;;
+    esac
+    sleep 2
+  done
+  kubectl -n "$ns" describe pod "$pod" | tail -25
+  fail "$pod/$name was neither refused nor started within the window (waiting message: ${msg:-none})"
+}
+
+# sha384_hex reads stdin and prints its SHA-384 as lowercase hex.
+sha384_hex() { openssl dgst -sha384 | awk '{print $NF}'; }
+
+# hex2bin writes the bytes of a hex string to stdout.
+hex2bin() {
+  local hex=$1 i
+  for ((i = 0; i < ${#hex}; i += 2)); do
+    printf '%b' "\\x${hex:i:2}"
+  done
+}
+
+# hex2octal prints a hex string as the \ooo escapes a POSIX printf turns
+# back into bytes, for a shell inside a container image that has no bash.
+hex2octal() {
+  local hex=$1 i
+  for ((i = 0; i < ${#hex}; i += 2)); do
+    printf '\\%03o' "0x${hex:i:2}"
+  done
+}
+
+# extend_hex <register-hex> <event-hex> prints SHA384(register || event),
+# the hardware extend (pkg/runtimemeasure Extend).
+extend_hex() { { hex2bin "$1"; hex2bin "$2"; } | sha384_hex; }
+
+# Mode events (pkg/runtimemeasure ModeStatic, ModeDynamic): SHA-384 of the
+# ASCII label.
+mode_static_hex() { printf '%s' 'c8s/rtmr3/mode/static/v1' | sha384_hex; }
+mode_dynamic_hex() { printf '%s' 'c8s/rtmr3/mode/dynamic/v1' | sha384_hex; }
+
+# bundle_index <static-allowlist.json> prints the index of a one-member
+# bundle: pkg/policybundle Bundle.Index, the canonical JSON of
+# {name: "sha256:<hex>"} over the member bytes.
+bundle_index() {
+  local sum
+  sum=$(sha256sum "$1" | cut -d' ' -f1)
+  printf '{"static-allowlist.json":"sha256:%s"}' "$sum"
+}
+
+# policy_event_hex <index> prints SHA384("c8s/rtmr3/policy/v1:" || index)
+# (pkg/runtimemeasure PolicyEvent).
+policy_event_hex() { printf 'c8s/rtmr3/policy/v1:%s' "$1" | sha384_hex; }
+
+# static_rtmr3_hex <static-allowlist.json> prints the register a node sealed
+# to the one-member bundle reports (pkg/runtimemeasure ForStaticAllowlist).
+static_rtmr3_hex() {
+  local zero
+  zero=$(printf '%096d' 0)
+  extend_hex "$(extend_hex "$zero" "$(mode_static_hex)")" "$(policy_event_hex "$(bundle_index "$1")")"
+}
+
+# operator_seed_hex <pubkey.pem> prints ForOperatorKey over the file's exact
+# bytes: SHA384(0x00*48 || SHA384(pubkey)).
+operator_seed_hex() {
+  local zero
+  zero=$(printf '%096d' 0)
+  extend_hex "$zero" "$(sha384_hex < "$1")"
+}
+
+# dynamic_rtmr3_hex <pubkey.pem> prints the register a dynamic node launched
+# with that operator key reports after the mode event
+# (pkg/runtimemeasure ForDynamic(ForOperatorKey(pub))).
+dynamic_rtmr3_hex() { extend_hex "$(operator_seed_hex "$1")" "$(mode_dynamic_hex)"; }
+
+# cilium_copy_manifest <namespace> <pod> <image> <shell-script>
+# Prints a pod that runs the node's own Cilium image privileged, with the
+# host /sys bound at /host/sys and the given script as its command: the
+# "privileged copy of cilium" the design names. Its digest is on the node's
+# floor, so only the sealed rules stand between it and node root. The
+# namespace must be one the chart's host-namespace admission policy exempts
+# (kube-system, or the release namespace), or the API server refuses the
+# hostPath volume before any node sees the container.
+cilium_copy_manifest() {
+  local ns=$1 pod=$2 image=$3 script=$4
+  cat <<YAML
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $pod
+  namespace: $ns
+spec:
+  restartPolicy: Never
+  enableServiceLinks: false
+  volumes:
+    - name: sys
+      hostPath:
+        path: /sys
+  containers:
+    - name: agent
+      image: $image
+      imagePullPolicy: IfNotPresent
+      command: ["/bin/sh", "-c", $script]
+      securityContext:
+        privileged: true
+      volumeMounts:
+        - name: sys
+          mountPath: /host/sys
+YAML
+}
+
+# cilium_image prints the image the node's Cilium DaemonSet runs.
+cilium_image() {
+  local image
+  image=$(kubectl -n kube-system get ds cilium \
+    -o jsonpath='{.spec.template.spec.containers[?(@.name=="cilium-agent")].image}' 2>/dev/null || true)
+  [ -n "$image" ] || fail "no cilium-agent container in the kube-system cilium DaemonSet"
+  printf '%s' "$image"
+}

--- a/test/e2e/static/privileged-copy-denied.sh
+++ b/test/e2e/static/privileged-copy-denied.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Live-cluster check that a sealed node refuses a privileged copy of a
+# node-TCB image. The pod runs the node's own Cilium image, whose digest is
+# on every node's floor, privileged and with the host /sys bound in. On a
+# dynamic node the floor admits that on the digest alone (forge-rtmr3.sh
+# relies on it); on a sealed node the Cilium rule's reviewed host paths do
+# not include /sys, so the container is refused before it starts.
+#
+# Needs kubectl pointed at a static-allowlist cluster.
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+# kube-system is exempt from the chart's host-namespace admission policy
+# (which denies the hostPath volume everywhere else) and from the restricted
+# PSA default; the sealed plugin exempts no namespace, so a denial here is
+# the sealed allowlist.
+ns=kube-system
+pod=cilium-copy-probe
+
+cleanup() {
+  local rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  kubectl -n "$ns" delete pod "$pod" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+image=$(cilium_image)
+echo "cilium image on this node: $image"
+cilium_copy_manifest "$ns" "$pod" "$image" '"sleep 3600"' | kubectl apply -f - >/dev/null
+wait_container_denied "$ns" "$pod" containerStatuses agent
+
+echo "PASS: a privileged copy of cilium is refused by the sealed allowlist"

--- a/test/e2e/static/privileged-copy-denied.sh
+++ b/test/e2e/static/privileged-copy-denied.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # Live-cluster check that a sealed node refuses a privileged copy of a
 # node-TCB image. The pod runs the node's own Cilium image, whose digest is
-# on every node's floor, privileged and with the host /sys bound in. On a
-# dynamic node the floor admits that on the digest alone (forge-rtmr3.sh
-# relies on it); on a sealed node the Cilium rule's reviewed host paths do
-# not include /sys, so the container is refused before it starts.
+# on every node's floor, privileged, with another argv (sleep) and with the
+# host /sys bound in. On a dynamic node the floor admits that on the digest
+# alone (forge-rtmr3.sh relies on it); on a sealed node the Cilium rule pins
+# the argv and its reviewed host paths do not include /sys, so the container
+# is refused before it starts.
 #
 # Needs kubectl pointed at a static-allowlist cluster.
 set -euo pipefail

--- a/test/e2e/static/reviews.json
+++ b/test/e2e/static/reviews.json
@@ -1,0 +1,145 @@
+{
+  "entries": {
+    "c8s-cds": {
+      "privileges": "CDS reads the measurements config the chart mounts as a ConfigMap, which the kubelet binds from its pod volume path. The file pins the static tuple CDS holds itself and every requester to; a rewritten file cannot loosen it below the entry install renders, because CDS refuses to start unless its own evidence matches the entry.",
+      "mounts": {
+        "/run/confai": "CDS attests itself over the node's attestation socket and pins every requester on the tuple it proves; no other verifier is reachable.",
+        "/run/confai/policy": "CDS seeds its store from the measured static-allowlist.json and checks the member index against the measured digest; the directory is read-only tmpfs written once by c8s-policy-measure."
+      }
+    },
+    "c8s-ratls-mesh": {
+      "privileges": "ratls-mesh programs the node's netfilter rules from the host network namespace; it is measured image content pinned by digest and is node TCB by design.",
+      "mounts": {
+        "/run/confai": "ratls-mesh verifies peer evidence over the node's attestation socket; no chart value can point it at another verifier."
+      }
+    },
+    "c8s-tls-lb": {
+      "privileges": "tls-lb's nginx config and the attest sidecar's measurements config arrive as ConfigMaps the kubelet binds from its pod volume path. Routing content is out of scope for this lane; the sidecars pin CDS on the node tuple and cannot be steered to another CDS.",
+      "mounts": {
+        "/run/confai": "The tls-lb sidecars attest over the node's attestation socket and pin CDS on the node's own tuple."
+      }
+    },
+    "demo-nginx": {
+      "mounts": {
+        "/run/confai": "The injected c8s-cert sidecar attests over the node's attestation socket and pins CDS on the node's own tuple, so a CDS on an unsealed node of the same image is refused."
+      }
+    }
+  },
+  "floor": {
+    "system-hardened-kubernetes-v1.34.5-rke2r1-build20260227": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net"],
+        "hostPaths": ["/var/lib/rancher/rke2/", "/etc/rancher/rke2/", "/var/lib/kubelet/", "/var/log/", "/etc/ssl/certs/", "/usr/share/ca-certificates/", "/usr/local/share/ca-certificates/", "/etc/ca-certificates/", "/etc/pki/"],
+        "review": "RKE2 control-plane static pods (kube-apiserver, kube-controller-manager, kube-scheduler): measured image content, node TCB. argv is left open until a reviewer pins it from a dynamic node's observation; the host paths are RKE2's state, config, logs and CA bundles."
+      }
+    },
+    "system-hardened-etcd-v3.6.7-k3s1-build20260227": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net"],
+        "hostPaths": ["/var/lib/rancher/rke2/"],
+        "review": "RKE2 etcd static pod: measured image content, node TCB. Its database lives under the RKE2 state directory on the encrypted scratch disk."
+      }
+    },
+    "system-rke2-cloud-provider-v1.34.4-0.20260211145917-c6017918a65": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net"],
+        "hostPaths": ["/var/lib/rancher/rke2/", "/etc/rancher/rke2/"],
+        "review": "RKE2 cloud-controller-manager static pod: measured image content, node TCB."
+      }
+    },
+    "system-mirrored-cilium-cilium-v1.19.1": {
+      "argv": "any",
+      "privileges": {
+        "privileged": true,
+        "hostNamespaces": ["net"],
+        "hostPaths": ["/sys/fs/bpf", "/sys/fs/cgroup", "/proc", "/run/cilium/", "/lib/modules", "/run/xtables.lock", "/etc/cni/net.d", "/opt/cni/bin", "/var/lib/cilium/", "/var/lib/kubelet/pods/"],
+        "review": "Cilium agent and its init containers: the CNI the node image bakes, node TCB. Privileged covers the mount-bpf-fs init container and the agent's capability set. The host paths are the ones the rke2-cilium chart binds; a copy that binds anything else (the lane binds /sys) is refused on that ground even though argv is open."
+      }
+    },
+    "system-mirrored-cilium-operator-generic-v1.19.1": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net"],
+        "hostPaths": ["/var/lib/kubelet/pods/"],
+        "review": "Cilium operator: baked CNI control plane, node TCB. It reads the cilium ConfigMap from the kubelet volume path."
+      }
+    },
+    "system-mirrored-cilium-cilium-envoy-v1.35.9-1770979049-232ed4a2": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net"],
+        "capabilities": ["CAP_NET_ADMIN", "CAP_SYS_ADMIN"],
+        "hostPaths": ["/sys/fs/bpf", "/run/cilium/", "/var/lib/kubelet/pods/"],
+        "review": "Cilium Envoy DaemonSet: baked CNI data path, node TCB."
+      }
+    },
+    "system-hardened-coredns-v1.14.1-build20260206": {
+      "argv": "any",
+      "privileges": {
+        "capabilities": ["CAP_NET_BIND_SERVICE"],
+        "hostPaths": ["/var/lib/kubelet/pods/"],
+        "review": "CoreDNS: baked cluster DNS, node TCB. It reads its Corefile ConfigMap from the kubelet volume path."
+      }
+    },
+    "system-hardened-cluster-autoscaler-v1.10.3-build20260206": {
+      "argv": "any",
+      "privileges": {
+        "review": "CoreDNS proportional autoscaler shipped by the rke2-coredns chart: baked, node TCB; it holds no host binds."
+      }
+    },
+    "system-hardened-k8s-metrics-server-v0.8.1-build20260206": {
+      "argv": "any",
+      "privileges": {
+        "review": "metrics-server shipped by RKE2: baked, node TCB; it holds no host binds."
+      }
+    },
+    "system-hardened-snapshot-controller-v8.4.0-build20260205": {
+      "argv": "any",
+      "privileges": {
+        "review": "CSI snapshot controller shipped by RKE2: baked, node TCB; it holds no host binds."
+      }
+    },
+    "system-klipper-helm-v0.9.14-build20260210": {
+      "argv": "any",
+      "privileges": {
+        "hostPaths": ["/var/lib/kubelet/pods/"],
+        "review": "RKE2 helm-controller job image: installs the packaged charts the image bakes (cilium, coredns, metrics-server, snapshot-controller) from ConfigMaps and Secrets the kubelet binds from its pod volume path. Node TCB: cluster-admin can drive it, but every pod it creates still meets the sealed rules."
+      }
+    },
+    "system-hardened-cni-plugins-v1.9.0-build20260206": {
+      "argv": "any",
+      "privileges": {
+        "hostPaths": ["/opt/cni/bin", "/etc/cni/net.d", "/var/lib/kubelet/pods/"],
+        "review": "RKE2 CNI plugin installer: baked, node TCB; writes only the CNI binary and config directories."
+      }
+    },
+    "system-mirrored-pause-3.6": {
+      "argv": "any",
+      "privileges": {
+        "hostNamespaces": ["net", "pid", "ipc"],
+        "review": "Sandbox pause container for every pod, including host-namespace system pods: baked, node TCB; it runs /pause and binds nothing."
+      }
+    }
+  },
+  "drop": [
+    "system-busybox",
+    "system-local-path-provisioner",
+    "system-k8s-device-plugin",
+    "system-hardened-addon-resizer-1.8.23-build20260206",
+    "system-hardened-dns-node-cache-1.26.7-build20260206",
+    "system-klipper-lb-v0.4.14",
+    "system-mirrored-cilium-certgen-v0.3.2",
+    "system-mirrored-cilium-clustermesh-apiserver-v1.19.1",
+    "system-mirrored-cilium-hubble-relay-v1.19.1",
+    "system-mirrored-cilium-hubble-ui-backend-v0.13.3",
+    "system-mirrored-cilium-hubble-ui-v0.13.3",
+    "system-mirrored-cilium-operator-aws-v1.19.1",
+    "system-mirrored-cilium-operator-azure-v1.19.1",
+    "system-mirrored-ingress-nginx-kube-webhook-certgen-v1.6.7",
+    "system-nginx-ingress-controller-v1.14.3-hardened3",
+    "system-rke2-runtime-v1.34.5-rke2r1"
+  ]
+}

--- a/test/e2e/static/reviews.json
+++ b/test/e2e/static/reviews.json
@@ -10,7 +10,8 @@
     "c8s-ratls-mesh": {
       "privileges": "ratls-mesh programs the node's netfilter rules from the host network namespace; it is measured image content pinned by digest and is node TCB by design.",
       "mounts": {
-        "/run/confai": "ratls-mesh verifies peer evidence over the node's attestation socket; no chart value can point it at another verifier."
+        "/run/confai": "ratls-mesh verifies peer evidence over the node's attestation socket; no chart value can point it at another verifier.",
+        "/var/run/secrets/kubernetes.io/serviceaccount": "ratls-mesh presents the token to the API server, which validates it; a forged token or extra files there gain the operator nothing they do not already hold as cluster-admin."
       }
     },
     "c8s-tls-lb": {
@@ -21,21 +22,20 @@
     },
     "demo-nginx": {
       "mounts": {
-        "/run/confai": "The injected c8s-cert sidecar attests over the node's attestation socket and pins CDS on the node's own tuple, so a CDS on an unsealed node of the same image is refused."
+        "/run/confai": "The injected c8s-cert sidecar attests over the node's attestation socket and pins CDS on the node's own tuple, so a CDS on an unsealed node of the same image is refused.",
+        "/var/run/secrets/kubernetes.io/serviceaccount": "nginx and the injected sidecars read nothing under the token directory; the sidecars authenticate to CDS with the node's admission inventory token, not the service account."
       }
     }
   },
   "floor": {
     "system-hardened-kubernetes-v1.34.5-rke2r1-build20260227": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net"],
         "hostPaths": ["/var/lib/rancher/rke2/", "/etc/rancher/rke2/", "/var/lib/kubelet/", "/var/log/", "/etc/ssl/certs/", "/usr/share/ca-certificates/", "/usr/local/share/ca-certificates/", "/etc/ca-certificates/", "/etc/pki/"],
-        "review": "RKE2 control-plane static pods (kube-apiserver, kube-controller-manager, kube-scheduler): measured image content, node TCB. argv is left open until a reviewer pins it from a dynamic node's observation; the host paths are RKE2's state, config, logs and CA bundles."
+        "review": "RKE2 control-plane static pods (kube-apiserver, kube-controller-manager, kube-scheduler): measured image content, node TCB. The argv, env and mounts still need a reviewer's observation from a dynamic node before this entry seals; the host paths are RKE2's state, config, logs and CA bundles."
       }
     },
     "system-hardened-etcd-v3.6.7-k3s1-build20260227": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net"],
         "hostPaths": ["/var/lib/rancher/rke2/"],
@@ -43,7 +43,6 @@
       }
     },
     "system-rke2-cloud-provider-v1.34.4-0.20260211145917-c6017918a65": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net"],
         "hostPaths": ["/var/lib/rancher/rke2/", "/etc/rancher/rke2/"],
@@ -51,16 +50,14 @@
       }
     },
     "system-mirrored-cilium-cilium-v1.19.1": {
-      "argv": "any",
       "privileges": {
         "privileged": true,
         "hostNamespaces": ["net"],
         "hostPaths": ["/sys/fs/bpf", "/sys/fs/cgroup", "/proc", "/run/cilium/", "/lib/modules", "/run/xtables.lock", "/etc/cni/net.d", "/opt/cni/bin", "/var/lib/cilium/", "/var/lib/kubelet/pods/"],
-        "review": "Cilium agent and its init containers: the CNI the node image bakes, node TCB. Privileged covers the mount-bpf-fs init container and the agent's capability set. The host paths are the ones the rke2-cilium chart binds; a copy that binds anything else (the lane binds /sys) is refused on that ground even though argv is open."
+        "review": "Cilium agent and its init containers: the CNI the node image bakes, node TCB. Privileged covers the mount-bpf-fs init container and the agent's capability set. The host paths are the ones the rke2-cilium chart binds; a copy with another argv (the lane runs sleep) or another bind (the lane binds /sys) is refused."
       }
     },
     "system-mirrored-cilium-operator-generic-v1.19.1": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net"],
         "hostPaths": ["/var/lib/kubelet/pods/"],
@@ -68,7 +65,6 @@
       }
     },
     "system-mirrored-cilium-cilium-envoy-v1.35.9-1770979049-232ed4a2": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net"],
         "capabilities": ["CAP_NET_ADMIN", "CAP_SYS_ADMIN"],
@@ -77,7 +73,6 @@
       }
     },
     "system-hardened-coredns-v1.14.1-build20260206": {
-      "argv": "any",
       "privileges": {
         "capabilities": ["CAP_NET_BIND_SERVICE"],
         "hostPaths": ["/var/lib/kubelet/pods/"],
@@ -85,39 +80,33 @@
       }
     },
     "system-hardened-cluster-autoscaler-v1.10.3-build20260206": {
-      "argv": "any",
       "privileges": {
         "review": "CoreDNS proportional autoscaler shipped by the rke2-coredns chart: baked, node TCB; it holds no host binds."
       }
     },
     "system-hardened-k8s-metrics-server-v0.8.1-build20260206": {
-      "argv": "any",
       "privileges": {
         "review": "metrics-server shipped by RKE2: baked, node TCB; it holds no host binds."
       }
     },
     "system-hardened-snapshot-controller-v8.4.0-build20260205": {
-      "argv": "any",
       "privileges": {
         "review": "CSI snapshot controller shipped by RKE2: baked, node TCB; it holds no host binds."
       }
     },
     "system-klipper-helm-v0.9.14-build20260210": {
-      "argv": "any",
       "privileges": {
         "hostPaths": ["/var/lib/kubelet/pods/"],
         "review": "RKE2 helm-controller job image: installs the packaged charts the image bakes (cilium, coredns, metrics-server, snapshot-controller) from ConfigMaps and Secrets the kubelet binds from its pod volume path. Node TCB: cluster-admin can drive it, but every pod it creates still meets the sealed rules."
       }
     },
     "system-hardened-cni-plugins-v1.9.0-build20260206": {
-      "argv": "any",
       "privileges": {
         "hostPaths": ["/opt/cni/bin", "/etc/cni/net.d", "/var/lib/kubelet/pods/"],
         "review": "RKE2 CNI plugin installer: baked, node TCB; writes only the CNI binary and config directories."
       }
     },
     "system-mirrored-pause-3.6": {
-      "argv": "any",
       "privileges": {
         "hostNamespaces": ["net", "pid", "ipc"],
         "review": "Sandbox pause container for every pod, including host-namespace system pods: baked, node TCB; it runs /pause and binds nothing."

--- a/test/e2e/static/static-overlay.yaml
+++ b/test/e2e/static/static-overlay.yaml
@@ -1,0 +1,16 @@
+# Values `c8s install --static-allowlist` adds on top of a dynamic node-mode
+# install (cmd/c8s/install_static.go staticModeArgs and pinArgs). The bundle
+# is rendered from the dynamic values plus this overlay, and build-bundle.sh
+# proves the result equals what `c8s render-values --static-allowlist` emits
+# for that bundle, so the two cannot drift apart unnoticed.
+#
+# cds.measurementsConfig and ratlsMesh.measurementsConfig are filled in by
+# build-bundle.sh: the chart refuses static mode without them, and their
+# RTMR[3] is the value the bundle itself determines.
+staticAllowlist:
+  enabled: true
+nriImagePolicy:
+  enabled: false
+cds:
+  persistence:
+    enabled: false

--- a/test/e2e/static/verify.sh
+++ b/test/e2e/static/verify.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Live check, from outside the cluster, that `c8s verify --static-allowlist`
+# proves the front door runs on a node sealed to the reviewed bundle: exit 0,
+# every register pinned including RTMR[3] derived from the bundle, and the
+# bundle's index digest reported as the static policy.
+#
+# Needs c8s, curl and jq on PATH and:
+#   E2E_LB_URL          tls-lb front door, https://<node>:443
+#   E2E_IMAGE_MANIFEST  manifest.json of the node image
+#   E2E_BUNDLE          the bundle directory the node booted with
+# Optional:
+#   E2E_WORKLOAD        entry the front door's leaf must be stamped with (default c8s-tls-lb)
+#   E2E_OUT             where to keep mesh-ca.pem and verify.json (default: a temp dir)
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+: "${E2E_LB_URL:?tls-lb front door URL}"
+: "${E2E_IMAGE_MANIFEST:?manifest.json of the node image}"
+: "${E2E_BUNDLE:?bundle directory}"
+workload=${E2E_WORKLOAD:-c8s-tls-lb}
+out=${E2E_OUT:-$(mktemp -d)}
+mkdir -p "$out"
+
+# The CA is fetched from the door it anchors: the e2e proves the evidence
+# chain, not the out-of-band distribution of the CA, which is the operator's.
+fetched=""
+for _ in $(seq 1 30); do
+  if curl -fsk --max-time 10 "$E2E_LB_URL/.well-known/mesh-ca.pem" -o "$out/mesh-ca.pem" && grep -q 'BEGIN CERTIFICATE' "$out/mesh-ca.pem"; then
+    fetched=1; break
+  fi
+  sleep 5
+done
+[ -n "$fetched" ] || fail "no mesh CA served at $E2E_LB_URL/.well-known/mesh-ca.pem"
+
+rc=0
+c8s verify "$E2E_LB_URL" --kind lb \
+  --image-manifest "$E2E_IMAGE_MANIFEST" \
+  --static-allowlist "$E2E_BUNDLE" \
+  --workload "$workload" \
+  --mesh-ca "$out/mesh-ca.pem" \
+  -o json > "$out/verify.json" || rc=$?
+cat "$out/verify.json"
+[ "$rc" -eq 0 ] || fail "c8s verify --static-allowlist exited $rc (0 = verified, 2 = failed, 3 = no evidence, 4 = partial)"
+jq -e '.verified == true' "$out/verify.json" >/dev/null || fail "verify exited 0 without verified=true"
+
+want_rtmr3=$(static_rtmr3_hex "$E2E_BUNDLE/static-allowlist.json")
+jq -e --arg pin "3:$want_rtmr3" '.rtmrs_pinned | index($pin) != null' "$out/verify.json" >/dev/null \
+  || fail "verify did not report RTMR[3] pinned to $want_rtmr3 (rtmrs_pinned: $(jq -c '.rtmrs_pinned' "$out/verify.json"))"
+want_index="sha256:$(bundle_index "$E2E_BUNDLE/static-allowlist.json" | sha256sum | cut -d' ' -f1)"
+jq -e --arg d "$want_index" '.static_policy_digest == $d' "$out/verify.json" >/dev/null \
+  || fail "verify reported static_policy_digest $(jq -r '.static_policy_digest' "$out/verify.json"), want $want_index"
+jq -e --arg w "$workload" '.workload == $w' "$out/verify.json" >/dev/null \
+  || fail "verify reported workload $(jq -r '.workload' "$out/verify.json"), want $workload"
+
+echo "PASS: c8s verify --static-allowlist proves the front door runs on a node sealed to the bundle"

--- a/test/e2e/static/workload.sh
+++ b/test/e2e/static/workload.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Live-cluster check of the sealed rules around one workload entry: the
+# sample from workloads/demo-nginx.yaml is admitted and scales, while the
+# same image with a ConfigMap mount, an env var the rule does not list, or
+# another argv is refused at container creation. The refused variants carry
+# the cw annotation too, so their injected c8s-cert init container runs and
+# obtains a certificate first: what is refused is the workload container
+# itself, for the one field that differs from the bundle's rule.
+#
+# Leaves the demo-nginx Deployment running for the checks that follow
+# (debug-refused.sh); `kubectl delete -f workloads/demo-nginx.yaml` removes
+# it. Needs kubectl pointed at a static-allowlist cluster whose bundle was
+# rendered from workloads/demo-nginx.yaml.
+set -euo pipefail
+# shellcheck disable=SC1091  # resolved relative to this script at run time
+. "$(dirname "$0")/lib.sh"
+
+here=$(cd "$(dirname "$0")" && pwd)
+ns=default
+deploy=demo-nginx
+variants=(configmap env argv)
+
+# The variants must differ from the admitted manifest in exactly the field
+# each one tests, so the image line is held identical across the four files.
+image=$(grep -oE '[[:graph:]]+@sha256:[0-9a-f]{64}' "$here/workloads/demo-nginx.yaml" | head -1)
+[ -n "$image" ] || fail "no digest-pinned image in workloads/demo-nginx.yaml"
+for v in "${variants[@]}"; do
+  grep -qF "image: $image" "$here/workloads/demo-nginx-$v.yaml" \
+    || fail "workloads/demo-nginx-$v.yaml does not pin $image; keep the image line identical across the variants"
+done
+
+cleanup() {
+  local rc=$?
+  [ "$rc" -eq 0 ] || return 0
+  for v in "${variants[@]}"; do
+    kubectl -n "$ns" delete -f "$here/workloads/demo-nginx-$v.yaml" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  done
+}
+trap cleanup EXIT
+
+for v in "${variants[@]}"; do
+  kubectl apply -f "$here/workloads/demo-nginx-$v.yaml" >/dev/null
+done
+wait_container_denied "$ns" demo-nginx-configmap containerStatuses nginx
+wait_container_denied "$ns" demo-nginx-env containerStatuses nginx
+wait_container_denied "$ns" demo-nginx-argv containerStatuses nginx
+
+# wait_ready <replicas>: the Deployment reports that many ready replicas.
+wait_ready() {
+  local want=$1 have=""
+  for _ in $(seq 1 60); do
+    have=$(kubectl -n "$ns" get deploy "$deploy" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true)
+    [ "${have:-0}" -ge "$want" ] && return 0
+    sleep 10
+  done
+  kubectl -n "$ns" describe pods -l "app=$deploy" | tail -40
+  fail "$deploy has ${have:-0} ready replicas, want $want"
+}
+
+kubectl apply -f "$here/workloads/demo-nginx.yaml" >/dev/null
+wait_ready 1
+names=$(kubectl -n "$ns" get pods -l "app=$deploy" \
+  -o jsonpath='{.items[0].spec.initContainers[*].name}' 2>/dev/null || true)
+case "$names" in
+  *c8s-cert*) ;;
+  *) fail "the webhook did not inject the c8s-cert sidecar (init containers: ${names:-none})" ;;
+esac
+echo "ok: $deploy Ready with the injected c8s-cert sidecar"
+
+kubectl -n "$ns" scale deploy "$deploy" --replicas=2 >/dev/null
+wait_ready 2
+echo "ok: $deploy scaled to 2 Ready"
+
+echo "PASS: the matching workload runs and scales; a ConfigMap mount, an unlisted env var and another argv are refused"

--- a/test/e2e/static/workloads/demo-nginx-argv.yaml
+++ b/test/e2e/static/workloads/demo-nginx-argv.yaml
@@ -1,0 +1,18 @@
+# demo-nginx with its command overridden: the rule pins argv exactly, so the
+# same image with another argv is refused at creation.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-nginx-argv
+  namespace: default
+  annotations:
+    confidential.ai/cw: demo-nginx
+spec:
+  enableServiceLinks: false
+  restartPolicy: Never
+  containers:
+    - name: nginx
+      image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 # 1.27-alpine
+      command: ["/bin/sh", "-c", "sleep 3600"]
+      ports:
+        - containerPort: 80

--- a/test/e2e/static/workloads/demo-nginx-configmap.yaml
+++ b/test/e2e/static/workloads/demo-nginx-configmap.yaml
@@ -1,0 +1,32 @@
+# demo-nginx with one ConfigMap volume mounted: the sealed rule admits no
+# ConfigMap source, so the nginx container is refused at creation.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: demo-nginx-steer
+  namespace: default
+data:
+  default.conf: "server { listen 80; return 200 'steered'; }"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-nginx-configmap
+  namespace: default
+  annotations:
+    confidential.ai/cw: demo-nginx
+spec:
+  enableServiceLinks: false
+  restartPolicy: Never
+  volumes:
+    - name: steer
+      configMap:
+        name: demo-nginx-steer
+  containers:
+    - name: nginx
+      image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 # 1.27-alpine
+      ports:
+        - containerPort: 80
+      volumeMounts:
+        - name: steer
+          mountPath: /etc/nginx/conf.d

--- a/test/e2e/static/workloads/demo-nginx-env.yaml
+++ b/test/e2e/static/workloads/demo-nginx-env.yaml
@@ -1,0 +1,20 @@
+# demo-nginx with one env var the rule does not list: an unlisted name under
+# an exact env policy is refused at creation, whatever its value.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-nginx-env
+  namespace: default
+  annotations:
+    confidential.ai/cw: demo-nginx
+spec:
+  enableServiceLinks: false
+  restartPolicy: Never
+  containers:
+    - name: nginx
+      image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 # 1.27-alpine
+      env:
+        - name: HTTP_PROXY
+          value: http://steer.example:3128
+      ports:
+        - containerPort: 80

--- a/test/e2e/static/workloads/demo-nginx.yaml
+++ b/test/e2e/static/workloads/demo-nginx.yaml
@@ -1,0 +1,29 @@
+# The sample confidential workload the static lane admits: the bundle carries
+# its rule, and workload.sh applies this exact manifest. It is
+# samples/nginx-confidential-pod.yaml with enableServiceLinks off, because the
+# kubelet otherwise injects one env var per Service in the namespace and no
+# exact rule can list those. Keep the image line identical across the
+# demo-nginx-*.yaml variants beside it.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-nginx
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-nginx
+  template:
+    metadata:
+      labels:
+        app: demo-nginx
+      annotations:
+        confidential.ai/cw: demo-nginx
+    spec:
+      enableServiceLinks: false
+      containers:
+        - name: nginx
+          image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 # 1.27-alpine
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
Implements a static allowlist design: a generic node image measures a per-launch policy bundle into RTMR[3] before RKE2 starts, the NRI plugin enforces that bundle as the whole policy, and `c8s verify --static-allowlist` recomputes the register from the reviewed bundle. Takes nothing from [#522](https://github.com/confidential-dot-ai/c8s/pull/522).

One commit per design sequencing step, each green on its own:

1. `runtimemeasure`: mode events, `ForStaticAllowlist`, `ForDynamic`; `pkg/policybundle`; `internal/tdxrtmr`. Existing clusters re-derive one value: a node image without the mode event is refused by cred-release from here on.
2. `allowlist`: sealed schema (`privileges`, env value rules, mount source rules), `Index.Admit`, `lint --sealed`, `render --sealed`, `systemfloor -floor`.
3. `nri-image-policy`: sealed mode from `/run/confai/policy/mode`, own-quote CDS pins over the node socket, full-observation admission, PostCreate/Start verdict cache, 1.5 s hook deadline, power-off on fatal state.
4. Node image: `c8s policy-measure` + `c8s-policy-measure.service`, `c8s-attest-socket.service`, static `cred-release`, containerd/nri fail-closed patch under `node-guest-image/c8s/patches/`.
5. CDS `--static-allowlist`, chart `staticAllowlist.*`, `c8s policy-disk`, `install`/`get-kubeconfig`/`verify --static-allowlist`, sidecars pinning CDS on the node's own tuple.
6. `tdx-metal-static-e2e.yml` (dispatch-only until it has a green history).
7. `docs/static-allowlist.md` and the RTMR[3] chain wherever the docs state it.
8. Review fixes: every sealed entry, privileged included, needs exact argv, env and mounts; hostPath rules bind a source path per destination; `local-volume` binds are not the reviewed `pvc` class; `serviceAccountToken` rules need a review string.

## Open breaks the review found

These need a decision or work outside this PR; `docs/static-allowlist.md` lists them under known gaps.

- **Kubelet exec probes and lifecycle hooks.** The kubelet runs `exec` probes and `postStart`/`preStop` through CRI ExecSync, which no NRI hook sees and which the debugging-handlers flag does not cover. Cluster-admin can run any argv inside an admitted container and read the output from pod events. `render --sealed` now reports every such probe; closing it needs an ExecSync refusal in the containerd patch and the plugin refusing a runtime without it.
- **The RKE2 floor cannot seal yet.** With `any` no longer accepted, floor entries for kube-apiserver and etcd need their observed argv, and that argv carries node-specific values (`--advertise-address`, etcd peer URLs) the schema has no `from` source for. The e2e bundle build stops at `lint --sealed` until the floor is completed from a dynamic node's observation and argv gains from-sources.
- **Unsealed spec fields:** `workingDir`, `runAsUser`, seccomp, `no_new_privileges`, `shareProcessNamespace`.

## Deviations from the design text

- The attestation-api unix listener is the in-image `c8s attest-proxy` unit on `/run/confai/attestation-api.sock`, not a native listener (attestation-api lives outside this repo).
- The containerd/nri fail-closed fix ships as a patch for the image pipeline; `runtime.require_fail_closed` stays `false` in the baked plugin config until that build exists, with the 1.5 s deny-on-timeout mitigation always on in sealed mode.
- The §2 kubelet drop-in is dropped: [#533](https://github.com/confidential-dot-ai/c8s/pull/533) already bakes it.
- `install`, `get-kubeconfig` and `verify` take the bundle as a directory or a loose `static-allowlist.json`; `.iso` inputs are refused. `policy-disk` writes the ISO through `xorrisofs`/`genisoimage`/`mkisofs`.
- `--mesh-ca` stays required with `--workload`: the mesh CA carries no evidence in this repo.
- `install` cannot preflight observed container specs from the client; it preflights every node's RTMR[3] through attestation-api (`--static-node-attest` for NAT-bound nodes) and pod digests against the bundle.
- Env `from` sources add `podUID` and `hostIP`; mount classes add `nodeState` (`/run/confai`) and `hostPath` (admitted only through `privileges.hostPaths`).
- On SEV-SNP the measurer writes `mode=dynamic` and touches no register; a `policydata` disk on SNP is fatal.

## Not in this PR

- The patched containerd build and the image pipeline flip of `require_fail_closed`.
- Mesh CA authenticated by evidence.
- CDI/GPU workloads: CDI injects hooks and host binds, so sealed mode denies them until a typed rule exists.
- The two e2e assertions that need an in-guest fault injector (plugin delayed past the deadline; container present at Synchronize). The e2e lane has not run on hardware: it needs an image built from this branch and the `tdx-rke2-image-refs` ConfigMap re-seeded.
- Mode and policy golden vectors are convention-only until a TDX read-back confirms them.
