### PR TITLE
ci(snp-metal): only a 404 may walk resolve_tag to the parent commit

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -75,15 +75,29 @@ jobs:
           # Under the post-merge trigger (workflow_run off Docker) this resolves
           # to $SHORT on the first probe. Anonymous pulls — the packages are public.
           resolve_tag(){
-            local comp=$1 tok code
-            tok=$(curl -fsSL "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
+            local comp=$1 tok code sha attempt
+            tok=$(curl -fsSL --max-time 20 "https://ghcr.io/token?scope=repository:confidential-dot-ai/${comp}:pull" | jq -r .token)
             for sha in $(git -C c8s log --format=%h --abbrev=7 -50); do
-              code=$(curl -s -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $tok" \
-                -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
-                "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${sha}")
-              [ "$code" = "200" ] && { echo "$sha"; return; }
+              # Only a 404 means "no image for this commit", and only that walks to the
+              # parent. A 429, 5xx or timeout on the head sha used to walk too, so one
+              # ghcr hiccup silently tested the previous commit's image under the head's
+              # chart, with no warning until 50 misses. Retry those, then refuse.
+              for attempt in 1 2 3 4; do
+                code=$(curl -s -o /dev/null --max-time 20 -w '%{http_code}' -H "Authorization: Bearer $tok" \
+                  -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+                  "https://ghcr.io/v2/confidential-dot-ai/${comp}/manifests/${sha}")
+                case "$code" in
+                  200) echo "$sha"; return 0 ;;
+                  404) break ;;
+                  *)   sleep $((attempt * 3)) ;;
+                esac
+              done
+              if [ "$code" != "404" ]; then
+                echo "::error::ghcr answered ${code} for ${comp}:${sha} on 4 attempts; refusing to fall back to an older image" >&2
+                return 1
+              fi
             done
-            echo "::warning::no sha tag found for ${comp} in the last 50 commits — falling back to :main (racy)" >&2
+            echo "::warning::no sha tag found for ${comp} in the last 50 commits: falling back to :main (racy)" >&2
             echo main
           }
           # PLATFORM digest (linux/amd64), not the index digest: the NRI allowlist


### PR DESCRIPTION
`resolve_tag` treated every non-200 from ghcr as "no image for this commit" and walked to the parent sha. A single 429, 5xx or timeout on the head sha therefore tested the previous commit's image under the head's chart, self-consistently and green, with no warning until 50 consecutive misses. That is a merge whose image never ran reporting as tested.

Reproduced against the real function with `curl` stubbed per sha, then fixed so only a 404 walks; anything else is retried on the same sha and then refuses:

```
scenario    original            fixed
absent      parentsha  rc=0     parentsha  rc=0   (genuine 404: unchanged)
ratelimit   parentsha  rc=0     <none>     rc=1   ::error::ghcr answered 429 ... on 4 attempts
outage      parentsha  rc=0     <none>     rc=1   ::error::ghcr answered 503 ...
timeout     parentsha  rc=0     <none>     rc=1   ::error::ghcr answered 000 ...
flaky       parentsha  rc=0     headsha    rc=0   (2 x 429 then 200: the retry recovers the right image)
```

The harness was run on the function as embedded in this YAML, extracted back out, not on a hand copy.

The callers are `OPTAG=$(resolve_tag c8s-operator)` and two more under `set -euo pipefail`, so a `return 1` aborts the step with the `::error::` already on stderr; verified empirically rather than assumed. Both curls now carry `--max-time 20`, so a hang cannot stall the loop that probes up to ~150 manifests per run.

Not covered: this makes a ghcr outage a red run instead of a silently wrong one, which is the intended direction but a new way to be red. The `:main` fallback after 50 genuine 404s is unchanged and still racy, as its own warning says.

Falsified by: a run whose head sha has a published image resolving to an older sha.
