### PR TITLE
docs: env and mount allowlist policy is not enforced in node mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,15 @@ than let you discover them:
   *together* — every running image must be allowlisted, but no gate requires
   the set in one pod to match a single workload entry.
 
+- **`mounts` and `env` allowlist policy is not enforced under
+  `--cvm-mode=node`.** The only enforcer running there, the host NRI
+  image-policy plugin, observes digest and argv only, so an `exact` `mounts`
+  or `env` policy is vacuously satisfied and admits every container. A leaf
+  certificate and workload receipt still derive from digest and argv only, so
+  a bind mount or environment variable added at the Deployment stays
+  invisible to a relying party. See [docs/allowlist-and-capabilities.md, "Node
+  mode: not enforced"](docs/allowlist-and-capabilities.md#node-mode-not-enforced).
+
 - **Secrets and encrypted volumes under pod-as-CVM carry weaker guarantees
   than on a node.** Both work — the injected fetchers redeem their sandbox
   token from the in-guest `policy-monitor` over loopback, and `volumed

--- a/README.md
+++ b/README.md
@@ -564,13 +564,14 @@ than let you discover them:
   the set in one pod to match a single workload entry.
 
 - **`mounts` and `env` allowlist policy is not enforced under
-  `--cvm-mode=node`.** The only enforcer running there, the host NRI
-  image-policy plugin, observes digest and argv only, so an `exact` `mounts`
-  or `env` policy is vacuously satisfied and admits every container. A leaf
-  certificate and workload receipt still derive from digest and argv only, so
-  a bind mount or environment variable added at the Deployment stays
-  invisible to a relying party. See [docs/allowlist-and-capabilities.md, "Node
-  mode: not enforced"](docs/allowlist-and-capabilities.md#node-mode-not-enforced).
+  `--cvm-mode=node`.** The host NRI image-policy plugin is the only
+  container-start enforcer in this mode. Its allowlist check supplies digest
+  and argv only. An `exact` `mounts` or `env` policy therefore does not narrow
+  admission: a container that passes digest and argv policy also passes these
+  unobserved constraints. The CDS matched-workload decision also has no mount
+  or environment observation, so a relying party cannot detect such a change
+  from that identity. See [docs/allowlist-and-capabilities.md, "Node mode: not
+  enforced"](docs/allowlist-and-capabilities.md#node-mode-not-enforced).
 
 - **Secrets and encrypted volumes under pod-as-CVM carry weaker guarantees
   than on a node.** Both work — the injected fetchers redeem their sandbox

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -210,17 +210,18 @@ constrained exactly as much as it was before.
 
 One limit worth stating: **the in-guest `policy-monitor` is the enforcer that
 honours them**. It reads the guest's own OCI spec, so it sees both the mount
-table and the environment. The host NRI plugin sees the CRI container and
-reports neither, and an unobserved field is treated as nothing-to-refuse rather
-than as a violation — so under `--cvm-mode=node`, where that plugin is the only
-enforcer, a `mounts` or `env` policy admits every container. `c8s allowlist
-lint` warns when a document carries one; `--cvm-mode=pod` silences it.
+table and the environment. The host NRI plugin currently supplies neither
+field to the matcher. An unobserved field is treated as nothing to refuse,
+rather than as a violation. Under `--cvm-mode=node`, `mounts` and `env`
+therefore do not narrow admission beyond the digest and argv checks. `c8s
+allowlist lint` warns when a document carries either exact policy outside pod
+mode; `--cvm-mode=pod` silences the warning.
 
 ### Node mode: not enforced
 
 Under `--cvm-mode=node`, the `mounts` and `env` policy is not enforced. The
-only enforcer running is the host NRI image-policy plugin, and it does not
-read either field.
+host NRI image-policy plugin is the only container-start enforcer, and its
+allowlist check does not read either field.
 
 `internal/cmds/nri-image-policy/plugin.go` builds the observation the plugin
 checks with only two fields set:
@@ -229,42 +230,56 @@ checks with only two fields set:
 allowlist.RunningContainer{Digest: digest, Argv: argv}
 ```
 
-The comment directly above that line says why:
-
-> Mount and env policy are left unobserved here: this plugin gates images on
-> a node CVM, where it sees the CRI container rather than a guest's mount
-> table, and an unobserved field is not a violation (allowlist.RunningContainer).
-
 `pkg/allowlist/match.go` documents `RunningContainer` the same way: "An
 enforcer that cannot observe a field leaves it nil, which an exact policy
 treats as 'nothing to refuse' rather than as a violation... the host-side NRI
 plugin gates images on a node CVM and fills Digest and Argv only." An
 `exact` `mounts` or `env` policy is therefore vacuously satisfied in node
-mode: every container passes, regardless of what it mounts or what
-environment variables it carries.
+mode. It does not make an arbitrary digest or argv valid. It does mean that
+every container already admitted by digest and argv receives no additional
+restriction from its `mounts` or `env` policy.
 
 **Threat model impact.** An operator credential that can patch a Deployment
-(or anyone who obtains it) can add environment variables (for example
-`LD_PRELOAD` pointing at a mounted library) or bind mounts (ConfigMap,
-Secret, emptyDir, PVC, projected) to an admitted container. The container
-starts. The CDS mesh certificate and the workload receipt derive from digest
-and argv only (`internal/cmds/cds/attest.go`, `matchWorkload`; and
-`pkg/ratls/matchedworkload.go`, the `MatchedWorkload` fields — `Name`,
-`AllowlistVersion`, `AllowlistDigest` — carry no mount or environment data),
-so the change is invisible to a relying party verifying the attestation. The
-allowlist's `env`/`mounts` fields therefore give a relying party no guarantee
-in node mode. `hostPath` remains blocked by the `deny-host-namespaces`
-`ValidatingAdmissionPolicy`.
+(or anyone who obtains it) can add environment variables or bind mounts to an
+otherwise admitted container. Examples include a ConfigMap, Secret, emptyDir,
+PVC or projected volume. If the credential can also supply executable content,
+it can, for example, set `LD_PRELOAD` to a mounted library. Digest and argv do
+not change, so the NRI admission check still passes.
 
-**What would close it.** The NRI `api.Container` the plugin already receives
-carries `Env` and `Mounts` (`github.com/containerd/nri`, `pkg/api`, fields
-`Args`, `Env`, `Mounts`). Filling `BindMounts` and `EnvNames` on the
-`allowlist.RunningContainer` the plugin builds would let the existing matcher
-(`everyIn` in `pkg/allowlist/match.go`) enforce exact policies in node mode
-the same way the in-guest `policy-monitor` does. An exact list built this way
-must still include the kubelet-added mounts and the Kubernetes-injected env
-names described in the paragraph above. Once the plugin fills those fields,
-`c8s allowlist lint` should stop warning for node mode.
+CDS is a separate allowlist enforcement point. At certificate issuance it
+checks digest membership and can stamp a unique matched workload from the
+inventory's digest and argv observations (`internal/cmds/cds/attest.go`,
+`matchWorkload`). `pkg/ratls/matchedworkload.go` carries only `Name`,
+`AllowlistVersion` and `AllowlistDigest`. Neither decision receives mount or
+environment data. A relying party can verify the TEE evidence, certificate
+chain, workload name and allowlist document, but cannot detect this mount or
+environment change from those values. The allowlist's `env` and `mounts`
+fields therefore provide no relying-party guarantee in node mode.
+
+With the default `hostNamespacePolicy` enabled, the
+`deny-host-namespaces` `ValidatingAdmissionPolicy` blocks `hostPath` and other
+unsafe pod settings in non-exempt workload namespaces. It does not block the
+Restricted-safe volume types listed above. Operators can disable that policy
+or exempt namespaces, so it is not an unconditional `hostPath` guarantee.
+
+**What a fix must cover.** The NRI `api.Container` passed to the plugin carries
+`Env` and `Mounts` (`github.com/containerd/nri`, `pkg/api`, fields `Args`,
+`Env`, `Mounts`). Supplying its environment names and bind-mount destinations
+to `allowlist.RunningContainer` would enforce the original CRI observation
+with the existing matcher (`everyIn` in `pkg/allowlist/match.go`). An exact
+list must include the kubelet-added mounts and Kubernetes-injected environment
+names described above.
+
+That change alone is not a complete final-state guarantee. NRI collects
+container adjustments from all mutating plugins after calling their
+`CreateContainer` handlers. An adjustment can add mounts or environment
+variables after this plugin checks the original container. This plugin also
+adds its inventory socket mount to selected injected sidecars after its image
+check. A complete fix must validate the effective result after applicable NRI
+adjustments, or prevent later unvalidated changes to these fields. NRI exposes
+`ValidateContainerAdjustment` for validation of the combined adjustments.
+Only after the effective mount and environment state is covered should `c8s
+allowlist lint` stop warning for node mode.
 
 ## Secret grants (`secrets`)
 

--- a/docs/allowlist-and-capabilities.md
+++ b/docs/allowlist-and-capabilities.md
@@ -216,6 +216,56 @@ than as a violation — so under `--cvm-mode=node`, where that plugin is the onl
 enforcer, a `mounts` or `env` policy admits every container. `c8s allowlist
 lint` warns when a document carries one; `--cvm-mode=pod` silences it.
 
+### Node mode: not enforced
+
+Under `--cvm-mode=node`, the `mounts` and `env` policy is not enforced. The
+only enforcer running is the host NRI image-policy plugin, and it does not
+read either field.
+
+`internal/cmds/nri-image-policy/plugin.go` builds the observation the plugin
+checks with only two fields set:
+
+```go
+allowlist.RunningContainer{Digest: digest, Argv: argv}
+```
+
+The comment directly above that line says why:
+
+> Mount and env policy are left unobserved here: this plugin gates images on
+> a node CVM, where it sees the CRI container rather than a guest's mount
+> table, and an unobserved field is not a violation (allowlist.RunningContainer).
+
+`pkg/allowlist/match.go` documents `RunningContainer` the same way: "An
+enforcer that cannot observe a field leaves it nil, which an exact policy
+treats as 'nothing to refuse' rather than as a violation... the host-side NRI
+plugin gates images on a node CVM and fills Digest and Argv only." An
+`exact` `mounts` or `env` policy is therefore vacuously satisfied in node
+mode: every container passes, regardless of what it mounts or what
+environment variables it carries.
+
+**Threat model impact.** An operator credential that can patch a Deployment
+(or anyone who obtains it) can add environment variables (for example
+`LD_PRELOAD` pointing at a mounted library) or bind mounts (ConfigMap,
+Secret, emptyDir, PVC, projected) to an admitted container. The container
+starts. The CDS mesh certificate and the workload receipt derive from digest
+and argv only (`internal/cmds/cds/attest.go`, `matchWorkload`; and
+`pkg/ratls/matchedworkload.go`, the `MatchedWorkload` fields — `Name`,
+`AllowlistVersion`, `AllowlistDigest` — carry no mount or environment data),
+so the change is invisible to a relying party verifying the attestation. The
+allowlist's `env`/`mounts` fields therefore give a relying party no guarantee
+in node mode. `hostPath` remains blocked by the `deny-host-namespaces`
+`ValidatingAdmissionPolicy`.
+
+**What would close it.** The NRI `api.Container` the plugin already receives
+carries `Env` and `Mounts` (`github.com/containerd/nri`, `pkg/api`, fields
+`Args`, `Env`, `Mounts`). Filling `BindMounts` and `EnvNames` on the
+`allowlist.RunningContainer` the plugin builds would let the existing matcher
+(`everyIn` in `pkg/allowlist/match.go`) enforce exact policies in node mode
+the same way the in-guest `policy-monitor` does. An exact list built this way
+must still include the kubelet-added mounts and the Kubernetes-injected env
+names described in the paragraph above. Once the plugin fills those fields,
+`c8s allowlist lint` should stop warning for node mode.
+
 ## Secret grants (`secrets`)
 
 An entry may grant secret-store paths to the workload it names. The subject is

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -421,7 +421,9 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	// and env policy are left unobserved here: this plugin gates images on a
 	// node CVM, where it sees the CRI container rather than a guest's mount
 	// table, and an unobserved field is not a violation
-	// (allowlist.RunningContainer).
+	// (allowlist.RunningContainer). See docs/allowlist-and-capabilities.md,
+	// "Node mode: not enforced", for the resulting gap under
+	// --cvm-mode=node.
 	if !p.policy.alwaysAllows(digest) && !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
 		// INVARIANT: the returned reason reaches a namespace-readable kubelet
 		// event, so it names only the image — argv can carry credentials and

--- a/internal/cmds/nri-image-policy/plugin.go
+++ b/internal/cmds/nri-image-policy/plugin.go
@@ -417,13 +417,12 @@ func (p *plugin) checkImage(ctx context.Context, cfg *config, namespace, podName
 	}
 
 	// always_allow digests admit regardless of argv; served digests require
-	// the effective argv to satisfy some entry's entrypoint/cmd policy. Mount
-	// and env policy are left unobserved here: this plugin gates images on a
-	// node CVM, where it sees the CRI container rather than a guest's mount
-	// table, and an unobserved field is not a violation
-	// (allowlist.RunningContainer). See docs/allowlist-and-capabilities.md,
-	// "Node mode: not enforced", for the resulting gap under
-	// --cvm-mode=node.
+	// the effective argv to satisfy some entry's entrypoint/cmd policy. This
+	// call leaves mount and env unobserved even though NRI's Container carries
+	// the original CRI values. An exact policy treats a nil observation as
+	// nothing to refuse (allowlist.RunningContainer). Checking those original
+	// values alone would not cover later NRI adjustments. See
+	// docs/allowlist-and-capabilities.md, "Node mode: not enforced".
 	if !p.policy.alwaysAllows(digest) && !snap.index.AdmitsContainer(allowlist.RunningContainer{Digest: digest, Argv: argv}) {
 		// INVARIANT: the returned reason reaches a namespace-readable kubelet
 		// event, so it names only the image — argv can carry credentials and


### PR DESCRIPTION
## Summary

Under `--cvm-mode=node`, c8s does not enforce the `mounts` or `env`
allowlist fields. The host NRI image-policy plugin is the only
container-start enforcer in this mode. Its allowlist check supplies only the
image digest and effective argv to the matcher.

An `exact` mount or environment policy therefore does not narrow node-mode
admission. A container that passes digest and argv policy also passes these
unobserved constraints.

This PR documents the behavior and its security effect. It does not change
runtime behavior.

## Enforcement path

The NRI plugin checks this observation in
`internal/cmds/nri-image-policy/plugin.go`:

```go
allowlist.RunningContainer{Digest: digest, Argv: argv}
```

`BindMounts` and `EnvNames` remain nil. In `pkg/allowlist/match.go`,
`everyIn` returns true for an empty observation. Therefore, an exact policy
cannot reject an extra mount or environment name in node mode.

Digest and argv enforcement still applies. This gap does not admit an
arbitrary image or command.

The in-guest `policy-monitor` used by `--cvm-mode=pod` reads the guest OCI
specification and supplies all four observations. It enforces `mounts` and
`env` in that mode.

CDS is a separate allowlist enforcement point. At certificate issuance it
checks digest membership and can derive a matched-workload identity from
digest and argv. It receives no mount or environment observation. A relying
party can verify the TEE evidence, certificate chain, workload name, and
allowlist document, but it cannot detect a mount or environment change from
those values.

## Security effect

A credential that can patch a Deployment can add environment variables or
Restricted-safe volume mounts to an otherwise admitted container. If it can
also supply executable content, it can use mechanisms such as `LD_PRELOAD`
with a mounted library. The image digest and argv remain unchanged.

With the default `hostNamespacePolicy` enabled, the
`deny-host-namespaces` `ValidatingAdmissionPolicy` blocks `hostPath` in
non-exempt workload namespaces. It does not block ConfigMap, Secret,
emptyDir, PVC, projected, and other Restricted-safe volume sources.

Known node-mode consumers include `confidential-inference` and
`confidential-inference-internal`. Their current checked-in production and
integration-staging allowlists use `policy: any` for `mounts` and `env`.
This is therefore a missing guarantee in their node-mode threat model, not a
bypass of an active exact constraint.

## Requirements for a runtime fix

NRI `api.Container` includes `Env` and `Mounts`. Supplying their environment
names and bind-mount destinations to `allowlist.RunningContainer` would cover
the original CRI observation.

That change alone would not prove the final container state. NRI collects
adjustments from all mutating plugins after it calls their `CreateContainer`
handlers. A later adjustment can add a mount or environment variable. c8s
also adds its inventory socket mount to selected injected sidecars after the
current image check.

A complete fix must validate the effective state after applicable NRI
adjustments, or prevent later unvalidated changes to these fields. NRI
provides `ValidateContainerAdjustment` for validation of the combined
adjustments. Exact policies must also include kubelet-added mounts and
Kubernetes-injected environment names.

`c8s allowlist lint` should continue to warn for node mode until the effective
mount and environment state is enforced.

## Verification

Review these paths in order:

1. `internal/cmds/nri-image-policy/plugin.go`: the `RunningContainer` literal
   supplies only digest and argv.
2. `pkg/allowlist/match.go`: `everyIn` accepts an empty observation.
3. `internal/cmds/policymonitor/run.go`: the pod-mode monitor supplies digest,
   argv, bind mounts, and environment names.
4. `internal/cmds/allowlist/lint.go`: node mode warns about exact mount and
   environment policy.
5. `internal/cmds/cds/attest.go` and `pkg/ratls/matchedworkload.go`: the CDS
   matched-workload path has digest and argv data, but no mount or environment
   data.

`git diff --check` and `gofmt -l internal/cmds/nri-image-policy/plugin.go`
report no issues.
