### PR TITLE
ci: gate measured pin domains independently

### DIFF
--- a/.github/scripts/repro-gate-changes
+++ b/.github/scripts/repro-gate-changes
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+readonly PIN_MANIFEST="$SCRIPT_DIR/pin-manifest.sh"
+
+die() {
+  echo "repro-gate-changes: $*" >&2
+  exit 1
+}
+
+main() {
+  if [ "$#" -ne 3 ]; then
+    echo "usage: repro-gate-changes CURRENT_MANIFEST BASE_MANIFEST CHANGED_PATHS_ZERO" >&2
+    return 2
+  fi
+
+  local current_manifest=$1 base_manifest=$2 changed_paths=$3 path
+  local image=false kernel_snapshot=false
+
+  [ -f "$changed_paths" ] || die "changed-path list not found: $changed_paths"
+  bash "$PIN_MANIFEST" validate --manifest "$current_manifest" >/dev/null
+  bash "$PIN_MANIFEST" validate --manifest "$base_manifest" >/dev/null
+
+  if ! jq -e -s '.[0].builds["node-image"] == .[1].builds["node-image"]' \
+    "$base_manifest" "$current_manifest" >/dev/null; then
+    image=true
+  fi
+  if ! jq -e -s '.[0].builds["kernel-snapshot"] == .[1].builds["kernel-snapshot"]' \
+    "$base_manifest" "$current_manifest" >/dev/null; then
+    kernel_snapshot=true
+  fi
+  if ! jq -e -s '
+    (.[0].builds["kata-guest"] | {confos_ref, mkosi_ref, mkosi_version})
+    == (.[1].builds["kata-guest"] | {confos_ref, mkosi_ref, mkosi_version})
+  ' "$base_manifest" "$current_manifest" >/dev/null; then
+    kernel_snapshot=true
+    jq -e '
+      .builds["kata-guest"].confos_ref
+      == .builds["kernel-snapshot"].confos_ref
+    ' "$current_manifest" >/dev/null ||
+      die "a kata-guest kernel-input change must advance kernel-snapshot.confos_ref"
+  fi
+
+  while IFS= read -r -d '' path; do
+    case "$path" in
+      .github/scripts/pin-manifest.sh | \
+        .github/scripts/repro-gate-changes | \
+        .github/actions/setup-mkosi/action.yml | \
+        .github/workflows/image-repro-gate.yml)
+        image=true
+        kernel_snapshot=true
+        ;;
+      node-guest-image/* | \
+        .github/workflows/c8s-image.yml | \
+        .github/workflows/c8s-image-publish.yml)
+        image=true
+        ;;
+      kata-guest-base/kernel/* | .github/workflows/kernel-snapshot.yml)
+        kernel_snapshot=true
+        ;;
+      .github/build-pins.json)
+        # The manifest's domain objects were compared above.
+        ;;
+    esac
+  done <"$changed_paths"
+
+  printf 'image=%s\nkernel_snapshot=%s\n' "$image" "$kernel_snapshot"
+}
+
+main "$@"

--- a/.github/scripts/tests/test-repro-gate-changes.sh
+++ b/.github/scripts/tests/test-repro-gate-changes.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TEST_SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly TEST_SCRIPT_DIR
+ROOT=$(cd -- "$TEST_SCRIPT_DIR/../../.." && pwd)
+readonly ROOT
+readonly CLASSIFIER="$TEST_SCRIPT_DIR/../repro-gate-changes"
+
+fail() {
+  echo "test-repro-gate-changes: $*" >&2
+  exit 1
+}
+
+test_dir=$(mktemp -d "${TMPDIR:-/tmp}/test-repro-gate-changes.XXXXXXXX")
+trap 'rm -rf "$test_dir"' EXIT
+base_manifest="$test_dir/base.json"
+current_manifest="$test_dir/current.json"
+changed_paths="$test_dir/changed-paths"
+
+reset_case() {
+  cp "$ROOT/.github/build-pins.json" "$base_manifest"
+  cp "$base_manifest" "$current_manifest"
+  : >"$changed_paths"
+}
+
+set_paths() {
+  : >"$changed_paths"
+  local path
+  for path in "$@"; do
+    printf '%s\0' "$path" >>"$changed_paths"
+  done
+}
+
+expect_result() {
+  local want_image=$1 want_kernel=$2 actual expected
+  actual=$(bash "$CLASSIFIER" "$current_manifest" "$base_manifest" "$changed_paths")
+  expected=$(printf 'image=%s\nkernel_snapshot=%s' "$want_image" "$want_kernel")
+  [ "$actual" = "$expected" ] || {
+    printf 'expected:\n%s\nactual:\n%s\n' "$expected" "$actual" >&2
+    fail "classification differs"
+  }
+}
+
+reset_case
+set_paths docs/development.md
+expect_result false false
+
+reset_case
+set_paths node-guest-image/mkosi.conf
+expect_result true false
+
+reset_case
+set_paths kata-guest-base/kernel/container.config
+expect_result false true
+
+reset_case
+set_paths .github/actions/setup-mkosi/action.yml
+expect_result true true
+
+reset_case
+jq '.builds["node-image"].confos_ref = "1111111111111111111111111111111111111111"' \
+  "$base_manifest" >"$current_manifest"
+set_paths .github/build-pins.json
+expect_result true false
+
+reset_case
+jq '.builds["kernel-snapshot"].confos_ref = "2222222222222222222222222222222222222222"' \
+  "$base_manifest" >"$current_manifest"
+set_paths .github/build-pins.json
+expect_result false true
+
+reset_case
+jq '.builds["kata-guest"].attestation_rs_ref = "3333333333333333333333333333333333333333"' \
+  "$base_manifest" >"$current_manifest"
+set_paths .github/build-pins.json
+expect_result false false
+
+reset_case
+jq '.builds["kata-guest"].confos_ref = "4444444444444444444444444444444444444444"' \
+  "$base_manifest" >"$current_manifest"
+set_paths .github/build-pins.json
+if bash "$CLASSIFIER" "$current_manifest" "$base_manifest" "$changed_paths" \
+  >"$test_dir/unexpected.stdout" 2>"$test_dir/unexpected.stderr"; then
+  fail "kata-guest confos change without a snapshot-lineage change unexpectedly passed"
+fi
+grep -q 'must advance kernel-snapshot.confos_ref' "$test_dir/unexpected.stderr" ||
+  fail "kata-guest confos mismatch did not explain the required snapshot-lineage change"
+
+reset_case
+printf 'not-json\n' >"$current_manifest"
+if bash "$CLASSIFIER" "$current_manifest" "$base_manifest" "$changed_paths" \
+  >"$test_dir/unexpected.stdout" 2>"$test_dir/unexpected.stderr"; then
+  fail "malformed current manifest unexpectedly passed"
+fi
+
+echo "repro gate change-classification tests passed"

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Test pin manifest utility
         run: bash .github/scripts/tests/test-pin-manifest.sh
 
+      - name: Test repro-gate change classification
+        run: bash .github/scripts/tests/test-repro-gate-changes.sh
+
       - name: Install actionlint (checksum-pinned)
         env:
           # SHA256 from the v1.7.12 release's checksums.txt (linux_amd64).
@@ -51,5 +54,7 @@ jobs:
           shellcheck \
             .github/scripts/calculate-release-version.sh \
             .github/scripts/pin-manifest.sh \
+            .github/scripts/repro-gate-changes \
             .github/scripts/tests/test-pin-manifest.sh \
+            .github/scripts/tests/test-repro-gate-changes.sh \
             kata-guest-base/scripts/ci/publish-release-aliases.sh

--- a/.github/workflows/image-repro-gate.yml
+++ b/.github/workflows/image-repro-gate.yml
@@ -1,9 +1,11 @@
-# Reproducibility gate for the node image: PRs touching the image definition
-# or its pins build the image TWICE (parallel legs, separate runners) and fail
-# unless every measured value matches (c8s#264). Runs on every PR and decides
-# relevance itself — a paths: filter would leave the required `compare` check
-# forever pending on unrelated PRs. Fork PRs are exempt from the gate
-# (security-over-coverage); the post-merge main build remains the published gate.
+# Reproducibility gates for measured images. Node-image changes build the image
+# TWICE and require every measured value to match (c8s#264). Kernel-snapshot
+# changes rebuild the resolved config and require it to match the committed
+# lockfile. Manifest objects are classified independently, so one measurement
+# domain never starts the other's build. This runs on every PR and decides
+# relevance itself — a paths filter would leave the required `compare` check
+# pending on unrelated PRs. Fork PRs are exempt (security-over-coverage); the
+# post-merge builds remain the publication gates.
 name: image repro gate
 on:
   pull_request:
@@ -23,31 +25,43 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       image: ${{ steps.diff.outputs.image }}
+      kernel_snapshot: ${{ steps.diff.outputs.kernel_snapshot }}
       c8s_ref: ${{ steps.diff.outputs.c8s_ref }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - id: diff
         env:
-          GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           if [ -z "$PR" ]; then
-            image=true  # manual dispatch: always run the full gate
-          elif gh api "repos/${{ github.repository }}/pulls/$PR/files" --paginate \
-                 --jq '.[].filename' \
-               | grep -qE "^(node-guest-image/|\.github/build-pins\.json|\.github/scripts/pin-manifest\.sh|\.github/actions/setup-mkosi/action\.yml|\.github/workflows/(c8s-image(-publish)?|image-repro-gate)\.yml)"; then
             image=true
+            kernel_snapshot=true
           else
-            image=false
+            base_manifest="$RUNNER_TEMP/base-build-pins.json"
+            changed_paths="$RUNNER_TEMP/changed-paths"
+            git cat-file -e "${BASE_SHA}^{commit}"
+            git show "${BASE_SHA}:.github/build-pins.json" >"$base_manifest"
+            git diff --name-only -z "$BASE_SHA" HEAD -- >"$changed_paths"
+            result=$(bash .github/scripts/repro-gate-changes \
+              .github/build-pins.json "$base_manifest" "$changed_paths")
+            image=$(sed -n 's/^image=//p' <<<"$result")
+            kernel_snapshot=$(sed -n 's/^kernel_snapshot=//p' <<<"$result")
+            [[ "$image" =~ ^(true|false)$ ]]
+            [[ "$kernel_snapshot" =~ ^(true|false)$ ]]
           fi
           echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "kernel_snapshot=$kernel_snapshot" >> "$GITHUB_OUTPUT"
           # Bake the same published components production uses: mkosi.sync's
           # own C8S_REF default, the single source of truth.
           ref=$(sed -n "s/^C8S_REF=\"\\\${C8S_REF:-\(.*\)}\"$/\1/p" node-guest-image/c8s/mkosi.sync)
           test -n "$ref"
           echo "c8s_ref=$ref" >> "$GITHUB_OUTPUT"
-          echo "image-relevant: $image (components at \`$ref\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "node-image relevant: $image (components at \`$ref\`)" >> "$GITHUB_STEP_SUMMARY"
+          echo "kernel-snapshot relevant: $kernel_snapshot" >> "$GITHUB_STEP_SUMMARY"
 
       # PR code must never run with the production module-signing key. This
       # keypair is shared by both legs, used only in unpublished gate images,
@@ -101,17 +115,32 @@ jobs:
       c8s_ref: ${{ needs.changes.outputs.c8s_ref }}
       gate_signing_artifact: module-signing-${{ github.run_id }}
 
+  kernel_snapshot:
+    needs: changes
+    if: needs.changes.outputs.kernel_snapshot == 'true'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/kernel-snapshot.yml
+
   compare:
-    # The required check: green fast on image-irrelevant PRs (and fork PRs,
-    # whose changes job is skipped), otherwise only after both legs built
-    # and every measured value matched.
-    needs: [changes, build-a, build-b]
+    # The required check: green fast when neither domain is relevant (and on
+    # fork PRs, whose changes job is skipped); otherwise enforce every build
+    # and comparison selected by the classifier.
+    needs: [changes, build-a, build-b, kernel_snapshot]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: Nothing image-relevant changed
-        if: needs.changes.outputs.image != 'true'
-        run: echo "no image paths touched — gate not applicable" >> "$GITHUB_STEP_SUMMARY"
+      - name: Change classification must have succeeded
+        if: needs.changes.result != 'success' && needs.changes.result != 'skipped'
+        env:
+          RESULT: ${{ needs.changes.result }}
+        run: |
+          echo "change-classification result: $RESULT" >&2
+          exit 1
+
+      - name: Nothing measurement-gate-relevant changed
+        if: needs.changes.outputs.image != 'true' && needs.changes.outputs.kernel_snapshot != 'true'
+        run: echo "no gated measurement inputs changed — gate not applicable" >> "$GITHUB_STEP_SUMMARY"
       - name: Legs must have succeeded
         if: needs.changes.outputs.image == 'true'
         env:
@@ -156,3 +185,42 @@ jobs:
           open(os.environ["GITHUB_STEP_SUMMARY"], "a").write("\n".join(lines) + "\n")
           sys.exit(1 if fail else 0)
           EOF
+
+      - name: Kernel snapshot build must have succeeded
+        if: needs.changes.outputs.kernel_snapshot == 'true'
+        env:
+          RESULT: ${{ needs.kernel_snapshot.result }}
+        run: |
+          test "$RESULT" = success || {
+            echo "kernel snapshot build result: $RESULT" >&2
+            exit 1
+          }
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.kernel_snapshot == 'true'
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: needs.changes.outputs.kernel_snapshot == 'true'
+        with:
+          name: config-x86_64.snapshot
+          path: kernel-evidence
+
+      - name: Resolved kernel config must match the lockfile
+        if: needs.changes.outputs.kernel_snapshot == 'true'
+        env:
+          EXPECTED_SHA256: ${{ needs.kernel_snapshot.outputs.snapshot_sha256 }}
+        run: |
+          set -euo pipefail
+          committed=kata-guest-base/kernel/config-x86_64.snapshot
+          built=kernel-evidence/config-x86_64.snapshot
+          built_sha=$(sha256sum "$built" | awk '{print $1}')
+          [ "$built_sha" = "$EXPECTED_SHA256" ] || {
+            echo "::error::downloaded snapshot digest differs from the build output" >&2
+            exit 1
+          }
+          if ! cmp -s "$committed" "$built"; then
+            diff -u "$committed" "$built" || true
+            echo "::error::resolved kernel config drifted; commit the regenerated snapshot" >&2
+            exit 1
+          fi
+          echo "kernel snapshot matches \`${built_sha}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/kernel-snapshot.yml
+++ b/.github/workflows/kernel-snapshot.yml
@@ -181,6 +181,7 @@ jobs:
           name: config-x86_64.snapshot
           path: c8s/kata-guest-base/kernel/config-x86_64.snapshot
           if-no-files-found: error
+          overwrite: true
 
       # --- bank the caches (shared keys + the completeness guard) ------------
       - name: Pack kernel-builder tools tree


### PR DESCRIPTION
## Summary

- Classify pull-request changes by measured pin domain using the canonical manifest
  subobjects, rather than treating every pin change as a node-image change.
- Rebuild the node image only for node-image inputs and reuse the existing kernel
  snapshot workflow only for kernel inputs.
- Download the generated snapshot, correlate it with the reported digest, and
  byte-compare it with the committed snapshot before the required gate passes.
- Keep attestation-only Kata changes out of the kernel build while requiring Kata
  kernel-input changes to advance the confidential OS snapshot reference.

## Why

The previous path-only gate conflated independent measured artifacts. That caused
unnecessary node rebuilds and left kernel-specific pin changes without an equivalent
reproducibility comparison. Domain-aware routing makes the required check match the
artifact whose measurement can actually change.

## Security

Fork pull requests never receive access to the self-hosted build jobs. Classifier
errors fail the required comparison job, and manifest/path inputs are handled as
NUL-delimited data to avoid filename parsing ambiguity.

## Validation

- `bash .github/scripts/tests/test-pin-manifest.sh` (12 cases)
- `bash .github/scripts/tests/test-repro-gate-changes.sh` (9 cases)
- repository CI-equivalent `actionlint`
- `shellcheck` on the classifier and its tests
- `git diff --check`
