### PR TITLE
refactor: extracted logic into meaningful func names

### DIFF
--- a/cmd/c8s/install.go
+++ b/cmd/c8s/install.go
@@ -592,7 +592,7 @@ func platformImageLines(pods []corev1.Pod, accept func(namespace, digest string)
 	seen := map[string]bool{}
 	var lines []string
 	for _, p := range pods {
-		if !platformPod(p) || p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed {
+		if !platformPod(p) || isTerminalPod(p) {
 			continue
 		}
 		for _, st := range podContainerStatuses(p) {
@@ -608,6 +608,10 @@ func platformImageLines(pods []corev1.Pod, accept func(namespace, digest string)
 	}
 	slices.Sort(lines)
 	return lines
+}
+
+func isTerminalPod(p corev1.Pod) bool {
+	return p.Status.Phase == corev1.PodSucceeded || p.Status.Phase == corev1.PodFailed
 }
 
 // deniedPlatformImages lists the platform-pod images the policy would deny.

--- a/internal/cmds/allowlist/lint.go
+++ b/internal/cmds/allowlist/lint.go
@@ -245,7 +245,7 @@ func shadowFinding(wide, narrow string) finding {
 func shadows(wide, narrow pkgallowlist.Workload) bool {
 	unconstrained := map[string]bool{}
 	for _, c := range allContainers(wide) {
-		if c.AnyArgv() && c.Mounts.Policy != pkgallowlist.PolicyExact && c.Env.Policy != pkgallowlist.PolicyExact {
+		if hasUnconstrainedRuntimePolicy(c) {
 			unconstrained[c.Digest.String()] = true
 		}
 	}
@@ -264,6 +264,10 @@ func shadows(wide, narrow pkgallowlist.Workload) bool {
 		}
 	}
 	return true
+}
+
+func hasUnconstrainedRuntimePolicy(c pkgallowlist.Container) bool {
+	return c.AnyArgv() && c.Mounts.Policy != pkgallowlist.PolicyExact && c.Env.Policy != pkgallowlist.PolicyExact
 }
 
 // unobservedFieldPolicies reports mount and env policy that the deployment's

--- a/internal/cmds/allowlist/workload.go
+++ b/internal/cmds/allowlist/workload.go
@@ -333,11 +333,15 @@ func runEditor(path string) error {
 
 func sanitizeFileName(name string) string {
 	return strings.Map(func(r rune) rune {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+		if isSafeFileNameRune(r) {
 			return r
 		}
 		return '_'
 	}, name)
+}
+
+func isSafeFileNameRune(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_'
 }
 
 func confirm(cmd *cobra.Command, prompt string) bool {

--- a/internal/cmds/cdsattest/backend.go
+++ b/internal/cmds/cdsattest/backend.go
@@ -185,7 +185,8 @@ func (l *upstreamCertLoader) getClientCertificate(*tls.CertificateRequestInfo) (
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if l.cached != nil && now.Before(l.recheckAt) && certutil.CheckValidity(l.cached.Leaf, now) == nil {
+	canReuseCachedCertificate := l.cached != nil && now.Before(l.recheckAt) && certutil.CheckValidity(l.cached.Leaf, now) == nil
+	if canReuseCachedCertificate {
 		return l.cached, nil
 	}
 

--- a/internal/cmds/getcert/run.go
+++ b/internal/cmds/getcert/run.go
@@ -344,7 +344,7 @@ func renewLoop(ctx context.Context, cfg config, client attestclient.Client, leaf
 				// close to expiry. Sleeping out --renew-interval here would
 				// leave the workload serving a dead certificate.
 				failures++
-				if leaf != nil && failures >= expiredExitFailures && time.Now().After(leaf.NotAfter) {
+				if shouldRestartAfterRenewalFailures(leaf, failures) {
 					// The installed leaf is dead and renewal from this process
 					// keeps failing, so retrying in-process serves an expired
 					// certificate indefinitely. Exit instead: as a native
@@ -490,6 +490,10 @@ func renewalRetryInterval(cfg config, leaf *x509.Certificate, failures int) time
 		delay *= 2
 	}
 	return min(delay, ceiling)
+}
+
+func shouldRestartAfterRenewalFailures(leaf *x509.Certificate, failures int) bool {
+	return leaf != nil && failures >= expiredExitFailures && time.Now().After(leaf.NotAfter)
 }
 
 // isNamedLeaf reports whether the installed leaf carries a valid

--- a/internal/cmds/getkubeconfig/run.go
+++ b/internal/cmds/getkubeconfig/run.go
@@ -104,7 +104,7 @@ func Run(ctx context.Context, cfg Config) error {
 		relCtx, cancel2 := context.WithTimeout(ctx, cfg.Timeout)
 		resp, err = requestCredential(relCtx, httpClient, cfg.ReleaseBaseURL, keyPEM, csrPEM)
 		cancel2()
-		if err == nil || !errors.Is(err, syscall.ECONNREFUSED) || !time.Now().Before(releaseDeadline) {
+		if !shouldRetryCredentialRelease(err, releaseDeadline) {
 			break
 		}
 		fmt.Fprintln(os.Stderr, "cred-release not listening yet; retrying")
@@ -125,6 +125,10 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 	fmt.Fprintf(os.Stderr, "wrote %s (context %q) — attested: image tuple + operator-key chain verified\n", cfg.OutPath, cfg.ContextName)
 	return nil
+}
+
+func shouldRetryCredentialRelease(err error, deadline time.Time) bool {
+	return err != nil && errors.Is(err, syscall.ECONNREFUSED) && time.Now().Before(deadline)
 }
 
 // publicKeyPEMFromPrivate derives the PKIX PEM public key from an ECDSA

--- a/internal/cmds/ratlsmesh/pod_ipsets_linux.go
+++ b/internal/cmds/ratlsmesh/pod_ipsets_linux.go
@@ -626,7 +626,7 @@ func selectMissingFamilyNodeIPs(byFamily map[iptablesFamily]string, needed map[i
 				if (fam == iptablesFamilyIPv4) != (ip.To4() != nil) {
 					continue
 				}
-				if ip.IsLoopback() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast() {
+				if isExcludedNodeAddress(ip) {
 					continue
 				}
 				ones, _ := a.mask.Size()
@@ -650,7 +650,9 @@ func selectMissingFamilyNodeIPs(byFamily map[iptablesFamily]string, needed map[i
 				}
 				continue
 			}
-			if c.ones > best.ones || (c.ones == best.ones && c.iface < best.iface) {
+			hasLongerPrefix := c.ones > best.ones
+			winsInterfaceNameTie := c.ones == best.ones && c.iface < best.iface
+			if hasLongerPrefix || winsInterfaceNameTie {
 				best = c
 			}
 		}
@@ -660,6 +662,10 @@ func selectMissingFamilyNodeIPs(byFamily map[iptablesFamily]string, needed map[i
 		out[fam] = best.ip.String()
 	}
 	return out, nil
+}
+
+func isExcludedNodeAddress(ip net.IP) bool {
+	return ip.IsLoopback() || ip.IsUnspecified() || ip.IsMulticast() || ip.IsLinkLocalUnicast()
 }
 
 // isHostUsableIPv6 reports whether ip (prefix length ones) is a host-style

--- a/internal/cmds/volumed/open.go
+++ b/internal/cmds/volumed/open.go
@@ -193,7 +193,7 @@ func (o *Opener) Open(ctx context.Context, req Request) error {
 // deviceConflict reports whether opening device in mode mutable conflicts with
 // a live mount or an in-flight open. Caller holds mu.
 func (o *Opener) deviceConflict(device string, mutable bool) bool {
-	if m, inFlight := o.opening[device]; inFlight && (m || mutable) {
+	if openingMutable, inFlight := o.opening[device]; inFlight && (openingMutable || mutable) {
 		return true
 	}
 	for _, m := range o.mounts {

--- a/internal/controller/confidentialworkload_controller.go
+++ b/internal/controller/confidentialworkload_controller.go
@@ -73,17 +73,7 @@ func (r *ConfidentialWorkloadReconciler) Reconcile(ctx context.Context, req ctrl
 
 	matchID := r.resolveWorkloadCWID(ctx, &cw)
 
-	summary := v1alpha2.AttestationSummary{}
-	for i := range pods.Items {
-		pod := &pods.Items[i]
-		if pod.Annotations[webhook.AnnotationWorkload] != matchID {
-			continue
-		}
-		summary.Total++
-		if isPodReady(pod) {
-			summary.Attested++
-		}
-	}
+	summary := summarizeWorkloadAttestation(pods.Items, matchID)
 	cw.Status.AttestationSummary = &summary
 	cw.Status.ObservedGeneration = cw.Generation
 
@@ -116,6 +106,21 @@ func (r *ConfidentialWorkloadReconciler) Reconcile(ctx context.Context, req ctrl
 
 	l.V(1).Info("status mirrored", "total", summary.Total, "attested", summary.Attested)
 	return ctrl.Result{RequeueAfter: statusMirrorRequeue}, nil
+}
+
+func summarizeWorkloadAttestation(pods []corev1.Pod, matchID string) v1alpha2.AttestationSummary {
+	summary := v1alpha2.AttestationSummary{}
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Annotations[webhook.AnnotationWorkload] != matchID {
+			continue
+		}
+		summary.Total++
+		if isPodReady(pod) {
+			summary.Attested++
+		}
+	}
+	return summary
 }
 
 // isPodReady is the heuristic for "this pod has attested": the kubelet has

--- a/internal/controller/workloadservice_controller.go
+++ b/internal/controller/workloadservice_controller.go
@@ -223,12 +223,8 @@ func servicePorts(template *corev1.PodTemplateSpec) []corev1.ServicePort {
 					continue
 				}
 				seen[key] = struct{}{}
-				name := fmt.Sprintf("port-%d", cp.ContainerPort)
-				if protocol != corev1.ProtocolTCP {
-					name = fmt.Sprintf("port-%d-%s", cp.ContainerPort, strings.ToLower(string(protocol)))
-				}
 				out = append(out, corev1.ServicePort{
-					Name:     name,
+					Name:     servicePortName(cp.ContainerPort, protocol),
 					Port:     cp.ContainerPort,
 					Protocol: protocol,
 				})
@@ -236,6 +232,13 @@ func servicePorts(template *corev1.PodTemplateSpec) []corev1.ServicePort {
 		}
 	}
 	return out
+}
+
+func servicePortName(port int32, protocol corev1.Protocol) string {
+	if protocol != corev1.ProtocolTCP {
+		return fmt.Sprintf("port-%d-%s", port, strings.ToLower(string(protocol)))
+	}
+	return fmt.Sprintf("port-%d", port)
 }
 
 func (r *WorkloadServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -696,7 +696,8 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// under kata. An operator with neither has nothing to point it at, so
 	// injecting would produce a Running pod whose fetcher CrashLoops while the
 	// workload blocks forever on a file that never lands. Refuse at admission.
-	if inj != nil && len(inj.Secrets.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
+	hasWorkloadClaimsEndpoint := m.cfg.WorkloadClaimsHostDir != "" || m.cfg.WorkloadClaimsGuest
+	if inj != nil && len(inj.Secrets.Specs) > 0 && !hasWorkloadClaimsEndpoint {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
 			"%w: %s needs an admission inventory, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/secrets.md",
 			errInvalidInjectionAnnotation, AnnotationSecrets))
@@ -705,7 +706,7 @@ func (m *podMutator) Handle(ctx context.Context, req admission.Request) admissio
 	// socket directory on node-CVM or on guest loopback under kata. An operator
 	// with neither shape has no daemon to hand it to, so the workload would wait
 	// on a mount that can never land (docs/volumes.md).
-	if inj != nil && len(inj.Volumes.Specs) > 0 && m.cfg.WorkloadClaimsHostDir == "" && !m.cfg.WorkloadClaimsGuest {
+	if inj != nil && len(inj.Volumes.Specs) > 0 && !hasWorkloadClaimsEndpoint {
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf(
 			"%w: %s needs a volume daemon, which this operator is not configured with (nri-image-policy disabled, and not the kata guest shape); see docs/volumes.md",
 			errInvalidInjectionAnnotation, AnnotationVolumes))


### PR DESCRIPTION
Abstracted some code sections into separate function blocks to enable reading long functions without having to parse the entire logic of each line