### PR TITLE
refactor(io): centralise bounded document reads

### DIFF
--- a/internal/cmds/verify/measurementsconfig.go
+++ b/internal/cmds/verify/measurementsconfig.go
@@ -2,11 +2,12 @@ package verify
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/readutil"
 	"github.com/confidential-dot-ai/c8s/pkg/measurements"
 )
 
@@ -38,12 +39,12 @@ func fetchServedMeasurements(ctx context.Context, base, serverName, wantCertSHA2
 	if resp.StatusCode != http.StatusOK {
 		return measurements.ReferenceValues{}, fmt.Errorf("/measurements returned %d", resp.StatusCode)
 	}
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxServedMeasurements+1))
+	body, err := readutil.ReadAll(resp.Body, maxServedMeasurements)
+	if errors.Is(err, readutil.ErrTooLarge) {
+		return measurements.ReferenceValues{}, fmt.Errorf("/measurements body exceeds %d bytes", maxServedMeasurements)
+	}
 	if err != nil {
 		return measurements.ReferenceValues{}, fmt.Errorf("read /measurements: %w", err)
-	}
-	if len(body) > maxServedMeasurements {
-		return measurements.ReferenceValues{}, fmt.Errorf("/measurements body exceeds %d bytes", maxServedMeasurements)
 	}
 	return measurements.ParseServed(body)
 }

--- a/internal/cmds/verify/operatorkeys.go
+++ b/internal/cmds/verify/operatorkeys.go
@@ -5,11 +5,12 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/hex"
+	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/readutil"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 )
 
@@ -46,12 +47,12 @@ func fetchOperatorKeyFingerprints(ctx context.Context, base, serverName, wantCer
 		return nil, nil, "", fmt.Errorf("/operator-keys returned %d", resp.StatusCode)
 	}
 
-	pemBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxOperatorKeysBytes+1))
+	pemBytes, err := readutil.ReadAll(resp.Body, maxOperatorKeysBytes)
+	if errors.Is(err, readutil.ErrTooLarge) {
+		return nil, nil, "", fmt.Errorf("/operator-keys response exceeds %d bytes", maxOperatorKeysBytes)
+	}
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("read /operator-keys: %w", err)
-	}
-	if len(pemBytes) > maxOperatorKeysBytes {
-		return nil, nil, "", fmt.Errorf("/operator-keys response exceeds %d bytes", maxOperatorKeysBytes)
 	}
 
 	keys, err := operatorauth.ParsePublicKeysPEM(pemBytes)

--- a/internal/httputil/body.go
+++ b/internal/httputil/body.go
@@ -3,8 +3,10 @@
 package httputil
 
 import (
-	"io"
+	"errors"
 	"net/http"
+
+	"github.com/confidential-dot-ai/c8s/internal/readutil"
 )
 
 // ReadCappedBody reads up to maxBytes from r.Body. On read failure it
@@ -12,13 +14,13 @@ import (
 // failure it returns (nil, false). On success it returns the body
 // bytes and true.
 func ReadCappedBody(w http.ResponseWriter, r *http.Request, maxBytes int64) ([]byte, bool) {
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxBytes+1))
-	if err != nil {
-		http.Error(w, "read request body", http.StatusBadRequest)
+	body, err := readutil.ReadAll(r.Body, maxBytes)
+	if errors.Is(err, readutil.ErrTooLarge) {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
 		return nil, false
 	}
-	if int64(len(body)) > maxBytes {
-		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+	if err != nil {
+		http.Error(w, "read request body", http.StatusBadRequest)
 		return nil, false
 	}
 	return body, true

--- a/internal/readutil/read.go
+++ b/internal/readutil/read.go
@@ -1,0 +1,28 @@
+// Package readutil reads complete documents with a byte limit.
+package readutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+)
+
+// ErrTooLarge reports a document exceeding its byte limit.
+var ErrTooLarge = errors.New("document exceeds byte limit")
+
+// ReadAll reads at most maxBytes+1 bytes and returns no data on failure.
+// Read errors take precedence over overflow. The caller owns the reader.
+func ReadAll(r io.Reader, maxBytes int64) ([]byte, error) {
+	if maxBytes < 0 || maxBytes == math.MaxInt64 {
+		return nil, fmt.Errorf("invalid byte limit %d", maxBytes)
+	}
+	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(body)) > maxBytes {
+		return nil, ErrTooLarge
+	}
+	return body, nil
+}

--- a/internal/readutil/read_test.go
+++ b/internal/readutil/read_test.go
@@ -1,0 +1,94 @@
+package readutil
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestReadAllBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name, input string
+		limit       int64
+		tooLarge    bool
+	}{
+		{"empty", "", 4, false},
+		{"below", "abc", 4, false},
+		{"exact", "abcd", 4, false},
+		{"above", "abcde", 4, true},
+		{"zero empty", "", 0, false},
+		{"zero nonempty", "a", 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := ReadAll(strings.NewReader(tc.input), tc.limit)
+			if tc.tooLarge {
+				if !errors.Is(err, ErrTooLarge) || body != nil {
+					t.Fatalf("overflow = %q, %v", body, err)
+				}
+			} else if err != nil || body == nil || string(body) != tc.input {
+				t.Fatalf("read = %q, %v; want %q", body, err, tc.input)
+			}
+		})
+	}
+}
+
+type readerFunc func([]byte) (int, error)
+
+func (f readerFunc) Read(p []byte) (int, error) { return f(p) }
+
+func TestReadAllStopsAfterOverflowByte(t *testing.T) {
+	var read int
+	endless := readerFunc(func(p []byte) (int, error) {
+		read += len(p)
+		return len(p), nil
+	})
+	body, err := ReadAll(endless, 4096)
+	if body != nil || !errors.Is(err, ErrTooLarge) || read != 4097 {
+		t.Fatalf("read = %d bytes, body length = %d, error = %v", read, len(body), err)
+	}
+}
+
+func TestReadAllPreservesReadErrors(t *testing.T) {
+	cause := errors.New("broken stream")
+	failure := fmt.Errorf("reader: %w", cause)
+	for _, input := range []string{"", "abc", "abcd", "abcde"} {
+		t.Run(input, func(t *testing.T) {
+			r := readerFunc(func(p []byte) (int, error) {
+				return copy(p, input), failure
+			})
+			body, err := ReadAll(r, 4)
+			if body != nil || err != failure || !errors.Is(err, cause) {
+				t.Fatalf("read = %q, %v; want original read error", body, err)
+			}
+		})
+	}
+}
+
+func TestReadAllDataWithEOF(t *testing.T) {
+	for _, input := range []string{"abcd", "abcde"} {
+		r := readerFunc(func(p []byte) (int, error) { return copy(p, input), io.EOF })
+		body, err := ReadAll(r, 4)
+		if len(input) == 4 {
+			if err != nil || string(body) != input {
+				t.Fatalf("exact body with EOF = %q, %v", body, err)
+			}
+		} else if body != nil || !errors.Is(err, ErrTooLarge) {
+			t.Fatalf("overflow with EOF = %q, %v", body, err)
+		}
+	}
+}
+
+func TestReadAllInvalidLimitsDoNotRead(t *testing.T) {
+	r := readerFunc(func([]byte) (int, error) {
+		t.Fatal("read with invalid limit")
+		return 0, io.EOF
+	})
+	for _, limit := range []int64{-1, math.MinInt64, math.MaxInt64} {
+		if body, err := ReadAll(r, limit); err == nil || body != nil {
+			t.Fatalf("limit %d: got %q, %v", limit, body, err)
+		}
+	}
+}

--- a/pkg/allowlistclient/client.go
+++ b/pkg/allowlistclient/client.go
@@ -9,6 +9,7 @@ package allowlistclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -17,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/internal/readutil"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/operatorauth"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -197,12 +199,12 @@ func isJSONContentType(ct string) bool {
 }
 
 func readCapped(r io.Reader, maxBytes int64) ([]byte, error) {
-	body, err := io.ReadAll(io.LimitReader(r, maxBytes+1))
+	body, err := readutil.ReadAll(r, maxBytes)
+	if errors.Is(err, readutil.ErrTooLarge) {
+		return nil, errAllowlistResponseTooLarge
+	}
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
-	}
-	if int64(len(body)) > maxBytes {
-		return nil, errAllowlistResponseTooLarge
 	}
 	return body, nil
 }

--- a/pkg/initdata/initdata.go
+++ b/pkg/initdata/initdata.go
@@ -22,11 +22,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"maps"
 	"slices"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/confidential-dot-ai/c8s/internal/readutil"
 )
 
 const (
@@ -280,12 +281,12 @@ func Decode(annotation string) ([]byte, error) {
 		return nil, fmt.Errorf("%w: gzip: %w", ErrMalformed, err)
 	}
 	defer zr.Close()
-	raw, err := io.ReadAll(io.LimitReader(zr, maxDecodedSize+1))
+	raw, err := readutil.ReadAll(zr, maxDecodedSize)
+	if errors.Is(err, readutil.ErrTooLarge) {
+		return nil, fmt.Errorf("%w: document exceeds %d bytes", ErrMalformed, maxDecodedSize)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("%w: gzip: %w", ErrMalformed, err)
-	}
-	if len(raw) > maxDecodedSize {
-		return nil, fmt.Errorf("%w: document exceeds %d bytes", ErrMalformed, maxDecodedSize)
 	}
 	return raw, nil
 }


### PR DESCRIPTION
Five document readers independently implemented the extra-byte check needed to distinguish an exact-size document from a truncated oversized one. A shared bounded reader now owns that contract, including discarding partial data and preserving read errors, while callers select their limits and error responses.

The helper composes `io.LimitReader` and `io.ReadAll`, returning `ErrTooLarge` for overflow. Callers retain stream ownership, their configured bounds, and protocol-specific error handling.

- Add `readutil.ReadAll` with exact-limit acceptance, overflow detection, and validation of limits that cannot support the extra-byte check.
- Migrate request bodies, allowlist replies, operator-key replies, measurement replies, and decompressed init-data.
- Map overflow back to each caller’s existing status, sentinel, or error message.
- Test boundary sizes, endless readers, data returned with EOF or errors, and partial-data rejection.

Review focus: check the extra-byte boundary and read-error precedence, and verify that HTTP 413 responses, the allowlist overflow sentinel, and init-data’s `ErrMalformed` wrapping remain intact.

Validation: `GOTOOLCHAIN=go1.26.3 make test` (full race-enabled suite), `GOTOOLCHAIN=go1.26.3 make lint`, and `git diff --check` pass. Removing the overflow byte or returning partial data independently makes the new tests fail. The non-test diff is 60 additions and 25 deletions (85 changed lines); tests are excluded from the 200-line limit.
