### PR TITLE
refactor(allowlist): reuse standard map-key ordering

### DIFF
--- a/internal/cmds/allowlist/cmd.go
+++ b/internal/cmds/allowlist/cmd.go
@@ -14,7 +14,6 @@ package allowlist
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -188,16 +187,6 @@ func missingComponents(images map[string]string, required []string) []string {
 		}
 	}
 	return missing
-}
-
-// sortedKeys returns the map keys sorted, for stable output.
-func sortedKeys(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }
 
 // ctx returns the command context or a background context as a fallback.

--- a/internal/cmds/allowlist/diff.go
+++ b/internal/cmds/allowlist/diff.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
+	"slices"
 	"sort"
 
 	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
@@ -138,11 +140,7 @@ func diffContainers(kind string, live, desired []pkgallowlist.Container) (added,
 	for d := range desiredByDigest {
 		digests[d] = true
 	}
-	ordered := make([]string, 0, len(digests))
-	for d := range digests {
-		ordered = append(ordered, d)
-	}
-	sort.Strings(ordered)
+	ordered := slices.Sorted(maps.Keys(digests))
 
 	for _, digest := range ordered {
 		onlyDesired := multisetSub(desiredByDigest[digest], liveByDigest[digest])
@@ -200,13 +198,13 @@ func printDiff(w io.Writer, format string, d allowlistDiff) error {
 	}
 
 	fmt.Fprintln(w, "floor:")
-	for _, digest := range sortedKeys(d.Floor.Added) {
+	for _, digest := range slices.Sorted(maps.Keys(d.Floor.Added)) {
 		fmt.Fprintf(w, "+ %s  %s\n", digest, d.Floor.Added[digest])
 	}
-	for _, digest := range sortedKeys(d.Floor.Removed) {
+	for _, digest := range slices.Sorted(maps.Keys(d.Floor.Removed)) {
 		fmt.Fprintf(w, "- %s  %s\n", digest, d.Floor.Removed[digest])
 	}
-	for _, digest := range sortedChangedKeys(d.Floor.Changed) {
+	for _, digest := range slices.Sorted(maps.Keys(d.Floor.Changed)) {
 		fmt.Fprintf(w, "~ %s  %s -> %s\n", digest, d.Floor.Changed[digest].From, d.Floor.Changed[digest].To)
 	}
 	if d.Floor.empty() {
@@ -220,11 +218,7 @@ func printDiff(w io.Writer, format string, d allowlistDiff) error {
 	for _, name := range d.WorkloadsRemoved {
 		fmt.Fprintf(w, "- %s\n", name)
 	}
-	changedNames := make([]string, 0, len(d.WorkloadsChanged))
-	for name := range d.WorkloadsChanged {
-		changedNames = append(changedNames, name)
-	}
-	sort.Strings(changedNames)
+	changedNames := slices.Sorted(maps.Keys(d.WorkloadsChanged))
 	for _, name := range changedNames {
 		fmt.Fprintf(w, "~ %s\n", name)
 		printEntryDiff(w, d.WorkloadsChanged[name])
@@ -248,13 +242,4 @@ func printEntryDiff(w io.Writer, e entryDiff) {
 	for _, c := range e.Changed {
 		fmt.Fprintf(w, "    ~ %s %s  %s -> %s\n", c.Kind, c.Digest, c.From, c.To)
 	}
-}
-
-func sortedChangedKeys(m map[string]changedEntry) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/internal/cmds/allowlist/diff_test.go
+++ b/internal/cmds/allowlist/diff_test.go
@@ -129,3 +129,28 @@ func TestPrintDiffTextSectionPlaceholders(t *testing.T) {
 		}
 	})
 }
+
+func TestPrintDiffOrdersMapEntries(t *testing.T) {
+	d := allowlistDiff{
+		Floor: floorDiff{
+			Added:   map[string]string{"b": "B", "a": "A"},
+			Removed: map[string]string{"d": "D", "c": "C"},
+			Changed: map[string]changedEntry{"f": {From: "old", To: "F"}, "e": {From: "old", To: "E"}},
+		},
+		WorkloadsChanged: map[string]entryDiff{
+			"z": {Label: &changedEntry{From: "old", To: "Z"}},
+			"y": {Label: &changedEntry{From: "old", To: "Y"}},
+		},
+	}
+	want := "floor:\n+ a  A\n+ b  B\n- c  C\n- d  D\n~ e  old -> E\n~ f  old -> F\n" +
+		"workloads:\n~ y\n    label: \"old\" -> \"Y\"\n~ z\n    label: \"old\" -> \"Z\"\n"
+	for range 20 {
+		var out bytes.Buffer
+		if err := printDiff(&out, "text", d); err != nil {
+			t.Fatal(err)
+		}
+		if out.String() != want {
+			t.Fatalf("diff output = %q, want %q", out.String(), want)
+		}
+	}
+}

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 
@@ -158,7 +160,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 	entriesByDigest := map[string]map[string]bool{}
 	fullyAny := map[string]bool{}
 
-	for _, name := range sortedWorkloadNames(al.Workloads) {
+	for _, name := range slices.Sorted(maps.Keys(al.Workloads)) {
 		w := al.Workloads[name]
 		if len(w.InitContainers) == 0 && len(w.Containers) == 0 {
 			warnings = append(warnings, warnf("workload %q has no init or main containers", name))
@@ -197,7 +199,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 		}
 	}
 
-	for _, d := range sortedKeysBool(fullyAny) {
+	for _, d := range slices.Sorted(maps.Keys(fullyAny)) {
 		if len(entriesByDigest[d]) > 1 {
 			warnings = append(warnings, warnf("digest %s appears in %d entries and one grants 'any'; the effective admission for that digest is 'any' (union across entries)", d, len(entriesByDigest[d])))
 		}
@@ -207,9 +209,9 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 	// policy an operator also wrote for the same digest in a workload — and for
 	// a secrets-bearing entry it also makes the entry unmatchable, since the
 	// digest is dropped from the candidate set.
-	for _, d := range sortedKeys(al.Digests) {
+	for _, d := range slices.Sorted(maps.Keys(al.Digests)) {
 		if names := entriesByDigest[d]; len(names) > 0 {
-			warnings = append(warnings, warnf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(sortedKeysBool(names), ", ")))
+			warnings = append(warnings, warnf("digest %s is floor-listed and also in workload entr(ies) [%s]; the floor admits it by digest alone, so those argv policies are not enforced (remove it from the floor to enforce them)", d, strings.Join(slices.Sorted(maps.Keys(names)), ", ")))
 		}
 	}
 
@@ -231,7 +233,7 @@ func unobservedFieldPolicies(al *pkgallowlist.Allowlist, cvmMode string) []findi
 		return nil
 	}
 	var warnings []finding
-	for _, name := range sortedWorkloadNames(al.Workloads) {
+	for _, name := range slices.Sorted(maps.Keys(al.Workloads)) {
 		for _, c := range allContainers(al.Workloads[name]) {
 			var fields []string
 			if c.Mounts.Policy == pkgallowlist.PolicyExact {
@@ -271,7 +273,7 @@ func indistinguishableEntries(al *pkgallowlist.Allowlist) []finding {
 // shape, in a stable order.
 func indistinguishableGroups(al *pkgallowlist.Allowlist) ([][]string, error) {
 	byShape := map[string][]string{}
-	for _, name := range sortedWorkloadNames(al.Workloads) {
+	for _, name := range slices.Sorted(maps.Keys(al.Workloads)) {
 		shape, err := entryShape(al.Workloads[name])
 		if err != nil {
 			// A shape that will not marshal cannot be compared; say so rather
@@ -281,7 +283,7 @@ func indistinguishableGroups(al *pkgallowlist.Allowlist) ([][]string, error) {
 		byShape[shape] = append(byShape[shape], name)
 	}
 	var out [][]string
-	for _, shape := range sortedKeysStrings(byShape) {
+	for _, shape := range slices.Sorted(maps.Keys(byShape)) {
 		if names := byShape[shape]; len(names) > 1 {
 			out = append(out, names)
 		}
@@ -332,21 +334,12 @@ func entryShape(w pkgallowlist.Workload) (string, error) {
 	return string(b), err
 }
 
-func sortedKeysStrings(m map[string][]string) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
-}
-
 // lintOnline checks each workload container digest is resolvable in its
 // registry via crane. It needs the container image label to know the repo.
 func lintOnline(ctx context.Context, al *pkgallowlist.Allowlist) []finding {
 	var warnings []finding
 	checked := map[string]bool{}
-	for _, name := range sortedWorkloadNames(al.Workloads) {
+	for _, name := range slices.Sorted(maps.Keys(al.Workloads)) {
 		w := al.Workloads[name]
 		for _, c := range allContainers(w) {
 			if c.Image == "" {
@@ -380,13 +373,4 @@ func isTagForm(image string) bool {
 	}
 	_, digested := named.(reference.Digested)
 	return !digested
-}
-
-func sortedKeysBool(m map[string]bool) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/internal/cmds/allowlist/read.go
+++ b/internal/cmds/allowlist/read.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
-	"sort"
+	"slices"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -148,7 +150,7 @@ func printFloorTable(w io.Writer, digests map[string]string) {
 	}
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "DIGEST\tIMAGE")
-	for _, d := range sortedKeys(digests) {
+	for _, d := range slices.Sorted(maps.Keys(digests)) {
 		fmt.Fprintf(tw, "%s\t%s\n", d, digests[d])
 	}
 	tw.Flush()
@@ -159,11 +161,7 @@ func printWorkloadTable(w io.Writer, workloads map[string]pkgallowlist.Workload)
 	if len(workloads) == 0 {
 		return
 	}
-	names := make([]string, 0, len(workloads))
-	for name := range workloads {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(workloads))
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "NAME\tINIT\tCTRS\tCOMMAND/ARGS\tPATHS")
@@ -203,19 +201,7 @@ func argvPolicyName(p pkgallowlist.ArgvPolicy) string {
 }
 
 func joinSet(set map[string]bool) string {
-	keys := make([]string, 0, len(set))
-	for k := range set {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	out := ""
-	for i, k := range keys {
-		if i > 0 {
-			out += ","
-		}
-		out += k
-	}
-	return out
+	return strings.Join(slices.Sorted(maps.Keys(set)), ",")
 }
 
 // argvSummary renders one argv policy for diff output.

--- a/internal/cmds/allowlist/read_write_test.go
+++ b/internal/cmds/allowlist/read_write_test.go
@@ -172,6 +172,10 @@ func TestListTextWorkloadTable(t *testing.T) {
 		t.Fatalf("missing summary line:\n%s", out)
 	}
 
+	if strings.Index(out, "\nplain ") > strings.Index(out, "\nweb ") {
+		t.Fatalf("workload rows are not sorted:\n%s", out)
+	}
+
 	rows := map[string][]string{}
 	for _, line := range strings.Split(out, "\n") {
 		if f := strings.Fields(line); len(f) > 0 {

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -127,7 +128,7 @@ digests in the file are ignored; use 'upload' or 'add'.`,
 				return fmt.Errorf("refusing to apply: %d lint error(s)", errs)
 			}
 
-			names := sortedWorkloadNames(entries)
+			names := slices.Sorted(maps.Keys(entries))
 			for _, name := range names {
 				if lw, ok := live.Workloads[name]; ok {
 					ed := diffEntry(lw, entries[name])
@@ -307,15 +308,6 @@ func parseWorkloadEntries(data []byte) (entries map[string]pkgallowlist.Workload
 		out[name] = *w
 	}
 	return out, 0, nil
-}
-
-func sortedWorkloadNames(m map[string]pkgallowlist.Workload) []string {
-	names := make([]string, 0, len(m))
-	for name := range m {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	return names
 }
 
 func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {


### PR DESCRIPTION
Allowlist commands duplicated deterministic map-key ordering across typed helpers and inline loops. Using the standard library makes that ordering explicit at each call site and reduces the code to maintain.

- Replace five typed helpers and four inline key-sorting implementations with slices.Sorted(maps.Keys(...)).
- Render sorted policy sets with strings.Join.
- Cover diff section ordering and workload table ordering with regression assertions.

The change removes 64 production lines (26 additions, 90 deletions), within the 200-line non-test limit. Including 29 added test lines, the codebase shrinks by 35 lines.

Review focus: preserved lexicographic ordering in reports, lint findings, and workload application, plus unchanged empty-map output.

Validation: `GOTOOLCHAIN=go1.26.3 go test -race ./internal/cmds/allowlist`, `GOTOOLCHAIN=go1.26.3 make test`, `GOTOOLCHAIN=go1.26.3 make lint`, and `git diff --check`.
