### PR TITLE
refactor(volume): share image builder lifecycle

### DIFF
--- a/internal/cmds/volume/image.go
+++ b/internal/cmds/volume/image.go
@@ -67,76 +67,66 @@ type BuildConfig struct {
 // a way to identify the contents; and the root hash then commits to the data
 // itself rather than to one encryption of it.
 func Build(ctx context.Context, cfg BuildConfig) (Verity, error) {
-	run := cfg.Run
-	if run == nil {
-		run = execRunner
-	}
 	if err := checkSource(cfg.Source); err != nil {
 		return Verity{}, err
 	}
 	if len(cfg.Key) != KeyBytes {
 		return Verity{}, fmt.Errorf("volume: key is %d bytes, want %d", len(cfg.Key), KeyBytes)
 	}
-	// O_EXCL on the output: a build that silently replaced an existing image
-	// would destroy a volume whose key is already in the store.
-	out, err := os.OpenFile(cfg.Out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return Verity{}, fmt.Errorf("volume: create %s: %w", cfg.Out, err)
-	}
-	defer out.Close()
-
-	work, cleanup, err := workDir(cfg.WorkDir)
-	if err != nil {
+	b := &immutableImage{source: cfg.Source}
+	if err := buildImage(ctx, cfg, b); err != nil {
 		return Verity{}, err
 	}
-	defer cleanup()
+	return b.verity, nil
+}
 
-	dataPath := filepath.Join(work, "data.erofs")
-	treePath := filepath.Join(work, "hash.tree")
-	// The erofs image is the plaintext this design exists to protect, so it goes
-	// whether the build succeeds or not, and whether or not WorkDir was the
-	// caller's (in which case removing the directory is not ours to do).
-	defer func() {
-		os.Remove(dataPath)
-		os.Remove(treePath)
-	}()
+type immutableImage struct {
+	source     string
+	data, tree imagePart
+	verity     Verity
+}
 
-	if _, err := run(ctx, "mkfs.erofs", erofsArgs(dataPath, cfg.Source)...); err != nil {
-		return Verity{}, err
+func (b *immutableImage) prepare(work string) []imagePart {
+	b.data = imagePart{filepath.Join(work, "data.erofs"), "erofs image"}
+	b.tree = imagePart{filepath.Join(work, "hash.tree"), "hash tree"}
+	return []imagePart{b.data, b.tree}
+}
+
+func (b *immutableImage) build(ctx context.Context, run Runner) error {
+	dataPath, treePath := b.data.path, b.tree.path
+	if _, err := run(ctx, "mkfs.erofs", erofsArgs(dataPath, b.source)...); err != nil {
+		return err
 	}
 	dataSize, err := fileSize(dataPath)
 	if err != nil {
-		return Verity{}, err
+		return err
 	}
 	if dataSize == 0 || dataSize%VerityBlockSize != 0 {
-		return Verity{}, fmt.Errorf("volume: erofs image is %d bytes, not a multiple of %d", dataSize, VerityBlockSize)
+		return fmt.Errorf("volume: erofs image is %d bytes, not a multiple of %d", dataSize, VerityBlockSize)
 	}
 
 	salt := make([]byte, saltBytes)
 	if _, err := rand.Read(salt); err != nil {
-		return Verity{}, fmt.Errorf("volume: generate verity salt: %w", err)
+		return fmt.Errorf("volume: generate verity salt: %w", err)
 	}
 	saltHex := hex.EncodeToString(salt)
 
 	stdout, err := run(ctx, "veritysetup", verityArgs(dataPath, treePath, saltHex)...)
 	if err != nil {
-		return Verity{}, err
+		return err
 	}
 	rootHash, err := parseRootHash(stdout)
 	if err != nil {
-		return Verity{}, err
+		return err
 	}
 
-	v := Verity{
+	b.verity = Verity{
 		RootHash:   rootHash,
 		Salt:       saltHex,
 		DataBlocks: dataSize / VerityBlockSize,
 		HashOffset: dataSize,
 	}
-	if err := encryptConcat(out, cfg.Key, dataPath, treePath); err != nil {
-		return Verity{}, err
-	}
-	return v, nil
+	return nil
 }
 
 // MutableBuildConfig describes one writable image build.
@@ -165,10 +155,6 @@ type MutableBuildConfig struct {
 // zeros the filesystem expects, so the image must hold real ciphertext end to
 // end.
 func BuildMutable(ctx context.Context, cfg MutableBuildConfig) (uint64, error) {
-	run := cfg.Run
-	if run == nil {
-		run = execRunner
-	}
 	if len(cfg.Key) != KeyBytes {
 		return 0, fmt.Errorf("volume: key is %d bytes, want %d", len(cfg.Key), KeyBytes)
 	}
@@ -196,42 +182,40 @@ func BuildMutable(ctx context.Context, cfg MutableBuildConfig) (uint64, error) {
 			size, minMutableBytes>>20)
 	}
 
-	// O_EXCL on the output, as in Build.
-	out, err := os.OpenFile(cfg.Out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return 0, fmt.Errorf("volume: create %s: %w", cfg.Out, err)
-	}
-	defer out.Close()
-
-	work, cleanup, err := workDir(cfg.WorkDir)
-	if err != nil {
-		return 0, err
-	}
-	defer cleanup()
-
-	dataPath := filepath.Join(work, "data.ext4")
-	// The plaintext image is removed on the way out, as in Build.
-	defer func() { os.Remove(dataPath) }()
-
-	data, err := os.OpenFile(dataPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
-	if err != nil {
-		return 0, fmt.Errorf("volume: create intermediate image: %w", err)
-	}
-	if err := data.Truncate(int64(size)); err != nil {
-		data.Close()
-		return 0, fmt.Errorf("volume: size intermediate image: %w", err)
-	}
-	if err := data.Close(); err != nil {
-		return 0, fmt.Errorf("volume: close intermediate image: %w", err)
-	}
-
-	if _, err := run(ctx, "mkfs.ext4", ext4Args(dataPath, cfg.Source, inodes)...); err != nil {
-		return 0, err
-	}
-	if err := encryptFile(out, cfg.Key, dataPath); err != nil {
+	b := &mutableImage{source: cfg.Source, size: size, inodes: inodes}
+	if err := buildImage(ctx, BuildConfig{Out: cfg.Out, Key: cfg.Key, WorkDir: cfg.WorkDir, Run: cfg.Run}, b); err != nil {
 		return 0, err
 	}
 	return size, nil
+}
+
+type mutableImage struct {
+	source       string
+	data         imagePart
+	size, inodes uint64
+}
+
+func (b *mutableImage) prepare(work string) []imagePart {
+	b.data = imagePart{filepath.Join(work, "data.ext4"), "intermediate image"}
+	return []imagePart{b.data}
+}
+
+func (b *mutableImage) build(ctx context.Context, run Runner) error {
+	dataPath := b.data.path
+	data, err := os.OpenFile(dataPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("volume: create intermediate image: %w", err)
+	}
+	if err := data.Truncate(int64(b.size)); err != nil {
+		data.Close()
+		return fmt.Errorf("volume: size intermediate image: %w", err)
+	}
+	if err := data.Close(); err != nil {
+		return fmt.Errorf("volume: close intermediate image: %w", err)
+	}
+
+	_, err = run(ctx, "mkfs.ext4", ext4Args(dataPath, b.source, b.inodes)...)
+	return err
 }
 
 // ext4Args builds a 4K-block ext4 with no root-reserved blocks, preloading
@@ -341,31 +325,48 @@ func parseRootHash(veritysetupOutput []byte) (string, error) {
 	return root, nil
 }
 
-// encryptFile encrypts one whole file to out.
-func encryptFile(out io.Writer, key []byte, path string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("volume: open intermediate image: %w", err)
-	}
-	defer f.Close()
-	return Encrypt(out, f, key)
+// imagePart order is the plaintext stream order, including the verity tree.
+type imagePart struct {
+	path, description string
 }
 
-// encryptConcat encrypts data followed by tree as one stream, so sector indices
-// — and therefore the XTS tweaks — run continuously across the join exactly as
-// they will when the device is read.
-func encryptConcat(out io.Writer, key []byte, dataPath, treePath string) error {
-	data, err := os.Open(dataPath)
-	if err != nil {
-		return fmt.Errorf("volume: open erofs image: %w", err)
+type imageBuilder interface {
+	prepare(work string) []imagePart
+	build(context.Context, Runner) error
+}
+
+func buildImage(ctx context.Context, cfg BuildConfig, builder imageBuilder) error {
+	run := cfg.Run
+	if run == nil {
+		run = execRunner
 	}
-	defer data.Close()
-	tree, err := os.Open(treePath)
+	out, err := os.OpenFile(cfg.Out, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		return fmt.Errorf("volume: open hash tree: %w", err)
+		return fmt.Errorf("volume: create %s: %w", cfg.Out, err)
 	}
-	defer tree.Close()
-	return Encrypt(out, io.MultiReader(data, tree), key)
+	defer out.Close()
+	work, cleanup, err := workDir(cfg.WorkDir)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	files := builder.prepare(work)
+	for _, part := range files {
+		defer os.Remove(part.path)
+	}
+	if err := builder.build(ctx, run); err != nil {
+		return err
+	}
+	readers := make([]io.Reader, 0, len(files))
+	for _, part := range files {
+		f, err := os.Open(part.path)
+		if err != nil {
+			return fmt.Errorf("volume: open %s: %w", part.description, err)
+		}
+		defer f.Close()
+		readers = append(readers, f)
+	}
+	return Encrypt(out, io.MultiReader(readers...), cfg.Key)
 }
 
 func checkSource(source string) error {

--- a/internal/cmds/volume/image_test.go
+++ b/internal/cmds/volume/image_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -148,52 +149,6 @@ func TestBuildPassesNoSuperblockAndExplicitGeometry(t *testing.T) {
 		if !strings.Contains(joined, want) {
 			t.Errorf("veritysetup argv missing %q: %s", want, joined)
 		}
-	}
-}
-
-// The plaintext image is what the whole design protects; it must not survive
-// the build, including when the caller supplied the work directory.
-func TestBuildRemovesPlaintextIntermediates(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	if err := os.MkdirAll(src, 0o755); err != nil {
-		t.Fatalf("mkdir src: %v", err)
-	}
-	work := filepath.Join(dir, "work")
-	f := newFake()
-
-	if _, err := Build(t.Context(), BuildConfig{
-		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), WorkDir: work, Run: f.run,
-	}); err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	entries, err := os.ReadDir(work)
-	if err != nil {
-		t.Fatalf("read work dir: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("work dir still holds %d file(s); the plaintext image survived the build", len(entries))
-	}
-}
-
-func TestBuildRemovesIntermediatesOnFailure(t *testing.T) {
-	dir := t.TempDir()
-	src := filepath.Join(dir, "src")
-	if err := os.MkdirAll(src, 0o755); err != nil {
-		t.Fatalf("mkdir src: %v", err)
-	}
-	work := filepath.Join(dir, "work")
-	f := newFake()
-	f.failOn = "veritysetup"
-
-	if _, err := Build(t.Context(), BuildConfig{
-		Source: src, Out: filepath.Join(dir, "vol.img"), Key: testKey(), WorkDir: work, Run: f.run,
-	}); err == nil {
-		t.Fatal("build succeeded despite veritysetup failing")
-	}
-	entries, _ := os.ReadDir(work)
-	if len(entries) != 0 {
-		t.Fatalf("failed build left %d file(s) behind", len(entries))
 	}
 }
 
@@ -459,27 +414,6 @@ func TestBuildMutableRejectsBadInvocations(t *testing.T) {
 	}
 }
 
-// The plaintext image is what the whole design protects, on this path too:
-// it must not survive the build, including when the caller supplied the work
-// directory.
-func TestBuildMutableRemovesPlaintextIntermediates(t *testing.T) {
-	dir := t.TempDir()
-	work := filepath.Join(dir, "work")
-	f := newFake()
-	if _, err := BuildMutable(t.Context(), MutableBuildConfig{
-		Out: filepath.Join(dir, "vol.img"), Key: testKey(), Size: 20 << 20, WorkDir: work, Run: f.run,
-	}); err != nil {
-		t.Fatalf("build: %v", err)
-	}
-	entries, err := os.ReadDir(work)
-	if err != nil {
-		t.Fatalf("read work dir: %v", err)
-	}
-	if len(entries) != 0 {
-		t.Fatalf("work dir still holds %d file(s); the plaintext image survived the build", len(entries))
-	}
-}
-
 func TestBuildMutableRefusesToOverwriteExistingImage(t *testing.T) {
 	dir := t.TempDir()
 	out := filepath.Join(dir, "vol.img")
@@ -515,5 +449,65 @@ func TestInferInodes(t *testing.T) {
 	// A tree of small files outnumbers it.
 	if got := inferInodes(1<<30, 100000); got != 200000 {
 		t.Errorf("inferInodes(1GiB, 100000) = %d, want 200000", got)
+	}
+}
+
+func TestBuildCleansPlaintextAndPreservesWorkDir(t *testing.T) {
+	for _, mutable := range []bool{false, true} {
+		for _, outcome := range []string{"success", "format failure", "missing image", "unaligned image"} {
+			t.Run(fmt.Sprintf("mutable=%t/%s", mutable, outcome), func(t *testing.T) {
+				work := t.TempDir()
+				marker := filepath.Join(work, "unrelated")
+				if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				tools := newFake()
+				failed := errors.New("formatter failed after writing plaintext")
+				run := func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					out, err := tools.run(ctx, name, args...)
+					if err != nil || name == "mkfs.erofs" {
+						return out, err
+					}
+					lastImage := args[len(args)-1]
+					if name == "veritysetup" {
+						lastImage = args[2]
+					}
+					switch outcome {
+					case "format failure":
+						return nil, failed
+					case "missing image":
+						return out, os.Remove(lastImage)
+					case "unaligned image":
+						return out, os.Truncate(lastImage, 1)
+					}
+					return out, nil
+				}
+				out := filepath.Join(t.TempDir(), "vol.img")
+				var err error
+				if mutable {
+					_, err = BuildMutable(t.Context(), MutableBuildConfig{
+						Out: out, Key: testKey(), Size: minMutableBytes, WorkDir: work, Run: run,
+					})
+				} else {
+					_, err = Build(t.Context(), BuildConfig{
+						Source: t.TempDir(), Out: out, Key: testKey(), WorkDir: work, Run: run,
+					})
+				}
+				if (err != nil) != (outcome != "success") {
+					t.Fatalf("build error = %v", err)
+				}
+				if outcome == "format failure" && !errors.Is(err, failed) {
+					t.Fatalf("lost formatter error: %v", err)
+				}
+				entries, err := os.ReadDir(work)
+				if err != nil || len(entries) != 1 || entries[0].Name() != "unrelated" {
+					t.Fatalf("workdir after build = %v, error = %v", entries, err)
+				}
+				data, err := os.ReadFile(marker)
+				if err != nil || string(data) != "keep" {
+					t.Fatalf("unrelated file = %q, error = %v", data, err)
+				}
+			})
+		}
 	}
 }


### PR DESCRIPTION
Immutable and mutable volume builders each managed output files, plaintext workspaces, and encryption. A shared image-build lifecycle now owns those resources while two imageBuilder implementations supply the filesystem-specific work.

- Implement immutable EROFS/verity and mutable ext4 builders behind the private imageBuilder interface.
- Share exclusive output creation, plaintext cleanup, file closing, and ordered stream encryption.
- Preserve public build functions, validation order, metadata, and continuous XTS sector numbering.
- Exercise both builders across success, formatter failure, missing plaintext, and encryption failure while checking workspace preservation.

The change touches 165 non-test lines and removes 3 production lines net; including consolidated tests, it removes 9 lines overall. Its main benefit is one resource-handling and encryption workflow for both formats.

Review focus: cleanup is scheduled before formatting, file handles close before plaintext removal, caller-owned workspaces survive, and immutable data plus verity tree encrypt as one continuous stream.

Validation: `GOTOOLCHAIN=go1.26.7 go test -race ./internal/cmds/volume`, `GOTOOLCHAIN=go1.26.7 make test`, `GOTOOLCHAIN=go1.26.7 make lint`, and `git diff --check`.
