### PR TITLE
feat(ratls-mesh): add --kubeconfig to the proxy and iptables-sync

### DIFF
--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
@@ -47,12 +48,22 @@ func Run(args []string) error {
 var inClusterConfig = rest.InClusterConfig
 
 // newKubeClientset builds the Kubernetes client used by the proxy and the
-// iptables-sync sidecar. Package var so tests can substitute a fake clientset;
-// production always uses the in-cluster config.
-var newKubeClientset = func() (kubernetes.Interface, error) {
-	restCfg, err := inClusterConfig()
-	if err != nil {
-		return nil, fmt.Errorf("k8s in-cluster config: %w", err)
+// iptables-sync sidecar: from kubeconfigPath when set, else from the
+// in-cluster service-account config. Package var so tests can substitute a
+// fake clientset.
+var newKubeClientset = func(kubeconfigPath string) (kubernetes.Interface, error) {
+	var restCfg *rest.Config
+	var err error
+	if kubeconfigPath != "" {
+		restCfg, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+		if err != nil {
+			return nil, fmt.Errorf("k8s config from --kubeconfig %s: %w", kubeconfigPath, err)
+		}
+	} else {
+		restCfg, err = inClusterConfig()
+		if err != nil {
+			return nil, fmt.Errorf("k8s in-cluster config: %w", err)
+		}
 	}
 	clientset, err := kubernetes.NewForConfig(restCfg)
 	if err != nil {
@@ -91,6 +102,7 @@ type proxyListeners struct {
 type proxyConfig struct {
 	platform                  string
 	attestationApiURL         string
+	kubeconfig                string
 	outboundPort              int
 	inboundPort               int
 	nodeIP                    string
@@ -138,6 +150,7 @@ type proxyConfig struct {
 func bindProxyFlags(fs *pflag.FlagSet, c *proxyConfig) {
 	fs.StringVar(&c.platform, "platform", "auto", "TEE platform: sev-snp, tdx, or auto (probes /dev/{tdx_guest,sev-guest})")
 	fs.StringVar(&c.attestationApiURL, "attestation-api-url", "", "URL of the local attestation-api (e.g. http://localhost:8400)")
+	fs.StringVar(&c.kubeconfig, "kubeconfig", "", "path to a kubeconfig for the pod resolver's API access; empty uses the in-cluster service-account config")
 	fs.IntVar(&c.outboundPort, "outbound-port", 15001, "outbound listener port (intercepted app traffic)")
 	fs.IntVar(&c.inboundPort, "inbound-port", 15006, "inbound listener port (RA-TLS from peer nodes)")
 	fs.StringVar(&c.nodeIP, "node-ip", "", "this node's IP (auto-detected from NODE_IP env if unset)")
@@ -204,7 +217,7 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	clientset, err := newKubeClientset()
+	clientset, err := newKubeClientset(c.kubeconfig)
 	if err != nil {
 		return err
 	}
@@ -563,6 +576,7 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 
 type iptablesSyncConfig struct {
 	outboundPort            int
+	kubeconfig              string
 	uid                     int
 	excludeUIDs             string
 	excludeSourceNamespaces string
@@ -589,6 +603,7 @@ func newIptablesSyncCommand() *cobra.Command {
 	}
 	fs := cmd.Flags()
 	fs.IntVar(&cfg.outboundPort, "outbound-port", 15001, "outbound listener port")
+	fs.StringVar(&cfg.kubeconfig, "kubeconfig", "", "path to a kubeconfig for the pod watch; empty uses the in-cluster service-account config")
 	fs.IntVar(&cfg.uid, "uid", defaultProxyUID, "UID to exclude from redirect")
 	fs.StringVar(&cfg.excludeUIDs, "exclude-uids", "0", "comma-separated UIDs to skip (e.g. root=0 so kubelet/containerd can reach registries)")
 	fs.StringVar(&cfg.excludeSourceNamespaces, "exclude-source-namespaces", defaultMeshExcludedSourceNamespacesCSV(), "comma-separated local source namespaces excluded from transparent mesh interception")

--- a/internal/cmds/ratlsmesh/main_run_test.go
+++ b/internal/cmds/ratlsmesh/main_run_test.go
@@ -50,7 +50,7 @@ func defaultTestProxyConfig(t *testing.T) *proxyConfig {
 func stubKubeClientset(t *testing.T, cs kubernetes.Interface, err error) {
 	t.Helper()
 	old := newKubeClientset
-	newKubeClientset = func() (kubernetes.Interface, error) { return cs, err }
+	newKubeClientset = func(string) (kubernetes.Interface, error) { return cs, err }
 	t.Cleanup(func() { newKubeClientset = old })
 }
 
@@ -232,14 +232,14 @@ func TestNewKubeClientsetConfigOutcomes(t *testing.T) {
 			AuthProvider: &clientcmdapi.AuthProviderConfig{Name: "azure"},
 		}, nil
 	}
-	if cs, err := newKubeClientset(); err == nil || !strings.Contains(err.Error(), "k8s clientset") {
+	if cs, err := newKubeClientset(""); err == nil || !strings.Contains(err.Error(), "k8s clientset") {
 		t.Fatalf("newKubeClientset() = %v, %v, want wrapped clientset error", cs, err)
 	}
 
 	inClusterConfig = func() (*rest.Config, error) {
 		return &rest.Config{Host: "https://127.0.0.1:1"}, nil
 	}
-	cs, err := newKubeClientset()
+	cs, err := newKubeClientset("")
 	if err != nil || cs == nil {
 		t.Fatalf("newKubeClientset() = %v, %v, want a clientset from a valid config", cs, err)
 	}
@@ -248,12 +248,49 @@ func TestNewKubeClientsetConfigOutcomes(t *testing.T) {
 func TestNewKubeClientsetDefaultOutsideCluster(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_HOST", "")
 	t.Setenv("KUBERNETES_SERVICE_PORT", "")
-	cs, err := newKubeClientset()
+	cs, err := newKubeClientset("")
 	if err == nil || !strings.Contains(err.Error(), "k8s in-cluster config") {
 		t.Fatalf("newKubeClientset() error = %v, want in-cluster config error", err)
 	}
 	if cs != nil {
 		t.Fatalf("newKubeClientset() clientset = %v, want nil on error", cs)
+	}
+}
+
+// A kubeconfig path must be honored without consulting the in-cluster config,
+// and a bad path must fail rather than fall back to it.
+func TestNewKubeClientsetKubeconfigPath(t *testing.T) {
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:1
+  name: c
+contexts:
+- context:
+    cluster: c
+    user: u
+  name: ctx
+current-context: ctx
+users:
+- name: u
+  user: {}
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cs, err := newKubeClientset(path)
+	if err != nil || cs == nil {
+		t.Fatalf("newKubeClientset(%q) = %v, %v, want a clientset", path, cs, err)
+	}
+
+	missing := filepath.Join(t.TempDir(), "absent")
+	cs, err = newKubeClientset(missing)
+	if err == nil || !strings.Contains(err.Error(), "--kubeconfig") {
+		t.Fatalf("newKubeClientset(%q) = %v, %v, want --kubeconfig error", missing, cs, err)
 	}
 }
 

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -145,7 +145,7 @@ func runIptablesSync(ctx context.Context, cfg *iptablesSyncConfig) error {
 	if err := resetReadyFile(cfg.readyFile); err != nil {
 		return err
 	}
-	clientset, err := newKubeClientset()
+	clientset, err := newKubeClientset(cfg.kubeconfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Review Focus Areas

| File / Area | Focus | Why |
|-------------|-------|-----|
| `internal/cmds/ratlsmesh/main.go` | Standard | K8s client construction gains a kubeconfig path; new `--kubeconfig` flag on the proxy and iptables-sync. The in-cluster default path must be byte-identical for the chart DaemonSet |
| `internal/cmds/ratlsmesh/pod_ipsets_linux.go` | Light | One-line call-site plumbing |
| `internal/cmds/ratlsmesh/main_run_test.go` | Standard | Stub signature updates + new test asserting a set path never falls back to in-cluster config |

## What Changed

`c8s ratls-mesh` and `c8s ratls-mesh iptables-sync` accept `--kubeconfig <path>`
to build their Kubernetes client from a kubeconfig file; empty keeps the
in-cluster ServiceAccount config, so the chart DaemonSet is unaffected.

## Why

Both build their client via `rest.InClusterConfig`, which only works as a pod
with an injected ServiceAccount token. Running the mesh as a plain process — a
systemd unit in a node guest image — leaves the pod resolver and the pod-IP
ipset watch with no API access. A node-image deployment passes the kubelet
kubeconfig and binds a pods-read ClusterRole to `system:nodes` server-side.

## Design Doc

N/A (small change; part of the node-image leader/follower work).

## Checklist

- [x] New dependencies justified (none — `clientcmd` is part of the existing client-go dependency)
- [x] Tests verify invariants, not just output format (set path is honored without in-cluster fallback; missing path fails instead of falling back)
- [x] No secrets in code, logs, or error messages
