### PR TITLE
refactor(policy): share sandbox admission history

### DIFF
--- a/internal/admissionhistory/history.go
+++ b/internal/admissionhistory/history.go
@@ -1,0 +1,50 @@
+// Package admissionhistory records a sandbox's cumulative container inventory.
+package admissionhistory
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+// History retains distinct admissions for a sandbox's lifetime. The zero value
+// is ready to use; callers must synchronise access.
+type History struct {
+	byKey      map[string]workloadclaims.SandboxContainer
+	unresolved map[string]struct{}
+}
+
+// Record adds an admission; only a resolved record for the same ID clears an
+// unresolved container. History owns its copy of argv.
+func (h *History) Record(id, digest string, argv []string) {
+	if h.byKey == nil {
+		h.byKey = map[string]workloadclaims.SandboxContainer{}
+		h.unresolved = map[string]struct{}{}
+	}
+	if digest == "" {
+		h.unresolved[id] = struct{}{}
+		return
+	}
+	delete(h.unresolved, id)
+	c := workloadclaims.SandboxContainer{Digest: digest, Argv: slices.Clone(argv)}
+	h.byKey[c.Key()] = c
+}
+
+// Snapshot returns sorted, independent copies of the digest set and admissions.
+// An unresolved container makes the entire snapshot unavailable.
+func (h History) Snapshot() ([]string, []workloadclaims.SandboxContainer, error) {
+	if len(h.unresolved) > 0 {
+		return nil, nil, fmt.Errorf("admitted a container with no resolved image digest")
+	}
+	digests := []string{}
+	containers := make([]workloadclaims.SandboxContainer, 0, len(h.byKey))
+	for _, c := range h.byKey {
+		digests = append(digests, c.Digest)
+		c.Argv = slices.Clone(c.Argv)
+		containers = append(containers, c)
+	}
+	slices.Sort(digests)
+	slices.SortFunc(containers, workloadclaims.SandboxContainer.Compare)
+	return slices.Compact(digests), containers, nil
+}

--- a/internal/admissionhistory/history_test.go
+++ b/internal/admissionhistory/history_test.go
@@ -1,0 +1,79 @@
+package admissionhistory
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
+)
+
+func TestHistoryRetainsDistinctAdmissions(t *testing.T) {
+	var h History
+	digests, containers, err := h.Snapshot()
+	if err != nil || digests == nil || containers == nil || len(digests)+len(containers) != 0 {
+		t.Fatalf("empty history = %v, %v, %v", digests, containers, err)
+	}
+	h.Record("one", "sha256:b", []string{"run", "z"})
+	h.Record("two", "sha256:a", nil)
+	h.Record("three", "sha256:a", []string{})
+	h.Record("replica", "sha256:b", []string{"run", "z"})
+	h.Record("one", "sha256:b", []string{"run", "a"})
+	h.Record("one", "sha256:a", []string{""})
+	digests, containers, err = h.Snapshot()
+	want := []workloadclaims.SandboxContainer{
+		{Digest: "sha256:a", Argv: []string{}},
+		{Digest: "sha256:a", Argv: []string{""}},
+		{Digest: "sha256:b", Argv: []string{"run", "a"}},
+		{Digest: "sha256:b", Argv: []string{"run", "z"}},
+	}
+	if err != nil || !reflect.DeepEqual(digests, []string{"sha256:a", "sha256:b"}) || !reflect.DeepEqual(containers, want) {
+		t.Fatalf("snapshot = %v, %#v, %v", digests, containers, err)
+	}
+}
+
+func TestHistoryResolutionIsPerContainer(t *testing.T) {
+	var h History
+	h.Record("known", "sha256:a", nil)
+	h.Record("first", "", nil)
+	h.Record("second", "", nil)
+	assertUnresolved := func() {
+		t.Helper()
+		digests, containers, err := h.Snapshot()
+		if err == nil || digests != nil || containers != nil {
+			t.Fatalf("unresolved history returned a partial answer: %v, %v, %v", digests, containers, err)
+		}
+	}
+	assertUnresolved()
+	h.Record("different", "sha256:b", nil)
+	assertUnresolved()
+	h.Record("first", "sha256:b", nil)
+	assertUnresolved()
+	h.Record("second", "sha256:b", nil)
+	if digests, containers, err := h.Snapshot(); err != nil || len(digests) != 2 || len(containers) != 2 {
+		t.Fatalf("resolved snapshot = %v, %v, %v", digests, containers, err)
+	}
+	h.Record("known", "", nil)
+	assertUnresolved()
+	h.Record("known", "sha256:c", nil)
+	if digests, _, err := h.Snapshot(); err != nil || len(digests) != 3 {
+		t.Fatalf("resolution lost an earlier admission: %v, %v", digests, err)
+	}
+}
+
+func TestHistoryOwnsArgumentsAndSnapshots(t *testing.T) {
+	var h History
+	argv := []string{"run", "original"}
+	h.Record("one", "sha256:a", argv)
+	argv[1] = "changed input"
+	digests, containers, err := h.Snapshot()
+	if err != nil || len(containers) != 1 || containers[0].Argv[1] != "original" {
+		t.Fatalf("input mutation changed history: %v, %v", containers, err)
+	}
+	digests[0] = "changed digest"
+	containers[0].Digest = "changed container"
+	containers[0].Argv[1] = "changed output"
+	digests, containers, err = h.Snapshot()
+	if err != nil || !reflect.DeepEqual(digests, []string{"sha256:a"}) || len(containers) != 1 || containers[0].Digest != "sha256:a" || containers[0].Argv[1] != "original" {
+		t.Fatalf("snapshot mutation changed history: %v, %v, %v", digests, containers, err)
+	}
+}

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -2,9 +2,9 @@ package nriimagepolicy
 
 import (
 	"fmt"
-	"slices"
 	"sync"
 
+	"github.com/confidential-dot-ai/c8s/internal/admissionhistory"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
@@ -20,9 +20,9 @@ import (
 // leave one running, and the inventory reports what runs.
 type admissionInventory struct {
 	mu         sync.RWMutex
-	containers map[string]ctrRec   // live containerID -> record (caller resolution)
-	admitted   map[string]sbxRec   // sandboxID -> everything ever admitted there
-	sandboxes  map[string]struct{} // live pod sandbox IDs
+	containers map[string]ctrRec                   // live containerID -> record (caller resolution)
+	admitted   map[string]admissionhistory.History // sandboxID -> everything ever admitted there
+	sandboxes  map[string]struct{}                 // live pod sandbox IDs
 	procRoot   string
 }
 
@@ -33,18 +33,10 @@ type ctrRec struct {
 	argv      []string
 }
 
-// sbxRec is a sandbox's admission high-water mark: every distinct (digest,
-// argv) admitted in it, keyed for dedup, never pruned while the sandbox lives.
-// See docs/secrets.md — "The report is a high-water mark".
-type sbxRec struct {
-	byKey      map[string]workloadclaims.SandboxContainer
-	unresolved map[string]struct{} // container IDs with no digest; cleared only by a later resolved record for the same ID
-}
-
 func newAdmissionInventory(procRoot string) *admissionInventory {
 	return &admissionInventory{
 		containers: map[string]ctrRec{},
-		admitted:   map[string]sbxRec{},
+		admitted:   map[string]admissionhistory.History{},
 		sandboxes:  map[string]struct{}{},
 		procRoot:   procRoot,
 	}
@@ -62,20 +54,8 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 	defer b.mu.Unlock()
 	b.containers[containerID] = ctrRec{sandboxID: sandboxID, name: name, digest: digest, argv: argv}
 
-	rec, ok := b.admitted[sandboxID]
-	if !ok {
-		rec = sbxRec{
-			byKey:      map[string]workloadclaims.SandboxContainer{},
-			unresolved: map[string]struct{}{},
-		}
-	}
-	if digest == "" {
-		rec.unresolved[containerID] = struct{}{}
-	} else {
-		delete(rec.unresolved, containerID)
-		c := workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
-		rec.byKey[c.Key()] = c
-	}
+	rec := b.admitted[sandboxID]
+	rec.Record(containerID, digest, argv)
 	b.admitted[sandboxID] = rec
 
 	// A container implies its sandbox, so a record arriving before (or without)
@@ -85,7 +65,7 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 
 // remove evicts a stopped container from caller resolution only. The sandbox's
 // admission record keeps it: a stopped container must not bind a caller, but it
-// still ran here (sbxRec). That includes an unresolved digest, so a container
+// still ran here. That includes an unresolved digest, so a container
 // that stops before one resolves closes its sandbox's answer for the sandbox's
 // life.
 func (b *admissionInventory) remove(containerID string) {
@@ -183,17 +163,9 @@ func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []wo
 	if _, ok := b.sandboxes[sandboxID]; !ok {
 		return nil, nil, false, nil
 	}
-	rec := b.admitted[sandboxID]
-	if len(rec.unresolved) > 0 {
-		return nil, nil, true, fmt.Errorf("sandbox %s admitted a container with no resolved image digest", sandboxID)
+	digests, containers, err := b.admitted[sandboxID].Snapshot()
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("sandbox %s %w", sandboxID, err)
 	}
-	digests := []string{}
-	containers := make([]workloadclaims.SandboxContainer, 0, len(rec.byKey))
-	for _, c := range rec.byKey {
-		digests = append(digests, c.Digest)
-		containers = append(containers, c)
-	}
-	slices.Sort(digests)
-	slices.SortFunc(containers, workloadclaims.SandboxContainer.Compare)
-	return slices.Compact(digests), containers, true, nil
+	return digests, containers, true, nil
 }

--- a/internal/cmds/policymonitor/inventory.go
+++ b/internal/cmds/policymonitor/inventory.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"slices"
 	"strconv"
 	"sync"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/admissionhistory"
 	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -33,10 +33,9 @@ var sandboxIDAnnotations = []string{
 // the guest boundary is the isolation, so no peer-credential check is needed.
 type admissionInventory struct {
 	mu         sync.RWMutex
-	containers map[string]string                          // live container id -> image digest
-	admitted   map[string]workloadclaims.SandboxContainer // key -> everything ever admitted
-	unresolved map[string]struct{}                        // container ids with no digest; cleared only by a later resolved record
-	sandboxID  string                                     // the guest's single pod sandbox
+	containers map[string]string // live container id -> image digest
+	admitted   admissionhistory.History
+	sandboxID  string // the guest's single pod sandbox
 	// refresh renders the allowlist-refresh posture. Set by runMonitor; nil
 	// leaves the field off the wire rather than reporting a false "disabled".
 	refresh func() workloadclaims.AllowlistRefresh
@@ -45,8 +44,6 @@ type admissionInventory struct {
 func newAdmissionInventory() *admissionInventory {
 	return &admissionInventory{
 		containers: map[string]string{},
-		admitted:   map[string]workloadclaims.SandboxContainer{},
-		unresolved: map[string]struct{}{},
 	}
 }
 
@@ -61,14 +58,10 @@ func (b *admissionInventory) record(cid, digest string, argv []string) {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if digest == "" {
-		b.unresolved[cid] = struct{}{}
-		return
+	b.admitted.Record(cid, digest, argv)
+	if digest != "" {
+		b.containers[cid] = digest
 	}
-	delete(b.unresolved, cid)
-	b.containers[cid] = digest
-	c := workloadclaims.SandboxContainer{Digest: digest, Argv: argv}
-	b.admitted[c.Key()] = c
 }
 
 // remove evicts a container whose bundle kata-agent has torn down. The
@@ -121,18 +114,11 @@ func (b *admissionInventory) DigestsForSandbox(sandboxID string) ([]string, []wo
 	if b.sandboxID == "" || sandboxID != b.sandboxID {
 		return nil, nil, false, nil
 	}
-	if len(b.unresolved) > 0 {
-		return nil, nil, true, fmt.Errorf("sandbox %s admitted a container with no resolved image digest", sandboxID)
+	digests, containers, err := b.admitted.Snapshot()
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("sandbox %s %w", sandboxID, err)
 	}
-	digests := []string{}
-	containers := make([]workloadclaims.SandboxContainer, 0, len(b.admitted))
-	for _, c := range b.admitted {
-		digests = append(digests, c.Digest)
-		containers = append(containers, c)
-	}
-	slices.Sort(digests)
-	slices.SortFunc(containers, workloadclaims.SandboxContainer.Compare)
-	return slices.Compact(digests), containers, true, nil
+	return digests, containers, true, nil
 }
 
 // AllowlistRefresh satisfies workloadclaims.AllowlistRefreshReporter: it puts


### PR DESCRIPTION
The node policy plugin and Kata guest monitor independently maintained the same cumulative admission history, so deduplication and unresolved-container rules had two implementations to review. A shared history now owns those rules and its argument data while each inventory manages its sandbox lifecycle and caller identity.

`History` encapsulates the cumulative record behind the two admission inventories. Their existing locks protect access; live-container removal and sandbox teardown remain inventory operations.

- Add `admissionhistory.History` with record and snapshot operations for distinct digest/argv admissions.
- Track unresolved admissions by container ID and reject partial snapshots until each resolves.
- Return sorted digest sets and container details with owned argv slices on input and output.
- Migrate both inventories and test retention, deduplication, resolution, ordering, and ownership.

Review focus: verify that resolving one container cannot clear another unresolved admission, that stopped containers remain in history until sandbox teardown, and that callers cannot mutate stored argv through inputs or snapshots.

Validation: `GOTOOLCHAIN=go1.26.3 make test` (full race-enabled suite), `GOTOOLCHAIN=go1.26.3 make lint`, and `git diff --check` pass. Removing either argv copy independently makes the ownership test fail. The changeset contains 152 additions and 65 deletions.
