### PR TITLE
fix(cds): wait for the attestation API instead of exiting when its socket is absent

### DIFF
--- a/pkg/workloadclaims/digests.go
+++ b/pkg/workloadclaims/digests.go
@@ -11,21 +11,24 @@ package workloadclaims
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"net"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
 	"crypto/ecdsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"fmt"
-	"io"
+	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
 
 // DigestsPort is the port every inventory serves its digests endpoint on, and
@@ -260,9 +263,9 @@ func NewDigestsClient(ctx context.Context, platform string, attestFunc func(ctx 
 	if err != nil {
 		return nil, fmt.Errorf("workloadclaims: build sandbox-digests client: %w", err)
 	}
-	warmupCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	warmupCtx, cancel := context.WithTimeout(ctx, warmUpBudget)
 	defer cancel()
-	if err := certMgr.WarmUp(warmupCtx); err != nil {
+	if err := warmUpCert(warmupCtx, certMgr); err != nil {
 		return nil, fmt.Errorf("workloadclaims: warm up sandbox-digests client cert: %w", err)
 	}
 	if timeout <= 0 {
@@ -285,6 +288,57 @@ func NewDigestsClient(ctx context.Context, platform string, attestFunc func(ctx 
 		},
 		timeout: timeout,
 	}, nil
+}
+
+const (
+	// Budget for provisioning the client certificate at startup.
+	warmUpBudget = 30 * time.Second
+	// Gap between attempts. The attestation API is reached over a DaemonSet's
+	// Unix socket, so the common failure is "not there yet" rather than "slow".
+	warmUpInterval = time.Second
+)
+
+// certWarmer is the slice of ratls.CertManager this needs, so the retry can be
+// tested without provisioning a real certificate.
+type certWarmer interface {
+	WarmUp(context.Context) error
+}
+
+// peerNotUpYet reports whether err means the attestation API is not listening
+// yet, as opposed to answering and refusing. Only the former is worth waiting
+// on: a live peer that rejects us is a real failure and must fail closed.
+func peerNotUpYet(err error) bool {
+	return errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// warmUpCert retries only while the attestation API has not come up, returning
+// the last failure once ctx's budget is spent.
+//
+// A single attempt is not enough: the attestation API lives on a DaemonSet
+// socket that may not exist yet when CDS starts, and lstat on a missing socket
+// fails instantly. One attempt therefore leaves the whole budget unspent and
+// aborts startup for a peer that is usually seconds away. That is expensive
+// because the allowlist is not persistent, so CDS exiting here drops every
+// operator-added digest on restart.
+//
+// Anything else returns immediately, so a peer that answers and refuses still
+// fails closed at once rather than after the budget. WarmUp caches on success,
+// so the repeated calls cost nothing once provisioning lands.
+func warmUpCert(ctx context.Context, w certWarmer) error {
+	for {
+		err := w.WarmUp(ctx)
+		if err == nil {
+			return nil
+		}
+		if !peerNotUpYet(err) {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(warmUpInterval):
+		}
+	}
 }
 
 // ErrSandboxUnknown reports that the inventory does not know the sandbox — it

--- a/pkg/workloadclaims/warmup_test.go
+++ b/pkg/workloadclaims/warmup_test.go
@@ -1,0 +1,121 @@
+package workloadclaims
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/confidential-dot-ai/c8s/pkg/attestclient"
+)
+
+// fakeWarmer fails the first failures calls, then succeeds, counting every call.
+type fakeWarmer struct {
+	failures int
+	calls    int
+	err      error
+}
+
+func (f *fakeWarmer) WarmUp(context.Context) error {
+	f.calls++
+	if f.calls <= f.failures {
+		return f.err
+	}
+	return nil
+}
+
+func TestWarmUpCertRetriesPastATransientFailure(t *testing.T) {
+	// The real trigger: the attestation-api socket does not exist yet, which
+	// fails instantly, so the old single attempt aborted CDS startup.
+	w := &fakeWarmer{failures: 3, err: fs.ErrNotExist}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*warmUpInterval)
+	defer cancel()
+
+	if err := warmUpCert(ctx, w); err != nil {
+		t.Fatalf("want success once the socket appears, got %v", err)
+	}
+	if w.calls != 4 {
+		t.Fatalf("want 4 calls (3 failures then success), got %d", w.calls)
+	}
+}
+
+func TestWarmUpCertSucceedsWithoutRetryingWhenTheSocketIsReady(t *testing.T) {
+	w := &fakeWarmer{}
+	if err := warmUpCert(context.Background(), w); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if w.calls != 1 {
+		t.Fatalf("a ready peer must cost exactly one call, got %d", w.calls)
+	}
+}
+
+func TestWarmUpCertGivesUpWhenTheBudgetIsSpent(t *testing.T) {
+	// Never succeeds: the call must return rather than block forever, and must
+	// surface the provisioning failure, not a bare context error.
+	sentinel := fs.ErrNotExist
+	w := &fakeWarmer{failures: 1 << 30, err: sentinel}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*warmUpInterval)
+	defer cancel()
+
+	start := time.Now()
+	err := warmUpCert(ctx, w)
+	if err == nil {
+		t.Fatal("want failure once the budget is spent")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("want the provisioning failure surfaced, got %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 30*warmUpInterval {
+		t.Fatalf("gave up far too late: %v", elapsed)
+	}
+	if w.calls < 2 {
+		t.Fatalf("want more than one attempt inside the budget, got %d", w.calls)
+	}
+}
+
+// A live peer that answers and refuses must fail closed immediately, not after
+// the budget: this is the invariant TestRun_RATLSWarmupFailureFailsClosed
+// encodes, and the reason the retry cannot be unconditional.
+func TestWarmUpCertDoesNotRetryARefusingPeer(t *testing.T) {
+	w := &fakeWarmer{failures: 1 << 30, err: errors.New("API error (500): no evidence for you")}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*warmUpInterval)
+	defer cancel()
+
+	start := time.Now()
+	if err := warmUpCert(ctx, w); err == nil {
+		t.Fatal("want failure")
+	}
+	if w.calls != 1 {
+		t.Fatalf("a refusing peer must cost exactly one attempt, got %d", w.calls)
+	}
+	if elapsed := time.Since(start); elapsed >= warmUpInterval {
+		t.Fatalf("returned after %v, want immediately", elapsed)
+	}
+}
+
+// The retry predicate reads an error produced by the real code path, not one
+// hand-built here: if any wrapper between the lstat and warmUpCert stops using
+// %w, this fails rather than the retry silently never firing again.
+func TestPeerNotUpYetMatchesARealMissingSocketError(t *testing.T) {
+	missing := "unix://" + t.TempDir() + "/attestation-api.sock"
+
+	_, err := attestclient.MakeSNPRATLSAttestFunc(attestclient.NewClient(""), missing)(
+		context.Background(), hexReportData())
+	if err == nil {
+		t.Fatal("want an error for a socket that does not exist")
+	}
+	if !peerNotUpYet(err) {
+		t.Fatalf("peerNotUpYet must recognise a missing verifier socket; chain was: %v", err)
+	}
+}
+
+// MakeSNPRATLSAttestFunc hex-decodes customData and slices 48 bytes off it.
+func hexReportData() string {
+	const b = "ab"
+	out := ""
+	for i := 0; i < 48; i++ {
+		out += b
+	}
+	return out
+}


### PR DESCRIPTION
CDS exits at startup when the attestation API is not listening yet:

```
workloadclaims: warm up sandbox-digests client cert: ratls: provision certificate:
ratls: get attestation: attestation-api: HTTP request failed: Post "http://unix/attest":
attestationclient: stat verifier socket "/var/run/nri-image-policy/attestation-api.sock":
no such file or directory
```

The warm-up already carries a 30s budget, but it makes a single attempt, and `lstat` on a socket that does not exist yet fails instantly rather than slowly. The whole budget goes unspent and startup aborts for a peer that is usually seconds away.

Exiting is expensive here, and CDS says so itself on the line above:

> allowlist store is not persistent (cds.persistence.enabled=false): a restart resets the served allowlist to the install seed and regenerates the mesh CA. Operator-added digests do not survive

Observed on the azure-snp lane: CDS crashed at 08:47:22, the allowlist step wrote its digests into the restart window and got `connection refused`, and the workload was then denied with `image not in allowlist: nginxinc/nginx-unprivileged@sha256:65e3e85…`.

The retry is deliberately narrow: it waits only while the peer is not up (`fs.ErrNotExist` or `ECONNREFUSED`). A peer that answers and refuses still fails closed on the first attempt. That distinction is not cosmetic — my first version retried unconditionally and broke `TestRun_RATLSWarmupFailureFailsClosed`, which exists precisely to assert a refusing attestation API aborts startup. That test is how I found the line, and it passes in 0.6s here rather than after the budget.

One test is worth calling out. `TestPeerNotUpYetMatchesARealMissingSocketError` drives the real code path with a `unix://` URL to a nonexistent socket and asserts the predicate matches the resulting error, rather than hand-building the error in the test. The predicate depends on five wrappers between the `lstat` and here all using `%w`; if any stops, that test fails instead of the retry silently never firing again.

Not covered: the budget stays at 30s. On a cold node where the attestation-api DaemonSet still has to pull its image, that may not be enough, and CDS will exit as before. Raising it is a separate judgement about how long startup should block, which I did not want to bundle in.

Also related but not addressed: #243 is a different race in the same area (the plugin's birth-time floor denying the new CDS image during a single-phase upgrade).
