### PR TITLE
feat(node-guest-image): make the restricted PodSecurity floor an invariant

### DIFF
--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -121,22 +121,36 @@ if ! grep -qF 'MIN_SECTORS=125000000' "$ngi/c8s/mkosi.extra/usr/local/bin/scratc
   exit 1
 fi
 
-# The restricted PodSecurity floor is an invariant: the admission config may
-# exempt only the platform namespaces that need privileged pods, and the
-# baked policy that stops tenants relabelling their namespaces must keep
-# naming `restricted` and failing closed.
+# psa-config.yaml exempts only the platform namespaces that need privileged
+# pods, and the baked policy that stops tenants relabelling their namespaces
+# keeps naming `restricted`, denying, and failing closed.
 psa="$ngi/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml"
 vap="$ngi/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml"
-exempt=$(sed -n '/^ *namespaces:/,$p' "$psa" | grep -E '^ *- ' | sed 's/^ *- //' | sort)
-if [ "$exempt" != "$(printf 'kube-system\nlocal-path-storage\n')" ]; then
-  echo "::error::$psa must exempt exactly kube-system and local-path-storage from restricted PodSecurity; got:"
-  echo "$exempt"
+exempt=$(sed -n '/^[[:space:]]*namespaces:/,/^[[:space:]]*[^[:space:]-]/s/^[[:space:]]*-[[:space:]]*//p' "$psa")
+if [ "$exempt" != "$(printf 'kube-system\nlocal-path-storage')" ]; then
+  echo "::error::$psa must exempt exactly kube-system and local-path-storage from restricted PodSecurity; got: $(echo "$exempt" | tr '\n' ' ')"
   exit 1
 fi
-grep -q 'enforce: "restricted"' "$psa" \
-  || { echo "::error::$psa must default to enforce: restricted"; exit 1; }
-grep -q "== 'restricted'" "$vap" && grep -q 'failurePolicy: Fail' "$vap" \
-  && grep -q 'resources: \["namespaces"\]' "$vap" \
-  || { echo "::error::$vap must deny namespace labels below restricted and fail closed"; exit 1; }
+if ! grep -q 'enforce: "restricted"' "$psa"; then
+  echo "::error::$psa must default to enforce: restricted"
+  exit 1
+fi
+if ! grep -q "== 'restricted'" "$vap" || ! grep -q "== 'latest'" "$vap"; then
+  echo "::error::$vap must pin the enforce label to restricted and enforce-version to latest"
+  exit 1
+fi
+if ! grep -q 'failurePolicy: Fail' "$vap"; then
+  echo "::error::$vap must fail closed (failurePolicy: Fail)"
+  exit 1
+fi
+if ! grep -q 'resources: \["namespaces", "namespaces/status", "namespaces/finalize"\]' "$vap" \
+   || ! grep -q 'operations: \["CREATE", "UPDATE"\]' "$vap"; then
+  echo "::error::$vap must match namespace CREATE and UPDATE on the resource and its status/finalize subresources, which also carry labels"
+  exit 1
+fi
+if ! grep -q '^    - Deny$' "$vap"; then
+  echo "::error::$vap binding must deny, not warn or audit"
+  exit 1
+fi
 
 echo "all node-guest-image invariants hold at CONFOS_REF $CONFOS_REF"

--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -121,4 +121,22 @@ if ! grep -qF 'MIN_SECTORS=125000000' "$ngi/c8s/mkosi.extra/usr/local/bin/scratc
   exit 1
 fi
 
+# The restricted PodSecurity floor is an invariant: the admission config may
+# exempt only the platform namespaces that need privileged pods, and the
+# baked policy that stops tenants relabelling their namespaces must keep
+# naming `restricted` and failing closed.
+psa="$ngi/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml"
+vap="$ngi/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml"
+exempt=$(sed -n '/^ *namespaces:/,$p' "$psa" | grep -E '^ *- ' | sed 's/^ *- //' | sort)
+if [ "$exempt" != "$(printf 'kube-system\nlocal-path-storage\n')" ]; then
+  echo "::error::$psa must exempt exactly kube-system and local-path-storage from restricted PodSecurity; got:"
+  echo "$exempt"
+  exit 1
+fi
+grep -q 'enforce: "restricted"' "$psa" \
+  || { echo "::error::$psa must default to enforce: restricted"; exit 1; }
+grep -q "== 'restricted'" "$vap" && grep -q 'failurePolicy: Fail' "$vap" \
+  && grep -q 'resources: \["namespaces"\]' "$vap" \
+  || { echo "::error::$vap must deny namespace labels below restricted and fail closed"; exit 1; }
+
 echo "all node-guest-image invariants hold at CONFOS_REF $CONFOS_REF"

--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -285,8 +285,8 @@ jobs:
             bash "\$E2E/cw-label-policy.sh" && say E2E_CW_LABEL_OK || FAILED="\$FAILED cw-label-policy"
             if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
             if [ "\$WOK" != "1" ]; then
-              \$K -n default describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
-              \$K -n default logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
+              \$K -n c8s-e2e-cw describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
+              \$K -n c8s-e2e-cw logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
               # csr_denied with "the inventory callback has no node addresses"
               # is CDS-side, and CERTLOG only shows the workload's half. With
               # cds.sandboxInventoryCIDRs unset CDS derives the bound from the

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -34,8 +34,16 @@ kubectl apply -f samples/confidentialworkload.yaml
 
 ## 3. Deploy an annotated workload
 
+The node image enforces the restricted PodSecurity standard in every tenant
+namespace. In node mode the injected sidecar mounts the node's inventory
+socket as a hostPath, which restricted forbids, so a namespace that hosts
+confidential workloads is opened by the operator. Only a credential allowed
+to grant PodSecurity exemptions can set this label; tenants cannot.
+
 ```sh
-kubectl apply -f samples/nginx-confidential-pod.yaml
+kubectl create namespace demo
+kubectl label namespace demo pod-security.kubernetes.io/enforce=privileged
+kubectl -n demo apply -f samples/nginx-confidential-pod.yaml
 ```
 
 The pod template annotation `confidential.ai/cw: demo-nginx` is the security
@@ -44,8 +52,8 @@ opt-in. The `ConfidentialWorkload` object is not required for injection.
 ## 4. Inspect the result
 
 ```sh
-kubectl get pods
-kubectl describe pod -l app=demo-nginx
+kubectl -n demo get pods
+kubectl -n demo describe pod -l app=demo-nginx
 kubectl get cwl -A
 ```
 
@@ -59,7 +67,7 @@ Expected injected pieces:
 ## Reset
 
 ```sh
-kubectl delete -f samples/nginx-confidential-pod.yaml
+kubectl delete namespace demo
 kubectl delete -f samples/confidentialworkload.yaml
 c8s uninstall
 ```

--- a/internal/helmchart/psa_level_policy_test.go
+++ b/internal/helmchart/psa_level_policy_test.go
@@ -1,0 +1,164 @@
+package helmchart
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	admissionregv1 "k8s.io/api/admissionregistration/v1"
+)
+
+// The node image bakes a ValidatingAdmissionPolicy that keeps the restricted
+// PodSecurity floor an invariant for namespace-scoped tenants. The manifest is
+// applied by RKE2, not the chart, so it is read from the image tree here.
+const psaLevelPolicyPath = "../../node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml"
+
+func loadPSALevelPolicy(t *testing.T) (admissionregv1.ValidatingAdmissionPolicy, admissionregv1.ValidatingAdmissionPolicyBinding) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Clean(psaLevelPolicyPath))
+	if err != nil {
+		t.Fatalf("read %s: %v", psaLevelPolicyPath, err)
+	}
+	var vap admissionregv1.ValidatingAdmissionPolicy
+	if !findDoc(t, string(raw), "ValidatingAdmissionPolicy", "confos-psa-level", &vap) {
+		t.Fatal("ValidatingAdmissionPolicy confos-psa-level not in manifest")
+	}
+	var binding admissionregv1.ValidatingAdmissionPolicyBinding
+	if !findDoc(t, string(raw), "ValidatingAdmissionPolicyBinding", "confos-psa-level", &binding) {
+		t.Fatal("ValidatingAdmissionPolicyBinding confos-psa-level not in manifest")
+	}
+	return vap, binding
+}
+
+func TestPSALevelPolicyShape(t *testing.T) {
+	vap, binding := loadPSALevelPolicy(t)
+	if vap.Spec.FailurePolicy == nil || *vap.Spec.FailurePolicy != admissionregv1.Fail {
+		t.Error("failurePolicy must be Fail so an evaluation error denies the write")
+	}
+	if len(vap.Spec.Validations) != 1 {
+		t.Fatalf("expected one validation, got %d", len(vap.Spec.Validations))
+	}
+	// Labels are writable through the status and finalize subresources too,
+	// and kubectl label is an UPDATE.
+	want := map[string]bool{"namespaces": false, "namespaces/status": false, "namespaces/finalize": false}
+	ops := map[admissionregv1.OperationType]bool{}
+	for _, r := range vap.Spec.MatchConstraints.ResourceRules {
+		for _, res := range r.Resources {
+			if _, ok := want[res]; ok {
+				want[res] = true
+			}
+		}
+		for _, op := range r.Operations {
+			ops[op] = true
+		}
+	}
+	for res, seen := range want {
+		if !seen {
+			t.Errorf("matchConstraints does not name %s", res)
+		}
+	}
+	for _, op := range []admissionregv1.OperationType{admissionregv1.Create, admissionregv1.Update} {
+		if !ops[op] {
+			t.Errorf("matchConstraints does not match %s", op)
+		}
+	}
+	if binding.Spec.PolicyName != vap.Name {
+		t.Errorf("binding names policy %q, want %q", binding.Spec.PolicyName, vap.Name)
+	}
+	if len(binding.Spec.ValidationActions) != 1 || binding.Spec.ValidationActions[0] != admissionregv1.Deny {
+		t.Errorf("binding must Deny, got %v", binding.Spec.ValidationActions)
+	}
+}
+
+// evalPSALevel runs the policy's expression with the given new and old
+// namespace and authorizer verdict. oldObject is nil on CREATE. The authorizer
+// is modelled as a dyn value whose chain ends in `allowed`.
+func evalPSALevel(t *testing.T, expr string, object, oldObject map[string]any, allowed bool) bool {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("object", cel.DynType),
+		cel.Variable("oldObject", cel.DynType),
+		cel.Variable("authorizer", cel.DynType),
+		cel.OptionalTypes(),
+	)
+	if err != nil {
+		t.Fatalf("cel env: %v", err)
+	}
+	// The k8s authorizer chain is not a CEL library; substitute a map lookup
+	// with the same truth value so the rest of the expression is exercised.
+	const chain = "authorizer.group('confidential.ai').resource('podsecurityexemptions').check('grant').allowed()"
+	if !strings.Contains(expr, chain) {
+		t.Fatalf("expression does not check the podsecurityexemptions grant: %q", expr)
+	}
+	expr = strings.ReplaceAll(expr, chain, "authorizer.allowed")
+	ast, iss := env.Compile(expr)
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("cel compile: %v", iss.Err())
+	}
+	prg, err := env.Program(ast)
+	if err != nil {
+		t.Fatalf("cel program: %v", err)
+	}
+	var old any
+	if oldObject != nil {
+		old = oldObject
+	}
+	out, _, err := prg.Eval(map[string]any{
+		"object":     object,
+		"oldObject":  old,
+		"authorizer": map[string]any{"allowed": allowed},
+	})
+	if err != nil {
+		t.Fatalf("cel eval: %v", err)
+	}
+	return out.Value() == true
+}
+
+func nsWithLabels(labels map[string]any) map[string]any {
+	md := map[string]any{"name": "tenant"}
+	if labels != nil {
+		md["labels"] = labels
+	}
+	return map[string]any{"metadata": md}
+}
+
+func TestPSALevelPolicyExpression(t *testing.T) {
+	vap, _ := loadPSALevelPolicy(t)
+	expr := vap.Spec.Validations[0].Expression
+	const enforce = "pod-security.kubernetes.io/enforce"
+	const version = "pod-security.kubernetes.io/enforce-version"
+	privileged := map[string]any{enforce: "privileged"}
+	for _, tc := range []struct {
+		name    string
+		object  map[string]any
+		old     map[string]any
+		allowed bool
+		want    bool
+	}{
+		{"create without labels", nsWithLabels(nil), nil, false, true},
+		{"create with unrelated labels", nsWithLabels(map[string]any{"team": "a"}), nil, false, true},
+		{"create restricted", nsWithLabels(map[string]any{enforce: "restricted"}), nil, false, true},
+		{"create restricted latest", nsWithLabels(map[string]any{enforce: "restricted", version: "latest"}), nil, false, true},
+		{"tenant creates privileged", nsWithLabels(privileged), nil, false, false},
+		{"tenant creates baseline", nsWithLabels(map[string]any{enforce: "baseline"}), nil, false, false},
+		{"tenant pins old version", nsWithLabels(map[string]any{enforce: "restricted", version: "v1.0"}), nil, false, false},
+		{"tenant pins old version without level", nsWithLabels(map[string]any{version: "v1.0"}), nil, false, false},
+		{"tenant lowers on update", nsWithLabels(privileged), nsWithLabels(nil), false, false},
+		{"tenant lowers on update from restricted", nsWithLabels(privileged), nsWithLabels(map[string]any{enforce: "restricted"}), false, false},
+		{"tenant raises to restricted", nsWithLabels(map[string]any{enforce: "restricted"}), nsWithLabels(privileged), false, true},
+		{"tenant removes privileged label", nsWithLabels(nil), nsWithLabels(privileged), false, true},
+		{"unrelated update of privileged namespace", nsWithLabels(map[string]any{enforce: "privileged", "team": "a"}), nsWithLabels(privileged), false, true},
+		{"status update keeps privileged", nsWithLabels(privileged), nsWithLabels(privileged), false, true},
+		{"granter creates privileged", nsWithLabels(privileged), nil, true, true},
+		{"granter lowers on update", nsWithLabels(privileged), nsWithLabels(nil), true, true},
+		{"granter pins old version", nsWithLabels(map[string]any{enforce: "restricted", version: "v1.25"}), nil, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := evalPSALevel(t, expr, tc.object, tc.old, tc.allowed); got != tc.want {
+				t.Errorf("allowed=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -77,6 +77,29 @@ The other disks are optional; each is owned by one unit under
   issued certificate's group to `cluster-admin` through ordinary RBAC;
   identity, TTL and revocation are documented in [operator.md].
 
+## Workload isolation
+
+Tenant pods run on the node's own kernel under runc, so what a pod may ask
+for is what stands between it and the measured host. The image enforces the
+restricted PodSecurity standard by default
+(`etc/rancher/rke2/psa-config.yaml`): no privileged pods, no host
+namespaces, no root user, no added capabilities, no unconfined seccomp or
+AppArmor. Only `kube-system` and `local-path-storage` are exempt. `default`
+is not: the sample workload in `samples/` is restricted-compliant, and so is
+the sidecar the webhook injects.
+
+A namespace label can normally lower that level. The baked
+`psa-level-policy.yaml` AddOn denies an `enforce` label other than
+`restricted` unless the caller is authorized to grant
+`podsecurityexemptions.confidential.ai` (verb `grant`), a virtual resource
+no default role includes. cluster-admin and system:masters pass, which is
+how `c8s install` labels its release namespace privileged for the
+node-level components; a tenant holding `admin` or `edit` in its own
+namespaces does not. The invariant therefore rests on tenancy: hand tenants
+namespace-scoped credentials, never cluster-admin, and the launch
+measurement vouches for the floor their pods run under. cluster-admin can
+delete the policy, and RKE2 does not recreate deleted AddOn objects.
+
 Migration state (see [#264] for the full plan):
 
 1. This directory is the canonical definition: `c8s-image.yml` builds via

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -84,21 +84,29 @@ for is what stands between it and the measured host. The image enforces the
 restricted PodSecurity standard by default
 (`etc/rancher/rke2/psa-config.yaml`): no privileged pods, no host
 namespaces, no root user, no added capabilities, no unconfined seccomp or
-AppArmor. Only `kube-system` and `local-path-storage` are exempt. `default`
-is not: the sample workload in `samples/` is restricted-compliant, and so is
-the sidecar the webhook injects.
+AppArmor. Only `kube-system` and `local-path-storage` are exempt; `default`
+is not.
 
 A namespace label can normally lower that level. The baked
 `psa-level-policy.yaml` AddOn denies an `enforce` label other than
-`restricted` unless the caller is authorized to grant
-`podsecurityexemptions.confidential.ai` (verb `grant`), a virtual resource
-no default role includes. cluster-admin and system:masters pass, which is
-how `c8s install` labels its release namespace privileged for the
-node-level components; a tenant holding `admin` or `edit` in its own
+`restricted`, or an `enforce-version` other than `latest`, unless the
+caller is authorized to grant `podsecurityexemptions.confidential.ai` (verb
+`grant`), a virtual resource no default role includes. cluster-admin and
+system:masters pass; a tenant holding `admin` or `edit` in its own
 namespaces does not. The invariant therefore rests on tenancy: hand tenants
 namespace-scoped credentials, never cluster-admin, and the launch
 measurement vouches for the floor their pods run under. cluster-admin can
 delete the policy, and RKE2 does not recreate deleted AddOn objects.
+
+The floor covers namespaces without confidential workloads. In node mode
+the webhook mounts the node's inventory socket into every
+`confidential.ai/cw` pod as a read-only hostPath, which restricted (and
+baseline) forbids, so a namespace hosting confidential workloads is opened
+by the operator with the privileged label, as `c8s install` does for its
+release namespace. Inside such a namespace the chart's own admission
+policies (host namespaces, hostPort, the mesh UID) are the controls, and the
+sample workload in `samples/` is restricted-compliant on its own so it can
+move back under the floor when the socket no longer needs a hostPath.
 
 Migration state (see [#264] for the full plan):
 

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
@@ -4,14 +4,12 @@
 # Restricted enforcement by default. kube-system and local-path-storage are
 # exempt (they ship privileged daemonsets / hostPath helpers); add more
 # namespaces here for any privileged platform component you deploy. Every
-# other namespace, `default` included, inherits restricted: no privileged
-# pods, no host namespaces, no root user, no added capabilities, no
-# unconfined seccomp or AppArmor. A namespace label can still pick a lower
-# level, but only for a caller that RBAC lets grant PodSecurity exemptions
-# (../../../var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml), so
-# a tenant with namespace-scoped access cannot lower its own namespace.
-# `c8s install` labels its release namespace privileged for the node-level
-# components it runs; the operator credential it uses is cluster-admin.
+# other namespace, `default` included, inherits restricted. The baked
+# ../../../var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml stops
+# a namespace label from lowering that level unless the caller may grant
+# PodSecurity exemptions. Namespaces hosting confidential workloads need
+# that grant in node mode (the injected sidecar mounts a hostPath); see
+# node-guest-image/README.md, "Workload isolation".
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:

--- a/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
+++ b/node-guest-image/c8s/mkosi.extra/etc/rancher/rke2/psa-config.yaml
@@ -3,9 +3,15 @@
 #
 # Restricted enforcement by default. kube-system and local-path-storage are
 # exempt (they ship privileged daemonsets / hostPath helpers); add more
-# namespaces here for any privileged platform component you deploy. Workload
-# namespaces inherit the restricted policy unless explicitly labelled
-# otherwise.
+# namespaces here for any privileged platform component you deploy. Every
+# other namespace, `default` included, inherits restricted: no privileged
+# pods, no host namespaces, no root user, no added capabilities, no
+# unconfined seccomp or AppArmor. A namespace label can still pick a lower
+# level, but only for a caller that RBAC lets grant PodSecurity exemptions
+# (../../../var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml), so
+# a tenant with namespace-scoped access cannot lower its own namespace.
+# `c8s install` labels its release namespace privileged for the node-level
+# components it runs; the operator credential it uses is cluster-admin.
 apiVersion: apiserver.config.k8s.io/v1
 kind: AdmissionConfiguration
 plugins:
@@ -26,7 +32,3 @@ plugins:
         namespaces:
           - kube-system
           - local-path-storage
-          # `default` is exempted because smoke tests run there. Move
-          # workloads to dedicated namespaces in production and drop this
-          # exemption.
-          - default

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml
@@ -1,42 +1,42 @@
-# Keeps the restricted PodSecurity floor from psa-config.yaml an invariant.
-#
+# Keeps the restricted PodSecurity floor from psa-config.yaml an invariant:
 # PodSecurity admission reads its level from namespace labels, so whoever can
-# label a namespace can hand its pods `privileged`: hostPath, host namespaces,
-# root, any capability. The admission config file on the measured root sets
-# the default and the exemption list, but says nothing about labels. This
-# policy does: a namespace may carry an `enforce` label other than
-# `restricted` only when the caller is authorized to grant PodSecurity
-# exemptions. That is expressed as an RBAC check on a virtual resource
-# (`podsecurityexemptions.confidential.ai`, verb `grant`) that no default role
-# grants, so cluster-admin (wildcard rules) and system:masters pass and a
-# tenant holding `admin`/`edit` in its own namespaces does not.
-#
-# RKE2 applies this file as an AddOn at server start, before any tenant can
-# reach the API. The policy is not a defence against cluster-admin, who can
-# delete it; the guarantee it upholds is the one the attestation can vouch
-# for: tenants scoped to their namespaces cannot lower the floor the image
-# booted with.
+# label a namespace could hand its pods `privileged`, or pin `enforce-version`
+# to an old standard that lacks the seccomp, capability and non-root checks.
+# A namespace may carry an `enforce` label other than `restricted`, or an
+# `enforce-version` other than `latest`, only when the caller passes an RBAC
+# check for a virtual resource (`podsecurityexemptions.confidential.ai`, verb
+# `grant`) that no default role grants: cluster-admin (wildcard rules) and
+# system:masters pass, a tenant holding `admin`/`edit` in its own namespaces
+# does not. A write that leaves both labels as they were passes without the
+# check, so a controller that touches an operator-labelled namespace's
+# annotations or status is not denied. The status and finalize subresources
+# are matched because their update strategies keep the labels a writer sends.
+# RKE2 applies this AddOn at server start, before any tenant can reach the
+# API. The tenancy assumption and the cluster-admin caveat are in
+# node-guest-image/README.md, "Workload isolation".
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: confos-psa-level
 spec:
   # Fail closed: a CEL evaluation error denies the namespace write. The
-  # expression is has()-guarded, so it should not error in practice.
+  # optional chains below cannot error on a missing label map or key.
   failurePolicy: Fail
   matchConstraints:
     resourceRules:
       - apiGroups: [""]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]
-        resources: ["namespaces"]
+        resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
   validations:
     - expression: >-
-        !has(object.metadata.labels) ||
-        !('pod-security.kubernetes.io/enforce' in object.metadata.labels) ||
-        object.metadata.labels['pod-security.kubernetes.io/enforce'] == 'restricted' ||
+        (object.metadata.?labels[?'pod-security.kubernetes.io/enforce'].orValue('restricted') == 'restricted' &&
+         object.metadata.?labels[?'pod-security.kubernetes.io/enforce-version'].orValue('latest') == 'latest') ||
+        (oldObject != null &&
+         object.metadata.?labels[?'pod-security.kubernetes.io/enforce'] == oldObject.metadata.?labels[?'pod-security.kubernetes.io/enforce'] &&
+         object.metadata.?labels[?'pod-security.kubernetes.io/enforce-version'] == oldObject.metadata.?labels[?'pod-security.kubernetes.io/enforce-version']) ||
         authorizer.group('confidential.ai').resource('podsecurityexemptions').check('grant').allowed()
-      message: "pod-security.kubernetes.io/enforce may only be lowered below restricted by a caller allowed to grant podsecurityexemptions.confidential.ai; this node image enforces the restricted PodSecurity standard for tenant namespaces."
+      message: "pod-security.kubernetes.io/enforce may not be set below restricted, nor enforce-version below latest, without permission to grant podsecurityexemptions.confidential.ai"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml
+++ b/node-guest-image/c8s/mkosi.extra/var/lib/rancher/rke2/server/manifests/psa-level-policy.yaml
@@ -1,0 +1,48 @@
+# Keeps the restricted PodSecurity floor from psa-config.yaml an invariant.
+#
+# PodSecurity admission reads its level from namespace labels, so whoever can
+# label a namespace can hand its pods `privileged`: hostPath, host namespaces,
+# root, any capability. The admission config file on the measured root sets
+# the default and the exemption list, but says nothing about labels. This
+# policy does: a namespace may carry an `enforce` label other than
+# `restricted` only when the caller is authorized to grant PodSecurity
+# exemptions. That is expressed as an RBAC check on a virtual resource
+# (`podsecurityexemptions.confidential.ai`, verb `grant`) that no default role
+# grants, so cluster-admin (wildcard rules) and system:masters pass and a
+# tenant holding `admin`/`edit` in its own namespaces does not.
+#
+# RKE2 applies this file as an AddOn at server start, before any tenant can
+# reach the API. The policy is not a defence against cluster-admin, who can
+# delete it; the guarantee it upholds is the one the attestation can vouch
+# for: tenants scoped to their namespaces cannot lower the floor the image
+# booted with.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: confos-psa-level
+spec:
+  # Fail closed: a CEL evaluation error denies the namespace write. The
+  # expression is has()-guarded, so it should not error in practice.
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["namespaces"]
+  validations:
+    - expression: >-
+        !has(object.metadata.labels) ||
+        !('pod-security.kubernetes.io/enforce' in object.metadata.labels) ||
+        object.metadata.labels['pod-security.kubernetes.io/enforce'] == 'restricted' ||
+        authorizer.group('confidential.ai').resource('podsecurityexemptions').check('grant').allowed()
+      message: "pod-security.kubernetes.io/enforce may only be lowered below restricted by a caller allowed to grant podsecurityexemptions.confidential.ai; this node image enforces the restricted PodSecurity standard for tenant namespaces."
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: confos-psa-level
+spec:
+  policyName: confos-psa-level
+  validationActions:
+    - Deny

--- a/samples/nginx-confidential-pod.yaml
+++ b/samples/nginx-confidential-pod.yaml
@@ -15,12 +15,24 @@ spec:
       annotations:
         confidential.ai/cw: demo-nginx
     spec:
+      # The node image enforces the restricted PodSecurity standard in every
+      # tenant namespace, `default` included, so the workload runs as a
+      # non-root user with every capability dropped. nginx-unprivileged is
+      # the upstream image built for exactly that; it listens on 8080.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: nginx
           # Confidential workloads reference images by digest: the guest pulls
           # this reference and admits it against the allowlist, and a tag names
           # whatever the registry serves at pull time. Bump with
-          # `c8s allowlist inspect-image nginx:<tag>`.
-          image: nginx@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10 # 1.27-alpine
+          # `c8s allowlist inspect-image nginxinc/nginx-unprivileged:<tag>`.
+          image: nginxinc/nginx-unprivileged@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0 # 1.27-alpine
           ports:
-            - containerPort: 80
+            - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]

--- a/samples/nginx-confidential-pod.yaml
+++ b/samples/nginx-confidential-pod.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: demo-nginx
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -15,10 +14,11 @@ spec:
       annotations:
         confidential.ai/cw: demo-nginx
     spec:
-      # The node image enforces the restricted PodSecurity standard in every
-      # tenant namespace, `default` included, so the workload runs as a
-      # non-root user with every capability dropped. nginx-unprivileged is
-      # the upstream image built for exactly that; it listens on 8080.
+      # The node image enforces restricted PodSecurity in every tenant
+      # namespace, `default` included. nginx-unprivileged runs non-root and
+      # listens on 8080. In node mode the injected sidecar still mounts the
+      # node's inventory socket as a hostPath, so deploy into a namespace the
+      # operator has labelled privileged (docs/DEMO.md).
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/test/e2e/allowlist-enforcement.sh
+++ b/test/e2e/allowlist-enforcement.sh
@@ -15,7 +15,8 @@ set -euo pipefail
 : "${C8S_MEASUREMENTS:?pins the launch measurement of that endpoint}"
 : "${C8S_OPERATOR_KEY:?path to the operator EC key PEM}"
 
-# `default` is exempt from the node image's restricted PSA default, so a denial
+# The node image enforces the restricted PodSecurity standard in `default`,
+# so the probe declares a restricted-compliant securityContext and a denial
 # here is the image floor and not PodSecurity.
 ns=default
 pod=allowlist-probe
@@ -24,7 +25,9 @@ image=busybox:1.36
 al() { c8s allowlist "$@" --url "$C8S_ALLOWLIST_URL" --measurements "$C8S_MEASUREMENTS"; }
 
 probe() {
-  kubectl -n "$ns" run "$pod" --image="$image" --restart=Never --command -- sleep 300 >/dev/null
+  kubectl -n "$ns" run "$pod" --image="$image" --restart=Never \
+    --overrides='{"spec":{"securityContext":{"runAsNonRoot":true,"runAsUser":65534,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"'"$pod"'","image":"'"$image"'","command":["sleep","300"],"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}' \
+    >/dev/null
 }
 
 digest=""

--- a/test/e2e/cw-workload.sh
+++ b/test/e2e/cw-workload.sh
@@ -12,16 +12,17 @@ set -euo pipefail
 manifest="$(dirname "$0")/../../samples/nginx-confidential-pod.yaml"
 [ -f "$manifest" ] || fail "sample manifest not found at $manifest"
 
-ns=default
+ns=c8s-e2e-cw
 deploy=demo-nginx
 
 # A failed workload is left standing for the caller to diagnose.
 cleanup() {
   local rc=$?
   [ "$rc" -eq 0 ] || return 0
-  kubectl -n "$ns" delete -f "$manifest" --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl delete namespace "$ns" --ignore-not-found --wait=false >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
+cw_namespace "$ns"
 
 image=$(grep -oE '[[:graph:]]+@sha256:[0-9a-f]{64}' "$manifest" | head -1)
 [ -n "$image" ] || fail "no digest-pinned image in $manifest"
@@ -35,7 +36,7 @@ if [ -n "${C8S_OPERATOR_KEY:-}" ]; then
   echo "ok: workload digest admitted"
 fi
 
-kubectl apply -f "$manifest" >/dev/null
+kubectl -n "$ns" apply -f "$manifest" >/dev/null
 
 ready=""
 for _ in $(seq 1 60); do

--- a/test/e2e/lib.sh
+++ b/test/e2e/lib.sh
@@ -7,3 +7,18 @@
 # fail prints a FAIL: line to stderr and exits non-zero. The "FAIL:" prefix is
 # the convention CI greps for, so keep both scripts on this one definition.
 fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# cw_namespace creates <ns> if missing and labels it privileged. The node
+# image enforces the restricted PodSecurity standard outside its platform
+# namespaces, and in node mode the webhook mounts the inventory socket into
+# every confidential-workload pod as a hostPath, which restricted forbids. A
+# namespace hosting CW pods is therefore opened by the operator, whose
+# credential may grant PodSecurity exemptions (node-guest-image/README.md,
+# "Workload isolation"); the e2e scripts run under that credential.
+cw_namespace() {
+  kubectl create namespace "$1" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
+  kubectl label namespace "$1" --overwrite \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged >/dev/null
+}

--- a/test/e2e/mesh-cw-enforcement.sh
+++ b/test/e2e/mesh-cw-enforcement.sh
@@ -73,8 +73,11 @@ echo "workload: $cw_ns/$cw_pod (cw=$cw_id) at $cw_ip:$cw_port on $cw_node ($cw_n
 # --- client pod (fresh namespace: a normal, non-excluded mesh source) -------
 
 kubectl create namespace "$ns" >/dev/null
+# A plain client pod: restricted-compliant, since the fresh namespace inherits
+# the node image's restricted PodSecurity default.
 kubectl run "$client" -n "$ns" --image="$client_image" --restart=Never \
-  --command -- sleep 3600 >/dev/null
+  --overrides='{"spec":{"securityContext":{"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}},"containers":[{"name":"'"$client"'","image":"'"$client_image"'","command":["sleep","3600"],"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}}]}}' \
+  >/dev/null
 kubectl wait --for=condition=Ready pod/"$client" -n "$ns" --timeout=120s >/dev/null
 
 client_node=$(kubectl get pod "$client" -n "$ns" -o jsonpath='{.spec.nodeName}')
@@ -247,7 +250,7 @@ if [ -n "$drop_line" ] && [ -n "$dns_line" ] && [ "$dns_line" -gt "$drop_line" ]
   fail "the UDP/53 carve-out is ordered below the non-TCP drop, so it is unreachable:
 $egress_chain"
 fi
-echo "ok: cw egress DNS carve-out is scoped to $cluster_dns and ordered above the drop"
+echo "ok: cw egress DNS carve-out is unscoped and ordered above the drop"
 
 # Membership is what the guard keys on. An empty set is enforcement that is not
 # running, and reads identically to a guard that is simply not being exercised.

--- a/test/e2e/volumes.sh
+++ b/test/e2e/volumes.sh
@@ -51,7 +51,7 @@ MUT=${E2E_VOL_MUT_NAME:-mut}
 MARKER=${E2E_VOL_MUT_MARKER:-c8s-e2e-mut-proof}
 CDS_PORT=${E2E_CDS_LOCAL_PORT:-18443}
 
-ns=default                       # exempt from the node image's restricted PSA default
+ns=c8s-e2e-volumes               # opened for CW pods by cw_namespace below
 READER=e2e-vol-reader
 WRITER=e2e-vol-writer
 DENIED=e2e-vol-denied
@@ -68,11 +68,12 @@ writer_script="until mountpoint -q /run/c8s/volumes/$MUT; do sleep 1; done; prin
 PF_PODS=""
 cleanup() {
   for p in $PF_PODS ${PF_CDS:-}; do kill "$p" 2>/dev/null || true; done
-  kubectl -n "$ns" delete pod $READER $WRITER $DENIED --ignore-not-found --wait=false >/dev/null 2>&1 || true
+  kubectl delete namespace "$ns" --ignore-not-found --wait=false >/dev/null 2>&1 || true
   al workload delete "$READER" "$WRITER" >/dev/null 2>&1 || true
   return 0
 }
 trap cleanup EXIT
+cw_namespace "$ns"
 
 # Every CDS call goes over a port-forward: tls-lb fronts /allowlist but not
 # /secrets, and the RA-TLS client verifies attestation rather than PKI


### PR DESCRIPTION
## Summary

The node image defaulted every namespace to the restricted PodSecurity standard from a measured config file, but two things kept that from being a guarantee: `default` was exempt for the smoke tests, and a namespace label could lower the level. This PR closes both. On node-as-CVM a tenant scoped to its namespaces cannot run pods below restricted, and the launch measurement vouches for the floor.

One honest limit: in node mode the webhook mounts the node's inventory socket into every confidential-workload pod as a read-only hostPath, which restricted forbids. A namespace hosting confidential workloads is therefore opened by the operator with the privileged label, the same way `c8s install` labels its release namespace, and the chart's own pod policies are the controls inside it. The floor covers every other namespace.

## Changes

- `psa-config.yaml` drops the `default` exemption. `kube-system` and `local-path-storage` stay exempt for their privileged helpers.
- New baked AddOn `psa-level-policy.yaml`: a ValidatingAdmissionPolicy on namespaces, including the status and finalize subresources, that denies a `pod-security.kubernetes.io/enforce` label other than `restricted` or an `enforce-version` other than `latest` unless the caller passes an RBAC check for `grant` on `podsecurityexemptions.confidential.ai`. No default role grants that virtual resource, so cluster-admin and system:masters pass and a tenant with `admin`/`edit` in its namespaces does not. A write that leaves both labels unchanged passes without the check.
- `internal/helmchart/psa_level_policy_test.go` loads the manifest, asserts the policy and binding shape, and evaluates the CEL across create, update, version-pinning and granter cases. The node-guest-image invariants gate checks the same shape in the lint workflow.
- `samples/nginx-confidential-pod.yaml` is restricted-compliant on its own: `nginxinc/nginx-unprivileged` pinned by digest, non-root, all capabilities dropped, RuntimeDefault seccomp, port 8080, no hardcoded namespace.
- The workload and volume e2e run in dedicated operator-labelled namespaces through a shared `cw_namespace` helper; the allowlist and mesh probes, which are not CW pods, declare restricted-compliant security contexts. The demo doc gains the create-and-label step.
- README gains a "Workload isolation" section stating the tenancy assumption and the hostPath limit. cluster-admin can delete the policy and RKE2 does not recreate deleted AddOn objects.

## Validation

- `go test ./internal/helmchart/` passes, including the new policy tests.
- Invariants script passes against the pinned confos ref; shellcheck clean on the touched scripts.
- Not run: a cluster. The metal e2e is the first real exercise of the sample under the new namespaces; `cw-label-policy.sh` labels its probe namespace privileged as system:masters, which the policy allows.

## Follow-ups

AppArmor on the node kernel and user namespaces for tenant pods are separate PRs. Moving the inventory socket off a hostPath would let CW namespaces back under the floor.
