### PR TITLE
ci(snp-metal): pin attestation-api to the attestation-rs commit the node image was built from

### DIFF
--- a/.github/workflows/snp-metal-e2e.yml
+++ b/.github/workflows/snp-metal-e2e.yml
@@ -128,14 +128,34 @@ jobs:
           # never tracked and get-cert dies with "caller cgroup names no tracked
           # container". Pin it like cds and nri already are.
           OPDIG=$(resolve_digest c8s-operator "$OPTAG")
-          # attestation-api is versioned by the attestation-rs repo, NOT c8s — a
-          # c8s-ancestry walk can never find its tags (learned the hard way:
-          # InvalidImageName, run 29473241754). :main is the canonical pointer the
-          # c8s-integration fleet uses; accepted race until c8s pins a digest.
-          # aa_ref lets a caller PIN it (tag or sha-<short>) — floating :main drifts
-          # (e.g. attestation-rs enforce-VMPL0/reject-debug-policy landed on :main and
-          # broke this dev-sandbox CVM while the boot image was unchanged).
-          AATAG="${{ inputs.aa_ref || 'main' }}"
+          # attestation-api is versioned by the attestation-rs repo, NOT c8s, so a
+          # c8s-ancestry walk can never find its tags (InvalidImageName, run
+          # 29473241754). Pin it to the attestation-rs commit the node image was
+          # built from (.github/build-pins.json, kept current by confos-pin-watch),
+          # so the DaemonSet and the copy baked into the guest are the same code.
+          # Floating :main ran two attestation-rs versions in one cluster and went
+          # red for attestation-rs reasons on days with no c8s change
+          # (enforce-VMPL0/reject-debug-policy landing on :main). aa_ref still
+          # overrides for a caller who wants tip on purpose.
+          PINS=c8s/.github/build-pins.json
+          if [ -n '${{ inputs.aa_ref }}' ]; then
+            AATAG='${{ inputs.aa_ref }}'
+          elif [ -f "$PINS" ]; then
+            AA_REF=$(jq -er '.builds["node-image"].attestation_rs_ref' "$PINS") \
+              || { echo "::error::$PINS exists but has no builds.node-image.attestation_rs_ref"; exit 1; }
+            AATAG="sha-${AA_REF:0:7}"
+            tok=$(curl -fsSL --max-time 20 "https://ghcr.io/token?scope=repository:confidential-dot-ai/attestation-api:pull" | jq -r .token)
+            code=$(curl -s -o /dev/null --max-time 20 -w '%{http_code}' -H "Authorization: Bearer $tok" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json' \
+              "https://ghcr.io/v2/confidential-dot-ai/attestation-api/manifests/${AATAG}")
+            # A pin that points at nothing is broken, not something to fall back from.
+            [ "$code" = 200 ] || { echo "::error::build-pins.json pins attestation-rs ${AA_REF:0:7} but ghcr has no attestation-api:${AATAG} (HTTP $code)"; exit 1; }
+          else
+            # c8s refs before 2026-09-03 (c8s#523) carry no pin file. Nothing to
+            # honour, so float, and say so.
+            echo "::warning title=attestation-api unpinned::this c8s ref has no $PINS; using attestation-api:main"
+            AATAG=main
+          fi
           echo "resolved image tags: c8s-operator=$OPTAG cds=$CDSTAG attestation-api=$AATAG (chart+values from $SHORT)"
 
           # c8s chart values — canonical per c8s/docs + the c8s-integration fleet:


### PR DESCRIPTION
The attestation-api DaemonSet image floated to `:main` while the node image bakes attestation-rs at the commit pinned in `.github/build-pins.json`. A run therefore tested two attestation-rs versions in one cluster, a combination nobody ships, and the lane went red for attestation-rs reasons on days with no c8s change (the comment this replaces records enforce-VMPL0/reject-debug-policy landing on `:main`).

Pin the DaemonSet to the same commit. Read `builds.node-image.attestation_rs_ref` from `build-pins.json` in the c8s checkout the lane already has and use `attestation-api:sha-<first 7>`. This is the version-pairing principle the lane already enforces for `c8sRef`, applied to the one component it skipped.

Edges, each tested under bash by extracting the block with `inputs.aa_ref` rendered per scenario, a fake `c8s/` checkout, and `curl` stubbed for the ghcr token and manifest probe:

```
pin present, tag exists            rc=0  AATAG=sha-d868688
pin present, tag missing           rc=1  ::error::build-pins.json pins attestation-rs d868688 but ghcr has no attestation-api:sha-0000000
pin file absent (old ref)          rc=0  AATAG=main   ::warning::attestation-api unpinned
pin file present, key missing      rc=1  ::error::... has no builds.node-image.attestation_rs_ref
aa_ref override wins               rc=0  AATAG=sha-abc1234
```

A pin that points at nothing fails rather than falling back, since that is a broken pin, not a transient. Refs older than the pin file (before c8s#523, 2026-09-03) have nothing to honour, so they warn and float. The healthy path also ran once against real ghcr (the harness shell did not export the stub) and passed, so `attestation-api:sha-d868688` is live today.

What this does to "what if attestation-rs changes": the pin moves through the existing weekly `confos-pin-watch`, which rolls the measurements and runs the reproducibility gate; last cycle attestation-rs landed `d868688` on 09-04 and c8s#548 merged the bump on 09-09. attestation-rs tip is proven on this same hardware by attestation-rs's own `confidential-e2e` on every push, so that question is answered there rather than by floating here.

Not covered: this file is vendored into confidential-ci; the re-vendor follows. The Azure lanes do not plumb `aa_ref` and take the chart default, a separate change. The c8s lane now lags attestation-rs by up to a week plus merge time; a c8s change that needs newer attestation-rs must land the bump first, the same discipline already in place for confos.

Falsified by: a run whose `resolved image tags` line shows `attestation-api=main` on a c8s ref that carries `build-pins.json`.
