### PR TITLE
ci: re-vendor cvm-e2e.yml after confidential-ci#110

### DIFF
--- a/.github/workflows/cvm-e2e.yml
+++ b/.github/workflows/cvm-e2e.yml
@@ -394,16 +394,8 @@ jobs:
           bash /tmp/gsend.sh "(setsid sh -c 'bash /tmp/drive.sh 2>&1 | tee /tmp/drive.out >/dev/ttyS0' </dev/null &) ; echo @@LAUNCHED@@"
 
           echo "--- payload progress (host-side polling of guest-console-log) ---"
-          # The payload is the side with diagnostics (FAIL_HELM, WARN_NRI_NOT_READY,
-          # FAIL_CDS_NOT_READY), so it must be the side that decides "too slow".
-          # Its own pre-suite caps sum to ~18 min (node Ready ~4, helm 45x12s=9,
-          # NRI health 60x5s=5) before any suite runs; 110 iterations here was
-          # ~18-22 min, so a slow image pull made the host give up first, report
-          # "did not report PAYLOAD_OK", and tear the guest down mid-work with no
-          # marker to explain it. 200 x ~12s is ~40 min, under the 55 min job
-          # timeout with room for the dump and teardown.
           seen=""; ok=""
-          for i in $(seq 1 200); do
+          for i in $(seq 1 110); do
             LOG=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g')
             NEW=$(printf '%s' "$LOG" | grep -oE '@@[^@]{1,140}@@' | sed 's/@@//g')
             comm -13 <(printf '%s\n' "$seen" | sort -u) <(printf '%s\n' "$NEW" | sort -u) 2>/dev/null | grep -vE '^$' | sed 's/^/  · /'
@@ -415,25 +407,47 @@ jobs:
           done
           M=$(kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | grep -oE '@@MEAS [0-9a-f]{96}@@' | tail -1 | grep -oE '[0-9a-f]{96}')
           echo "measurement=${M:-}" >> "$GITHUB_OUTPUT"
-          # golden drift check (warn-mode; promote to fail-closed after one clean
-          # image bump). The reference is the RUNTIME measurement captured at
-          # image-bump time into the refs CM — NOT the image manifest's
+          # Golden drift check, fail-closed. It shipped warn-only "until one clean
+          # image bump"; that bump never came (the lane cannot move off the June
+          # image), and meanwhile this is the only thing that would notice the
+          # image moving under the sandboxInventoryCIDRs holding action. Seven
+          # green runs matching the same golden is the evidence the bump was
+          # meant to provide. The reference is the RUNTIME measurement captured
+          # into the refs CM at image-bump time, NOT the manifest's
           # snp_launch_digest, which is computed under different boot assumptions
-          # and has been wrong twice. Capture/refresh after a bump:
+          # and has been wrong twice. Refresh after a bump:
           #   kubectl -n confai-images patch cm <refs-cm> --type merge \
           #     -p '{"data":{"runtimeLaunchDigest":"<measurement from a green run>"}}'
           GOLD=$(kubectl -n "$NS" get cm "$REFS_CM" -o jsonpath='{.data.runtimeLaunchDigest}' 2>/dev/null)
+          DRIFT=""
           if [ -n "${CORES_OVERRIDDEN:-}" ]; then
             # The golden pins the cell's default vCPU count, so it cannot match
             # a deliberate override. Print the measurement instead: that is the
             # value a per-SMP digest is confirmed against.
-            echo "::notice title=launch measurement (smp$CORES)::$M — cores_override in effect, golden drift check skipped (the golden pins this cell's default vCPU count)"
-          elif [ -n "$GOLD" ] && [ -n "$M" ] && [ "${GOLD,,}" != "${M,,}" ]; then
-            echo "::warning title=launch measurement drift::runtime $M != $REFS_CM.runtimeLaunchDigest $GOLD — image bumped without refreshing the golden, or unexpected boot-config change"
+            echo "::notice title=launch measurement (smp$CORES)::$M, cores_override in effect, golden drift check skipped (the golden pins this cell's default vCPU count)"
+          elif [ -z "$GOLD" ]; then
+            # No golden means no drift detection at all, which used to pass in
+            # silence. rke2-node is the enforcement flavour and must carry one;
+            # base-cpu's refs CM has none today, so there it is visible, not fatal.
+            if [ '${{ inputs.flavor }}' = rke2-node ]; then
+              DRIFT="$REFS_CM has no runtimeLaunchDigest, so launch-measurement drift cannot be detected; capture one from a green run (see above)"
+            else
+              echo "::warning title=no golden measurement::$REFS_CM has no runtimeLaunchDigest; launch-measurement drift is not checked for this flavour"
+            fi
+          elif [ -z "$M" ]; then
+            DRIFT="the guest reported no launch measurement to compare against $REFS_CM.runtimeLaunchDigest"
+          elif [ "${GOLD,,}" != "${M,,}" ]; then
+            DRIFT="runtime $M != $REFS_CM.runtimeLaunchDigest $GOLD: image bumped without refreshing the golden, or an unexpected boot-config change"
           fi
           if [ -z "$ok" ]; then
             echo "::error::payload did not report PAYLOAD_OK. Driver console output:"
             kubectl -n "$NS" logs "pod/$POD" -c guest-console-log 2>/dev/null | tr -cd '[:print:]\n' | sed -e 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '@@.*@@' | tail -60
+            exit 1
+          fi
+          # After the payload verdict, so a run that both failed and drifted
+          # reports the failure with its console first.
+          if [ -n "$DRIFT" ]; then
+            echo "::error title=launch measurement drift::$DRIFT"
             exit 1
           fi
           echo "✅ ${{ inputs.platform }}/${{ inputs.flavor }}: attested CVM (runtime launch measurement ${M:-unknown}) ran the payload to PAYLOAD_OK"


### PR DESCRIPTION
confidential-ci owns this primitive and c8s carries a byte-identical copy, so confidential-ci#110 has to land here or `vendored-lane-drift` goes red.

The golden launch-measurement check is now fail-closed instead of warn-only. Drift is an error; an absent golden is an error on `rke2-node` (the enforcement flavour) and a visible warning on `base-cpu`, whose refs ConfigMap has none; a missing guest measurement against a set golden is an error; `cores_override` still skips. The drift exit comes after the payload verdict so a failed payload reports its console first.

Seven-scenario harness in confidential-ci#110. The merge fired the metal lanes on main and they passed with the golden matching, which proves the happy path; the error branches rest on the harness.
