### PR TITLE
ci: re-vendor tdx-metal-e2e.yml and cvm-e2e.yml after confidential-ci#109

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -394,8 +394,16 @@ jobs:
           bash /tmp/gsend.sh "(setsid sh -c 'bash /tmp/drive.sh 2>&1 | tee /tmp/drive.out >/dev/ttyS0' </dev/null &) ; echo @@LAUNCHED@@"
 
           echo "--- payload progress (host-side polling of guest-console-log) ---"
+          # The payload is the side with diagnostics (FAIL_HELM, WARN_NRI_NOT_READY,
+          # FAIL_CDS_NOT_READY), so it must be the side that decides "too slow".
+          # Its own pre-suite caps sum to ~18 min (node Ready ~4, helm 45x12s=9,
+          # NRI health 60x5s=5) before any suite runs; 110 iterations here was
+          # ~18-22 min, so a slow image pull made the host give up first, report
+          # "did not report PAYLOAD_OK", and tear the guest down mid-work with no
+          # marker to explain it. 200 x ~12s is ~40 min, under the 55 min job
+          # timeout with room for the dump and teardown.
           seen=""; ok=""
-          for i in $(seq 1 110); do
+          for i in $(seq 1 200); do
             LOG=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g')
             NEW=$(printf '%s' "$LOG" | grep -oE '@@[^@]{1,140}@@' | sed 's/@@//g')
             comm -13 <(printf '%s\n' "$seen" | sort -u) <(printf '%s\n' "$NEW" | sort -u) 2>/dev/null | grep -vE '^$' | sed 's/^/  · /'

--- a/.github/workflows/tdx-metal-e2e.yml
+++ b/.github/workflows/tdx-metal-e2e.yml
@@ -200,6 +200,12 @@ jobs:
             [ -n "$v" ] || { echo "::error::$REFS_CM missing '$k'. The TDX refs CM is the single source of truth for image+measurement+paired ref (rtmr1/rtmr2 complete the image tuple get-kubeconfig now requires)"; exit 1; }
             echo "$k=$v" >> "$GITHUB_ENV"
           done
+          # Optional: the oras tag of the manifest artifact, for when the
+          # digest-to-tag walk below cannot derive it. Two error messages in the
+          # get-kubeconfig step tell the operator to set this key, but nothing
+          # read it, so the documented remedy could not work.
+          v=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.imageTag}' 2>/dev/null)
+          [ -z "$v" ] || echo "imageTag=$v" >> "$GITHUB_ENV"
           # An explicit input overrides the pin, but say so loudly: the floor is
           # fail-closed, so an unpaired ref is the likeliest cause of a red run.
           if [ -n '${{ inputs.c8s_ref }}' ]; then
@@ -426,11 +432,6 @@ jobs:
           # Capture the config git actually reads and the exchange it actually
           # gets, redacting any credential the trace would otherwise print.
           clone_diag() {
-            # Diagnostics must not abort themselves: this runs under the step's
-            # set -e, and `grep` with no match (a clean runner has no GIT_/GH_
-            # vars) would otherwise kill the function before the wire trace,
-            # which is the one artifact that explains the failure.
-            set +e
             echo "::group::c8s clone diagnostics"
             git config --list --show-origin 2>&1 \
               | sed -E 's/(extraheader|authorization|helper|password|token)=.*/\1=<redacted>/I' \
@@ -442,7 +443,6 @@ jobs:
               | sed -E 's/(authorization|Authorization|AUTHORIZATION):.*/\1: <redacted>/' \
               | tail -40 | sed 's/^/wire /'
             echo "::endgroup::"
-            set -e
           }
           retry 'rm -rf /tmp/c8s-src && git clone -q https://github.com/confidential-dot-ai/c8s.git /tmp/c8s-src' \
             || { clone_diag; exit 1; }


### PR DESCRIPTION
confidential-ci owns both lanes and c8s carries byte-identical copies, so confidential-ci#109 has to land here or `vendored-lane-drift` goes red.

`tdx-metal-e2e.yml` now reads the optional `imageTag` key from the refs ConfigMap. Two error messages in get-kubeconfig already told operators to set it; nothing read it, so the documented remedy could not work. Absent, nothing changes.

`cvm-e2e.yml`'s host poll is now 200 iterations (~40 min, under the 55 min job timeout) instead of 110 (~18-22 min). The payload's own pre-suite caps sum to ~18 min, so the host could give up first and tear the guest down mid-work with no marker; the payload's capped waits carry diagnostics and are now the side that decides.

Both proven in confidential-ci#109 by extracted-step tests and an arithmetic gate, and the merge fired the metal lanes on main under the new push paths.
