### PR TITLE
refactor(certificates): share nginx reload logic

### DIFF
--- a/internal/cmds/acme/cmd.go
+++ b/internal/cmds/acme/cmd.go
@@ -27,6 +27,8 @@ import (
 	"github.com/confidential-dot-ai/c8s/internal/cmds/cmdsutil"
 )
 
+var procRoot = "/proc"
+
 const letsEncryptDirectoryURL = "https://acme-v02.api.letsencrypt.org/directory"
 
 type config struct {
@@ -147,7 +149,7 @@ func run(cfg config) error {
 		if !cfg.reloadNginx {
 			return
 		}
-		if err := reloadNginx(logger); err != nil {
+		if err := cmdsutil.ReloadNginx(procRoot, logger); err != nil {
 			logger.Error("nginx reload failed", "error", err)
 		}
 	})

--- a/internal/cmds/acme/reload_test.go
+++ b/internal/cmds/acme/reload_test.go
@@ -1,14 +1,12 @@
 package acme
 
 import (
-	"log/slog"
 	"os"
 	"os/signal"
 	"path/filepath"
 	"strconv"
 	"syscall"
 	"testing"
-	"time"
 )
 
 // overrideProcRoot substitutes a fake /proc tree and restores the real one on
@@ -20,7 +18,7 @@ func overrideProcRoot(t *testing.T, root string) {
 	t.Cleanup(func() { procRoot = old })
 }
 
-// presentAsNginxMaster makes reloadNginx find this test process under root.
+// presentAsNginxMaster makes ReloadNginx find this test process under root.
 func presentAsNginxMaster(t *testing.T, root string) {
 	t.Helper()
 	pidDir := filepath.Join(root, strconv.Itoa(os.Getpid()))
@@ -35,93 +33,11 @@ func presentAsNginxMaster(t *testing.T, root string) {
 	}
 }
 
-// catchSIGHUP subscribes for the reload signal reloadNginx sends the master.
+// catchSIGHUP subscribes for the reload signal ReloadNginx sends the master.
 func catchSIGHUP(t *testing.T) <-chan os.Signal {
 	t.Helper()
 	hup := make(chan os.Signal, 1)
 	signal.Notify(hup, syscall.SIGHUP)
 	t.Cleanup(func() { signal.Stop(hup) })
 	return hup
-}
-
-func TestFindNginxMasterPID(t *testing.T) {
-	t.Run("finds the master among decoys", func(t *testing.T) {
-		root := t.TempDir()
-		writeProcEntry := func(pid, comm, cmdline string) {
-			t.Helper()
-			dir := filepath.Join(root, pid)
-			if err := os.MkdirAll(dir, 0o755); err != nil {
-				t.Fatal(err)
-			}
-			if comm != "" {
-				if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if cmdline != "" {
-				if err := os.WriteFile(filepath.Join(dir, "cmdline"), []byte(cmdline), 0o644); err != nil {
-					t.Fatal(err)
-				}
-			}
-		}
-		// Decoys exercising every skip branch: a non-pid dir, a plain file, a
-		// non-nginx process, an nginx worker, an nginx without cmdline.
-		writeProcEntry("self", "nginx\n", "nginx: master process\x00")
-		if err := os.WriteFile(filepath.Join(root, "42"), []byte("file"), 0o644); err != nil {
-			t.Fatal(err)
-		}
-		writeProcEntry("100", "bash\n", "bash\x00")
-		writeProcEntry("101", "nginx\n", "nginx: worker process\x00")
-		writeProcEntry("102", "nginx\n", "")
-		writeProcEntry("103", "", "nginx: master process\x00")
-		writeProcEntry("200", "nginx\n", "nginx: master process /etc/nginx/nginx.conf\x00")
-		overrideProcRoot(t, root)
-
-		pid, err := findNginxMasterPID()
-		if err != nil {
-			t.Fatalf("findNginxMasterPID: %v", err)
-		}
-		if pid != 200 {
-			t.Fatalf("pid = %d, want 200", pid)
-		}
-	})
-
-	t.Run("no master present", func(t *testing.T) {
-		overrideProcRoot(t, t.TempDir())
-		if _, err := findNginxMasterPID(); err == nil {
-			t.Fatal("findNginxMasterPID succeeded, want no-master error")
-		}
-	})
-
-	t.Run("proc root unreadable", func(t *testing.T) {
-		overrideProcRoot(t, filepath.Join(t.TempDir(), "missing"))
-		if _, err := findNginxMasterPID(); err == nil {
-			t.Fatal("findNginxMasterPID succeeded, want read error")
-		}
-	})
-}
-
-func TestReloadNginx(t *testing.T) {
-	t.Run("signals the master", func(t *testing.T) {
-		hup := catchSIGHUP(t)
-		root := t.TempDir()
-		presentAsNginxMaster(t, root)
-		overrideProcRoot(t, root)
-
-		if err := reloadNginx(slog.Default()); err != nil {
-			t.Fatalf("reloadNginx: %v", err)
-		}
-		select {
-		case <-hup:
-		case <-time.After(5 * time.Second):
-			t.Fatal("SIGHUP not delivered")
-		}
-	})
-
-	t.Run("no master", func(t *testing.T) {
-		overrideProcRoot(t, t.TempDir())
-		if err := reloadNginx(slog.Default()); err == nil {
-			t.Fatal("reloadNginx succeeded, want no-master error")
-		}
-	})
 }

--- a/internal/cmds/cmdsutil/nginx.go
+++ b/internal/cmds/cmdsutil/nginx.go
@@ -1,4 +1,4 @@
-package acme
+package cmdsutil
 
 import (
 	"fmt"
@@ -9,16 +9,10 @@ import (
 	"syscall"
 )
 
-// procRoot is the procfs mount findNginxMasterPID scans. It is a package
-// variable only so tests can substitute a fake /proc tree.
-var procRoot = "/proc"
-
-// reloadNginx sends SIGHUP to the nginx master process so it picks up the
-// installed certificate. Requires shareProcessNamespace: true in the pod
-// spec. Walks /proc directly instead of shelling out to pgrep so this works
-// in distroless images (same mechanism as get-cert's --reload-nginx).
-func reloadNginx(log *slog.Logger) error {
-	pid, err := findNginxMasterPID()
+// ReloadNginx finds the nginx master in procRoot and sends SIGHUP.
+// The caller must share its process namespace with nginx.
+func ReloadNginx(procRoot string, log *slog.Logger) error {
+	pid, err := findNginxMasterPID(procRoot)
 	if err != nil {
 		return err
 	}
@@ -35,7 +29,7 @@ func reloadNginx(log *slog.Logger) error {
 
 // findNginxMasterPID scans /proc for the nginx master process.
 // Match: /proc/<pid>/comm == "nginx" AND cmdline contains "master".
-func findNginxMasterPID() (int, error) {
+func findNginxMasterPID(procRoot string) (int, error) {
 	entries, err := os.ReadDir(procRoot)
 	if err != nil {
 		return 0, fmt.Errorf("read %s: %w", procRoot, err)

--- a/internal/cmds/cmdsutil/nginx_test.go
+++ b/internal/cmds/cmdsutil/nginx_test.go
@@ -1,0 +1,99 @@
+package cmdsutil
+
+import (
+	"log/slog"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestFindNginxMasterPID(t *testing.T) {
+	t.Run("finds the master among decoys", func(t *testing.T) {
+		root := t.TempDir()
+		writeProcEntry := func(pid, comm, cmdline string) {
+			t.Helper()
+			dir := filepath.Join(root, pid)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if comm != "" {
+				if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if cmdline != "" {
+				if err := os.WriteFile(filepath.Join(dir, "cmdline"), []byte(cmdline), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		// Decoys exercising every skip branch: a non-pid dir, a plain file, a
+		// non-nginx process, an nginx worker, an nginx without cmdline.
+		writeProcEntry("self", "nginx\n", "nginx: master process\x00")
+		if err := os.WriteFile(filepath.Join(root, "42"), []byte("file"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		writeProcEntry("100", "bash\n", "bash\x00")
+		writeProcEntry("101", "nginx\n", "nginx: worker process\x00")
+		writeProcEntry("102", "nginx\n", "")
+		writeProcEntry("103", "", "nginx: master process\x00")
+		writeProcEntry("200", "nginx\n", "nginx: master process /etc/nginx/nginx.conf\x00")
+
+		pid, err := findNginxMasterPID(root)
+		if err != nil {
+			t.Fatalf("findNginxMasterPID: %v", err)
+		}
+		if pid != 200 {
+			t.Fatalf("pid = %d, want 200", pid)
+		}
+	})
+
+	t.Run("no master present", func(t *testing.T) {
+		root := t.TempDir()
+		if _, err := findNginxMasterPID(root); err == nil {
+			t.Fatal("findNginxMasterPID succeeded, want no-master error")
+		}
+	})
+
+	t.Run("proc root unreadable", func(t *testing.T) {
+		root := filepath.Join(t.TempDir(), "missing")
+		if _, err := findNginxMasterPID(root); err == nil {
+			t.Fatal("findNginxMasterPID succeeded, want read error")
+		}
+	})
+}
+
+func TestReloadNginx(t *testing.T) {
+	t.Run("signals the master", func(t *testing.T) {
+		hup := make(chan os.Signal, 1)
+		signal.Notify(hup, syscall.SIGHUP)
+		t.Cleanup(func() { signal.Stop(hup) })
+		root := t.TempDir()
+		dir := filepath.Join(root, strconv.Itoa(os.Getpid()))
+		if err := os.Mkdir(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for file, value := range map[string]string{"comm": "nginx\n", "cmdline": "nginx: master process\x00"} {
+			if err := os.WriteFile(filepath.Join(dir, file), []byte(value), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := ReloadNginx(root, slog.Default()); err != nil {
+			t.Fatal(err)
+		}
+		select {
+		case <-hup:
+		case <-time.After(5 * time.Second):
+			t.Fatal("SIGHUP not delivered")
+		}
+	})
+	t.Run("no master", func(t *testing.T) {
+		if err := ReloadNginx(t.TempDir(), slog.Default()); err == nil {
+			t.Fatal("ReloadNginx succeeded, want no-master error")
+		}
+	})
+}

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -81,8 +81,7 @@ type config struct {
 // the control plane cannot redirect).
 var inventoryEndpoint = workloadclaims.InventoryEndpoint
 
-// procRoot is the procfs mount findNginxMasterPID scans. It is a package
-// variable only so tests can substitute a fake /proc tree.
+// procRoot is the procfs mount used to find nginx; tests substitute a fake tree.
 var procRoot = "/proc"
 
 var (
@@ -360,7 +359,7 @@ func renewLoop(ctx context.Context, cfg config, client attestclient.Client, leaf
 				unnamedRuns++
 			}
 			if cfg.ReloadNginx {
-				if err := reloadNginx(); err != nil {
+				if err := cmdsutil.ReloadNginx(procRoot, slog.Default()); err != nil {
 					slog.Warn("certificate renewed but nginx reload failed", "error", err)
 				}
 			}
@@ -376,7 +375,7 @@ func renewLoop(ctx context.Context, cfg config, client attestclient.Client, leaf
 				continue
 			}
 			slog.Info("watched file changed, reloading nginx")
-			if err := reloadNginx(); err != nil {
+			if err := cmdsutil.ReloadNginx(procRoot, slog.Default()); err != nil {
 				slog.Warn("watched file changed but nginx reload failed", "error", err)
 			}
 		}
@@ -614,58 +613,6 @@ func fetchSandboxToken(ctx context.Context, cfg config, pub crypto.PublicKey, no
 		return nil, fmt.Errorf("marshal sandbox token: %w", err)
 	}
 	return raw, nil
-}
-
-// reloadNginx sends SIGHUP to the nginx master process to reload certs.
-// Requires shareProcessNamespace: true in the pod spec. Walks /proc directly
-// instead of shelling out to pgrep so this works in distroless images.
-func reloadNginx() error {
-	pid, err := findNginxMasterPID()
-	if err != nil {
-		return err
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("find process %d: %w", pid, err)
-	}
-	if err := proc.Signal(syscall.SIGHUP); err != nil {
-		return fmt.Errorf("SIGHUP nginx (pid %d): %w", pid, err)
-	}
-	slog.Info("sent SIGHUP to nginx", "pid", pid)
-	return nil
-}
-
-// findNginxMasterPID scans /proc for the nginx master process.
-// Match: /proc/<pid>/comm == "nginx" AND cmdline contains "master".
-func findNginxMasterPID() (int, error) {
-	entries, err := os.ReadDir(procRoot)
-	if err != nil {
-		return 0, fmt.Errorf("read %s: %w", procRoot, err)
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		pid, err := strconv.Atoi(e.Name())
-		if err != nil {
-			continue
-		}
-		comm, err := os.ReadFile(procRoot + "/" + e.Name() + "/comm")
-		if err != nil || strings.TrimSpace(string(comm)) != "nginx" {
-			continue
-		}
-		cmdline, err := os.ReadFile(procRoot + "/" + e.Name() + "/cmdline")
-		if err != nil {
-			continue
-		}
-		// /proc/<pid>/cmdline is NUL-separated; nginx master argv[0] is
-		// "nginx: master process ...".
-		if !strings.Contains(string(cmdline), "master") {
-			continue
-		}
-		return pid, nil
-	}
-	return 0, fmt.Errorf("no nginx master process found")
 }
 
 // validateConfig checks that all required configuration is valid.

--- a/internal/cmds/getcert/run_loop_test.go
+++ b/internal/cmds/getcert/run_loop_test.go
@@ -156,7 +156,7 @@ func waitForAttempts(t *testing.T, attempts func() []time.Time, n int) []time.Ti
 	}
 }
 
-// catchSIGHUP subscribes for the reload signal reloadNginx sends the master.
+// catchSIGHUP subscribes for the reload signal ReloadNginx sends the master.
 func catchSIGHUP(t *testing.T) <-chan os.Signal {
 	t.Helper()
 	hup := make(chan os.Signal, 1)
@@ -165,7 +165,7 @@ func catchSIGHUP(t *testing.T) <-chan os.Signal {
 	return hup
 }
 
-// presentAsNginxMaster makes reloadNginx find this test process under root.
+// presentAsNginxMaster makes ReloadNginx find this test process under root.
 func presentAsNginxMaster(t *testing.T, root string) {
 	t.Helper()
 	pidDir := filepath.Join(root, strconv.Itoa(os.Getpid()))
@@ -453,88 +453,6 @@ func overrideProcRoot(t *testing.T, root string) {
 	old := procRoot
 	procRoot = root
 	t.Cleanup(func() { procRoot = old })
-}
-
-func TestFindNginxMasterPID(t *testing.T) {
-	t.Run("finds the master among decoys", func(t *testing.T) {
-		root := t.TempDir()
-		writeProcEntry := func(pid, comm, cmdline string) {
-			t.Helper()
-			dir := filepath.Join(root, pid)
-			if err := os.MkdirAll(dir, 0755); err != nil {
-				t.Fatal(err)
-			}
-			if comm != "" {
-				if err := os.WriteFile(filepath.Join(dir, "comm"), []byte(comm), 0644); err != nil {
-					t.Fatal(err)
-				}
-			}
-			if cmdline != "" {
-				if err := os.WriteFile(filepath.Join(dir, "cmdline"), []byte(cmdline), 0644); err != nil {
-					t.Fatal(err)
-				}
-			}
-		}
-		// Decoys exercising every skip branch: a non-pid dir, a plain file, a
-		// non-nginx process, an nginx worker, an nginx without cmdline.
-		writeProcEntry("self", "nginx\n", "nginx: master process\x00")
-		if err := os.WriteFile(filepath.Join(root, "42"), []byte("file"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		writeProcEntry("100", "bash\n", "bash\x00")
-		writeProcEntry("101", "nginx\n", "nginx: worker process\x00")
-		writeProcEntry("102", "nginx\n", "")
-		writeProcEntry("103", "", "nginx: master process\x00")
-		writeProcEntry("200", "nginx\n", "nginx: master process /etc/nginx/nginx.conf\x00")
-		overrideProcRoot(t, root)
-
-		pid, err := findNginxMasterPID()
-		if err != nil {
-			t.Fatalf("findNginxMasterPID: %v", err)
-		}
-		if pid != 200 {
-			t.Fatalf("pid = %d, want 200", pid)
-		}
-	})
-
-	t.Run("no master present", func(t *testing.T) {
-		overrideProcRoot(t, t.TempDir())
-		if _, err := findNginxMasterPID(); err == nil {
-			t.Fatal("findNginxMasterPID succeeded, want no-master error")
-		}
-	})
-
-	t.Run("proc root unreadable", func(t *testing.T) {
-		overrideProcRoot(t, filepath.Join(t.TempDir(), "missing"))
-		if _, err := findNginxMasterPID(); err == nil {
-			t.Fatal("findNginxMasterPID succeeded, want read error")
-		}
-	})
-}
-
-func TestReloadNginx(t *testing.T) {
-	t.Run("signals the master", func(t *testing.T) {
-		hup := catchSIGHUP(t)
-		root := t.TempDir()
-		presentAsNginxMaster(t, root)
-		overrideProcRoot(t, root)
-
-		if err := reloadNginx(); err != nil {
-			t.Fatalf("reloadNginx: %v", err)
-		}
-		select {
-		case <-hup:
-		case <-time.After(5 * time.Second):
-			t.Fatal("SIGHUP not delivered")
-		}
-	})
-
-	t.Run("no master", func(t *testing.T) {
-		overrideProcRoot(t, t.TempDir())
-		if err := reloadNginx(); err == nil {
-			t.Fatal("reloadNginx succeeded, want no-master error")
-		}
-	})
 }
 
 func TestRunRenewalModeFailsOnBadWatchSnapshot(t *testing.T) {

--- a/internal/cmds/verify/attestedfetch_test.go
+++ b/internal/cmds/verify/attestedfetch_test.go
@@ -83,10 +83,13 @@ func TestAttestedFetchClosesConnection(t *testing.T) {
 }
 
 func TestAttestedFetchBoundsBodyRead(t *testing.T) {
+	release := make(chan struct{})
+	defer close(release)
 	base, pin := startKeysTLSServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.(http.Flusher).Flush()
-		<-r.Context().Done()
+		// Keep the response incomplete until the client observes cancellation.
+		<-release
 	})
 	for _, cancelEarly := range []bool{false, true} {
 		ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
ACME and get-cert maintained identical nginx process discovery and reload logic. A shared helper keeps certificate reload behavior consistent while removing duplicate code and tests.

- Route certificate installation, renewal, and watched-file reloads through cmdsutil.ReloadNginx.
- Preserve procfs master matching, SIGHUP delivery, error wrapping, and each caller's logger.
- Consolidate discovery and signal tests while retaining both commands' integration coverage.
- Keep the fetch-cancellation test response open through its assertion to prevent clean EOF racing cancellation.

Production code shrinks by 57 lines, with 191 non-test lines changed counting the moved file in full. Including consolidated tests, the codebase shrinks by 121 lines.

Review focus: master-versus-worker filtering, unchanged reload triggers and error handling, and preservation of ACME's logger and get-cert's default logger.

Validation: `GOTOOLCHAIN=go1.26.3 go test -race ./internal/cmds/cmdsutil ./internal/cmds/acme ./internal/cmds/getcert`, `GOTOOLCHAIN=go1.26.7 make test`, `GOTOOLCHAIN=go1.26.7 make lint`, `GOTOOLCHAIN=go1.26.7 go test -race -count=30 ./internal/cmds/verify -run TestAttestedFetchBoundsBodyRead`, and `git diff --check`.
