### PR TITLE
fix(ci): keep kubectl on the launcher runner in-cluster

### DIFF
--- a/.github/actions/tdx-metal-e2e/action.yml
+++ b/.github/actions/tdx-metal-e2e/action.yml
@@ -146,8 +146,8 @@ runs:
       # different node. No cluster-scoped node-list authority is needed.
       bash .github/scripts/tdx-image-acceptance.sh binder \
         "$VM" "$NS" "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" | kubectl create -f -
-      kubectl --request-timeout=130s -n "$NS" wait --for=condition=PodScheduled "pod/$VM-binder" --timeout=120s
-      kubectl --request-timeout=130s -n "$NS" wait --for=jsonpath='{.status.phase}'=Bound "pvc/$VM-root" --timeout=120s
+      timeout 130 kubectl -n "$NS" wait --for=condition=PodScheduled "pod/$VM-binder" --timeout=120s
+      timeout 130 kubectl -n "$NS" wait --for=jsonpath='{.status.phase}'=Bound "pvc/$VM-root" --timeout=120s
       bash .github/scripts/tdx-image-acceptance.sh start-import \
         "$RUNNER_TEMP/tdx-image-acceptance" "$SOURCE_SHA" "$GITHUB_RUN_ID" "$VM" "$NS" "$GITHUB_REPOSITORY"
       bash .github/scripts/tdx-image-acceptance.sh wait "$VM" "$NS" "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY"

--- a/.github/scripts/tdx-image-acceptance.sh
+++ b/.github/scripts/tdx-image-acceptance.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # Exact-image evidence is supplied by the trusted publisher in this workflow run.
 set -euo pipefail
+# The launcher runner reaches the outer cluster with in-cluster credentials.
+# kubectl only falls back to those when the flag-merged config equals its
+# built-in default, and --request-timeout breaks that equality, so it would
+# dial localhost:8080 instead. Bound each call with coreutils timeout.
 
 fail() { echo "tdx-image-acceptance: $*" >&2; exit 1; }
 
@@ -82,9 +86,9 @@ case ${1:-} in
     [[ $# == 7 ]] || fail 'usage: start-import EVIDENCE SOURCE_SHA RUN_ID VM NAMESPACE REPOSITORY'
     validate "$2" "$3" "$4"
     identity "$5" "$6" "$4" "$7"
-    object=$(kubectl --request-timeout=30s -n "$6" get pvc "$5-root" -o json)
+    object=$(timeout 30 kubectl -n "$6" get pvc "$5-root" -o json)
     owned_root "$object" "$5" "$4" "$7" || fail 'refusing an unowned root PVC'
-    binder=$(kubectl --request-timeout=30s -n "$6" get pod "$5-binder" -o json)
+    binder=$(timeout 30 kubectl -n "$6" get pod "$5-binder" -o json)
     owned_root "$binder" "$5" "$4" "$7" binder || fail 'refusing an unowned binder Pod'
     node=$(jq -er '.spec.nodeName | select(type == "string" and length > 0)' <<<"$binder")
     jq -e --arg node "$node" '.status.phase == "Bound" and
@@ -94,7 +98,7 @@ case ${1:-} in
       any(.status.conditions[]; .type == "PodScheduled" and .status == "True")' <<<"$binder" >/dev/null ||
       fail 'TDX binder is not scheduled'
     image=$(jq -r .image "$2/acceptance.json")
-    kubectl --request-timeout=30s -n "$6" annotate pvc "$5-root" \
+    timeout 30 kubectl -n "$6" annotate pvc "$5-root" \
       cdi.kubevirt.io/storage.import.source=registry \
       "cdi.kubevirt.io/storage.import.endpoint=docker://$image" \
       cdi.kubevirt.io/storage.contentType=kubevirt --overwrite=false
@@ -108,7 +112,7 @@ case ${1:-} in
     while (( SECONDS < deadline )); do
       remaining=$((deadline - SECONDS))
       request_timeout=$((remaining < 30 ? remaining : 30))
-      object=$(kubectl --request-timeout="${request_timeout}s" -n "$3" get pvc "$2-root" -o json)
+      object=$(timeout "$request_timeout" kubectl -n "$3" get pvc "$2-root" -o json)
       owned_root "$object" "$2" "$4" "$5" || fail 'refusing an unowned root PVC'
       phase=$(jq -r '.metadata.annotations["cdi.kubevirt.io/storage.pod.phase"] // "Pending"' <<<"$object")
       case $phase in
@@ -133,15 +137,15 @@ case ${1:-} in
     else
       bash "$0" cleanup-binder "$2" "$3" "$4" "$5"
     fi
-    object=$(kubectl --request-timeout=30s -n "$3" get "$resource" "$2-$kind" --ignore-not-found -o json)
+    object=$(timeout 30 kubectl -n "$3" get "$resource" "$2-$kind" --ignore-not-found -o json)
     [[ -n $object ]] || exit 0
     owned_root "$object" "$2" "$4" "$5" "$kind" || fail 'refusing to delete an unowned acceptance resource'
-    kubectl --request-timeout=30s -n "$3" delete "$resource" "$2-$kind" --ignore-not-found --wait=true --timeout=120s
+    timeout 130 kubectl -n "$3" delete "$resource" "$2-$kind" --ignore-not-found --wait=true --timeout=120s
     ;;
   reap)
     [[ $# == 4 ]] || fail 'usage: reap NAMESPACE CURRENT_RUN_ID REPOSITORY'
     [[ $3 =~ ^[0-9]+$ ]] || fail 'invalid current run'
-    roots=$(kubectl --request-timeout=30s -n "$2" get pvc \
+    roots=$(timeout 30 kubectl -n "$2" get pvc \
       -l ci.confidential.ai/resource=acceptance-root -o json)
     now=$(date -u +%s)
     while IFS= read -r object; do
@@ -152,7 +156,7 @@ case ${1:-} in
       owned_root "$object" "$vm" "$run" "$4" || continue
       # Root imports can outlive a cancelled run before its VM even exists.
       # Never delete a PVC while any matching VM is still present.
-      existing=$(kubectl --request-timeout=30s -n "$2" get vm "$vm" --ignore-not-found -o name) || continue
+      existing=$(timeout 30 kubectl -n "$2" get vm "$vm" --ignore-not-found -o name) || continue
       [[ -z $existing ]] || continue
       status=$(gh api "repos/$4/actions/runs/$run" --jq .status 2>/dev/null || true)
       created=$(jq -r .metadata.creationTimestamp <<<"$object")


### PR DESCRIPTION
The first exact-image acceptance run on main (34621353943) failed before importing anything: every kubectl call in the acceptance script was refused at localhost:8080, while the reap step right before it, in the same job with the same environment, listed the standing VM fine.

kubectl only falls back to in-cluster credentials when the flag-merged config is identical to its built-in default (`DeferredLoadingClientConfig.ClientConfig` in client-go). `--request-timeout` sets a timeout on that config, so it no longer matches, the fallback is skipped, and the client dials the default host. The launcher runner has no kubeconfig, only its service account, so every call carrying the flag fails there. The script was the first thing on that runner to use the flag, which is why the metal lane never saw it.

The calls are now bounded with coreutils `timeout` instead, in the script and in the two wait lines of the composite action. The bound on the cleanup delete is 130s, since it waits up to 120s for the resource to go. Script tests (45 assertions), shellcheck and actionlint pass.

Merging re-publishes the node image and re-runs the acceptance lane, which is the first real boot of the AppArmor gate from #543.