### PR TITLE
feat(nri): block loader-control environment variables in NRI admission

### DIFF
--- a/docs/loader-environment-policy.md
+++ b/docs/loader-environment-policy.md
@@ -1,0 +1,50 @@
+# Loader-control environment policy
+
+The node-side `nri-image-policy` plugin blocks container creation when the
+runtime environment contains any name beginning with these case-sensitive prefixes:
+
+| Prefix | Scope |
+| --- | --- |
+| `LD_` | Every name beginning with `LD_`, including `LD_PRELOAD`, `LD_LIBRARY_PATH`, `LD_AUDIT`, tracing, debugging, profiling, and future controls |
+| `GLIBC_TUNABLES` | glibc runtime and loader tuning, including all suffixed names |
+| `GCONV_PATH` | Search path for dynamically loaded character-conversion modules, including all suffixed names |
+
+The check applies to every `CreateContainer` request, including floor images,
+workload images, captured namespace exemptions, and requests during startup.
+It also applies in image-policy audit mode and with image allowlisting disabled.
+Empty values, duplicate entries, and bare blocked names are rejected. Operators
+resolve a rejection by removing the blocked variable from the image or deployment.
+The policy has one strict setting, shared by all namespaces and workloads.
+
+The plugin checks the runtime environment supplied by containerd through NRI,
+which includes resolved image and deployment environment settings. The check
+runs before image admission and inventory registration. A rejection returns the
+blocked name and emits an audit event with reason `loader_env_blocked`.
+Environment values remain private in both errors and policy logs.
+
+## Security scope
+
+This rule blocks loader-control variables at container creation. Existing
+containers keep their current lifecycle when the plugin is upgraded; recreating
+a container applies the rule. The rule ships in both the baked node plugin and
+the chart-installed node plugin. Pod-as-CVM uses its separate in-guest policy.
+
+Runtime components and other NRI plugins remain trusted to preserve the checked
+environment. Commands executed later inside an admitted container follow the
+workload's own execution controls. Library files, `/etc/ld.so.preload`, direct
+loader invocation, application plugins, and interpreter configuration require
+image, command, filesystem, and application policy appropriate to the workload.
+Ordinary application environment variables remain configurable.
+
+## Implementation and verification
+
+`internal/cmds/nri-image-policy/loader_env.go` defines the reserved names and
+rejection behavior. `plugin.go` calls the check at the start of `CreateContainer`.
+`loader_env_test.go` covers reserved names, empty and duplicate values, ordinary
+configuration, and admission through startup, floor, namespace, and audit paths.
+
+Run the plugin suite with:
+
+```sh
+go test ./internal/cmds/nri-image-policy
+```

--- a/internal/cmds/nri-image-policy/loader_env.go
+++ b/internal/cmds/nri-image-policy/loader_env.go
@@ -1,0 +1,42 @@
+package nriimagepolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/confidential-dot-ai/c8s/internal/audit"
+	"github.com/containerd/nri/pkg/api"
+)
+
+// See docs/loader-environment-policy.md for the reserved prefixes.
+func blockedLoaderEnv(env []string) string {
+	prefixes := [...]string{"LD_", "GLIBC_TUNABLES", "GCONV_PATH"}
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(name, prefix) {
+				return name
+			}
+		}
+	}
+	return ""
+}
+
+// enforceLoaderEnv is an unconditional container-creation gate. Floor images,
+// namespace snapshots, initialization, and image-policy audit mode all pass
+// through this gate before admission or inventory registration.
+func (p *plugin) enforceLoaderEnv(pod *api.PodSandbox, ctr *api.Container) error {
+	name := blockedLoaderEnv(ctr.GetEnv())
+	if name == "" {
+		return nil
+	}
+	// Values can contain credentials. Only the variable name is reported.
+	p.logger.Warn("blocked loader-control environment variable",
+		"namespace", pod.GetNamespace(), "pod", pod.GetName(),
+		"container", ctr.GetName(), "variable", name)
+	p.audit.Log(audit.Event{
+		Action: "deny", Reason: "loader_env_blocked",
+		Namespace: pod.GetNamespace(), Pod: pod.GetName(), Container: ctr.GetName(),
+	})
+	return fmt.Errorf("loader-control environment variable %q is blocked", name)
+}

--- a/internal/cmds/nri-image-policy/loader_env_test.go
+++ b/internal/cmds/nri-image-policy/loader_env_test.go
@@ -1,0 +1,92 @@
+package nriimagepolicy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestBlockedLoaderEnv(t *testing.T) {
+	for _, name := range []string{"LD_PRELOAD", "LD_LIBRARY_PATH", "LD_AUDIT", "LD_DEBUG", "LD_DEBUG_OUTPUT", "LD_PROFILE", "LD_TRACE_LOADED_OBJECTS", "LD_FUTURE_CONTROL", "GLIBC_TUNABLES", "GLIBC_TUNABLES_DEBUG", "GLIBC_TUNABLES_EXTRA", "GLIBC_TUNABLES2", "GCONV_PATH", "GCONV_PATH_DEBUG", "GCONV_PATH2"} {
+		for _, suffix := range []string{"", "=", "=/private/value=with-equals"} {
+			t.Run(name+suffix, func(t *testing.T) {
+				if got := blockedLoaderEnv([]string{"PATH=/usr/bin", name + suffix}); got != name {
+					t.Fatalf("got %q, want %q", got, name)
+				}
+			})
+		}
+	}
+	for _, env := range [][]string{nil, {"PATH=/usr/bin", "HOME=/app", "MODEL_PATH=/models", "TOKEN=LD_PRELOAD=secret"}, {"ld_preload=x", "MY_LD_PRELOAD=x", "MY_GLIBC_TUNABLES=x", "MY_GCONV_PATH=x", "glibc_tunables=x", "gconv_path=x"}} {
+		if got := blockedLoaderEnv(env); got != "" {
+			t.Fatalf("ordinary environment rejected: %q", got)
+		}
+	}
+	if got := blockedLoaderEnv([]string{"LD_PRELOAD=", "LD_PRELOAD=/injected"}); got != "LD_PRELOAD" {
+		t.Fatalf("duplicate blocked variable admitted: %q", got)
+	}
+}
+
+func TestCreateContainerLoaderEnvHardGate(t *testing.T) {
+	for _, ready := range []bool{false, true} {
+		for _, mode := range []string{ModeFailClosed, ModeAudit} {
+			for _, admission := range []string{"floor", "workload", "namespace-snapshot", "allowlist-disabled"} {
+				t.Run(fmt.Sprintf("ready=%t/%s/%s", ready, mode, admission), func(t *testing.T) {
+					p := floorPlugin(t)
+					p.cfg.Policy.Mode = mode
+					if ready {
+						p.SetReady()
+					}
+					pod := makePod("kube-system", "pod")
+					digest := pushDigestA
+					switch admission {
+					case "workload":
+						digest = pushDigestB
+						p.policy.apply(workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"}), 1)
+					case "namespace-snapshot":
+						digest = pushDigestB
+						p.cfg.Policy.ExemptNamespaces = []string{"kube-system"}
+						snapshot := newExemptSnapshot(p.cfg.Policy.ExemptNamespaces)
+						snapshot.add("kube-system", digest)
+						p.exempt.Store(snapshot)
+					case "allowlist-disabled":
+						p.cfg.Allowlist = allowlistConfig{}
+					}
+					ctr := makeCtrWithImage(pod.Id, "ctr", "registry/repo@"+digest)
+					ctr.Args = []string{"/bin/app", "--serve"}
+					ctr.Env = []string{"LD_PRELOAD=/sensitive-value"}
+					var logs bytes.Buffer
+					p.logger = slog.New(slog.NewJSONHandler(&logs, nil))
+					events := captureAudit(t, func() {
+						adjustment, updates, err := p.CreateContainer(context.Background(), pod, ctr)
+						if err == nil || !strings.Contains(err.Error(), "LD_PRELOAD") {
+							t.Fatalf("want named denial, got %v", err)
+						}
+						if strings.Contains(err.Error(), "sensitive-value") {
+							t.Fatal("denial exposed environment value")
+						}
+						if adjustment != nil || len(updates) != 0 {
+							t.Fatal("denied container produced adjustments")
+						}
+					})
+					if len(events) != 1 || events[0]["reason"] != "loader_env_blocked" || events[0]["action"] != "deny" {
+						t.Fatalf("unexpected audit events: %v", events)
+					}
+					if _, recorded := p.inventory.containers[ctr.Id]; recorded {
+						t.Fatal("denied container was recorded in inventory")
+					}
+					if strings.Contains(logs.String(), "sensitive-value") || strings.Contains(fmt.Sprint(events), "sensitive-value") {
+						t.Fatal("policy logs exposed environment value")
+					}
+					// The same admission route accepts ordinary configuration.
+					ctr.Env = []string{"MODEL_PATH=/models", "TOKEN=ordinary"}
+					if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+						t.Fatalf("ordinary environment rejected: %v", err)
+					}
+				})
+			}
+		}
+	}
+}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -716,6 +716,9 @@ func (p *plugin) admitWhileInitializing(ctx context.Context, cfg *config, pod *a
 // CreateContainer is called when a container is being created.
 // Returning an error will reject the container creation.
 func (p *plugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+	if err := p.enforceLoaderEnv(pod, ctr); err != nil {
+		return nil, nil, err
+	}
 	cfg := p.cfg
 	imageRef := ctr.GetAnnotations()[annotationImageName]
 

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -79,6 +79,11 @@ The other disks are optional; each is owned by one unit under
 
 ## Workload isolation
 
+The measured NRI plugin blocks loader-control environment variables on every
+container creation: all names beginning with `LD_`, `GLIBC_TUNABLES`, or `GCONV_PATH`. The
+[loader environment policy](../docs/loader-environment-policy.md) defines the
+reserved names, admission behavior, and rollout scope.
+
 Tenant pods run on the node's own kernel under runc, so what a pod may ask
 for is what stands between it and the measured host. The image enforces the
 restricted PodSecurity standard by default


### PR DESCRIPTION
Approved images could receive environment variables that influence loaded code. NRI now rejects these variables at container creation across all admission modes.

- Block LD_*, GLIBC_TUNABLES, and GCONV_PATH.
- Enforce before floor, namespace exemption, and audit-mode admission.
- Add regression tests and document the policy.