### PR TITLE
fix(verify): centralize attested document fetching

### DIFF
--- a/internal/cmds/verify/attestedfetch.go
+++ b/internal/cmds/verify/attestedfetch.go
@@ -1,0 +1,50 @@
+package verify
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// fetchAttested gets an HTTPS response bound to the previously attested leaf.
+// The caller owns Body; closing it releases this fetch's connection.
+func fetchAttested(ctx context.Context, endpoint, serverName, certSHA256 string, timeout time.Duration) (*http.Response, error) {
+	if certSHA256 == "" {
+		return nil, fmt.Errorf("no attested serving certificate to bind the fetch to")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	if req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("attested fetch requires HTTPS")
+	}
+	client := &http.Client{
+		Timeout: timeout,
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec // the attested leaf fingerprint authenticates the peer
+				ServerName:         serverName,
+				VerifyConnection: func(cs tls.ConnectionState) error {
+					if len(cs.PeerCertificates) == 0 {
+						return fmt.Errorf("no peer certificate")
+					}
+					sum := sha256.Sum256(cs.PeerCertificates[0].Raw)
+					if got := hex.EncodeToString(sum[:]); got != certSHA256 {
+						return fmt.Errorf("serving cert changed between attestation and fetch (got sha256 %s, attested %s)", got, certSHA256)
+					}
+					return nil
+				},
+			},
+		},
+	}
+	return client.Do(req)
+}

--- a/internal/cmds/verify/attestedfetch_test.go
+++ b/internal/cmds/verify/attestedfetch_test.go
@@ -1,0 +1,122 @@
+package verify
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAttestedFetchRejectsPlaintextAndRedirects(t *testing.T) {
+	var hits atomic.Int32
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+	}))
+	defer target.Close()
+	base, pin := startKeysTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL, http.StatusFound)
+	})
+	for _, tc := range []struct {
+		name string
+		get  func(string) error
+	}{
+		{"keys", func(url string) error {
+			_, _, _, err := fetchOperatorKeyFingerprints(context.Background(), url, "", pin, time.Second)
+			return err
+		}},
+		{"measurements", func(url string) error {
+			_, err := fetchServedMeasurements(context.Background(), url, "", pin, time.Second)
+			return err
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, url := range []string{target.URL, base} {
+				if err := tc.get(url); err == nil {
+					t.Fatalf("accepted %s", url)
+				}
+			}
+		})
+	}
+	if hits.Load() != 0 {
+		t.Fatalf("sent %d unauthenticated requests", hits.Load())
+	}
+}
+
+func TestAttestedFetchClosesConnection(t *testing.T) {
+	closed := make(chan struct{}, 1)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.TLS.ServerName != "attested.example" {
+			t.Errorf("SNI = %q", r.TLS.ServerName)
+		}
+		w.Write([]byte("document"))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			closed <- struct{}{}
+		}
+	}
+	srv.StartTLS()
+	defer srv.Close()
+	sum := sha256.Sum256(srv.Certificate().Raw)
+	resp, err := fetchAttested(context.Background(), srv.URL, "attested.example", hex.EncodeToString(sum[:]), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil || string(body) != "document" {
+		t.Fatalf("body = %q, error = %v", body, err)
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("fetch retained an idle connection")
+	}
+}
+
+func TestAttestedFetchBoundsBodyRead(t *testing.T) {
+	base, pin := startKeysTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	})
+	for _, cancelEarly := range []bool{false, true} {
+		ctx, cancel := context.WithCancel(context.Background())
+		timeout := time.Second
+		if cancelEarly {
+			timeout = 5 * time.Second
+		}
+		resp, err := fetchAttested(ctx, base, "", pin, timeout)
+		if err != nil {
+			cancel()
+			t.Fatal(err)
+		}
+		if cancelEarly {
+			cancel()
+		}
+		_, err = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancel()
+		want := context.DeadlineExceeded
+		if cancelEarly {
+			want = context.Canceled
+		}
+		if !errors.Is(err, want) {
+			t.Fatalf("body read: got %v, want %v", err, want)
+		}
+	}
+}
+
+func TestAttestedFetchRejectsMalformedURL(t *testing.T) {
+	if _, err := fetchAttested(context.Background(), "://", "", strings.Repeat("ab", 32), time.Second); err == nil {
+		t.Fatal("accepted malformed URL")
+	}
+}

--- a/internal/cmds/verify/measurementsconfig.go
+++ b/internal/cmds/verify/measurementsconfig.go
@@ -2,10 +2,6 @@ package verify
 
 import (
 	"context"
-	"crypto/sha256"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,37 +24,9 @@ type measurementsReport struct {
 	note     string
 }
 
-// fetchServedMeasurements GETs <base>/measurements bound to the endpoint whose
-// attestation was just verified: the handshake requires the presented leaf's
-// SHA-256 to equal wantCertSHA256, so a different endpoint — or a MITM on this
-// second connection — cannot substitute its own set into the report.
+// fetchServedMeasurements parses /measurements from the attested endpoint.
 func fetchServedMeasurements(ctx context.Context, base, serverName, wantCertSHA256 string, timeout time.Duration) (measurements.ReferenceValues, error) {
-	if wantCertSHA256 == "" {
-		return measurements.ReferenceValues{}, fmt.Errorf("no attested serving certificate to bind the fetch to")
-	}
-	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // trust comes from the attested-cert pin below, not PKI
-		ServerName:         serverName,
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return fmt.Errorf("no peer certificate")
-			}
-			sum := sha256.Sum256(rawCerts[0])
-			if got := hex.EncodeToString(sum[:]); got != wantCertSHA256 {
-				return fmt.Errorf("serving cert changed between attestation and measurement fetch (got sha256 %s, attested %s)", got, wantCertSHA256)
-			}
-			return nil
-		},
-	}
-	client := &http.Client{
-		Timeout:   timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/measurements", nil)
-	if err != nil {
-		return measurements.ReferenceValues{}, err
-	}
-	resp, err := client.Do(req)
+	resp, err := fetchAttested(ctx, base+"/measurements", serverName, wantCertSHA256, timeout)
 	if err != nil {
 		return measurements.ReferenceValues{}, fmt.Errorf("fetch /measurements: %w", err)
 	}

--- a/internal/cmds/verify/operatorkeys.go
+++ b/internal/cmds/verify/operatorkeys.go
@@ -3,7 +3,6 @@ package verify
 import (
 	"context"
 	"crypto/sha256"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"fmt"
@@ -25,43 +24,10 @@ const maxOperatorKeysBytes = 256 * 1024
 // it), plus the served set's KeySetDigest for comparison against the attested
 // --operator-keys bundle (applySandboxPolicy).
 //
-// The fetch is bound to the endpoint whose attestation was just verified: the
-// TLS handshake requires the presented leaf certificate's SHA-256 to equal
-// wantCertSHA256 (the attested serving cert), so a different endpoint — or a
-// MITM on this second connection — cannot inject its own key list into the
-// report.
-//
 // A 404 sets note and returns the empty-set digest: the endpoint reports
 // allowlist writes disabled, which --operator-keys can still be checked against.
 func fetchOperatorKeyFingerprints(ctx context.Context, base, serverName, wantCertSHA256 string, timeout time.Duration) (fingerprints []string, digest []byte, note string, err error) {
-	if wantCertSHA256 == "" {
-		return nil, nil, "", fmt.Errorf("no attested serving certificate to bind the fetch to")
-	}
-
-	tlsCfg := &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // trust comes from the attested-cert pin below, not PKI
-		ServerName:         serverName,
-		VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-			if len(rawCerts) == 0 {
-				return fmt.Errorf("no peer certificate")
-			}
-			sum := sha256.Sum256(rawCerts[0])
-			if got := hex.EncodeToString(sum[:]); got != wantCertSHA256 {
-				return fmt.Errorf("serving cert changed between attestation and key fetch (got sha256 %s, attested %s)", got, wantCertSHA256)
-			}
-			return nil
-		},
-	}
-	client := &http.Client{
-		Timeout:   timeout,
-		Transport: &http.Transport{TLSClientConfig: tlsCfg},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/operator-keys", nil)
-	if err != nil {
-		return nil, nil, "", err
-	}
-	resp, err := client.Do(req)
+	resp, err := fetchAttested(ctx, base+"/operator-keys", serverName, wantCertSHA256, timeout)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("fetch /operator-keys: %w", err)
 	}


### PR DESCRIPTION
The operator-key and measurement fetches each assembled their own certificate-pinned HTTP client, leaving endpoint binding and connection lifetime spread across callers. A shared attested fetch now keeps both cross-checks on a direct HTTPS connection authenticated by the previously attested certificate.

`fetchAttested` owns transport authentication and lifetime; the two fetch functions interpret their respective documents.

- Add a package-local fetch helper that enforces HTTPS and matches the attested leaf fingerprint during TLS verification.
- Migrate both cross-checks while retaining their endpoint-specific parsing, response limits, and status handling.
- Return redirect responses to the callers and disable connection reuse for each one-shot fetch.
- Test plaintext and redirect rejection, connection closure, SNI, cancellation, and response-body timeouts.

Review focus: check that every returned document comes through the pinned TLS handshake, that redirects remain visible to the callers as errors, and that response-body reads remain bounded by cancellation and the configured timeout. Confirm the existing 404 and size-limit semantics at each endpoint.

Validation: `GOTOOLCHAIN=go1.26.3 make test` (full race-enabled suite), `GOTOOLCHAIN=go1.26.3 make lint`, and `git diff --check` pass. Running the new plaintext/redirect regression test against the original callers fails with four unauthenticated requests; the updated callers pass. The changeset contains 175 additions and 69 deletions.
