### PR TITLE
ci(snp-metal): refuse an unmeasured install and report failures after their diagnostics

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -225,6 +225,10 @@ jobs:
           \$K create ns c8s-system >/dev/null 2>&1
           \$K label ns c8s-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=privileged pod-security.kubernetes.io/audit=privileged --overwrite >/dev/null 2>&1 && say NS_LABELED || say FAIL_NS
           if printf '%s' "\$MEAS" | grep -qE '^[0-9a-fA-F]{96}\$'; then MSED="s/RUNTIME_MEASUREMENT/\$MEAS/"; MMARK=MEAS_ENFORCED; else MSED='s/\["RUNTIME_MEASUREMENT"\]/[]/'; MMARK=MEAS_ACCEPTANY; fi
+          # The lane's claim is "a cert is issued only against the pinned launch
+          # digest". An empty or malformed MEAS used to install the chart with
+          # measurements: [] and still reach PAYLOAD_OK. Refuse before the apply.
+          [ "\$MMARK" = MEAS_ENFORCED ] || { say "FAIL_MEAS_UNAVAILABLE len=\${#MEAS}"; exit 0; }
           NODEIP=\$(\$K get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' 2>/dev/null)
           { printf '%s' "\$NODEIP" | grep -qE '^[0-9.]+\$'; } || { say FAIL_NODEIP; exit 0; }
           say "NODE_CIDR \$NODEIP/32"
@@ -256,6 +260,7 @@ jobs:
             \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | grep -i 'pull' | tail -6 | sed 's/^/@@EV /;s/\$/@@/'
             \$K -n c8s-system logs deploy/c8s-cds --tail=15 2>&1 | sed 's/^/@@CDSLOG /;s/\$/@@/'
             \$K -n c8s-system logs ds/c8s-attestation-api --tail=8 2>&1 | sed 's/^/@@AALOG /;s/\$/@@/'
+            say FAIL_CDS_NOT_READY; exit 0
           fi
           if [ "\$CDSOK" = "1" ]; then
             # Gate on the POLICY plane, not just CDS. The injected c8s-cert sidecar
@@ -283,7 +288,6 @@ jobs:
             # Under MEAS_ENFORCED the cert is only issued if the node attests the pinned measurement, so this is the enforcement test.
             bash "\$E2E/cw-workload.sh" && { WOK=1; say WORKLOAD_OK; } || FAILED="\$FAILED cw-workload"
             bash "\$E2E/cw-label-policy.sh" && say E2E_CW_LABEL_OK || FAILED="\$FAILED cw-label-policy"
-            if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
             if [ "\$WOK" != "1" ]; then
               \$K -n c8s-e2e-cw describe pods -l app=demo-nginx 2>&1 | grep -iE 'Warning|Failed|Error|Back-off|Reason' | tail -10 | sed 's/^/@@CWDESC /;s/\$/@@/'
               \$K -n c8s-e2e-cw logs -l app=demo-nginx -c c8s-cert --tail=10 2>&1 | sed 's/^/@@CERTLOG /;s/\$/@@/'
@@ -300,6 +304,9 @@ jobs:
               \$K get nodes -o jsonpath='{range .items[*]}{.metadata.name} internalIP={.status.addresses[?(@.type=="InternalIP")].address} podCIDR={.spec.podCIDR}{"\\n"}{end}' 2>&1 \\
                 | sed 's/^/@@NODEADDR /;s/\$/@@/'
             fi
+            # Verdict LAST: the host tears the VM down on the first FAIL_ marker,
+            # which used to cut off the CWDESC/CERTLOG/CDSBOUND lines above.
+            if [ -n "\$FAILED" ]; then say "FAIL_E2E:\$FAILED"; else say PAYLOAD_OK; fi
           fi
           \$K -n c8s-system get events --sort-by=.lastTimestamp 2>&1 | tail -10 | sed 's/^/@@EV /;s/\$/@@/'
           PAYLOAD


### PR DESCRIPTION
Three defects in the snp-metal payload. Each was reproduced by regenerating the real `payload.sh` from this heredoc (only `$VALS` and `$FULL` expand at generation) and executing the relevant block under stubbed `kubectl` and e2e scripts, then fed to the host loop's break logic from `cvm-e2e.yml`.

**`MEAS` could be empty and the lane still passed.** When configfs-tsm or python3 fails in the guest, `MEAS` is `""`, and line 227 then installs the chart with `measurements: []`. CDS accepts any measurement, `cw-workload` gets its cert trivially, and the run reports `PAYLOAD_OK` with the enforcement the lane exists to prove switched off. Nothing on the host fails on `MEAS_ACCEPTANY`, and the final banner prints `${M:-unknown}`. The payload now refuses before the HelmChart apply:

```
MEAS len=0:  @@FAIL_MEAS_UNAVAILABLE len=0@@  apply-called=0
MEAS len=2:  @@FAIL_MEAS_UNAVAILABLE len=2@@  apply-called=0
MEAS len=96: continues to the apply
```

**The verdict pre-empted its own diagnostics.** `FAIL_E2E` was said before the `CWDESC`/`CERTLOG`/`CDSBOUND`/`NODEADDR` lines, and the host tears the VM down on the first `FAIL_` marker, so the lines this payload's own comment calls "the only way to tell the cause apart" were cut off. With `cw-workload.sh` stubbed to fail, the host's view before the verdict:

```
original: NRIH, NRI_PLUGIN_READY, E2E_CW_LABEL_OK
fixed:    NRIH, NRI_PLUGIN_READY, E2E_CW_LABEL_OK, CWDESC x2, CERTLOG, CDSBOUND, NODEADDR
```

The verdict stays inside the `CDSOK` block. Moving it past the outer `fi` would have turned the CDS-not-ready path into a false `PAYLOAD_OK`, since `FAILED` is only set inside.

**The CDS-not-ready path emitted no verdict.** It dumped `EV`/`CDSLOG`/`AALOG` and fell through, so the host reported a generic "driver ended without PAYLOAD_OK". It now says `FAIL_CDS_NOT_READY` and exits, mirroring `FAIL_HELM`.

This file is c8s-owned and vendored into confidential-ci, whose copy is also still on the pre-#542 `default` namespace; the re-vendor after this merges fixes both.

Not covered: unit-level only. The post-merge wrapper will run the lane; the `MEAS` guard is the part most worth watching, since a guest where the TSM read genuinely cannot work will now fail where it used to pass silently. That is the intended direction. `FAIL_MEAS_UNAVAILABLE` reports `len=` and not the value, so a partial digest never lands in the log.

Falsified by: a run with `@@MEAS none@@` in the console that still reaches `PAYLOAD_OK`; a `FAIL_E2E` run whose artifact lacks the `CWDESC` lines.
