### PR TITLE
refactor(allowlist): one Index for the bootstrap admission layers

### DIFF
--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
 	"slices"
 	"sync"
@@ -48,20 +49,17 @@ type policySnapshot struct {
 // The always_allow digests are checked ahead of every snapshot, so a failed or
 // withheld pull never drops them.
 type policyStore struct {
-	alwaysAllow map[string]struct{} // canonical digests admitted by digest alone
+	alwaysAllow *allowlist.Index // digests admitted by digest alone
 	snap        atomic.Pointer[policySnapshot]
 }
 
 // newPolicyStore seeds the store with an empty snapshot (version 0) so admission
 // enforces always_allow alone before the first pull lands and after any pull
-// failure.
+// failure. Config validation has already rejected a malformed digest, so
+// DigestIndex's warnings cannot fire here.
 func newPolicyStore(alwaysAllow map[string]string) *policyStore {
-	s := &policyStore{alwaysAllow: make(map[string]struct{}, len(alwaysAllow))}
-	for d := range alwaysAllow {
-		if pd, err := types.ParseDigest(d); err == nil {
-			s.alwaysAllow[pd.String()] = struct{}{}
-		}
-	}
+	idx, _ := allowlist.DigestIndex(slices.Collect(maps.Keys(alwaysAllow)))
+	s := &policyStore{alwaysAllow: idx}
 	s.snap.Store(&policySnapshot{index: (&allowlist.Allowlist{}).BuildIndex()})
 	return s
 }
@@ -78,12 +76,7 @@ func (s *policyStore) alwaysAllows(digest string) bool {
 	if s == nil {
 		return false
 	}
-	pd, err := types.ParseDigest(digest)
-	if err != nil {
-		return false
-	}
-	_, ok := s.alwaysAllow[pd.String()]
-	return ok
+	return s.alwaysAllow.AdmitsDigest(digest)
 }
 
 // apply installs the pulled document at version, unless version is below the

--- a/internal/cmds/nri-image-policy/refresh_test.go
+++ b/internal/cmds/nri-image-policy/refresh_test.go
@@ -64,7 +64,7 @@ func canonicalBody(t *testing.T, al *allowlist.Allowlist) []byte {
 // the served index.
 func admitsDigest(store *policyStore, digest string) bool {
 	snap := store.current()
-	return store.alwaysAllows(digest) || (snap != nil && snap.index != nil && snap.index.AdmitsDigest(digest))
+	return store.alwaysAllows(digest) || (snap != nil && snap.index.AdmitsDigest(digest))
 }
 
 func TestStartupSourceMode(t *testing.T) {

--- a/internal/cmds/policymonitor/allowlist.go
+++ b/internal/cmds/policymonitor/allowlist.go
@@ -20,18 +20,12 @@ package policymonitor
 // is the baked seed UNION the latest served document. See
 // docs/kata-image-policy.md.
 //
-// Match semantics:
-//
-//   - Allowlist entries are normalised to bare 64-hex strings (no
-//     "sha256:" prefix, lowercased) at load time.
-//   - On lookup, the candidate digest is normalised the same way before
-//     comparison. Anything that doesn't normalise to 64 hex chars is
-//     treated as "no digest available" and the container is denied.
-//   - The match is exact-equality. We do not try to be clever about
-//     image-tag aliases (no registry-side digest resolution) — the
-//     point of post-attestation enforcement is "the bytes you measured
-//     are the bytes you ran", and digest equality is the only honest
-//     definition of that.
+// Match semantics: the seed is an allowlist.Index built by DigestIndex, which
+// admits each entry whatever it runs. The match is exact digest equality. We do
+// not try to be clever about image-tag aliases (no registry-side digest
+// resolution) — the point of post-attestation enforcement is "the bytes you
+// measured are the bytes you ran", and digest equality is the only honest
+// definition of that.
 
 import (
 	"encoding/json"
@@ -39,20 +33,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/confidential-dot-ai/c8s/pkg/types"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
-
-// allowlist holds the parsed, normalised set of permitted digests. The
-// zero value is empty; deny everything in that case (load returns an
-// error on empty input so the daemon never enters a permissive state
-// silently — operators get a clear startup failure instead).
-//
-// It is written once by loadAllowlist and only read after that, so
-// per-container decision goroutines share it without a lock.
-type allowlist struct {
-	// digests is the set of bare hex strings (no "sha256:" prefix).
-	digests map[string]struct{}
-}
 
 // bootstrapAllowlistFile is the on-disk JSON shape. Fields that aren't
 // recognised by this parser (e.g. `_comment`) are silently ignored by
@@ -62,8 +44,8 @@ type bootstrapAllowlistFile struct {
 	Sha256Digests []string `json:"sha256_digests"`
 }
 
-// loadAllowlist parses the on-disk JSON allowlist and returns a ready-
-// to-use *allowlist. Returns a non-nil error when:
+// loadAllowlist parses the on-disk JSON allowlist and returns the seed index.
+// Returns a non-nil error when:
 //   - the file cannot be opened (most likely cause: IGVM build defect);
 //   - the JSON is malformed;
 //   - the file contains no entries at all (we refuse to start with an
@@ -75,7 +57,10 @@ type bootstrapAllowlistFile struct {
 // entry, because the threat model favours "best-effort enforcement
 // with some allowlisted images" over "no enforcement because one
 // digest had a typo".
-func loadAllowlist(path string) (*allowlist, []error, error) {
+//
+// The returned index is written once here and only read after that, so
+// per-container decision goroutines share it without a lock.
+func loadAllowlist(path string) (*allowlist.Index, []error, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read allowlist %s: %w", path, err)
@@ -86,51 +71,9 @@ func loadAllowlist(path string) (*allowlist, []error, error) {
 		return nil, nil, fmt.Errorf("parse allowlist %s: %w", path, err)
 	}
 
-	a := &allowlist{digests: make(map[string]struct{}, len(file.Sha256Digests))}
-	var warnings []error
-	for _, d := range file.Sha256Digests {
-		norm, err := normalizeDigest(d)
-		if err != nil {
-			warnings = append(warnings, fmt.Errorf("skip allowlist entry %q: %w", d, err))
-			continue
-		}
-		a.digests[norm] = struct{}{}
-	}
-
-	if len(a.digests) == 0 {
+	seed, warnings := allowlist.DigestIndex(file.Sha256Digests)
+	if seed.Size() == 0 {
 		return nil, warnings, errors.New("allowlist contains no valid digests; refusing to start (bake-time defect)")
 	}
-	return a, warnings, nil
-}
-
-// Contains reports whether digest (in any of the accepted formats) is on
-// the allowlist. Returns false on any malformed or empty input — the
-// caller treats that as "not allowlisted" and proceeds to kill.
-func (a *allowlist) Contains(digest string) bool {
-	if a == nil {
-		return false
-	}
-	norm, err := normalizeDigest(digest)
-	if err != nil {
-		return false
-	}
-	_, ok := a.digests[norm]
-	return ok
-}
-
-// Size returns the number of accepted entries, for the startup and refresh
-// logs.
-func (a *allowlist) Size() int {
-	if a == nil {
-		return 0
-	}
-	return len(a.digests)
-}
-
-// normalizeDigest takes any of the forms we see in the wild
-// (types.NormalizeDigest) and returns the bare 64-hex string — this
-// package's allowlist map keys carry no "sha256:" prefix.
-func normalizeDigest(s string) (string, error) {
-	d, err := types.NormalizeDigest(s)
-	return d.Hex(), err
+	return seed, warnings, nil
 }

--- a/internal/cmds/policymonitor/allowlist_test.go
+++ b/internal/cmds/policymonitor/allowlist_test.go
@@ -38,11 +38,11 @@ func TestLoadAllowlist_HappyPath(t *testing.T) {
 	if a.Size() != 2 {
 		t.Fatalf("Size = %d, want 2", a.Size())
 	}
-	if !a.Contains("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+	if !a.AdmitsDigest("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
 		t.Fatal("missing first digest")
 	}
 	// Case-insensitive match: input upper-case, allowlist normalises to lower.
-	if !a.Contains("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") {
+	if !a.AdmitsDigest("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb") {
 		t.Fatal("missing second digest (case-insensitive)")
 	}
 }
@@ -90,35 +90,13 @@ func TestLoadAllowlist_MissingFile(t *testing.T) {
 	}
 }
 
-// The accepted input forms are pinned by pkg/types; this only asserts the
-// package's map-key contract — bare hex out, errors passed through.
-func TestNormalizeDigestReturnsBareHex(t *testing.T) {
-	hex := strings.Repeat("a", 64)
-	if got, err := normalizeDigest("sha256:" + hex); err != nil || got != hex {
-		t.Fatalf("normalizeDigest = %q, %v; want the bare hex", got, err)
-	}
-	if _, err := normalizeDigest("ghcr.io/confidential-dot-ai/assam:v1.0.0"); err == nil {
-		t.Fatal("a tag-only reference was accepted")
-	}
-}
-
-func TestAllowlistNilReceivers(t *testing.T) {
-	var a *allowlist
-	if a.Contains("sha256:" + strings.Repeat("a", 64)) {
-		t.Error("nil allowlist Contains should be false")
-	}
-	if a.Size() != 0 {
-		t.Error("nil allowlist Size should be 0")
-	}
-}
-
-func TestAllowlistContains_Malformed(t *testing.T) {
+func TestSeedAdmitsDigest_Malformed(t *testing.T) {
 	a := newSeededAllowlist(t, "sha256:"+strings.Repeat("a", 64))
-	if a.Contains("garbage") {
-		t.Error("Contains should be false for malformed input")
+	if a.AdmitsDigest("garbage") {
+		t.Error("AdmitsDigest should be false for malformed input")
 	}
-	if a.Contains("") {
-		t.Error("Contains should be false for empty input")
+	if a.AdmitsDigest("") {
+		t.Error("AdmitsDigest should be false for empty input")
 	}
 }
 

--- a/internal/cmds/policymonitor/cds_refresh.go
+++ b/internal/cmds/policymonitor/cds_refresh.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
 	"github.com/confidential-dot-ai/c8s/pkg/ratls"
 )
@@ -36,7 +37,7 @@ import (
 // until ctx is cancelled. Construction failures (bad measurements, RA-TLS
 // setup) disable refresh but never crash the monitor — the baked seed
 // still enforces.
-func runAllowlistRefresh(ctx context.Context, logger *slog.Logger, cfg *Config, a *allowlist, overlay *policyOverlay, state *refreshState) {
+func runAllowlistRefresh(ctx context.Context, logger *slog.Logger, cfg *Config, a *allowlist.Index, overlay *policyOverlay, state *refreshState) {
 	measurements, err := ratls.ParseHexMeasurementsList(splitCSV(cfg.CDSMeasurements))
 	if err != nil {
 		disableRefresh(logger, state, reasonBadMeasurements, a, "error", err)
@@ -116,7 +117,7 @@ const refreshCallTimeoutMax = 15 * time.Second
 // disableRefresh records why the refresh will not run and says so at ERROR,
 // naming the frozen entry count so the line states the blast radius rather than
 // only the cause.
-func disableRefresh(logger *slog.Logger, state *refreshState, reason string, a *allowlist, args ...any) {
+func disableRefresh(logger *slog.Logger, state *refreshState, reason string, a *allowlist.Index, args ...any) {
 	state.disable(reason)
 	// Terminal, so the seed is the final answer: settling here keeps a guest
 	// that will never refresh from making every deny serve out the budget.

--- a/internal/cmds/policymonitor/cds_refresh_test.go
+++ b/internal/cmds/policymonitor/cds_refresh_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/allowlistclient"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
@@ -22,19 +22,19 @@ import (
 
 // anyAllowlist builds an allowlist with one any-argv entry per digest, named
 // "w-" plus the first 12 hex digits of the digest.
-func anyAllowlist(t *testing.T, digests map[string]string) *allowlistpkg.Allowlist {
+func anyAllowlist(t *testing.T, digests map[string]string) *allowlist.Allowlist {
 	t.Helper()
-	al := &allowlistpkg.Allowlist{Schema: allowlistpkg.Schema, Workloads: map[string]allowlistpkg.Workload{}}
+	al := &allowlist.Allowlist{Schema: allowlist.Schema, Workloads: map[string]allowlist.Workload{}}
 	for d, image := range digests {
 		digest, err := types.ParseDigest(d)
 		if err != nil {
 			t.Fatal(err)
 		}
-		al.Workloads["w-"+digest.Hex()[:12]] = allowlistpkg.Workload{Label: image, Containers: []allowlistpkg.Container{{
+		al.Workloads["w-"+digest.Hex()[:12]] = allowlist.Workload{Label: image, Containers: []allowlist.Container{{
 			Digest:  digest,
 			Image:   image,
-			Command: allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
-			Args:    allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+			Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+			Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
 		}}}
 	}
 	return al
@@ -69,8 +69,8 @@ func testLogger(t *testing.T) *slog.Logger {
 	return logger
 }
 
-// newSeededAllowlist builds an *allowlist with a single seed digest.
-func newSeededAllowlist(t *testing.T, seed string) *allowlist {
+// newSeededAllowlist builds a seed index holding a single digest.
+func newSeededAllowlist(t *testing.T, seed string) *allowlist.Index {
 	t.Helper()
 	dir := t.TempDir()
 	body, err := json.Marshal(bootstrapAllowlistFile{Sha256Digests: []string{seed}})
@@ -131,13 +131,13 @@ func TestRefreshOnce_InstallsServedDocument(t *testing.T) {
 		t.Fatal("pull did not land")
 	}
 
-	if a.Size() != 1 || !a.Contains(seed) {
+	if a.Size() != 1 || !a.AdmitsDigest(seed) {
 		t.Fatalf("seed changed by a pull: size %d", a.Size())
 	}
 	if overlay.version != 2 {
 		t.Errorf("overlay version = %d, want 2", overlay.version)
 	}
-	if !overlay.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: pulled, Argv: []string{"/anything"}}) {
+	if !overlay.index().AdmitsContainer(allowlist.RunningContainer{Digest: pulled, Argv: []string{"/anything"}}) {
 		t.Error("pulled digest not admitted by the overlay")
 	}
 }
@@ -167,7 +167,7 @@ func TestRefreshOnce_RolledBackVersionIgnored(t *testing.T) {
 		t.Fatalf("overlay version after rollback = %d, want 5 (unchanged)", overlay.version)
 	}
 	// Nothing the rolled-back document adds is admitted, by the seed or the overlay.
-	if a.Contains(pulled) || overlay.index().AdmitsDigest(pulled) {
+	if a.AdmitsDigest(pulled) || overlay.index().AdmitsDigest(pulled) {
 		t.Error("a rolled-back document must not admit its digests")
 	}
 }
@@ -189,7 +189,7 @@ func TestRefreshOnce_CDSErrorKeepsAllowlist(t *testing.T) {
 	if a.Size() != 1 {
 		t.Fatalf("size after failed refresh = %d, want 1 (seed preserved)", a.Size())
 	}
-	if !a.Contains(seed) {
+	if !a.AdmitsDigest(seed) {
 		t.Error("seed dropped after CDS failure")
 	}
 }

--- a/internal/cmds/policymonitor/monitor.go
+++ b/internal/cmds/policymonitor/monitor.go
@@ -53,7 +53,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 
 	"github.com/confidential-dot-ai/c8s/internal/kataspec"
-	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
@@ -84,13 +84,13 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 	logger.Info("allowlist loaded", "entries", a.Size())
 
 	m := &monitor{
-		cfg:       cfg,
-		logger:    logger,
-		allowlist: a,
-		overlay:   &policyOverlay{},
-		refresh:   &refreshState{reason: reasonNotYetStarted},
-		killer:    newCgroupKiller(cfg.CgroupRoot),
-		ready:     notifyReady,
+		cfg:     cfg,
+		logger:  logger,
+		seed:    a,
+		overlay: &policyOverlay{},
+		refresh: &refreshState{reason: reasonNotYetStarted},
+		killer:  newCgroupKiller(cfg.CgroupRoot),
+		ready:   notifyReady,
 		// The bundle directory appears when the guest pull STARTS and
 		// config.json is written only once it finishes, so the wait is a
 		// registry fetch. configReadDeadline is just how long to poll
@@ -180,9 +180,9 @@ func runMonitor(ctx context.Context, cfg *Config) error {
 type monitor struct {
 	cfg                   *Config
 	logger                *slog.Logger
-	allowlist             *allowlist     // baked seed: digest set measured into the guest
-	overlay               *policyOverlay // latest CDS pull's workload policy
-	refresh               *refreshState  // whether the allowlist still tracks CDS
+	seed                  *allowlist.Index // baked seed: digest set measured into the guest
+	overlay               *policyOverlay   // latest CDS pull's workload policy
+	refresh               *refreshState    // whether the allowlist still tracks CDS
 	killer                containerKiller
 	inventory             *admissionInventory          // sandbox identity + digests (docs/ratls.md); always set
 	signers               *workloadclaims.SignerHolder // token signer, installed once the pod network resolves
@@ -205,11 +205,11 @@ type monitor struct {
 // replaced by the single refresh goroutine.
 type policyOverlay struct {
 	mu      sync.RWMutex
-	idx     *allowlistpkg.Index
+	idx     *allowlist.Index
 	version uint64
 }
 
-func (o *policyOverlay) index() *allowlistpkg.Index {
+func (o *policyOverlay) index() *allowlist.Index {
 	if o == nil {
 		return nil
 	}
@@ -228,7 +228,7 @@ func (o *policyOverlay) index() *allowlistpkg.Index {
 // trusted whatever its version, then state re-syncs from CDS. A guest reboot is a
 // fresh CVM, so this resets every boot; a reboot-durable guarantee needs an
 // attested freshness/monotonic-counter mechanism, out of scope here.
-func (o *policyOverlay) apply(al *allowlistpkg.Allowlist, version uint64) bool {
+func (o *policyOverlay) apply(al *allowlist.Allowlist, version uint64) bool {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.idx != nil && version <= o.version {
@@ -244,14 +244,8 @@ func (o *policyOverlay) apply(al *allowlistpkg.Allowlist, version uint64) bool {
 // — digest, argv, bind-mount destinations and env names. With no overlay (CDS
 // refresh disabled, or no successful pull yet) only the baked seed admits —
 // behavior from t=0.
-func (m *monitor) admits(rc allowlistpkg.RunningContainer) bool {
-	if m.allowlist.Contains(rc.Digest) {
-		return true
-	}
-	if idx := m.overlay.index(); idx != nil {
-		return idx.AdmitsContainer(rc)
-	}
-	return false
+func (m *monitor) admits(rc allowlist.RunningContainer) bool {
+	return m.seed.AdmitsDigest(rc.Digest) || m.overlay.index().AdmitsContainer(rc)
 }
 
 func (m *monitor) run(ctx context.Context) error {
@@ -554,7 +548,7 @@ func (m *monitor) handleNewContainer(ctx context.Context, dir string) {
 
 	// What the container actually runs, as the allowlist describes it. The
 	// baked seed ignores all of it; a served entry is gated on the whole set.
-	rc := allowlistpkg.RunningContainer{
+	rc := allowlist.RunningContainer{
 		Digest:     digest,
 		BindMounts: bindMountDestinations(spec.Mounts),
 	}
@@ -609,7 +603,7 @@ func (m *monitor) frozenAttrs() []any {
 	if reason == "" {
 		return nil
 	}
-	return []any{"allowlist_frozen", true, "frozen_reason", reason, "allowlist_entries", m.allowlist.Size()}
+	return []any{"allowlist_frozen", true, "frozen_reason", reason, "allowlist_entries", m.seed.Size()}
 }
 
 // kill resolves the denied container's cgroup and terminates it as a unit,

--- a/internal/cmds/policymonitor/monitor_lifecycle_test.go
+++ b/internal/cmds/policymonitor/monitor_lifecycle_test.go
@@ -141,19 +141,6 @@ func cgroupKillContent(t *testing.T, dir string) string {
 	return string(b)
 }
 
-// --- normalizeDigest edge: separator at position zero ----------------------
-
-func TestNormalizeDigest_SeparatorAtStart(t *testing.T) {
-	hex := strings.Repeat("a", 64)
-	got, err := normalizeDigest("@sha256:" + hex)
-	if err != nil {
-		t.Fatalf("normalizeDigest: %v", err)
-	}
-	if got != hex {
-		t.Fatalf("got %q, want %q", got, hex)
-	}
-}
-
 // --- writeCgroupKill --------------------------------------------------------
 
 func TestWriteCgroupKill_WritesOne(t *testing.T) {
@@ -442,7 +429,7 @@ func TestRunAllowlistRefresh_InstallsFromCDS(t *testing.T) {
 	}) {
 		t.Fatal("pulled digest never installed; refresh loop did not run")
 	}
-	if a.Contains(pulled) {
+	if a.AdmitsDigest(pulled) {
 		t.Fatal("a pull must not grow the baked seed")
 	}
 	cancel()

--- a/internal/cmds/policymonitor/monitor_test.go
+++ b/internal/cmds/policymonitor/monitor_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/confidential-dot-ai/c8s/internal/kataspec"
-	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/certutil"
 	"github.com/confidential-dot-ai/c8s/pkg/types"
 )
@@ -56,15 +56,15 @@ func writeConfigJSONArgs(t *testing.T, watchDir, cid string, annotations map[str
 
 // exactEntrypointOverlay builds a workload overlay pinning wlDigest to an exact
 // entrypoint (cmd unconstrained).
-func exactEntrypointOverlay(t *testing.T, wlDigest string, entrypoint []string) *allowlistpkg.Allowlist {
+func exactEntrypointOverlay(t *testing.T, wlDigest string, entrypoint []string) *allowlist.Allowlist {
 	t.Helper()
-	return &allowlistpkg.Allowlist{
-		Schema: allowlistpkg.Schema,
-		Workloads: map[string]allowlistpkg.Workload{
-			"w": {Containers: []allowlistpkg.Container{{
+	return &allowlist.Allowlist{
+		Schema: allowlist.Schema,
+		Workloads: map[string]allowlist.Workload{
+			"w": {Containers: []allowlist.Container{{
 				Digest:  mustParseDigest(t, wlDigest),
-				Command: allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyExact, Argv: entrypoint},
-				Args:    allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
+				Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyExact, Argv: entrypoint},
+				Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
 			}}},
 		},
 	}
@@ -121,7 +121,7 @@ func newTestMonitor(t *testing.T, allowlistEntries []string) (*monitor, *fakeKil
 			LogLevel:      "debug",
 		},
 		logger:                logger,
-		allowlist:             a,
+		seed:                  a,
 		overlay:               &policyOverlay{},
 		killer:                killer,
 		configReadDeadline:    200 * time.Millisecond,
@@ -262,10 +262,10 @@ func TestPolicyOverlayAntiRollback(t *testing.T) {
 		t.Fatalf("version = %d, want 5 (rollback ignored)", o.version)
 	}
 	// The version-5 policy still governs: /bin/app matches, /bin/other does not.
-	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
+	if !o.index().AdmitsContainer(allowlist.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("version-5 argv policy dropped by rollback attempt")
 	}
-	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
+	if o.index().AdmitsContainer(allowlist.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("rolled-back argv policy took effect")
 	}
 }
@@ -282,10 +282,10 @@ func TestPolicyOverlayIgnoresEqualVersion(t *testing.T) {
 	if o.apply(exactEntrypointOverlay(t, wl, []string{"/bin/other"}), 5) {
 		t.Fatal("replayed version 5 was applied")
 	}
-	if !o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
+	if !o.index().AdmitsContainer(allowlist.RunningContainer{Digest: wl, Argv: []string{"/bin/app"}}) {
 		t.Fatal("original version-5 policy dropped by equal-version replay")
 	}
-	if o.index().AdmitsContainer(allowlistpkg.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
+	if o.index().AdmitsContainer(allowlist.RunningContainer{Digest: wl, Argv: []string{"/bin/other"}}) {
 		t.Fatal("equal-version replay policy took effect")
 	}
 }

--- a/internal/cmds/policymonitor/mountpolicy_test.go
+++ b/internal/cmds/policymonitor/mountpolicy_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	allowlistpkg "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 )
 
 // writeSpec writes a bundle config.json carrying the fields workload policy is
@@ -34,15 +34,15 @@ func writeSpec(t *testing.T, watchDir, cid string, annotations map[string]string
 	}
 }
 
-func mountPolicyOverlay(t *testing.T, digest string, destinations []string) *allowlistpkg.Allowlist {
+func mountPolicyOverlay(t *testing.T, digest string, destinations []string) *allowlist.Allowlist {
 	t.Helper()
-	return &allowlistpkg.Allowlist{
-		Schema: allowlistpkg.Schema,
-		Workloads: map[string]allowlistpkg.Workload{"w": {Containers: []allowlistpkg.Container{{
+	return &allowlist.Allowlist{
+		Schema: allowlist.Schema,
+		Workloads: map[string]allowlist.Workload{"w": {Containers: []allowlist.Container{{
 			Digest:  mustParseDigest(t, digest),
-			Command: allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
-			Args:    allowlistpkg.ArgvPolicy{Policy: allowlistpkg.PolicyAny},
-			Mounts:  allowlistpkg.MountPolicy{Policy: allowlistpkg.PolicyExact, Destinations: destinations},
+			Command: allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+			Args:    allowlist.ArgvPolicy{Policy: allowlist.PolicyAny},
+			Mounts:  allowlist.MountPolicy{Policy: allowlist.PolicyExact, Destinations: destinations},
 		}}}},
 	}
 }

--- a/internal/cmds/policymonitor/refreshstate_test.go
+++ b/internal/cmds/policymonitor/refreshstate_test.go
@@ -178,7 +178,7 @@ func TestSettleIsIdempotent(t *testing.T) {
 func TestDisabledRefreshSettlesImmediately(t *testing.T) {
 	s := &refreshState{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
-	disableRefresh(logger, s, reasonNoMeasurements, &allowlist{})
+	disableRefresh(logger, s, reasonNoMeasurements, nil)
 
 	start := time.Now()
 	s.awaitSettled(context.Background(), time.Minute)

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -1,9 +1,15 @@
 package allowlist
 
-import "github.com/confidential-dot-ai/c8s/pkg/types"
+import (
+	"fmt"
 
-// Index answers admission queries for enforcers in O(1). Build it once from a
-// normalized Allowlist.
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+// Index answers admission queries for enforcers in O(1). Build it once, from a
+// normalized Allowlist (BuildIndex) or from a bare digest set (DigestIndex). A
+// nil *Index admits nothing, so an enforcer with no policy yet can query it
+// without a guard.
 type Index struct {
 	byDigest map[string][]Container
 }
@@ -22,10 +28,49 @@ func (a *Allowlist) BuildIndex() *Index {
 	return idx
 }
 
+// DigestIndex builds an index that admits each digest whatever it runs — the
+// shape of a DigestEntry, without a document to carry one. The bootstrap layers
+// are its callers: the NRI plugin's always_allow set and the guest monitor's
+// baked seed both sit beside a pulled snapshot rather than inside it, so a
+// withheld or failed pull cannot drop them.
+//
+// Digests arrive in the forms enforcers see (types.NormalizeDigest). One that
+// does not normalize is skipped and named in warnings, which leaves the caller
+// to decide whether a single bad entry is fatal.
+func DigestIndex(digests []string) (*Index, []error) {
+	idx := &Index{byDigest: map[string][]Container{}}
+	var warnings []error
+	for _, raw := range digests {
+		d, err := types.NormalizeDigest(raw)
+		if err != nil {
+			warnings = append(warnings, fmt.Errorf("skip digest %q: %w", raw, err))
+			continue
+		}
+		idx.byDigest[d.String()] = []Container{{
+			Digest:  d,
+			Command: ArgvPolicy{Policy: PolicyAny},
+			Args:    ArgvPolicy{Policy: PolicyAny},
+		}}
+	}
+	return idx, warnings
+}
+
+// Size reports how many distinct digests the index lists. Enforcers log it to
+// say how much policy is in force.
+func (i *Index) Size() int {
+	if i == nil {
+		return 0
+	}
+	return len(i.byDigest)
+}
+
 // AdmitsDigest reports whether an image with this digest may run at all — as
 // any workload container. It ignores argv, so it answers the coarse "are these
 // bytes allowlisted" question the CDS issuance gate asks.
 func (i *Index) AdmitsDigest(digest string) bool {
+	if i == nil {
+		return false
+	}
 	d, err := types.ParseDigest(digest)
 	if err != nil {
 		return false
@@ -38,6 +83,9 @@ func (i *Index) AdmitsDigest(digest string) bool {
 // the union across every entry that lists the digest: the observation must
 // satisfy some declared container's argv, mount and env policy together.
 func (i *Index) AdmitsContainer(r RunningContainer) bool {
+	if i == nil {
+		return false
+	}
 	d, err := types.ParseDigest(r.Digest)
 	if err != nil {
 		return false

--- a/pkg/allowlist/policy_test.go
+++ b/pkg/allowlist/policy_test.go
@@ -1,6 +1,9 @@
 package allowlist
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestIndex_AnyArgvEntryAdmitsAnyArgv(t *testing.T) {
 	idx := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"cds":{"containers":[
@@ -89,5 +92,48 @@ func TestIndex_UnknownDigestDenied(t *testing.T) {
 		{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"}}]}}}`).BuildIndex()
 	if idx.AdmitsDigest(digestB) || idx.AdmitsContainer(RunningContainer{Digest: digestB, Argv: nil}) {
 		t.Fatal("unknown digest must be denied")
+	}
+}
+
+func TestDigestIndex_AdmitsListedDigestWhateverItRuns(t *testing.T) {
+	idx, warnings := DigestIndex([]string{digestA, strings.ToUpper(digestB[7:]), "ghcr.io/acme/app@" + digestC})
+	if len(warnings) != 0 {
+		t.Fatalf("DigestIndex warnings = %v, want none", warnings)
+	}
+	if idx.Size() != 3 {
+		t.Fatalf("Size() = %d, want 3", idx.Size())
+	}
+	for _, d := range []string{digestA, digestB, digestC} {
+		if !idx.AdmitsDigest(d) {
+			t.Errorf("AdmitsDigest(%s) = false, want true", d)
+		}
+		if !idx.AdmitsContainer(RunningContainer{
+			Digest:     d,
+			Argv:       []string{"/bin/sh", "-c", "anything"},
+			BindMounts: []string{"/host"},
+			EnvNames:   []string{"TOKEN"},
+		}) {
+			t.Errorf("AdmitsContainer(%s) = false, want a digest-alone admission", d)
+		}
+	}
+}
+
+func TestDigestIndex_SkipsMalformedAndWarns(t *testing.T) {
+	idx, warnings := DigestIndex([]string{digestA, "not-a-digest", "", "ghcr.io/acme/app:v1"})
+	if idx.Size() != 1 {
+		t.Fatalf("Size() = %d, want 1", idx.Size())
+	}
+	if len(warnings) != 3 {
+		t.Fatalf("warnings = %v, want one per malformed entry", warnings)
+	}
+	if idx.AdmitsDigest(digestB) {
+		t.Error("an unlisted digest must not be admitted")
+	}
+}
+
+func TestIndex_NilAdmitsNothing(t *testing.T) {
+	var idx *Index
+	if idx.AdmitsDigest(digestA) || idx.AdmitsContainer(RunningContainer{Digest: digestA}) || idx.Size() != 0 {
+		t.Fatal("a nil *Index must admit nothing and report size 0")
 	}
 }

--- a/pkg/types/digest_normalize_test.go
+++ b/pkg/types/digest_normalize_test.go
@@ -18,6 +18,7 @@ func TestNormalizeDigest(t *testing.T) {
 		{name: "uppercase hex", in: "sha256:" + strings.ToUpper(hex), want: "sha256:" + hex},
 		{name: "bare hex", in: hex, want: "sha256:" + hex},
 		{name: "image ref with digest", in: "ghcr.io/acme/app@sha256:" + hex, want: "sha256:" + hex},
+		{name: "separator at position zero", in: "@sha256:" + hex, want: "sha256:" + hex},
 		{name: "surrounding whitespace", in: " sha256:" + hex + " ", want: "sha256:" + hex},
 		{name: "empty", in: "", wantErr: true},
 		{name: "tag only", in: "ghcr.io/acme/app:v1.0.0", wantErr: true},


### PR DESCRIPTION
The NRI plugin's `always_allow` set and the guest monitor's baked seed express the same thing — digests admitted whatever they run, checked beside the pulled snapshot so a withheld or failed pull cannot drop them — and each hand-rolled its own digest map. policymonitor's keyed on bare hex, unlike every other digest map in the tree.

`allowlist.DigestIndex` builds that layer as an `*Index`. Adds `Index.Size` and nil-receiver semantics, so an enforcer with no policy yet queries without a guard. Both enforcers now hold an `*Index`, and `policymonitor`'s admission is one line:

```go
return m.seed.AdmitsDigest(rc.Digest) || m.overlay.index().AdmitsContainer(rc)
```

Deletes policymonitor's private `allowlist` type and its `normalizeDigest`; the `@sha256:`-at-position-zero case it pinned moves to `pkg/types`.

No behavior change. Query-side digest parsing is `types.ParseDigest` throughout, which is what both enforcers already fed it.

Groundwork for the injected-container drop set, which is the other place digest policy is decided outside `pkg/allowlist`.