### PR TITLE
refactor(operatorauth): centralize signed request construction

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -251,6 +251,10 @@ whose public half is pinned in `cds.operatorKeys`. The `c8s allowlist` CLI mints
 that token (see the README, "Managing the image allowlist"). Without
 `cds.operatorKeys` set, allowlist writes are rejected while reads keep serving.
 
+Operator clients construct signed requests through `operatorauth.NewRequest`,
+which binds the token to the actual HTTP method, parsed URL path (including
+any base URL prefix), and an owned copy of the body.
+
 CA-bundle refresh traffic uses the chart-managed cluster Service. Trust for
 those flows comes from EAR validation, measurement allowlists, and CA
 continuity checks rather than WebPKI on the Service hop.

--- a/internal/cmds/getkubeconfig/release.go
+++ b/internal/cmds/getkubeconfig/release.go
@@ -1,7 +1,6 @@
 package getkubeconfig
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -67,18 +66,11 @@ func requestCredential(ctx context.Context, httpClient *http.Client, baseURL str
 		return nil, err
 	}
 
-	// The JWT binds method/path/body (pbh) — must match exactly what we send.
-	authz, err := signer.Authorization(http.MethodPost, credrelease.ReleasePath, body)
-	if err != nil {
-		return nil, fmt.Errorf("sign operator token: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+credrelease.ReleasePath, bytes.NewReader(body))
+	req, err := operatorauth.NewRequest(ctx, http.MethodPost, baseURL+credrelease.ReleasePath, body, signer)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", authz)
 
 	resp, err := httpClient.Do(req)
 	if err != nil {

--- a/internal/cmds/secrets/client.go
+++ b/internal/cmds/secrets/client.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -11,6 +10,7 @@ import (
 	"strings"
 
 	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 )
 
 // client writes secrets to CDS over an attested channel.
@@ -21,9 +21,7 @@ type client struct {
 
 // authorizer mints the operator Authorization header for one write, bound to
 // its method, path, and body. Implemented by operatorauth.Signer.
-type authorizer interface {
-	Authorization(method, path string, body []byte) (string, error)
-}
+type authorizer = operatorauth.Authorizer
 
 // result is what a write did. Created reports a path that held nothing;
 // Existing names what put the value the write displaced, or on a refusal what
@@ -48,16 +46,11 @@ func (c client) put(ctx context.Context, path string, value []byte, overwrite bo
 	}
 
 	url := c.baseURL + "/secrets" + path
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	req, err := operatorauth.NewRequest(ctx, http.MethodPut, url, body, auth)
 	if err != nil {
 		return result{}, err
 	}
-	authz, err := auth.Authorization(http.MethodPut, req.URL.Path, body)
-	if err != nil {
-		return result{}, fmt.Errorf("authorize request: %w", err)
-	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", authz)
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -96,15 +89,10 @@ func (c client) put(ctx context.Context, path string, value []byte, overwrite bo
 func (c client) explain(ctx context.Context, sandboxID string, auth authorizer) (intsecrets.ExplainResponse, error) {
 	var out intsecrets.ExplainResponse
 	url := c.baseURL + "/secrets-explain/" + sandboxID
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := operatorauth.NewRequest(ctx, http.MethodGet, url, nil, auth)
 	if err != nil {
 		return out, err
 	}
-	authz, err := auth.Authorization(http.MethodGet, req.URL.Path, nil)
-	if err != nil {
-		return out, fmt.Errorf("authorize request: %w", err)
-	}
-	req.Header.Set("Authorization", authz)
 
 	resp, err := c.http.Do(req)
 	if err != nil {

--- a/internal/cmds/volume/cmd.go
+++ b/internal/cmds/volume/cmd.go
@@ -1,7 +1,6 @@
 package volume
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cdsconn"
 	"github.com/confidential-dot-ai/c8s/internal/localverify"
 	intsecrets "github.com/confidential-dot-ai/c8s/internal/secrets"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 )
 
 // options holds the flags every subcommand shares.
@@ -84,16 +84,11 @@ func putBlob(ctx context.Context, hc *http.Client, baseURL, path string, blob Bl
 		return err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, baseURL+"/secrets"+path, bytes.NewReader(body))
+	req, err := operatorauth.NewRequest(ctx, http.MethodPut, baseURL+"/secrets"+path, body, auth)
 	if err != nil {
 		return err
 	}
-	authz, err := auth.Authorization(http.MethodPut, req.URL.Path, body)
-	if err != nil {
-		return fmt.Errorf("authorize request: %w", err)
-	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", authz)
 
 	resp, err := hc.Do(req)
 	if err != nil {
@@ -115,6 +110,4 @@ func putBlob(ctx context.Context, hc *http.Client, baseURL, path string, blob Bl
 
 // authorizer mints the operator Authorization header for one write, bound to
 // its method, path, and body. Implemented by operatorauth.Signer.
-type authorizer interface {
-	Authorization(method, path string, body []byte) (string, error)
-}
+type authorizer = operatorauth.Authorizer

--- a/pkg/allowlistclient/client.go
+++ b/pkg/allowlistclient/client.go
@@ -7,7 +7,6 @@
 package allowlistclient
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -19,6 +18,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
 
@@ -44,9 +44,7 @@ func NewClientWithHTTP(baseURL string, httpClient *http.Client) Client {
 // Authorizer produces the HTTP Authorization header value for a mutation,
 // binding it to the exact method, URL path, and body the client will send.
 // Implemented by operatorauth.Signer.
-type Authorizer interface {
-	Authorization(method, path string, body []byte) (string, error)
-}
+type Authorizer = operatorauth.Authorizer
 
 // List returns the current allowlist and its version (the ETag counter).
 func (c Client) List(ctx context.Context) (*allowlist.Allowlist, string, error) {
@@ -155,22 +153,13 @@ func (c Client) mutate(ctx context.Context, method, path string, body []byte, au
 	if auth == nil {
 		return fmt.Errorf("allowlistclient: nil Authorizer")
 	}
-	var reader io.Reader
-	if body != nil {
-		reader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, reader)
+	req, err := operatorauth.NewRequest(ctx, method, c.baseURL+path, body, auth)
 	if err != nil {
 		return err
-	}
-	authz, err := auth.Authorization(method, req.URL.Path, body)
-	if err != nil {
-		return fmt.Errorf("authorize request: %w", err)
 	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Authorization", authz)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/operatorauth/request.go
+++ b/pkg/operatorauth/request.go
@@ -1,0 +1,35 @@
+package operatorauth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+)
+
+// Authorizer binds an Authorization header to an HTTP method, URL path, and
+// body. Signer implements it with a short-lived operator token.
+type Authorizer interface {
+	Authorization(method, path string, body []byte) (string, error)
+}
+
+// NewRequest constructs a request and authorizes its actual method, parsed URL
+// path, and body. It owns a copy of body so later changes to the input cannot
+// invalidate the token. Callers must not change the returned method, path, or
+// body; content type, transport, and response handling remain their concern.
+func NewRequest(ctx context.Context, method, url string, body []byte, auth Authorizer) (*http.Request, error) {
+	if auth == nil {
+		return nil, fmt.Errorf("operatorauth: nil Authorizer")
+	}
+	body = bytes.Clone(body)
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	authz, err := auth.Authorization(req.Method, req.URL.Path, body)
+	if err != nil {
+		return nil, fmt.Errorf("authorize request: %w", err)
+	}
+	req.Header.Set("Authorization", authz)
+	return req, nil
+}

--- a/pkg/operatorauth/request_test.go
+++ b/pkg/operatorauth/request_test.go
@@ -1,0 +1,106 @@
+package operatorauth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewRequestBinding(t *testing.T) {
+	key, pub := genKey(t, elliptic.P256())
+	signer, err := NewSignerFromKeyPEM(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := Verifier{Keys: []*ecdsa.PublicKey{pub}}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Error(err)
+		}
+		if err := verifier.Authorize(r, body); err != nil {
+			t.Errorf("verify received request: %v", err)
+			w.WriteHeader(http.StatusForbidden)
+		}
+	}))
+	defer server.Close()
+	for _, tc := range []struct {
+		method, path string
+		body         []byte
+	}{
+		{http.MethodPut, "/secrets/key", []byte(`{"value":"secret"}`)},
+		{http.MethodPost, "/prefix/release", []byte(`{"csr":"test"}`)},
+		{http.MethodDelete, "/allowlist/workloads/a%20b", nil},
+		{"", "/secrets-explain/sandbox?detail=true", nil},
+		{http.MethodPut, "/empty", []byte{}},
+	} {
+		t.Run(tc.method+tc.path, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			req, err := NewRequest(ctx, tc.method, server.URL+tc.path, tc.body, signer)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if req.Context() != ctx {
+				t.Fatal("request lost its context")
+			}
+			// Neither the initial send nor a replay may alias the caller's bytes.
+			for i := range tc.body {
+				tc.body[i] = 'x'
+			}
+			if req.GetBody != nil {
+				replay, err := req.GetBody()
+				if err != nil {
+					t.Fatal(err)
+				}
+				body, err := io.ReadAll(replay)
+				replay.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := verifier.Authorize(req, body); err != nil {
+					t.Fatalf("verify replay body: %v", err)
+				}
+			}
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d", resp.StatusCode)
+			}
+		})
+	}
+}
+
+type failedAuthorizer struct{ err error }
+
+func (a failedAuthorizer) Authorization(string, string, []byte) (string, error) {
+	return "", a.err
+}
+
+func TestNewRequestErrors(t *testing.T) {
+	failure := errors.New("signing failed")
+	for _, tc := range []struct {
+		name, url string
+		auth      Authorizer
+		want      error
+	}{
+		{"signer failure", "http://cds/secrets/key", failedAuthorizer{failure}, failure},
+		{"invalid URL", "://", failedAuthorizer{failure}, nil},
+		{"nil authorizer", "http://cds/secrets/key", nil, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := NewRequest(context.Background(), http.MethodPut, tc.url, nil, tc.auth)
+			if req != nil || err == nil || tc.want != nil && !errors.Is(err, tc.want) {
+				t.Fatalf("request = %v, error = %v; want no request and error %v", req, err, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Operator clients assembled and signed requests independently at five call sites, making the method, path, and body binding easy to drift. A shared constructor now binds each token to the constructed request and owns its body bytes so caller mutations cannot invalidate the signature.

The constructor encapsulates request construction and token binding; callers control content type, transport, and response handling.

- Add `operatorauth.NewRequest` to construct and authorize requests from their actual method, parsed path, and copied body.
- Migrate allowlist mutations, secret writes and explanations, volume key writes, and credential release to the constructor.
- Share the authorizer interface through existing client type names.
- Test signature verification across escaped and prefixed paths, empty bodies, body mutation, and error cases.
- Document the shared request construction behavior.

Review focus: confirm that the parsed URL path matches server-side verification, including credential-release URLs with a prefix, and that the initial and replay bodies retain the signed bytes. Check that each migrated caller preserves its response and error handling.

Validation: `make test` (full race-enabled suite), `make lint`, and `git diff --check` passed with Go 1.26.3. The changeset contains 156 additions and 49 deletions.
