### PR TITLE
fix(ci): preserve in-cluster auth for TDX acceptance

### DIFF
--- a/.github/actions/tdx-metal-e2e/action.yml
+++ b/.github/actions/tdx-metal-e2e/action.yml
@@ -146,8 +146,8 @@ runs:
       # different node. No cluster-scoped node-list authority is needed.
       bash .github/scripts/tdx-image-acceptance.sh binder \
         "$VM" "$NS" "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY" | kubectl create -f -
-      kubectl --request-timeout=130s -n "$NS" wait --for=condition=PodScheduled "pod/$VM-binder" --timeout=120s
-      kubectl --request-timeout=130s -n "$NS" wait --for=jsonpath='{.status.phase}'=Bound "pvc/$VM-root" --timeout=120s
+      timeout --signal=KILL 130s kubectl -n "$NS" wait --for=condition=PodScheduled "pod/$VM-binder" --timeout=120s
+      timeout --signal=KILL 130s kubectl -n "$NS" wait --for=jsonpath='{.status.phase}'=Bound "pvc/$VM-root" --timeout=120s
       bash .github/scripts/tdx-image-acceptance.sh start-import \
         "$RUNNER_TEMP/tdx-image-acceptance" "$SOURCE_SHA" "$GITHUB_RUN_ID" "$VM" "$NS" "$GITHUB_REPOSITORY"
       bash .github/scripts/tdx-image-acceptance.sh wait "$VM" "$NS" "$GITHUB_RUN_ID" "$GITHUB_REPOSITORY"

--- a/.github/scripts/tdx-image-acceptance.sh
+++ b/.github/scripts/tdx-image-acceptance.sh
@@ -4,6 +4,15 @@ set -euo pipefail
 
 fail() { echo "tdx-image-acceptance: $*" >&2; exit 1; }
 
+# A kubectl request-timeout override prevents client-go from falling back to
+# the launcher's in-cluster credentials. Bound the process without changing
+# its client configuration. KILL leaves no grace period beyond the deadline.
+kubectl_bounded() {
+  local duration=$1
+  shift
+  timeout --signal=KILL "${duration}s" kubectl "$@"
+}
+
 validate() {
   local evidence=$1 source_sha=$2 run_id=$3 actual
   [[ $source_sha =~ ^[0-9a-f]{40}$ && $run_id =~ ^[0-9]+$ ]] || fail 'invalid expected build identity'
@@ -82,9 +91,9 @@ case ${1:-} in
     [[ $# == 7 ]] || fail 'usage: start-import EVIDENCE SOURCE_SHA RUN_ID VM NAMESPACE REPOSITORY'
     validate "$2" "$3" "$4"
     identity "$5" "$6" "$4" "$7"
-    object=$(kubectl --request-timeout=30s -n "$6" get pvc "$5-root" -o json)
+    object=$(kubectl_bounded 30 -n "$6" get pvc "$5-root" -o json)
     owned_root "$object" "$5" "$4" "$7" || fail 'refusing an unowned root PVC'
-    binder=$(kubectl --request-timeout=30s -n "$6" get pod "$5-binder" -o json)
+    binder=$(kubectl_bounded 30 -n "$6" get pod "$5-binder" -o json)
     owned_root "$binder" "$5" "$4" "$7" binder || fail 'refusing an unowned binder Pod'
     node=$(jq -er '.spec.nodeName | select(type == "string" and length > 0)' <<<"$binder")
     jq -e --arg node "$node" '.status.phase == "Bound" and
@@ -94,7 +103,7 @@ case ${1:-} in
       any(.status.conditions[]; .type == "PodScheduled" and .status == "True")' <<<"$binder" >/dev/null ||
       fail 'TDX binder is not scheduled'
     image=$(jq -r .image "$2/acceptance.json")
-    kubectl --request-timeout=30s -n "$6" annotate pvc "$5-root" \
+    kubectl_bounded 30 -n "$6" annotate pvc "$5-root" \
       cdi.kubevirt.io/storage.import.source=registry \
       "cdi.kubevirt.io/storage.import.endpoint=docker://$image" \
       cdi.kubevirt.io/storage.contentType=kubevirt --overwrite=false
@@ -107,8 +116,9 @@ case ${1:-} in
     deadline=$((SECONDS + timeout_seconds))
     while (( SECONDS < deadline )); do
       remaining=$((deadline - SECONDS))
+      ((remaining > 0)) || break
       request_timeout=$((remaining < 30 ? remaining : 30))
-      object=$(kubectl --request-timeout="${request_timeout}s" -n "$3" get pvc "$2-root" -o json)
+      object=$(kubectl_bounded "$request_timeout" -n "$3" get pvc "$2-root" -o json)
       owned_root "$object" "$2" "$4" "$5" || fail 'refusing an unowned root PVC'
       phase=$(jq -r '.metadata.annotations["cdi.kubevirt.io/storage.pod.phase"] // "Pending"' <<<"$object")
       case $phase in
@@ -133,15 +143,15 @@ case ${1:-} in
     else
       bash "$0" cleanup-binder "$2" "$3" "$4" "$5"
     fi
-    object=$(kubectl --request-timeout=30s -n "$3" get "$resource" "$2-$kind" --ignore-not-found -o json)
+    object=$(kubectl_bounded 30 -n "$3" get "$resource" "$2-$kind" --ignore-not-found -o json)
     [[ -n $object ]] || exit 0
     owned_root "$object" "$2" "$4" "$5" "$kind" || fail 'refusing to delete an unowned acceptance resource'
-    kubectl --request-timeout=30s -n "$3" delete "$resource" "$2-$kind" --ignore-not-found --wait=true --timeout=120s
+    kubectl_bounded 130 -n "$3" delete "$resource" "$2-$kind" --ignore-not-found --wait=true --timeout=120s
     ;;
   reap)
     [[ $# == 4 ]] || fail 'usage: reap NAMESPACE CURRENT_RUN_ID REPOSITORY'
     [[ $3 =~ ^[0-9]+$ ]] || fail 'invalid current run'
-    roots=$(kubectl --request-timeout=30s -n "$2" get pvc \
+    roots=$(kubectl_bounded 30 -n "$2" get pvc \
       -l ci.confidential.ai/resource=acceptance-root -o json)
     now=$(date -u +%s)
     while IFS= read -r object; do
@@ -152,7 +162,7 @@ case ${1:-} in
       owned_root "$object" "$vm" "$run" "$4" || continue
       # Root imports can outlive a cancelled run before its VM even exists.
       # Never delete a PVC while any matching VM is still present.
-      existing=$(kubectl --request-timeout=30s -n "$2" get vm "$vm" --ignore-not-found -o name) || continue
+      existing=$(kubectl_bounded 30 -n "$2" get vm "$vm" --ignore-not-found -o name) || continue
       [[ -z $existing ]] || continue
       status=$(gh api "repos/$4/actions/runs/$run" --jq .status 2>/dev/null || true)
       created=$(jq -r .metadata.creationTimestamp <<<"$object")

--- a/.github/scripts/tests/test-tdx-image-acceptance.sh
+++ b/.github/scripts/tests/test-tdx-image-acceptance.sh
@@ -6,6 +6,11 @@ script="$test_dir/../tdx-image-acceptance.sh"
 fixture=$(mktemp -d)
 trap 'rm -rf -- "$fixture"' EXIT
 mkdir -p "$fixture/evidence" "$fixture/bin"
+# Keep the real timer and sleeper available after installing PATH fixtures.
+export FIXTURE_TIMEOUT
+FIXTURE_TIMEOUT=$(command -v timeout)
+export FIXTURE_SLEEP
+FIXTURE_SLEEP=$(command -v sleep)
 tests=0
 pass() { tests=$((tests + 1)); }
 fail() { echo "FAIL: $*" >&2; exit 1; }
@@ -93,6 +98,19 @@ cat > "$fixture/bin/kubectl" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$FIXTURE_LOG"
+# The ARC launcher relies on client-go's implicit in-cluster configuration.
+# Any nonzero request-timeout overrides that fallback with localhost:8080.
+for arg in "$@"; do
+  case "$arg" in
+    --request-timeout|--request-timeout=*) echo 'in-cluster fallback disabled' >&2; exit 64 ;;
+  esac
+done
+if [[ ${FIXTURE_HANG:-0} == 1 ]]; then
+  printf '%s\n' started > "$FIXTURE_HANG_STARTED"
+  # Ignore TERM to prove the helper enforces its deadline without a grace wait.
+  trap '' TERM
+  exec "$FIXTURE_SLEEP" 30
+fi
 record_delete() {
   while [[ $# -gt 0 && $1 != delete ]]; do shift; done
   [[ $# -ge 3 ]] || exit 1
@@ -107,6 +125,11 @@ case " $* " in
   *' delete pod '*|*' delete pvc '*) record_delete "$@" ;;
   *) exit 1 ;;
 esac
+SH
+cat > "$fixture/bin/timeout" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FIXTURE_TIMEOUT_LOG"
+exec "$FIXTURE_TIMEOUT" "$@"
 SH
 cat > "$fixture/bin/gh" <<'SH'
 #!/usr/bin/env bash
@@ -128,6 +151,7 @@ export PATH="$fixture/bin:$PATH"
 export FIXTURE_LOG="$fixture/calls" FIXTURE_PVC="$fixture/pvc.json"
 export FIXTURE_DELETES="$fixture/deletes" FIXTURE_ROOTS="$fixture/roots.json"
 export FIXTURE_BINDER="$fixture/binder.json" FIXTURE_ANNOTATIONS="$fixture/annotations"
+export FIXTURE_TIMEOUT_LOG="$fixture/timeouts" FIXTURE_HANG_STARTED="$fixture/hang-started"
 : > "$FIXTURE_BINDER"
 : > "$FIXTURE_ANNOTATIONS"
 : > "$FIXTURE_DELETES"
@@ -139,6 +163,19 @@ reject bash "$script" wait "$vm" "$ns" "$run" "$repo"
 cp "$fixture/pvc-good.json" "$FIXTURE_PVC"
 reject bash "$script" wait "$vm" "$ns" "$run" "$repo" 1
 reject bash "$script" wait "$vm" "$ns" "$run" "$repo" 0
+# Run the production poll with a real blocked process and its one-second
+# deadline. The outer watchdog only prevents a broken timer hanging the suite.
+started=$SECONDS
+status=0
+"$FIXTURE_TIMEOUT" --kill-after=1s 5s env FIXTURE_HANG=1 \
+  bash "$script" wait "$vm" "$ns" "$run" "$repo" 1 \
+  >"$fixture/stdout" 2>"$fixture/stderr" || status=$?
+[[ -s $FIXTURE_HANG_STARTED ]] || fail 'hanging kubectl fixture was never invoked'
+[[ $status == 137 && $((SECONDS - started)) -lt 4 ]] ||
+  fail "poll did not enforce its one-second deadline (status=$status)"
+[[ ! -s $FIXTURE_ANNOTATIONS && ! -s $FIXTURE_DELETES ]] ||
+  fail 'timed-out poll mutated a resource'
+pass
 jq '.metadata.labels["ci.confidential.ai/run-id"] = "456"' "$fixture/pvc-good.json" > "$FIXTURE_PVC"
 reject bash "$script" wait "$vm" "$ns" "$run" "$repo"
 reject bash "$script" cleanup "$vm" "$ns" "$run" "$repo"
@@ -146,6 +183,8 @@ reject bash "$script" cleanup "$vm" "$ns" "$run" "$repo"
 cp "$fixture/pvc-good.json" "$FIXTURE_PVC"
 bash "$script" cleanup "$vm" "$ns" "$run" "$repo"
 expect_deletes "pvc/$vm-root"
+grep -Fxq -- "--signal=KILL 130s kubectl -n $ns delete pvc $vm-root --ignore-not-found --wait=true --timeout=120s" \
+  "$FIXTURE_TIMEOUT_LOG" || fail 'cleanup shortened its existing two-minute deletion wait'
 pass
 : > "$FIXTURE_PVC"
 bash "$script" cleanup "$vm" "$ns" "$run" "$repo"

--- a/node-guest-image/README.md
+++ b/node-guest-image/README.md
@@ -211,8 +211,13 @@ source rejection, E2E routing and caller-isolation tests with
 That job imports the digest-pinned disk into its own 80Gi `local-path` PVC.
 A restricted scheduling pod selects a TDX node before CDI import starts;
 the pod has no service-account token or disk mount. Import has a 20-minute
-deadline, and cleanup checks ownership of the temporary pod and PVC. This
-requires working CDI, enough local disk space, and the launcher's existing
+deadline, and cleanup checks ownership of the temporary pod and PVC.
+The launcher uses its implicit in-cluster service-account configuration.
+GNU `timeout` bounds these acceptance calls externally because a
+`kubectl --request-timeout` override disables that fallback. Reads get at
+most 30 seconds within the import deadline; binder waits and cleanup deletes
+retain 120-second kubectl timeouts with a 130-second external process limit.
+This requires working CDI, enough local disk space, and the launcher's existing
 namespace-scoped Pod/PVC permissions; no shared image ConfigMap, root PVC,
 or cluster-wide RBAC is changed. The hardware path must still be exercised
 on the TDX runner; the local evidence/lifecycle fixtures are run with:

--- a/test/workflows/tdx_structure_test.go
+++ b/test/workflows/tdx_structure_test.go
@@ -216,6 +216,11 @@ func TestTDXLifecycleDoesNotAcquireWorkflowSource(t *testing.T) {
 		if step.Run != "" && step.Shell != "bash" {
 			t.Errorf("%s must declare shell bash", step.Name)
 		}
+		// A request-timeout override disables client-go's implicit in-cluster
+		// config on ARC. External process timeouts preserve that fallback.
+		if strings.Contains(step.Run, "--request-timeout") {
+			t.Errorf("%s disables the launcher's in-cluster Kubernetes configuration", step.Name)
+		}
 		if strings.HasPrefix(step.Uses, "actions/checkout@") || strings.HasPrefix(step.Uses, "actions/download-artifact@") {
 			t.Errorf("%s acquires source/evidence inside the shared lifecycle", step.Name)
 		}


### PR DESCRIPTION
Superseded by merged #602, which independently fixed the same in-cluster configuration failure while this PR was being prepared. Closed to avoid duplicate changes.

## Summary

Published-image TDX acceptance failed before importing or booting a VM because `kubectl --request-timeout` disabled client-go's automatic in-cluster configuration and selected `localhost:8080`. The untimed reaper in the same launcher could access Kubernetes. [The failed post-merge run](https://github.com/confidential-dot-ai/c8s/actions/runs/34621353943) built and published both images successfully, but skipped hardware acceptance.

Bound kubectl with GNU `timeout` without changing its client configuration:

- Reads and annotations have a 30-second process limit; import polls use the smaller of 30 seconds and the remaining 20-minute deadline.
- Binder waits and ownership-checked deletion keep their existing 120-second waits within a 130-second process limit.
- Immediate termination avoids extending the deadline with a kill grace period. A positive remaining-time guard prevents `timeout 0` from disabling the bound.

No new kubeconfig, credential handling, permissions or acceptance entrypoints are introduced. Ownership checks and nonzero cleanup failures remain enforced.

## Validation

- **46** exact-image helper assertions passed, including a real blocked process terminated by its one-second polling deadline and preservation of deletion waits.
- The regression rejects the unchanged previous helper with the in-cluster configuration failure (**RED**), and passes after the fix.
- Workflow Go race tests, actionlint including the composite action, scoped ShellCheck and diff checks passed.
- Security review found no issues.
- Fresh PR CI is pending. Hardware acceptance requires a fresh automatic publication after merge; rerunning the unchanged failed source would retain the bug and a failed-job-only rerun would lack current-attempt evidence.
