### PR TITLE
refactor(get-kubeconfig): separate platform verification policies

### DIFF
--- a/internal/cmds/getkubeconfig/flow_test.go
+++ b/internal/cmds/getkubeconfig/flow_test.go
@@ -113,7 +113,7 @@ type testEnv struct {
 	attestURL    string
 	releaseURL   string
 	outPath      string
-	exp          measuredPolicy
+	exp          tdxMeasuredPolicy
 }
 
 func newTestEnv(t *testing.T, attestURL string, releaseStatus int, releaseBody string) testEnv {
@@ -133,10 +133,11 @@ func newTestEnv(t *testing.T, attestURL string, releaseStatus int, releaseBody s
 		t.Fatal(err)
 	}
 	manifestPath := writeTestManifest(t, tdxManifest())
-	exp, err := policyFor(manifestPath, pub, nil)
+	policy, err := policyFor(manifestPath, pub, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	exp := requireTDXPolicy(t, policy)
 	stubVerify(t, verifiedResultFor(exp), nil)
 
 	release := newAttestedTLSServer(t, releaseHandler(t, releaseStatus, releaseBody))
@@ -391,7 +392,7 @@ func TestCheckMeasuredIdentityNoRTMR3Claim(t *testing.T) {
 	exp := testPolicy(t, operatorPub(t))
 	res := verifiedResultFor(exp)
 	res.Claims.PlatformData["rtmr_3"] = ""
-	err := checkMeasuredIdentity(res, exp)
+	err := exp.checkIdentity(res)
 	if err == nil || !strings.Contains(err.Error(), "no rtmr_3") {
 		t.Fatalf("want no-rtmr_3 error, got %v", err)
 	}
@@ -410,7 +411,7 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bare.rtmr3 != runtimemeasure.ForOperatorKey(pub) {
+	if requireTDXPolicy(t, bare).rtmr3 != runtimemeasure.ForOperatorKey(pub) {
 		t.Error("with no workload images the expected register must equal the bare operator-key seed")
 	}
 
@@ -420,7 +421,7 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 	}
 	want := runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(pub),
 		[]string{digA, "sha256:" + strings.Repeat("bb", 32)})
-	if chained.rtmr3 != want {
+	if requireTDXPolicy(t, chained).rtmr3 != want {
 		t.Error("workload images must chain onto the operator-key seed via the shared convention")
 	}
 
@@ -428,7 +429,7 @@ func TestPolicyForWorkloadImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if reversed.rtmr3 == chained.rtmr3 {
+	if requireTDXPolicy(t, reversed).rtmr3 == requireTDXPolicy(t, chained).rtmr3 {
 		t.Error("extend order must change the expected register — the chain is ordered")
 	}
 
@@ -469,7 +470,7 @@ func TestPolicyForRejectsDuplicateWorkloadImages(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if single.rtmr3 != runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(pub), []string{dig}) {
+	if requireTDXPolicy(t, single).rtmr3 != runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(pub), []string{dig}) {
 		t.Error("the deduped, ordered set is what FromDigestsSeeded expects")
 	}
 }

--- a/internal/cmds/getkubeconfig/getkubeconfig_test.go
+++ b/internal/cmds/getkubeconfig/getkubeconfig_test.go
@@ -23,10 +23,12 @@ func TestPolicyForSeedMatchesGuestConvention(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	tdx := requireTDXPolicy(t, exp)
+
 	keyDigest := sha512.Sum384(pub)
 	want := sha512.Sum384(append(make([]byte, 48), keyDigest[:]...))
-	if hex.EncodeToString(exp.rtmr3[:]) != hex.EncodeToString(want[:]) {
-		t.Errorf("expected RTMR[3] = %x, want %x", exp.rtmr3, want)
+	if hex.EncodeToString(tdx.rtmr3[:]) != hex.EncodeToString(want[:]) {
+		t.Errorf("expected RTMR[3] = %x, want %x", tdx.rtmr3, want)
 	}
 }
 

--- a/internal/cmds/getkubeconfig/policy_test.go
+++ b/internal/cmds/getkubeconfig/policy_test.go
@@ -1,0 +1,55 @@
+package getkubeconfig
+
+import (
+	"crypto/x509"
+	"errors"
+	"testing"
+
+	"github.com/confidential-dot-ai/attestation-go/attestation/teetypes"
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+type recordingPolicy struct {
+	calls int
+	err   error
+}
+
+func (*recordingPolicy) platform() teetypes.PlatformType { return teetypes.PlatformTDX }
+func (p *recordingPolicy) verifyEvidence(teetypes.AttestationEvidence, []byte, []byte) (*teetypes.VerificationResult, error) {
+	p.calls++
+	return nil, p.err
+}
+func (p *recordingPolicy) verifyCertificate(*x509.Certificate) error {
+	p.calls++
+	return p.err
+}
+
+func TestMeasuredPolicyCommonGates(t *testing.T) {
+	p := &recordingPolicy{err: errors.New("platform verification refused")}
+	for _, envelope := range []string{
+		`{`,
+		`{"platform":"snp","evidence":{}}`,
+		`{"platform":"tdx"}`,
+		`{"platform":"tdx","evidence":{"platform":"tdx","evidence":{}}}`,
+	} {
+		if _, err := verifyEvidence([]byte(envelope), nil, p); err == nil || errors.Is(err, p.err) {
+			t.Fatalf("envelope %s must fail before platform verification: %v", envelope, err)
+		}
+	}
+	if p.calls != 0 {
+		t.Fatal("invalid envelopes reached platform verifier")
+	}
+	if _, err := verifyEvidence([]byte(tdxEnvelope), nil, p); !errors.Is(err, p.err) || p.calls != 1 {
+		t.Fatalf("validated envelope did not propagate platform refusal: %v", err)
+	}
+
+	cert := attestedCert(t, types.AttestationEvidence{Platform: "tdx"})
+	cert.Signature[0] ^= 0xff
+	if err := verifyServerCert(cert, p); err == nil || errors.Is(err, p.err) || p.calls != 1 {
+		t.Fatalf("invalid certificate body reached platform verifier: %v", err)
+	}
+	cert.Signature[0] ^= 0xff
+	if err := verifyServerCert(cert, p); !errors.Is(err, p.err) || p.calls != 2 {
+		t.Fatalf("authenticated certificate did not propagate platform refusal: %v", err)
+	}
+}

--- a/internal/cmds/getkubeconfig/ratls_verify.go
+++ b/internal/cmds/getkubeconfig/ratls_verify.go
@@ -67,15 +67,10 @@ func verifyServerCert(leaf *x509.Certificate, exp measuredPolicy) error {
 	if body != certutil.BodySelfSigned {
 		return fmt.Errorf("ratls: cred-release serving cert is not self-signed (issuer != subject), so its body is authenticated by nothing this flow checks; the RA-TLS leaf must carry its own signature under the attested key")
 	}
-	// Bare-metal SNP RA-TLS certs carry a RAW report, not a JSON envelope
-	// (pkg/ratls: EmbeddedEvidence is the TDX/az-snp shape), and the raw
-	// report has no inline VCEK — so the embedded-envelope path below cannot
-	// verify them. localverify handles exactly that shape, fetching the VCEK
-	// from AMD KDS, and takes the same two pins this gate enforces.
-	if exp.platform == teetypes.PlatformSNP {
-		return verifySNPServerCert(leaf, exp)
-	}
+	return exp.verifyCertificate(leaf)
+}
 
+func (exp tdxMeasuredPolicy) verifyCertificate(leaf *x509.Certificate) error {
 	att, err := ratls.ExtractAttestation(leaf)
 	if err != nil {
 		return fmt.Errorf("ratls: %w", err)
@@ -116,7 +111,7 @@ var verifySNPRATLS localverify.VerifyFunc = localverify.Verify
 // (VCEK from AMD KDS) crosses the network. VerifyConnection has no context.
 const snpRATLSTimeout = 30 * time.Second
 
-// verifySNPServerCert is verifyServerCert's SNP arm: it enforces the SAME two
+// verifyCertificate verifies an SNP serving certificate: it enforces the SAME two
 // pins as the attest gate — the launch digest must be one of the manifest's
 // per-SMP variants, and HOSTDATA must equal the operator-key binding — over
 // evidence extracted from a bare-metal SNP RA-TLS cert (a raw report, no
@@ -124,7 +119,7 @@ const snpRATLSTimeout = 30 * time.Second
 //
 // The REPORTDATA anchor is the cert's own key hash, so a captured quote from
 // another guest cannot be replayed onto this channel.
-func verifySNPServerCert(leaf *x509.Certificate, exp measuredPolicy) error {
+func (exp snpMeasuredPolicy) verifyCertificate(leaf *x509.Certificate) error {
 	platform, evidence, expectedReportData, err := localverify.CertEnvelope(leaf)
 	if err != nil {
 		return fmt.Errorf("ratls: %w", err)
@@ -135,18 +130,9 @@ func verifySNPServerCert(leaf *x509.Certificate, exp measuredPolicy) error {
 		return fmt.Errorf("ratls: serving cert platform is %q: the SNP trust gate pins launch-time HOSTDATA, which only bare-metal snp launches carry as the operator-key binding", platform)
 	}
 
-	measurements := make([][]byte, 0, len(exp.snpPins.BySMP))
-	for _, d := range exp.snpPins.Digests() {
-		measurements = append(measurements, append([]byte(nil), d[:]...))
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), snpRATLSTimeout)
 	defer cancel()
-	res, err := verifySNPRATLS(ctx, platform, evidence, localverify.Params{
-		ExpectedReportData:   expectedReportData,
-		Measurements:         measurements,
-		ExpectedInitDataHash: exp.hostData[:],
-	})
+	res, err := verifySNPRATLS(ctx, platform, evidence, exp.verificationParams(expectedReportData))
 	if err != nil {
 		return fmt.Errorf("ratls: verify serving cert evidence: %w", err)
 	}
@@ -156,7 +142,7 @@ func verifySNPServerCert(leaf *x509.Certificate, exp measuredPolicy) error {
 	if !res.SignatureValid {
 		return fmt.Errorf("ratls: quote signature invalid")
 	}
-	if err := checkSNPMeasuredIdentity(res, exp); err != nil {
+	if err := exp.checkIdentity(res); err != nil {
 		return fmt.Errorf("ratls: %w", err)
 	}
 	return nil

--- a/internal/cmds/getkubeconfig/ratls_verify_test.go
+++ b/internal/cmds/getkubeconfig/ratls_verify_test.go
@@ -63,13 +63,13 @@ func snpManifest() string {
 
 // testPolicy builds the full measured policy for the test tuple + operator
 // key, with no workload images (bare-seed RTMR[3]).
-func testPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
+func testPolicy(t *testing.T, operatorPubPEM []byte) tdxMeasuredPolicy {
 	t.Helper()
 	exp, err := policyFor(writeTestManifest(t, tdxManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return exp
+	return requireTDXPolicy(t, exp)
 }
 
 // operatorPub is a throwaway operator public key PEM for the tests.
@@ -164,7 +164,7 @@ func stubVerify(t *testing.T, res *teetypes.VerificationResult, err error) *veri
 
 // verifiedResultFor builds a passing VerificationResult whose claims satisfy
 // exp exactly. Tests break individual claims from here.
-func verifiedResultFor(exp measuredPolicy) *teetypes.VerificationResult {
+func verifiedResultFor(exp tdxMeasuredPolicy) *teetypes.VerificationResult {
 	return &teetypes.VerificationResult{
 		SignatureValid:  true,
 		Platform:        teetypes.PlatformTDX,
@@ -373,19 +373,23 @@ func TestVerifyServerCertAuthenticatesBody(t *testing.T) {
 }
 
 // snpTestPolicy builds an SNP gate from a two-variant manifest.
-func snpTestPolicy(t *testing.T, operatorPubPEM []byte) measuredPolicy {
+func snpTestPolicy(t *testing.T, operatorPubPEM []byte) snpMeasuredPolicy {
 	t.Helper()
 	exp, err := policyFor(writeTestManifest(t, snpManifest()), operatorPubPEM, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if exp.platform != teetypes.PlatformSNP {
-		t.Fatalf("policy platform = %q, want snp", exp.platform)
+	if exp.platform() != teetypes.PlatformSNP {
+		t.Fatalf("policy platform = %q, want snp", exp.platform())
 	}
-	return exp
+	p, ok := exp.(snpMeasuredPolicy)
+	if !ok {
+		t.Fatalf("policy type = %T, want SNP", exp)
+	}
+	return p
 }
 
-func snpResultFor(exp measuredPolicy, smp int) *teetypes.VerificationResult {
+func snpResultFor(exp snpMeasuredPolicy, smp int) *teetypes.VerificationResult {
 	digest := exp.snpPins.BySMP[smp]
 	return &teetypes.VerificationResult{
 		SignatureValid:  true,
@@ -403,7 +407,7 @@ func snpResultFor(exp measuredPolicy, smp int) *teetypes.VerificationResult {
 func TestSNPGateAcceptsEveryPinnedVariant(t *testing.T) {
 	exp := snpTestPolicy(t, operatorPub(t))
 	for _, smp := range []int{2, 4} {
-		if err := checkMeasuredIdentity(snpResultFor(exp, smp), exp); err != nil {
+		if err := exp.checkIdentity(snpResultFor(exp, smp)); err != nil {
 			t.Errorf("smp%d: %v", smp, err)
 		}
 	}
@@ -441,7 +445,7 @@ func TestSNPGateFailsClosed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			res := snpResultFor(exp, 2)
 			mutate(res)
-			if err := checkMeasuredIdentity(res, exp); err == nil {
+			if err := exp.checkIdentity(res); err == nil {
 				t.Fatal("expected error, got nil")
 			}
 		})
@@ -629,4 +633,13 @@ func TestAttestGateSNPFailsClosed(t *testing.T) {
 			}
 		})
 	}
+}
+
+func requireTDXPolicy(t *testing.T, policy measuredPolicy) tdxMeasuredPolicy {
+	t.Helper()
+	p, ok := policy.(tdxMeasuredPolicy)
+	if !ok {
+		t.Fatalf("policy type = %T, want TDX", policy)
+	}
+	return p
 }

--- a/internal/cmds/getkubeconfig/verify.go
+++ b/internal/cmds/getkubeconfig/verify.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -34,30 +35,25 @@ import (
 // verdict.
 var verifyEnvelope = teeverify.Verify
 
-// measuredPolicy is the full trust gate a node must satisfy before any
-// credential flows: the TDX image tuple from one provenanced build-artifact
-// manifest, and the expected RTMR[3] chain. RTMR[3] alone is not an identity
-// gate — the untrusted host stages the operator key, so it can boot ANY image
-// and reproduce the bare operator-key register — which is why the image tuple
-// anchors the policy and RTMR[3] then binds the key and workload set.
-type measuredPolicy struct {
-	// platform is the TEE this policy gates, inferred from the manifest's
-	// shape (see policyFor). Other platforms are refused before the claims
-	// are read.
-	platform teetypes.PlatformType
+// measuredPolicy receives a validated envelope or an authenticated certificate body.
+type measuredPolicy interface {
+	platform() teetypes.PlatformType
+	verifyEvidence(env teetypes.AttestationEvidence, envelopeJSON, expectedReportData []byte) (*teetypes.VerificationResult, error)
+	verifyCertificate(*x509.Certificate) error
+}
 
-	pins runtimemeasure.ImagePins
-	// rtmr3 = FromDigestsSeeded(ForOperatorKey(pubPEM), workload digests):
-	// equal to the bare operator-key seed only when no workload images are
-	// expected. TDX only.
+type tdxMeasuredPolicy struct {
+	pins  runtimemeasure.ImagePins
 	rtmr3 [runtimemeasure.Size]byte
+}
 
-	// SNP: the pinned per-SMP launch digests plus the operator-key binding
-	// committed as HOSTDATA at launch. No runtime-extend register, so there
-	// is no workload chain to pin (c8s#331).
+type snpMeasuredPolicy struct {
 	snpPins  runtimemeasure.SNPImagePins
 	hostData [runtimemeasure.HostDataSize]byte
 }
+
+func (tdxMeasuredPolicy) platform() teetypes.PlatformType { return teetypes.PlatformTDX }
+func (snpMeasuredPolicy) platform() teetypes.PlatformType { return teetypes.PlatformSNP }
 
 // policyFor builds the trust gate from the operator's inputs: the image
 // manifest (MRTD + RTMR[1] + RTMR[2], loaded atomically), the operator public
@@ -76,7 +72,7 @@ func policyFor(manifestPath string, operatorPubPEM []byte, workloadImages []stri
 	}
 	snpPins, snpErr := runtimemeasure.LoadSNPImageManifest(manifestPath)
 	if snpErr != nil {
-		return measuredPolicy{}, fmt.Errorf("--image-manifest: %w", tdxErr)
+		return nil, fmt.Errorf("--image-manifest: %w", tdxErr)
 	}
 	return snpPolicy(snpPins, operatorPubPEM, workloadImages)
 }
@@ -87,10 +83,9 @@ func snpPolicy(pins runtimemeasure.SNPImagePins, operatorPubPEM []byte, workload
 	// Accepting --workload-image here would claim an enforcement that cannot
 	// exist rather than silently ignoring the flag.
 	if len(workloadImages) > 0 {
-		return measuredPolicy{}, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
+		return nil, fmt.Errorf("--workload-image requires a TDX node: SEV-SNP has no runtime measurement register, so workload extends cannot be verified; rerun without it")
 	}
-	return measuredPolicy{
-		platform: teetypes.PlatformSNP,
+	return snpMeasuredPolicy{
 		snpPins:  pins,
 		hostData: runtimemeasure.HostDataForOperatorKey(operatorPubPEM),
 	}, nil
@@ -104,7 +99,7 @@ func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadIma
 	for _, ref := range workloadImages {
 		d, err := runtimemeasure.CanonicalDigest(ref)
 		if err != nil {
-			return measuredPolicy{}, fmt.Errorf("--workload-image: %w", err)
+			return nil, fmt.Errorf("--workload-image: %w", err)
 		}
 		// RTMR[3] is an ordered extend chain over the deduped digest set (see
 		// FromDigests): the node's measurer extends a given image once, so a
@@ -113,15 +108,14 @@ func tdxPolicy(pins runtimemeasure.ImagePins, operatorPubPEM []byte, workloadIma
 		// dedup silently — a repeat is a copy/paste, and a permanently red
 		// gate is worse than a usage error.
 		if prev, dup := seen[d]; dup {
-			return measuredPolicy{}, fmt.Errorf("--workload-image %q and %q are the same image (%s): each expected image must be given once, in first-extend order, or the expected RTMR[3] chain can never match the node's", prev, ref, d)
+			return nil, fmt.Errorf("--workload-image %q and %q are the same image (%s): each expected image must be given once, in first-extend order, or the expected RTMR[3] chain can never match the node's", prev, ref, d)
 		}
 		seen[d] = ref
 		digests = append(digests, d)
 	}
-	return measuredPolicy{
-		platform: teetypes.PlatformTDX,
-		pins:     pins,
-		rtmr3:    runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(operatorPubPEM), digests),
+	return tdxMeasuredPolicy{
+		pins:  pins,
+		rtmr3: runtimemeasure.FromDigestsSeeded(runtimemeasure.ForOperatorKey(operatorPubPEM), digests),
 	}, nil
 }
 
@@ -139,8 +133,8 @@ func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy)
 	// The policy's platform comes from the manifest; the node must be that
 	// platform. Bare-metal snp only: on az-snp/gcp-snp the HOSTDATA field is
 	// owned by the cloud stack, so it cannot carry the operator-key binding.
-	if env.Platform != exp.platform {
-		return nil, fmt.Errorf("node platform is %q but --image-manifest pins %q: credential release requires the node to be the platform the manifest describes", env.Platform, exp.platform)
+	if env.Platform != exp.platform() {
+		return nil, fmt.Errorf("node platform is %q but --image-manifest pins %q: credential release requires the node to be the platform the manifest describes", env.Platform, exp.platform())
 	}
 	if len(env.Evidence) == 0 {
 		return nil, fmt.Errorf("evidence envelope carries no evidence object")
@@ -156,16 +150,10 @@ func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy)
 		return nil, fmt.Errorf("evidence envelope is double-wrapped ({platform,evidence} inside evidence); the envelope must wrap the platform evidence object exactly once")
 	}
 
-	// Bare-metal SNP evidence is a raw report with NO inline VCEK — the guest
-	// attestation-api serves cert_chain: null and offers no endpoint to fetch
-	// one — so attestation-go's offline path cannot verify it. localverify
-	// handles that shape and fetches the VCEK from AMD KDS, and is already
-	// what the RA-TLS dial arm uses; routing the gate through it too keeps
-	// the two halves of one policy able to consume the same evidence (c8s#415).
-	if exp.platform == teetypes.PlatformSNP {
-		return verifySNPEvidence(env, expectedReportData, exp)
-	}
+	return exp.verifyEvidence(env, envelopeJSON, expectedReportData)
+}
 
+func (exp tdxMeasuredPolicy) verifyEvidence(_ teetypes.AttestationEvidence, envelopeJSON, expectedReportData []byte) (*teetypes.VerificationResult, error) {
 	res, err := verifyEnvelope(envelopeJSON, teetypes.VerifyParams{
 		ExpectedReportData: expectedReportData,
 	})
@@ -180,21 +168,18 @@ func verifyEvidence(envelopeJSON, expectedReportData []byte, exp measuredPolicy)
 	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
 		return nil, fmt.Errorf("report_data does not match the expected binding (stale/replayed quote)")
 	}
-	if err := checkMeasuredIdentity(res, exp); err != nil {
+	if err := exp.checkIdentity(res); err != nil {
 		return nil, err
 	}
 	return res, nil
 }
 
-// checkMeasuredIdentity asserts the verified claims match the full policy:
+// checkIdentity asserts the verified claims match the full policy:
 // MRTD against the launch digest, RTMR[1]/[2] against the image tuple,
 // RTMR[3] against the operator-key/workload chain. The compares are over the
 // claims attestation-go extracted from the signature-verified quote body.
 // Absent or malformed claims fail closed.
-func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy) error {
-	if exp.platform == teetypes.PlatformSNP {
-		return checkSNPMeasuredIdentity(res, exp)
-	}
+func (exp tdxMeasuredPolicy) checkIdentity(res *teetypes.VerificationResult) error {
 	launch := strings.ToLower(strings.TrimSpace(res.Claims.LaunchDigest))
 	if launch == "" {
 		return fmt.Errorf("verified claims carry no launch digest (MRTD)")
@@ -222,12 +207,12 @@ func checkMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy)
 	return nil
 }
 
-// checkSNPMeasuredIdentity asserts the verified claims match the SNP policy:
+// checkIdentity asserts the verified claims match the SNP policy:
 // the launch digest against the pinned per-SMP set, and HOSTDATA against the
 // operator-key binding the launcher committed. Together these are the SNP
 // analog of TDX's image tuple + RTMR[3] (c8s#331). Absent or malformed claims
 // fail closed.
-func checkSNPMeasuredIdentity(res *teetypes.VerificationResult, exp measuredPolicy) error {
+func (exp snpMeasuredPolicy) checkIdentity(res *teetypes.VerificationResult) error {
 	launch := strings.ToLower(strings.TrimSpace(res.Claims.LaunchDigest))
 	if launch == "" {
 		return fmt.Errorf("verified claims carry no launch digest (SNP MEASUREMENT)")
@@ -317,27 +302,18 @@ func postAttest(ctx context.Context, attestURL string, nonce []byte) ([]byte, er
 // (VCEK from AMD KDS) crosses the network.
 const snpAttestTimeout = 30 * time.Second
 
-// verifySNPEvidence is verifyEvidence's SNP arm. It verifies a bare-metal SNP
+// verifyEvidence verifies SNP evidence. It verifies a bare-metal SNP
 // envelope through localverify — which accepts the raw-report shape and pulls
 // the VCEK from AMD KDS, rather than requiring the guest to have volunteered
 // it inline — then enforces the same measured identity the RA-TLS dial does.
 //
 // The engine already enforces both pins (Measurements, ExpectedInitDataHash);
-// checkSNPMeasuredIdentity re-checks them over the returned claims so a
+// checkIdentity re-checks them over the returned claims so a
 // success the claims contradict is never accepted.
-func verifySNPEvidence(env teetypes.AttestationEvidence, expectedReportData []byte, exp measuredPolicy) (*teetypes.VerificationResult, error) {
-	measurements := make([][]byte, 0, len(exp.snpPins.BySMP))
-	for _, d := range exp.snpPins.Digests() {
-		measurements = append(measurements, append([]byte(nil), d[:]...))
-	}
-
+func (exp snpMeasuredPolicy) verifyEvidence(env teetypes.AttestationEvidence, _ []byte, expectedReportData []byte) (*teetypes.VerificationResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), snpAttestTimeout)
 	defer cancel()
-	res, err := verifySNPRATLS(ctx, string(env.Platform), env.Evidence, localverify.Params{
-		ExpectedReportData:   expectedReportData,
-		Measurements:         measurements,
-		ExpectedInitDataHash: exp.hostData[:],
-	})
+	res, err := verifySNPRATLS(ctx, string(env.Platform), env.Evidence, exp.verificationParams(expectedReportData))
 	if err != nil {
 		return nil, fmt.Errorf("verify evidence: %w", err)
 	}
@@ -347,8 +323,20 @@ func verifySNPEvidence(env teetypes.AttestationEvidence, expectedReportData []by
 	if res.ReportDataMatch == nil || !*res.ReportDataMatch {
 		return nil, fmt.Errorf("report_data does not match the expected binding (stale/replayed quote)")
 	}
-	if err := checkSNPMeasuredIdentity(res, exp); err != nil {
+	if err := exp.checkIdentity(res); err != nil {
 		return nil, err
 	}
 	return res, nil
+}
+
+func (exp snpMeasuredPolicy) verificationParams(reportData []byte) localverify.Params {
+	measurements := make([][]byte, 0, len(exp.snpPins.BySMP))
+	for _, d := range exp.snpPins.Digests() {
+		measurements = append(measurements, append([]byte(nil), d[:]...))
+	}
+	return localverify.Params{
+		ExpectedReportData:   reportData,
+		Measurements:         measurements,
+		ExpectedInitDataHash: exp.hostData[:],
+	}
 }


### PR DESCRIPTION
The credential-release policy stored both SNP and TDX fields and repeatedly selected verification behavior using a platform tag. Separate measured-policy implementations now own their platform-specific state and checks while shared entrypoints enforce envelope and certificate-body validation.

- Replace the tagged policy struct with a private measuredPolicy interface and concrete SNP and TDX policies.
- Move evidence, certificate, and measured-identity verification onto the corresponding policy types.
- Share SNP verifier parameters between attestation and certificate verification.
- Preserve existing rejection tests and verify that common validation gates run before policy dispatch.

Review focus: certificate-body authentication and envelope validation precede dispatch; platform restrictions, nonce/key bindings, SNP HOST_DATA checks, TDX register ordering, and verifier errors retain their existing behavior.

The change touches 138 production lines and removes 26 net, largely from obsolete comments; executable code is essentially unchanged. Tests add 71 net lines, for an overall increase of 45 lines.

Validation: `GOTOOLCHAIN=go1.26.7 go test -race ./internal/cmds/getkubeconfig`, `GOTOOLCHAIN=go1.26.7 make test`, `GOTOOLCHAIN=go1.26.7 make lint`, and `git diff --cached --check`.
