### PR TITLE
refactor(ratls-mesh): share host and guest runtime

### DIFF
--- a/internal/cmds/ratlsmesh/in_guest_linux.go
+++ b/internal/cmds/ratlsmesh/in_guest_linux.go
@@ -16,7 +16,6 @@ package ratlsmesh
 
 import (
 	"context"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -324,7 +323,7 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 	// authenticate it by hardware attestation, not by SAN/hostname. The
 	// CDS-issued upgrade cert carries no SAN either; its CN binds the pod IP
 	// (see cdsclient.Client.createCSR).
-	serverTLS, serverCertMgr, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+	runtime, err := newMeshRuntime(&ratls.ServerConfig{
 		Platform:        c.platform,
 		AttestFunc:      attestFunc,
 		CertTTL:         c.certTTL,
@@ -332,93 +331,10 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 		DynamicCACert:   true,
 		RotationTimeout: c.rotationTimeout,
 		Logger:          logger,
-	})
+	}, logger, 0)
 	if err != nil {
-		return fmt.Errorf("in-guest: create server TLS config: %w", err)
+		return fmt.Errorf("in-guest: %w", err)
 	}
-	clientTLS, clientCertMgr, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
-		Policy:          meshPolicy,
-		Platform:        c.platform,
-		AttestFunc:      attestFunc,
-		DynamicCACert:   true,
-		CertTTL:         c.certTTL,
-		RotationTimeout: c.rotationTimeout,
-		Logger:          logger,
-	})
-	if err != nil {
-		return fmt.Errorf("in-guest: create client TLS config: %w", err)
-	}
-
-	m := newMetrics()
-	m.certModeConfigured.Store(1)
-	if len(meshPolicy.Measurements) > 0 {
-		m.measurementPinning.Set(1)
-	}
-
-	wrapVerify := func(orig func([][]byte, [][]*x509.Certificate) error) func([][]byte, [][]*x509.Certificate) error {
-		if orig == nil {
-			return nil
-		}
-		return func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
-			err := orig(rawCerts, chains)
-			if err != nil {
-				m.attestationFailures.Inc()
-			}
-			return err
-		}
-	}
-	serverTLS.VerifyPeerCertificate = wrapVerify(serverTLS.VerifyPeerCertificate)
-	clientTLS.VerifyPeerCertificate = wrapVerify(clientTLS.VerifyPeerCertificate)
-	serverCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
-	if clientCertMgr != nil {
-		clientCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
-	}
-
-	resolver := &inGuestResolver{podIP: normalizeIP(podIP)}
-	health := newHealthServer(m, serverCertMgr, clientCertMgr, 10, 5*time.Second, 10*time.Second)
-
-	proxy := &Proxy{
-		outboundAddr:      fmt.Sprintf(":%d", inGuestOutboundPort),
-		inboundAddr:       fmt.Sprintf(":%d", inGuestInboundPort),
-		serverTLS:         serverTLS,
-		clientTLS:         clientTLS,
-		nodeIP:            podIP,
-		inboundPort:       inGuestInboundPort,
-		resolver:          resolver,
-		origDstFunc:       defaultOrigDstFunc,
-		logger:            logger,
-		metrics:           m,
-		accessLog:         true,
-		dialTimeout:       c.dialTimeout,
-		tlsDialTimeout:    c.tlsDialTimeout,
-		destHeaderTimeout: c.destHeaderTimeout,
-		drainTimeout:      c.drainTimeout,
-		keepAlive:         c.keepAlive,
-		maxDestHeaderSize: 256,
-		pipeBufferSize:    32768,
-		bufPool:           newBufPool(32768),
-		onReady: func() {
-			warmupCtx, cancel := context.WithTimeout(ctx, 2*c.rotationTimeout)
-			defer cancel()
-			if err := serverCertMgr.WarmUp(warmupCtx); err != nil {
-				logger.Error("server certificate warm-up failed", "error", err)
-			}
-			if clientCertMgr != nil {
-				if err := clientCertMgr.WarmUp(warmupCtx); err != nil {
-					logger.Error("client certificate warm-up failed", "error", err)
-				}
-			}
-			health.ready.Store(true)
-		},
-		onShutdown: func() { health.ready.Store(false) },
-	}
-
-	go func() {
-		if err := health.serve(ctx, fmt.Sprintf(":%d", inGuestHealthPort), nil); err != nil {
-			logger.Error("health server error", "error", err)
-		}
-	}()
-
 	cdsCfg := &cdsclient.Config{
 		CDSURL:            c.cdsURL,
 		AttestationApiURL: c.attestationServiceURL,
@@ -430,43 +346,53 @@ func runInGuest(ctx context.Context, c *inGuestConfig) error {
 		CDSMeasurements:   cdsPins.Measurements,
 		CDSRTMRs:          cdsPins.RTMRs,
 	}
-	// A provider-construction failure (config validation) is logged and the
-	// mesh keeps serving self-signed certs; it never blocks startup.
-	if provider, err := cdsclient.NewProvider(cdsCfg, logger); err != nil {
-		logger.Error("in-guest cds provider creation failed", "error", err)
-	} else {
-		go cdsUpgrade{
-			logger:          logger,
-			logPrefix:       "in-guest cds",
-			provider:        provider,
-			retryBackoff:    c.cdsRetryBackoff,
-			retryMaxBackoff: c.cdsRetryMaxBackoff,
-			opTimeout:       c.cdsOpTimeout,
-			serverCertMgr:   serverCertMgr,
-			clientCertMgr:   clientCertMgr,
-			metrics:         m,
-		}.run(ctx)
-
-		go caBundleRefresh{
-			logger:        logger,
-			logPrefix:     "in-guest cds",
-			provider:      provider,
-			interval:      c.caPollInterval,
-			opTimeout:     c.cdsOpTimeout,
-			serverCertMgr: serverCertMgr,
-			clientCertMgr: clientCertMgr,
-		}.run(ctx)
+	if err := runtime.run(ctx, guestMesh{c: c, podIP: podIP, cds: cdsCfg}); err != nil {
+		return fmt.Errorf("in-guest proxy: %w", err)
 	}
+	return nil
+}
 
+type guestMesh struct {
+	c     *inGuestConfig
+	podIP string
+	cds   *cdsclient.Config
+}
+
+func (e guestMesh) configure(r *meshRuntime) *Proxy {
+	c, podIP := e.c, e.podIP
+	r.metrics.certModeConfigured.Store(1)
+	r.health = newHealthServer(r.metrics, r.serverCertMgr, r.clientCertMgr, 10, 5*time.Second, 10*time.Second)
+	r.healthPort = inGuestHealthPort
+	resolver := &inGuestResolver{podIP: normalizeIP(podIP)}
+	return &Proxy{
+		outboundAddr:      fmt.Sprintf(":%d", inGuestOutboundPort),
+		inboundAddr:       fmt.Sprintf(":%d", inGuestInboundPort),
+		nodeIP:            podIP,
+		inboundPort:       inGuestInboundPort,
+		resolver:          resolver,
+		accessLog:         true,
+		dialTimeout:       c.dialTimeout,
+		tlsDialTimeout:    c.tlsDialTimeout,
+		destHeaderTimeout: c.destHeaderTimeout,
+		drainTimeout:      c.drainTimeout,
+		keepAlive:         c.keepAlive,
+		maxDestHeaderSize: 256,
+		pipeBufferSize:    32768,
+	}
+}
+
+func (e guestMesh) start(ctx context.Context, r *meshRuntime) {
+	c := e.c
+	r.startCDS(ctx, e.cds, cdsUpgrade{
+		logPrefix: "in-guest cds", retryBackoff: c.cdsRetryBackoff,
+		retryMaxBackoff: c.cdsRetryMaxBackoff, opTimeout: c.cdsOpTimeout,
+	}, c.caPollInterval)
+	logger, proxy := r.logger, r.proxy
 	logger.Info("ratls-mesh in-guest listening",
 		"outbound", proxy.outboundAddr,
 		"inbound", proxy.inboundAddr,
 		"health", inGuestHealthPort,
 	)
-	if err := proxy.Run(ctx); err != nil {
-		return fmt.Errorf("in-guest proxy: %w", err)
-	}
-	return nil
 }
 
 // inGuestVerifyPins parses the env-delivered identity pins into the mesh

--- a/internal/cmds/ratlsmesh/main.go
+++ b/internal/cmds/ratlsmesh/main.go
@@ -5,7 +5,6 @@ package ratlsmesh
 import (
 	"context"
 	"crypto/sha512"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
@@ -298,7 +297,7 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 	// hardware attestation, not by SAN/hostname (NewServerTLSConfig sets
 	// InsecureSkipVerify and verifies the RA-TLS extension). The CDS-issued
 	// upgrade cert does carry a DNS SAN (see cdsclient.Config.DNSSAN).
-	serverTLS, serverCertMgr, err := ratls.NewServerTLSConfig(&ratls.ServerConfig{
+	runtime, err := newMeshRuntime(&ratls.ServerConfig{
 		Platform:        c.platform,
 		AttestFunc:      attestFunc,
 		CertTTL:         c.certTTL,
@@ -307,79 +306,54 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		DynamicCACert:   effectiveCAURL != "",
 		RotationTimeout: c.rotationTimeout,
 		Logger:          logger,
-	})
+	}, logger, c.sessionCacheSize)
 	if err != nil {
-		return fmt.Errorf("create server TLS config: %w", err)
+		return err
 	}
-
-	clientTLS, clientCertMgr, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
-		Policy:          meshPolicy,
-		Platform:        c.platform,
-		AttestFunc:      attestFunc,
-		CACert:          caCerts,
-		DynamicCACert:   effectiveCAURL != "",
-		CertTTL:         c.certTTL,
-		RotationTimeout: c.rotationTimeout,
-		Logger:          logger,
-	})
-	if err != nil {
-		return fmt.Errorf("create client TLS config: %w", err)
+	cdsCfg := &cdsclient.Config{
+		CDSURL:            c.cdsURL,
+		AttestationApiURL: c.attestationApiURL,
+		CDSCAURL:          c.cdsURL,
+		CACertURL:         effectiveCAURL,
+		NodeIP:            c.nodeIP,
+		DNSSAN:            c.certDNSSAN,
+		TEEType:           teeType,
+		CDSMeasurements:   cdsMeasurements,
+		CDSRTMRs:          cdsRTMRs,
+		CDSEntries:        pins.Entries,
 	}
-
-	if c.sessionCacheSize > 0 {
-		clientTLS.ClientSessionCache = tls.NewLRUClientSessionCache(c.sessionCacheSize)
+	if err := runtime.run(ctx, hostMesh{c: c, resolver: resolver, cds: cdsCfg}); err != nil {
+		return fmt.Errorf("proxy: %w", err)
 	}
+	return nil
+}
 
-	m := newMetrics()
+type hostMesh struct {
+	c        *proxyConfig
+	resolver *k8sResolver
+	cds      *cdsclient.Config
+}
+
+func (e hostMesh) configure(r *meshRuntime) *Proxy {
+	c, resolver := e.c, e.resolver
 	if c.certMode == "cds" {
-		m.certModeConfigured.Store(1)
+		r.metrics.certModeConfigured.Store(1)
 	}
-	if len(meshPolicy.Measurements) > 0 {
-		m.measurementPinning.Set(1)
-	}
-
-	// Wire attestation failure counter into TLS peer verification callbacks.
-	wrapVerify := func(orig func([][]byte, [][]*x509.Certificate) error) func([][]byte, [][]*x509.Certificate) error {
-		if orig == nil {
-			return nil
-		}
-		return func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
-			err := orig(rawCerts, chains)
-			if err != nil {
-				m.attestationFailures.Inc()
-			}
-			return err
-		}
-	}
-	serverTLS.VerifyPeerCertificate = wrapVerify(serverTLS.VerifyPeerCertificate)
-	clientTLS.VerifyPeerCertificate = wrapVerify(clientTLS.VerifyPeerCertificate)
-
-	// Wire rotation failure metrics.
-	serverCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
-	if clientCertMgr != nil {
-		clientCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
-	}
-
-	health := newHealthServer(m, serverCertMgr, clientCertMgr, c.acceptErrThreshold, c.healthReadTimeout, c.healthWriteTimeout)
-
+	r.health = newHealthServer(r.metrics, r.serverCertMgr, r.clientCertMgr, c.acceptErrThreshold, c.healthReadTimeout, c.healthWriteTimeout)
+	r.healthPort, r.healthListener = c.healthPort, c.listeners.health
 	var connSem chan struct{}
 	if c.maxConns > 0 {
 		connSem = make(chan struct{}, c.maxConns)
 	}
 
-	proxy := &Proxy{
+	return &Proxy{
 		outboundAddr:      fmt.Sprintf(":%d", c.outboundPort),
 		inboundAddr:       fmt.Sprintf(":%d", c.inboundPort),
 		outboundLn:        c.listeners.outbound,
 		inboundLn:         c.listeners.inbound,
-		serverTLS:         serverTLS,
-		clientTLS:         clientTLS,
 		nodeIP:            c.nodeIP,
 		inboundPort:       c.inboundPort,
 		resolver:          resolver,
-		origDstFunc:       defaultOrigDstFunc,
-		logger:            logger,
-		metrics:           m,
 		accessLog:         c.accessLog,
 		dialTimeout:       c.dialTimeout,
 		tlsDialTimeout:    c.tlsDialTimeout,
@@ -389,37 +363,15 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		idleTimeout:       c.idleTimeout,
 		maxDestHeaderSize: c.maxDestHeaderSize,
 		pipeBufferSize:    c.pipeBufferSize,
-		bufPool:           newBufPool(c.pipeBufferSize),
 		connSem:           connSem,
 		maxConnsPerSrc:    c.maxConnsPerSource,
-		onReady: func() {
-			// Eagerly provision certificates before marking ready.
-			// Bound the warm-up so a hanging attestation binary (missing
-			// /dev/sev, TPM not loaded) doesn't block readiness forever.
-			warmupTimeout := 2 * c.rotationTimeout
-			warmupCtx, warmupCancel := context.WithTimeout(ctx, warmupTimeout)
-			defer warmupCancel()
-
-			if err := serverCertMgr.WarmUp(warmupCtx); err != nil {
-				logger.Error("server certificate warm-up failed", "error", err)
-			}
-			if clientCertMgr != nil {
-				if err := clientCertMgr.WarmUp(warmupCtx); err != nil {
-					logger.Error("client certificate warm-up failed", "error", err)
-				}
-			}
-			health.ready.Store(true)
-		},
-		onShutdown: func() { health.ready.Store(false) },
 	}
+}
 
-	// Start health/metrics server.
-	go func() {
-		if err := health.serve(ctx, fmt.Sprintf(":%d", c.healthPort), c.listeners.health); err != nil {
-			logger.Error("health server error", "error", err)
-		}
-	}()
-
+func (e hostMesh) start(ctx context.Context, r *meshRuntime) {
+	c, resolver := e.c, e.resolver
+	logger, m, proxy := r.logger, r.metrics, r.proxy
+	serverCertMgr, clientCertMgr := r.serverCertMgr, r.clientCertMgr
 	// Periodically update resolver cache and cert expiry metrics.
 	go func() {
 		t := time.NewTicker(c.metricsUpdateInterval)
@@ -458,51 +410,11 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		}
 	}()
 
-	// CDS certificate upgrade: after self-signed RA-TLS boot, a background
-	// goroutine contacts CDS, gets CA-signed certs, and hot-swaps them via
-	// CertManager.SwapProvider. cds serves both attestation and CA bundle on
-	// one URL, so CDSURL and CDSCAURL both take --cds-url.
-	if c.certMode == "cds" {
-		cdsCfg := &cdsclient.Config{
-			CDSURL:            c.cdsURL,
-			AttestationApiURL: c.attestationApiURL,
-			CDSCAURL:          c.cdsURL,
-			CACertURL:         effectiveCAURL,
-			NodeIP:            c.nodeIP,
-			DNSSAN:            c.certDNSSAN,
-			TEEType:           teeType,
-			CDSMeasurements:   cdsMeasurements,
-			CDSRTMRs:          cdsRTMRs,
-			CDSEntries:        pins.Entries,
-		}
-		// A provider-construction failure (config validation) is logged and
-		// the mesh keeps serving self-signed certs; it never blocks startup.
-		if provider, err := cdsclient.NewProvider(cdsCfg, logger); err != nil {
-			logger.Error("cds provider creation failed", "error", err)
-		} else {
-			go cdsUpgrade{
-				logger:          logger,
-				logPrefix:       "cds",
-				provider:        provider,
-				retryBackoff:    c.cdsRetryBackoff,
-				retryMaxBackoff: c.cdsRetryMaxBackoff,
-				opTimeout:       c.cdsOpTimeout,
-				serverCertMgr:   serverCertMgr,
-				clientCertMgr:   clientCertMgr,
-				metrics:         m,
-			}.run(ctx)
-
-			go caBundleRefresh{
-				logger:        logger,
-				logPrefix:     "cds",
-				provider:      provider,
-				interval:      c.caPollInterval,
-				opTimeout:     c.cdsOpTimeout,
-				serverCertMgr: serverCertMgr,
-				clientCertMgr: clientCertMgr,
-			}.run(ctx)
-			logger.Info("CA bundle refresh enabled", "url", effectiveCAURL, "interval", c.caPollInterval)
-		}
+	if c.certMode == "cds" && r.startCDS(ctx, e.cds, cdsUpgrade{
+		logPrefix: "cds", retryBackoff: c.cdsRetryBackoff,
+		retryMaxBackoff: c.cdsRetryMaxBackoff, opTimeout: c.cdsOpTimeout,
+	}, c.caPollInterval) {
+		logger.Info("CA bundle refresh enabled", "url", e.cds.CACertURL, "interval", c.caPollInterval)
 	}
 
 	// Cert pipeline health probe: periodically check CDS /readyz.
@@ -567,11 +479,6 @@ func runProxy(ctx context.Context, c *proxyConfig) error {
 		"keepalive", c.keepAlive,
 		"session_cache_size", c.sessionCacheSize,
 	)
-
-	if err := proxy.Run(ctx); err != nil {
-		return fmt.Errorf("proxy: %w", err)
-	}
-	return nil
 }
 
 type iptablesSyncConfig struct {

--- a/internal/cmds/ratlsmesh/runtime.go
+++ b/internal/cmds/ratlsmesh/runtime.go
@@ -1,0 +1,132 @@
+//go:build linux
+
+package ratlsmesh
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls/cdsclient"
+)
+
+type meshEnvironment interface {
+	// configure supplies routing and listeners and initializes the runtime health server.
+	configure(*meshRuntime) *Proxy
+	start(context.Context, *meshRuntime)
+}
+
+type meshRuntime struct {
+	logger                       *slog.Logger
+	serverTLS, clientTLS         *tls.Config
+	serverCertMgr, clientCertMgr *ratls.CertManager
+	metrics                      *metrics
+	health                       *healthServer
+	healthPort                   int
+	healthListener               net.Listener
+	rotationTimeout              time.Duration
+	proxy                        *Proxy
+}
+
+func newMeshRuntime(cfg *ratls.ServerConfig, logger *slog.Logger, sessionCacheSize int) (*meshRuntime, error) {
+	serverTLS, serverCertMgr, err := ratls.NewServerTLSConfig(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create server TLS config: %w", err)
+	}
+	clientTLS, clientCertMgr, err := ratls.NewClientTLSConfig(&ratls.ClientConfig{
+		Policy:          cfg.ClientPolicy,
+		Platform:        cfg.Platform,
+		AttestFunc:      cfg.AttestFunc,
+		CACert:          cfg.CACert,
+		DynamicCACert:   cfg.DynamicCACert,
+		CertTTL:         cfg.CertTTL,
+		RotationTimeout: cfg.RotationTimeout,
+		Logger:          cfg.Logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create client TLS config: %w", err)
+	}
+	if sessionCacheSize > 0 {
+		clientTLS.ClientSessionCache = tls.NewLRUClientSessionCache(sessionCacheSize)
+	}
+	m := newMetrics()
+	if len(cfg.ClientPolicy.Measurements) > 0 {
+		m.measurementPinning.Set(1)
+	}
+	wrapVerify := func(orig func([][]byte, [][]*x509.Certificate) error) func([][]byte, [][]*x509.Certificate) error {
+		if orig == nil {
+			return nil
+		}
+		return func(rawCerts [][]byte, chains [][]*x509.Certificate) error {
+			err := orig(rawCerts, chains)
+			if err != nil {
+				m.attestationFailures.Inc()
+			}
+			return err
+		}
+	}
+	serverTLS.VerifyPeerCertificate = wrapVerify(serverTLS.VerifyPeerCertificate)
+	clientTLS.VerifyPeerCertificate = wrapVerify(clientTLS.VerifyPeerCertificate)
+	serverCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
+	if clientCertMgr != nil {
+		clientCertMgr.SetOnRotationFail(func() { m.certRotationFailures.Inc() })
+	}
+	return &meshRuntime{
+		logger: logger, serverTLS: serverTLS, clientTLS: clientTLS,
+		serverCertMgr: serverCertMgr, clientCertMgr: clientCertMgr,
+		metrics: m, rotationTimeout: cfg.RotationTimeout,
+	}, nil
+}
+
+func (r *meshRuntime) run(ctx context.Context, env meshEnvironment) error {
+	p := env.configure(r)
+	r.proxy = p
+	p.serverTLS, p.clientTLS = r.serverTLS, r.clientTLS
+	p.logger, p.metrics = r.logger, r.metrics
+	p.origDstFunc = defaultOrigDstFunc
+	p.bufPool = newBufPool(p.pipeBufferSize)
+	p.onReady = func() {
+		warmupCtx, cancel := context.WithTimeout(ctx, 2*r.rotationTimeout)
+		defer cancel()
+		if err := r.serverCertMgr.WarmUp(warmupCtx); err != nil {
+			r.logger.Error("server certificate warm-up failed", "error", err)
+		}
+		if r.clientCertMgr != nil {
+			if err := r.clientCertMgr.WarmUp(warmupCtx); err != nil {
+				r.logger.Error("client certificate warm-up failed", "error", err)
+			}
+		}
+		r.health.ready.Store(true)
+	}
+	p.onShutdown = func() { r.health.ready.Store(false) }
+	go func() {
+		if err := r.health.serve(ctx, fmt.Sprintf(":%d", r.healthPort), r.healthListener); err != nil {
+			r.logger.Error("health server error", "error", err)
+		}
+	}()
+	env.start(ctx, r)
+	return p.Run(ctx)
+}
+
+func (r *meshRuntime) startCDS(ctx context.Context, cfg *cdsclient.Config, upgrade cdsUpgrade, interval time.Duration) bool {
+	provider, err := cdsclient.NewProvider(cfg, r.logger)
+	if err != nil {
+		r.logger.Error(upgrade.logPrefix+" provider creation failed", "error", err)
+		return false
+	}
+	upgrade.logger, upgrade.provider = r.logger, provider
+	upgrade.serverCertMgr, upgrade.clientCertMgr = r.serverCertMgr, r.clientCertMgr
+	upgrade.metrics = r.metrics
+	go upgrade.run(ctx)
+	go caBundleRefresh{
+		logger: r.logger, logPrefix: upgrade.logPrefix, provider: provider,
+		interval: interval, opTimeout: upgrade.opTimeout,
+		serverCertMgr: r.serverCertMgr, clientCertMgr: r.clientCertMgr,
+	}.run(ctx)
+	return true
+}

--- a/internal/cmds/ratlsmesh/runtime_test.go
+++ b/internal/cmds/ratlsmesh/runtime_test.go
@@ -1,0 +1,90 @@
+//go:build linux
+
+package ratlsmesh
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
+)
+
+func TestMeshEnvironmentRouting(t *testing.T) {
+	const localPod = "10.244.0.5"
+	const remotePod = "10.244.1.5"
+	cfg := defaultTestProxyConfig(t)
+	cfg.nodeIP = "10.0.0.1"
+	cfg.maxConns = 3
+	cfg.maxConnsPerSource = 2
+	bindProxyPorts(t, cfg)
+	resolver := &k8sResolver{
+		nodeIP: cfg.nodeIP, logger: testLogger(),
+		podMap: map[string]podEntry{
+			localPod:  {nodeIP: cfg.nodeIP, uid: "local"},
+			remotePod: {nodeIP: "10.0.0.2", uid: "remote"},
+		},
+	}
+	for _, tc := range []struct {
+		name         string
+		env          meshEnvironment
+		remoteNode   string
+		allowUnknown bool
+	}{
+		{"host", hostMesh{c: cfg, resolver: resolver}, "10.0.0.2", false},
+		{"guest", guestMesh{c: &inGuestConfig{}, podIP: localPod}, remotePod, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &meshRuntime{metrics: newMetrics()}
+			p := tc.env.configure(r)
+			if node, local := p.resolver.Resolve(remotePod); node != tc.remoteNode || local {
+				t.Fatalf("remote route = (%q, %v), want (%q, false)", node, local, tc.remoteNode)
+			}
+			if !p.resolver.ValidateLocalDest(localPod) || p.resolver.ValidateLocalDest(remotePod) {
+				t.Fatal("local ownership must reject remote pods")
+			}
+			if allowed, _ := p.resolver.ValidateOutboundDest("10.99.0.1"); allowed != tc.allowUnknown {
+				t.Fatalf("unknown destination allowed = %v, want %v", allowed, tc.allowUnknown)
+			}
+			if allowed, _ := p.resolver.ValidateOutboundDest("127.0.0.1"); allowed {
+				t.Fatal("loopback must not enter the mesh")
+			}
+			if tc.name == "host" {
+				if p.inboundLn != cfg.listeners.inbound || p.outboundLn != cfg.listeners.outbound || r.healthListener != cfg.listeners.health {
+					t.Fatal("host must adopt reserved listeners")
+				}
+				if cap(p.connSem) != cfg.maxConns || p.maxConnsPerSrc != cfg.maxConnsPerSource {
+					t.Fatal("host connection limits lost")
+				}
+			} else if p.inboundLn != nil || p.outboundLn != nil || r.healthListener != nil || p.connSem != nil || p.maxConnsPerSrc != 0 {
+				t.Fatal("guest must use its own listeners and default connection limits")
+			}
+		})
+	}
+}
+
+func TestMeshRuntimeVerification(t *testing.T) {
+	for _, cacheSize := range []int{0, 4} {
+		r, err := newMeshRuntime(&ratls.ServerConfig{
+			AttestFunc: func(context.Context, string) (string, error) { return "", errors.New("unexpected attestation request") },
+			Platform:   "sev-snp", ClientPolicy: &ratls.VerifyPolicy{}, DynamicCACert: true,
+		}, testLogger(), cacheSize)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if (r.clientTLS.ClientSessionCache != nil) != (cacheSize > 0) {
+			t.Fatalf("session cache setting %d not preserved", cacheSize)
+		}
+		for _, verify := range []func([][]byte, [][]*x509.Certificate) error{
+			r.serverTLS.VerifyPeerCertificate, r.clientTLS.VerifyPeerCertificate,
+		} {
+			if verify == nil || verify([][]byte{[]byte("invalid certificate")}, nil) == nil {
+				t.Fatal("both TLS roles must reject malformed peer certificates before CDS upgrade")
+			}
+		}
+		if got := registryValue(t, r.metrics, "ratls_mesh_attestation_failures_total", nil); got != 2 {
+			t.Fatalf("attestation failures = %v, want 2", got)
+		}
+	}
+}


### PR DESCRIPTION
Host and guest mesh startup duplicated TLS construction, certificate metrics, readiness hooks, and CDS worker setup. A shared mesh runtime now owns that lifecycle while host and guest environment implementations retain their routing and background work.

- Introduce meshEnvironment implementations for host and guest proxy configuration and worker startup.
- Share TLS managers, verification metrics, certificate warmup, health serving, and CDS upgrade and CA refresh setup.
- Preserve host ownership checks and limits, guest direct routing and firewall setup order, and mode-specific certificate settings.
- Test environment routing differences, reserved listeners, connection limits, session caching, and malformed-peer rejection.

The change touches 451 production lines and removes 35 net. New routing and TLS tests add 90 lines, for a total net increase of 55 lines.

Review focus: host Kubernetes ownership versus guest direct routing, guest firewall setup before runtime initialization, preserved certificate policy and identity inputs, and startup/readiness ordering.

Validation: `GOTOOLCHAIN=go1.26.7 go test -race ./internal/cmds/ratlsmesh`, `GOTOOLCHAIN=go1.26.7 make test`, `GOTOOLCHAIN=go1.26.7 make lint`, and `git diff --cached --check`.
