### PR TITLE
security(node-guest-image): latch kernel.modules_disabled in the c8s profile

### DIFF
--- a/.github/scripts/node-guest-image-invariants.sh
+++ b/.github/scripts/node-guest-image-invariants.sh
@@ -35,6 +35,27 @@ for src in "$ngi/kernel/c8s.config" confos/kernel/dev.config; do
   fi
 done
 
+# CONFIG_MODULES=y is a c8s-only widening (the base kernel compiles modules
+# out, which is why confos's 99-kspp-hardening.conf omits the key). The
+# profile must therefore latch kernel.modules_disabled itself: the gpu
+# profile's latch is absent from the GPU-less composition.
+latch="$ngi/c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service"
+preset="$ngi/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset"
+if grep -qx 'CONFIG_MODULES=y' "$ngi/kernel/c8s.config"; then
+  if ! grep -qF 'kernel.modules_disabled=1' "$latch"; then
+    echo "::error::$ngi/kernel/c8s.config sets CONFIG_MODULES=y, so $latch must set kernel.modules_disabled=1"
+    exit 1
+  fi
+  if ! grep -qx 'enable c8s-modules-latch.service' "$preset"; then
+    echo "::error::$preset must enable c8s-modules-latch.service; an unenabled latch never runs"
+    exit 1
+  fi
+  if ! grep -qx 'RequiredBy=rke2-server.service rke2-agent.service' "$latch"; then
+    echo "::error::$latch must be RequiredBy the rke2 pair so rke2 cannot start with modules still loadable"
+    exit 1
+  fi
+fi
+
 # The baked NRI floor is a template whose always_allow entries are
 # @-tokens the sync fills with ref-resolved digests; a hardcoded
 # sha256 would bake a stale digest the fail-closed floor can't

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -108,6 +108,26 @@ policies (host namespaces, hostPort, the mesh UID) are the controls, and the
 sample workload in `samples/` is restricted-compliant on its own so it can
 move back under the floor when the socket no longer needs a hostPath.
 
+## Module loading
+
+`kernel/c8s.config` sets `CONFIG_MODULES=y`, which the confos base kernel
+compiles out. It is on for exactly two out-of-tree modules, `nvidia.ko` and
+`nvidia-uvm.ko` (see [MODULE-SIGNING.md](MODULE-SIGNING.md)); every symbol
+kubelet, containerd and Cilium need is `=y`, so nothing modprobes at runtime.
+
+Because the key exists on this kernel, the runtime lock has to be set here:
+confos's `99-kspp-hardening.conf` omits `kernel.modules_disabled` on the
+grounds that the base kernel has no such key. `c8s-modules-latch.service`
+sets it to 1 once boot-time loading is done, ordered after the gpu profile's
+`nvidia-modules-latch.service` and before the rke2 pair, which it is
+`RequiredBy`. The latch is one-way for the rest of the boot.
+
+The gpu profile ships a latch of its own, so on the canonical GPU build both
+run and the second rewrites a 1. This one also covers the GPU-less
+composition (`attest` + `c8s`, no `gpu`), where that unit is absent. The same
+split applies to `99-c8s-bpf.conf`: the c8s profile owns the runtime locks its
+own kernel fragment makes necessary.
+
 Migration state (see [#264] for the full plan):
 
 1. This directory is the canonical definition: `c8s-image.yml` builds via

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service
@@ -30,7 +30,7 @@ RemainAfterExit=yes
 # One-way: 1 cannot go back to 0 without a reboot.
 ExecStart=/sbin/sysctl -w kernel.modules_disabled=1
 
-# vsock fence: only attestation-api may use AF_VSOCK (see kernel/c8s.config).
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/gpu.config).
 RestrictAddressFamilies=AF_UNIX
 
 [Install]

--- a/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service
+++ b/node-guest-image/c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service
@@ -1,0 +1,41 @@
+# Restore the no-further-modules posture on a GPU-less composition.
+#
+# kernel/c8s.config turns CONFIG_MODULES back on (the base kernel compiles it
+# out) so the two signed NVIDIA modules can load. That makes
+# kernel.modules_disabled a live key on this image, and confos's
+# 99-kspp-hardening.conf omits it precisely because the base kernel has no such
+# key. The only latch confos ships lives in its gpu profile, so the GPU-less
+# composition documented in mkosi.conf boots with modules loadable for the
+# whole boot, and nothing pins the gpu profile into the canonical build.
+#
+# Same split as 99-c8s-bpf.conf: the c8s profile owns the runtime lock its own
+# kernel fragment makes necessary.
+[Unit]
+Description=Latch kernel.modules_disabled once boot-time module loading is done
+# Skip cleanly if a later fragment compiles modules out again: no key means
+# the stronger compile-time posture is already in force.
+ConditionPathExists=/proc/sys/kernel/modules_disabled
+# Ordered after every boot-time load and after the gpu profile's own latch, so
+# on the canonical GPU build this runs last and rewrites an already-set 1.
+# None of these units exist in a GPU-less build; a missing After= target is
+# inert ordering, not a requirement.
+After=nvidia-modules-latch.service nvidia-cc-ready.service systemd-modules-load.service
+# rke2's ExecStartPre modprobes are already overridden to a no-op
+# (rke2-server.service.d/no-modprobe.conf), which assumes this latch has run.
+Before=rke2-server.service rke2-agent.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# One-way: 1 cannot go back to 0 without a reboot.
+ExecStart=/sbin/sysctl -w kernel.modules_disabled=1
+
+# vsock fence: only attestation-api may use AF_VSOCK (see kernel/c8s.config).
+RestrictAddressFamilies=AF_UNIX
+
+[Install]
+WantedBy=multi-user.target
+# Preset creates the .requires links, so rke2 cannot start while the latch is
+# failing. A skipped condition is not a failure, so a modules-less kernel
+# still boots.
+RequiredBy=rke2-server.service rke2-agent.service

--- a/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
+++ b/node-guest-image/c8s/mkosi.extra/usr/lib/systemd/system-preset/50-rke2.preset
@@ -26,6 +26,10 @@ enable gpu-cc-enforce.service
 # Fail closed when the initrd fell back to the tmpfs rootfs upper; RequiredBy
 # the rke2 pair so a scratch-less node powers off instead of flapping.
 enable scratch-enforce.service
+# Latch kernel.modules_disabled before rke2 starts. The gpu profile enables its
+# own latch; this one also covers the GPU-less composition, where that unit is
+# absent.
+enable c8s-modules-latch.service
 # Role dispatch + the role-gated rke2 pair.
 enable rke2-role.service
 enable rke2-server.service


### PR DESCRIPTION
## Summary

`node-guest-image/kernel/c8s.config` sets `CONFIG_MODULES=y` — a c8s-only widening, on for exactly two out-of-tree modules (`nvidia.ko`, `nvidia-uvm.ko`). Nothing in this profile latches `kernel.modules_disabled`:

- confos's `99-kspp-hardening.conf` deliberately omits the key, on the stated grounds that the base kernel compiles modules out.
- The only latch confos ships, `nvidia-modules-latch.service`, lives in and is enabled by its **gpu** profile.

`c8s/mkosi.conf` and `kernel/c8s.config` both name that unit as the reason every container/k8s symbol is `=y`, but the profile neither ships it nor pins it. It runs today only because `node-guest-image/build` hardcodes `--profile gpu`. The GPU-less composition documented at `c8s/mkosi.conf:14` (`attest` + `c8s`, no `gpu`) boots with modules loadable for the whole boot, and a change to that profile list would silently drop the latch from the canonical build.

## Changes

- `c8s/mkosi.extra/etc/systemd/system/c8s-modules-latch.service`: sets `kernel.modules_disabled=1`, ordered `After=` the gpu latch, `nvidia-cc-ready.service` and `systemd-modules-load.service` (all inert when absent), `Before=`/`RequiredBy=` the rke2 pair. `ConditionPathExists=/proc/sys/kernel/modules_disabled` skips it cleanly if a later fragment compiles modules out again — a skipped condition is not a failure, so `RequiredBy` does not wedge a modules-less kernel.
- `50-rke2.preset`: enable it.
- `.github/scripts/node-guest-image-invariants.sh`: while `c8s.config` has `CONFIG_MODULES=y`, pin the unit's sysctl write, its preset entry, and the `RequiredBy` line.
- `README.md`: a `Module loading` section for the split — same one `99-c8s-bpf.conf` already documents for BPF.

On the canonical GPU build both latches run and this one rewrites an already-set 1.

## Scope

No kernel config change, so the measurement does not roll from the fragment; the new unit and preset symlink are in the verity root, so the image digest does.

## Validation

Invariants gate passes against the pinned `node-image` confos ref (`cffb512`), and fails as intended with the preset line removed.

Deliberately no case in `tests/rke2-role-systemd-test.sh`: that harness boots systemd privileged with `--cgroupns=host`, so letting this unit start would set `kernel.modules_disabled=1` on the runner's own kernel until reboot.

## Separately

`user.max_user_namespaces` is still unset while `CONFIG_USER_NS=y` (another c8s-only widening; confos omits the key as disruptive). Worth its own change once the runtime impact on `hostUsers: false` pods is settled.
