### PR TITLE
refactor(ci): share the guest kernel build lifecycle

### DIFF
--- a/.github/actions/build-guest-kernel/action.yml
+++ b/.github/actions/build-guest-kernel/action.yml
@@ -1,0 +1,117 @@
+name: Build guest kernel
+description: Build and cache the confos guest kernel and capture its resolved config.
+inputs:
+  confos-ref:
+    description: Pinned confos revision used by the kernel cache.
+    required: true
+  mkosi-ref:
+    description: Pinned mkosi revision used by the tools cache.
+    required: true
+  check-snapshot:
+    description: Fail on resolved config drift before building the rootfs.
+    default: '0'
+outputs:
+  snapshot-sha256:
+    description: SHA256 of the resolved kernel config.
+    value: ${{ steps.snapshot.outputs.sha256 }}
+runs:
+  using: composite
+  steps:
+    - name: Restore confos build
+      id: confos-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: confidential-os-builder/target/release/confos
+        key: ${{ runner.os }}-confos-${{ hashFiles('confidential-os-builder/Cargo.lock', 'confidential-os-builder/src/**', 'confidential-os-builder/crates/**') }}
+
+    - name: Build confos
+      id: build-confos
+      if: steps.confos-cache.outputs.cache-hit != 'true'
+      working-directory: confidential-os-builder
+      shell: bash
+      run: cargo build --release
+
+    - name: Save confos build
+      if: steps.confos-cache.outputs.cache-hit != 'true' && steps.build-confos.outcome == 'success'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: confidential-os-builder/target/release/confos
+        key: ${{ steps.confos-cache.outputs.cache-primary-key }}
+
+    - name: Restore kernel-builder tools tree
+      id: tools-tree-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/confos-tools-tree.tar.zst
+        key: ${{ runner.os }}-confos-tools-tree-mkosi-${{ inputs.mkosi-ref }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf') }}
+
+    - name: Unpack kernel-builder tools tree
+      if: steps.tools-tree-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
+          -xpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
+          -C confidential-os-builder/mkosi/kernel-builder
+
+    - name: Restore guest kernel build
+      id: kernel-cache
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          confidential-os-builder/output/kernel
+          confidential-os-builder/kernel/config-x86_64.snapshot
+        key: ${{ runner.os }}-kata-kernel-v3-${{ inputs.confos-ref }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
+        restore-keys: |
+          ${{ runner.os }}-kata-kernel-v3-${{ inputs.confos-ref }}-
+
+    - name: Build guest kernel and check snapshot
+      id: snapshot
+      shell: bash
+      env:
+        CHECK_SNAPSHOT: ${{ inputs.check-snapshot }}
+      run: |
+        sudo rm -rf c8s/kata-guest-base/output
+        bash c8s/kata-guest-base/scripts/build-kernel.sh confidential-os-builder c8s/kata-guest-base
+        sha=$(sha256sum c8s/kata-guest-base/kernel/config-x86_64.snapshot | awk '{print $1}')
+        echo "sha256=$sha" >> "$GITHUB_OUTPUT"
+
+    - name: Pack kernel-builder tools tree
+      id: tools-tree-tar
+      if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        if [[ -f confidential-os-builder/mkosi/kernel-builder/mkosi.output/.confos-tools-stamp ]]; then
+          sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
+            -cpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
+            -C confidential-os-builder/mkosi/kernel-builder mkosi.output
+          echo "exists=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "exists=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Save kernel-builder tools tree
+      if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true' && steps.tools-tree-tar.outputs.exists == 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ${{ runner.temp }}/confos-tools-tree.tar.zst
+        key: ${{ steps.tools-tree-cache.outputs.cache-primary-key }}
+
+    - name: Check guest kernel output
+      id: kernel-out
+      if: always()
+      shell: bash
+      run: |
+        if [[ -f confidential-os-builder/output/kernel/vmlinuz && -f confidential-os-builder/output/kernel/manifest.json ]]; then
+          echo "complete=true" >> "${GITHUB_OUTPUT}"
+        else
+          echo "complete=false" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Save guest kernel build
+      if: always() && steps.kernel-cache.outputs.cache-hit != 'true' && steps.kernel-out.outputs.complete == 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          confidential-os-builder/output/kernel
+          confidential-os-builder/kernel/config-x86_64.snapshot
+        key: ${{ runner.os }}-kata-kernel-v3-${{ inputs.confos-ref }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}

--- a/.github/scripts/repro-gate-changes
+++ b/.github/scripts/repro-gate-changes
@@ -58,7 +58,8 @@ main() {
         .github/workflows/c8s-image-publish.yml)
         image=true
         ;;
-      kata-guest-base/kernel/* | .github/workflows/kernel-snapshot.yml)
+      kata-guest-base/kernel/* | kata-guest-base/scripts/build-kernel.sh | \
+        .github/actions/build-guest-kernel/* | .github/workflows/kernel-snapshot.yml)
         kernel_snapshot=true
         ;;
       .github/build-pins.json)

--- a/.github/scripts/tests/test-build-guest-kernel.sh
+++ b/.github/scripts/tests/test-build-guest-kernel.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../.." && pwd)
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+confos="$scratch/confos"
+guest="$scratch/guest"
+mkdir -p "$confos/target/release" "$guest/kernel"
+printf 'fragment\n' > "$guest/kernel/container.config"
+cat > "$confos/target/release/confos" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$1" == kernel && "$2" == --kernel-config-fragment && -f "$3" ]]
+[[ "${RESULT:-}" != failure ]] || exit 17
+mkdir -p output/kernel kernel
+[[ "${RESULT:-}" == no-kernel ]] || printf 'kernel\n' > output/kernel/vmlinuz
+[[ "${RESULT:-}" == no-snapshot ]] || printf '%s\n' "$RESOLVED" > kernel/config-x86_64.snapshot
+STUB
+chmod +x "$confos/target/release/confos"
+
+run_case() {
+  local mode=$1 resolved=$2 check=$3 expected=$4
+  rm -rf "$confos/output" "$confos/kernel" "$guest/output"
+  printf 'committed\n' > "$guest/kernel/config-x86_64.snapshot"
+  local status=0
+  RESULT="$mode" RESOLVED="$resolved" CHECK_SNAPSHOT="$check" \
+    bash "$root/kata-guest-base/scripts/build-kernel.sh" "$confos" "$guest" > "$scratch/log" 2>&1 || status=$?
+  if [[ "$expected" == success && "$status" != 0 || "$expected" == failure && "$status" == 0 ]]; then
+    cat "$scratch/log" >&2
+    echo "unexpected result for $mode/$resolved/$check: $status" >&2
+    exit 1
+  fi
+}
+
+run_case normal committed 1 success
+cmp "$confos/output/kernel/vmlinuz" "$guest/output/vmlinuz"
+[[ $(stat -c %a "$guest/output/vmlinuz") == 644 ]]
+run_case normal changed 0 success
+[[ $(cat "$guest/kernel/config-x86_64.snapshot") == changed ]]
+run_case normal changed 1 failure
+grep -q 'resolved kernel config drifted' "$scratch/log"
+[[ $(cat "$guest/kernel/config-x86_64.snapshot") == changed ]]
+run_case no-kernel committed 1 failure
+grep -q 'confos did not produce' "$scratch/log"
+run_case no-snapshot committed 1 failure
+grep -q 'cannot capture the resolved-config snapshot' "$scratch/log"
+run_case failure committed 1 failure
+[[ ! -e "$guest/output/vmlinuz" ]]
+[[ $(cat "$guest/kernel/config-x86_64.snapshot") == committed ]]
+printf 'shared guest kernel tests passed\n'
+
+# Exercise the composite's cache probes and ownership-preserving tar commands.
+run_step() {
+  awk -v name="$1" '
+    /^    - name:/ { if (active) exit; active = ($0 == "    - name: " name) }
+    active && /^      run: \|/ { body = 1; next }
+    active && body { sub(/^        /, ""); print }
+  ' "$root/.github/actions/build-guest-kernel/action.yml" > "$scratch/step"
+  [[ -s "$scratch/step" ]]
+  (cd "$scratch" && bash -euo pipefail "$scratch/step")
+}
+export GITHUB_OUTPUT="$scratch/outputs" RUNNER_TEMP="$scratch"
+export TAR_CALLS="$scratch/tar-calls"
+mkdir -p "$scratch/bin" "$scratch/confidential-os-builder/output/kernel"
+cat > "$scratch/bin/sudo" <<'STUB'
+#!/usr/bin/env bash
+[[ "${FAIL_SUDO:-0}" == 0 ]] || exit 19
+printf '%s\n' "$*" >> "$TAR_CALLS"
+STUB
+chmod +x "$scratch/bin/sudo"
+export PATH="$scratch/bin:$PATH"
+run_step 'Check guest kernel output'
+grep -qx complete=false "$GITHUB_OUTPUT"
+touch "$scratch/confidential-os-builder/output/kernel/vmlinuz"
+: > "$GITHUB_OUTPUT"
+run_step 'Check guest kernel output'
+grep -qx complete=false "$GITHUB_OUTPUT"
+touch "$scratch/confidential-os-builder/output/kernel/manifest.json"
+: > "$GITHUB_OUTPUT"
+run_step 'Check guest kernel output'
+grep -qx complete=true "$GITHUB_OUTPUT"
+: > "$GITHUB_OUTPUT"
+run_step 'Pack kernel-builder tools tree'
+grep -qx exists=false "$GITHUB_OUTPUT"
+[[ ! -e "$TAR_CALLS" ]]
+mkdir -p "$scratch/confidential-os-builder/mkosi/kernel-builder/mkosi.output"
+touch "$scratch/confidential-os-builder/mkosi/kernel-builder/mkosi.output/.confos-tools-stamp"
+: > "$GITHUB_OUTPUT"
+run_step 'Pack kernel-builder tools tree'
+grep -qx exists=true "$GITHUB_OUTPUT"
+run_step 'Unpack kernel-builder tools tree'
+[[ $(wc -l < "$TAR_CALLS") == 2 ]]
+grep -q -- "--numeric-owner --xattrs --xattrs-include=\* -cpf" "$TAR_CALLS"
+grep -q -- "--numeric-owner --xattrs --xattrs-include=\* -xpf" "$TAR_CALLS"
+printf 'shared kernel cache tests passed\n'
+
+: > "$GITHUB_OUTPUT"
+status=0
+FAIL_SUDO=1 run_step 'Build guest kernel and check snapshot' || status=$?
+[[ "$status" == 19 && ! -s "$GITHUB_OUTPUT" ]]
+printf 'kernel staging cleanup failure stops the build\n'

--- a/.github/scripts/tests/test-repro-gate-changes.sh
+++ b/.github/scripts/tests/test-repro-gate-changes.sh
@@ -96,3 +96,9 @@ if bash "$CLASSIFIER" "$current_manifest" "$base_manifest" "$changed_paths" \
 fi
 
 echo "repro gate change-classification tests passed"
+
+for path in kata-guest-base/scripts/build-kernel.sh .github/actions/build-guest-kernel/action.yml; do
+  reset_case
+  set_paths "$path"
+  expect_result false true
+done

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Test repro-gate change classification
         run: bash .github/scripts/tests/test-repro-gate-changes.sh
 
+      - name: Test shared guest kernel build
+        run: bash .github/scripts/tests/test-build-guest-kernel.sh
+
       - name: Install actionlint (checksum-pinned)
         env:
           # SHA256 from the v1.7.12 release's checksums.txt (linux_amd64).
@@ -57,4 +60,6 @@ jobs:
             .github/scripts/repro-gate-changes \
             .github/scripts/tests/test-pin-manifest.sh \
             .github/scripts/tests/test-repro-gate-changes.sh \
-            kata-guest-base/scripts/ci/publish-release-aliases.sh
+            kata-guest-base/scripts/ci/publish-release-aliases.sh \
+            kata-guest-base/scripts/build-kernel.sh \
+            .github/scripts/tests/test-build-guest-kernel.sh

--- a/.github/workflows/kata-guest-base.yml
+++ b/.github/workflows/kata-guest-base.yml
@@ -275,32 +275,6 @@ jobs:
       - name: Install systemd-container (mkosi sandbox dep)
         run: sudo apt-get update && sudo apt-get install -y systemd-container
 
-      # restore/save split for the same reason as attestation-api above —
-      # the save must not hang off whole-job success while we stabilise the
-      # kata-guest-base build.
-      - name: Restore confos build
-        id: confos-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: confidential-os-builder/target/release/confos
-          key: ${{ runner.os }}-confos-${{ hashFiles('confidential-os-builder/Cargo.lock', 'confidential-os-builder/src/**', 'confidential-os-builder/crates/**') }}
-
-      # confos changes less often than this repo; skip the rebuild when the cached
-      # binary matches the source. (Without this gate the cache restored the
-      # binary but cargo rebuilt it anyway — its fingerprints aren't cached.)
-      - name: Build confos
-        id: build-confos
-        if: steps.confos-cache.outputs.cache-hit != 'true'
-        working-directory: confidential-os-builder
-        run: cargo build --release
-
-      - name: Save confos build
-        if: steps.confos-cache.outputs.cache-hit != 'true' && steps.build-confos.outcome == 'success'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: confidential-os-builder/target/release/confos
-          key: ${{ steps.confos-cache.outputs.cache-primary-key }}
-
       # --- Assemble + build the rootfs image ---------------------------
 
       # Set up oras BEFORE fetch.sh runs: the script's bootstrap-
@@ -412,87 +386,18 @@ jobs:
           path: ${{ runner.temp }}/kata-base-rootfs.tar.zst
           key: kata-base-rootfs-${{ env.KATA_VERSION }}-${{ hashFiles('c8s/kata-guest-base/scripts/build.sh', 'c8s/kata-guest-base/patches/*.patch') }}
 
-      # Cache the guest kernel build output (confidential-os-builder/output/kernel) — the most
-      # expensive INVARIANT in this job. build.sh Step 1/5 runs `confos kernel`,
-      # which short-circuits the compile + the mkosi tools-tree build (and the
-      # kernel-source download under output/kernel/cache/) when its
-      # manifest.json fingerprint matches the inputs (confos
-      # src/commands/kernel.rs).
-      #
-      # The resolved-config snapshot (confidential-os-builder/kernel/config-x86_64.snapshot) MUST
-      # be cached alongside: confos rewrites it during the build (committed
-      # baseline + our container.config fragment merged in) and hashes it into
-      # the fingerprint. Without it a fresh confos checkout reverts the snapshot
-      # to the committed baseline, the fingerprint never matches, and the
-      # "cached" kernel rebuilds every run — tools tree (~200s) + compile
-      # (~150s) — which is exactly what happened before the -v2 key.
-      # Bumping the version literal busts stale entries (cache keys are
-      # immutable, so an exact hit on a bad entry would skip the save forever).
-      # -v2 dropped the old snapshot-less entries; -v3 drops the incomplete
-      # ~30 KiB snapshot-only entries an unguarded always()-save once seeded
-      # when a build died mid-kernel (see the Save step's completeness guard).
-      #
-      # Key on CONFOS_REF (a different confos can yield a different kernel) + the
-      # c8s kernel config fragment; restore-keys falls back to the latest
-      # same-confos cache so even a fragment change reuses the cached
-      # kernel-source tarball. confos re-validates the fingerprint internally,
-      # so a stale restore can never yield the wrong kernel — it just rebuilds.
-      # Restore here (before build); the matching always()-save is after the
-      # build step below.
-      - name: Restore guest kernel build
-        id: kernel-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Build guest kernel
+        uses: ./c8s/.github/actions/build-guest-kernel
         with:
-          path: |
-            confidential-os-builder/output/kernel
-            confidential-os-builder/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
-          restore-keys: |
-            ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-
-
-      # Cache confos's mkosi kernel-builder tools tree (build.sh Step 1 →
-      # `confos kernel` Step 0a). The tools tree is the only part of this job
-      # that talks to snapshot.ubuntu.com — the point-in-time apt mirror
-      # pinned in confos's mkosi/kernel-builder/mkosi.conf — which 5xxes often
-      # enough to be the job's top flake source. A cache hit takes it off the
-      # network entirely: confos owns the reuse decision (it stamps
-      # mkosi.output/.confos-tools-stamp with the mkosi.conf hash and skips the
-      # `sudo mkosi --force` rebuild on a match — src/commands/kernel.rs
-      # ensure_tools_tree), so a restored tree short-circuits Step 0a and a
-      # stale one is merely rebuilt, never trusted.
-      #
-      # Like the base rootfs, the cache unit is a sudo-tar, NOT the directory:
-      # mkosi runs under sudo and leaves a root-owned tree, and actions/cache
-      # tars as the runner user, which would drop that ownership. The tarball
-      # contains mkosi.output itself (not just its contents) so the
-      # directory's own ownership/mode round-trip too — confos (running
-      # unprivileged) must still be able to manage the stamp file inside.
-      #
-      # Key: the mkosi.conf hash — the exact digest confos stamps the tree
-      # with (the snapshot mirror URL and package list are both in that file)
-      # — plus the exact mkosi ref from the manifest, because the stamp only
-      # covers the conf while the tree is built by whatever mkosi the Setup
-      # step installs. No restore-keys: a prefix match could only restore a
-      # stamp-mismatched tree that confos would rebuild anyway.
-      - name: Restore kernel-builder tools tree
-        id: tools-tree-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/confos-tools-tree.tar.zst
-          key: ${{ runner.os }}-confos-tools-tree-mkosi-${{ steps.pins.outputs.mkosi }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf') }}
-
-      - name: Unpack kernel-builder tools tree
-        if: steps.tools-tree-cache.outputs.cache-hit == 'true'
-        run: |
-          sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
-            -xpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
-            -C confidential-os-builder/mkosi/kernel-builder
+          confos-ref: ${{ steps.pins.outputs.confos }}
+          mkosi-ref: ${{ steps.pins.outputs.mkosi }}
+          check-snapshot: ${{ (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) && '1' || '0' }}
 
       # Docker/AppArmor compatibility on the persistent `the-machine` runner
       # is a provisioning invariant. CI deliberately never tears down AppArmor
       # or changes host security policy: cancellation cannot guarantee repair.
 
-      - name: Build kata-guest-base image (confos kernel + kata osbuilder)
+      - name: Build kata-guest-base image (kata osbuilder)
         working-directory: c8s/kata-guest-base
         env:
           # build.sh fetches the kata-containers source at the pinned
@@ -506,14 +411,7 @@ jobs:
           # Step 2; otherwise build.sh packs the freshly built rootfs here,
           # right after Step 2, for the Save step below.
           ROOTFS_CACHE_TAR: ${{ runner.temp }}/kata-base-rootfs.tar.zst
-          # Snapshot drift gate: on the master / release-tag publish path, make
-          # build.sh abort at Step 1 (before osbuilder + the GHCR push) if the
-          # resolved kernel config doesn't match the committed lockfile
-          # kata-guest-base/kernel/config-x86_64.snapshot. Off for
-          # workflow_dispatch (head_branch empty) so a side-branch test build of
-          # an in-flight kernel change can still publish a branch-* image before
-          # the snapshot is committed.
-          CHECK_SNAPSHOT: ${{ (github.event.workflow_run.head_branch == 'main' || startsWith(github.event.workflow_run.head_branch, 'v')) && '1' || '0' }}
+          SKIP_KERNEL: "1" # The shared kernel action already checked the snapshot.
           # Re-lay toolchain gate (values = published artifact's relay_toolchain): a runner upgrade fails preflight instead of silently shifting root_hash; re-pin on upgrade, expecting a new measurement.
           REPRO_E2FSPROGS_VERSION: "1.47.0"
           REPRO_CRYPTSETUP_VERSION: "2.7.0"
@@ -528,55 +426,7 @@ jobs:
           BUILD_NVIDIA: "1"
         run: ./scripts/build.sh
 
-      # Save the guest kernel build even when a LATER step failed — the kernel
-      # is Step 1/5 of build.sh, so an osbuilder/rootfs/publish failure (the
-      # historically flaky part) still leaves a complete output/kernel worth
-      # keeping. if: always() is the whole point: the default success()-gated
-      # post-save of the unified cache action would skip on those late failures
-      # and re-pay the ~10-min compile next run. Skip only on an exact-key hit
-      # (nothing new to store); a restore-keys-only (prefix) hit still saves
-      # under the new fragment's key.
-      #
-      # COMPLETENESS GUARD: always() also fires when the build died DURING the
-      # kernel (a Step 0a tools-tree flake or a Step 0d compile error) — but by
-      # then Step 0c.5 has already written confidential-os-builder/kernel/config-x86_64.snapshot,
-      # so an unguarded save banks a snapshot-only ~30 KiB cache with no
-      # vmlinuz/manifest. That entry then exact-hits the key forever (this save
-      # only re-runs on a miss), so every later build recompiles against a cache
-      # that can never satisfy confos's fingerprint. Only save when output/kernel
-      # is actually complete — the same existence-probe the rootfs/tools-tree
-      # saves use.
-      - name: Check guest kernel output
-        id: kernel-out
-        if: always()
-        run: |
-          if [[ -f confidential-os-builder/output/kernel/vmlinuz && -f confidential-os-builder/output/kernel/manifest.json ]]; then
-            echo "complete=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "complete=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Save guest kernel build
-        if: always() && steps.kernel-cache.outputs.cache-hit != 'true' && steps.kernel-out.outputs.complete == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          # Keep in lockstep with the Restore step: the snapshot must travel
-          # with output/kernel or confos's fingerprint check misses every run.
-          path: |
-            confidential-os-builder/output/kernel
-            confidential-os-builder/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
-
-      # Publish the resolved kernel-config snapshot build.sh wrote in Step 1
-      # (confos's required+hardening baseline + our container.config, merged) as
-      # a downloadable artifact — the runner-produced source of truth for the
-      # committed lockfile kata-guest-base/kernel/config-x86_64.snapshot and the
-      # reference a future drift gate diffs. Pulling it from the build (not the
-      # kernel cache) means it always matches THIS run's kernel; the cache can
-      # legitimately hold an earlier resolve. always() + warn: the snapshot is
-      # written early (Step 1), so it's captured even when a later
-      # osbuilder/publish step fails; a build that died before Step 1 has
-      # nothing to upload and the warn is harmless.
+      # Keep the resolved snapshot available after a later image-build failure.
       - name: Upload kernel-config snapshot
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -584,36 +434,6 @@ jobs:
           name: config-x86_64.snapshot
           path: c8s/kata-guest-base/kernel/config-x86_64.snapshot
           if-no-files-found: warn
-
-      # Pack + save the kernel-builder tools tree (see the Restore step
-      # above). The stamp file is the completeness witness: confos writes it
-      # only after a successful `mkosi --force` and wipes it before any
-      # rebuild, so stamp present ⇒ tree complete, and a Step-0a failure
-      # (e.g. snapshot.ubuntu.com 5xx mid-build) leaves nothing to save.
-      # if: always() for the usual reason — the historically flaky steps come
-      # later, and the tools tree is worth banking even when they fail. Note
-      # a kernel-cache HIT run skips Step 0a entirely and produces no tree;
-      # exists=false then skips the save, leaving the cold-build run to seed
-      # this cache.
-      - name: Pack kernel-builder tools tree
-        id: tools-tree-tar
-        if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true'
-        run: |
-          if [[ -f confidential-os-builder/mkosi/kernel-builder/mkosi.output/.confos-tools-stamp ]]; then
-            sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
-              -cpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
-              -C confidential-os-builder/mkosi/kernel-builder mkosi.output
-            echo "exists=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Save kernel-builder tools tree
-        if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true' && steps.tools-tree-tar.outputs.exists == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/confos-tools-tree.tar.zst
-          key: ${{ steps.tools-tree-cache.outputs.cache-primary-key }}
 
       # build.sh packs the tarball right after Step 2, before the later steps
       # that historically fail, so an always()-save still banks the ~4-min

--- a/.github/workflows/kernel-snapshot.yml
+++ b/.github/workflows/kernel-snapshot.yml
@@ -14,13 +14,6 @@ name: Kernel config snapshot
 #                       gate calls this, diffs the artifact against the committed
 #                       lockfile, and fails on drift.
 #
-# DUPLICATION (deliberate, temporary): the confos setup + cache steps below
-# mirror kata-guest-base.yml. The two SHARE cache keys (confos build, mkosi
-# tools tree, the kata-kernel-v3 kernel cache), so a run here warms the cache
-# kata-guest-base uses and vice-versa. The end state is kata-guest-base.yml
-# calling this workflow for its kernel (vmlinuz as an artifact + SKIP_KERNEL=1),
-# which removes the duplication — deferred to its own PR so the production
-# measured-boot image build isn't refactored here.
 
 on:
   workflow_dispatch:
@@ -53,7 +46,7 @@ jobs:
     # a user-namespaced GitHub-hosted runner.
     runs-on: the-machine
     outputs:
-      snapshot_sha256: ${{ steps.snapshot.outputs.sha256 }}
+      snapshot_sha256: ${{ steps.kernel.outputs.snapshot-sha256 }}
     steps:
       # c8s -> ./c8s and confidential-os-builder -> ./confidential-os-builder,
       # mirroring kata-guest-base.yml so the cache keys (which hashFiles these
@@ -103,77 +96,12 @@ jobs:
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
 
-      # --- confos binary (shared cache with kata-guest-base.yml) --------------
-      - name: Restore confos build
-        id: confos-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Build guest kernel
+        id: kernel
+        uses: ./c8s/.github/actions/build-guest-kernel
         with:
-          path: confidential-os-builder/target/release/confos
-          key: ${{ runner.os }}-confos-${{ hashFiles('confidential-os-builder/Cargo.lock', 'confidential-os-builder/src/**', 'confidential-os-builder/crates/**') }}
-
-      - name: Build confos
-        id: build-confos
-        if: steps.confos-cache.outputs.cache-hit != 'true'
-        working-directory: confidential-os-builder
-        run: cargo build --release
-
-      - name: Save confos build
-        if: steps.confos-cache.outputs.cache-hit != 'true' && steps.build-confos.outcome == 'success'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: confidential-os-builder/target/release/confos
-          key: ${{ steps.confos-cache.outputs.cache-primary-key }}
-
-      # --- mkosi kernel-builder tools tree (shared cache; the 58-min part) ---
-      # Hit here means Step 0a short-circuits (confos checks its .confos-tools-stamp
-      # against the mkosi.conf hash). See kata-guest-base.yml for the full rationale.
-      - name: Restore kernel-builder tools tree
-        id: tools-tree-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/confos-tools-tree.tar.zst
-          key: ${{ runner.os }}-confos-tools-tree-mkosi-${{ steps.pins.outputs.mkosi }}-${{ hashFiles('confidential-os-builder/mkosi/kernel-builder/mkosi.conf') }}
-
-      - name: Unpack kernel-builder tools tree
-        if: steps.tools-tree-cache.outputs.cache-hit == 'true'
-        run: |
-          sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
-            -xpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
-            -C confidential-os-builder/mkosi/kernel-builder
-
-      # --- guest kernel output (shared kata-kernel-v3 cache) ----------------
-      - name: Restore guest kernel build
-        id: kernel-cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            confidential-os-builder/output/kernel
-            confidential-os-builder/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}
-          restore-keys: |
-            ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-
-
-      # Resolve + compile the kernel and capture the snapshot. Mirrors
-      # build.sh Step 1 (`cd confidential-os-builder && confos kernel --kernel-config-fragment
-      # <c8s fragment>`), then copies confos's resolved snapshot to the in-repo
-      # path build.sh writes it to, so the uploaded artifact is identical to
-      # what a full kata-guest-base build would commit. confos escalates to sudo
-      # internally for mkosi/nspawn, exactly as under build.sh.
-      - name: Build confos kernel + capture snapshot
-        id: snapshot
-        run: |
-          set -euo pipefail
-          frag="${GITHUB_WORKSPACE}/c8s/kata-guest-base/kernel/container.config"
-          [[ -f "${frag}" ]] || { echo "::error::kernel fragment missing: ${frag}"; exit 1; }
-          [[ -x confidential-os-builder/target/release/confos ]] || { echo "::error::confos binary missing"; exit 1; }
-          ( cd confidential-os-builder && ./target/release/confos kernel --kernel-config-fragment "${frag}" )
-          src="confidential-os-builder/kernel/config-x86_64.snapshot"
-          [[ -f "${src}" ]] || { echo "::error::confos did not write ${src}"; exit 1; }
-          dest="c8s/kata-guest-base/kernel/config-x86_64.snapshot"
-          install -m 0644 "${src}" "${dest}"
-          sha="$(sha256sum "${dest}" | awk '{print $1}')"
-          echo "sha256=${sha}" >> "${GITHUB_OUTPUT}"
-          echo "resolved kernel-config snapshot sha256: ${sha}"
+          confos-ref: ${{ steps.pins.outputs.confos }}
+          mkosi-ref: ${{ steps.pins.outputs.mkosi }}
 
       - name: Upload kernel-config snapshot
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -182,45 +110,3 @@ jobs:
           path: c8s/kata-guest-base/kernel/config-x86_64.snapshot
           if-no-files-found: error
           overwrite: true
-
-      # --- bank the caches (shared keys + the completeness guard) ------------
-      - name: Pack kernel-builder tools tree
-        id: tools-tree-tar
-        if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true'
-        run: |
-          if [[ -f confidential-os-builder/mkosi/kernel-builder/mkosi.output/.confos-tools-stamp ]]; then
-            sudo tar --zstd --numeric-owner --xattrs --xattrs-include='*' \
-              -cpf "${RUNNER_TEMP}/confos-tools-tree.tar.zst" \
-              -C confidential-os-builder/mkosi/kernel-builder mkosi.output
-            echo "exists=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "exists=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Save kernel-builder tools tree
-        if: always() && steps.tools-tree-cache.outputs.cache-hit != 'true' && steps.tools-tree-tar.outputs.exists == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ runner.temp }}/confos-tools-tree.tar.zst
-          key: ${{ steps.tools-tree-cache.outputs.cache-primary-key }}
-
-      # Same completeness guard as kata-guest-base.yml: never bank a kernel
-      # cache without vmlinuz + manifest, or it poisons the shared key.
-      - name: Check guest kernel output
-        id: kernel-out
-        if: always()
-        run: |
-          if [[ -f confidential-os-builder/output/kernel/vmlinuz && -f confidential-os-builder/output/kernel/manifest.json ]]; then
-            echo "complete=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "complete=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Save guest kernel build
-        if: always() && steps.kernel-cache.outputs.cache-hit != 'true' && steps.kernel-out.outputs.complete == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            confidential-os-builder/output/kernel
-            confidential-os-builder/kernel/config-x86_64.snapshot
-          key: ${{ runner.os }}-kata-kernel-v3-${{ steps.pins.outputs.confos }}-${{ hashFiles('c8s/kata-guest-base/kernel/container.config') }}

--- a/kata-guest-base/scripts/build-kernel.sh
+++ b/kata-guest-base/scripts/build-kernel.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Build the guest kernel and capture its resolved config before checking drift.
+set -euo pipefail
+
+CONFOS_DIR="$(realpath "${1:?confos checkout required}")"
+IMAGE_DIR="$(realpath "${2:?guest image directory required}")"
+KERNEL_FRAGMENT="${IMAGE_DIR}/kernel/container.config"
+KERNEL_SNAPSHOT="${IMAGE_DIR}/kernel/config-x86_64.snapshot"
+CONFOS_SNAPSHOT="${CONFOS_DIR}/kernel/config-x86_64.snapshot"
+VMLINUZ_OUT="${3:-${IMAGE_DIR}/output}/vmlinuz"
+die() { echo "FATAL: $*" >&2; exit 1; }
+[[ -f "$KERNEL_FRAGMENT" ]] || die "kernel fragment missing: $KERNEL_FRAGMENT"
+mkdir -p "$(dirname "$VMLINUZ_OUT")"
+
+[[ -d "${CONFOS_DIR}" ]] || die "confos checkout not found at ${CONFOS_DIR} (set CONFOS_DIR)."
+CONFOS_BIN="${CONFOS_BIN:-${CONFOS_DIR}/target/release/confos}"
+if [[ ! -x "${CONFOS_BIN}" ]]; then
+    echo "    building confos (cargo build --release)"
+    ( cd "${CONFOS_DIR}" && cargo build --release )
+fi
+( cd "${CONFOS_DIR}" && "${CONFOS_BIN}" kernel \
+    --kernel-config-fragment "${KERNEL_FRAGMENT}" )
+CONFOS_VMLINUZ="${CONFOS_DIR}/output/kernel/vmlinuz"
+[[ -f "${CONFOS_VMLINUZ}" ]] || die "confos did not produce ${CONFOS_VMLINUZ}"
+install -m 0644 "${CONFOS_VMLINUZ}" "${VMLINUZ_OUT}"
+
+[[ -f "${CONFOS_SNAPSHOT}" ]] || die "confos did not produce ${CONFOS_SNAPSHOT} — cannot capture the resolved-config snapshot."
+snapshot_drift=0
+if [[ -f "${KERNEL_SNAPSHOT}" ]] && ! cmp -s "${CONFOS_SNAPSHOT}" "${KERNEL_SNAPSHOT}"; then
+    snapshot_drift=1
+    committed_sha="$(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}')"
+fi
+install -m 0644 "${CONFOS_SNAPSHOT}" "${KERNEL_SNAPSHOT}"
+echo "    snapshot: ${KERNEL_SNAPSHOT} (sha256 $(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}'))"
+if [[ "${CHECK_SNAPSHOT:-0}" == "1" && "${snapshot_drift}" == "1" ]]; then
+    die "resolved kernel config drifted from the committed snapshot.
+   committed ${KERNEL_SNAPSHOT}: ${committed_sha}
+   resolved  (this build):       $(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}')
+   confos's baseline (CONFOS_REF) or kernel/container.config changed without
+   re-committing kata-guest-base/kernel/config-x86_64.snapshot. Re-resolve and
+   commit it (run the 'Kernel config snapshot' workflow, or a local build), or
+   revert the change that moved it. Failing before osbuilder + the GHCR push."
+fi

--- a/kata-guest-base/scripts/build.sh
+++ b/kata-guest-base/scripts/build.sh
@@ -156,11 +156,8 @@ KATA_NVIDIA_VMLINUZ="${KATA_NVIDIA_VMLINUZ:-/opt/kata/share/kata-containers/vmli
 # snapshot into this repo (KERNEL_SNAPSHOT), committed, so any drift is
 # reviewable in git. See README.md "Build" + container.config header.
 KERNEL_FRAGMENT="${IMAGE_DIR}/kernel/container.config"
-# Resolved-config lockfile: confos writes CONFOS_SNAPSHOT during the kernel
-# build; Step 1 copies it to KERNEL_SNAPSHOT (tracked in git) for drift
-# detection. Not read by the build.
+# Resolved-config lockfile captured and checked by build-kernel.sh.
 KERNEL_SNAPSHOT="${IMAGE_DIR}/kernel/config-x86_64.snapshot"
-CONFOS_SNAPSHOT="${CONFOS_DIR}/kernel/config-x86_64.snapshot"
 
 log() { printf '\n=== %s ===\n' "$*"; }
 die() { echo "FATAL: $*" >&2; exit 1; }
@@ -254,56 +251,7 @@ VMLINUZ_OUT="${OUTPUT_DIR}/vmlinuz"
 if [[ "${SKIP_KERNEL:-0}" == "1" && -f "${VMLINUZ_OUT}" ]]; then
     log "Step 1/5: reusing existing kernel (SKIP_KERNEL=1): ${VMLINUZ_OUT}"
 else
-    log "Step 1/5: building hardened kernel with confos"
-    [[ -d "${CONFOS_DIR}" ]] || die "confos checkout not found at ${CONFOS_DIR} (set CONFOS_DIR)."
-    CONFOS_BIN="${CONFOS_BIN:-${CONFOS_DIR}/target/release/confos}"
-    if [[ ! -x "${CONFOS_BIN}" ]]; then
-        echo "    building confos (cargo build --release)"
-        ( cd "${CONFOS_DIR}" && cargo build --release )
-    fi
-    # confos writes output/kernel/vmlinuz relative to its own dir. confos
-    # resolves its config snapshot internally (fixed kernel/config-x86_64.snapshot
-    # in the confos tree, auto-updated each build), so we pass only the fragment —
-    # the old --kernel-snapshot flag no longer exists.
-    ( cd "${CONFOS_DIR}" && "${CONFOS_BIN}" kernel \
-        --kernel-config-fragment "${KERNEL_FRAGMENT}" )
-    CONFOS_VMLINUZ="${CONFOS_DIR}/output/kernel/vmlinuz"
-    [[ -f "${CONFOS_VMLINUZ}" ]] || die "confos did not produce ${CONFOS_VMLINUZ}"
-    install -m 0644 "${CONFOS_VMLINUZ}" "${VMLINUZ_OUT}"
-
-    # Capture the resolved-config snapshot confos just wrote (baseline +
-    # our container.config, merged). confos keeps it in its own tree where
-    # it gets overwritten/discarded; copy it next to the fragment in THIS
-    # repo so the merged config is committed and reviewable — this is how a
-    # change in confos's kernel base that affects our guest kernel becomes
-    # visible here. Not a build input. (SKIP_KERNEL reuses an existing
-    # vmlinuz without re-resolving, so it intentionally leaves the
-    # committed snapshot untouched.)
-    [[ -f "${CONFOS_SNAPSHOT}" ]] || die "confos did not produce ${CONFOS_SNAPSHOT} — cannot capture the resolved-config snapshot."
-    # Drift gate: compare the freshly-resolved config against the committed
-    # lockfile BEFORE overwriting it. CHECK_SNAPSHOT=1 (set by CI on the
-    # publish path) makes a mismatch fatal HERE — at Step 1, before osbuilder
-    # (Steps 2-5) and the GHCR push — so a guest image whose kernel config
-    # drifted from what's committed/reviewed never gets built or published.
-    # Local builds leave CHECK_SNAPSHOT unset and just refresh the lockfile.
-    snapshot_drift=0
-    if [[ -f "${KERNEL_SNAPSHOT}" ]] && ! cmp -s "${CONFOS_SNAPSHOT}" "${KERNEL_SNAPSHOT}"; then
-        snapshot_drift=1
-        committed_sha="$(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}')"
-    fi
-    # Copy regardless (so the uploaded artifact reflects what THIS build
-    # resolved, even on a gate failure) — then enforce.
-    install -m 0644 "${CONFOS_SNAPSHOT}" "${KERNEL_SNAPSHOT}"
-    echo "    snapshot: ${KERNEL_SNAPSHOT} (sha256 $(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}'))"
-    if [[ "${CHECK_SNAPSHOT:-0}" == "1" && "${snapshot_drift}" == "1" ]]; then
-        die "resolved kernel config drifted from the committed snapshot.
-       committed ${KERNEL_SNAPSHOT}: ${committed_sha}
-       resolved  (this build):       $(sha256sum "${KERNEL_SNAPSHOT}" | awk '{print $1}')
-   confos's baseline (CONFOS_REF) or kernel/container.config changed without
-   re-committing kata-guest-base/kernel/config-x86_64.snapshot. Re-resolve and
-   commit it (run the 'Kernel config snapshot' workflow, or a local build), or
-   revert the change that moved it. Failing before osbuilder + the GHCR push."
-    fi
+    bash "${HERE}/build-kernel.sh" "${CONFOS_DIR}" "${IMAGE_DIR}" "${OUTPUT_DIR}"
 fi
 echo "    kernel: ${VMLINUZ_OUT}"
 


### PR DESCRIPTION
The Kata image and kernel snapshot workflows maintained separate kernel build and cache steps. Both now use one composite action and the same snapshot validation script as local builds.

- Consolidate confos compilation and kernel/tools-tree cache restoration and saving.
- Validate snapshot drift before Kata consumes the prepared kernel, retaining the resolved snapshot on rejection.
- Save complete caches immediately after the kernel phase so later rootfs failures retain them.
- Preserve existing cache keys, fallback keys, completeness guards, archive ownership flags, and workflow triggers and permissions.
- Add shell tests for build failures and cache probes and trigger the repro gate for changes to the shared action or script.

Review focus: snapshot validation before rootfs construction, persistent-runner output cleanup, and cache compatibility across both callers.

Validation: all workflows pass actionlint with the existing CI exclusions; changed scripts pass ShellCheck; pin-manifest, repro-gate classification, and shared kernel shell tests pass; composite shell steps and expressions were linted through a temporary workflow wrapper; git diff --check passes. Full kernel/image builds require CI on the self-hosted runner and were not run locally.

Size: 180 fewer production lines (30 fewer excluding comments and blank lines), and 73 fewer lines overall including tests; production churn is 548 lines, above the initial estimate largely because obsolete duplicated comments were removed.
