### PR TITLE
feat(workload): pin workload env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,8 +199,8 @@ jobs:
       # kind is not on the runner image; pin the release binary by sha256.
       - name: Install kind
         run: |
-          curl -fsSL -o kind https://kind.sigs.k8s.io/dl/v0.30.0/kind-linux-amd64
-          echo "517ab7fc89ddeed5fa65abf71530d90648d9638ef0c4cde22c2c11f8097b8889  kind" | sha256sum -c -
+          curl -fsSL -o kind https://kind.sigs.k8s.io/dl/v0.33.0/kind-linux-amd64
+          echo "aee6151561422756b764a4ae28e7f44cda5af5a9eead3cc9985112b1de8d8e0d  kind" | sha256sum -c -
           sudo install kind /usr/local/bin/kind
 
       - name: Run the cluster integration harness

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ workload-agnostic: anything that runs on Kubernetes can run confidentially.
 - **Container image and command-line allowlisting.** Every container is
   enforced against a CDS-served allowlist of named workload entries, each
   pinning the image digests a workload runs and the command line each may run
-  with. Enforced by an NRI plugin on the node inside the CVM.
+  with, and the environment values it launches with. Enforced by an NRI plugin
+  on the node inside the CVM.
 
 - **Attestation-gated secrets.** CDS releases an application secret only once
   a pod's running containers resolve to a single allowlist entry carrying a
@@ -475,8 +476,8 @@ than let you discover them:
 
 - **The image allowlist gates digest and command line, not the rest of the
   pod spec.** Each container's `command` prefix and `args` remainder are
-  enforced against the effective argv, and bind-mount destinations and env
-  variable names are enforceable in the guest; capabilities and the
+  enforced against the effective argv, env values are enforced by both backends,
+  and bind-mount destinations are enforceable in the guest; capabilities and the
   remaining pod-spec fields are not. Nothing enforces which images run
   *together* — every running image must be allowlisted, but no gate requires
   the set in one pod to match a single workload entry.

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -16,8 +16,9 @@ into attestation).
 
 The allowlist is a map of named **workload entries**. Each entry pins an
 init/main container set. Every container binds a **digest** to the process
-policy (`command`, `args`) permitted for those bytes, and the entry as a whole
-may carry a secret-store grant (`secrets`).
+policy (`command`, `args`) permitted for those bytes, optionally to the
+environment values it may launch with (`env`), and the entry as a whole may
+carry a secret-store grant (`secrets`).
 The entry name is operator-chosen; the entry `label` and per-container `image`
 are informational. Policy is always resolved by container digest.
 
@@ -164,6 +165,23 @@ under any argv, and which that entry needs nothing more running for, is
 match and `lint`, `apply` and `add` refuse it. To tighten a seeded any-argv
 entry, edit it; do not add a narrower entry for the same image beside it.
 
+## Environment policy (`env`)
+
+`env` constrains the complete OCI launch environment: `exact` requires
+equality, so all names and values must match, including image defaults and
+runtime additions. `deny` requires an observed empty environment; `any` permits
+any environment. Missing env evidence fails `exact` and `deny`. An empty
+`exact.values` normalizes to `deny`, and an absent policy defaults to `any`.
+
+```json
+"env": { "policy": "exact", "values": {"PATH": "/usr/bin:/bin", "MODEL_DIR": "/models"} }
+```
+
+The NRI plugin enforces env after cumulative NRI adjustments, and the admission
+inventory carries an environment fingerprint for CDS workload matching and
+secret release.
+
+
 ## Secret grants (`secrets`)
 
 An entry may grant secret-store paths to the workload it names. The subject is
@@ -196,10 +214,11 @@ install still setting the per-container `paths` field needs
 
 Two independent points enforce, at different strengths:
 
-1. **Host NRI plugin** (`nri-image-policy`), at CreateContainer, per container.
-   Resolves the image digest and checks the effective argv against the allowlist
-   index. Fail-closed before the allowlist first loads; the plugin runs
-   inside the node CVM and is the primary admission gate.
+1. **Host NRI plugin** (`nri-image-policy`), per container. Resolves the image
+   digest and checks the effective argv at creation, validates env after
+   cumulative NRI adjustments, and rechecks the final OCI spec before start.
+   Fail-closed before the allowlist first loads; the plugin runs inside the
+   node CVM and is the primary admission gate.
 
 2. **CDS at cert issuance**, in `resolveSandboxWorkload`. Before signing a leaf
    for a pod, CDS asks that pod's own inventory which images its sandbox is

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -98,7 +98,10 @@ make test-integration-cluster
 Needs docker (or podman with `KIND_EXPERIMENTAL_PROVIDER=podman`), kind,
 kubectl, helm, go, openssl, curl, python3. The kind node image is pinned by
 digest in run.sh; bump it with the kind release. CI installs kind itself
-(`.github/workflows/ci.yml`, pinned binary sha256).
+(`.github/workflows/ci.yml`, pinned binary sha256). Custom node images must
+provide NRI `ValidateContainerAdjustment` support (the pinned image uses
+containerd 2.3.4 / NRI 0.12.0); older runtimes reject the env-enforcing plugin
+at registration.
 
 ### Failure notes
 

--- a/internal/admissionhistory/history.go
+++ b/internal/admissionhistory/history.go
@@ -3,6 +3,7 @@ package admissionhistory
 
 import (
 	"fmt"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"slices"
 
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
@@ -17,7 +18,7 @@ type History struct {
 
 // Record adds an admission; only a resolved record for the same ID clears an
 // unresolved container. History owns its copy of argv.
-func (h *History) Record(id, digest string, argv []string) {
+func (h *History) Record(id, digest string, argv []string, env ...*allowlist.EnvObservation) {
 	if h.byKey == nil {
 		h.byKey = map[string]workloadclaims.SandboxContainer{}
 		h.unresolved = map[string]struct{}{}
@@ -28,6 +29,9 @@ func (h *History) Record(id, digest string, argv []string) {
 	}
 	delete(h.unresolved, id)
 	c := workloadclaims.SandboxContainer{Digest: digest, Argv: slices.Clone(argv)}
+	if len(env) > 0 {
+		c.Env = env[0].Clone()
+	}
 	h.byKey[c.Key()] = c
 }
 
@@ -42,6 +46,7 @@ func (h History) Snapshot() ([]string, []workloadclaims.SandboxContainer, error)
 	for _, c := range h.byKey {
 		digests = append(digests, c.Digest)
 		c.Argv = slices.Clone(c.Argv)
+		c.Env = c.Env.Clone()
 		containers = append(containers, c)
 	}
 	slices.Sort(digests)

--- a/internal/admissionhistory/history.go
+++ b/internal/admissionhistory/history.go
@@ -18,7 +18,7 @@ type History struct {
 
 // Record adds an admission; only a resolved record for the same ID clears an
 // unresolved container. History owns its copy of argv.
-func (h *History) Record(id, digest string, argv []string, env ...*allowlist.EnvObservation) {
+func (h *History) Record(id, digest string, argv []string, env *allowlist.EnvObservation) {
 	if h.byKey == nil {
 		h.byKey = map[string]workloadclaims.SandboxContainer{}
 		h.unresolved = map[string]struct{}{}
@@ -28,10 +28,7 @@ func (h *History) Record(id, digest string, argv []string, env ...*allowlist.Env
 		return
 	}
 	delete(h.unresolved, id)
-	c := workloadclaims.SandboxContainer{Digest: digest, Argv: slices.Clone(argv)}
-	if len(env) > 0 {
-		c.Env = env[0].Clone()
-	}
+	c := workloadclaims.SandboxContainer{Digest: digest, Argv: slices.Clone(argv), Env: env.Clone()}
 	h.byKey[c.Key()] = c
 }
 

--- a/internal/admissionhistory/history_test.go
+++ b/internal/admissionhistory/history_test.go
@@ -14,12 +14,12 @@ func TestHistoryRetainsDistinctAdmissions(t *testing.T) {
 	if err != nil || digests == nil || containers == nil || len(digests)+len(containers) != 0 {
 		t.Fatalf("empty history = %v, %v, %v", digests, containers, err)
 	}
-	h.Record("one", "sha256:b", []string{"run", "z"})
-	h.Record("two", "sha256:a", nil)
-	h.Record("three", "sha256:a", []string{})
-	h.Record("replica", "sha256:b", []string{"run", "z"})
-	h.Record("one", "sha256:b", []string{"run", "a"})
-	h.Record("one", "sha256:a", []string{""})
+	h.Record("one", "sha256:b", []string{"run", "z"}, nil)
+	h.Record("two", "sha256:a", nil, nil)
+	h.Record("three", "sha256:a", []string{}, nil)
+	h.Record("replica", "sha256:b", []string{"run", "z"}, nil)
+	h.Record("one", "sha256:b", []string{"run", "a"}, nil)
+	h.Record("one", "sha256:a", []string{""}, nil)
 	digests, containers, err = h.Snapshot()
 	want := []workloadclaims.SandboxContainer{
 		{Digest: "sha256:a", Argv: []string{}},
@@ -34,9 +34,9 @@ func TestHistoryRetainsDistinctAdmissions(t *testing.T) {
 
 func TestHistoryResolutionIsPerContainer(t *testing.T) {
 	var h History
-	h.Record("known", "sha256:a", nil)
-	h.Record("first", "", nil)
-	h.Record("second", "", nil)
+	h.Record("known", "sha256:a", nil, nil)
+	h.Record("first", "", nil, nil)
+	h.Record("second", "", nil, nil)
 	assertUnresolved := func() {
 		t.Helper()
 		digests, containers, err := h.Snapshot()
@@ -45,17 +45,17 @@ func TestHistoryResolutionIsPerContainer(t *testing.T) {
 		}
 	}
 	assertUnresolved()
-	h.Record("different", "sha256:b", nil)
+	h.Record("different", "sha256:b", nil, nil)
 	assertUnresolved()
-	h.Record("first", "sha256:b", nil)
+	h.Record("first", "sha256:b", nil, nil)
 	assertUnresolved()
-	h.Record("second", "sha256:b", nil)
+	h.Record("second", "sha256:b", nil, nil)
 	if digests, containers, err := h.Snapshot(); err != nil || len(digests) != 2 || len(containers) != 2 {
 		t.Fatalf("resolved snapshot = %v, %v, %v", digests, containers, err)
 	}
-	h.Record("known", "", nil)
+	h.Record("known", "", nil, nil)
 	assertUnresolved()
-	h.Record("known", "sha256:c", nil)
+	h.Record("known", "sha256:c", nil, nil)
 	if digests, _, err := h.Snapshot(); err != nil || len(digests) != 3 {
 		t.Fatalf("resolution lost an earlier admission: %v, %v", digests, err)
 	}
@@ -64,7 +64,7 @@ func TestHistoryResolutionIsPerContainer(t *testing.T) {
 func TestHistoryOwnsArgumentsAndSnapshots(t *testing.T) {
 	var h History
 	argv := []string{"run", "original"}
-	h.Record("one", "sha256:a", argv)
+	h.Record("one", "sha256:a", argv, nil)
 	argv[1] = "changed input"
 	digests, containers, err := h.Snapshot()
 	if err != nil || len(containers) != 1 || containers[0].Argv[1] != "original" {
@@ -83,7 +83,7 @@ func TestHistoryEnvVariantsAndOwnership(t *testing.T) {
 	var h History
 	a, _ := allowlist.ObserveEnv([]string{"MODE=a"})
 	b, _ := allowlist.ObserveEnv([]string{"MODE=b"})
-	h.Record("c", "sha256:a", []string{"run"}) // older/unavailable evidence
+	h.Record("c", "sha256:a", []string{"run"}, nil) // older/unavailable evidence
 	h.Record("c", "sha256:a", []string{"run"}, a)
 	h.Record("c", "sha256:a", []string{"run"}, b)
 	a.Digest = "mutated"

--- a/internal/admissionhistory/history_test.go
+++ b/internal/admissionhistory/history_test.go
@@ -1,6 +1,7 @@
 package admissionhistory
 
 import (
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"reflect"
 	"testing"
 
@@ -75,5 +76,45 @@ func TestHistoryOwnsArgumentsAndSnapshots(t *testing.T) {
 	digests, containers, err = h.Snapshot()
 	if err != nil || !reflect.DeepEqual(digests, []string{"sha256:a"}) || len(containers) != 1 || containers[0].Digest != "sha256:a" || containers[0].Argv[1] != "original" {
 		t.Fatalf("snapshot mutation changed history: %v, %v, %v", digests, containers, err)
+	}
+}
+
+func TestHistoryEnvVariantsAndOwnership(t *testing.T) {
+	var h History
+	a, _ := allowlist.ObserveEnv([]string{"MODE=a"})
+	b, _ := allowlist.ObserveEnv([]string{"MODE=b"})
+	h.Record("c", "sha256:a", []string{"run"}) // older/unavailable evidence
+	h.Record("c", "sha256:a", []string{"run"}, a)
+	h.Record("c", "sha256:a", []string{"run"}, b)
+	a.Digest = "mutated"
+	_, cs, err := h.Snapshot()
+	if err != nil || len(cs) != 3 {
+		t.Fatalf("history lost variants: %v %v", cs, err)
+	}
+	for _, c := range cs {
+		if c.Env != nil {
+			if !c.Env.Valid() {
+				t.Fatal("history borrowed input")
+			}
+			c.Env.Digest = "mutated"
+		}
+	}
+	_, cs, _ = h.Snapshot()
+	for _, c := range cs {
+		if c.Env != nil && !c.Env.Valid() {
+			t.Fatal("snapshot borrowed history")
+		}
+	}
+	// Framing must distinguish an extra argv item from any env field.
+	seen := map[string]bool{}
+	for _, c := range []workloadclaims.SandboxContainer{
+		{Digest: "d", Argv: []string{"run"}, Env: b},
+		{Digest: "d", Argv: []string{"run", b.Format, b.Digest}},
+		{Digest: "d", Argv: []string{"run"}},
+	} {
+		if seen[c.Key()] {
+			t.Fatal("tuple key collision")
+		}
+		seen[c.Key()] = true
 	}
 }

--- a/internal/allowlist/handler.go
+++ b/internal/allowlist/handler.go
@@ -87,7 +87,12 @@ func (h Handler) HandlePutWorkload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	entry, err := pkgallowlist.ParseWorkloadJSON(body)
+	current, _, err := h.Store.LoadAll()
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+	entry, err := pkgallowlist.ParseWorkloadJSONForSchema(body, current.Schema)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return

--- a/internal/allowlist/handler.go
+++ b/internal/allowlist/handler.go
@@ -87,12 +87,7 @@ func (h Handler) HandlePutWorkload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	current, _, err := h.Store.LoadAll()
-	if err != nil {
-		http.Error(w, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	entry, err := pkgallowlist.ParseWorkloadJSONForSchema(body, current.Schema)
+	entry, err := pkgallowlist.ParseWorkloadJSON(body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 		return

--- a/internal/allowlist/store.go
+++ b/internal/allowlist/store.go
@@ -40,8 +40,6 @@ const (
 var ErrInvalidWorkload = errors.New("invalid workload entry")
 
 const initSQL = `
-CREATE TABLE IF NOT EXISTS allowlist_format (id INTEGER PRIMARY KEY CHECK(id=1), schema TEXT NOT NULL);
-INSERT OR IGNORE INTO allowlist_format VALUES (1, 'c8s.allowlist/v1');
 CREATE TABLE IF NOT EXISTS allowlist_version (
 	version TEXT NOT NULL DEFAULT '1'
 );
@@ -121,12 +119,8 @@ func (s *Store) LoadAll() (*pkgallowlist.Allowlist, string, error) {
 		return nil, "", err
 	}
 
-	var schema string
-	if err := s.db.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
-		return nil, "", err
-	}
 	return &pkgallowlist.Allowlist{
-		Schema:    schema,
+		Schema:    pkgallowlist.Schema,
 		Workloads: workloads,
 	}, version, nil
 }
@@ -250,10 +244,6 @@ func (s *Store) SeedWorkloads(workloads map[string]pkgallowlist.Workload) (int, 
 // seedWorkloadsTx inserts every entry whose name is free and returns how many
 // it inserted.
 func seedWorkloadsTx(tx *sql.Tx, workloads map[string]pkgallowlist.Workload) (int, error) {
-	var schema string
-	if err := tx.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
-		return 0, err
-	}
 	var added int
 	for name, w := range workloads {
 		var exists int
@@ -262,9 +252,6 @@ func seedWorkloadsTx(tx *sql.Tx, workloads map[string]pkgallowlist.Workload) (in
 		}
 		if exists != 0 {
 			continue
-		}
-		if err := w.ValidateEnvSchema(schema); err != nil {
-			return 0, fmt.Errorf("%w: %v", ErrInvalidWorkload, err)
 		}
 		entryJSON, err := json.Marshal(w)
 		if err != nil {
@@ -299,11 +286,7 @@ func seedWorkloadsTx(tx *sql.Tx, workloads map[string]pkgallowlist.Workload) (in
 func (s *Store) PutWorkload(name string, w pkgallowlist.Workload) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var schema string
-	if err := s.db.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
-		return err
-	}
-	norm, err := normalizeEntryForSchema(name, w, schema)
+	norm, err := normalizeEntry(name, w)
 	if err != nil {
 		return err
 	}
@@ -383,17 +366,6 @@ func (s *Store) ReplaceAll(al *pkgallowlist.Allowlist) error {
 // replaceContentsTx clears every entry and reloads them from al, without
 // touching the version. Callers set the version (bump or restore).
 func replaceContentsTx(tx *sql.Tx, al *pkgallowlist.Allowlist) error {
-	if al.Schema != pkgallowlist.Schema && al.Schema != pkgallowlist.SchemaV2 {
-		return fmt.Errorf("unknown allowlist schema")
-	}
-	for _, w := range al.Workloads {
-		if err := w.ValidateEnvSchema(al.Schema); err != nil {
-			return err
-		}
-	}
-	if _, err := tx.Exec("UPDATE allowlist_format SET schema=? WHERE id=1", al.Schema); err != nil {
-		return err
-	}
 	for _, stmt := range []string{
 		"DELETE FROM workload_entry",
 		"DELETE FROM workload_entry_digest",
@@ -452,11 +424,11 @@ func indexWorkloadTx(tx *sql.Tx, name string, w pkgallowlist.Workload) error {
 	return nil
 }
 
-// normalizeEntryForSchema validates name and w through the allowlist validator and
+// normalizeEntry validates name and w through the allowlist validator and
 // returns the canonical entry to store. A rejection wraps ErrInvalidWorkload.
-func normalizeEntryForSchema(name string, w pkgallowlist.Workload, schema string) (pkgallowlist.Workload, error) {
+func normalizeEntry(name string, w pkgallowlist.Workload) (pkgallowlist.Workload, error) {
 	probe := &pkgallowlist.Allowlist{
-		Schema:    schema,
+		Schema:    pkgallowlist.Schema,
 		Workloads: map[string]pkgallowlist.Workload{name: w},
 	}
 	canon, err := probe.Canonical()

--- a/internal/allowlist/store.go
+++ b/internal/allowlist/store.go
@@ -40,6 +40,8 @@ const (
 var ErrInvalidWorkload = errors.New("invalid workload entry")
 
 const initSQL = `
+CREATE TABLE IF NOT EXISTS allowlist_format (id INTEGER PRIMARY KEY CHECK(id=1), schema TEXT NOT NULL);
+INSERT OR IGNORE INTO allowlist_format VALUES (1, 'c8s.allowlist/v1');
 CREATE TABLE IF NOT EXISTS allowlist_version (
 	version TEXT NOT NULL DEFAULT '1'
 );
@@ -119,8 +121,12 @@ func (s *Store) LoadAll() (*pkgallowlist.Allowlist, string, error) {
 		return nil, "", err
 	}
 
+	var schema string
+	if err := s.db.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
+		return nil, "", err
+	}
 	return &pkgallowlist.Allowlist{
-		Schema:    pkgallowlist.Schema,
+		Schema:    schema,
 		Workloads: workloads,
 	}, version, nil
 }
@@ -244,8 +250,22 @@ func (s *Store) SeedWorkloads(workloads map[string]pkgallowlist.Workload) (int, 
 // seedWorkloadsTx inserts every entry whose name is free and returns how many
 // it inserted.
 func seedWorkloadsTx(tx *sql.Tx, workloads map[string]pkgallowlist.Workload) (int, error) {
+	var schema string
+	if err := tx.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
+		return 0, err
+	}
 	var added int
 	for name, w := range workloads {
+		var exists int
+		if err := tx.QueryRow("SELECT COUNT(*) FROM workload_entry WHERE name=?", name).Scan(&exists); err != nil {
+			return 0, err
+		}
+		if exists != 0 {
+			continue
+		}
+		if err := w.ValidateEnvSchema(schema); err != nil {
+			return 0, fmt.Errorf("%w: %v", ErrInvalidWorkload, err)
+		}
 		entryJSON, err := json.Marshal(w)
 		if err != nil {
 			return 0, err
@@ -277,13 +297,16 @@ func seedWorkloadsTx(tx *sql.Tx, workloads map[string]pkgallowlist.Workload) (in
 // validated against the frozen allowlist rules; a rejection wraps
 // ErrInvalidWorkload.
 func (s *Store) PutWorkload(name string, w pkgallowlist.Workload) error {
-	norm, err := normalizeEntry(name, w)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var schema string
+	if err := s.db.QueryRow("SELECT schema FROM allowlist_format WHERE id=1").Scan(&schema); err != nil {
+		return err
+	}
+	norm, err := normalizeEntryForSchema(name, w, schema)
 	if err != nil {
 		return err
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	tx, err := s.db.Begin()
 	if err != nil {
@@ -360,6 +383,17 @@ func (s *Store) ReplaceAll(al *pkgallowlist.Allowlist) error {
 // replaceContentsTx clears every entry and reloads them from al, without
 // touching the version. Callers set the version (bump or restore).
 func replaceContentsTx(tx *sql.Tx, al *pkgallowlist.Allowlist) error {
+	if al.Schema != pkgallowlist.Schema && al.Schema != pkgallowlist.SchemaV2 {
+		return fmt.Errorf("unknown allowlist schema")
+	}
+	for _, w := range al.Workloads {
+		if err := w.ValidateEnvSchema(al.Schema); err != nil {
+			return err
+		}
+	}
+	if _, err := tx.Exec("UPDATE allowlist_format SET schema=? WHERE id=1", al.Schema); err != nil {
+		return err
+	}
 	for _, stmt := range []string{
 		"DELETE FROM workload_entry",
 		"DELETE FROM workload_entry_digest",
@@ -418,11 +452,11 @@ func indexWorkloadTx(tx *sql.Tx, name string, w pkgallowlist.Workload) error {
 	return nil
 }
 
-// normalizeEntry validates name and w through the frozen allowlist validator and
+// normalizeEntryForSchema validates name and w through the allowlist validator and
 // returns the canonical entry to store. A rejection wraps ErrInvalidWorkload.
-func normalizeEntry(name string, w pkgallowlist.Workload) (pkgallowlist.Workload, error) {
+func normalizeEntryForSchema(name string, w pkgallowlist.Workload, schema string) (pkgallowlist.Workload, error) {
 	probe := &pkgallowlist.Allowlist{
-		Schema:    pkgallowlist.Schema,
+		Schema:    schema,
 		Workloads: map[string]pkgallowlist.Workload{name: w},
 	}
 	canon, err := probe.Canonical()

--- a/internal/allowlist/store_test.go
+++ b/internal/allowlist/store_test.go
@@ -478,18 +478,15 @@ func TestGenerationMovesOnEveryMutation(t *testing.T) {
 	}
 }
 
-func TestEnvironmentSchemaMigrationPersists(t *testing.T) {
+func TestEnvironmentValuesPersist(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "allowlist.db")
 	store, err := OpenStore(path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v2","workloads":{"w":{"containers":[{"digest":"` + digestA + `","env":{"policy":"exact","values":{"MODE":"production"}}}]}}}`))
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[{"digest":"` + digestA + `","env":{"policy":"exact","values":{"MODE":"production"}}}]}}}`))
 	if err != nil {
 		t.Fatal(err)
-	}
-	if err := store.PutWorkload("w", al.Workloads["w"]); err == nil {
-		t.Fatal("v2 policy entered v1 document")
 	}
 	if err := store.ReplaceAll(al); err != nil {
 		t.Fatal(err)
@@ -501,19 +498,11 @@ func TestEnvironmentSchemaMigrationPersists(t *testing.T) {
 	}
 	defer store.Close()
 	got, _, err := store.LoadAll()
-	if err != nil || got.Schema != pkgallowlist.SchemaV2 {
+	if err != nil || got.Schema != pkgallowlist.Schema || got.Workloads["w"].Containers[0].Env.Values["MODE"] != "production" {
 		t.Fatalf("schema lost: %v %v", got, err)
 	}
 	if err := store.PutWorkload("w", al.Workloads["w"]); err != nil {
 		t.Fatal(err)
 	}
-	legacy := al.Workloads["w"]
-	legacy.Containers = append([]pkgallowlist.Container{}, legacy.Containers...)
-	legacy.Containers[0].Env = pkgallowlist.EnvPolicy{}
-	if err := store.PutWorkload("w", legacy); err == nil {
-		t.Fatal("implicit env accepted in v2")
-	}
-	if _, err := store.SeedWorkloads(map[string]pkgallowlist.Workload{"legacy": legacy}); err == nil {
-		t.Fatal("seed bypassed v2 schema")
-	}
+
 }

--- a/internal/allowlist/store_test.go
+++ b/internal/allowlist/store_test.go
@@ -477,3 +477,43 @@ func TestGenerationMovesOnEveryMutation(t *testing.T) {
 		t.Fatal("a read moved the generation")
 	}
 }
+
+func TestEnvironmentSchemaMigrationPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "allowlist.db")
+	store, err := OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	al, err := pkgallowlist.ParseJSON([]byte(`{"schema":"c8s.allowlist/v2","workloads":{"w":{"containers":[{"digest":"` + digestA + `","env":{"policy":"exact","values":{"MODE":"production"}}}]}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutWorkload("w", al.Workloads["w"]); err == nil {
+		t.Fatal("v2 policy entered v1 document")
+	}
+	if err := store.ReplaceAll(al); err != nil {
+		t.Fatal(err)
+	}
+	store.Close()
+	store, err = OpenStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	got, _, err := store.LoadAll()
+	if err != nil || got.Schema != pkgallowlist.SchemaV2 {
+		t.Fatalf("schema lost: %v %v", got, err)
+	}
+	if err := store.PutWorkload("w", al.Workloads["w"]); err != nil {
+		t.Fatal(err)
+	}
+	legacy := al.Workloads["w"]
+	legacy.Containers = append([]pkgallowlist.Container{}, legacy.Containers...)
+	legacy.Containers[0].Env = pkgallowlist.EnvPolicy{}
+	if err := store.PutWorkload("w", legacy); err == nil {
+		t.Fatal("implicit env accepted in v2")
+	}
+	if _, err := store.SeedWorkloads(map[string]pkgallowlist.Workload{"legacy": legacy}); err == nil {
+		t.Fatal("seed bypassed v2 schema")
+	}
+}

--- a/internal/cmds/allowlist/derive.go
+++ b/internal/cmds/allowlist/derive.go
@@ -3,6 +3,7 @@ package allowlist
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -91,6 +92,7 @@ func deriveContainers(cs []templateContainer) ([]allowlist.Container, error) {
 func newDeriveCmd(_ *options) *cobra.Command {
 	var secrets []string
 	var label string
+	var envMode, envFile string
 	cmd := &cobra.Command{
 		Use:   "derive <name> <file|->",
 		Short: "Build an entry from a live Kubernetes object",
@@ -104,6 +106,11 @@ wrong. Init containers are part of the set CDS matches, so omitting them makes
 every release fail with "no workload entry matches the running containers". And
 a container with a command and no args needs an args policy of "deny", because
 "exact" requires a non-empty argv.
+
+Environment policy must be supplied using --env=any|deny or --env-file, a JSON
+map of container names to env policies. Exact values describe the complete OCI
+launch environment, including image/runtime additions. Pod env/envFrom alone
+cannot establish it. Value policies require a v2 allowlist on CDS.
 
 The entry pins argv, so it expires the moment a container command changes:
 re-derive and re-apply whenever the workload is edited.
@@ -128,6 +135,45 @@ deliberately absent from the derived entry.`,
 			if err != nil {
 				return err
 			}
+			if (envMode == "") == (envFile == "") {
+				return fmt.Errorf("specify exactly one of --env=any|deny or --env-file")
+			}
+			var policies map[string]allowlist.EnvPolicy
+			if envFile != "" {
+				data, err := os.ReadFile(envFile)
+				if err != nil {
+					return err
+				}
+				policies, err = allowlist.ParseEnvPoliciesJSON(data)
+				if err != nil {
+					return err
+				}
+			} else if envMode != allowlist.PolicyAny && envMode != allowlist.PolicyDeny {
+				return fmt.Errorf("--env must be any or deny; use --env-file for exact values")
+			}
+			used := map[string]bool{}
+			for _, part := range []struct {
+				templates  []templateContainer
+				containers []allowlist.Container
+			}{{spec.InitContainers, initContainers}, {spec.Containers, containers}} {
+				for i, c := range part.templates {
+					p := allowlist.EnvPolicy{Policy: envMode}
+					if envFile != "" {
+						var ok bool
+						p, ok = policies[c.Name]
+						if !ok {
+							return fmt.Errorf("missing env policy for container %q", c.Name)
+						}
+						used[c.Name] = true
+					}
+					part.containers[i].Env = p
+				}
+			}
+			for name := range policies {
+				if !used[name] {
+					return fmt.Errorf("env policy names unknown container %q", name)
+				}
+			}
 			w := allowlist.Workload{
 				Label:          label,
 				InitContainers: initContainers,
@@ -146,6 +192,8 @@ deliberately absent from the derived entry.`,
 	}
 	cmd.Flags().StringArrayVar(&secrets, "secret-read", nil,
 		"grant read on this secret path (repeatable); omit for no secrets block")
+	cmd.Flags().StringVar(&envMode, "env", "", "environment policy for every container: any or deny")
+	cmd.Flags().StringVar(&envFile, "env-file", "", "JSON map of container names to explicit env policies (including exact values)")
 	cmd.Flags().StringVar(&label, "label", "", "optional entry label")
 	return cmd
 }

--- a/internal/cmds/allowlist/derive.go
+++ b/internal/cmds/allowlist/derive.go
@@ -152,10 +152,11 @@ deliberately absent from the derived entry.`,
 				return fmt.Errorf("--env must be any or deny; use --env-file for exact values")
 			}
 			used := map[string]bool{}
-			for _, part := range []struct {
+			type derivedContainerGroup struct {
 				templates  []templateContainer
 				containers []allowlist.Container
-			}{{spec.InitContainers, initContainers}, {spec.Containers, containers}} {
+			}
+			for _, part := range []derivedContainerGroup{{spec.InitContainers, initContainers}, {spec.Containers, containers}} {
 				for i, c := range part.templates {
 					p := allowlist.EnvPolicy{Policy: envMode}
 					if envFile != "" {

--- a/internal/cmds/allowlist/derive_test.go
+++ b/internal/cmds/allowlist/derive_test.go
@@ -50,7 +50,7 @@ func runDerive(t *testing.T, stdin string, args ...string) (map[string]pkgallowl
 }
 
 func TestDeriveCoversInitContainers(t *testing.T) {
-	got, err := runDerive(t, deployJSON(), "dynamo", "-")
+	got, err := runDerive(t, deployJSON(), "dynamo", "-", "--env=any")
 	if err != nil {
 		t.Fatalf("derive: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestDeriveCoversInitContainers(t *testing.T) {
 }
 
 func TestDeriveArgvPolicies(t *testing.T) {
-	got, _ := runDerive(t, deployJSON(), "dynamo", "-")
+	got, _ := runDerive(t, deployJSON(), "dynamo", "-", "--env=any")
 	w := got["dynamo"]
 
 	// A command with no args is Deny. Exact would be rejected on apply
@@ -91,12 +91,12 @@ func TestDeriveArgvPolicies(t *testing.T) {
 }
 
 func TestDeriveSecretsOnlyWhenAsked(t *testing.T) {
-	got, _ := runDerive(t, deployJSON(), "dynamo", "-")
+	got, _ := runDerive(t, deployJSON(), "dynamo", "-", "--env=any")
 	if got["dynamo"].Secrets != nil {
 		t.Errorf("secrets block emitted without --secret-read")
 	}
 
-	got, _ = runDerive(t, deployJSON(), "dynamo", "-", "--secret-read", "/dynamo/volumes/w235")
+	got, _ = runDerive(t, deployJSON(), "dynamo", "-", "--env=any", "--secret-read", "/dynamo/volumes/w235")
 	s := got["dynamo"].Secrets
 	if s == nil {
 		t.Fatal("no secrets block with --secret-read")
@@ -108,7 +108,7 @@ func TestDeriveSecretsOnlyWhenAsked(t *testing.T) {
 
 func TestDeriveAcceptsABarePod(t *testing.T) {
 	pod := `{"kind":"Pod","spec":{"containers":[{"name":"c","image":"` + testImage + `","command":["sleep","inf"]}]}}`
-	got, err := runDerive(t, pod, "p", "-")
+	got, err := runDerive(t, pod, "p", "-", "--env=any")
 	if err != nil {
 		t.Fatalf("derive pod: %v", err)
 	}

--- a/internal/cmds/allowlist/diff.go
+++ b/internal/cmds/allowlist/diff.go
@@ -40,18 +40,22 @@ func (e entryDiff) empty() bool {
 
 // allowlistDiff is the entry-level diff of two allowlists.
 type allowlistDiff struct {
+	Schema           *changedEntry        `json:"schema,omitempty"`
 	WorkloadsAdded   []string             `json:"workloadsAdded"`
 	WorkloadsRemoved []string             `json:"workloadsRemoved"`
 	WorkloadsChanged map[string]entryDiff `json:"workloadsChanged"`
 }
 
 func (d allowlistDiff) empty() bool {
-	return len(d.WorkloadsAdded) == 0 && len(d.WorkloadsRemoved) == 0 && len(d.WorkloadsChanged) == 0
+	return d.Schema == nil && len(d.WorkloadsAdded) == 0 && len(d.WorkloadsRemoved) == 0 && len(d.WorkloadsChanged) == 0
 }
 
 // diffAllowlists computes the entry- and field-level diff of desired over live.
 func diffAllowlists(live, desired *pkgallowlist.Allowlist) allowlistDiff {
 	d := allowlistDiff{WorkloadsChanged: map[string]entryDiff{}}
+	if live.Schema != desired.Schema {
+		d.Schema = &changedEntry{From: live.Schema, To: desired.Schema}
+	}
 	for name, dw := range desired.Workloads {
 		lw, ok := live.Workloads[name]
 		if !ok {
@@ -91,8 +95,8 @@ func diffEntry(live, desired pkgallowlist.Workload) entryDiff {
 // exactly one dropped and one introduced policy it is reported as a change;
 // otherwise the policies are reported as separate additions/removals.
 func diffContainers(kind string, live, desired []pkgallowlist.Container) (added, removed, changed []containerDiff) {
-	liveByDigest := groupSummaries(live)
-	desiredByDigest := groupSummaries(desired)
+	liveByDigest := groupPolicies(live)
+	desiredByDigest := groupPolicies(desired)
 
 	digests := map[string]bool{}
 	for d := range liveByDigest {
@@ -107,26 +111,39 @@ func diffContainers(kind string, live, desired []pkgallowlist.Container) (added,
 		onlyDesired := multisetSub(desiredByDigest[digest], liveByDigest[digest])
 		onlyLive := multisetSub(liveByDigest[digest], desiredByDigest[digest])
 		if len(onlyDesired) == 1 && len(onlyLive) == 1 {
-			changed = append(changed, containerDiff{Kind: kind, Digest: digest, From: onlyLive[0], To: onlyDesired[0]})
+			changed = append(changed, containerDiff{Kind: kind, Digest: digest, From: policySummary(onlyLive[0]), To: policySummary(onlyDesired[0])})
 			continue
 		}
 		for _, s := range onlyDesired {
-			added = append(added, containerDiff{Kind: kind, Digest: digest, To: s})
+			added = append(added, containerDiff{Kind: kind, Digest: digest, To: policySummary(s)})
 		}
 		for _, s := range onlyLive {
-			removed = append(removed, containerDiff{Kind: kind, Digest: digest, From: s})
+			removed = append(removed, containerDiff{Kind: kind, Digest: digest, From: policySummary(s)})
 		}
 	}
 	return added, removed, changed
 }
 
-func groupSummaries(cs []pkgallowlist.Container) map[string][]string {
+func groupPolicies(cs []pkgallowlist.Container) map[string][]string {
 	out := map[string][]string{}
 	for _, c := range cs {
 		d := c.Digest.String()
-		out[d] = append(out[d], containerSummary(c))
+		// Comparison uses framed JSON, not an ambiguous human argv rendering.
+		b, _ := json.Marshal(struct {
+			Command pkgallowlist.ArgvPolicy  `json:"command"`
+			Args    pkgallowlist.ArgvPolicy  `json:"args"`
+			Mounts  pkgallowlist.MountPolicy `json:"mounts"`
+			Env     pkgallowlist.EnvPolicy   `json:"env"`
+		}{c.Command, c.Args, c.Mounts, c.Env})
+		out[d] = append(out[d], string(b))
 	}
 	return out
+}
+
+func policySummary(key string) string {
+	var c pkgallowlist.Container
+	_ = json.Unmarshal([]byte(key), &c)
+	return containerSummary(c)
 }
 
 // multisetSub returns the elements of a not covered by an equal element of b,
@@ -158,6 +175,9 @@ func printDiff(w io.Writer, format string, d allowlistDiff) error {
 		return nil
 	}
 
+	if d.Schema != nil {
+		fmt.Fprintf(w, "schema: %s -> %s\n", d.Schema.From, d.Schema.To)
+	}
 	fmt.Fprintln(w, "workloads:")
 	for _, name := range d.WorkloadsAdded {
 		fmt.Fprintf(w, "+ %s\n", name)

--- a/internal/cmds/allowlist/diff.go
+++ b/internal/cmds/allowlist/diff.go
@@ -40,22 +40,18 @@ func (e entryDiff) empty() bool {
 
 // allowlistDiff is the entry-level diff of two allowlists.
 type allowlistDiff struct {
-	Schema           *changedEntry        `json:"schema,omitempty"`
 	WorkloadsAdded   []string             `json:"workloadsAdded"`
 	WorkloadsRemoved []string             `json:"workloadsRemoved"`
 	WorkloadsChanged map[string]entryDiff `json:"workloadsChanged"`
 }
 
 func (d allowlistDiff) empty() bool {
-	return d.Schema == nil && len(d.WorkloadsAdded) == 0 && len(d.WorkloadsRemoved) == 0 && len(d.WorkloadsChanged) == 0
+	return len(d.WorkloadsAdded) == 0 && len(d.WorkloadsRemoved) == 0 && len(d.WorkloadsChanged) == 0
 }
 
 // diffAllowlists computes the entry- and field-level diff of desired over live.
 func diffAllowlists(live, desired *pkgallowlist.Allowlist) allowlistDiff {
 	d := allowlistDiff{WorkloadsChanged: map[string]entryDiff{}}
-	if live.Schema != desired.Schema {
-		d.Schema = &changedEntry{From: live.Schema, To: desired.Schema}
-	}
 	for name, dw := range desired.Workloads {
 		lw, ok := live.Workloads[name]
 		if !ok {
@@ -175,9 +171,6 @@ func printDiff(w io.Writer, format string, d allowlistDiff) error {
 		return nil
 	}
 
-	if d.Schema != nil {
-		fmt.Fprintf(w, "schema: %s -> %s\n", d.Schema.From, d.Schema.To)
-	}
 	fmt.Fprintln(w, "workloads:")
 	for _, name := range d.WorkloadsAdded {
 		fmt.Fprintf(w, "+ %s\n", name)

--- a/internal/cmds/allowlist/env_test.go
+++ b/internal/cmds/allowlist/env_test.go
@@ -1,0 +1,65 @@
+package allowlist
+
+import (
+	pkgallowlist "github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDeriveRequiresExplicitEnvironment(t *testing.T) {
+	if _, err := runDerive(t, deployJSON(), "w", "-"); err == nil {
+		t.Fatal("implicit env accepted")
+	}
+	for _, mode := range []string{"any", "deny"} {
+		got, err := runDerive(t, deployJSON(), "w", "-", "--env="+mode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, c := range allContainers(got["w"]) {
+			if c.Env.Policy != mode {
+				t.Fatal("policy not applied to every container")
+			}
+		}
+	}
+	file := filepath.Join(t.TempDir(), "env.json")
+	data := `{"seed":{"policy":"deny"},"frontend":{"policy":"exact","values":{"MODE":"production"}},"worker":{"policy":"any"}}`
+	if err := os.WriteFile(file, []byte(data), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := runDerive(t, deployJSON(), "w", "-", "--env-file", file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["w"].Containers[0].Env.Values["MODE"] != "production" {
+		t.Fatal("exact values not derived")
+	}
+	if _, err := runDerive(t, deployJSON(), "w", "-", "--env-file", file, "--env=any"); err == nil {
+		t.Fatal("conflicting policies accepted")
+	}
+}
+
+func TestEnvironmentEditsAndCollisionShapes(t *testing.T) {
+	parse := func(value string) pkgallowlist.Workload {
+		w, err := pkgallowlist.ParseWorkloadJSON([]byte(`{"containers":[{"digest":"` + testDigest + `","command":{"policy":"exact","argv":["/app"]},"args":{"policy":"deny"},"env":{"policy":"exact","values":{"MODE":"` + value + `"}}}]}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		return *w
+	}
+	a, b := parse("a"), parse("b")
+	if diffEntry(a, b).empty() {
+		t.Fatal("env-only edit invisible")
+	}
+	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.SchemaV2, Workloads: map[string]pkgallowlist.Workload{"a": a, "b": b}}
+	if len(indistinguishableEntries(al)) != 0 {
+		t.Fatal("env-distinct workloads treated as identical")
+	}
+	al.Workloads["b"] = a
+	if len(indistinguishableEntries(al)) != 1 {
+		t.Fatal("identical workloads not flagged")
+	}
+	if _, err := parseWorkloadEntriesForSchema([]byte(`{"w":{"containers":[{"digest":"`+testDigest+`"}]}}`), pkgallowlist.SchemaV2); err == nil {
+		t.Fatal("v2 apply silently defaults env")
+	}
+}

--- a/internal/cmds/allowlist/env_test.go
+++ b/internal/cmds/allowlist/env_test.go
@@ -51,15 +51,12 @@ func TestEnvironmentEditsAndCollisionShapes(t *testing.T) {
 	if diffEntry(a, b).empty() {
 		t.Fatal("env-only edit invisible")
 	}
-	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.SchemaV2, Workloads: map[string]pkgallowlist.Workload{"a": a, "b": b}}
+	al := &pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: map[string]pkgallowlist.Workload{"a": a, "b": b}}
 	if len(indistinguishableEntries(al)) != 0 {
 		t.Fatal("env-distinct workloads treated as identical")
 	}
 	al.Workloads["b"] = a
 	if len(indistinguishableEntries(al)) != 1 {
 		t.Fatal("identical workloads not flagged")
-	}
-	if _, err := parseWorkloadEntriesForSchema([]byte(`{"w":{"containers":[{"digest":"`+testDigest+`"}]}}`), pkgallowlist.SchemaV2); err == nil {
-		t.Fatal("v2 apply silently defaults env")
 	}
 }

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -18,6 +18,7 @@ import (
 
 func newLintCmd(o *options) *cobra.Command {
 	var online, strict bool
+	var cvmMode string
 	cmd := &cobra.Command{
 		Use:   "lint <file|->",
 		Short: "Validate an allowlist file and report semantic warnings",
@@ -43,6 +44,7 @@ same.`,
 				return err
 			}
 			findings := lintOffline(al)
+			findings = append(findings, unobservedFieldPolicies(al, cvmMode)...)
 			if online {
 				if err := crane.Require(); err != nil {
 					return err
@@ -68,6 +70,7 @@ same.`,
 	}
 	cmd.Flags().BoolVar(&online, "online", false, "also check each digest exists in its registry via crane")
 	cmd.Flags().BoolVar(&strict, "strict", false, "exit non-zero if there are any warnings")
+	cmd.Flags().StringVar(&cvmMode, "cvm-mode", "", "deployment mode the allowlist targets (pod, node, gke, aks); pod silences the mount/env scope warning")
 	return cmd
 }
 
@@ -169,7 +172,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 				entriesByDigest[d] = map[string]bool{}
 			}
 			entriesByDigest[d][name] = true
-			if c.AnyArgv() {
+			if c.AnyArgv() && (c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "") && c.Mounts.Policy != pkgallowlist.PolicyExact {
 				fullyAny[d] = true
 			}
 			if argvPolicyName(c.Command) == pkgallowlist.PolicyDeny {
@@ -180,6 +183,11 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 			}
 		}
 		if w.Secrets != nil {
+			for _, c := range allContainers(w) {
+				if c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "" || c.Env.Names != nil {
+					warnings = append(warnings, warnf("workload %q grants secrets without pinning environment values for container %s", name, c.Digest))
+				}
+			}
 			for _, g := range append(append([]string{}, w.Secrets.Read...), w.Secrets.Write...) {
 				if g == "/**" {
 					warnings = append(warnings, warnf("workload %q grants the root secret subtree %q (every secret in the store)", name, g))
@@ -264,7 +272,36 @@ func shadows(wide, narrow pkgallowlist.Workload) bool {
 }
 
 func hasUnconstrainedRuntimePolicy(c pkgallowlist.Container) bool {
-	return c.AnyArgv()
+	return c.AnyArgv() && c.Mounts.Policy != pkgallowlist.PolicyExact &&
+		(c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "")
+}
+
+// unobservedFieldPolicies reports mount and env policy that the deployment's
+// enforcer cannot see. Only the in-guest policy-monitor reads the guest OCI
+// spec; the host NRI plugin sees the CRI container, reports neither field, and
+// an unobserved field is vacuously satisfied — so outside pod mode such a
+// policy admits every container with no signal at write, install or deny time.
+func unobservedFieldPolicies(al *pkgallowlist.Allowlist, cvmMode string) []finding {
+	if cvmMode == "pod" {
+		return nil
+	}
+	var warnings []finding
+	for _, name := range slices.Sorted(maps.Keys(al.Workloads)) {
+		for _, c := range allContainers(al.Workloads[name]) {
+			var fields []string
+			if c.Mounts.Policy == pkgallowlist.PolicyExact {
+				fields = append(fields, "mounts")
+			}
+			if c.Env.Policy == pkgallowlist.PolicyExact && c.Env.Names != nil {
+				fields = append(fields, "env")
+			}
+			if fields == nil {
+				continue
+			}
+			warnings = append(warnings, warnf("workload %q container %s constrains %s; only the in-guest policy-monitor observes those fields, so on a deployment enforced by the host NRI plugin this policy admits every container (pass --cvm-mode=pod if this allowlist targets kata)", name, c.Digest.String(), strings.Join(fields, " and ")))
+		}
+	}
+	return warnings
 }
 
 // indistinguishableEntries reports entries that no running set can tell apart.
@@ -309,7 +346,7 @@ func indistinguishableGroups(al *pkgallowlist.Allowlist) ([][]string, error) {
 
 func ambiguousGroupFinding(names []string) finding {
 	return errorf(
-		"workloads [%s] declare the same containers with the same argv policy; release requires exactly one entry to match, so all of them are refused (merge them, or narrow the argv policy so a running pod resolves to one)",
+		"workloads [%s] declare the same containers with the same command, args and env policy; release requires exactly one entry to match, so all of them are refused (merge them, or narrow the launch policy so a running pod resolves to one)",
 		strings.Join(names, ", "))
 }
 
@@ -322,11 +359,16 @@ func entryShape(w pkgallowlist.Workload) (string, error) {
 		Digest  string                  `json:"digest"`
 		Command pkgallowlist.ArgvPolicy `json:"command"`
 		Args    pkgallowlist.ArgvPolicy `json:"args"`
+		Env     pkgallowlist.EnvPolicy  `json:"env"`
 	}
 	shape := func(cs []pkgallowlist.Container) ([]string, error) {
 		out := make([]string, 0, len(cs))
 		for _, c := range cs {
-			b, err := json.Marshal(containerShape{Digest: c.Digest.String(), Command: c.Command, Args: c.Args})
+			env := c.Env
+			if env.Names != nil || env.Policy == "" {
+				env = pkgallowlist.EnvPolicy{Policy: pkgallowlist.PolicyAny}
+			}
+			b, err := json.Marshal(containerShape{Digest: c.Digest.String(), Command: c.Command, Args: c.Args, Env: env})
 			if err != nil {
 				return nil, err
 			}

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -172,7 +172,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 				entriesByDigest[d] = map[string]bool{}
 			}
 			entriesByDigest[d][name] = true
-			if c.AnyArgv() && (c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "") && c.Mounts.Policy != pkgallowlist.PolicyExact {
+			if hasUnconstrainedRuntimePolicy(c) {
 				fullyAny[d] = true
 			}
 			if argvPolicyName(c.Command) == pkgallowlist.PolicyDeny {
@@ -184,7 +184,7 @@ func lintOffline(al *pkgallowlist.Allowlist) []finding {
 		}
 		if w.Secrets != nil {
 			for _, c := range allContainers(w) {
-				if c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "" || c.Env.Names != nil {
+				if c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "" {
 					warnings = append(warnings, warnf("workload %q grants secrets without pinning environment values for container %s", name, c.Digest))
 				}
 			}
@@ -271,16 +271,7 @@ func shadows(wide, narrow pkgallowlist.Workload) bool {
 	return true
 }
 
-func hasUnconstrainedRuntimePolicy(c pkgallowlist.Container) bool {
-	return c.AnyArgv() && c.Mounts.Policy != pkgallowlist.PolicyExact &&
-		(c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "")
-}
-
-// unobservedFieldPolicies reports mount and env policy that the deployment's
-// enforcer cannot see. Only the in-guest policy-monitor reads the guest OCI
-// spec; the host NRI plugin sees the CRI container, reports neither field, and
-// an unobserved field is vacuously satisfied — so outside pod mode such a
-// policy admits every container with no signal at write, install or deny time.
+// unobservedFieldPolicies reports mount restrictions outside pod mode.
 func unobservedFieldPolicies(al *pkgallowlist.Allowlist, cvmMode string) []finding {
 	if cvmMode == "pod" {
 		return nil
@@ -291,9 +282,6 @@ func unobservedFieldPolicies(al *pkgallowlist.Allowlist, cvmMode string) []findi
 			var fields []string
 			if c.Mounts.Policy == pkgallowlist.PolicyExact {
 				fields = append(fields, "mounts")
-			}
-			if c.Env.Policy == pkgallowlist.PolicyExact && c.Env.Names != nil {
-				fields = append(fields, "env")
 			}
 			if fields == nil {
 				continue
@@ -365,7 +353,7 @@ func entryShape(w pkgallowlist.Workload) (string, error) {
 		out := make([]string, 0, len(cs))
 		for _, c := range cs {
 			env := c.Env
-			if env.Names != nil || env.Policy == "" {
+			if env.Policy == "" {
 				env = pkgallowlist.EnvPolicy{Policy: pkgallowlist.PolicyAny}
 			}
 			b, err := json.Marshal(containerShape{Digest: c.Digest.String(), Command: c.Command, Args: c.Args, Env: env})
@@ -431,4 +419,9 @@ func isTagForm(image string) bool {
 	}
 	_, digested := named.(reference.Digested)
 	return !digested
+}
+
+func hasUnconstrainedRuntimePolicy(c pkgallowlist.Container) bool {
+	return c.AnyArgv() && c.Mounts.Policy != pkgallowlist.PolicyExact &&
+		(c.Env.Policy == pkgallowlist.PolicyAny || c.Env.Policy == "")
 }

--- a/internal/cmds/allowlist/lint_test.go
+++ b/internal/cmds/allowlist/lint_test.go
@@ -165,7 +165,7 @@ func entryPair(t *testing.T, a, b string) *pkgallowlist.Allowlist {
 func ambiguityErrors(findings []finding) []string {
 	var out []string
 	for _, f := range findings {
-		if f.err && strings.Contains(f.msg, "same containers with the same argv policy") {
+		if f.err && strings.Contains(f.msg, "same containers with the same command, args and env policy") {
 			out = append(out, f.msg)
 		}
 	}

--- a/internal/cmds/allowlist/read.go
+++ b/internal/cmds/allowlist/read.go
@@ -233,9 +233,6 @@ func summarizeEnv(w pkgallowlist.Workload) string {
 		if mode == "" {
 			mode = pkgallowlist.PolicyAny
 		}
-		if c.Env.Names != nil {
-			mode = "names"
-		}
 		modes[mode] = true
 	}
 	return joinSet(modes)

--- a/internal/cmds/allowlist/read.go
+++ b/internal/cmds/allowlist/read.go
@@ -148,12 +148,12 @@ func printWorkloadTable(w io.Writer, workloads map[string]pkgallowlist.Workload)
 	names := slices.Sorted(maps.Keys(workloads))
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tLABEL\tINIT\tCTRS\tCOMMAND/ARGS\tSECRETS")
+	fmt.Fprintln(tw, "NAME\tLABEL\tINIT\tCTRS\tCOMMAND/ARGS\tENV\tSECRETS")
 	for _, name := range names {
 		wl := workloads[name]
 		command, args, secrets := summarizeWorkload(wl)
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\t%s\n", name, wl.Label, len(wl.InitContainers), len(wl.Containers),
-			"command="+command+" args="+args, secrets)
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%d\t%s\t%s\t%s\n", name, wl.Label, len(wl.InitContainers), len(wl.Containers),
+			"command="+command+" args="+args, "env="+summarizeEnv(wl), secrets)
 	}
 	tw.Flush()
 }
@@ -210,7 +210,9 @@ func secretsSummary(p *pkgallowlist.SecretsPolicy) string {
 // containerSummary renders one container's argv policy pair, e.g.
 // "command=exact[/bin/sh -c] args=any".
 func containerSummary(c pkgallowlist.Container) string {
-	return fmt.Sprintf("command=%s args=%s", argvSummary(c.Command), argvSummary(c.Args))
+	env, _ := json.Marshal(c.Env)
+	mounts, _ := json.Marshal(c.Mounts)
+	return fmt.Sprintf("command=%s args=%s env=%s mounts=%s", argvSummary(c.Command), argvSummary(c.Args), env, mounts)
 }
 
 func shellJoin(argv []string) string {
@@ -222,4 +224,19 @@ func shellJoin(argv []string) string {
 		out += a
 	}
 	return out
+}
+
+func summarizeEnv(w pkgallowlist.Workload) string {
+	modes := map[string]bool{}
+	for _, c := range allContainers(w) {
+		mode := c.Env.Policy
+		if mode == "" {
+			mode = pkgallowlist.PolicyAny
+		}
+		if c.Env.Names != nil {
+			mode = "names"
+		}
+		modes[mode] = true
+	}
+	return joinSet(modes)
 }

--- a/internal/cmds/allowlist/read_write_test.go
+++ b/internal/cmds/allowlist/read_write_test.go
@@ -182,8 +182,8 @@ func TestListTextWorkloadTable(t *testing.T) {
 		}
 	}
 	want := map[string][]string{
-		"web":   {"web", "web-img", "0", "2", "command=any,exact", "args=any,deny", "allow(r=2,w=1)"},
-		"plain": {"plain", "0", "1", "command=exact", "args=deny", "allow(r=1,w=0)"},
+		"web":   {"web", "web-img", "0", "2", "command=any,exact", "args=any,deny", "env=any", "allow(r=2,w=1)"},
+		"plain": {"plain", "0", "1", "command=exact", "args=deny", "env=any", "allow(r=1,w=0)"},
 	}
 	for name, wantRow := range want {
 		got, ok := rows[name]

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -72,10 +72,6 @@ replaced whole — this never field-merges into a live entry.`,
 				return err
 			}
 
-			entries, err = parseWorkloadEntriesForSchema(data, live.Schema)
-			if err != nil {
-				return err
-			}
 			findings := lintOffline(&pkgallowlist.Allowlist{Schema: live.Schema, Workloads: entries})
 			// The ambiguity check is the one finding that cannot be made from
 			// the file alone: the entry it collides with is usually one already
@@ -148,7 +144,7 @@ func newEditCmd(o *options) *cobra.Command {
 				return fmt.Errorf("no workload entry named %q", name)
 			}
 
-			edited, err := editWorkloadInEditor(orig, name, live.Schema)
+			edited, err := editWorkloadInEditor(orig, name)
 			if err != nil {
 				return err
 			}
@@ -253,14 +249,7 @@ func collisionsWithLive(entries map[string]pkgallowlist.Workload, live *pkgallow
 // parseWorkloadEntries accepts either a full/partial allowlist document or a
 // bare name-keyed map of workload entries.
 func parseWorkloadEntries(data []byte) (map[string]pkgallowlist.Workload, error) {
-	return parseWorkloadEntriesForSchema(data, "")
-}
-
-func parseWorkloadEntriesForSchema(data []byte, schema string) (map[string]pkgallowlist.Workload, error) {
 	if al, perr := pkgallowlist.ParseJSON(data); perr == nil {
-		if schema != "" && schema != al.Schema {
-			return nil, fmt.Errorf("document schema differs from CDS; use allowlist upload for an explicit whole-document migration")
-		}
 		if al.Workloads == nil {
 			al.Workloads = map[string]pkgallowlist.Workload{}
 		}
@@ -275,7 +264,7 @@ func parseWorkloadEntriesForSchema(data []byte, schema string) (map[string]pkgal
 	}
 	out := make(map[string]pkgallowlist.Workload, len(raw))
 	for name, body := range raw {
-		w, werr := pkgallowlist.ParseWorkloadJSONForSchema(body, schema)
+		w, werr := pkgallowlist.ParseWorkloadJSON(body)
 		if werr != nil {
 			return nil, fmt.Errorf("workload %q: %w", name, werr)
 		}
@@ -297,7 +286,7 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 
 // editWorkloadInEditor writes the entry to a temp file, opens $EDITOR (vi if
 // unset) on it, and re-validates the result via ParseWorkloadJSON.
-func editWorkloadInEditor(w pkgallowlist.Workload, name string, schema ...string) (*pkgallowlist.Workload, error) {
+func editWorkloadInEditor(w pkgallowlist.Workload, name string) (*pkgallowlist.Workload, error) {
 	tmp, err := os.CreateTemp("", "c8s-workload-"+sanitizeFileName(name)+"-*.json")
 	if err != nil {
 		return nil, err
@@ -322,9 +311,6 @@ func editWorkloadInEditor(w pkgallowlist.Workload, name string, schema ...string
 	edited, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
-	}
-	if len(schema) > 0 {
-		return pkgallowlist.ParseWorkloadJSONForSchema(edited, schema[0])
 	}
 	return pkgallowlist.ParseWorkloadJSON(edited)
 }

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -63,8 +63,6 @@ replaced whole — this never field-merges into a live entry.`,
 				return fmt.Errorf("no workload entries in %q", args[0])
 			}
 
-			findings := lintOffline(&pkgallowlist.Allowlist{Schema: pkgallowlist.Schema, Workloads: entries})
-
 			c, err := o.client(ctx(cmd))
 			if err != nil {
 				return err
@@ -74,6 +72,11 @@ replaced whole — this never field-merges into a live entry.`,
 				return err
 			}
 
+			entries, err = parseWorkloadEntriesForSchema(data, live.Schema)
+			if err != nil {
+				return err
+			}
+			findings := lintOffline(&pkgallowlist.Allowlist{Schema: live.Schema, Workloads: entries})
 			// The ambiguity check is the one finding that cannot be made from
 			// the file alone: the entry it collides with is usually one already
 			// served. Only pairs that span both are added here, since a
@@ -145,7 +148,7 @@ func newEditCmd(o *options) *cobra.Command {
 				return fmt.Errorf("no workload entry named %q", name)
 			}
 
-			edited, err := editWorkloadInEditor(orig, name)
+			edited, err := editWorkloadInEditor(orig, name, live.Schema)
 			if err != nil {
 				return err
 			}
@@ -250,7 +253,14 @@ func collisionsWithLive(entries map[string]pkgallowlist.Workload, live *pkgallow
 // parseWorkloadEntries accepts either a full/partial allowlist document or a
 // bare name-keyed map of workload entries.
 func parseWorkloadEntries(data []byte) (map[string]pkgallowlist.Workload, error) {
+	return parseWorkloadEntriesForSchema(data, "")
+}
+
+func parseWorkloadEntriesForSchema(data []byte, schema string) (map[string]pkgallowlist.Workload, error) {
 	if al, perr := pkgallowlist.ParseJSON(data); perr == nil {
+		if schema != "" && schema != al.Schema {
+			return nil, fmt.Errorf("document schema differs from CDS; use allowlist upload for an explicit whole-document migration")
+		}
 		if al.Workloads == nil {
 			al.Workloads = map[string]pkgallowlist.Workload{}
 		}
@@ -265,7 +275,7 @@ func parseWorkloadEntries(data []byte) (map[string]pkgallowlist.Workload, error)
 	}
 	out := make(map[string]pkgallowlist.Workload, len(raw))
 	for name, body := range raw {
-		w, werr := pkgallowlist.ParseWorkloadJSON(body)
+		w, werr := pkgallowlist.ParseWorkloadJSONForSchema(body, schema)
 		if werr != nil {
 			return nil, fmt.Errorf("workload %q: %w", name, werr)
 		}
@@ -287,7 +297,7 @@ func readFileOrStdin(cmd *cobra.Command, path string) ([]byte, error) {
 
 // editWorkloadInEditor writes the entry to a temp file, opens $EDITOR (vi if
 // unset) on it, and re-validates the result via ParseWorkloadJSON.
-func editWorkloadInEditor(w pkgallowlist.Workload, name string) (*pkgallowlist.Workload, error) {
+func editWorkloadInEditor(w pkgallowlist.Workload, name string, schema ...string) (*pkgallowlist.Workload, error) {
 	tmp, err := os.CreateTemp("", "c8s-workload-"+sanitizeFileName(name)+"-*.json")
 	if err != nil {
 		return nil, err
@@ -312,6 +322,9 @@ func editWorkloadInEditor(w pkgallowlist.Workload, name string) (*pkgallowlist.W
 	edited, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
+	}
+	if len(schema) > 0 {
+		return pkgallowlist.ParseWorkloadJSONForSchema(edited, schema[0])
 	}
 	return pkgallowlist.ParseWorkloadJSON(edited)
 }

--- a/internal/cmds/cds/attest.go
+++ b/internal/cmds/cds/attest.go
@@ -515,7 +515,7 @@ func (h AttestHandler) matchWorkload(ctx context.Context, snapshot *PolicySnapsh
 		if err != nil {
 			return unnamed(slog.LevelError, "inventory reported a malformed container digest", "error", err)
 		}
-		canonical = append(canonical, workloadclaims.SandboxContainer{Digest: digest.String(), Argv: c.Argv})
+		canonical = append(canonical, workloadclaims.SandboxContainer{Digest: digest.String(), Argv: c.Argv, Env: c.Env})
 		containerSet[digest.String()] = struct{}{}
 	}
 	// The two views describe the same sandbox and must agree. The inventory is

--- a/internal/cmds/cds/attest_matchedworkload_test.go
+++ b/internal/cmds/cds/attest_matchedworkload_test.go
@@ -264,3 +264,25 @@ func TestAttest_MatchedWorkload_NamedLeafTTLCeiling(t *testing.T) {
 		})
 	}
 }
+
+func TestAttest_WorkloadStampRequiresEnv(t *testing.T) {
+	for _, tc := range []struct {
+		name, value string
+		known, want bool
+	}{
+		{"exact", "production", true, true}, {"wrong", "unsafe", true, false}, {"unknown", "", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := completeAPIStore(t)
+			store.workloads["api"].Containers[0].Env = pkgallowlist.EnvPolicy{Policy: pkgallowlist.PolicyExact, Values: map[string]string{"MODE": "production"}}
+			containers := containersView(wlDigestA)
+			if tc.known {
+				containers[0].Env, _ = pkgallowlist.ObserveEnv([]string{"MODE=" + tc.value})
+			}
+			matched := issueWithInventory(t, store, []string{wlDigestA}, containers, nil)
+			if (matched != nil) != tc.want {
+				t.Fatalf("stamp=%v", matched)
+			}
+		})
+	}
+}

--- a/internal/cmds/nri-image-policy/env.go
+++ b/internal/cmds/nri-image-policy/env.go
@@ -1,0 +1,77 @@
+package nriimagepolicy
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/containerd/nri/pkg/api"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+)
+
+// ValidateContainerAdjustment runs after all create-time plugins. Unlike a
+// StartContainer notification, a failed/disconnected validator rejects creation.
+// Together with containerd's required_plugins configuration this prevents a
+// plugin disconnect between creation and start from bypassing env admission.
+func (p *plugin) ValidateContainerAdjustment(ctx context.Context, req *api.ValidateContainerAdjustmentRequest) error {
+	if req.GetContainer() == nil || req.GetPod() == nil {
+		return fmt.Errorf("missing container or sandbox in NRI validation")
+	}
+	ctr, env := adjustedLaunchContainer(req)
+	verdict, reason := p.checkContainerObserved(ctx, p.cfg, req.GetPod(), ctr, ctr.GetAnnotations()[annotationImageName], true, env)
+	if verdict == verdictDeny && p.cfg.Policy.Mode != ModeAudit {
+		return fmt.Errorf("%s", reason)
+	}
+	// No inventory record here: later validators can still reject creation, and
+	// CDI transformations under an any policy have not happened yet.
+	return nil
+}
+
+// adjustedLaunchContainer applies the env/argv part of cumulative NRI edits.
+// For valid unique input names this is equivalent to NRI's AdjustEnv: the last
+// edit per name wins; marked names are removed. Order is irrelevant to policy.
+// Invalid input or deferred CDI injection yields unknown env evidence, so only
+// unrestricted env policies can admit it at this stage. Never guess an empty env.
+func adjustedLaunchContainer(req *api.ValidateContainerAdjustmentRequest) (*api.Container, *allowlist.EnvObservation) {
+	ctr := proto.Clone(req.GetContainer()).(*api.Container)
+	adjust := req.GetAdjust()
+	if len(adjust.GetArgs()) > 0 {
+		ctr.Args = slices.Clone(adjust.GetArgs())
+	}
+	if len(adjust.GetCDIDevices()) > 0 {
+		return ctr, nil
+	}
+	if len(adjust.GetEnv()) == 0 {
+		return ctr, containerEnv(ctr)
+	}
+	if _, err := allowlist.ObserveEnv(ctr.Env); err != nil {
+		return ctr, nil
+	}
+	values := map[string]string{}
+	for _, entry := range ctr.Env {
+		name, value, _ := strings.Cut(entry, "=")
+		values[name] = value
+	}
+	for _, edit := range adjust.GetEnv() {
+		if edit == nil {
+			return ctr, nil
+		}
+		name, remove := edit.IsMarkedForRemoval()
+		if name == "" || strings.ContainsAny(name, "=\x00") {
+			return ctr, nil
+		}
+		if remove {
+			delete(values, name)
+		} else {
+			values[name] = edit.Value
+		}
+	}
+	ctr.Env = nil
+	for name, value := range values {
+		ctr.Env = append(ctr.Env, name+"="+value)
+	}
+	return ctr, containerEnv(ctr)
+}

--- a/internal/cmds/nri-image-policy/env_test.go
+++ b/internal/cmds/nri-image-policy/env_test.go
@@ -1,0 +1,134 @@
+package nriimagepolicy
+
+import (
+	"context"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
+	"github.com/containerd/nri/pkg/api"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// Exercise containerd's create/start lifecycle for older admission tests.
+func createAndStart(p *plugin, ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
+	a, u, err := p.CreateContainer(ctx, pod, ctr)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err = p.ValidateContainerAdjustment(ctx, &api.ValidateContainerAdjustmentRequest{Pod: pod, Container: ctr, Adjust: a}); err != nil {
+		return nil, nil, err
+	}
+	if err = p.StartContainer(ctx, pod, ctr); err != nil {
+		return nil, nil, err
+	}
+	return a, u, nil
+}
+
+func TestEnvAdmissionUsesFinalStartSpec(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		initial, final []string
+		want           bool
+	}{
+		{"later injection", nil, []string{"MODE=production"}, true},
+		{"later tampering", []string{"MODE=production"}, []string{"MODE=unsafe"}, false},
+		{"duplicate", nil, []string{"MODE=unsafe", "MODE=production"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			al := workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"})
+			al.Workloads["w"].Containers[0].Env = allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Values: map[string]string{"MODE": "production"}}
+			p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}, Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "floor"}}}, al)
+			p.SetReady()
+			p.inventory = newAdmissionInventory(t.TempDir())
+			pod := makePod("default", "pod")
+			ctr := makeCtrWithImage(pod.Id, "ctr", "registry/repo@"+pushDigestB)
+			ctr.Args = []string{"/bin/app", "--serve"}
+			ctr.Env = tc.initial
+			if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+				t.Fatal(err)
+			}
+			if len(p.inventory.containers) != 0 {
+				t.Fatal("pre-final environment recorded")
+			}
+			ctr.Env = tc.final
+			err := p.StartContainer(context.Background(), pod, ctr)
+			if (err == nil) != tc.want {
+				t.Fatalf("start=%v", err)
+			}
+			_, cs, _, err := p.inventory.DigestsForSandbox(pod.Id)
+			if tc.want {
+				if err != nil || len(cs) != 1 || !cs[0].Env.Valid() {
+					t.Fatalf("missing final evidence: %v %v", cs, err)
+				}
+			} else if len(cs) != 0 {
+				t.Fatal("denied start recorded")
+			}
+		})
+	}
+}
+
+func TestIncompleteProcessIsNotEmptyEnv(t *testing.T) {
+	if containerEnv(&api.Container{}) != nil {
+		t.Fatal("missing OCI process looks like empty env")
+	}
+	o := containerEnv(&api.Container{Args: []string{"/app"}})
+	if !o.Valid() {
+		t.Fatal("observed empty OCI env lost")
+	}
+}
+
+func TestEnvCreationValidatorChecksCumulativeEdits(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		initial []string
+		edits   []*api.KeyValue
+		cdi     bool
+		any     bool
+		want    bool
+	}{
+		{name: "unchanged", initial: []string{"MODE=production"}, want: true},
+		{name: "override", initial: []string{"MODE=unsafe"}, edits: []*api.KeyValue{{Key: "MODE", Value: "production"}}, want: true},
+		{name: "tamper", initial: []string{"MODE=production"}, edits: []*api.KeyValue{{Key: "MODE", Value: "unsafe"}}},
+		{name: "remove extra", initial: []string{"MODE=production", "EXTRA=x"}, edits: []*api.KeyValue{{Key: "-EXTRA"}}, want: true},
+		{name: "remove required", initial: []string{"MODE=production"}, edits: []*api.KeyValue{{Key: "-MODE"}}},
+		{name: "extra", initial: []string{"MODE=production"}, edits: []*api.KeyValue{{Key: "EXTRA", Value: "x"}}},
+		{name: "last edit", edits: []*api.KeyValue{{Key: "MODE", Value: "unsafe"}, {Key: "MODE", Value: "production"}}, want: true},
+		{name: "bad original", initial: []string{"MODE=unsafe", "MODE=production"}, edits: []*api.KeyValue{{Key: "MODE", Value: "production"}}},
+		{name: "bad edit", edits: []*api.KeyValue{{Key: "MODE=production", Value: ""}}},
+		{name: "deferred CDI", initial: []string{"MODE=production"}, cdi: true},
+		{name: "unrestricted CDI", cdi: true, any: true, want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			al := workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"})
+			policy := allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Values: map[string]string{"MODE": "production"}}
+			if tc.any {
+				policy = allowlist.EnvPolicy{Policy: allowlist.PolicyAny}
+			}
+			al.Workloads["w"].Containers[0].Env = policy
+			p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}, Allowlist: allowlistConfig{AlwaysAllow: map[string]string{pushDigestA: "floor"}}}, al)
+			p.SetReady()
+			p.inventory = newAdmissionInventory(t.TempDir())
+			pod := makePod("default", "pod")
+			ctr := makeCtrWithImageArgs(pod.Id, "ctr", "registry/repo@"+pushDigestB, []string{"/bin/app", "--serve"})
+			ctr.Env = tc.initial
+			adjust := &api.ContainerAdjustment{Env: tc.edits}
+			if tc.cdi {
+				adjust.CDIDevices = []*api.CDIDevice{{Name: "vendor/device=gpu"}}
+			}
+			req := &api.ValidateContainerAdjustmentRequest{Pod: pod, Container: ctr, Adjust: adjust}
+			err := p.ValidateContainerAdjustment(context.Background(), req)
+			if (err == nil) != tc.want {
+				t.Fatalf("validation=%v want admitted=%v", err, tc.want)
+			}
+			if len(p.inventory.containers) != 0 {
+				t.Fatal("validator prematurely recorded an admission")
+			}
+			if !slices.Equal(ctr.Env, tc.initial) {
+				t.Fatal("validator mutated request")
+			}
+			if err != nil && strings.Contains(err.Error(), "unsafe") {
+				t.Fatal("denial disclosed env value")
+			}
+		})
+	}
+}

--- a/internal/cmds/nri-image-policy/exempt_plugin_test.go
+++ b/internal/cmds/nri-image-policy/exempt_plugin_test.go
@@ -60,7 +60,7 @@ func TestExempt_CaptureAtSyncAdmitsLaterCreate(t *testing.T) {
 	}
 
 	next := makeCtrWithImage(pod.Id, "coredns-2", "registry/repo@"+pushDigestB)
-	if _, _, err := p.CreateContainer(context.Background(), pod, next); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, next); err != nil {
 		t.Fatalf("a captured kube-system image must be admitted on create: %v", err)
 	}
 }
@@ -78,7 +78,7 @@ func TestExempt_UncapturedDigestDeniedInExemptNamespace(t *testing.T) {
 	}
 
 	uncaptured := makeCtrWithImage(pod.Id, "evil", "registry/repo@"+pushDigestB)
-	if _, _, err := p.CreateContainer(context.Background(), pod, uncaptured); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, uncaptured); err == nil {
 		t.Fatal("an uncaptured non-floor image in an exempt namespace must be denied")
 	}
 }
@@ -98,7 +98,7 @@ func TestExempt_CapturedDigestNotAdmittedInTenantNamespace(t *testing.T) {
 
 	tenantPod := makePod("default", "tenant")
 	tenant := makeCtrWithImage(tenantPod.Id, "c", "registry/repo@"+pushDigestB)
-	if _, _, err := p.CreateContainer(context.Background(), tenantPod, tenant); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), tenantPod, tenant); err == nil {
 		t.Fatal("a kube-system-captured digest must not admit in a tenant namespace")
 	}
 }

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -47,7 +47,7 @@ func newAdmissionInventory(procRoot string) *admissionInventory {
 // an inventory of what was admitted in the sandbox, and the injected images are
 // admitted under any argv, so CDS drops them from workload matching itself.
 // argv is the effective OCI process.args the container runs.
-func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string, env ...*allowlist.EnvObservation) {
+func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string, env *allowlist.EnvObservation) {
 	if containerID == "" || sandboxID == "" {
 		return
 	}
@@ -56,7 +56,7 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 	b.containers[containerID] = ctrRec{sandboxID: sandboxID, name: name, digest: digest, argv: argv}
 
 	rec := b.admitted[sandboxID]
-	rec.Record(containerID, digest, argv, env...)
+	rec.Record(containerID, digest, argv, env)
 	b.admitted[sandboxID] = rec
 
 	// A container implies its sandbox, so a record arriving before (or without)

--- a/internal/cmds/nri-image-policy/inventory.go
+++ b/internal/cmds/nri-image-policy/inventory.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/confidential-dot-ai/c8s/internal/admissionhistory"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"github.com/confidential-dot-ai/c8s/pkg/workloadclaims"
 )
 
@@ -46,7 +47,7 @@ func newAdmissionInventory(procRoot string) *admissionInventory {
 // an inventory of what was admitted in the sandbox, and the injected images are
 // admitted under any argv, so CDS drops them from workload matching itself.
 // argv is the effective OCI process.args the container runs.
-func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string) {
+func (b *admissionInventory) record(containerID, sandboxID, name, digest string, argv []string, env ...*allowlist.EnvObservation) {
 	if containerID == "" || sandboxID == "" {
 		return
 	}
@@ -55,7 +56,7 @@ func (b *admissionInventory) record(containerID, sandboxID, name, digest string,
 	b.containers[containerID] = ctrRec{sandboxID: sandboxID, name: name, digest: digest, argv: argv}
 
 	rec := b.admitted[sandboxID]
-	rec.Record(containerID, digest, argv)
+	rec.Record(containerID, digest, argv, env...)
 	b.admitted[sandboxID] = rec
 
 	// A container implies its sandbox, so a record arriving before (or without)

--- a/internal/cmds/nri-image-policy/inventory_test.go
+++ b/internal/cmds/nri-image-policy/inventory_test.go
@@ -75,11 +75,11 @@ func TestInventoryResolvesPodAndIsolatesOtherPods(t *testing.T) {
 		pod2 = "sandbox-2"
 	)
 	// pod1: get-cert sidecar + two app containers.
-	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil)
-	b.record(cidApp1, pod1, "app", digestApp, nil)
-	b.record(cidApp2, pod1, "worker", digestApp2, nil)
+	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil, nil)
+	b.record(cidApp1, pod1, "app", digestApp, nil, nil)
+	b.record(cidApp2, pod1, "worker", digestApp2, nil, nil)
 	// pod2: a different app; must never appear in pod1's answer.
-	b.record(cidOther, pod2, "app", digestOther, nil)
+	b.record(cidOther, pod2, "app", digestOther, nil, nil)
 
 	// The caller is the get-cert process in pod1.
 	writeCgroup(t, procRoot, 4242, cidGetCert)
@@ -98,7 +98,7 @@ func TestInventoryResolvesPodAndIsolatesOtherPods(t *testing.T) {
 func TestInventoryRejectsUntrackedAndZeroPID(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
 
 	if _, err := sandboxDigestsFor(b, 0); err == nil {
 		t.Fatal("peer pid 0 accepted (node-CVM must bind the caller)")
@@ -118,9 +118,9 @@ func TestInventoryRejectsNestedVictimCgroup(t *testing.T) {
 	b := newAdmissionInventory(procRoot)
 
 	const pod1, pod2 = "sandbox-1", "sandbox-2"
-	b.record(cidApp1, pod1, "app", digestApp, nil) // victim's app in pod1
-	b.record(cidGetCert, pod2, "c8s-cert", digestOther, nil)
-	b.record(cidApp2, pod2, "app", digestApp2, nil) // attacker's own app in pod2
+	b.record(cidApp1, pod1, "app", digestApp, nil, nil) // victim's app in pod1
+	b.record(cidGetCert, pod2, "c8s-cert", digestOther, nil, nil)
+	b.record(cidApp2, pod2, "app", digestApp2, nil, nil) // attacker's own app in pod2
 
 	// Attacker's process: its real scope is cidGetCert (pod2), with a nested
 	// child cgroup named cidApp1 (pod1's container).
@@ -152,9 +152,9 @@ func TestInventoryRefusesUnresolvedDigest(t *testing.T) {
 	b := newAdmissionInventory(procRoot)
 
 	const pod1 = "sandbox-1"
-	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil)
-	b.record(cidApp1, pod1, "app", digestApp, nil)
-	b.record(cidApp2, pod1, "worker", "", nil) // resolve failed at admission
+	b.record(cidGetCert, pod1, "c8s-cert", digestOther, nil, nil)
+	b.record(cidApp1, pod1, "app", digestApp, nil, nil)
+	b.record(cidApp2, pod1, "worker", "", nil, nil) // resolve failed at admission
 	writeCgroup(t, procRoot, 4242, cidGetCert)
 
 	if _, err := sandboxDigestsFor(b, 4242); err == nil {
@@ -169,8 +169,8 @@ func TestInventoryRefusesUnresolvedDigest(t *testing.T) {
 func TestInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
-	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
 	writeCgroup(t, procRoot, 77, cidGetCert)
 
 	b.remove(cidApp1)
@@ -201,7 +201,7 @@ func TestInventoryRemoveKeepsAdmissionRecord(t *testing.T) {
 func TestInventorySandboxForPeer(t *testing.T) {
 	procRoot := t.TempDir()
 	b := newAdmissionInventory(procRoot)
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil, nil)
 	writeCgroup(t, procRoot, 4242, cidGetCert)
 
 	got, err := b.SandboxForPeer(workloadclaims.PeerForPID(4242))
@@ -239,10 +239,10 @@ func TestInventoryDigestsForSandbox(t *testing.T) {
 	}
 
 	// The inventory includes injected containers, deduplicates, and sorts.
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil)
-	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
-	b.record(cidApp2, "sandbox-1", "worker", digestApp, nil)
-	b.record(cidOther, "sandbox-2", "app", digestApp2, nil)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", digestOther, nil, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
+	b.record(cidApp2, "sandbox-1", "worker", digestApp, nil, nil)
+	b.record(cidOther, "sandbox-2", "app", digestApp2, nil, nil)
 	got, _, known, err = b.DigestsForSandbox("sandbox-1")
 	if err != nil || !known {
 		t.Fatalf("known=%v err=%v", known, err)
@@ -262,8 +262,8 @@ func slicesSorted(in []string) []string {
 // the inventory covers every running container, injected ones included.
 func TestInventoryDigestsForSandboxRefusesUnresolved(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
-	b.record(cidGetCert, "sandbox-1", "c8s-cert", "", nil)
-	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	b.record(cidGetCert, "sandbox-1", "c8s-cert", "", nil, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
 
 	if _, _, _, err := b.DigestsForSandbox("sandbox-1"); err == nil {
 		t.Fatal("served a subset of the sandbox inventory")
@@ -275,12 +275,12 @@ func TestInventoryDigestsForSandboxRefusesUnresolved(t *testing.T) {
 func TestInventorySandboxLifecycle(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
 
-	b.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	b.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
 	if _, _, known, _ := b.DigestsForSandbox("sandbox-1"); !known {
 		t.Fatal("recorded container did not imply its sandbox")
 	}
 
-	b.record(cidOther, "sandbox-2", "app", digestApp2, nil)
+	b.record(cidOther, "sandbox-2", "app", digestApp2, nil, nil)
 	b.removeSandbox("sandbox-1")
 	if _, _, known, _ := b.DigestsForSandbox("sandbox-1"); known {
 		t.Fatal("removed sandbox still known")
@@ -304,8 +304,8 @@ func TestInventoryArgvSeparatorDoesNotEraseAdmissions(t *testing.T) {
 	b := newAdmissionInventory(t.TempDir())
 	const sandbox = "sandbox-1"
 
-	b.record(cidApp1, sandbox, "app", digestApp, []string{"/app\x1f--serve"})
-	b.record(cidApp2, sandbox, "app", digestApp, []string{"/app", "--serve"})
+	b.record(cidApp1, sandbox, "app", digestApp, []string{"/app\x1f--serve"}, nil)
+	b.record(cidApp2, sandbox, "app", digestApp, []string{"/app", "--serve"}, nil)
 
 	_, containers, known, err := b.DigestsForSandbox(sandbox)
 	if err != nil || !known {
@@ -327,20 +327,20 @@ func TestInventoryArgvSeparatorDoesNotEraseAdmissions(t *testing.T) {
 // record that resolves that same container reopens it.
 func TestInventory_UnresolvedClearsWhenTheContainerResolves(t *testing.T) {
 	inv := newAdmissionInventory(t.TempDir())
-	inv.record("ctr-1", "sbx-1", "app", "", nil)
-	inv.record("ctr-2", "sbx-1", "side", pushDigestA, nil)
+	inv.record("ctr-1", "sbx-1", "app", "", nil, nil)
+	inv.record("ctr-2", "sbx-1", "side", pushDigestA, nil, nil)
 
 	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
 		t.Fatal("an unresolved container must fail the whole answer")
 	}
 
-	inv.record("ctr-3", "sbx-1", "other", "", nil)
-	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil)
+	inv.record("ctr-3", "sbx-1", "other", "", nil, nil)
+	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil, nil)
 	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
 		t.Fatal("a second unresolved container must keep the answer closed")
 	}
 
-	inv.record("ctr-3", "sbx-1", "other", pushDigestC, nil)
+	inv.record("ctr-3", "sbx-1", "other", pushDigestC, nil, nil)
 	digests, _, _, err := inv.DigestsForSandbox("sbx-1")
 	if err != nil {
 		t.Fatalf("resolving every container must reopen the answer: %v", err)
@@ -356,14 +356,14 @@ func TestInventory_UnresolvedClearsWhenTheContainerResolves(t *testing.T) {
 // sandbox can share a name, and one resolving must not clear the other.
 func TestInventory_UnresolvedIsKeyedOnContainerID(t *testing.T) {
 	inv := newAdmissionInventory(t.TempDir())
-	inv.record("ctr-1", "sbx-1", "app", "", nil)
-	inv.record("ctr-2", "sbx-1", "app", pushDigestA, nil)
+	inv.record("ctr-1", "sbx-1", "app", "", nil, nil)
+	inv.record("ctr-2", "sbx-1", "app", pushDigestA, nil, nil)
 
 	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err == nil {
 		t.Fatal("a namesake container cleared another container's unresolved marker")
 	}
 
-	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil)
+	inv.record("ctr-1", "sbx-1", "app", pushDigestB, nil, nil)
 	if _, _, _, err := inv.DigestsForSandbox("sbx-1"); err != nil {
 		t.Fatalf("resolving the container itself must reopen the answer: %v", err)
 	}

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -215,6 +215,8 @@ func (p *plugin) Configure(ctx context.Context, config, runtime, version string)
 
 	var mask api.EventMask
 	mask.Set(api.Event_CREATE_CONTAINER)
+	mask.Set(api.Event_START_CONTAINER)
+	mask.Set(api.Event_VALIDATE_CONTAINER_ADJUSTMENT)
 	if p.inventory != nil {
 		// The inventory needs eviction on stop to stay correct across pod churn,
 		// and the pod-sandbox lifecycle to keep its sandbox set (the /sandbox
@@ -288,7 +290,8 @@ func (p *plugin) recordDigest(ctr *api.Container, digest string) {
 	if p.inventory == nil {
 		return
 	}
-	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest, ctr.GetArgs())
+	env := containerEnv(ctr)
+	p.inventory.record(ctr.GetId(), ctr.GetPodSandboxId(), ctr.GetName(), digest, ctr.GetArgs(), env)
 }
 
 // resolveDigest returns the canonical store digest for imageRef using the same
@@ -348,7 +351,15 @@ func (p *plugin) checkLabels(cfg *config, namespace, podName, containerName stri
 // container's effective OCI process.args (NRI api.Container.Args): always_allow
 // digests are admitted regardless of it, served digests only when it satisfies
 // an entry's entrypoint/cmd policy. Returns the verdict and an error string.
-func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName, containerName, imageRef string, argv []string) (imageVerdict, string) {
+func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName, containerName, imageRef string, argv []string, env ...*allowlist.EnvObservation) (imageVerdict, string) {
+	var observed *allowlist.EnvObservation
+	if len(env) > 0 {
+		observed = env[0]
+	}
+	return p.checkImagePhase(ctx, cfg, namespace, podName, containerName, imageRef, argv, observed, true)
+}
+
+func (p *plugin) checkImagePhase(ctx context.Context, cfg *config, namespace, podName, containerName, imageRef string, argv []string, observed *allowlist.EnvObservation, final bool) (imageVerdict, string) {
 	log := p.logger.With(
 		"namespace", namespace,
 		"pod", podName,
@@ -416,20 +427,22 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 		return verdictDeny, fmt.Sprintf("no allowlist available for %s", imageRef)
 	}
 
-	// always_allow digests admit regardless of argv; served digests require
-	// the effective argv to satisfy some entry's entrypoint/cmd policy. Mount
-	// and env policy are left unobserved here: this plugin gates images on a
-	// node CVM, where it sees the CRI container rather than a guest's mount
-	// table, and an unobserved field is not a violation
-	// (allowlist.RunningContainer).
-	if !p.policy.alwaysAllows(digest) && !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
+	// always_allow is the explicit platform bootstrap exemption. Served entries
+	// are matched against the final OCI argv and environment; mounts remain
+	// unobserved on this backend.
+	rc := allowlist.RunningContainer{Digest: digest, Argv: argv, Env: observed}
+	admitted := snap.index.AdmitsProcess(rc)
+	if final {
+		admitted = snap.index.AdmitsContainer(rc)
+	}
+	if !p.policy.alwaysAllows(digest) && !admitted {
 		// INVARIANT: the returned reason reaches a namespace-readable kubelet
 		// event, so it names only the image — argv can carry credentials and
 		// stays in the node-local log.
 		reason, denial := "not_in_allowlist", fmt.Sprintf("image not in allowlist: %s", imageRef)
 		if listed := snap.index.AdmitsDigest(digest); listed {
-			reason = "argv_not_admitted"
-			denial = fmt.Sprintf("image %s is allowlisted, but its command satisfies no workload entry's argv policy", imageRef)
+			reason = "launch_not_admitted"
+			denial = fmt.Sprintf("image %s is allowlisted, but its launch specification satisfies no workload entry's command, args or env policy", imageRef)
 		}
 		log.Warn("image not admitted by allowlist", "digest", digest, "argv", argv, "reason", reason)
 		p.audit.Log(audit.Event{
@@ -465,11 +478,19 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 // then. The exemption runs last, only downgrades, and is keyed on the resolved
 // digest — a local fact — not the namespace name the control plane chooses.
 func (p *plugin) checkContainer(ctx context.Context, cfg *config, pod *api.PodSandbox, ctr *api.Container, imageRef string) (imageVerdict, string) {
+	return p.checkContainerPhase(ctx, cfg, pod, ctr, imageRef, true)
+}
+
+func (p *plugin) checkContainerPhase(ctx context.Context, cfg *config, pod *api.PodSandbox, ctr *api.Container, imageRef string, final bool) (imageVerdict, string) {
+	return p.checkContainerObserved(ctx, cfg, pod, ctr, imageRef, final, containerEnv(ctr))
+}
+
+func (p *plugin) checkContainerObserved(ctx context.Context, cfg *config, pod *api.PodSandbox, ctr *api.Container, imageRef string, final bool, env *allowlist.EnvObservation) (imageVerdict, string) {
 	namespace, podName, ctrName := pod.GetNamespace(), pod.GetName(), ctr.GetName()
 
 	verdict, reason := p.checkLabels(cfg, namespace, podName, ctrName, pod.GetLabels())
 	if verdict != verdictDeny && cfg.AllowlistEnabled() {
-		verdict, reason = p.checkImage(ctx, cfg, namespace, podName, ctrName, imageRef, ctr.GetArgs())
+		verdict, reason = p.checkImagePhase(ctx, cfg, namespace, podName, ctrName, imageRef, ctr.GetArgs(), env, final)
 	}
 
 	if verdict == verdictDeny && slices.Contains(cfg.Policy.ExemptNamespaces, namespace) {
@@ -725,27 +746,41 @@ func (p *plugin) admitWhileInitializing(ctx context.Context, cfg *config, pod *a
 	return nil
 }
 
-// CreateContainer is called when a container is being created.
-// Returning an error will reject the container creation.
+// CreateContainer supplies the socket mount and checks digest/argv early.
+// Final admission is at StartContainer, where containerd reports the persisted
+// OCI spec after all NRI/CDI edits.
+// Nothing is added to the admission history until that final check.
 func (p *plugin) CreateContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) (*api.ContainerAdjustment, []*api.ContainerUpdate, error) {
-	cfg := p.cfg
-	imageRef := ctr.GetAnnotations()[annotationImageName]
-
-	if !p.Ready() {
-		if err := p.admitWhileInitializing(ctx, cfg, pod, ctr, imageRef); err != nil {
-			return nil, nil, err
+	verdict, reason := p.checkContainerPhase(ctx, p.cfg, pod, ctr, ctr.GetAnnotations()[annotationImageName], false)
+	if verdict == verdictDeny && p.cfg.Policy.Mode != ModeAudit {
+		if !p.Ready() {
+			return nil, nil, fmt.Errorf("image policy plugin initializing: %s", reason)
 		}
-		p.recordUncheckedForInventory(ctr, imageRef)
-		return p.socketDirAdjustment(pod, ctr), nil, nil
-	}
-
-	verdict, reason := p.checkContainer(ctx, cfg, pod, ctr, imageRef)
-	if verdict == verdictDeny && cfg.Policy.Mode != ModeAudit {
 		return nil, nil, fmt.Errorf("%s", reason)
 	}
-
-	p.recordForInventory(ctx, ctr, imageRef)
 	return p.socketDirAdjustment(pod, ctr), nil, nil
+}
+
+// StartContainer runs before task.Start/execve. Its environment is the final
+// persisted OCI spec, unlike CreateContainer (or adjustment validation), which
+// precedes other plugins and runtime CDI injection. Start updates cannot edit
+// argv/env. Failed checks leave no admitted-container evidence.
+func (p *plugin) StartContainer(ctx context.Context, pod *api.PodSandbox, ctr *api.Container) error {
+	cfg := p.cfg
+	imageRef := ctr.GetAnnotations()[annotationImageName]
+	if !p.Ready() {
+		if err := p.admitWhileInitializing(ctx, cfg, pod, ctr, imageRef); err != nil {
+			return err
+		}
+		p.recordUncheckedForInventory(ctr, imageRef)
+		return nil
+	}
+	verdict, reason := p.checkContainer(ctx, cfg, pod, ctr, imageRef)
+	if verdict == verdictDeny && cfg.Policy.Mode != ModeAudit {
+		return fmt.Errorf("%s", reason)
+	}
+	p.recordForInventory(ctx, ctr, imageRef)
+	return nil
 }
 
 // socketDirAdjustment bind-mounts the inventory's socket directory, read-only,
@@ -787,4 +822,15 @@ func extractDigest(imageRef string) string {
 		return ""
 	}
 	return d.String()
+}
+
+// containerEnv refuses an incomplete OCI process. containerd can report an
+// empty spec after a failed spec read; that must not look like observed-empty.
+// A runnable OCI process has at least one argument, even when its env is empty.
+func containerEnv(ctr *api.Container) *allowlist.EnvObservation {
+	if len(ctr.GetArgs()) == 0 {
+		return nil
+	}
+	env, _ := allowlist.ObserveEnv(ctr.GetEnv())
+	return env
 }

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -173,7 +173,7 @@ func TestCreateContainer_NotReady_DeniesNonFloorImage(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtrWithImage(pod.Id, "myctr", "registry/repo@"+pushDigestB)
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err == nil {
 		t.Fatal("expected error when plugin not ready and the image is not in the floor")
 	}
@@ -190,7 +190,7 @@ func TestCreateContainer_NotReady_AdmitsFloorDigest(t *testing.T) {
 	pod := makePod("kube-system", "coredns")
 	ctr := makeCtrWithImage(pod.Id, "coredns", "registry/repo@"+pushDigestA)
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 		t.Fatalf("a floor digest should be admitted while initializing, got: %v", err)
 	}
 }
@@ -205,7 +205,7 @@ func TestCreateContainer_NotReady_AuditModeAllows(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtr(pod.Id, "myctr")
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err != nil {
 		t.Fatalf("expected audit mode to allow during init, got error: %v", err)
 	}
@@ -297,7 +297,7 @@ func TestCreateContainer_Ready_PassesThrough(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtr(pod.Id, "myctr")
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err == nil {
 		t.Fatal("expected error from normal allowlist check path")
 	}
@@ -341,7 +341,7 @@ func TestCreateContainer_MountsSocketDirIntoInjectedSidecars(t *testing.T) {
 				workloadclaims.SecretContainerName,
 				workloadclaims.VolumeContainerName,
 			} {
-				adjust, _, err := p.CreateContainer(context.Background(), pod, makeCtr(pod.Id, ctrName))
+				adjust, _, err := createAndStart(p, context.Background(), pod, makeCtr(pod.Id, ctrName))
 				if err != nil {
 					t.Fatalf("%s: %v", ctrName, err)
 				}
@@ -393,7 +393,7 @@ func TestCreateContainer_NoSocketDirMountOutsideInjectedSidecars(t *testing.T) {
 			p.SetReady()
 			p.policy = newPolicyStore(map[string]string{})
 
-			adjust, _, err := p.CreateContainer(context.Background(), tc.pod, makeCtr(tc.pod.Id, tc.ctr))
+			adjust, _, err := createAndStart(p, context.Background(), tc.pod, makeCtr(tc.pod.Id, tc.ctr))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -422,7 +422,7 @@ func TestCreateContainer_DeniedContainerGetsNoAdjustment(t *testing.T) {
 			pod := makePod("default", "pod1")
 			pod.Annotations = map[string]string{workloadclaims.AnnotationInjected: "true"}
 
-			adjust, _, err := p.CreateContainer(context.Background(), pod, makeCtr(pod.Id, workloadclaims.CertContainerName))
+			adjust, _, err := createAndStart(p, context.Background(), pod, makeCtr(pod.Id, workloadclaims.CertContainerName))
 			if err == nil {
 				t.Fatal("denied container admitted")
 			}
@@ -614,7 +614,7 @@ func TestCreateContainer_LabelRuleDeny_FailClosed(t *testing.T) {
 	pod := makePodWithLabels("default", "mypod", map[string]string{"tenant": "evil"})
 	ctr := makeCtr(pod.Id, "myctr")
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err == nil {
 		t.Fatal("expected error from label rule denial")
 	}
@@ -639,7 +639,7 @@ func TestCreateContainer_LabelRuleDeny_AuditMode(t *testing.T) {
 	pod := makePodWithLabels("default", "mypod", map[string]string{"tenant": "evil"})
 	ctr := makeCtr(pod.Id, "myctr")
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err != nil {
 		t.Fatalf("expected audit mode to allow, got error: %v", err)
 	}
@@ -664,7 +664,7 @@ func TestCreateContainer_AllowlistDisabled_SkipsImageCheck(t *testing.T) {
 	pod := makePodWithLabels("default", "mypod", map[string]string{"tenant": "acme"})
 	ctr := makeCtr(pod.Id, "myctr")
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err != nil {
 		t.Fatalf("expected no error with allowlist disabled, got: %v", err)
 	}
@@ -818,7 +818,7 @@ func TestCheckImage_DenialSeparatesUnlistedFromArgvMismatch(t *testing.T) {
 
 	_, argvMismatch := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
 		"registry/repo@"+pushDigestB, []string{"/bin/evil"})
-	if !strings.Contains(argvMismatch, "satisfies no workload entry's argv policy") {
+	if !strings.Contains(argvMismatch, "satisfies no workload entry's command, args or env policy") {
 		t.Fatalf("a listed digest denied on argv should say so, got %q", argvMismatch)
 	}
 
@@ -839,12 +839,12 @@ func TestCreateContainer_WorkloadArgv_MatchAndMismatch(t *testing.T) {
 	pod := makePod("default", "mypod")
 
 	match := makeCtrWithImageArgs(pod.Id, "match", "registry/repo@"+pushDigestB, []string{"/bin/app", "--serve"})
-	if _, _, err := p.CreateContainer(context.Background(), pod, match); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, match); err != nil {
 		t.Fatalf("matching argv should be admitted, got: %v", err)
 	}
 
 	mismatch := makeCtrWithImageArgs(pod.Id, "mismatch", "registry/repo@"+pushDigestB, []string{"/bin/evil"})
-	if _, _, err := p.CreateContainer(context.Background(), pod, mismatch); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, mismatch); err == nil {
 		t.Fatal("non-matching argv should be denied")
 	}
 }
@@ -878,7 +878,7 @@ func TestCreateContainer_DigestNotInAllowlist_FailClosed(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtrWithImage(pod.Id, "myctr", "registry/repo@"+pushDigestB)
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err == nil {
 		t.Fatal("expected denial for image not in allowlist")
 	}
@@ -894,7 +894,7 @@ func TestCreateContainer_DigestNotInAllowlist_AuditAllows(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtrWithImage(pod.Id, "myctr", "registry/repo@"+pushDigestB)
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err != nil {
 		t.Fatalf("audit mode should allow despite deny verdict, got: %v", err)
 	}
@@ -910,7 +910,7 @@ func TestCreateContainer_DigestInAllowlist_Allows(t *testing.T) {
 	pod := makePod("default", "mypod")
 	ctr := makeCtrWithImage(pod.Id, "myctr", "registry/repo@"+pushDigestA)
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err != nil {
 		t.Fatalf("expected allow for allowlisted digest, got: %v", err)
 	}
@@ -929,7 +929,7 @@ func TestCreateContainer_PodAnnotationDoesNotSupplyImage(t *testing.T) {
 	pod.Annotations = map[string]string{annotationImageName: "registry/repo@" + pushDigestA}
 	ctr := makeCtr(pod.Id, "myctr") // no annotations
 
-	_, _, err := p.CreateContainer(context.Background(), pod, ctr)
+	_, _, err := createAndStart(p, context.Background(), pod, ctr)
 	if err == nil {
 		t.Fatal("expected denial: the container carries no image annotation")
 	}
@@ -1199,12 +1199,12 @@ func TestFloorContainerIsRecordedOnEveryPath(t *testing.T) {
 	}{
 		{"create hook", func(t *testing.T, p *plugin) {
 			p.SetReady()
-			if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+			if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 				t.Fatalf("floor digest should be admitted: %v", err)
 			}
 		}},
 		{"create hook while initializing", func(t *testing.T, p *plugin) {
-			if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+			if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 				t.Fatalf("floor digest should be admitted: %v", err)
 			}
 		}},
@@ -1311,10 +1311,10 @@ func TestCreateContainer_NotReady_ResolvesForAdmission_RecordsInlineOnly(t *test
 	pod := makePod("kube-system", "pod1")
 	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo:latest") // no inline digest
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 		t.Fatalf("a tag resolving to the floor should be admitted: %v", err)
 	}
-	if len(resolved) != 1 {
+	if len(resolved) != 3 {
 		t.Fatalf("admission did not resolve the tag: %v", resolved)
 	}
 	rec, ok := p.inventory.containers[ctr.Id]
@@ -1340,7 +1340,7 @@ func TestCreateContainer_NotReady_TagOutsideFloor_Denied(t *testing.T) {
 	pod := makePod("kube-system", "pod1")
 	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo:latest")
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err == nil {
 		t.Fatal("a tag resolving outside the floor must be denied while initializing")
 	}
 }
@@ -1357,7 +1357,7 @@ func TestCreateContainer_NotReady_ResolveFails_Denied(t *testing.T) {
 	pod := makePod("kube-system", "pod1")
 	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo:latest")
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err == nil {
 		t.Fatal("a tag that fails to resolve while initializing must be denied")
 	}
 }
@@ -1374,7 +1374,7 @@ func TestCreateContainer_AuditModeDenial_IsRecorded(t *testing.T) {
 	pod := makePod("default", "pod1")
 	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 		t.Fatalf("audit mode should admit: %v", err)
 	}
 	rec, ok := p.inventory.containers[ctr.Id]
@@ -1509,7 +1509,7 @@ func TestCreateContainer_RecordsTheContainerArgv(t *testing.T) {
 	argv := []string{"/bin/app", "--serve"}
 	ctr := makeCtrWithImageArgs(pod.Id, "ctr1", "registry/repo@"+pushDigestA, argv)
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err != nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err != nil {
 		t.Fatalf("allowlisted digest should be admitted: %v", err)
 	}
 	if rec := p.inventory.containers[ctr.Id]; !slices.Equal(rec.argv, argv) {
@@ -1532,7 +1532,7 @@ func TestCreateContainer_DeniedContainerIsNotRecorded(t *testing.T) {
 	pod := makePod("default", "pod1")
 	ctr := makeCtrWithImage(pod.Id, "ctr1", "registry/repo@"+pushDigestB)
 
-	if _, _, err := p.CreateContainer(context.Background(), pod, ctr); err == nil {
+	if _, _, err := createAndStart(p, context.Background(), pod, ctr); err == nil {
 		t.Fatal("expected denial for an image not in the floor")
 	}
 	if _, ok := p.inventory.containers[ctr.Id]; ok {
@@ -1550,7 +1550,41 @@ func TestConfigure_SetsCreateContainerMask(t *testing.T) {
 	}
 	var want api.EventMask
 	want.Set(api.Event_CREATE_CONTAINER)
+	want.Set(api.Event_START_CONTAINER)
+	want.Set(api.Event_VALIDATE_CONTAINER_ADJUSTMENT)
 	if mask != want {
 		t.Fatalf("mask = %v, want %v", mask, want)
+	}
+}
+
+// TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath pins the host
+// path's field scope. Both policies are `exact` with an empty list, so an
+// enforcer that reported any bind destination or any environment name would
+// refuse this container; admitting it is the assertion that this plugin passes
+// neither. Node-as-CVM operators are warned about the consequence by
+// `c8s allowlist lint`.
+func TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath(t *testing.T) {
+	al := workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"})
+	c := al.Workloads["w"].Containers[0]
+	c.Mounts = allowlist.MountPolicy{Policy: allowlist.PolicyExact}
+	c.Env = allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{}}
+	al.Workloads["w"].Containers[0] = c
+
+	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}}, al)
+
+	verdict, reason := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
+		"registry/repo@"+pushDigestB, []string{"/bin/app", "--serve"})
+	if verdict != verdictAllow {
+		t.Fatalf("host path must leave mounts and env unobserved, got verdict %d (reason=%q)", verdict, reason)
+	}
+
+	// Non-vacuity: the same entry refuses a container that does report one, so
+	// the admit above is this plugin's silence rather than a dead policy.
+	if p.policy.current().index.AdmitsContainer(allowlist.RunningContainer{
+		Digest:     pushDigestB,
+		Argv:       []string{"/bin/app", "--serve"},
+		BindMounts: []string{"/injected"},
+	}) {
+		t.Error("the entry admitted a reported bind mount; the exact-empty policy is not live")
 	}
 }

--- a/internal/cmds/nri-image-policy/plugin_test.go
+++ b/internal/cmds/nri-image-policy/plugin_test.go
@@ -1557,17 +1557,12 @@ func TestConfigure_SetsCreateContainerMask(t *testing.T) {
 	}
 }
 
-// TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath pins the host
-// path's field scope. Both policies are `exact` with an empty list, so an
-// enforcer that reported any bind destination or any environment name would
-// refuse this container; admitting it is the assertion that this plugin passes
-// neither. Node-as-CVM operators are warned about the consequence by
-// `c8s allowlist lint`.
-func TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath(t *testing.T) {
+// The NRI path leaves bind mounts unobserved.
+func TestCheckImage_MountPolicyIsUnobservedOnTheHostPath(t *testing.T) {
 	al := workloadAllowlist(t, pushDigestA, pushDigestB, []string{"/bin/app"})
 	c := al.Workloads["w"].Containers[0]
 	c.Mounts = allowlist.MountPolicy{Policy: allowlist.PolicyExact}
-	c.Env = allowlist.EnvPolicy{Policy: allowlist.PolicyExact, Names: []string{}}
+	c.Env = allowlist.EnvPolicy{Policy: allowlist.PolicyAny}
 	al.Workloads["w"].Containers[0] = c
 
 	p, _ := newCachedPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}}, al)
@@ -1575,7 +1570,7 @@ func TestCheckImage_MountAndEnvPolicyIsUnobservedOnTheHostPath(t *testing.T) {
 	verdict, reason := p.checkImage(context.Background(), p.cfg, "default", "pod", "ctr",
 		"registry/repo@"+pushDigestB, []string{"/bin/app", "--serve"})
 	if verdict != verdictAllow {
-		t.Fatalf("host path must leave mounts and env unobserved, got verdict %d (reason=%q)", verdict, reason)
+		t.Fatalf("host path must leave mounts unobserved, got verdict %d (reason=%q)", verdict, reason)
 	}
 
 	// Non-vacuity: the same entry refuses a container that does report one, so

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -103,6 +103,8 @@ func TestConfigure_InventoryAddsRemoveContainerMask(t *testing.T) {
 	}
 	var want api.EventMask
 	want.Set(api.Event_CREATE_CONTAINER)
+	want.Set(api.Event_START_CONTAINER)
+	want.Set(api.Event_VALIDATE_CONTAINER_ADJUSTMENT)
 	want.Set(api.Event_REMOVE_CONTAINER)
 	// The inventory also needs the pod-sandbox lifecycle for its sandbox set.
 	want.Set(api.Event_RUN_POD_SANDBOX)

--- a/internal/cmds/nri-image-policy/run_test.go
+++ b/internal/cmds/nri-image-policy/run_test.go
@@ -82,7 +82,7 @@ func TestPluginRun_StopsOnContextCancel(t *testing.T) {
 func TestRemoveContainer_EvictsFromInventory(t *testing.T) {
 	p := newTestPlugin(&config{Policy: policyConfig{Mode: ModeFailClosed}})
 	p.inventory = newAdmissionInventory(t.TempDir())
-	p.inventory.record(cidApp1, "sandbox-1", "app", digestApp, nil)
+	p.inventory.record(cidApp1, "sandbox-1", "app", digestApp, nil, nil)
 
 	ctr := &api.Container{Id: cidApp1, PodSandboxId: "sandbox-1", Name: "app"}
 	if err := p.RemoveContainer(context.Background(), &api.PodSandbox{Id: "sandbox-1"}, ctr); err != nil {

--- a/internal/helmchart/c8s/templates/_allowlist.tpl
+++ b/internal/helmchart/c8s/templates/_allowlist.tpl
@@ -73,7 +73,7 @@
 {{- $digests := dict -}}
 {{- range $name, $entry := (.Values.nriImagePolicy.bootstrapAllowlist.workloads | default dict) -}}
 {{- range $c := concat (default list $entry.initContainers) (default list $entry.containers) -}}
-{{- if and (eq (dig "command" "policy" "" $c) "any") (eq (dig "args" "policy" "" $c) "any") -}}
+{{- if and (eq (dig "command" "policy" "" $c) "any") (eq (dig "args" "policy" "" $c) "any") (eq (dig "env" "policy" "any" $c) "any") (eq (dig "mounts" "policy" "any" $c) "any") -}}
 {{- $_ := set $digests $c.digest (default $entry.label $c.image | default "") -}}
 {{- end -}}
 {{- end -}}
@@ -95,7 +95,7 @@
 {{- $workloads := dict -}}
 {{- range $digest, $image := (include "c8s.imageAllowlist" . | fromJson) -}}
 {{- $name := include "c8s.digestWorkloadName" (dict "digest" $digest "image" $image) -}}
-{{- $container := dict "digest" $digest "image" $image "command" (dict "policy" "any") "args" (dict "policy" "any") -}}
+{{- $container := dict "digest" $digest "image" $image "command" (dict "policy" "any") "args" (dict "policy" "any") "env" (dict "policy" "any") -}}
 {{- $_ := set $workloads $name (dict "label" $image "initContainers" list "containers" (list $container)) -}}
 {{- end -}}
 {{- range $name, $entry := (.Values.nriImagePolicy.bootstrapAllowlist.workloads | default dict) -}}

--- a/internal/secrets/explain.go
+++ b/internal/secrets/explain.go
@@ -23,9 +23,10 @@ const ExplainRoute = "/secrets-explain/{sandboxID}"
 // ReportedContainer is one container the inventory named, and whether the
 // release path drops it as a platform-injected one.
 type ReportedContainer struct {
-	Digest   string   `json:"digest"`
-	Argv     []string `json:"argv"`
-	Injected bool     `json:"injected"`
+	Env      *pkgallowlist.EnvObservation `json:"env,omitempty"`
+	Digest   string                       `json:"digest"`
+	Argv     []string                     `json:"argv"`
+	Injected bool                         `json:"injected"`
 }
 
 // EntryVerdict is one workload entry measured against the candidate set.
@@ -157,13 +158,13 @@ func (h ExplainHandler) explain(ctx context.Context, sandboxID string) ExplainRe
 	var candidates []pkgallowlist.RunningContainer
 	for _, c := range reported {
 		injected := isInjected(al, c)
-		entry := ReportedContainer{Digest: c.Digest, Argv: c.Argv, Injected: injected}
+		entry := ReportedContainer{Digest: c.Digest, Argv: c.Argv, Env: c.Env, Injected: injected}
 		resp.Reported = append(resp.Reported, entry)
 		if injected {
 			continue
 		}
 		resp.Candidates = append(resp.Candidates, entry)
-		candidates = append(candidates, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+		candidates = append(candidates, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv, Env: c.Env})
 	}
 	if len(candidates) == 0 {
 		resp.Refusal = "every container the sandbox reports is a platform-injected one, so there is nothing to match"
@@ -179,7 +180,7 @@ func (h ExplainHandler) explain(ctx context.Context, sandboxID string) ExplainRe
 			HasGrant: al.Workloads[name].Secrets != nil,
 		}
 		for _, f := range d.Foreign {
-			v.Foreign = append(v.Foreign, ReportedContainer{Digest: f.Digest, Argv: f.Argv})
+			v.Foreign = append(v.Foreign, ReportedContainer{Digest: f.Digest, Argv: f.Argv, Env: f.Env})
 		}
 		for _, m := range d.MissingMains {
 			v.MissingMains = append(v.MissingMains, MissingContainer{Digest: m.Digest.String(), Image: m.Image})

--- a/internal/secrets/handler.go
+++ b/internal/secrets/handler.go
@@ -458,7 +458,7 @@ func WorkloadContainers(al *pkgallowlist.Allowlist, reported []workloadclaims.Sa
 		if isInjected(al, c) {
 			continue
 		}
-		out = append(out, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv})
+		out = append(out, pkgallowlist.RunningContainer{Digest: c.Digest, Argv: c.Argv, Env: c.Env})
 	}
 	return out
 }

--- a/internal/secrets/handler_test.go
+++ b/internal/secrets/handler_test.go
@@ -970,3 +970,31 @@ func TestSecretValueNeverReachesTheLog(t *testing.T) {
 		}
 	}
 }
+
+func TestSecretReleaseEnforcesEnvEvidence(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		env     []string
+		unknown bool
+		want    int
+	}{
+		{"matches", []string{"MODE=production"}, false, http.StatusCreated},
+		{"wrong", []string{"MODE=unsafe"}, false, http.StatusForbidden},
+		{"old inventory", nil, true, http.StatusForbidden},
+		{"empty", nil, false, http.StatusForbidden},
+		{"duplicate", []string{"MODE=unsafe", "MODE=production"}, false, http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hn := newHarness(t)
+			al := hn.h.Policy.(fakePolicy).al
+			al.Workloads["api"].Containers[0].Env = pkgallowlist.EnvPolicy{Policy: pkgallowlist.PolicyExact, Values: map[string]string{"MODE": "production"}}
+			if !tc.unknown {
+				hn.inv.containers[0].Env, _ = pkgallowlist.ObserveEnv(tc.env)
+			}
+			w := do(hn.h, hn.request(t, http.MethodPost, "/api/db"))
+			if w.Code != tc.want {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body)
+			}
+		})
+	}
+}

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -3,7 +3,7 @@
 //
 // The allowlist is a map of named workload entries. Each entry pins an
 // init/main container set; every container binds a digest to the process
-// (argv) permitted for those bytes, and the
+// (argv), bind-mount and environment policy permitted for those bytes, and the
 // entry as a whole carries a secret-store grant. An image that may run however
 // it is invoked — a standalone or injected c8s component, whose argv is
 // per-pod — is an entry whose container policy is any. Policy is always looked
@@ -35,6 +35,9 @@ import (
 // Schema identifies the allowlist document format. It is the first field of the
 // canonical form.
 const Schema = "c8s.allowlist/v1"
+
+// SchemaV2 adds exact environment values and requires explicit env policies.
+const SchemaV2 = "c8s.allowlist/v2"
 
 // Policy values. Argv policies use Deny/Any/Exact; secrets grants use
 // Deny/Allow — never Any (normalizeSecrets).
@@ -68,6 +71,8 @@ type Container struct {
 	Image   string       `json:"image,omitempty"`
 	Command ArgvPolicy   `json:"command"`
 	Args    ArgvPolicy   `json:"args"`
+	Mounts  MountPolicy  `json:"mounts,omitempty"`
+	Env     EnvPolicy    `json:"env,omitempty"`
 }
 
 // ArgvPolicy governs part of a container's effective argv (the OCI process.args
@@ -78,6 +83,33 @@ type Container struct {
 type ArgvPolicy struct {
 	Policy string   `json:"policy"`
 	Argv   []string `json:"argv,omitempty"`
+}
+
+// MountPolicy governs where the host may bind content into the container.
+//
+// It constrains BIND mounts only — a mount whose source is an absolute guest
+// path. The rest of a container's mount table names filesystem types (proc,
+// sysfs, tmpfs, devpts, mqueue, cgroup) and carries nothing in, so pinning it
+// would make an operator restate the OCI base set to say nothing.
+//
+// Exact requires every bind destination to appear in Destinations, which is the
+// set an operator recognises: it is what the pod spec's volumeMounts declare,
+// plus the handful the kubelet always adds (/etc/hosts, /etc/hostname,
+// /etc/resolv.conf, /dev/termination-log, /dev/shm, the serviceaccount token).
+// Any leaves them unconstrained, and is what an absent policy means — unlike
+// argv, a Deny default would refuse every real pod, since the base set is never
+// empty.
+type MountPolicy struct {
+	Policy       string   `json:"policy"`
+	Destinations []string `json:"destinations,omitempty"`
+}
+
+// EnvPolicy constrains the OCI launch environment. Values is an exact map;
+// Names is retained only for legacy v1 permitted-name policies.
+type EnvPolicy struct {
+	Policy string            `json:"policy"`
+	Names  []string          `json:"names,omitempty"`
+	Values map[string]string `json:"values,omitempty"`
 }
 
 // SecretsPolicy grants secret-store read/write globs to a whole workload entry.
@@ -109,6 +141,9 @@ func ParseServedJSON(data []byte) (*Allowlist, error) {
 }
 
 func parseJSON(data []byte, strict bool) (*Allowlist, error) {
+	if err := validateJSON(data); err != nil {
+		return nil, err
+	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	if strict {
 		dec.DisallowUnknownFields()
@@ -127,11 +162,28 @@ func parseJSON(data []byte, strict bool) (*Allowlist, error) {
 // a PUT /allowlist/workloads/{name} — applying the same normalization as
 // ParseJSON so a stored entry is canonical.
 func ParseWorkloadJSON(data []byte) (*Workload, error) {
+	return parseWorkloadJSON(data, "")
+}
+
+// ParseWorkloadJSONForSchema validates before normalization can default legacy fields.
+func ParseWorkloadJSONForSchema(data []byte, schema string) (*Workload, error) {
+	return parseWorkloadJSON(data, schema)
+}
+
+func parseWorkloadJSON(data []byte, schema string) (*Workload, error) {
+	if err := validateJSON(data); err != nil {
+		return nil, err
+	}
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
 	var w Workload
 	if err := dec.Decode(&w); err != nil {
 		return nil, fmt.Errorf("decode workload: %w", err)
+	}
+	if schema != "" {
+		if err := w.ValidateEnvSchema(schema); err != nil {
+			return nil, err
+		}
 	}
 	if err := normalizeContainers("entry", "initContainers", w.InitContainers); err != nil {
 		return nil, err
@@ -222,6 +274,7 @@ func DigestEntry(digest types.Digest, image string) Workload {
 			Image:   image,
 			Command: ArgvPolicy{Policy: PolicyAny},
 			Args:    ArgvPolicy{Policy: PolicyAny},
+			Env:     EnvPolicy{Policy: PolicyAny},
 		}},
 	}
 }
@@ -268,10 +321,13 @@ func (a *Allowlist) CanonicalDigest() ([]byte, error) {
 // break every allowlist pull in the cluster over one legacy name — so an
 // over-long entry is dropped instead. See docs/allowlist-and-capabilities.md.
 func (a *Allowlist) normalize(strict bool) error {
-	if a.Schema != Schema {
-		return fmt.Errorf("allowlist: unknown schema %q (expected %q)", a.Schema, Schema)
+	if a.Schema != Schema && a.Schema != SchemaV2 {
+		return fmt.Errorf("allowlist: unknown schema %q (expected %q or %q)", a.Schema, Schema, SchemaV2)
 	}
 	for name, w := range a.Workloads {
+		if err := w.ValidateEnvSchema(a.Schema); err != nil {
+			return fmt.Errorf("workload %q: %w", name, err)
+		}
 		// The grammar is not negotiable on either path: the name is used
 		// verbatim as a URL path segment.
 		if !workloadNameGrammarOK(name) {
@@ -321,8 +377,101 @@ func normalizeContainers(workload, field string, cs []Container) error {
 		if err := normalizeArgv(&c.Args); err != nil {
 			return fmt.Errorf("workload %q %s %s args: %w", workload, field, c.Digest, err)
 		}
+		if err := normalizeMounts(&c.Mounts); err != nil {
+			return fmt.Errorf("workload %q %s %s mounts: %w", workload, field, c.Digest, err)
+		}
+		if err := normalizeEnv(&c.Env); err != nil {
+			return fmt.Errorf("workload %q %s %s env: %w", workload, field, c.Digest, err)
+		}
 	}
 	return nil
+}
+
+// normalizeMounts validates a mount policy. An absent policy canonicalizes to
+// Any: every container has a mount table it did not ask for (the OCI base set,
+// /etc/hosts, the serviceaccount token), so Deny would refuse every real pod and
+// an operator adopting this field would be opting into an outage.
+func normalizeMounts(p *MountPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "":
+		if len(p.Destinations) != 0 {
+			return fmt.Errorf("any policy takes no destinations")
+		}
+		p.Policy = PolicyAny
+		p.Destinations = nil
+	case PolicyExact:
+		if len(p.Destinations) == 0 {
+			return fmt.Errorf("exact policy requires at least one destination")
+		}
+		for _, d := range p.Destinations {
+			if !path.IsAbs(d) {
+				return fmt.Errorf("destination %q is not an absolute path", d)
+			}
+		}
+		p.Destinations = sortedUnique(p.Destinations)
+	default:
+		return fmt.Errorf("unknown mount policy %q (want any or exact)", p.Policy)
+	}
+	return nil
+}
+
+// normalizeEnv validates both versions. Only v1 permits an absent policy,
+// defaulting to Any; ValidateEnvSchema rejects absence before v2 normalization.
+func normalizeEnv(p *EnvPolicy) error {
+	switch p.Policy {
+	case PolicyAny, "", PolicyDeny:
+		if len(p.Names) != 0 || p.Values != nil {
+			return fmt.Errorf("%s policy takes no names or values", p.Policy)
+		}
+		if p.Policy == "" {
+			p.Policy = PolicyAny
+		}
+		p.Names = nil
+	case PolicyExact:
+		if p.Names != nil {
+			if p.Values != nil || len(p.Names) == 0 {
+				return fmt.Errorf("exact legacy env requires names only")
+			}
+			for _, n := range p.Names {
+				if !validEnvPair(n, "") {
+					return fmt.Errorf("invalid environment name")
+				}
+			}
+			p.Names = sortedUnique(p.Names)
+		} else {
+			if p.Values == nil {
+				return fmt.Errorf("exact env requires values (or legacy names)")
+			}
+			for n, v := range p.Values {
+				if !validEnvPair(n, v) {
+					return fmt.Errorf("invalid environment name or value")
+				}
+			}
+			if len(p.Values) == 0 {
+				p.Policy = PolicyDeny
+				p.Values = nil
+			}
+		}
+	default:
+		return fmt.Errorf("unknown env policy %q (want deny, any, or exact)", p.Policy)
+	}
+	return nil
+}
+
+// sortedUnique makes a list a function of its content, so Canonical does not
+// churn on the order an operator happened to write.
+func sortedUnique(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // normalizeArgv validates an argv policy and canonicalizes an absent policy to
@@ -433,7 +582,7 @@ func sortContainers(cs []Container) {
 }
 
 func policyKey(c Container) string {
-	b, _ := json.Marshal([]any{c.Command, c.Args})
+	b, _ := json.Marshal([]any{c.Command, c.Args, c.Mounts, c.Env})
 	return string(b)
 }
 

--- a/pkg/allowlist/allowlist.go
+++ b/pkg/allowlist/allowlist.go
@@ -36,9 +36,6 @@ import (
 // canonical form.
 const Schema = "c8s.allowlist/v1"
 
-// SchemaV2 adds exact environment values and requires explicit env policies.
-const SchemaV2 = "c8s.allowlist/v2"
-
 // Policy values. Argv policies use Deny/Any/Exact; secrets grants use
 // Deny/Allow — never Any (normalizeSecrets).
 const (
@@ -104,11 +101,9 @@ type MountPolicy struct {
 	Destinations []string `json:"destinations,omitempty"`
 }
 
-// EnvPolicy constrains the OCI launch environment. Values is an exact map;
-// Names is retained only for legacy v1 permitted-name policies.
+// EnvPolicy constrains the complete OCI launch environment. An absent policy means Any.
 type EnvPolicy struct {
 	Policy string            `json:"policy"`
-	Names  []string          `json:"names,omitempty"`
 	Values map[string]string `json:"values,omitempty"`
 }
 
@@ -162,15 +157,6 @@ func parseJSON(data []byte, strict bool) (*Allowlist, error) {
 // a PUT /allowlist/workloads/{name} — applying the same normalization as
 // ParseJSON so a stored entry is canonical.
 func ParseWorkloadJSON(data []byte) (*Workload, error) {
-	return parseWorkloadJSON(data, "")
-}
-
-// ParseWorkloadJSONForSchema validates before normalization can default legacy fields.
-func ParseWorkloadJSONForSchema(data []byte, schema string) (*Workload, error) {
-	return parseWorkloadJSON(data, schema)
-}
-
-func parseWorkloadJSON(data []byte, schema string) (*Workload, error) {
 	if err := validateJSON(data); err != nil {
 		return nil, err
 	}
@@ -179,11 +165,6 @@ func parseWorkloadJSON(data []byte, schema string) (*Workload, error) {
 	var w Workload
 	if err := dec.Decode(&w); err != nil {
 		return nil, fmt.Errorf("decode workload: %w", err)
-	}
-	if schema != "" {
-		if err := w.ValidateEnvSchema(schema); err != nil {
-			return nil, err
-		}
 	}
 	if err := normalizeContainers("entry", "initContainers", w.InitContainers); err != nil {
 		return nil, err
@@ -321,13 +302,10 @@ func (a *Allowlist) CanonicalDigest() ([]byte, error) {
 // break every allowlist pull in the cluster over one legacy name — so an
 // over-long entry is dropped instead. See docs/allowlist-and-capabilities.md.
 func (a *Allowlist) normalize(strict bool) error {
-	if a.Schema != Schema && a.Schema != SchemaV2 {
-		return fmt.Errorf("allowlist: unknown schema %q (expected %q or %q)", a.Schema, Schema, SchemaV2)
+	if a.Schema != Schema {
+		return fmt.Errorf("allowlist: unknown schema %q (expected %q)", a.Schema, Schema)
 	}
 	for name, w := range a.Workloads {
-		if err := w.ValidateEnvSchema(a.Schema); err != nil {
-			return fmt.Errorf("workload %q: %w", name, err)
-		}
 		// The grammar is not negotiable on either path: the name is used
 		// verbatim as a URL path segment.
 		if !workloadNameGrammarOK(name) {
@@ -415,42 +393,27 @@ func normalizeMounts(p *MountPolicy) error {
 	return nil
 }
 
-// normalizeEnv validates both versions. Only v1 permits an absent policy,
-// defaulting to Any; ValidateEnvSchema rejects absence before v2 normalization.
 func normalizeEnv(p *EnvPolicy) error {
 	switch p.Policy {
 	case PolicyAny, "", PolicyDeny:
-		if len(p.Names) != 0 || p.Values != nil {
-			return fmt.Errorf("%s policy takes no names or values", p.Policy)
+		if p.Values != nil {
+			return fmt.Errorf("%s env policy takes no values", p.Policy)
 		}
 		if p.Policy == "" {
 			p.Policy = PolicyAny
 		}
-		p.Names = nil
 	case PolicyExact:
-		if p.Names != nil {
-			if p.Values != nil || len(p.Names) == 0 {
-				return fmt.Errorf("exact legacy env requires names only")
+		if p.Values == nil {
+			return fmt.Errorf("exact env requires values")
+		}
+		for n, v := range p.Values {
+			if !validEnvPair(n, v) {
+				return fmt.Errorf("invalid environment name or value")
 			}
-			for _, n := range p.Names {
-				if !validEnvPair(n, "") {
-					return fmt.Errorf("invalid environment name")
-				}
-			}
-			p.Names = sortedUnique(p.Names)
-		} else {
-			if p.Values == nil {
-				return fmt.Errorf("exact env requires values (or legacy names)")
-			}
-			for n, v := range p.Values {
-				if !validEnvPair(n, v) {
-					return fmt.Errorf("invalid environment name or value")
-				}
-			}
-			if len(p.Values) == 0 {
-				p.Policy = PolicyDeny
-				p.Values = nil
-			}
+		}
+		if len(p.Values) == 0 {
+			p.Policy = PolicyDeny
+			p.Values = nil
 		}
 	default:
 		return fmt.Errorf("unknown env policy %q (want deny, any, or exact)", p.Policy)

--- a/pkg/allowlist/env.go
+++ b/pkg/allowlist/env.go
@@ -1,0 +1,129 @@
+package allowlist
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// EnvObservation commits to the complete OCI launch environment. Nil means
+// unavailable evidence, never an empty environment. Values are never reported.
+type EnvObservation struct {
+	Format string `json:"format"`
+	Digest string `json:"digest"`
+}
+
+const EnvFormat = "c8s.env/v1"
+
+// ObserveEnv validates before canonicalizing: duplicate names and malformed
+// entries must not disappear into a map and later satisfy a constrained grant.
+// Errors contain no environment names or values.
+func ObserveEnv(entries []string) (*EnvObservation, error) {
+	values := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		name, value, ok := strings.Cut(entry, "=")
+		if !ok || !validEnvPair(name, value) {
+			return nil, fmt.Errorf("malformed OCI environment")
+		}
+		if _, exists := values[name]; exists {
+			return nil, fmt.Errorf("duplicate OCI environment name")
+		}
+		values[name] = value
+	}
+	return fingerprintEnv(values), nil
+}
+
+func validEnvPair(name, value string) bool {
+	return name != "" && !strings.ContainsAny(name, "=\x00") && !strings.ContainsRune(value, 0) && utf8.ValidString(name) && utf8.ValidString(value)
+}
+
+// The encoding is the UTF-8 domain string "c8s.env/v1", a NUL, then Go
+// encoding/json's compact object (sorted keys, HTML escaping enabled). Empty
+// maps encode as {}, never null. Version this encoding if it ever changes.
+func fingerprintEnv(values map[string]string) *EnvObservation {
+	if values == nil {
+		values = map[string]string{}
+	}
+	b, _ := json.Marshal(values)
+	sum := sha256.Sum256(append([]byte(EnvFormat+"\x00"), b...))
+	return &EnvObservation{Format: EnvFormat, Digest: hex.EncodeToString(sum[:])}
+}
+
+func (o *EnvObservation) Valid() bool {
+	if o == nil || o.Format != EnvFormat || len(o.Digest) != 64 {
+		return false
+	}
+	b, err := hex.DecodeString(o.Digest)
+	return err == nil && hex.EncodeToString(b) == o.Digest
+}
+
+func (o *EnvObservation) Clone() *EnvObservation {
+	if o == nil {
+		return nil
+	}
+	c := *o
+	return &c
+}
+
+func (p EnvPolicy) admitsObservation(o *EnvObservation) bool {
+	switch p.Policy {
+	case PolicyAny, "":
+		return true // absent only in legacy v1
+	case PolicyDeny:
+		return o.Valid() && *o == *fingerprintEnv(nil)
+	case PolicyExact:
+		return p.Names == nil && p.Values != nil && o.Valid() && *o == *fingerprintEnv(p.Values)
+	default:
+		return false
+	}
+}
+
+// ValidateEnvSchema prevents older consumers from silently accepting value
+// restrictions as names-only v1 policies. New v2 entries require explicit env.
+func (w Workload) ValidateEnvSchema(schema string) error {
+	for _, c := range w.containers() {
+		switch schema {
+		case SchemaV2:
+			if c.Env.Policy == "" {
+				return fmt.Errorf("v2 requires an explicit env policy")
+			}
+			if c.Env.Names != nil {
+				return fmt.Errorf("v2 env uses values, not legacy names")
+			}
+		case Schema:
+			if c.Env.Values != nil || c.Env.Policy == PolicyDeny {
+				return fmt.Errorf("env value pinning requires c8s.allowlist/v2; replace the complete document to migrate")
+			}
+		default:
+			return fmt.Errorf("unknown allowlist schema")
+		}
+	}
+	return nil
+}
+
+// ParseEnvPoliciesJSON reads per-container policies for CLI derivation. Exact
+// literals are deliberately supplied by the operator, never fetched from a Pod.
+func ParseEnvPoliciesJSON(data []byte) (map[string]EnvPolicy, error) {
+	if err := validateJSON(data); err != nil {
+		return nil, err
+	}
+	var policies map[string]EnvPolicy
+	dec := json.NewDecoder(strings.NewReader(string(data)))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&policies); err != nil {
+		return nil, fmt.Errorf("invalid environment policy file")
+	}
+	for name, p := range policies {
+		if p.Policy == "" || p.Names != nil {
+			return nil, fmt.Errorf("container %q requires a v2 env policy", name)
+		}
+		if err := normalizeEnv(&p); err != nil {
+			return nil, fmt.Errorf("container %q: %w", name, err)
+		}
+		policies[name] = p
+	}
+	return policies, nil
+}

--- a/pkg/allowlist/env.go
+++ b/pkg/allowlist/env.go
@@ -71,37 +71,14 @@ func (o *EnvObservation) Clone() *EnvObservation {
 func (p EnvPolicy) admitsObservation(o *EnvObservation) bool {
 	switch p.Policy {
 	case PolicyAny, "":
-		return true // absent only in legacy v1
+		return true
 	case PolicyDeny:
 		return o.Valid() && *o == *fingerprintEnv(nil)
 	case PolicyExact:
-		return p.Names == nil && p.Values != nil && o.Valid() && *o == *fingerprintEnv(p.Values)
+		return p.Values != nil && o.Valid() && *o == *fingerprintEnv(p.Values)
 	default:
 		return false
 	}
-}
-
-// ValidateEnvSchema prevents older consumers from silently accepting value
-// restrictions as names-only v1 policies. New v2 entries require explicit env.
-func (w Workload) ValidateEnvSchema(schema string) error {
-	for _, c := range w.containers() {
-		switch schema {
-		case SchemaV2:
-			if c.Env.Policy == "" {
-				return fmt.Errorf("v2 requires an explicit env policy")
-			}
-			if c.Env.Names != nil {
-				return fmt.Errorf("v2 env uses values, not legacy names")
-			}
-		case Schema:
-			if c.Env.Values != nil || c.Env.Policy == PolicyDeny {
-				return fmt.Errorf("env value pinning requires c8s.allowlist/v2; replace the complete document to migrate")
-			}
-		default:
-			return fmt.Errorf("unknown allowlist schema")
-		}
-	}
-	return nil
 }
 
 // ParseEnvPoliciesJSON reads per-container policies for CLI derivation. Exact
@@ -117,8 +94,8 @@ func ParseEnvPoliciesJSON(data []byte) (map[string]EnvPolicy, error) {
 		return nil, fmt.Errorf("invalid environment policy file")
 	}
 	for name, p := range policies {
-		if p.Policy == "" || p.Names != nil {
-			return nil, fmt.Errorf("container %q requires a v2 env policy", name)
+		if p.Policy == "" {
+			return nil, fmt.Errorf("container %q requires an explicit env policy", name)
 		}
 		if err := normalizeEnv(&p); err != nil {
 			return nil, fmt.Errorf("container %q: %w", name, err)

--- a/pkg/allowlist/env_test.go
+++ b/pkg/allowlist/env_test.go
@@ -66,7 +66,7 @@ func TestEnvEncodingAndPrivacy(t *testing.T) {
 	}
 }
 
-func TestEnvSchemaMigration(t *testing.T) {
+func TestEnvPolicyParsing(t *testing.T) {
 	doc := func(schema, env string) []byte {
 		return []byte(`{"schema":"` + schema + `","workloads":{"w":{"containers":[{"digest":"` + digestA + `","env":` + env + `}]}}}`)
 	}
@@ -74,16 +74,13 @@ func TestEnvSchemaMigration(t *testing.T) {
 		schema, env string
 		want        bool
 	}{
-		{Schema, `{"policy":"exact","names":["A"]}`, true},
-		{Schema, `{"policy":"exact","values":{"A":"x"}}`, false},
-		{Schema, `{"policy":"deny"}`, false},
-		{SchemaV2, `{"policy":"exact","names":["A"]}`, false},
-		{SchemaV2, `{"policy":"exact","values":{"A":"x"}}`, true},
-		{SchemaV2, `{"policy":"exact","values":{}}`, true},
-		{SchemaV2, `{"policy":"deny"}`, true},
-		{SchemaV2, `{}`, false},
-		{SchemaV2, `{"policy":"exact","values":{"A":"x","A":"y"}}`, false},
-		{SchemaV2, `{"policy":"any","values":{"A":"x"}}`, false},
+		{Schema, `{"policy":"exact","names":["A"]}`, false},
+		{Schema, `{"policy":"exact","values":{"A":"x"}}`, true},
+		{Schema, `{"policy":"exact","values":{}}`, true},
+		{Schema, `{"policy":"deny"}`, true},
+		{Schema, `{}`, true},
+		{Schema, `{"policy":"exact","values":{"A":"x","A":"y"}}`, false},
+		{Schema, `{"policy":"any","values":{"A":"x"}}`, false},
 	} {
 		for _, parse := range []func([]byte) (*Allowlist, error){ParseJSON, ParseServedJSON} {
 			al, err := parse(doc(tc.schema, tc.env))
@@ -95,13 +92,13 @@ func TestEnvSchemaMigration(t *testing.T) {
 			}
 		}
 	}
-	if _, err := ParseJSON(append(doc(SchemaV2, `{"policy":"any"}`), []byte(`{}`)...)); err == nil {
+	if _, err := ParseJSON(append(doc(Schema, `{"policy":"any"}`), []byte(`{}`)...)); err == nil {
 		t.Fatal("trailing JSON accepted")
 	}
 }
 
 func TestEnvDistinguishesWorkloadsAndHistory(t *testing.T) {
-	al := mustParse(t, `{"schema":"c8s.allowlist/v2","workloads":{
+	al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{
  "a":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","values":{"MODE":"a"}}}]},
  "b":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","values":{"MODE":"b"}}}]}}}`)
 	a, _ := ObserveEnv([]string{"MODE=a"})
@@ -125,7 +122,7 @@ func TestEnvCanonicalOrder(t *testing.T) {
 	c := `{"digest":"` + digestA + `","env":{"policy":"exact","values":{"A":"VALUE"}}}`
 	a, b := strings.ReplaceAll(c, "VALUE", "a"), strings.ReplaceAll(c, "VALUE", "b")
 	parse := func(cs string) []byte {
-		al := mustParse(t, `{"schema":"c8s.allowlist/v2","workloads":{"w":{"containers":[`+cs+`]}}}`)
+		al := mustParse(t, `{"schema":"c8s.allowlist/v1","workloads":{"w":{"containers":[`+cs+`]}}}`)
 		out, _ := al.Canonical()
 		return out
 	}

--- a/pkg/allowlist/env_test.go
+++ b/pkg/allowlist/env_test.go
@@ -1,0 +1,159 @@
+package allowlist
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEnvironmentValueMatching(t *testing.T) {
+	exact := EnvPolicy{Policy: PolicyExact, Values: map[string]string{"A": "one=two", "B": ""}}
+	for _, tc := range []struct {
+		name string
+		env  []string
+		want bool
+	}{
+		{"exact", []string{"A=one=two", "B="}, true},
+		{"reordered", []string{"B=", "A=one=two"}, true},
+		{"missing", []string{"A=one=two"}, false},
+		{"changed", []string{"A=bad", "B="}, false},
+		{"extra", []string{"A=one=two", "B=", "C=x"}, false},
+		{"duplicate", []string{"A=bad", "A=one=two", "B="}, false},
+		{"malformed", []string{"A=one=two", "B=", "bad"}, false},
+		{"empty", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			o, _ := ObserveEnv(tc.env)
+			if got := exact.admitsObservation(o); got != tc.want {
+				t.Fatalf("match=%v want %v", got, tc.want)
+			}
+		})
+	}
+	empty, _ := ObserveEnv(nil)
+	for _, p := range []EnvPolicy{{Policy: PolicyDeny}, exact} {
+		if p.admitsObservation(nil) {
+			t.Fatal("unknown evidence admitted")
+		}
+	}
+	if !(EnvPolicy{Policy: PolicyDeny}).admitsObservation(empty) {
+		t.Fatal("observed empty denied")
+	}
+	if !(EnvPolicy{Policy: PolicyAny}).admitsObservation(nil) {
+		t.Fatal("any requires evidence")
+	}
+	invalid := *empty
+	invalid.Format = "future"
+	if (EnvPolicy{Policy: PolicyDeny}).admitsObservation(&invalid) {
+		t.Fatal("unknown format admitted")
+	}
+	for _, e := range []string{"=value", "A\x00=x", "A=x\x00", "A=\xff"} {
+		if _, err := ObserveEnv([]string{e}); err == nil {
+			t.Fatal("malformed env accepted")
+		}
+	}
+}
+
+func TestEnvEncodingAndPrivacy(t *testing.T) {
+	o, _ := ObserveEnv([]string{"B=", "A=one=two"})
+	// Independent fixed vector pins domain, encoding, and hash across producers.
+	if o.Digest != "2ca95b966d05cb4c862d7900e3a342caf052531fe89ba5f1a8e4c806d770eb73" {
+		t.Fatalf("fingerprint %s", o.Digest)
+	}
+	b, _ := json.Marshal(o)
+	if bytes.Contains(b, []byte("one=two")) {
+		t.Fatal("raw value disclosed")
+	}
+}
+
+func TestEnvSchemaMigration(t *testing.T) {
+	doc := func(schema, env string) []byte {
+		return []byte(`{"schema":"` + schema + `","workloads":{"w":{"containers":[{"digest":"` + digestA + `","env":` + env + `}]}}}`)
+	}
+	for _, tc := range []struct {
+		schema, env string
+		want        bool
+	}{
+		{Schema, `{"policy":"exact","names":["A"]}`, true},
+		{Schema, `{"policy":"exact","values":{"A":"x"}}`, false},
+		{Schema, `{"policy":"deny"}`, false},
+		{SchemaV2, `{"policy":"exact","names":["A"]}`, false},
+		{SchemaV2, `{"policy":"exact","values":{"A":"x"}}`, true},
+		{SchemaV2, `{"policy":"exact","values":{}}`, true},
+		{SchemaV2, `{"policy":"deny"}`, true},
+		{SchemaV2, `{}`, false},
+		{SchemaV2, `{"policy":"exact","values":{"A":"x","A":"y"}}`, false},
+		{SchemaV2, `{"policy":"any","values":{"A":"x"}}`, false},
+	} {
+		for _, parse := range []func([]byte) (*Allowlist, error){ParseJSON, ParseServedJSON} {
+			al, err := parse(doc(tc.schema, tc.env))
+			if (err == nil) != tc.want {
+				t.Fatalf("%s %s: %v", tc.schema, tc.env, err)
+			}
+			if err == nil && al.Schema != tc.schema {
+				t.Fatal("schema changed")
+			}
+		}
+	}
+	if _, err := ParseJSON(append(doc(SchemaV2, `{"policy":"any"}`), []byte(`{}`)...)); err == nil {
+		t.Fatal("trailing JSON accepted")
+	}
+}
+
+func TestEnvDistinguishesWorkloadsAndHistory(t *testing.T) {
+	al := mustParse(t, `{"schema":"c8s.allowlist/v2","workloads":{
+ "a":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","values":{"MODE":"a"}}}]},
+ "b":{"containers":[{"digest":"`+digestA+`","command":{"policy":"any"},"args":{"policy":"any"},"env":{"policy":"exact","values":{"MODE":"b"}}}]}}}`)
+	a, _ := ObserveEnv([]string{"MODE=a"})
+	b, _ := ObserveEnv([]string{"MODE=b"})
+	running := []RunningContainer{{Digest: digestA, Env: a}}
+	if name, _, err := al.MatchWorkload(running); err != nil || name != "a" {
+		t.Fatalf("match %q %v", name, err)
+	}
+	running = append(running, RunningContainer{Digest: digestA, Env: b})
+	if _, _, err := al.MatchWorkload(running); err == nil {
+		t.Fatal("foreign historical env ignored")
+	}
+	running = running[:1]
+	running[0].Env = nil
+	if _, _, err := al.MatchWorkload(running); err == nil {
+		t.Fatal("old inventory matched")
+	}
+}
+
+func TestEnvCanonicalOrder(t *testing.T) {
+	c := `{"digest":"` + digestA + `","env":{"policy":"exact","values":{"A":"VALUE"}}}`
+	a, b := strings.ReplaceAll(c, "VALUE", "a"), strings.ReplaceAll(c, "VALUE", "b")
+	parse := func(cs string) []byte {
+		al := mustParse(t, `{"schema":"c8s.allowlist/v2","workloads":{"w":{"containers":[`+cs+`]}}}`)
+		out, _ := al.Canonical()
+		return out
+	}
+	if !bytes.Equal(parse(a+","+b), parse(b+","+a)) {
+		t.Fatal("env policy order changes canonical bytes")
+	}
+}
+
+func TestEnvUnicodeAndDuplicatePolicyKeys(t *testing.T) {
+	for _, tc := range []struct {
+		value string
+		want  bool
+	}{
+		{`"\ud800"`, false}, {`"\udfff"`, false}, {`"\ud800x"`, false},
+		{`"\ud83d\ude00"`, true}, {`"\\ud800"`, true}, {`"�"`, true},
+	} {
+		_, err := ParseEnvPoliciesJSON([]byte(`{"app":{"policy":"exact","values":{"A":` + tc.value + `}}}`))
+		if (err == nil) != tc.want {
+			t.Fatalf("%s: %v", tc.value, err)
+		}
+	}
+	for _, data := range []string{
+		`{"app":{"policy":"deny"},"app":{"policy":"any"}}`,
+		`{"app":{"policy":"deny","policy":"any"}}`,
+		`{"app":{"policy":"exact","values":{"A":"one","A":"two"}}}`,
+	} {
+		if _, err := ParseEnvPoliciesJSON([]byte(data)); err == nil {
+			t.Fatal("duplicate policy key accepted")
+		}
+	}
+}

--- a/pkg/allowlist/json_validation.go
+++ b/pkg/allowlist/json_validation.go
@@ -1,0 +1,115 @@
+package allowlist
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"unicode/utf8"
+)
+
+// Reject duplicate object keys before decoding into maps (which otherwise
+// silently keep the last value). Error messages must not expose env literals.
+func validateJSON(data []byte) error {
+	if !utf8.Valid(data) {
+		return fmt.Errorf("JSON must be UTF-8")
+	}
+	if err := validateUnicodeEscapes(data); err != nil {
+		return err
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	var value func() error
+	value = func() error {
+		tok, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		d, ok := tok.(json.Delim)
+		if !ok {
+			return nil
+		}
+		switch d {
+		case '{':
+			seen := map[string]bool{}
+			for dec.More() {
+				key, err := dec.Token()
+				if err != nil {
+					return err
+				}
+				k, ok := key.(string)
+				if !ok {
+					return fmt.Errorf("invalid JSON key")
+				}
+				if seen[k] {
+					return fmt.Errorf("duplicate JSON object key")
+				}
+				seen[k] = true
+				if err := value(); err != nil {
+					return err
+				}
+			}
+		case '[':
+			for dec.More() {
+				if err := value(); err != nil {
+					return err
+				}
+			}
+		default:
+			return fmt.Errorf("unexpected JSON delimiter")
+		}
+		_, err = dec.Token()
+		return err
+	}
+	if err := value(); err != nil {
+		return err
+	}
+	if _, err := dec.Token(); err != io.EOF {
+		return fmt.Errorf("expected exactly one JSON document")
+	}
+	return nil
+}
+
+// encoding/json replaces unpaired surrogates with U+FFFD. Reject them rather
+// than allowing distinct policy strings to silently collapse during decoding.
+func validateUnicodeEscapes(data []byte) error {
+	inString := false
+	for i := 0; i < len(data); i++ {
+		if data[i] == '"' {
+			inString = !inString
+			continue
+		}
+		if !inString || data[i] != '\\' {
+			continue
+		}
+		i++
+		if i >= len(data) {
+			break
+		}
+		if data[i] != 'u' {
+			continue
+		}
+		if i+4 >= len(data) {
+			break
+		}
+		n, err := strconv.ParseUint(string(data[i+1:i+5]), 16, 16)
+		if err != nil {
+			continue
+		}
+		i += 4
+		if n >= 0xdc00 && n <= 0xdfff {
+			return fmt.Errorf("unpaired Unicode surrogate")
+		}
+		if n >= 0xd800 && n <= 0xdbff {
+			if i+6 >= len(data) || data[i+1] != '\\' || data[i+2] != 'u' {
+				return fmt.Errorf("unpaired Unicode surrogate")
+			}
+			low, err := strconv.ParseUint(string(data[i+3:i+7]), 16, 16)
+			if err != nil || low < 0xdc00 || low > 0xdfff {
+				return fmt.Errorf("unpaired Unicode surrogate")
+			}
+			i += 6
+		}
+	}
+	return nil
+}

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -2,22 +2,12 @@ package allowlist
 
 import "fmt"
 
-// RunningContainer is one container as an enforcer observes it: the bytes, the
-// effective argv they were told to run, the destinations of its BIND mounts
-// (the ones that can carry host-supplied content in), and its environment
-// commitment without values (and legacy variable names).
-//
-// A local type rather than the inventory's own keeps this package a pure
-// function of the allowlist — the caller converts.
-//
-// Missing Env is unavailable evidence, and fails v2 exact/deny policies.
-// Legacy v1 mount/name-set policies retain their historical subset semantics.
-// Kata fills bind mounts and legacy names; both backends report v2 env evidence.
+// RunningContainer holds the launch characteristics observed by an enforcer.
+// Missing Env is unavailable evidence and fails exact/deny policies.
 type RunningContainer struct {
 	Digest     string
 	Argv       []string
 	BindMounts []string
-	EnvNames   []string // legacy v1 only
 	Env        *EnvObservation
 }
 
@@ -172,12 +162,7 @@ func (p MountPolicy) admits(destinations []string) bool {
 	return everyIn(destinations, p.Destinations)
 }
 
-// matches preserves v1 names-only semantics; v2 value policies always require
-// complete observed evidence, including for deny.
 func (p EnvPolicy) matches(r RunningContainer) bool {
-	if p.Policy == PolicyExact && p.Names != nil {
-		return everyIn(r.EnvNames, p.Names)
-	}
 	return p.admitsObservation(r.Env)
 }
 

--- a/pkg/allowlist/match.go
+++ b/pkg/allowlist/match.go
@@ -2,14 +2,23 @@ package allowlist
 
 import "fmt"
 
-// RunningContainer is one container as an enforcer observes it: the image digest
-// and the effective argv it was told to run.
+// RunningContainer is one container as an enforcer observes it: the bytes, the
+// effective argv they were told to run, the destinations of its BIND mounts
+// (the ones that can carry host-supplied content in), and its environment
+// commitment without values (and legacy variable names).
 //
 // A local type rather than the inventory's own keeps this package a pure
 // function of the allowlist — the caller converts.
+//
+// Missing Env is unavailable evidence, and fails v2 exact/deny policies.
+// Legacy v1 mount/name-set policies retain their historical subset semantics.
+// Kata fills bind mounts and legacy names; both backends report v2 env evidence.
 type RunningContainer struct {
-	Digest string
-	Argv   []string
+	Digest     string
+	Argv       []string
+	BindMounts []string
+	EnvNames   []string // legacy v1 only
+	Env        *EnvObservation
 }
 
 // ErrNoMatch reports that no entry describes the running set; ErrAmbiguous that
@@ -138,9 +147,55 @@ func (c Container) admits(r RunningContainer) bool {
 	if c.Digest.String() != r.Digest {
 		return false
 	}
+	if !c.admitsProcess(r) {
+		return false
+	}
+	return c.Mounts.admits(r.BindMounts) && c.Env.matches(r)
+}
+
+func (c Container) admitsProcess(r RunningContainer) bool {
+	if c.Digest.String() != r.Digest {
+		return false
+	}
 	rest, ok := c.Command.matchCommand(r.Argv)
 	if !ok || !c.Args.matchArgs(rest) {
 		return false
+	}
+	return true
+}
+
+// admits reports whether every bind destination is one this policy names.
+func (p MountPolicy) admits(destinations []string) bool {
+	if p.Policy != PolicyExact {
+		return true
+	}
+	return everyIn(destinations, p.Destinations)
+}
+
+// matches preserves v1 names-only semantics; v2 value policies always require
+// complete observed evidence, including for deny.
+func (p EnvPolicy) matches(r RunningContainer) bool {
+	if p.Policy == PolicyExact && p.Names != nil {
+		return everyIn(r.EnvNames, p.Names)
+	}
+	return p.admitsObservation(r.Env)
+}
+
+// everyIn reports whether every observed value appears in allowed. An empty
+// observation is vacuously true — see RunningContainer on enforcers that cannot
+// see a field.
+func everyIn(observed, allowed []string) bool {
+	if len(observed) == 0 {
+		return true
+	}
+	set := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		set[a] = struct{}{}
+	}
+	for _, o := range observed {
+		if _, ok := set[o]; !ok {
+			return false
+		}
 	}
 	return true
 }

--- a/pkg/allowlist/mountenv_test.go
+++ b/pkg/allowlist/mountenv_test.go
@@ -1,6 +1,140 @@
 package allowlist
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/confidential-dot-ai/c8s/pkg/types"
+)
+
+func mustDigest(t *testing.T, s string) types.Digest {
+	t.Helper()
+	d, err := types.ParseDigest(s)
+	if err != nil {
+		t.Fatalf("ParseDigest(%q): %v", s, err)
+	}
+	return d
+}
+
+func containerWith(t *testing.T, mounts MountPolicy, env EnvPolicy) Container {
+	t.Helper()
+	c := Container{
+		Digest:  mustDigest(t, "sha256:"+strings.Repeat("a", 64)),
+		Command: ArgvPolicy{Policy: PolicyAny},
+		Args:    ArgvPolicy{Policy: PolicyAny},
+		Mounts:  mounts,
+		Env:     env,
+	}
+	// normalizeContainers mutates the slice it is given, so read the result back
+	// out of it rather than off the copy that went in.
+	cs := []Container{c}
+	if err := normalizeContainers("w", "containers", cs); err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	return cs[0]
+}
+
+func running(digest string, mounts, env []string) RunningContainer {
+	observed, _ := ObserveEnv(env)
+	return RunningContainer{Digest: digest, BindMounts: mounts, Env: observed}
+}
+
+// The threat this policy exists for: the host stages bytes in the sandbox
+// seeding directory (a legitimate CopyFile destination) and binds them over a
+// path inside an allowlisted image, so the container runs host code while every
+// digest still reports as admitted.
+func TestMountPolicyRefusesAnUndeclaredDestination(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts", "/var/run/secrets/kubernetes.io/serviceaccount"}},
+		EnvPolicy{Policy: PolicyAny})
+
+	if !c.admits(running(digest, []string{"/etc/hosts"}, nil)) {
+		t.Error("a declared destination was refused")
+	}
+	if c.admits(running(digest, []string{"/etc/hosts", "/usr/local/bin/get-cert"}, nil)) {
+		t.Error("a bind over an image path was admitted")
+	}
+}
+
+// An absent policy has to mean "unconstrained": every container carries a mount
+// table it never declared, so a Deny default would refuse every real pod.
+func TestAbsentMountAndEnvPolicyAreUnconstrained(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{}, EnvPolicy{})
+
+	if c.Mounts.Policy != PolicyAny || c.Env.Policy != PolicyAny {
+		t.Fatalf("normalized to %q/%q, want %q", c.Mounts.Policy, c.Env.Policy, PolicyAny)
+	}
+	if !c.admits(running(digest, []string{"/anything", "/at/all"}, []string{"LD_PRELOAD"})) {
+		t.Error("an absent policy refused a container")
+	}
+}
+
+// LD_PRELOAD is the sharp case: an injected name is code execution inside an
+// otherwise-allowlisted image.
+func TestEnvPolicyRefusesAnUndeclaredName(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t, MountPolicy{Policy: PolicyAny},
+		EnvPolicy{Policy: PolicyExact, Values: map[string]string{"PATH": "/bin", "HOME": "/"}})
+
+	if !c.admits(running(digest, nil, []string{"PATH=/bin", "HOME=/"})) {
+		t.Error("declared names were refused")
+	}
+	if c.admits(running(digest, nil, []string{"PATH=/bin", "HOME=/", "LD_PRELOAD=/evil.so"})) {
+		t.Error("an injected environment name was admitted")
+	}
+}
+
+// An enforcer that cannot see a field leaves it nil. That is not a violation —
+// the host-side NRI plugin gates images on a node CVM and never sees a guest's
+// mount table, and refusing there would deny every pod it checks.
+func TestUnobservedMountsAreNotViolations(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/etc/hosts"}},
+		EnvPolicy{Policy: PolicyAny})
+
+	if !c.admits(RunningContainer{Digest: digest}) {
+		t.Error("an enforcer that observes neither field was refused")
+	}
+}
+
+func TestMountAndEnvPolicyValidation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		c    Container
+	}{
+		{"exact mounts with no destinations", Container{Mounts: MountPolicy{Policy: PolicyExact}}},
+		{"any mounts carrying destinations", Container{Mounts: MountPolicy{Policy: PolicyAny, Destinations: []string{"/x"}}}},
+		{"relative destination", Container{Mounts: MountPolicy{Policy: PolicyExact, Destinations: []string{"etc/hosts"}}}},
+		{"unknown mount policy", Container{Mounts: MountPolicy{Policy: "sometimes"}}},
+		{"exact env with no values", Container{Env: EnvPolicy{Policy: PolicyExact}}},
+		{"any env carrying values", Container{Env: EnvPolicy{Policy: PolicyAny, Values: map[string]string{"PATH": "/bin"}}}},
+		{"name containing =", Container{Env: EnvPolicy{Policy: PolicyExact, Values: map[string]string{"PATH=/bin": ""}}}},
+		{"unknown env policy", Container{Env: EnvPolicy{Policy: "sometimes"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := tc.c
+			c.Digest = mustDigest(t, "sha256:"+strings.Repeat("a", 64))
+			if err := normalizeContainers("w", "containers", []Container{c}); err == nil {
+				t.Error("normalize accepted an invalid policy")
+			}
+		})
+	}
+}
+
+// Canonical is compared byte-for-byte across pulls, so the lists have to be a
+// function of content rather than of the order an operator wrote them.
+func TestMountDestinationsAreOrderIndependent(t *testing.T) {
+	c := containerWith(t,
+		MountPolicy{Policy: PolicyExact, Destinations: []string{"/b", "/a", "/b"}},
+		EnvPolicy{Policy: PolicyAny})
+
+	if got := strings.Join(c.Mounts.Destinations, ","); got != "/a,/b" {
+		t.Errorf("destinations = %q, want sorted and deduplicated", got)
+	}
+}
 
 // A document from a newer release must not freeze an older consumer's policy.
 func TestServedParseIgnoresUnknownFields(t *testing.T) {

--- a/pkg/allowlist/policy.go
+++ b/pkg/allowlist/policy.go
@@ -149,3 +149,23 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// AdmitsProcess is the preliminary NRI create-time check. It deliberately checks
+// only digest/argv; a successful result MUST be followed by AdmitsContainer on
+// the finalized OCI spec before start, and must never authorize secret release.
+func (i *Index) AdmitsProcess(r RunningContainer) bool {
+	if i == nil {
+		return false
+	}
+	d, err := types.ParseDigest(r.Digest)
+	if err != nil {
+		return false
+	}
+	r.Digest = d.String()
+	for _, c := range i.byDigest[r.Digest] {
+		if c.admitsProcess(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/workloadclaims/container_key.go
+++ b/pkg/workloadclaims/container_key.go
@@ -2,39 +2,37 @@ package workloadclaims
 
 import (
 	"cmp"
+	"encoding/binary"
 	"slices"
 	"strings"
 )
 
-// Key identifies this (digest, argv) pair in an inventory's admission
-// high-water mark, where it is the deduplication key.
-//
-// The encoding MUST be injective, so it is /proc/cmdline's: NUL after every
-// element, digest included. NUL is the one byte neither field can carry — an
-// execve argument is a NUL-terminated C string and a digest is hex — and
-// terminating rather than separating keeps an empty argv list distinct from a
-// single empty argument.
-//
-// A non-injective key is not merely untidy. Two distinct admissions that
-// collide onto one key erase each other from the sandbox's record, and the
-// erasure is invisible to CDS: it drops the container from the digests and
-// containers views alike, so the cross-check between them still agrees and the
-// sandbox can then be named for a workload it did not actually run.
+// Key identifies a (digest, argv, env) admission in the cumulative inventory.
+// The framing must be injective: a collision erases historical evidence and can
+// allow a sandbox to match a workload it did not actually run.
 func (c SandboxContainer) Key() string {
-	var b strings.Builder
-	b.Grow(len(c.Digest) + 1 + len(c.Argv))
-	b.WriteString(c.Digest)
-	b.WriteByte(0)
+	// Length-prefix every field and count argv elements. Preserve arbitrary
+	// argument bytes: JSON string encoding would collapse invalid UTF-8.
+	var b []byte
+	field := func(s string) { b = binary.AppendUvarint(b, uint64(len(s))); b = append(b, s...) }
+	field(c.Digest)
+	b = binary.AppendUvarint(b, uint64(len(c.Argv)))
 	for _, a := range c.Argv {
-		b.WriteString(a)
-		b.WriteByte(0)
+		field(a)
 	}
-	return b.String()
+	if c.Env == nil {
+		b = append(b, 0)
+	} else {
+		b = append(b, 1)
+		field(c.Env.Format)
+		field(c.Env.Digest)
+	}
+	return string(b)
 }
 
-// Compare orders containers by digest, then argv — the stable order the
+// Compare orders containers by digest, argv, then env — the stable order the
 // digests endpoint serves, so identical sandboxes report identical
 // inventories.
 func (c SandboxContainer) Compare(o SandboxContainer) int {
-	return cmp.Or(strings.Compare(c.Digest, o.Digest), slices.Compare(c.Argv, o.Argv))
+	return cmp.Or(strings.Compare(c.Digest, o.Digest), slices.Compare(c.Argv, o.Argv), strings.Compare(c.Key(), o.Key()))
 }

--- a/pkg/workloadclaims/workloadclaims.go
+++ b/pkg/workloadclaims/workloadclaims.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/confidential-dot-ai/c8s/pkg/allowlist"
 	"io"
 	"net"
 	"net/http"
@@ -164,7 +165,7 @@ type SandboxTokenRequest struct {
 //
 // Digests is the deduplicated digest set cert issuance gates on. Containers
 // carries each container's effective argv, deduplicated by SandboxContainer.Key
-// (the whole (digest, argv) pair, not the digest alone), so a consumer can hold
+// (the whole (digest, argv, env) tuple, not the digest alone), so a consumer can hold
 // a sandbox to the pair each container actually ran with.
 //
 // Digests is [] (never null) for a known sandbox with no containers. Containers
@@ -176,9 +177,10 @@ type SandboxDigestsResponse struct {
 }
 
 // SandboxContainer is one admitted container: the bytes, and what they were
-// told to run.
+// told to run, plus an optional commitment to its final OCI environment.
 type SandboxContainer struct {
-	Digest string `json:"digest"`
+	Env    *allowlist.EnvObservation `json:"env,omitempty"`
+	Digest string                    `json:"digest"`
 	// Argv is the effective OCI process.args — the merged image-config and
 	// pod-spec command, which is what the argv policy is written against.
 	Argv []string `json:"argv,omitempty"`

--- a/pkg/workloadclaims/workloadclaims_test.go
+++ b/pkg/workloadclaims/workloadclaims_test.go
@@ -819,6 +819,9 @@ func TestSandboxContainerKeyIsInjective(t *testing.T) {
 		{"/app\x1e--serve"},
 		{"/app --serve"},
 		{"/app\t--serve"},
+		{"/app", "\xff"},
+		{"/app", "\xfe"},
+		{"/app", "�"},
 		{"/app\n--serve"},
 		{"/app", "", "--serve"},
 	}

--- a/test/integration/cluster/run.sh
+++ b/test/integration/cluster/run.sh
@@ -35,8 +35,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 cd "$REPO_ROOT"
 
 CLUSTER="${C8S_IT_CLUSTER:-c8s-it}"
-# kind v0.30.0's default node image, pinned by digest.
-NODE_IMAGE="${C8S_IT_NODE_IMAGE:-kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a}"
+# kind v0.33.0's Kubernetes 1.34 image, pinned by digest. Its containerd
+# includes NRI adjustment validation, required for env enforcement.
+NODE_IMAGE="${C8S_IT_NODE_IMAGE:-kindest/node:v1.34.11@sha256:44e222ee2132dab25ff87301682f89eb82c7880ea3a1bf543bfe9708fd08d67d}"
 IMAGE_TAG=it
 NS=c8s-system
 CDS_LOCAL_PORT=18443
@@ -67,6 +68,10 @@ diagnostics() {
     kubectl get pods -A -o wide 2>&1 || true
     kubectl -n "$NS" logs deploy/c8s-cds --tail=40 2>&1 || true
     kubectl -n "$NS" logs deploy/c8s-operator --tail=40 2>&1 || true
+    kubectl -n "$NS" logs ds/c8s-nri-image-policy-worker -c install --tail=80 2>&1 || true
+    if [ -n "$NODE" ]; then
+        node_exec journalctl -u containerd --no-pager -n 100 2>&1 || true
+    fi
     mesh_diagnostics
 }
 


### PR DESCRIPTION
## Why

Workload entries pin image digests and command/args, but the environment a container launches with is unconstrained — an allowlisted image can still be pointed at `LD_PRELOAD` or a credential path. Entries can now pin the complete OCI launch environment by value, so a workload runs with exactly its declared environment or not at all.

## Description

The host NRI plugin enforces env at the OCI launch-environment level: it validates the env after cumulative NRI creation adjustments and re-checks the final OCI spec before container start, so a refused env blocks creation. Evidence travels as a fingerprint — a digest commitment over the canonical env map — through the admission inventory, admission history, and CDS workload matching, so the node proves an env match without reporting values; an `exact` or `deny` policy fails when evidence is unavailable rather than passing vacuously. The schema stays `c8s.allowlist/v1` and an absent env policy defaults to `any`, so existing entries are unaffected.

## Changes

- Add per-container `env` policies: `any` permits any environment, `deny` requires an observed empty one, and `exact` requires the given names and values with no additions or omissions.
- Add the `c8s.env/v1` env fingerprint and carry it through the admission inventory, admission history, CDS workload matching, and secret release, refusing constrained matches when evidence is missing.
- Enforce env in the NRI plugin via `ValidateContainerAdjustment`, with a final check and inventory record before container start.
- Add `--env=any|deny` and per-container `--env-file` to `allowlist derive`, and include env in list, diff, lint collision checks, and canonical ordering.
- Keep env-constrained bootstrap entries out of the unconditional digest floor.
- Bump the kind test node image for NRI adjustment validation.

## Focus areas for review

- Exact-map semantics: observed-empty versus unavailable evidence — missing evidence fails `exact` and `deny`, never passes vacuously.
- Env variants preserved through workload matching and admission history.
- NRI validation/start ordering: `exact` and `deny` reject deferred CDI device adjustments, whose env effects are unavailable at validation time.

`go build ./...` and the full `go test ./...` pass on the rebased branch.
