### PR TITLE
refactor(state): reuse atomic file publication

### DIFF
--- a/internal/cmds/nri-image-policy/exempt.go
+++ b/internal/cmds/nri-image-policy/exempt.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 )
 
 // exemptSnapshot admits a container in an exempt namespace when its image
@@ -125,23 +127,5 @@ func (s *exemptSnapshot) persist(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil {
-		os.Remove(tmpName)
-		return err
-	}
-	return nil
+	return fileutil.WriteAtomic(path, b, 0o600)
 }

--- a/internal/cmds/nri-image-policy/exempt_test.go
+++ b/internal/cmds/nri-image-policy/exempt_test.go
@@ -46,13 +46,20 @@ func TestExemptSnapshot_NilAdmitsNothing(t *testing.T) {
 }
 
 func TestExemptSnapshot_PersistLoadRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "exempt-snapshot.json")
+	path := filepath.Join(t.TempDir(), "state", "exempt-snapshot.json")
 	s := newExemptSnapshot([]string{"kube-system", "gmp-system"})
 	s.add("kube-system", pushDigestA)
 	s.add("kube-system", pushDigestB)
 	s.add("gmp-system", pushDigestC)
 	if err := s.persist(path); err != nil {
 		t.Fatalf("persist: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("snapshot mode = %o, want 600", got)
 	}
 
 	loaded, err := loadExemptSnapshot(path)

--- a/internal/cmds/nri-image-policy/setpins.go
+++ b/internal/cmds/nri-image-policy/setpins.go
@@ -8,13 +8,13 @@ import (
 	"io"
 	"maps"
 	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
@@ -208,23 +208,7 @@ func writeFileAtomic(path string, data []byte) error {
 	if fi, err := os.Stat(path); err == nil {
 		mode = fi.Mode().Perm()
 	}
-	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*")
-	if err != nil {
-		return fmt.Errorf("create temp file: %w", err)
-	}
-	defer os.Remove(tmp.Name())
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return fmt.Errorf("write temp file: %w", err)
-	}
-	if err := tmp.Chmod(mode); err != nil {
-		tmp.Close()
-		return fmt.Errorf("chmod temp file: %w", err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("close temp file: %w", err)
-	}
-	if err := os.Rename(tmp.Name(), path); err != nil {
+	if err := fileutil.WriteAtomic(path, data, mode); err != nil {
 		return fmt.Errorf("replace %s: %w", path, err)
 	}
 	return nil

--- a/internal/cmds/nri-image-policy/setpins_test.go
+++ b/internal/cmds/nri-image-policy/setpins_test.go
@@ -70,6 +70,21 @@ func setPins(t *testing.T, path string, extra ...string) string {
 	return strings.TrimSpace(out.String())
 }
 
+func TestSetCDSPinsPreservesFileMode(t *testing.T) {
+	path := writeConfig(t, bakedConfig)
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	setPins(t, path, "--cds-measurements", pinA)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("mode = %o, want 600", got)
+	}
+}
+
 // The pins land and the baked floor — which the chart cannot re-render, because
 // only the image build resolves the RKE2 system digests — survives untouched.
 func TestSetCDSPinsKeepsTheBakedFloor(t *testing.T) {

--- a/internal/cmds/rtmr3measurer/measurer.go
+++ b/internal/cmds/rtmr3measurer/measurer.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 	"github.com/confidential-dot-ai/c8s/internal/kataspec"
 	"github.com/confidential-dot-ai/c8s/pkg/runtimemeasure"
 )
@@ -282,13 +283,7 @@ func (m *measurer) unrecordLast(digest string) {
 		sb.WriteString(d)
 		sb.WriteByte('\n')
 	}
-	tmp := m.statePath + ".tmp"
-	if err := os.WriteFile(tmp, []byte(sb.String()), 0o600); err == nil {
-		err = os.Rename(tmp, m.statePath)
-		if err != nil {
-			m.logger.Error("rewrite measured-digest log failed", "error", err)
-		}
-	} else {
+	if err := fileutil.WriteAtomic(m.statePath, []byte(sb.String()), 0o600); err != nil {
 		m.logger.Error("rewrite measured-digest log failed", "error", err)
 	}
 }

--- a/internal/cmds/rtmr3measurer/measurer_errors_test.go
+++ b/internal/cmds/rtmr3measurer/measurer_errors_test.go
@@ -217,6 +217,39 @@ func TestUnrecordLastRewriteFailureIsLoggedNotFatal(t *testing.T) {
 	}
 }
 
+func TestUnrecordLastRenameFailureCleansUpTemp(t *testing.T) {
+	dir := t.TempDir()
+	state := filepath.Join(dir, "measured")
+	if err := os.Mkdir(state, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(state, "keep")
+	if err := os.WriteFile(marker, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var logs bytes.Buffer
+	m := newMeasurer(slog.New(slog.NewTextHandler(&logs, nil)))
+	m.statePath = state
+	m.measuredOrder = []string{"sha256:" + hexA}
+	m.unrecordLast("sha256:" + hexA)
+	if len(m.measuredOrder) != 0 {
+		t.Fatalf("measuredOrder = %v, want empty", m.measuredOrder)
+	}
+	if !bytes.Contains(logs.Bytes(), []byte("rewrite measured-digest log failed")) {
+		t.Fatalf("rewrite failure was not logged: %s", logs.String())
+	}
+	if got, err := os.ReadFile(marker); err != nil || string(got) != "original" {
+		t.Fatalf("failed rewrite changed destination: %q, %v", got, err)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "measured" {
+		t.Fatalf("failed rewrite left temporary files: %v", entries)
+	}
+}
+
 // The real sysfs helpers, pointed at a temp file standing in for the TSM node.
 func TestSysfsExtendAndReadRegister(t *testing.T) {
 	orig := rtmr3Sysfs

--- a/internal/issuer/bundle.go
+++ b/internal/issuer/bundle.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/fileutil"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 )
 
@@ -167,7 +168,7 @@ func (bm *BundleManager) persistLocked(certs []*x509.Certificate, retiredAt map[
 	if err := bm.persistRetirementsLocked(retiredAt); err != nil {
 		return err
 	}
-	if err := writeFileAtomic(bundleFile, encodeCertBundlePEM(certs), 0644); err != nil {
+	if err := fileutil.WriteAtomic(bundleFile, encodeCertBundlePEM(certs), 0644); err != nil {
 		return fmt.Errorf("write bundle: %w", err)
 	}
 
@@ -289,33 +290,10 @@ func (bm *BundleManager) persistRetirementsLocked(retiredAt map[string]time.Time
 		return fmt.Errorf("marshal bundle retirements: %w", err)
 	}
 	data = append(data, '\n')
-	if err := writeFileAtomic(bm.retirementsFile(), data, 0644); err != nil {
+	if err := fileutil.WriteAtomic(bm.retirementsFile(), data, 0644); err != nil {
 		return fmt.Errorf("write bundle retirements: %w", err)
 	}
 	return nil
-}
-
-func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-")
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	defer os.Remove(tmpName)
-
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Chmod(perm); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	return os.Rename(tmpName, path)
 }
 
 func (bm *BundleManager) retirementsFile() string {


### PR DESCRIPTION
Several state writers duplicated temporary-file creation, replacement, and cleanup, and measurement-log rollback could leave its temporary file behind after a failed rename. They now use the existing atomic writer so publication and cleanup are implemented in one place.

The callers serialize their state and select its mode; `fileutil.WriteAtomic` owns the sibling temporary file, replacement, and cleanup.

- Route CA bundle and retirement metadata writes through `fileutil.WriteAtomic`.
- Use the same writer for exemption snapshots, CDS pin updates, and measurement-log rollback.
- Keep file-mode selection and parent-directory creation at the call sites.
- Test pin-file permissions, nested exemption persistence, and rollback cleanup after a failed rename.

Review focus: verify the retained modes (`0600` for exemption and measurement state, `0644` for public CA files, and the existing mode for pin updates), CA retirement-before-bundle ordering, and error propagation from failed replacement.

Validation: `GOTOOLCHAIN=go1.26.3 make test` (full race-enabled suite), `GOTOOLCHAIN=go1.26.3 make lint`, and `git diff --check` pass. The rollback cleanup regression fails against the original implementation because `measured.tmp` remains after rename failure. Non-test diff: 10 additions and 69 deletions (79 changed lines); tests are excluded from the 200-line budget.
