### PR TITLE
ci(c8s-image): survive a cold apt cache against a slow snapshot mirror

### DIFF
--- a/.github/actions/setup-go-c8s/action.yml
+++ b/.github/actions/setup-go-c8s/action.yml
@@ -25,9 +25,12 @@ inputs:
     default: go.sum
   cache:
     description: >-
-      Use setup-go's built-in cache. Set "false" when the job manages its own
-      restore/save (setup-go only saves on a key miss, so a go.sum-keyed cache
-      goes stale between dependency bumps).
+      Restore the Go module and build caches that ci.yml's test job saves
+      (go-mod-<go.sum hash>, go-ci-<main sha>). Restore only: every job
+      that did its own save-on-miss (setup-go's built-in cache did, per
+      go.sum hash, Go version and branch) left a duplicate 300-500 MB
+      entry, and those crowded the repository's 10 GB cache cap. Set
+      "false" in the job that saves.
     default: "true"
 
 runs:
@@ -68,5 +71,20 @@ runs:
     - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ steps.go-minor.outputs.version }}
-        cache: ${{ inputs.cache }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        cache: false
+
+    # Same keys and paths as ci.yml's test job, which is the only writer.
+    - if: inputs.cache == 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/go/pkg/mod
+        key: go-mod-${{ hashFiles(inputs.cache-dependency-path) }}
+        restore-keys: |
+          go-mod-
+    - if: inputs.cache == 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/go-build
+        key: go-ci-${{ github.sha }}
+        restore-keys: |
+          go-ci-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,8 @@ updates:
         update-types: ["minor", "patch"]
 
   # The runtime bases of attestation-gated components: nri-image-policy's image
-  # is in the measured allowlist floor, and docker.yml's type=gha cache means a
-  # repointed base can otherwise ride a warm layer unnoticed.
+  # is in the measured allowlist floor, so a repointed base must not go
+  # unnoticed.
   - package-ecosystem: docker
     directories:
       - /cmd/c8s

--- a/.github/scripts/host-deps.sh
+++ b/.github/scripts/host-deps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Installs the node-image host toolchain with confos's snapshot-pinned
+# host-deps (confos#36), retrying the whole transaction: host-deps bounds
+# each file fetch but has no transaction retry, so a snapshot.ubuntu.com
+# 5xx mid-fetch fails it outright. Extra arguments (--cache-dir ...) go to
+# host-deps. Run from the directory holding confidential-os-builder/.
+#
+# No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
+# base ovmf is for the SNP path. libclang-dev/clang: bindgen from nvat.h.
+# libtss2-dev: tss-esapi-sys. iasl (acpica-tools, DSDT) and clang shape
+# measured bytes, which is why the set is snapshot-pinned at all.
+#
+# Retries are budgeted by time, not count: a flapping mirror fails a
+# transaction in seconds (index fetches 5xx, nothing to install) or after
+# minutes (one deb 5xx at the end), and three tries of the former are
+# over before it recovers. HOST_DEPS_BUDGET seconds, default 25 minutes,
+# sits under the calling step's 30 minute bound.
+set -euo pipefail
+budget=${HOST_DEPS_BUDGET:-1500}
+start=$(date +%s)
+attempt=0
+while :; do
+  attempt=$((attempt + 1))
+  if confidential-os-builder/bin/host-deps "$@" \
+       systemd-container ovmf cpio acpica-tools \
+       libclang-dev clang libtss2-dev; then
+    exit 0
+  fi
+  elapsed=$(( $(date +%s) - start ))
+  if [ "$elapsed" -ge "$budget" ]; then
+    echo "host-deps attempt $attempt failed after ${elapsed}s; budget of ${budget}s spent" >&2
+    exit 1
+  fi
+  echo "host-deps attempt $attempt failed after ${elapsed}s; retrying in 60s" >&2
+  sleep 60
+done

--- a/.github/workflows/c8s-image.yml
+++ b/.github/workflows/c8s-image.yml
@@ -73,8 +73,80 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  host-deps:
+    name: Seed build-dep debs
+    # One cold apt install per run instead of one per platform leg: the
+    # legs otherwise fetch the same set concurrently from a mirror whose
+    # throughput is the scarce resource. Warm runs cost a checkout and a
+    # cache lookup. Same runner as the legs: the cache key carries the
+    # runner image.
+    if: |
+      inputs.gate == true ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository &&
+       (github.event.workflow_run.event == 'push' ||
+        github.event.workflow_run.event == 'workflow_dispatch') &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: the-machine
+    timeout-minutes: 45
+    steps:
+      - name: Checkout c8s
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          path: c8s
+          sparse-checkout: .github
+
+      - name: Load measured-build pins
+        id: pins
+        env:
+          CONFOS_REF_OVERRIDE: ${{ inputs.confos_ref }}
+        run: |
+          set -euo pipefail
+          bash c8s/.github/scripts/pin-manifest.sh export \
+            --manifest c8s/.github/build-pins.json \
+            --domain node-image \
+            --format github-output \
+            --confos-override "$CONFOS_REF_OVERRIDE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout confidential-os-builder (host-deps and its sources)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          repository: confidential-dot-ai/confidential-os-builder
+          ref: ${{ steps.pins.outputs.confos }}
+          path: confidential-os-builder
+
+      - name: Compute runner-image cache term
+        id: image
+        run: echo "key=${ImageOS:-unknown}-${ImageVersion:-unknown}" >> "$GITHUB_OUTPUT"
+
+      - name: Look up build-dep debs
+        id: apt-debs
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: apt-debs
+          key: apt-debs-${{ steps.image.outputs.key }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+          lookup-only: true
+
+      - name: Install build deps
+        # See the legs' step of the same name for the bound.
+        if: steps.apt-debs.outputs.cache-hit != 'true'
+        timeout-minutes: 30
+        run: bash c8s/.github/scripts/host-deps.sh --cache-dir apt-debs
+
+      - name: Save build-dep debs
+        if: steps.apt-debs.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: apt-debs
+          key: apt-debs-${{ steps.image.outputs.key }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
+
   build-and-push:
     name: Build c8s node image (${{ matrix.platform }})
+    needs: host-deps
     # Auto path: Docker succeeded on main (its PR runs don't publish components).
     # Gate legs arrive via workflow_call, where event_name is the caller's.
     if: |
@@ -206,8 +278,12 @@ jobs:
         # Keyed on the runner-image release and the host-deps pin (script +
         # the base mkosi.sources it reads): the resolved deb set is a
         # function of confos's committed snapshot and the preinstalled
-        # package state. Warm runs never touch the apt mirror, whose
-        # degradation has taken out gate legs repeatedly.
+        # package state. Seeded by the host-deps job, so a miss here is a
+        # race with eviction and the install below falls back to the
+        # mirror. Warm runs never touch it. No restore-keys:
+        # host-deps only uses a cache whose snapshot and package set match
+        # its manifest exactly, so a prefix candidate from another pin is a
+        # download it would discard.
         id: apt-debs
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -215,20 +291,18 @@ jobs:
           key: apt-debs-${{ steps.image.outputs.key }}-${{ hashFiles('confidential-os-builder/bin/host-deps', 'confidential-os-builder/mkosi/base/mkosi.sandbox/etc/apt/sources.list.d/mkosi.sources') }}
 
       - name: Install build deps
-        # No ovmf-inteltdx: #82 TDX firmware is vendored (firmware/OVMF.inteltdx.fd);
-        # base ovmf is for the SNP path.
-        # libclang-dev/clang: bindgen from nvat.h. libtss2-dev: tss-esapi-sys.
-        # iasl (DSDT) and clang (bindgen) shape measured bytes: host-deps
-        # installs them snapshot-pinned, fail-closed on live-mirror fetches
-        # (confos#36); with a warm apt-debs it reinstalls fully offline.
-        # Bounded: a dead mirror connection otherwise hangs until the job's
-        # 3h limit.
-        timeout-minutes: 10
+        # The package set and why it is snapshot-pinned: host-deps.sh.
+        # With a warm apt-debs this reinstalls fully offline. Bounded so
+        # a wedged mirror cannot hold the job to its 3h limit: host-deps
+        # bounds each file fetch (see its apt_snapshot), not the
+        # transaction, and a cold install is ~30 debs plus indexes,
+        # ~85 MB, which a degraded snapshot.ubuntu.com has served at tens
+        # of KB/s, so 10 minutes is not enough and 30 is. The script
+        # retries the transaction within a 25 minute budget under it.
+        timeout-minutes: 30
         run: |
           set -euo pipefail
-          confidential-os-builder/bin/host-deps --cache-dir apt-debs \
-            systemd-container ovmf cpio acpica-tools \
-            libclang-dev clang libtss2-dev
+          bash c8s/.github/scripts/host-deps.sh --cache-dir apt-debs
           # The exact host set, for auditing a published measurement's toolchain.
           { echo "### host build-dep debs"; find apt-debs -maxdepth 1 -name '*.deb' -printf '- %f\n' | sort; } >> "$GITHUB_STEP_SUMMARY"
 
@@ -384,6 +458,11 @@ jobs:
           ldd target/release/attestation-api | grep -q libnvat
 
       - name: Build c8s image
+        # Warm builds take 2 minutes; a cold pkgcache or driver download
+        # took 20 in the last 40 runs. Bounded so a wedged mirror fails
+        # here rather than at the job's 3h limit, which exists for the
+        # kernel rebuild step above.
+        timeout-minutes: 60
         working-directory: confidential-os-builder
         env:
           ATTEST_GPU_BIN: ${{ github.workspace }}/attestation-rs/target/release/attestation-api

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,17 +172,25 @@ jobs:
           path: ~/.cache/go-build
           key: go-ci-${{ github.sha }}
 
-      - name: Prune superseded go-ci caches
-        # Only go-ci-* entries this job created; never touches other caches.
+      - name: Prune superseded Go caches
+        # Only the Go cache families this job writes (go-ci-*, go-mod-*)
+        # and the setup-go-* entries setup-go-c8s used to write; never
+        # touches other caches. Cache entries are scoped per ref, so a
+        # go-mod-* saved on a PR branch is a duplicate of main's: keep one
+        # entry per family, the current key on main.
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ github.token }}
-          CURRENT_KEY: go-ci-${{ github.sha }}
+          CURRENT_CI: go-ci-${{ github.sha }}
+          CURRENT_MOD: go-mod-${{ hashFiles('go.sum') }}
           REPO: ${{ github.repository }}
         run: |
-          gh api "repos/$REPO/actions/caches?per_page=100" \
-            --jq '.actions_caches[]|select(.key|startswith("go-ci-"))|"\(.id) \(.key)"' |
-            awk -v cur="$CURRENT_KEY" '$2 != cur {print $1}' |
+          for prefix in go-ci- go-mod- setup-go-; do
+            gh api --paginate "repos/$REPO/actions/caches?key=$prefix&per_page=100" \
+              --jq '.actions_caches[]|"\(.id) \(.key) \(.ref)"'
+          done |
+            awk -v ci="$CURRENT_CI" -v mod="$CURRENT_MOD" \
+              '!(($2 == ci || $2 == mod) && $3 == "refs/heads/main") {print $1}' |
             while read -r id; do
               gh api -X DELETE "repos/$REPO/actions/caches/$id" || true
             done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -181,6 +181,9 @@ jobs:
   images:
     name: Docker (${{ matrix.binary }})
     runs-on: ubuntu-latest
+    # A build here is under a minute; a wedged registry or apt mirror
+    # must not hold the job for hours.
+    timeout-minutes: 30
     needs: [changes, go-modules]
     if: needs.changes.outputs.has_images == 'true'
     strategy:
@@ -234,10 +237,17 @@ jobs:
           # `latest`.
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # GHA layer caching. ignore-error: a cache-service blip during the
-          # export must not fail a build that already succeeded.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          # Layer cache rides inside the pushed :main image (inline), not
+          # the Actions cache: exporting every layer there filled a third
+          # of the repository's 10 GB cap and evicted the small caches
+          # image builds depend on (c8s-image.yml, apt-debs). The only
+          # layers that can hit are the apt-get installs that precede the
+          # binary COPY, and sharing those is what matters: the release
+          # rebuild in semver-tag.yml resolves the same packages as the
+          # image CI scanned instead of whatever the mirror holds later.
+          # PR runs read :main and, not pushing, write nothing.
+          cache-from: type=registry,ref=${{ matrix.image }}:main
+          cache-to: type=inline
 
       - name: Scan Docker image
         id: container-scan

--- a/.github/workflows/image-repro-debug.yml
+++ b/.github/workflows/image-repro-debug.yml
@@ -67,11 +67,9 @@ jobs:
       - name: Install build deps
         # Same snapshot-pinned toolchain as c8s-image (confos#36): the A/B
         # verdicts only describe the real pipeline if the host debs match.
-        timeout-minutes: 10
-        run: |
-          confidential-os-builder/bin/host-deps \
-            systemd-container ovmf cpio acpica-tools \
-            libclang-dev clang libtss2-dev
+        # Same bound and retry as c8s-image.yml, for the reason given there.
+        timeout-minutes: 30
+        run: bash c8s/.github/scripts/host-deps.sh
 
       - name: Setup ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1

--- a/.github/workflows/semver-tag.yml
+++ b/.github/workflows/semver-tag.yml
@@ -220,8 +220,9 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ inputs.target-sha }}
             org.opencontainers.image.version=${{ needs.calculate.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max,ignore-error=true
+          # The apt layers come from the :main image CI built and scanned;
+          # see docker.yml.
+          cache-from: type=registry,ref=${{ matrix.image }}:main
 
       - name: Validate commit-scoped staging image
         env:


### PR DESCRIPTION
## Summary

The image repro gate on #552 failed four times on 2026-09-08 in `Install build deps`, never reaching the sync. The step is designed to run offline from the `apt-debs` cache, but that cache was gone, and a cold run has to pull `host-deps`' cold set, about 30 debs and 85 MB with indexes, from `snapshot.ubuntu.com` inside a 10 minute bound. The mirror answered 502/503 and then delivered 65 to 130 KB/s, so the four attempts moved 40 to 80 MB each before timing out, and the cache is only saved when the step succeeds, so nothing reseeded it.

Why the cache was gone: the repository sits at the 10 GB Actions cache cap (586 entries, 10.3 GB), and the oldest surviving entry was last accessed 20 hours ago. `apt-debs` is ~60 MB and only image builds touch it, so it loses LRU to the buildkit blobs (3.7 GB, 379 entries) and the Go caches (setup-go 1.9 GB, six copies of one go-mod key 1.5 GB, go-ci 1 GB) every day there is no image build.

- The cold install happens once per run. A `host-deps` job seeds the cache and the platform legs restore it; the four gate legs used to fetch the same set concurrently from a mirror whose throughput was the scarce resource. Warm runs cost the seed job a checkout and a lookup.

- The install is retried and bounded. `host-deps` bounds each file fetch but has no transaction retry, so a mirror 5xx mid-fetch fails it outright; the install moves to a shared script that retries the transaction within a 25 minute budget. Budgeted by time rather than count because a flapping mirror fails a transaction in seconds when the index fetches 5xx, and three such tries are over before it recovers. The bound goes from 10 to 30 minutes, which covers the slowest rate seen, while the per-file timeouts still keep a dead mirror well short of the job's 3 h limit. `image-repro-debug` uses the same script and bound. The mkosi build step, which fetches a far larger set from the same mirror on a cold `pkgcache`, gets a 60 minute bound: warm builds take 2 minutes and the coldest of the last 40 took 20. No `restore-keys` fallback: `host-deps` discards any cache whose snapshot or package set differs from its manifest, so a prefix candidate from another pin is a download it cannot use.

- The docker and release workflows keep the layer cache inside the pushed `:main` image instead of the Actions cache. Every Dockerfile they build copies a binary compiled in the step before, so the only layers that can hit again are the three apt-get installs that precede the copy; the build step takes 8 to 14 seconds today. The Actions-cache export was 379 blobs and 3.7 GB, and its churn (121 blobs in one hour) is what evicts the small caches image builds depend on. The inline cache is the hit that matters: the release rebuild resolves the same apt packages the image CI scanned rather than whatever the mirror holds later. The image job gets a 30 minute bound.

- The Go caches become one shared set. `setup-go`'s built-in cache saves on every miss, keyed per go.sum hash, Go version and ref, so every job on every branch that missed left its own 300 to 500 MB entry. `setup-go-c8s` now restores the `go-mod` and `go-ci` entries that ci.yml's test job already saves, read-only, and the main-push prune covers every Go cache family, keeping one entry per family on main. The prune also filters and paginates server-side; a single page of 100 was missing most of the repository's entries.

## Follow-up, outside this repo

The deeper fix is progressive: `host-deps` in confidential-os-builder could seed apt's archives directory from whatever the cache dir already holds on a cold install and keep the partial download on failure, so a timed-out attempt leaves the next one less to fetch. As written it discards its scratch directory on exit and only writes the cache after a complete install.

## Verification

actionlint on the workflows and shellcheck on the script; the composite action parses and its steps gate on the input. The gate ran on this branch against the still-degraded mirror: one seed job completed the cold install in 16 minutes and saved the cache, after which both of its legs restored it and installed offline in about a minute. The other seed job spent three attempts on mirror 502s, which is what moved the retry to a time budget. Both legs then failed in the mkosi build on the same 502s against the guest snapshot; confos already retries each file three times, and nothing here can make a sustained outage pass. The apt-debs change cannot be exercised until the mirror recovers; the first green image build seeds the cache under the exact key. The prune's filter was checked against a synthetic listing: it keeps only the current keys on `refs/heads/main`.
